### PR TITLE
perf(sm12x): optimize and unify static MoE

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/b12x_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/b12x_moe.py
@@ -514,7 +514,9 @@ class B12xMoEWrapper:
         static_max_rows = (
             min(
                 max_routed_rows,
-                _get_static_compact_cutover_pairs(self.activation_precision),
+                _get_static_compact_cutover_pairs(
+                    self.activation_precision, quant_mode=self.quant_mode
+                ),
             )
             if needs_dynamic
             else max_routed_rows

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -62,6 +62,7 @@ _NVFP4_BLOCK_SIZE = 16
 _MXFP4_BLOCK_SIZE = 32
 _LEVEL_TILE_M = 128
 _LEVEL_TILE_N = 128
+_STATIC_RETAINED_GROUP_N = 2 * _LEVEL_TILE_N
 # Must equal the kernel's task materialization granularity or the task
 # queue is mis-sized.
 _DYNAMIC_SLICE_CHUNK = _TASK_SLICE_CHUNK
@@ -392,6 +393,7 @@ class Sm120StaticMoEWorkspace:
     # followed by [weight_E, max_chunks] chunk -> local expert id map. The
     # static route kernel re-initializes it every launch (graph-replay safe).
     virt_route_scratch: torch.Tensor  # [weight_E*(1+max_chunks)] int32
+    route_output_scratch: torch.Tensor  # [max_rows, ceil(n/256), k] bf16
 
     # Views (set after allocation)
     packed_a_view: torch.Tensor | None = None
@@ -428,6 +430,7 @@ def allocate_sm120_static_workspace(
     quant_mode: str = "nvfp4",
 ) -> Sm120StaticMoEWorkspace:
     """Allocate workspace buffers for the SM120 static MoE kernel."""
+    n = _align_up(n, _STATIC_RETAINED_GROUP_N)
     activation_precision = _normalize_activation_precision(activation_precision)
     if activation_precision == "bf16":
         raise ValueError(
@@ -444,8 +447,10 @@ def allocate_sm120_static_workspace(
     # total_rows/32, so ceil(max_rows/32) extra slots always suffice.
     max_chunks = (max_rows + 31) // 32
     virt_E = state_E + max_chunks
+    retained_groups = max(1, n // _STATIC_RETAINED_GROUP_N)
     _check_memref_limit("static packed_input", virt_E * max_rows * (k // 2))
     _check_memref_limit("static packed_input_scale", virt_E * rows_pad_k * cols_pad_k)
+    _check_memref_limit("static route_output_scratch", max_rows * retained_groups * k)
     packed_input = torch.empty(
         virt_E, max_rows, k // 2, dtype=torch.uint8, device=device
     )
@@ -480,6 +485,13 @@ def allocate_sm120_static_workspace(
             # shared by the retained NVFP4 and MXFP4 implementation.
             weight_E * (1 + max_chunks) + 8,
             dtype=torch.int32,
+            device=device,
+        ),
+        route_output_scratch=torch.empty(
+            max_rows,
+            retained_groups,
+            k,
+            dtype=torch.bfloat16,
             device=device,
         ),
     )
@@ -996,6 +1008,11 @@ def _get_static_kernel(
         (state_E * max_rows * (k // 2),),
         assumed_align=16,
     )
+    route_output_scratch_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.BFloat16,
+        (max_rows * max(1, n // _STATIC_RETAINED_GROUP_N) * k,),
+        assumed_align=16,
+    )
     scale_storage_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Uint8,
         (state_E * rows_pad_k * cols_pad_k,),
@@ -1100,6 +1117,7 @@ def _get_static_kernel(
             packed_a_fake,
             sfa_fake,
             packed_a_storage_fake,
+            route_output_scratch_fake,
             scale_storage_fake,
             barrier_count_fake,
             barrier_epoch_fake,
@@ -1743,6 +1761,7 @@ def launch_sm120_static_moe(
             swiglu_limit=swiglu_limit,
             quant_mode=quant_mode,
         )
+        route_output_scratch_args: Tuple[Any, ...] = ()
         virt_scratch_args: Tuple[Any, ...] = ()
     else:
         compiled, mac = _get_static_kernel(
@@ -1765,6 +1784,7 @@ def launch_sm120_static_moe(
             quant_mode=quant_mode,
         )
         launch_ids = flat_ids
+        route_output_scratch_args = (workspace.route_output_scratch.view(-1),)
         virt_scratch_args = (workspace.virt_route_scratch,)
 
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
@@ -1779,6 +1799,7 @@ def launch_sm120_static_moe(
         workspace.packed_a_view,
         workspace.packed_input_scale.data_ptr(),
         workspace.packed_a_flat,
+        *route_output_scratch_args,
         workspace.scale_flat,
         workspace.barrier_count,
         workspace.barrier_epoch,
@@ -3199,6 +3220,98 @@ def _pad_intermediate_to_tile(
     return result
 
 
+def _validate_static_workspace_for_launch(
+    workspace,
+    *,
+    state_E: int,
+    weight_E: int,
+    routed_rows: int,
+    k: int,
+    n: int,
+    num_topk: int,
+    device: torch.device,
+    activation_precision: str,
+    quant_mode: str,
+) -> None:
+    """Reject stale or undersized shared static workspaces before launch."""
+    if type(workspace) is not Sm120StaticMoEWorkspace:
+        raise ValueError(
+            "pre-allocated static workspace must be Sm120StaticMoEWorkspace"
+        )
+    expected_metadata = {
+        "state_E": state_E,
+        "weight_E": weight_E,
+        "k": k,
+        "n": n,
+        "num_topk": num_topk,
+        "device": torch.device(device),
+        "activation_precision": activation_precision,
+        "quant_mode": quant_mode,
+    }
+    for name, expected in expected_metadata.items():
+        if getattr(workspace, name, None) != expected:
+            raise ValueError(
+                f"pre-allocated static workspace {name} mismatch: "
+                f"expected {expected!r}, got {getattr(workspace, name, None)!r}."
+            )
+    if not isinstance(workspace.max_rows, int) or workspace.max_rows < routed_rows:
+        raise ValueError(
+            "pre-allocated static workspace capacity is too small: "
+            f"max_rows={getattr(workspace, 'max_rows', None)!r}, "
+            f"routed_rows={routed_rows}."
+        )
+
+    max_rows = workspace.max_rows
+    max_chunks = (max_rows + 31) // 32
+    virt_E = state_E + max_chunks
+    sf_vec_size, _ = _sf_params_for_quant_mode(quant_mode)
+    rows_pad_k = _align_up(max_rows, 128)
+    cols_pad_k = _align_up(k // sf_vec_size, 4)
+    retained_groups = max(1, n // _STATIC_RETAINED_GROUP_N)
+    tensors = {
+        "row_counts": ((virt_E,), torch.int32),
+        "token_map": ((virt_E, max_rows), torch.int32),
+        "token_weights": ((virt_E, max_rows), torch.float32),
+        "packed_input": ((virt_E, max_rows, k // 2), torch.uint8),
+        "packed_input_scale": (
+            (virt_E, rows_pad_k, cols_pad_k),
+            torch.uint8,
+        ),
+        "route_output_scratch": (
+            (max_rows, retained_groups, k),
+            torch.bfloat16,
+        ),
+    }
+    for name, (shape, dtype) in tensors.items():
+        value = getattr(workspace, name, None)
+        if (
+            not isinstance(value, torch.Tensor)
+            or tuple(value.shape) != shape
+            or value.dtype != dtype
+            or value.device != torch.device(device)
+        ):
+            raise ValueError(
+                f"pre-allocated static workspace {name} mismatch: expected "
+                f"shape={shape}, dtype={dtype}, device={torch.device(device)}."
+            )
+
+    packed = workspace.packed_input
+    route = workspace.route_output_scratch
+    packed_range = (
+        packed.data_ptr(),
+        packed.data_ptr() + packed.numel() * packed.element_size(),
+    )
+    route_range = (
+        route.data_ptr(),
+        route.data_ptr() + route.numel() * route.element_size(),
+    )
+    if max(packed_range[0], route_range[0]) < min(packed_range[1], route_range[1]):
+        raise ValueError(
+            "pre-allocated static workspace packed_input and "
+            "route_output_scratch storage overlap"
+        )
+
+
 def launch_sm120_moe(
     *,
     a: torch.Tensor,
@@ -3300,15 +3413,6 @@ def launch_sm120_moe(
             _prepared_weights=_prepared_weights,
         )
 
-    if fc2_input_scale is None:
-        if quant_mode == "nvfp4":
-            raise ValueError("fc2_input_scale is required when quant_mode='nvfp4'.")
-        # MXFP4 has no tensor-wide FC2 input scale. Reuse an existing
-        # per-expert tensor because the shared kernel signature still carries
-        # the argument; the MXFP4 quantizer ignores it.
-        down_input_scale = w2_alpha
-    else:
-        down_input_scale = fc2_input_scale
     if quant_mode == "nvfp4" and input_global_scale is not None:
         input_gs = input_global_scale
         if _weight_views is None:
@@ -3320,27 +3424,7 @@ def launch_sm120_moe(
     else:
         input_gs = w1_alpha
 
-    weights = (
-        _weight_views
-        if _weight_views is not None
-        else _get_weight_views(
-            w1_fp4=w1_weight,
-            w1_blockscale=w1_weight_sf,
-            w2_fp4=w2_weight,
-            w2_blockscale=w2_weight_sf,
-            w1_alphas=w1_alpha,
-            w2_alphas=w2_alpha,
-            n=n,
-            k=k,
-            activation_precision=activation_precision,
-            quant_mode=quant_mode,
-        )
-    )
-
-    # Resolve workspace and backend selection.
-    # When a pre-allocated workspace is provided (CUDA graph wrapper path),
-    # infer the backend from the workspace type so they stay in sync —
-    # the caller already committed to a backend at allocation time.
+    # Resolve the backend before applying its private physical geometry.
     if _workspace is not None:
         workspace = _workspace
         workspace_activation_precision = getattr(
@@ -3370,6 +3454,7 @@ def launch_sm120_moe(
         else:
             backend = "static"
     else:
+        workspace = None
         backend = select_sm120_moe_backend(
             num_tokens=num_tokens,
             num_topk=top_k,
@@ -3382,6 +3467,61 @@ def launch_sm120_moe(
         # has global-to-local expert remapping.
         if backend == "dynamic" and num_local_experts != num_experts:
             backend = "static"
+
+    # retained2 always consumes two adjacent N128 slices. Keep that physical
+    # padding inside the static dispatch path; the wrapper remains unaware of
+    # the schedule and dynamic keeps its native N128 geometry.
+    weight_views = _weight_views
+    if backend == "static" and n % _STATIC_RETAINED_GROUP_N != 0:
+        (
+            w1_weight,
+            w1_weight_sf,
+            w2_weight,
+            w2_weight_sf,
+            fc2_input_scale,
+            n,
+        ) = _pad_intermediate_to_tile(
+            w1_weight,
+            w1_weight_sf,
+            w2_weight,
+            w2_weight_sf,
+            fc2_input_scale,
+            n,
+            _STATIC_RETAINED_GROUP_N,
+            k,
+            w1_weight.size(0),
+            is_gated,
+            quant_mode,
+        )
+        weight_views = None
+
+    if fc2_input_scale is None:
+        if quant_mode == "nvfp4":
+            raise ValueError("fc2_input_scale is required when quant_mode='nvfp4'.")
+        # MXFP4 has no tensor-wide FC2 input scale. Reuse an existing
+        # per-expert tensor because the shared kernel signature still carries
+        # the argument; the MXFP4 quantizer ignores it.
+        down_input_scale = w2_alpha
+    else:
+        down_input_scale = fc2_input_scale
+    weights = (
+        weight_views
+        if weight_views is not None
+        else _get_weight_views(
+            w1_fp4=w1_weight,
+            w1_blockscale=w1_weight_sf,
+            w2_fp4=w2_weight,
+            w2_blockscale=w2_weight_sf,
+            w1_alphas=w1_alpha,
+            w2_alphas=w2_alpha,
+            n=n,
+            k=k,
+            activation_precision=activation_precision,
+            quant_mode=quant_mode,
+        )
+    )
+
+    if workspace is None:
         workspace = _get_cached_workspace(
             backend=backend,
             state_E=num_local_experts,
@@ -3394,6 +3534,20 @@ def launch_sm120_moe(
             activation_precision=activation_precision,
             quant_mode=quant_mode,
             activation=activation,
+        )
+
+    if backend == "static":
+        _validate_static_workspace_for_launch(
+            workspace,
+            state_E=num_local_experts,
+            weight_E=num_experts,
+            routed_rows=routed_rows,
+            k=k,
+            n=n,
+            num_topk=top_k,
+            device=a.device,
+            activation_precision=activation_precision,
+            quant_mode=quant_mode,
         )
 
     if backend == "dynamic":

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -84,7 +84,14 @@ _DIRECT_MICRO_MAX_N = 512
 # Test/bench hook: force one backend ("direct_micro", "micro", "static",
 # "dynamic"). Deliberately module-level (a monkeypatch target), not an env var.
 _FORCED_BACKEND: str | None = None
+# Production static band: pairs <= 640 (M <= 80 at topk=8). The kernel's
+# 32-row virtual-expert split keeps every scheduled tile inside the tile64
+# kernel's single computed M step, making the full compact band correct at
+# any per-expert row count.
 _STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT = 640
+# The retained NVFP4 path uses the tile64 schedule through 1024 routed pairs.
+# MXFP4 keeps the generic 640-pair compact boundary.
+_STATIC_COMPACT_CUTOVER_PAIRS_NVFP4_DEFAULT = 1024
 _STATIC_COMPACT_CUTOVER_PAIRS = _STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT
 _STATIC_COMPACT_CUTOVER_PAIRS_CACHE: Dict[str, int] = {}
 
@@ -98,25 +105,20 @@ _MICRO_MAC_LADDER: Tuple[Tuple[int, int], ...] = (
     (16, 63),
     (20, 84),
 )
+# Max-active-cluster policy for the retained2 tile64 static band, keyed by
+# routed-row range after the 32-row virtual-expert split.
 _STATIC_MAC_LADDER: Tuple[Tuple[int, int], ...] = (
-    (24, 148),
-    (32, 169),
-    (40, 132),
-    (48, 149),
-    (64, 134),
-    (80, 175),
-    (96, 171),
-    (120, 125),
-    (128, 130),
-    (160, 171),
-    (192, 166),
-    (256, 141),
-    (320, 158),
-    (512, 175),
-    (640, 188),
+    (64, 110),
+    (256, 92),
+    (448, 110),
+    (512, 92),
+    (640, 110),
+    (768, 92),
+    (1024, 110),
 )
-# Workloads at or below the static cutover (640 routed pairs by default)
-# take the static kernel, so only the 1024 entry is normally reachable.
+# Workloads at or below the static cutover (640 pairs MXFP4, 1024 NVFP4)
+# take the static kernel, so for NVFP4 these entries are reachable only
+# when the dynamic backend is forced; MXFP4 still reaches the 1024 entry.
 _DYNAMIC_MAC_LADDER: Tuple[Tuple[int, int], ...] = (
     (640, 188),
     (1024, 147),
@@ -270,9 +272,17 @@ def _select_dynamic_tile_m(
     return _LEVEL_TILE_M
 
 
-def _get_static_compact_cutover_pairs(activation_precision: str = "fp4") -> int:
+def _get_static_compact_cutover_pairs(
+    activation_precision: str = "fp4",
+    quant_mode: str | None = None,
+) -> int:
     activation_precision = _normalize_activation_precision(activation_precision)
-    cached = _STATIC_COMPACT_CUTOVER_PAIRS_CACHE.get(activation_precision)
+    cache_key = (
+        f"{activation_precision}:{quant_mode}"
+        if quant_mode is not None
+        else activation_precision
+    )
+    cached = _STATIC_COMPACT_CUTOVER_PAIRS_CACHE.get(cache_key)
     if cached is not None:
         return cached
 
@@ -284,10 +294,17 @@ def _get_static_compact_cutover_pairs(activation_precision: str = "fp4") -> int:
     )
     cutover = _first_env(*cutover_names)
     if cutover is None:
-        cached = _STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT
+        # Only the retained NVFP4 implementation earns the wider band; the
+        # generic implementation (MXFP4, or unspecified quant mode) keeps
+        # the original boundary.
+        cached = (
+            _STATIC_COMPACT_CUTOVER_PAIRS_NVFP4_DEFAULT
+            if quant_mode == "nvfp4"
+            else _STATIC_COMPACT_CUTOVER_PAIRS_DEFAULT
+        )
     else:
         cached = max(0, int(cutover))
-    _STATIC_COMPACT_CUTOVER_PAIRS_CACHE[activation_precision] = cached
+    _STATIC_COMPACT_CUTOVER_PAIRS_CACHE[cache_key] = cached
     return cached
 
 
@@ -305,6 +322,13 @@ def _select_moe_mma_tiler_mn(
     sm_count = get_num_sm(torch.device("cuda"))
     coarse_tile = (128, 128)
     if routed_rows <= 32 and n <= 256:
+        return (64, 128)
+    # The retained2 static path uses narrow tiles throughout the compact band.
+    # The 32-row virtual-expert split bounds each scheduled tile to at most 32
+    # valid rows, so tile64 remains valid regardless of physical expert skew.
+    # 1024 covers the NVFP4 static band; MXFP4's static band ends at its
+    # 640-pair cutover, below which both thresholds pick the same tile.
+    if routed_rows <= 1024:
         return (64, 128)
     if resident_clusters is not None and resident_clusters < sm_count:
         return coarse_tile
@@ -361,9 +385,13 @@ class Sm120StaticMoEWorkspace:
     barrier_count: torch.Tensor  # [1] int32
     barrier_epoch: torch.Tensor  # [1] int32
     active_expert_count: torch.Tensor  # [1] int32
-    weight_expert_ids: torch.Tensor  # [state_E] int32
+    weight_expert_ids: torch.Tensor  # [virt_E] int32
     global_to_local_expert: torch.Tensor  # [weight_E] int32
     compact_topk_ids: torch.Tensor  # [state_E] int32, for micro kernel pre-pass
+    # 32-row virtual-expert split scratch: [weight_E] monotone row allocators
+    # followed by [weight_E, max_chunks] chunk -> local expert id map. The
+    # static route kernel re-initializes it every launch (graph-replay safe).
+    virt_route_scratch: torch.Tensor  # [weight_E*(1+max_chunks)] int32
 
     # Views (set after allocation)
     packed_a_view: torch.Tensor | None = None
@@ -411,10 +439,15 @@ def allocate_sm120_static_workspace(
     sf_vec_size, sf_dtype = _sf_params_for_quant_mode(quant_mode)
     rows_pad_k = _align_up(max_rows, 128)
     cols_pad_k = _align_up(k // sf_vec_size, 4)
-    _check_memref_limit("static packed_input", state_E * max_rows * (k // 2))
-    _check_memref_limit("static packed_input_scale", state_E * rows_pad_k * cols_pad_k)
+    # The 32-row virtual-expert split may open extra compact expert slots for
+    # experts with >32 routed rows. Sum(ceil(rows_e/32)) <= actives +
+    # total_rows/32, so ceil(max_rows/32) extra slots always suffice.
+    max_chunks = (max_rows + 31) // 32
+    virt_E = state_E + max_chunks
+    _check_memref_limit("static packed_input", virt_E * max_rows * (k // 2))
+    _check_memref_limit("static packed_input_scale", virt_E * rows_pad_k * cols_pad_k)
     packed_input = torch.empty(
-        state_E, max_rows, k // 2, dtype=torch.uint8, device=device
+        virt_E, max_rows, k // 2, dtype=torch.uint8, device=device
     )
 
     workspace = Sm120StaticMoEWorkspace(
@@ -427,22 +460,27 @@ def allocate_sm120_static_workspace(
         device=device,
         activation_precision=activation_precision,
         quant_mode=quant_mode,
-        row_counts=torch.zeros(state_E, dtype=torch.int32, device=device),
-        token_map=torch.zeros(state_E, max_rows, dtype=torch.int32, device=device),
-        token_weights=torch.zeros(
-            state_E, max_rows, dtype=torch.float32, device=device
-        ),
+        row_counts=torch.zeros(virt_E, dtype=torch.int32, device=device),
+        token_map=torch.zeros(virt_E, max_rows, dtype=torch.int32, device=device),
+        token_weights=torch.zeros(virt_E, max_rows, dtype=torch.float32, device=device),
         packed_input=packed_input,
         packed_input_scale=torch.empty(
-            state_E, rows_pad_k, cols_pad_k, dtype=torch.uint8, device=device
+            virt_E, rows_pad_k, cols_pad_k, dtype=torch.uint8, device=device
         ),
         barrier_count=torch.zeros(1, dtype=torch.int32, device=device),
         barrier_epoch=torch.zeros(1, dtype=torch.int32, device=device),
         active_expert_count=torch.zeros(1, dtype=torch.int32, device=device),
-        weight_expert_ids=torch.arange(state_E, dtype=torch.int32, device=device),
+        weight_expert_ids=torch.arange(virt_E, dtype=torch.int32, device=device),
         global_to_local_expert=torch.empty(weight_E, dtype=torch.int32, device=device),
         compact_topk_ids=torch.empty(
             max(state_E, max_rows), dtype=torch.int32, device=device
+        ),
+        virt_route_scratch=torch.empty(
+            # Row allocator + chunk map + work-claim counter (8-slot pad);
+            # shared by the retained NVFP4 and MXFP4 implementation.
+            weight_E * (1 + max_chunks) + 8,
+            dtype=torch.int32,
+            device=device,
         ),
     )
 
@@ -1045,6 +1083,11 @@ def _get_static_kernel(
         stride_order=(1, 0),
         assumed_align=16,
     )
+    virt_route_scratch_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Int32,
+        (weight_E * (1 + (max_rows + 31) // 32) + 8,),
+        assumed_align=4,
+    )
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
     compiled = build_and_load_cute_dsl_kernel(
         _CUTE_DSL_MODULE,
@@ -1068,6 +1111,7 @@ def _get_static_kernel(
             active_expert_count_fake,
             weight_expert_ids_fake,
             global_to_local_expert_fake,
+            virt_route_scratch_fake,
             input_gs_fake,
             alpha_fake,
             down_alpha_fake,
@@ -1677,7 +1721,9 @@ def launch_sm120_static_moe(
         tuned_mac = _lookup_mac_ladder(_MICRO_MAC_LADDER, routed_rows)
         micro_mac = min(tuned_mac or base_mac, micro_work_tiles, base_mac)
         compiled, mac = _get_micro_kernel(
-            workspace.state_E,
+            # Physical compact-expert slot count (state_E + virtual-split
+            # slots); fake tensor extents must match the allocated arrays.
+            int(workspace.row_counts.shape[0]),
             num_experts,
             num_tokens,
             k,
@@ -1697,9 +1743,10 @@ def launch_sm120_static_moe(
             swiglu_limit=swiglu_limit,
             quant_mode=quant_mode,
         )
+        virt_scratch_args: Tuple[Any, ...] = ()
     else:
         compiled, mac = _get_static_kernel(
-            workspace.state_E,
+            int(workspace.row_counts.shape[0]),
             num_experts,
             num_tokens,
             k,
@@ -1718,6 +1765,7 @@ def launch_sm120_static_moe(
             quant_mode=quant_mode,
         )
         launch_ids = flat_ids
+        virt_scratch_args = (workspace.virt_route_scratch,)
 
     # Pointer arguments must be passed as raw ints (data_ptr()) at runtime.
     # No stream argument: the kernels compile against
@@ -1742,6 +1790,7 @@ def launch_sm120_static_moe(
         workspace.active_expert_count,
         workspace.weight_expert_ids,
         workspace.global_to_local_expert,
+        *virt_scratch_args,
         input_gs,
         weights.w1_alpha,
         weights.w2_alpha,
@@ -1777,7 +1826,7 @@ def select_sm120_moe_backend(
         # Both micro variants launch through the static workspace path.
         return "static"
     routed_rows = num_tokens * num_topk
-    if routed_rows <= _get_static_compact_cutover_pairs("fp4"):
+    if routed_rows <= _get_static_compact_cutover_pairs("fp4", quant_mode=mode):
         return "static"
     return "dynamic"
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_dispatch.py
@@ -3238,13 +3238,19 @@ def _validate_static_workspace_for_launch(
         raise ValueError(
             "pre-allocated static workspace must be Sm120StaticMoEWorkspace"
         )
+    expected_device = _canonical_cuda_device(device)
+    try:
+        workspace_device = _canonical_cuda_device(workspace.device)
+    except (RuntimeError, TypeError, ValueError) as error:
+        raise ValueError(
+            f"pre-allocated static workspace device is invalid: {workspace.device!r}."
+        ) from error
     expected_metadata = {
         "state_E": state_E,
         "weight_E": weight_E,
         "k": k,
         "n": n,
         "num_topk": num_topk,
-        "device": torch.device(device),
         "activation_precision": activation_precision,
         "quant_mode": quant_mode,
     }
@@ -3254,6 +3260,11 @@ def _validate_static_workspace_for_launch(
                 f"pre-allocated static workspace {name} mismatch: "
                 f"expected {expected!r}, got {getattr(workspace, name, None)!r}."
             )
+    if workspace_device != expected_device:
+        raise ValueError(
+            f"pre-allocated static workspace device mismatch: expected "
+            f"{expected_device}, got {workspace_device}."
+        )
     if not isinstance(workspace.max_rows, int) or workspace.max_rows < routed_rows:
         raise ValueError(
             "pre-allocated static workspace capacity is too small: "
@@ -3277,22 +3288,74 @@ def _validate_static_workspace_for_launch(
             (virt_E, rows_pad_k, cols_pad_k),
             torch.uint8,
         ),
+        "barrier_count": ((1,), torch.int32),
+        "barrier_epoch": ((1,), torch.int32),
+        "active_expert_count": ((1,), torch.int32),
+        "weight_expert_ids": ((virt_E,), torch.int32),
+        "global_to_local_expert": ((weight_E,), torch.int32),
+        "compact_topk_ids": ((max(state_E, max_rows),), torch.int32),
+        "virt_route_scratch": (
+            (weight_E * (1 + max_chunks) + 8,),
+            torch.int32,
+        ),
         "route_output_scratch": (
             (max_rows, retained_groups, k),
             torch.bfloat16,
         ),
+        "packed_a_view": (
+            (max_rows, k // 2, virt_E),
+            torch.float4_e2m1fn_x2,
+        ),
+        "packed_a_flat": ((virt_E * max_rows * (k // 2),), torch.uint8),
+        "scale_flat": (
+            (virt_E * rows_pad_k * cols_pad_k,),
+            torch.uint8,
+        ),
     }
+    if (
+        quant_mode == "nvfp4"
+        and state_E == weight_E
+        and _direct_micro_candidate(k, n, num_topk, weight_E)
+    ):
+        dm_rows = min(max_rows, _MICRO_MAX_TOKENS * num_topk)
+        dm_slots = dm_rows + _MICRO_MAX_TOKENS * 16
+        fc2_n_chunks = (n // 2 + 127) // 128
+        dm_intermediate = _MICRO_MAX_TOKENS * num_topk * fc2_n_chunks * 128
+        tensors.update(
+            {
+                "dm_barrier_count": ((dm_slots,), torch.int32),
+                "dm_barrier_epoch": ((dm_slots,), torch.int32),
+                "dm_intermediate": ((dm_intermediate,), torch.float32),
+                "dm_input_gs": ((weight_E,), torch.float32),
+                "dm_down_input_scale": ((weight_E,), torch.float32),
+            }
+        )
     for name, (shape, dtype) in tensors.items():
         value = getattr(workspace, name, None)
         if (
             not isinstance(value, torch.Tensor)
             or tuple(value.shape) != shape
             or value.dtype != dtype
-            or value.device != torch.device(device)
+            or _canonical_cuda_device(value.device) != expected_device
+            or value.data_ptr() % 16 != 0
         ):
             raise ValueError(
                 f"pre-allocated static workspace {name} mismatch: expected "
-                f"shape={shape}, dtype={dtype}, device={torch.device(device)}."
+                f"shape={shape}, dtype={dtype}, device={expected_device}, "
+                "and 16-byte alignment."
+            )
+
+    for view_name, storage_name in (
+        ("packed_a_view", "packed_input"),
+        ("packed_a_flat", "packed_input"),
+        ("scale_flat", "packed_input_scale"),
+    ):
+        if (
+            getattr(workspace, view_name).data_ptr()
+            != getattr(workspace, storage_name).data_ptr()
+        ):
+            raise ValueError(
+                f"pre-allocated static workspace {view_name} must alias {storage_name}"
             )
 
     packed = workspace.packed_input

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -963,6 +963,7 @@ class MoEStaticKernel:
         packed_a: cute.Tensor,  # [max_rows, K, E] fp4x2 view for compute
         sfa_ptr: cute.Pointer,
         packed_a_storage: cute.Tensor,  # flat uint8 backing packed_a
+        route_output_scratch: cute.Tensor,  # flat bf16 [route, retained_group, K]
         scale_storage: cute.Tensor,  # flat uint8 backing sfa_ptr
         barrier_count: cute.Tensor,  # [1] int32 (host-zeroed)
         barrier_epoch: cute.Tensor,  # [1] int32 (host-zeroed)
@@ -1062,6 +1063,7 @@ class MoEStaticKernel:
             topk_ids,
             topk_weights,
             packed_a_storage,
+            route_output_scratch,
             scale_storage,
             barrier_count,
             barrier_epoch,
@@ -1120,7 +1122,7 @@ class MoEStaticKernel:
         final_grid_z = (final_vec_count + 255) // 256
         final_grid = (1, 1, final_grid_z)
         self.finalize_kernel(
-            packed_a_storage,
+            route_output_scratch,
             scatter_output,
             topk_ids,
             retained_group_count,
@@ -1139,6 +1141,7 @@ class MoEStaticKernel:
         topk_ids: cute.Tensor,
         topk_weights: cute.Tensor,
         packed_a_storage: cute.Tensor,
+        route_output_scratch: cute.Tensor,
         scale_storage: cute.Tensor,
         barrier_count: cute.Tensor,
         barrier_epoch: cute.Tensor,
@@ -1685,13 +1688,6 @@ class MoEStaticKernel:
         )
         output_tile_cnt = cute.size(gB_down, mode=[2])
         retained_group_count = (gate_tile_cnt + Int32(1)) // Int32(2)
-        # The wrapper reserves packed-A capacity for max_num_tokens, while the
-        # compact static path consumes only the contiguous active-expert
-        # prefix.  Use the high end as a private
-        # [route, retained_group, K] BF16 contribution buffer.
-        route_scratch_bytes = total_pairs * retained_group_count * cols * Int32(2)
-        route_scratch_base = Int32(packed_a_storage.shape[0]) - route_scratch_bytes
-
         prod_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.ab_stage
         )
@@ -2481,17 +2477,15 @@ class MoEStaticKernel:
                                 route_partial = intermediate_slice // Int32(2)
                                 store_weighted_bf16x8_route(
                                     get_ptr_as_int64(
-                                        packed_a_storage,
-                                        route_scratch_base
-                                        + (
+                                        route_output_scratch,
+                                        (
                                             (
                                                 route_idx * retained_group_count
                                                 + route_partial
                                             )
                                             * scatter_N
                                             + global_col
-                                        )
-                                        * Int32(2),
+                                        ),
                                     ),
                                     sc_smem_addr,
                                     wv,
@@ -2735,7 +2729,7 @@ class MoEStaticKernel:
     @cute.kernel
     def finalize_kernel(
         self,
-        packed_a_storage: cute.Tensor,
+        route_output_scratch: cute.Tensor,
         scatter_output: cute.Tensor,
         topk_ids: cute.Tensor,
         retained_group_count: cutlass.Constexpr,
@@ -2750,11 +2744,6 @@ class MoEStaticKernel:
         cols = Int32(scatter_output.shape[1])
         total_pairs = Int32(topk_ids.shape[0])
         num_topk = total_pairs // num_tokens
-        route_scratch_bytes = (
-            total_pairs * Int32(retained_group_count) * cols * Int32(2)
-        )
-        route_scratch_base = Int32(packed_a_storage.shape[0]) - route_scratch_bytes
-
         vecs_per_token = cols // Int32(8)
         final_vec_count = num_tokens * vecs_per_token
         final_vec_idx = flat_tid
@@ -2770,17 +2759,15 @@ class MoEStaticKernel:
                 while final_partial < Int32(retained_group_count):
                     route_values = load_global_bf16x8_to_f32x8(
                         get_ptr_as_int64(
-                            packed_a_storage,
-                            route_scratch_base
-                            + (
+                            route_output_scratch,
+                            (
                                 (
                                     final_route * Int32(retained_group_count)
                                     + final_partial
                                 )
                                 * cols
                                 + final_col
-                            )
-                            * Int32(2),
+                            ),
                         )
                     )
                     for final_elem in cutlass.range_constexpr(8):

--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_static_kernel.py
@@ -1,5 +1,10 @@
-"""
-MoEStaticKernel — static-scheduled routed W4A4 MoE kernel for SM120/SM121.
+"""Retained static NVFP4/MXFP4 MoE with route-major finalization.
+
+The gated path keeps the paired Gate/Up transaction and groups two adjacent
+N128 intermediate slices.  Both Q1 tensors remain in the two existing A/SFA
+shared stages, FC2 accumulates them before one scatter, and the task count is
+halved without adding shared storage.  Both FP4 formats share this schedule;
+only the MMA atom, quantization block width, and packed byte count differ.
 
 Ported from the b12x kernel library to FlashInfer.
 
@@ -26,7 +31,8 @@ implementation:
   Common:
     Quant:   intermediate -> FP4      (cooperative quantization into shared A)
     FC2:     sweep all output tiles   (reuse the cached intermediate slice)
-    Scatter: bf16x2 atomic add        (directly into token-major output)
+    Scatter: route-major BF16 store   (one private contribution per route)
+    Finalize: token-major FP32 sum    (top-k contributions, one BF16 output)
 
 What changes relative to the old split path:
   the compute launch used to expect the frontend to have already produced:
@@ -91,11 +97,11 @@ import cutlass.utils.blockscaled_layout as blockscaled_utils
 
 from cutlass.cutlass_dsl import (
     Int32,
+    Integer,
     Int64,
     Uint8,
     Uint64,
     T,
-    Integer,
     dsl_user_op,
 )
 from cutlass._mlir.dialects import llvm
@@ -114,70 +120,178 @@ from flashinfer.cute_dsl.fp4_common import (
     quantize_block_fp4_fast,
     quantize_block_mxfp4,
     get_ptr_as_int64,
-    ld_shared_i32_relaxed,
+    get_smem_ptr_as_int32,
     st_global_f32,
     st_global_i32,
     shared_ptr_to_u32,
     st_shared_u8,
     st_global_u64,
-    scatter_add_v4_bf16x2,
 )
 from flashinfer.gemm.kernels.dense_blockscaled_gemm_sm120_b12x import (
     Sm120B12xBlockScaledDenseGemmKernel as DenseGemmKernel,
 )
 from .moe_activation import gated_activation_f32, is_gated_activation
+from ._moe_dynamic.gated import (
+    MoEGatedDynamicKernel,
+    load_shared_bf16x8_to_f32x8,
+    load_shared_i32_f32_pair,
+)
 
 
 _SF_VEC_SIZE = 16
 _COMPACT_STATIC_TILE_M = 128
 
 
-@cute.jit
-def _compact_static_get_work_tile(
-    row_counts: cute.Tensor,
-    active_expert_count: cute.Tensor,
+@dsl_user_op
+def store_weighted_bf16x8_route(
+    addr,
+    smem_addr,
+    route_weight,
+    down_alpha_value,
     *,
-    tile_m: Int32,
-    num_tiles_n: Int32,
-    cluster_shape_mn: Tuple[Int32, Int32],
-    current_work_linear_idx: Int32,
-    current_local_expert_idx: Int32,
-    accum_tile_m: Int32,
-    cta_id_in_cluster: cute.Coord,
-) -> Tuple[Tuple[Int32, Int32, Int32], Integer, Int32, Int32]:
+    loc=None,
+    ip=None,
+):
+    """Write one private weighted route contribution without a global REDG."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            Int32(smem_addr).ir_value(loc=loc, ip=ip),
+            route_weight.ir_value(loc=loc, ip=ip),
+            down_alpha_value.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b32 p0,p1,p2,p3,w2; .reg .b16 w;"
+        " .reg .f32 combined_scale;"
+        " ld.shared.v4.u32 {p0,p1,p2,p3}, [$1];"
+        " mul.rn.f32 combined_scale, $2, $3;"
+        " cvt.rn.bf16.f32 w, combined_scale;"
+        " mov.b32 w2, {w,w};"
+        " mul.rn.bf16x2 p0, p0, w2;"
+        " mul.rn.bf16x2 p1, p1, w2;"
+        " mul.rn.bf16x2 p2, p2, w2;"
+        " mul.rn.bf16x2 p3, p3, w2;"
+        " st.global.v4.u32 [$0], {p0,p1,p2,p3}; }",
+        "l,r,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def load_global_bf16x8_to_f32x8(addr: Int64, *, loc=None, ip=None):
+    """Load one route-major BF16x8 contribution as eight FP32 values."""
+    result = llvm.inline_asm(
+        llvm.StructType.get_literal([T.f32()] * 8),
+        [Int64(addr).ir_value(loc=loc, ip=ip)],
+        """
+        {
+            .reg .b32 p0, p1, p2, p3;
+            .reg .b16 b0, b1, b2, b3, b4, b5, b6, b7;
+            ld.global.v4.u32 {p0, p1, p2, p3}, [$8];
+            mov.b32 {b0, b1}, p0;
+            mov.b32 {b2, b3}, p1;
+            mov.b32 {b4, b5}, p2;
+            mov.b32 {b6, b7}, p3;
+            cvt.f32.bf16 $0, b0;
+            cvt.f32.bf16 $1, b1;
+            cvt.f32.bf16 $2, b2;
+            cvt.f32.bf16 $3, b3;
+            cvt.f32.bf16 $4, b4;
+            cvt.f32.bf16 $5, b5;
+            cvt.f32.bf16 $6, b6;
+            cvt.f32.bf16 $7, b7;
+        }
+        """,
+        "=f,=f,=f,=f,=f,=f,=f,=f,l",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(llvm.extractvalue(T.f32(), result, [idx], loc=loc, ip=ip))
+        for idx in range(8)
+    )
+
+
+@dsl_user_op
+def store_global_f32x8_as_bf16(
+    addr,
+    v0,
+    v1,
+    v2,
+    v3,
+    v4,
+    v5,
+    v6,
+    v7,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Round one finalized FP32x8 vector once and store BF16x8."""
+    llvm.inline_asm(
+        None,
+        [
+            Int64(addr).ir_value(loc=loc, ip=ip),
+            v0.ir_value(loc=loc, ip=ip),
+            v1.ir_value(loc=loc, ip=ip),
+            v2.ir_value(loc=loc, ip=ip),
+            v3.ir_value(loc=loc, ip=ip),
+            v4.ir_value(loc=loc, ip=ip),
+            v5.ir_value(loc=loc, ip=ip),
+            v6.ir_value(loc=loc, ip=ip),
+            v7.ir_value(loc=loc, ip=ip),
+        ],
+        "{ .reg .b32 p0,p1,p2,p3;"
+        " cvt.rn.satfinite.bf16x2.f32 p0, $2, $1;"
+        " cvt.rn.satfinite.bf16x2.f32 p1, $4, $3;"
+        " cvt.rn.satfinite.bf16x2.f32 p2, $6, $5;"
+        " cvt.rn.satfinite.bf16x2.f32 p3, $8, $7;"
+        " st.global.v4.u32 [$0], {p0,p1,p2,p3}; }",
+        "l,f,f,f,f,f,f,f,f",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _compact_static_get_single_m_tile_work(
+    row_counts,
+    active_expert_count,
+    *,
+    tile_m,
+    num_tiles_n,
+    cluster_shape_mn,
+    current_work_linear_idx,
+    current_local_expert_idx,
+    accum_tile_m,
+    cta_id_in_cluster,
+):
+    """O(1) scheduler for compact experts whose routed rows fit one M tile.
+
+    The retained2 35B small-row path has two N-pair tasks per compact expert
+    and at most one M tile.  Keeping the generic signature makes this helper a
+    drop-in experiment while eliminating repeated row-count scans.
+    """
     num_active_experts = active_expert_count[Int32(0)]
-    scan_local_expert_idx = current_local_expert_idx
-    tile_m_minus_one = tile_m - Int32(1)
-
-    while scan_local_expert_idx < num_active_experts:
-        batch_rows = row_counts[scan_local_expert_idx]
-        batch_m_tiles = (batch_rows + tile_m_minus_one) // tile_m
-        if (accum_tile_m + batch_m_tiles) * num_tiles_n > current_work_linear_idx:
-            current_local_expert_idx = scan_local_expert_idx
-            scan_local_expert_idx = num_active_experts
-        else:
-            accum_tile_m += batch_m_tiles
-            scan_local_expert_idx += Int32(1)
-            current_local_expert_idx = scan_local_expert_idx
-
-    is_valid = current_local_expert_idx < num_active_experts
-    if is_valid:
-        batch_rows = row_counts[current_local_expert_idx]
-        is_valid = (
-            accum_tile_m + (batch_rows + tile_m_minus_one) // tile_m
-        ) * num_tiles_n > current_work_linear_idx
-
-    cur_cluster_coord = (
-        current_work_linear_idx // num_tiles_n - accum_tile_m,
-        current_work_linear_idx % num_tiles_n,
-        current_local_expert_idx,
-    )
+    local_expert_idx = current_work_linear_idx // num_tiles_n
+    is_valid = local_expert_idx < num_active_experts
     cur_tile_coord = (
-        Int32(cur_cluster_coord[0]) * cluster_shape_mn[0] + cta_id_in_cluster[0],
-        Int32(cur_cluster_coord[1]) * cluster_shape_mn[1] + cta_id_in_cluster[1],
-        Int32(cur_cluster_coord[2]),
+        cta_id_in_cluster[0],
+        (current_work_linear_idx % num_tiles_n) * cluster_shape_mn[1]
+        + cta_id_in_cluster[1],
+        local_expert_idx,
     )
-    return cur_tile_coord, is_valid, current_local_expert_idx, accum_tile_m
+    return cur_tile_coord, is_valid, local_expert_idx, local_expert_idx
 
 
 @dsl_user_op
@@ -338,7 +452,7 @@ def _atomic_cas_global_i32(addr, compare, value, *, loc=None, ip=None):
 
 
 class MoEStaticKernel:
-    """Compact static MoE kernel for small routed working sets."""
+    """Compact retained static MoE kernel for both SM12x FP4 formats."""
 
     def __init__(
         self,
@@ -353,6 +467,8 @@ class MoEStaticKernel:
         swiglu_beta: float = 1.0,
         swiglu_limit: float | None = None,
     ):
+        if sf_vec_size not in (16, 32):
+            raise ValueError(f"unsupported FP4 scale vector size {sf_vec_size}")
         if activation not in {"silu", "relu2", "gelu_tanh", "swigluoai_uninterleave"}:
             raise ValueError(f"unsupported activation {activation!r}")
         self._dense_cls = DenseGemmKernel
@@ -366,11 +482,12 @@ class MoEStaticKernel:
         self.swiglu_alpha = float(swiglu_alpha)
         self.swiglu_beta = float(swiglu_beta)
         self.swiglu_limit = float(swiglu_limit) if swiglu_limit is not None else None
-        # The fused epilogue feeds one 128-wide FC1 slice directly to FC2.
-        # MXFP4 therefore keeps K=128 (four block-32 scales) instead of using
-        # the dense GEMM default of 32*8=256.
-        tile_k = 128 if sf_vec_size == 32 else sf_vec_size * 8
+        # Both formats use one K128 retained slice.  NVFP4 has eight block-16
+        # scales per slice; MXFP4 has four block-32 scales.
+        tile_k = 128
         self.tile_shape_mnk = (mma_tiler_mn[0], mma_tiler_mn[1], tile_k)
+        # Packed-A itself can use the actual M64 tile.  Keep SFA at M128 below
+        # because the block-scaled MMA scale layout is 128-row granular.
         self.sa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
         self.sa_tiles_per_block = self.sa_tile_shape_mk[0] // mma_tiler_mn[0]
         self.sfa_tile_shape_mk = (max(128, mma_tiler_mn[0]), tile_k)
@@ -383,9 +500,13 @@ class MoEStaticKernel:
         self.epi_tile = (mma_tiler_mn[0], mma_tiler_mn[1])
         self.occupancy = 1
         self.num_mma_warps = 4
+        self.num_frontend_warps = 10
         self.tma_load_warp_id = self.num_mma_warps
         self.num_threads_per_warp = 32
-        self.threads_per_cta = (self.num_mma_warps + 1) * self.num_threads_per_warp
+        self.compute_threads_per_cta = (
+            self.num_mma_warps + 1
+        ) * self.num_threads_per_warp
+        self.threads_per_cta = self.num_frontend_warps * self.num_threads_per_warp
         self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_120")
         self.buffer_align_bytes = 1024
 
@@ -395,7 +516,7 @@ class MoEStaticKernel:
         )
         self.pass_sync_barrier = pipeline.NamedBarrier(
             barrier_id=2,
-            num_threads=self.threads_per_cta,
+            num_threads=self.compute_threads_per_cta,
         )
         self.load_register_requirement = 32
         self.mma_register_requirement = 232
@@ -411,6 +532,232 @@ class MoEStaticKernel:
 
     def _get_layoutSFB_TV(self, tiled_mma):
         return self._dense_cls._get_layoutSFB_TV(self, tiled_mma)  # type: ignore[arg-type]
+
+    # The stage-selectable FC2 loader is format-independent.
+    load_fc2_a_fragments = MoEGatedDynamicKernel.load_fc2_a_fragments
+
+    @cute.jit
+    def quantize_q1_sC_to_sA_sSFA(
+        self,
+        tidx,
+        valid_rows: Int32,
+        task_expert_idx: Int32,
+        global_scale: cute.Tensor,
+        sC: cute.Tensor,
+        sA: cute.Tensor,
+        fc1_tRS_sD: cute.Tensor,
+        sfa_base_addr: Int32,
+        sfa_stage_elements: Int32,
+        q1_stage_idx: Int32,
+        epi_rest_m,
+    ):
+        """Quantize one retained FC1 slice for the FC2 A operand."""
+        sA_u8 = cute.recast_tensor(sA[None, None, q1_stage_idx], cutlass.Uint8)
+        packed_cols = Int32(self.tile_shape_mnk[2] // 2)
+        sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
+        gs_value = cutlass.Float32(1.0)
+        if cutlass.const_expr(self.sf_vec_size == 16):
+            gs_value = global_scale[task_expert_idx].to(cutlass.Float32)
+            if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(0.0):
+                if self.fast_math:
+                    gs_value = rcp_approx_ftz(gs_value)
+                else:
+                    gs_value = cutlass.Float32(1.0) / gs_value
+
+        for epi_m in cutlass.range_constexpr(epi_rest_m):
+            epi_m_valid = valid_rows - Int32(epi_m) * Int32(self.epi_tile[0])
+            gated_epi_buffer = Int32(epi_m) % cute.size(fc1_tRS_sD, mode=[3])
+            if epi_m_valid > Int32(0):
+                rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
+                epi_rows = epi_m_valid
+                if epi_rows > Int32(self.epi_tile[0]):
+                    epi_rows = Int32(self.epi_tile[0])
+                if epi_rows < Int32(0):
+                    epi_rows = Int32(0)
+                quant_idx = Int32(tidx)
+                while quant_idx < epi_rows * sf_blocks_per_row:
+                    local_row = quant_idx // sf_blocks_per_row
+                    row = rows_offset + local_row
+                    sf_block = quant_idx - local_row * sf_blocks_per_row
+                    block_start = sf_block * Int32(self.sf_vec_size)
+
+                    values = cute.make_rmem_tensor((self.sf_vec_size,), cutlass.Float32)
+                    block_max = cutlass.Float32(0.0)
+                    for load_idx in cutlass.range_constexpr(self.sf_vec_size // 8):
+                        sc_element_offset = Int32(
+                            sC.layout(
+                                (
+                                    local_row,
+                                    block_start + Int32(load_idx * 8),
+                                    gated_epi_buffer,
+                                )
+                            )
+                        )
+                        sc_element_offset = sc_element_offset ^ (
+                            (sc_element_offset & Int32(0x1C0)) >> Int32(3)
+                        )
+                        loaded = load_shared_bf16x8_to_f32x8(
+                            get_smem_ptr_as_int32(sC, sc_element_offset)
+                        )
+                        for elem_idx in cutlass.range_constexpr(8):
+                            value = loaded[elem_idx]
+                            values[load_idx * 8 + elem_idx] = value
+                            block_max = fmax_f32(block_max, fabs_f32(value))
+
+                    packed_lo = Uint64(0)
+                    packed_hi = Uint64(0)
+                    scale_byte = Uint8(0)
+                    if cutlass.const_expr(self.sf_vec_size == 32):
+                        packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
+                            values, block_max
+                        )
+                    else:
+                        if self.fast_math:
+                            packed_lo, scale_byte = quantize_block_fp4_fast(
+                                values, block_max, gs_value
+                            )
+                        else:
+                            packed_lo, scale_byte = quantize_block_fp4(
+                                values, block_max, gs_value
+                            )
+
+                    packed_base = sf_block * Int32(self.sf_vec_size // 2)
+                    dst_pcol = row & Int32(63)
+                    xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+                    row_high = row >> Int32(6)
+                    for byte_idx in cutlass.range_constexpr(self.sf_vec_size // 2):
+                        src_pcol = packed_base + Int32(byte_idx)
+                        dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                        dst_flat = dst_row * packed_cols + dst_pcol
+                        if cutlass.const_expr(byte_idx < 8):
+                            byte_val = Uint8(
+                                (packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF)
+                            )
+                        else:
+                            byte_val = Uint8(
+                                (packed_hi >> Uint64((byte_idx - 8) * 8)) & Uint64(0xFF)
+                            )
+                        sA_u8[dst_flat] = byte_val
+
+                    outer_m_idx = row % Int32(32)
+                    inner_m_idx = row // Int32(32)
+                    inner_k_idx = sf_block % Int32(4)
+                    k_tile_idx = sf_block // Int32(4)
+                    sf_raw_idx = (
+                        k_tile_idx * Int32(32 * 4 * 4)
+                        + outer_m_idx * Int32(4 * 4)
+                        + inner_m_idx * Int32(4)
+                        + inner_k_idx
+                    )
+                    st_shared_u8(
+                        sfa_base_addr + q1_stage_idx * sfa_stage_elements + sf_raw_idx,
+                        scale_byte,
+                    )
+                    quant_idx += Int32(self.num_mma_warps * self.num_threads_per_warp)
+        return
+
+    @cute.jit
+    def _load_valid_fc1_a_stage(
+        self,
+        tidx,
+        packed_a_storage: cute.Tensor,
+        scale_storage: cute.Tensor,
+        local_expert_idx: Int32,
+        tile_m_base: Int32,
+        shared_row_base: Int32,
+        valid_tile_rows: Int32,
+        k_tile: Int32,
+        stage_idx: Int32,
+        max_rows: Int32,
+        output_bytes_per_row: Int32,
+        expert_scale_stride: Int32,
+        num_k_tiles: Int32,
+        sA: cute.Tensor,
+        sfa_base_addr: Int32,
+        sfa_stage_elements: Int32,
+    ):
+        # One K128 stage contains eight FP4x16 or four FP4x32 blocks.
+        # Copy only live rows; invalid physical-M128 rows are never consumed by
+        # scatter, so they need neither a global read nor an explicit clear.
+        blocks_per_stage = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
+        bytes_per_block = Int32(self.sf_vec_size // 2)
+        packed_cols = Int32(self.tile_shape_mnk[2] // 2)
+        sA_u8 = cute.recast_tensor(sA[None, None, stage_idx], cutlass.Uint8)
+        quant_idx = Int32(tidx)
+        while quant_idx < valid_tile_rows * blocks_per_stage:
+            local_row = quant_idx // blocks_per_stage
+            local_block = quant_idx - local_row * blocks_per_stage
+            global_row = tile_m_base + local_row
+            global_block = k_tile * blocks_per_stage + local_block
+            packed_lo = _ld_global_u64(
+                get_ptr_as_int64(
+                    packed_a_storage,
+                    local_expert_idx * max_rows * output_bytes_per_row
+                    + global_row * output_bytes_per_row
+                    + global_block * bytes_per_block,
+                )
+            )
+            packed_hi = Uint64(0)
+            if cutlass.const_expr(self.sf_vec_size == 32):
+                packed_hi = _ld_global_u64(
+                    get_ptr_as_int64(
+                        packed_a_storage,
+                        local_expert_idx * max_rows * output_bytes_per_row
+                        + global_row * output_bytes_per_row
+                        + global_block * bytes_per_block
+                        + Int32(8),
+                    )
+                )
+
+            row = shared_row_base + local_row
+            packed_base = local_block * bytes_per_block
+            dst_pcol = row & Int32(63)
+            xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
+            row_high = row >> Int32(6)
+            for byte_idx in cutlass.range_constexpr(self.sf_vec_size // 2):
+                src_pcol = packed_base + Int32(byte_idx)
+                dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
+                dst_flat = dst_row * packed_cols + dst_pcol
+                if cutlass.const_expr(byte_idx < 8):
+                    byte_val = Uint8((packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF))
+                else:
+                    byte_val = Uint8(
+                        (packed_hi >> Uint64((byte_idx - 8) * 8)) & Uint64(0xFF)
+                    )
+                sA_u8[dst_flat] = byte_val
+
+            global_m_tile = global_row // Int32(32 * 4)
+            global_k_tile = global_block // Int32(4)
+            global_outer_m = global_row % Int32(32)
+            global_inner_m = (global_row % Int32(32 * 4)) // Int32(32)
+            global_inner_k = global_block % Int32(4)
+            scale_byte = scale_storage[
+                local_expert_idx * expert_scale_stride
+                + global_m_tile * num_k_tiles * Int32(32 * 4 * 4)
+                + global_k_tile * Int32(32 * 4 * 4)
+                + global_outer_m * Int32(4 * 4)
+                + global_inner_m * Int32(4)
+                + global_inner_k
+            ]
+
+            shared_outer_m = row % Int32(32)
+            shared_inner_m = row // Int32(32)
+            shared_inner_k = local_block % Int32(4)
+            shared_k_tile = local_block // Int32(4)
+            shared_sf_idx = (
+                shared_k_tile * Int32(32 * 4 * 4)
+                + shared_outer_m * Int32(4 * 4)
+                + shared_inner_m * Int32(4)
+                + shared_inner_k
+            )
+            st_shared_u8(
+                sfa_base_addr + stage_idx * sfa_stage_elements + shared_sf_idx,
+                scale_byte,
+            )
+            quant_idx += Int32(self.num_mma_warps * self.num_threads_per_warp)
+
+        cute.arch.fence_proxy("async.shared", space="cta")
+        self.epilog_sync_barrier.arrive_and_wait()
 
     def _make_a_smem_layout(self, ab_stage: int):
         import cutlass.utils.hopper_helpers as sm90_utils
@@ -472,9 +819,12 @@ class MoEStaticKernel:
         def _align_up(value: int, align: int) -> int:
             return ((value + align - 1) // align) * align
 
-        pipeline_count = 3 if self.is_gated else 2
+        # Gate and up share one transaction barrier in the paired FC1 path.
+        # The payload still has separate B/SFB buffers, but A/SFA is fetched
+        # only once and both branch operands become visible atomically.
+        pipeline_count = 2
         offset = (
-            3 * 4
+            8 * 4
             + pipeline_count * (self.ab_stage * 2 * 8)
             + _COMPACT_STATIC_TILE_M * 4
             + _COMPACT_STATIC_TILE_M * 4
@@ -513,8 +863,7 @@ class MoEStaticKernel:
                 self.acc_dtype,
                 self.sf_dtype,
             )
-        atom_shape = (2, 2, 1)
-        atom_layout = cute.make_layout(atom_shape)
+        atom_layout = cute.make_layout((2, 2, 1))
         permutation_mnk = sm120_utils.get_permutation_mnk(
             self.tile_shape_mnk,
             self.sf_vec_size,
@@ -527,8 +876,8 @@ class MoEStaticKernel:
         )
         self.mma_atom = cute.make_mma_atom(mma_op)
         self.cta_layout_mnk = cute.make_layout(self.cluster_shape_mnk)
-        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * atom_shape[0])
-        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * atom_shape[1])
+        self.num_m_tiles = self.tile_shape_mnk[0] // (16 * 4)
+        self.num_n_tiles = self.tile_shape_mnk[1] // (8 * 2)
         self.num_k_blocks = self.tile_shape_mnk[2] // 64
 
         sfa_smem = sm120_make_smem_layout_sfa(
@@ -556,13 +905,10 @@ class MoEStaticKernel:
             self.smem_capacity,
             self.occupancy,
         )
-        self.ab_stage = max(1, min(self.ab_stage, 2))
-        # ab_stage must divide k_tile_cnt evenly to avoid pipeline phase mismatch.
-        # _compute_stages returns the max that fits in smem, but it may not
-        # divide k_tile_cnt. Round down to the nearest divisor.
-        k_tile_cnt = self._hidden_size // self.tile_shape_mnk[2]
-        while self.ab_stage > 1 and k_tile_cnt % self.ab_stage != 0:
-            self.ab_stage -= 1
+        # M64 leaves enough shared memory for a third A/Gate/Up stage.  Keep
+        # the pipeline state continuous across retained slices and work items;
+        # it does not need to return to stage zero after every 16 K tiles.
+        self.ab_stage = max(1, min(self.ab_stage, 3))
         self.epi_stage = 1
         while True:
             (
@@ -585,8 +931,6 @@ class MoEStaticKernel:
             ):
                 break
             self.ab_stage -= 1
-            while self.ab_stage > 1 and 32 % self.ab_stage != 0:
-                self.ab_stage -= 1
 
     @cute.jit
     def _resident_grid_barrier(
@@ -630,6 +974,7 @@ class MoEStaticKernel:
         active_expert_count: cute.Tensor,  # [1] active expert count
         weight_expert_ids: cute.Tensor,  # [E] local expert id -> global weight expert id
         global_to_local_expert: cute.Tensor,  # [weight_E] global expert id -> local expert id
+        virt_route_scratch: cute.Tensor,  # [weight_E*(1+max_chunks)] row alloc + chunk map
         input_global_scale: cute.Tensor,  # [E] per-expert FC1 input scale
         alpha: cute.Tensor,
         down_alpha: cute.Tensor,
@@ -744,6 +1089,7 @@ class MoEStaticKernel:
             active_expert_count,
             weight_expert_ids,
             global_to_local_expert,
+            virt_route_scratch,
             input_global_scale,
             alpha,
             down_alpha,
@@ -758,6 +1104,31 @@ class MoEStaticKernel:
             # A regular launch beside other stream work can admit only part
             # of the grid, deadlocking the software grid barriers below.
             cooperative=True,
+            stream=stream,
+        )
+
+        # The first kernel's completion on this stream is the global handoff;
+        # no resident-grid spin barrier is needed for finalization.
+        # w13 rows cover both branches only for gated activations; the
+        # non-gated FC1 slice count is the full w13 tile count.  This must
+        # match the device-side gate_tile_cnt/retained_group_count, or the
+        # finalize sums the wrong route-scratch slots.
+        fc1_branch_rows = b_w13.shape[0] // 2 if self.is_gated else b_w13.shape[0]
+        gate_tile_count = fc1_branch_rows // self.tile_shape_mnk[1]
+        retained_group_count = (gate_tile_count + 1) // 2
+        final_vec_count = (a_input.shape[0] * hidden_size) // 8
+        final_grid_z = (final_vec_count + 255) // 256
+        final_grid = (1, 1, final_grid_z)
+        self.finalize_kernel(
+            packed_a_storage,
+            scatter_output,
+            topk_ids,
+            retained_group_count,
+        ).launch(
+            grid=final_grid,
+            block=[256, 1, 1],
+            cluster=[1, 1, 1],
+            cooperative=False,
             stream=stream,
         )
 
@@ -795,6 +1166,7 @@ class MoEStaticKernel:
         active_expert_count: cute.Tensor,
         weight_expert_ids: cute.Tensor,
         global_to_local_expert: cute.Tensor,
+        virt_route_scratch: cute.Tensor,
         input_global_scale: cute.Tensor,
         alpha: cute.Tensor,
         down_alpha: cute.Tensor,
@@ -811,6 +1183,7 @@ class MoEStaticKernel:
         _, _, gdim_z = cute.arch.grid_dim()
         warp_idx = cute.arch.warp_idx()
         warp_idx = cute.arch.make_warp_uniform(warp_idx)
+        lane_id = Int32(tidx) & Int32(31)
         is_cta_leader = Int32(Int32(tidx) == Int32(0))
 
         if warp_idx == 0:
@@ -824,16 +1197,17 @@ class MoEStaticKernel:
         cta_rank = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         cluster_coord = cta_layout_mnk.get_flat_coord(cta_rank)
 
-        a_smem_one = cute.slice_(a_smem_staged, (None, None, 0))
         b_smem_one = cute.slice_(b_smem_staged, (None, None, 0))
-        sfa_smem_one = cute.slice_(sfa_smem_staged, (None, None, 0))
         sfb_smem_one = cute.slice_(sfb_smem_staged, (None, None, 0))
-        tma_copy_bytes = (
-            cute.size_in_bytes(self.a_dtype, a_smem_one)
-            + cute.size_in_bytes(self.b_dtype, b_smem_one)
-            + cute.size_in_bytes(self.sf_dtype, sfa_smem_one)
-            + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
-        )
+        # A/SFA are copied by the MMA warps from valid rows only.
+        # The TMA completion barrier therefore tracks only B/SFB payloads.
+        tma_copy_bytes = cute.size_in_bytes(
+            self.b_dtype, b_smem_one
+        ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
+        if cutlass.const_expr(self.is_gated):
+            tma_copy_bytes += cute.size_in_bytes(
+                self.b_dtype, b_smem_one
+            ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
         phase2_tma_copy_bytes = cute.size_in_bytes(
             self.b_dtype, b_smem_one
         ) + cute.size_in_bytes(self.sf_dtype, sfb_smem_one)
@@ -842,17 +1216,13 @@ class MoEStaticKernel:
 
         @cute.struct
         class StorageGated:
-            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            ctrl: cute.struct.MemRange[cutlass.Int32, 8]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
-            up_pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             phase2_pipeline_array: cute.struct.MemRange[
                 cutlass.Int64, self.ab_stage * 2
             ]
-            scatter_tok_cache: cute.struct.MemRange[
-                cutlass.Int32, _COMPACT_STATIC_TILE_M
-            ]
-            scatter_weight_cache: cute.struct.MemRange[
-                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            scatter_meta_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M * 2
             ]
             sA: cute.struct.Align[
                 cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
@@ -885,16 +1255,13 @@ class MoEStaticKernel:
 
         @cute.struct
         class StorageRelu2:
-            ctrl: cute.struct.MemRange[cutlass.Int32, 2]
+            ctrl: cute.struct.MemRange[cutlass.Int32, 8]
             pipeline_array: cute.struct.MemRange[cutlass.Int64, self.ab_stage * 2]
             phase2_pipeline_array: cute.struct.MemRange[
                 cutlass.Int64, self.ab_stage * 2
             ]
-            scatter_tok_cache: cute.struct.MemRange[
-                cutlass.Int32, _COMPACT_STATIC_TILE_M
-            ]
-            scatter_weight_cache: cute.struct.MemRange[
-                cutlass.Float32, _COMPACT_STATIC_TILE_M
+            scatter_meta_cache: cute.struct.MemRange[
+                cutlass.Int32, _COMPACT_STATIC_TILE_M * 2
             ]
             sA: cute.struct.Align[
                 cute.struct.MemRange[self.a_dtype, cute.cosize(a_smem_staged)],
@@ -932,18 +1299,6 @@ class MoEStaticKernel:
             barrier_storage=storage.pipeline_array.data_ptr(),
             cta_layout_vmnk=cta_layout_vmnk,
         )
-        up_pipeline = (
-            pipeline.PipelineTmaAsync.create(
-                num_stages=self.ab_stage,
-                producer_group=prod_group,
-                consumer_group=cons_group,
-                tx_count=tma_copy_bytes,
-                barrier_storage=storage.up_pipeline_array.data_ptr(),
-                cta_layout_vmnk=cta_layout_vmnk,
-            )
-            if self.is_gated
-            else ml_pipeline
-        )
         phase2_pipeline = pipeline.PipelineTmaAsync.create(
             num_stages=self.ab_stage,
             producer_group=prod_group,
@@ -976,10 +1331,11 @@ class MoEStaticKernel:
             swizzle=epi_smem_staged.inner,
         )
         sfa_base_addr = shared_ptr_to_u32(storage.sSFA.data_ptr())
+        sfa_smem_one = cute.slice_(sfa_smem_staged, (None, None, 0))
+        sfa_stage_elements = Int32(cute.cosize(sfa_smem_one))
         ctrl_base_addr = shared_ptr_to_u32(storage.ctrl.data_ptr())
-        scatter_tok_base_addr = shared_ptr_to_u32(storage.scatter_tok_cache.data_ptr())
-        scatter_weight_base_addr = shared_ptr_to_u32(
-            storage.scatter_weight_cache.data_ptr()
+        scatter_meta_base_addr = shared_ptr_to_u32(
+            storage.scatter_meta_cache.data_ptr()
         )
 
         num_tokens = Int32(a_input.shape[0])
@@ -994,10 +1350,10 @@ class MoEStaticKernel:
         num_global_experts = Int32(global_to_local_expert.shape[0])
         flat_tid = Int32(bidz) * Int32(self.threads_per_cta) + Int32(tidx)
         flat_stride = Int32(gdim_z) * Int32(self.threads_per_cta)
-        sf_k_tile = Int32(self.sf_vec_size * 4)
-        num_k_tiles = (cols + sf_k_tile - Int32(1)) // sf_k_tile
+        num_k_tiles = (cols + Int32(63)) // Int32(64)
 
-        # Phase 0: cooperative init — zero row_counts and scatter_output
+        # Phase 0: cooperative init.  The finalizer overwrites every output
+        # element, so unlike REDG scatter this path needs no output clear.
         i = flat_tid
         while i < num_experts:
             row_counts[i] = Int32(0)
@@ -1006,13 +1362,30 @@ class MoEStaticKernel:
         while i < num_global_experts:
             global_to_local_expert[i] = Int32(-1)
             i += flat_stride
+        # virt_route_scratch layout:
+        #   [row allocator: weight_E][chunk->local map: weight_E*max_chunks]
+        #   [work-claim counter + pad: 8]
+        virt_scratch_total = Int32(virt_route_scratch.shape[0])
+        claim_slot = virt_scratch_total - Int32(8)
+        max_chunks = claim_slot // num_global_experts - Int32(1)
+        i = flat_tid
+        while i < virt_scratch_total:
+            scratch_init = Int32(-1)
+            if i < num_global_experts:
+                scratch_init = Int32(0)
+            if i >= claim_slot:
+                scratch_init = Int32(0)
+            if i == claim_slot:
+                # The first two waves stay statically assigned (CTA b takes
+                # linear idx b and b+gdim_z); the counter hands out every
+                # task after that. Early waves are inherently balanced, so
+                # claiming them only adds an atomic round-trip on the fetch
+                # path — measurable at tiny M (M16 +2.9us).
+                scratch_init = Int32(2) * Int32(gdim_z)
+            virt_route_scratch[i] = scratch_init
+            i += flat_stride
         if flat_tid == Int32(0):
             active_expert_count[Int32(0)] = Int32(0)
-        scatter_total = num_tokens * cols
-        j = flat_tid
-        while j < scatter_total:
-            scatter_output[j // cols, j % cols] = cutlass.BFloat16(0.0)
-            j += flat_stride
         cute.arch.sync_threads()
         self._resident_grid_barrier(
             barrier_count,
@@ -1021,16 +1394,29 @@ class MoEStaticKernel:
             is_cta_leader,
         )
 
-        pair_idx = Int32(bidz)
+        pair_idx = Int32(bidz) * Int32(self.num_frontend_warps) + warp_idx
         while pair_idx < total_pairs:
             expert_id = topk_ids[pair_idx].to(Int32)
             token_idx = pair_idx // num_topk
             weight = topk_weights[pair_idx].to(cutlass.Float32)
             local_expert_id = Int32(0)
             row = Int32(0)
-            if is_cta_leader > Int32(0):
+            if lane_id == Int32(0):
+                # 32-row virtual-expert split: a monotone per-global-expert
+                # allocator yields (chunk, row-in-chunk); every chunk claims
+                # its own compact local expert id, so each scheduled tile
+                # holds <=32 valid rows — exactly the one M step the tile64
+                # MMA computes. Big experts become several tiles instead of
+                # silently losing rows past 32 (or 64 at tile128).
+                alloc_row = atomic_add_global_i32(
+                    get_ptr_as_int64(virt_route_scratch, expert_id),
+                    Int32(1),
+                )
+                chunk = alloc_row >> Int32(5)
+                row = alloc_row & Int32(31)
+                vslot = num_global_experts + expert_id * max_chunks + chunk
                 prior_local_expert_id = _atomic_cas_global_i32(
-                    get_ptr_as_int64(global_to_local_expert, expert_id),
+                    get_ptr_as_int64(virt_route_scratch, vslot),
                     Int32(-1),
                     Int32(-2),
                 )
@@ -1040,63 +1426,76 @@ class MoEStaticKernel:
                         Int32(1),
                     )
                     weight_expert_ids[local_expert_id] = expert_id
+                    if chunk == Int32(0):
+                        # Keep the legacy global->local mapping for chunk 0;
+                        # the micro pre-pass and diagnostics still read it.
+                        _st_global_release_i32(
+                            get_ptr_as_int64(global_to_local_expert, expert_id),
+                            local_expert_id,
+                        )
                     _st_global_release_i32(
-                        get_ptr_as_int64(global_to_local_expert, expert_id),
+                        get_ptr_as_int64(virt_route_scratch, vslot),
                         local_expert_id,
                     )
                 else:
                     if prior_local_expert_id == Int32(-2):
-                        # TODO: revisit whether we can replace this with a
-                        # weaker ordering path once the compact publish
-                        # sequence is better characterized.
                         _spin_wait_global_eq_i32(
-                            get_ptr_as_int64(global_to_local_expert, expert_id),
+                            get_ptr_as_int64(virt_route_scratch, vslot),
                             Int32(-2),
                         )
                         prior_local_expert_id = _ld_global_acquire_i32(
-                            get_ptr_as_int64(global_to_local_expert, expert_id),
+                            get_ptr_as_int64(virt_route_scratch, vslot),
                         )
                     local_expert_id = prior_local_expert_id
-                row = atomic_add_global_i32(
+                atomic_add_global_i32(
                     get_ptr_as_int64(row_counts, local_expert_id),
                     Int32(1),
                 )
                 map_idx = local_expert_id * max_rows + row
-                st_global_i32(get_ptr_as_int64(token_map, map_idx), token_idx)
+                # Preserve the unique routed-pair id.  Compute only needs its
+                # token quotient, while scatter needs a collision-free scratch
+                # row for the later token-major finalization.
+                st_global_i32(get_ptr_as_int64(token_map, map_idx), pair_idx)
                 st_global_f32(get_ptr_as_int64(token_weights, map_idx), weight)
-                _st_shared_i32(ctrl_base_addr + Int32(0), local_expert_id)
-                _st_shared_i32(ctrl_base_addr + Int32(4), row)
-            cute.arch.sync_threads()
-            local_expert_id = _ld_shared_i32(ctrl_base_addr + Int32(0))
-            row = _ld_shared_i32(ctrl_base_addr + Int32(4))
+            local_expert_id = cute.arch.shuffle_sync(local_expert_id, Int32(0))
+            row = cute.arch.shuffle_sync(row, Int32(0))
 
             # Distribute quantization across ALL CTA threads, not just leader.
-            # Each scale vector can be quantized and packed independently.
-            gs_value = input_global_scale[expert_id].to(cutlass.Float32)
-            if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(0.0):
-                if self.fast_math:
-                    gs_value = rcp_approx_ftz(gs_value)
-                else:
-                    gs_value = cutlass.Float32(1.0) / gs_value
-            sf_idx = Int32(tidx)
+            # Each FP4 block (16 elements) is independent — perfect parallelism.
+            gs_value = cutlass.Float32(1.0)
+            if cutlass.const_expr(self.sf_vec_size == 16):
+                gs_value = input_global_scale[expert_id].to(cutlass.Float32)
+                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
+                    0.0
+                ):
+                    if self.fast_math:
+                        gs_value = rcp_approx_ftz(gs_value)
+                    else:
+                        gs_value = cutlass.Float32(1.0) / gs_value
+            sf_idx = lane_id
             while sf_idx < sf_blocks_per_row:
                 block_start = sf_idx * Int32(self.sf_vec_size)
                 values = cute.make_rmem_tensor((self.sf_vec_size,), cutlass.Float32)
                 block_max = cutlass.Float32(0.0)
-                for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
-                    value = cutlass.Float32(
-                        a_input[token_idx, block_start + Int32(elem_idx)]
+                # Vectorized BF16 loads cover either one 16-value NVFP4 block
+                # or one 32-value MXFP4 block.
+                block_addr = get_ptr_as_int64(a_input, token_idx * cols + block_start)
+                for load_idx in cutlass.range_constexpr(self.sf_vec_size // 8):
+                    loaded = load_global_bf16x8_to_f32x8(
+                        block_addr + Int64(load_idx * 16)
                     )
-                    values[elem_idx] = value
-                    block_max = fmax_f32(block_max, fabs_f32(value))
+                    for elem_idx in cutlass.range_constexpr(8):
+                        value = loaded[elem_idx]
+                        values[load_idx * 8 + elem_idx] = value
+                        block_max = fmax_f32(block_max, fabs_f32(value))
+                packed_lo = Uint64(0)
+                packed_hi = Uint64(0)
                 scale_byte = Uint8(0)
                 if cutlass.const_expr(self.sf_vec_size == 32):
                     packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
                         values, block_max
                     )
                 else:
-                    packed_lo = Uint64(0)
-                    packed_hi = Uint64(0)
                     if self.fast_math:
                         packed_lo, scale_byte = quantize_block_fp4_fast(
                             values, block_max, gs_value
@@ -1134,10 +1533,9 @@ class MoEStaticKernel:
                     + inner_k_idx
                 )
                 scale_storage[scale_offset] = scale_byte
-                sf_idx += Int32(self.threads_per_cta)
+                sf_idx += Int32(32)
 
-            cute.arch.sync_threads()
-            pair_idx += Int32(gdim_z)
+            pair_idx += Int32(gdim_z) * Int32(self.num_frontend_warps)
 
         self._resident_grid_barrier(
             barrier_count,
@@ -1255,6 +1653,8 @@ class MoEStaticKernel:
         )
         tCsB = thr_mma.partition_B(sB)
         tCrB = tiled_mma.make_fragment_B(tCsB[None, None, None, 0])
+        tCsB_up = thr_mma.partition_B(sB_up)
+        tCrB_up = tiled_mma.make_fragment_B(tCsB_up[None, None, None, 0])
         tCrSFB_full = self._dense_cls._partition_fragment_SFB(
             self,  # type: ignore[arg-type]
             sSFB[None, None, 0],
@@ -1284,26 +1684,19 @@ class MoEStaticKernel:
             else intermediate_tile_cnt
         )
         output_tile_cnt = cute.size(gB_down, mode=[2])
+        retained_group_count = (gate_tile_cnt + Int32(1)) // Int32(2)
+        # The wrapper reserves packed-A capacity for max_num_tokens, while the
+        # compact static path consumes only the contiguous active-expert
+        # prefix.  Use the high end as a private
+        # [route, retained_group, K] BF16 contribution buffer.
+        route_scratch_bytes = total_pairs * retained_group_count * cols * Int32(2)
+        route_scratch_base = Int32(packed_a_storage.shape[0]) - route_scratch_bytes
 
         prod_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.ab_stage
         )
         cons_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Consumer, self.ab_stage
-        )
-        up_prod_state = (
-            pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Producer, self.ab_stage
-            )
-            if self.is_gated
-            else prod_state
-        )
-        up_cons_state = (
-            pipeline.make_pipeline_state(
-                pipeline.PipelineUserType.Consumer, self.ab_stage
-            )
-            if self.is_gated
-            else cons_state
         )
         phase2_prod_state = pipeline.make_pipeline_state(
             pipeline.PipelineUserType.Producer, self.ab_stage
@@ -1356,6 +1749,7 @@ class MoEStaticKernel:
             csB = thr_ld_B.partition_S(sB)
             csB_up = thr_ld_B.partition_S(sB_up)
             crB = thr_ld_B.retile(tCrB)
+            crB_up = thr_ld_B.retile(tCrB_up)
 
             thr_ld_SFA = smem_copy_SFA.get_slice(tidx)
             thr_ld_SFB = smem_copy_SFB.get_slice(tidx)
@@ -1364,6 +1758,13 @@ class MoEStaticKernel:
             csSFB_full = thr_ld_SFB.partition_S(sSFB)
             csSFB_up_full = thr_ld_SFB.partition_S(sSFB_up)
             crSFB_full = thr_ld_SFB.retile(tCrSFB_full)
+            tCrSFB_up_full = self._dense_cls._partition_fragment_SFB(
+                self,  # type: ignore[arg-type]
+                sSFB_up[None, None, 0],
+                thr_mma,
+                tidx,
+            )
+            crSFB_up_full = thr_ld_SFB.retile(tCrSFB_up_full)
 
             num_persistent_clusters = Int32(gdim_z)
             cluster_shape_mn = (
@@ -1378,12 +1779,13 @@ class MoEStaticKernel:
             current_work_linear_idx = Int32(bidz)
             current_local_expert_idx = Int32(0)
             accum_tile_m = Int32(0)
+            published_work_linear_idx = Int32(bidz)
             tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
-                _compact_static_get_work_tile(
+                _compact_static_get_single_m_tile_work(
                     row_counts,
                     active_expert_count,
                     tile_m=Int32(self.tile_shape_mnk[0]),
-                    num_tiles_n=Int32(self.output_tile_count_n),
+                    num_tiles_n=Int32((self.output_tile_count_n + 1) // 2),
                     cluster_shape_mn=cluster_shape_mn,
                     current_work_linear_idx=current_work_linear_idx,
                     current_local_expert_idx=current_local_expert_idx,
@@ -1399,7 +1801,7 @@ class MoEStaticKernel:
                 alpha_value = alpha[weight_expert_idx].to(cutlass.Float32)
                 valid_rows = row_counts[local_expert_idx]
                 tile_m_base = tile_coord[0] * Int32(self.tile_shape_mnk[0])
-                intermediate_slice = tile_coord[1]
+                intermediate_slice = tile_coord[1] * Int32(2)
                 sa_tile_offset = tile_coord[0] % self.sa_tiles_per_block
                 sa_row_base = sa_tile_offset * Int32(self.tile_shape_mnk[0])
                 if cutlass.const_expr(self.sa_tiles_per_block > 1):
@@ -1458,11 +1860,20 @@ class MoEStaticKernel:
                         tidx,
                     )
                     crSFB_tile = thr_ld_SFB.retile(tCrSFB_tile)
+                    tCrSFB_up_tile = self._dense_cls._partition_fragment_SFB(
+                        self,  # type: ignore[arg-type]
+                        sSFB_up_tile[None, None, 0],
+                        thr_mma,
+                        tidx,
+                    )
+                    crSFB_up_tile = thr_ld_SFB.retile(tCrSFB_up_tile)
                 else:
                     csSFB_tile = csSFB_full
                     csSFB_up_tile = csSFB_up_full
                     tCrSFB_tile = tCrSFB_full
                     crSFB_tile = crSFB_full
+                    tCrSFB_up_tile = tCrSFB_up_full
+                    crSFB_up_tile = crSFB_up_full
                 valid_tile_rows = valid_rows - tile_m_base
                 if valid_tile_rows > Int32(self.tile_shape_mnk[0]):
                     valid_tile_rows = Int32(self.tile_shape_mnk[0])
@@ -1471,17 +1882,18 @@ class MoEStaticKernel:
 
                 cache_row = Int32(tidx)
                 if cache_row < Int32(_COMPACT_STATIC_TILE_M):
-                    tok = Int32(0)
+                    route_idx = Int32(0)
                     wv = cutlass.Float32(0.0)
                     if cache_row < valid_tile_rows:
-                        tok = token_map[local_expert_idx, tile_m_base + cache_row].to(
-                            Int32
-                        )
+                        route_idx = token_map[
+                            local_expert_idx, tile_m_base + cache_row
+                        ].to(Int32)
                         wv = token_weights[
                             local_expert_idx, tile_m_base + cache_row
                         ].to(cutlass.Float32)
-                    _st_shared_i32(scatter_tok_base_addr + cache_row * Int32(4), tok)
-                    _st_shared_f32(scatter_weight_base_addr + cache_row * Int32(4), wv)
+                    meta_addr = scatter_meta_base_addr + cache_row * Int32(8)
+                    _st_shared_i32(meta_addr, route_idx)
+                    _st_shared_f32(meta_addr + Int32(4), wv)
                 self.epilog_sync_barrier.arrive_and_wait()
 
                 _is_m_major = self.c_layout.is_m_major_c()
@@ -1525,149 +1937,56 @@ class MoEStaticKernel:
                 # PHASE A: FC1 for this slice (gate + up)
                 # ============================================================
 
-                # Gate GEMM (inlined to avoid @cute.jit pass-by-value for acc)
-                fz_crSFA = cute.filter_zeros(crSFA_tile)
-                fz_crSFB = cute.filter_zeros(crSFB_tile)
-                gate_acc.fill(0.0)
-                cons_state.reset_count()
-                peek = ml_pipeline.consumer_try_wait(cons_state)
-                ml_pipeline.consumer_wait(cons_state, peek)
-                csA_p = csA_tile[None, None, None, cons_state.index]
-                csB_p = csB[None, None, None, cons_state.index]
-                csSFA_p = csSFA_tile[None, None, None, cons_state.index]
-                csSFB_p = csSFB_tile[None, None, None, cons_state.index]
-                cute.copy(smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0])
-                cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
-                fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                cute.copy(
-                    smem_copy_SFA, fz_csSFA_p[None, None, 0], fz_crSFA[None, None, 0]
-                )
-                cute.copy(
-                    smem_copy_SFB, fz_csSFB_p[None, None, 0], fz_crSFB[None, None, 0]
-                )
-                for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
-                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                        k_next = (
-                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
-                        )
-                        if k_block_idx == num_k_blocks - 1:
-                            ml_pipeline.consumer_release(cons_state)
-                            cons_state.advance()
-                            peek = ml_pipeline.consumer_try_wait(cons_state)
-                            csA_p = csA_tile[None, None, None, cons_state.index]
-                            csB_p = csB[None, None, None, cons_state.index]
-                            csSFA_p = csSFA_tile[None, None, None, cons_state.index]
-                            csSFB_p = csSFB_tile[None, None, None, cons_state.index]
-                            fz_csSFA_p = cute.filter_zeros(csSFA_p)
-                            fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                            ml_pipeline.consumer_wait(cons_state, peek)
-                        for _mt in range(self.num_m_tiles):
-                            for _nt in range(self.num_n_tiles):
-                                mma_atom.set(
-                                    WarpField.SFA,
-                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
-                                )
-                                mma_atom.set(
-                                    WarpField.SFB,
-                                    tCrSFB_tile[None, _nt, k_block_idx].iterator,
-                                )
-                                cute.gemm(
-                                    mma_atom,
-                                    gate_acc[None, _mt, _nt],
-                                    tCrA_tile[None, _mt, k_block_idx],
-                                    tCrB[None, _nt, k_block_idx],
-                                    gate_acc[None, _mt, _nt],
-                                )
-                        cute.copy(
-                            smem_copy_A,
-                            csA_p[None, None, k_next],
-                            crA_tile[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_B,
-                            csB_p[None, None, k_next],
-                            crB[None, None, k_next],
-                        )
-                        fz_csSFA_cur = cute.filter_zeros(
-                            csSFA_tile[None, None, None, cons_state.index]
-                        )
-                        fz_csSFB_cur = cute.filter_zeros(
-                            csSFB_tile[None, None, None, cons_state.index]
-                        )
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_cur[None, None, k_next],
-                            fz_crSFA[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFB,
-                            fz_csSFB_cur[None, None, k_next],
-                            fz_crSFB[None, None, k_next],
-                        )
-                for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                    k_next = 0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
-                    if k_block_idx == num_k_blocks - 1:
-                        ml_pipeline.consumer_release(cons_state)
-                        cons_state.advance()
-                    if k_next > 0 and fc1_k_tile_cnt > Int32(0):
-                        cute.copy(
-                            smem_copy_A,
-                            csA_p[None, None, k_next],
-                            crA_tile[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_B,
-                            csB_p[None, None, k_next],
-                            crB[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFA,
-                            fz_csSFA_p[None, None, k_next],
-                            fz_crSFA[None, None, k_next],
-                        )
-                        cute.copy(
-                            smem_copy_SFB,
-                            fz_csSFB_p[None, None, k_next],
-                            fz_crSFB[None, None, k_next],
-                        )
-                    for _mt in range(self.num_m_tiles):
-                        for _nt in range(self.num_n_tiles):
-                            mma_atom.set(
-                                WarpField.SFA,
-                                tCrSFA_tile[None, _mt, k_block_idx].iterator,
-                            )
-                            mma_atom.set(
-                                WarpField.SFB,
-                                tCrSFB_tile[None, _nt, k_block_idx].iterator,
-                            )
-                            cute.gemm(
-                                mma_atom,
-                                gate_acc[None, _mt, _nt],
-                                tCrA_tile[None, _mt, k_block_idx],
-                                tCrB[None, _nt, k_block_idx],
-                                gate_acc[None, _mt, _nt],
-                            )
-                # Drain the FC1 gate/only pass before the DMA warp reuses the
-                # gate staging buffers, either for the up pass or FC2 prefetch.
-                self.pass_sync_barrier.arrive_and_wait()
-
-                if cutlass.const_expr(self.is_gated):
-                    # Up GEMM (inlined, same pattern)
-                    up_acc.fill(0.0)
-                    up_cons_state.reset_count()
-                    peek = up_pipeline.consumer_try_wait(up_cons_state)
-                    up_pipeline.consumer_wait(up_cons_state, peek)
-                    csA_p = csA_tile[None, None, None, up_cons_state.index]
-                    csB_p = csB_up[None, None, None, up_cons_state.index]
-                    csSFA_p = csSFA_tile[None, None, None, up_cons_state.index]
-                    csSFB_p = csSFB_up_tile[None, None, None, up_cons_state.index]
+                for retained_slice_idx in cutlass.range_constexpr(2):
+                    # Paired Gate/Up GEMM.  One A/SFA load feeds both branches;
+                    # independent B/SFB register fragments keep the two branch
+                    # operands live across the back-to-back MMA cadence.
+                    fz_crSFA = cute.filter_zeros(crSFA_tile)
+                    fz_crSFB = cute.filter_zeros(crSFB_tile)
+                    fz_crSFB_up = cute.filter_zeros(crSFB_up_tile)
+                    gate_acc.fill(0.0)
+                    if cutlass.const_expr(self.is_gated):
+                        up_acc.fill(0.0)
+                    cons_state.reset_count()
+                    peek = ml_pipeline.consumer_try_wait(cons_state)
+                    ml_pipeline.consumer_wait(cons_state, peek)
+                    self._load_valid_fc1_a_stage(
+                        tidx,
+                        packed_a_storage,
+                        scale_storage,
+                        local_expert_idx,
+                        tile_m_base,
+                        sa_row_base,
+                        valid_tile_rows,
+                        Int32(0),
+                        cons_state.index,
+                        max_rows,
+                        output_bytes_per_row,
+                        expert_scale_stride,
+                        num_k_tiles,
+                        sA,
+                        sfa_base_addr,
+                        sfa_stage_elements,
+                    )
+                    csA_p = csA_tile[None, None, None, cons_state.index]
+                    csB_p = csB[None, None, None, cons_state.index]
+                    csB_up_p = csB_up[None, None, None, cons_state.index]
+                    csSFA_p = csSFA_tile[None, None, None, cons_state.index]
+                    csSFB_p = csSFB_tile[None, None, None, cons_state.index]
+                    csSFB_up_p = csSFB_up_tile[None, None, None, cons_state.index]
                     cute.copy(
                         smem_copy_A, csA_p[None, None, 0], crA_tile[None, None, 0]
                     )
                     cute.copy(smem_copy_B, csB_p[None, None, 0], crB[None, None, 0])
+                    if cutlass.const_expr(self.is_gated):
+                        cute.copy(
+                            smem_copy_B,
+                            csB_up_p[None, None, 0],
+                            crB_up[None, None, 0],
+                        )
                     fz_csSFA_p = cute.filter_zeros(csSFA_p)
                     fz_csSFB_p = cute.filter_zeros(csSFB_p)
+                    fz_csSFB_up_p = cute.filter_zeros(csSFB_up_p)
                     cute.copy(
                         smem_copy_SFA,
                         fz_csSFA_p[None, None, 0],
@@ -1678,6 +1997,12 @@ class MoEStaticKernel:
                         fz_csSFB_p[None, None, 0],
                         fz_crSFB[None, None, 0],
                     )
+                    if cutlass.const_expr(self.is_gated):
+                        cute.copy(
+                            smem_copy_SFB,
+                            fz_csSFB_up_p[None, None, 0],
+                            fz_crSFB_up[None, None, 0],
+                        )
                     for _k_tile in range(0, fc1_k_tile_cnt - 1, 1, unroll=4):  # type: ignore[call-overload]
                         for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                             k_next = (
@@ -1686,20 +2011,39 @@ class MoEStaticKernel:
                                 else k_block_idx + 1
                             )
                             if k_block_idx == num_k_blocks - 1:
-                                up_pipeline.consumer_release(up_cons_state)
-                                up_cons_state.advance()
-                                peek = up_pipeline.consumer_try_wait(up_cons_state)
-                                csA_p = csA_tile[None, None, None, up_cons_state.index]
-                                csB_p = csB_up[None, None, None, up_cons_state.index]
-                                csSFA_p = csSFA_tile[
-                                    None, None, None, up_cons_state.index
-                                ]
-                                csSFB_p = csSFB_up_tile[
-                                    None, None, None, up_cons_state.index
+                                ml_pipeline.consumer_release(cons_state)
+                                cons_state.advance()
+                                peek = ml_pipeline.consumer_try_wait(cons_state)
+                                csA_p = csA_tile[None, None, None, cons_state.index]
+                                csB_p = csB[None, None, None, cons_state.index]
+                                csB_up_p = csB_up[None, None, None, cons_state.index]
+                                csSFA_p = csSFA_tile[None, None, None, cons_state.index]
+                                csSFB_p = csSFB_tile[None, None, None, cons_state.index]
+                                csSFB_up_p = csSFB_up_tile[
+                                    None, None, None, cons_state.index
                                 ]
                                 fz_csSFA_p = cute.filter_zeros(csSFA_p)
                                 fz_csSFB_p = cute.filter_zeros(csSFB_p)
-                                up_pipeline.consumer_wait(up_cons_state, peek)
+                                fz_csSFB_up_p = cute.filter_zeros(csSFB_up_p)
+                                ml_pipeline.consumer_wait(cons_state, peek)
+                                self._load_valid_fc1_a_stage(
+                                    tidx,
+                                    packed_a_storage,
+                                    scale_storage,
+                                    local_expert_idx,
+                                    tile_m_base,
+                                    sa_row_base,
+                                    valid_tile_rows,
+                                    Int32(_k_tile + 1),
+                                    cons_state.index,
+                                    max_rows,
+                                    output_bytes_per_row,
+                                    expert_scale_stride,
+                                    num_k_tiles,
+                                    sA,
+                                    sfa_base_addr,
+                                    sfa_stage_elements,
+                                )
                             for _mt in range(self.num_m_tiles):
                                 for _nt in range(self.num_n_tiles):
                                     mma_atom.set(
@@ -1712,11 +2056,25 @@ class MoEStaticKernel:
                                     )
                                     cute.gemm(
                                         mma_atom,
-                                        up_acc[None, _mt, _nt],
+                                        gate_acc[None, _mt, _nt],
                                         tCrA_tile[None, _mt, k_block_idx],
                                         tCrB[None, _nt, k_block_idx],
-                                        up_acc[None, _mt, _nt],
+                                        gate_acc[None, _mt, _nt],
                                     )
+                                    if cutlass.const_expr(self.is_gated):
+                                        mma_atom.set(
+                                            WarpField.SFB,
+                                            tCrSFB_up_tile[
+                                                None, _nt, k_block_idx
+                                            ].iterator,
+                                        )
+                                        cute.gemm(
+                                            mma_atom,
+                                            up_acc[None, _mt, _nt],
+                                            tCrA_tile[None, _mt, k_block_idx],
+                                            tCrB_up[None, _nt, k_block_idx],
+                                            up_acc[None, _mt, _nt],
+                                        )
                             cute.copy(
                                 smem_copy_A,
                                 csA_p[None, None, k_next],
@@ -1727,23 +2085,44 @@ class MoEStaticKernel:
                                 csB_p[None, None, k_next],
                                 crB[None, None, k_next],
                             )
+                            if cutlass.const_expr(self.is_gated):
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_up_p[None, None, k_next],
+                                    crB_up[None, None, k_next],
+                                )
+                            fz_csSFA_cur = cute.filter_zeros(
+                                csSFA_tile[None, None, None, cons_state.index]
+                            )
+                            fz_csSFB_cur = cute.filter_zeros(
+                                csSFB_tile[None, None, None, cons_state.index]
+                            )
                             cute.copy(
                                 smem_copy_SFA,
-                                fz_csSFA_p[None, None, k_next],
+                                fz_csSFA_cur[None, None, k_next],
                                 fz_crSFA[None, None, k_next],
                             )
                             cute.copy(
                                 smem_copy_SFB,
-                                fz_csSFB_p[None, None, k_next],
+                                fz_csSFB_cur[None, None, k_next],
                                 fz_crSFB[None, None, k_next],
                             )
+                            if cutlass.const_expr(self.is_gated):
+                                fz_csSFB_up_cur = cute.filter_zeros(
+                                    csSFB_up_tile[None, None, None, cons_state.index]
+                                )
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    fz_csSFB_up_cur[None, None, k_next],
+                                    fz_crSFB_up[None, None, k_next],
+                                )
                     for k_block_idx in cutlass.range_constexpr(num_k_blocks):
                         k_next = (
                             0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
                         )
                         if k_block_idx == num_k_blocks - 1:
-                            up_pipeline.consumer_release(up_cons_state)
-                            up_cons_state.advance()
+                            ml_pipeline.consumer_release(cons_state)
+                            cons_state.advance()
                         if k_next > 0 and fc1_k_tile_cnt > Int32(0):
                             cute.copy(
                                 smem_copy_A,
@@ -1755,6 +2134,12 @@ class MoEStaticKernel:
                                 csB_p[None, None, k_next],
                                 crB[None, None, k_next],
                             )
+                            if cutlass.const_expr(self.is_gated):
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_up_p[None, None, k_next],
+                                    crB_up[None, None, k_next],
+                                )
                             cute.copy(
                                 smem_copy_SFA,
                                 fz_csSFA_p[None, None, k_next],
@@ -1765,6 +2150,12 @@ class MoEStaticKernel:
                                 fz_csSFB_p[None, None, k_next],
                                 fz_crSFB[None, None, k_next],
                             )
+                            if cutlass.const_expr(self.is_gated):
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    fz_csSFB_up_p[None, None, k_next],
+                                    fz_crSFB_up[None, None, k_next],
+                                )
                         for _mt in range(self.num_m_tiles):
                             for _nt in range(self.num_n_tiles):
                                 mma_atom.set(
@@ -1777,155 +2168,118 @@ class MoEStaticKernel:
                                 )
                                 cute.gemm(
                                     mma_atom,
-                                    up_acc[None, _mt, _nt],
+                                    gate_acc[None, _mt, _nt],
                                     tCrA_tile[None, _mt, k_block_idx],
                                     tCrB[None, _nt, k_block_idx],
-                                    up_acc[None, _mt, _nt],
+                                    gate_acc[None, _mt, _nt],
                                 )
-
-                # Activation + quant into sA
-                sA_u8 = cute.recast_tensor(sA[None, None, 0], cutlass.Uint8)
-                packed_cols = Int32(self.tile_shape_mnk[2] // 2)
-                sf_blocks_per_row = Int32(self.tile_shape_mnk[2] // self.sf_vec_size)
-                gs_value = global_scale[weight_expert_idx].to(cutlass.Float32)
-                if self.input_scales_are_reciprocal and gs_value != cutlass.Float32(
-                    0.0
-                ):
-                    if self.fast_math:
-                        gs_value = rcp_approx_ftz(gs_value)
-                    else:
-                        gs_value = cutlass.Float32(1.0) / gs_value
-
-                for epi_m in cutlass.range_constexpr(epi_rest_m):
-                    epi_m_valid = (
-                        valid_rows
-                        - tile_m_base
-                        - Int32(epi_m) * Int32(self.epi_tile[0])
-                    )
-                    silu_epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
-                    if epi_m_valid > Int32(0):
-                        for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
-                            for mma_m_in_epi in cutlass.range_constexpr(MmaMPerEpiM):
-                                mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
-                                mma_n = mma_n_in_epi
-                                tRS_rD_slice = tRS_rD[
-                                    (None, mma_m_in_epi, mma_n_in_epi)
-                                ]
-                                gate_slice = tRS_rGate[(None, mma_m, mma_n)]
                                 if cutlass.const_expr(self.is_gated):
-                                    up_slice = tRS_rUp[(None, mma_m, mma_n)]
-                                    for elem_idx in cutlass.range_constexpr(
-                                        cute.size(tRS_rD_slice)
-                                    ):
-                                        g = alpha_value * gate_slice[elem_idx]
-                                        u = alpha_value * up_slice[elem_idx]
-                                        tRS_rD_slice[elem_idx] = gated_activation_f32(
-                                            g,
-                                            u,
-                                            activation=self.activation,
-                                            limit=self.swiglu_limit,
-                                            alpha=self.swiglu_alpha,
-                                            beta=self.swiglu_beta,
-                                            fast_math=self.fast_math,
-                                        )
-                                else:
-                                    for elem_idx in cutlass.range_constexpr(
-                                        cute.size(tRS_rD_slice)
-                                    ):
-                                        g = alpha_value * gate_slice[elem_idx]
-                                        relu_g = fmax_f32(g, cutlass.Float32(0.0))
-                                        tRS_rD_slice[elem_idx] = relu_g * relu_g
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_up_tile[None, _nt, k_block_idx].iterator,
+                                    )
+                                    cute.gemm(
+                                        mma_atom,
+                                        up_acc[None, _mt, _nt],
+                                        tCrA_tile[None, _mt, k_block_idx],
+                                        tCrB_up[None, _nt, k_block_idx],
+                                        up_acc[None, _mt, _nt],
+                                    )
 
-                        acc_vec = tRS_rD.load()
-                        acc_vec = acc_vec.to(cutlass.BFloat16)
-                        tRS_rD_out.store(acc_vec)
-                        cute.copy(
-                            tiled_copy_r2s,
-                            tRS_rD_out,
-                            tRS_sD[(None, None, None, silu_epi_buffer)],
+                    # After the second FC1 has drained, the DMA warp may reuse the
+                    # Gate B/SFB stages for FC2 while math warps materialize Q1.
+                    if retained_slice_idx == 1:
+                        self.pass_sync_barrier.arrive_and_wait()
+
+                        # sC still holds the first slice.  FC1 no longer needs the
+                        # two A/SFA pipeline stages, so quantize it into Stage0.
+                        self.quantize_q1_sC_to_sA_sSFA(
+                            tidx,
+                            valid_tile_rows,
+                            weight_expert_idx,
+                            global_scale,
+                            sC,
+                            sA,
+                            tRS_sD,
+                            sfa_base_addr,
+                            sfa_stage_elements,
+                            Int32(0),
+                            epi_rest_m,
                         )
                         cute.arch.fence_proxy("async.shared", space="cta")
-                    self.epilog_sync_barrier.arrive_and_wait()
+                        self.epilog_sync_barrier.arrive_and_wait()
 
-                    rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
-                    epi_rows = epi_m_valid
-                    if epi_rows > Int32(self.epi_tile[0]):
-                        epi_rows = Int32(self.epi_tile[0])
-                    if epi_rows < Int32(0):
-                        epi_rows = Int32(0)
-                    quant_idx = Int32(tidx)
-                    while quant_idx < epi_rows * sf_blocks_per_row:
-                        local_row = quant_idx // sf_blocks_per_row
-                        row = sa_row_base + rows_offset + local_row
-                        sf_block = quant_idx - local_row * sf_blocks_per_row
-                        block_start = sf_block * Int32(self.sf_vec_size)
-
-                        values = cute.make_rmem_tensor(
-                            (self.sf_vec_size,), cutlass.Float32
+                    # Materialize this slice's activation in BF16 sC.  For slice0
+                    # it remains resident while slice1 FC1 runs; for slice1 it is
+                    # immediately quantized into Stage1 below.
+                    for epi_m in cutlass.range_constexpr(epi_rest_m):
+                        epi_m_valid = valid_tile_rows - Int32(epi_m) * Int32(
+                            self.epi_tile[0]
                         )
-                        block_max = cutlass.Float32(0.0)
-                        for elem_idx in cutlass.range_constexpr(self.sf_vec_size):
-                            value = cutlass.Float32(
-                                sC[local_row, block_start + elem_idx, silu_epi_buffer]
+                        silu_epi_buffer = Int32(epi_m) % cute.size(tRS_sD, mode=[3])
+                        if epi_m_valid > Int32(0):
+                            for mma_n_in_epi in cutlass.range_constexpr(MmaNPerEpiN):
+                                for mma_m_in_epi in cutlass.range_constexpr(
+                                    MmaMPerEpiM
+                                ):
+                                    mma_m = epi_m * MmaMPerEpiM + mma_m_in_epi
+                                    mma_n = mma_n_in_epi
+                                    tRS_rD_slice = tRS_rD[
+                                        (None, mma_m_in_epi, mma_n_in_epi)
+                                    ]
+                                    gate_slice = tRS_rGate[(None, mma_m, mma_n)]
+                                    if cutlass.const_expr(self.is_gated):
+                                        up_slice = tRS_rUp[(None, mma_m, mma_n)]
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            g = alpha_value * gate_slice[elem_idx]
+                                            u = alpha_value * up_slice[elem_idx]
+                                            tRS_rD_slice[elem_idx] = (
+                                                gated_activation_f32(
+                                                    g,
+                                                    u,
+                                                    activation=self.activation,
+                                                    limit=self.swiglu_limit,
+                                                    alpha=self.swiglu_alpha,
+                                                    beta=self.swiglu_beta,
+                                                    fast_math=self.fast_math,
+                                                )
+                                            )
+                                    else:
+                                        for elem_idx in cutlass.range_constexpr(
+                                            cute.size(tRS_rD_slice)
+                                        ):
+                                            g = alpha_value * gate_slice[elem_idx]
+                                            relu_g = fmax_f32(g, cutlass.Float32(0.0))
+                                            tRS_rD_slice[elem_idx] = relu_g * relu_g
+
+                            acc_vec = tRS_rD.load().to(cutlass.BFloat16)
+                            tRS_rD_out.store(acc_vec)
+                            cute.copy(
+                                tiled_copy_r2s,
+                                tRS_rD_out,
+                                tRS_sD[(None, None, None, silu_epi_buffer)],
                             )
-                            values[elem_idx] = value
-                            block_max = fmax_f32(block_max, fabs_f32(value))
+                            cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
 
-                        scale_byte = Uint8(0)
-                        if cutlass.const_expr(self.sf_vec_size == 32):
-                            packed_lo, packed_hi, scale_byte = quantize_block_mxfp4(
-                                values, block_max
-                            )
-                        else:
-                            packed_lo = Uint64(0)
-                            packed_hi = Uint64(0)
-                            if self.fast_math:
-                                packed_lo, scale_byte = quantize_block_fp4_fast(
-                                    values, block_max, gs_value
-                                )
-                            else:
-                                packed_lo, scale_byte = quantize_block_fp4(
-                                    values, block_max, gs_value
-                                )
-                        packed_base = sf_block * Int32(self.sf_vec_size // 2)
-                        dst_pcol = row & Int32(63)
-                        xor_bits = ((dst_pcol >> Int32(1)) & Int32(0x3)) << Int32(4)
-                        row_high = row >> Int32(6)
-                        for byte_idx in cutlass.range_constexpr(self.sf_vec_size // 2):
-                            src_pcol = packed_base + Int32(byte_idx)
-                            dst_row = ((src_pcol ^ xor_bits) << Int32(1)) + row_high
-                            dst_flat = dst_row * packed_cols + dst_pcol
-                            if cutlass.const_expr(byte_idx < 8):
-                                byte_val = Uint8(
-                                    (packed_lo >> Uint64(byte_idx * 8)) & Uint64(0xFF)
-                                )
-                            else:
-                                byte_val = Uint8(
-                                    (packed_hi >> Uint64((byte_idx - 8) * 8))
-                                    & Uint64(0xFF)
-                                )
-                            sA_u8[dst_flat] = byte_val
-
-                        outer_m_idx = row % Int32(32)
-                        inner_m_idx = row // Int32(32)
-                        inner_k_idx = sf_block % Int32(4)
-                        k_tile_idx = sf_block // Int32(4)
-                        sf_raw_idx = (
-                            k_tile_idx * Int32(32 * 4 * 4)
-                            + outer_m_idx * Int32(4 * 4)
-                            + inner_m_idx * Int32(4)
-                            + inner_k_idx
+                    if retained_slice_idx == 1:
+                        self.quantize_q1_sC_to_sA_sSFA(
+                            tidx,
+                            valid_tile_rows,
+                            weight_expert_idx,
+                            global_scale,
+                            sC,
+                            sA,
+                            tRS_sD,
+                            sfa_base_addr,
+                            sfa_stage_elements,
+                            Int32(1),
+                            epi_rest_m,
                         )
-                        st_shared_u8(sfa_base_addr + sf_raw_idx, scale_byte)
-                        quant_idx += Int32(
-                            self.num_mma_warps * self.num_threads_per_warp
-                        )
-
-                cute.arch.fence_proxy("async.shared", space="cta")
-                # epilog_sync: MMA-only barrier. DMA warp doesn't need to wait
-                # for quant — it only loads B_down into sB (separate buffer).
-                # This allows DMA to prefetch B_down tiles earlier.
-                self.epilog_sync_barrier.arrive_and_wait()
+                        cute.arch.fence_proxy("async.shared", space="cta")
+                        self.epilog_sync_barrier.arrive_and_wait()
 
                 # ============================================================
                 # PHASE B: Sweep ALL FC2 output tiles using cached sA
@@ -1938,39 +2292,13 @@ class MoEStaticKernel:
                 scatter_N = Int32(scatter_output.shape[1])
                 lane_id = Int32(tidx) & Int32(31)
                 warp_in_tile = Int32(tidx) >> Int32(5)
-                warp_m_base = (warp_in_tile >> Int32(1)) * Int32(64)
-                warp_n_base = (warp_in_tile & Int32(1)) * Int32(64)
-
-                csA_phase2 = csA_tile[None, None, None, 0]
-                csSFA_phase2 = csSFA_tile[None, None, None, 0]
-
-                # Consume all output tiles continuously from phase2_pipeline.
-
-                # Hoist A-side register loads: sA is constant across all
-                # FC2 output tiles (quantized intermediate). Load crA and
-                # crSFA for all k-blocks once, reuse for all 32 tiles.
-                fz_crSFA_p2 = cute.filter_zeros(crSFA_tile)
-                cute.copy(
-                    smem_copy_A, csA_phase2[None, None, 0], crA_tile[None, None, 0]
-                )
-                fz_csSFA_p2 = cute.filter_zeros(csSFA_phase2)
-                cute.copy(
-                    smem_copy_SFA,
-                    fz_csSFA_p2[None, None, 0],
-                    fz_crSFA_p2[None, None, 0],
-                )
-                for _kb_pre in cutlass.range_constexpr(num_k_blocks - 1):
-                    k_pre = _kb_pre + 1
-                    cute.copy(
-                        smem_copy_A,
-                        csA_phase2[None, None, k_pre],
-                        crA_tile[None, None, k_pre],
-                    )
-                    cute.copy(
-                        smem_copy_SFA,
-                        fz_csSFA_p2[None, None, k_pre],
-                        fz_crSFA_p2[None, None, k_pre],
-                    )
+                # M64 uses two warp rows: four MMA warps scatter four disjoint
+                # 32x64 quadrants.  The old M128-derived stride of 64 left
+                # warps 2/3 idle during every FC2 epilogue.
+                warp_m_span = Int32(self.tile_shape_mnk[0] // 2)
+                warp_n_span = Int32(self.tile_shape_mnk[1] // 2)
+                warp_m_base = (warp_in_tile >> Int32(1)) * warp_m_span
+                warp_n_base = (warp_in_tile & Int32(1)) * warp_n_span
 
                 phase2_cons_state.reset_count()
                 for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
@@ -1992,60 +2320,80 @@ class MoEStaticKernel:
                         csSFB_phase2_tile = csSFB_full
                         tCrSFB_phase2 = tCrSFB_full
                         crSFB_phase2 = crSFB_full
-                    phase2_peek = phase2_pipeline.consumer_try_wait(phase2_cons_state)
-                    phase2_pipeline.consumer_wait(phase2_cons_state, phase2_peek)
-                    csB_phase2 = csB[None, None, None, phase2_cons_state.index]
-                    csSFB_phase2 = csSFB_phase2_tile[
-                        None, None, None, phase2_cons_state.index
-                    ]
-
-                    # Only load B-side (B_down changes per output tile; A is hoisted)
-                    cute.copy(
-                        smem_copy_B, csB_phase2[None, None, 0], crB[None, None, 0]
-                    )
-                    f2 = cute.filter_zeros(csSFB_phase2)
-                    f4 = cute.filter_zeros(crSFB_phase2)
-                    cute.copy(smem_copy_SFB, f2[None, None, 0], f4[None, None, 0])
-
                     down_acc.fill(0.0)
-                    for k_block_idx in cutlass.range_constexpr(num_k_blocks):
-                        k_next = (
-                            0 if k_block_idx + 1 == num_k_blocks else k_block_idx + 1
+                    for retained_slice_idx in cutlass.range_constexpr(2):
+                        # Each retained slice occupies one of the two former
+                        # FC1 A/SFA pipeline stages.  Reload its fragments, then
+                        # accumulate the matching FC2 B tile into one down_acc.
+                        self.load_fc2_a_fragments(
+                            num_k_blocks,
+                            Int32(retained_slice_idx),
+                            Int32(retained_slice_idx),
+                            (csA_tile, csSFA_tile),
+                            (crA_tile, crSFA_tile),
+                            (smem_copy_A, smem_copy_SFA),
                         )
-                        if k_block_idx == num_k_blocks - 1:
-                            phase2_pipeline.consumer_release(phase2_cons_state)
-                            phase2_cons_state.advance()
-                        if k_next > 0:
-                            # Only B-side for next k-block (A already in registers)
-                            cute.copy(
-                                smem_copy_B,
-                                csB_phase2[None, None, k_next],
-                                crB[None, None, k_next],
+
+                        phase2_peek = phase2_pipeline.consumer_try_wait(
+                            phase2_cons_state
+                        )
+                        phase2_pipeline.consumer_wait(phase2_cons_state, phase2_peek)
+                        csB_phase2 = csB[None, None, None, phase2_cons_state.index]
+                        csSFB_phase2 = csSFB_phase2_tile[
+                            None, None, None, phase2_cons_state.index
+                        ]
+                        cute.copy(
+                            smem_copy_B,
+                            csB_phase2[None, None, 0],
+                            crB[None, None, 0],
+                        )
+                        f2 = cute.filter_zeros(csSFB_phase2)
+                        f4 = cute.filter_zeros(crSFB_phase2)
+                        cute.copy(
+                            smem_copy_SFB,
+                            f2[None, None, 0],
+                            f4[None, None, 0],
+                        )
+
+                        for k_block_idx in cutlass.range_constexpr(num_k_blocks):
+                            k_next = (
+                                0
+                                if k_block_idx + 1 == num_k_blocks
+                                else k_block_idx + 1
                             )
-                            f2 = cute.filter_zeros(csSFB_phase2)
-                            f4 = cute.filter_zeros(crSFB_phase2)
-                            cute.copy(
-                                smem_copy_SFB,
-                                f2[None, None, k_next],
-                                f4[None, None, k_next],
-                            )
-                        for _mt in range(self.num_m_tiles):
-                            for _nt in range(self.num_n_tiles):
-                                mma_atom.set(
-                                    WarpField.SFA,
-                                    tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                            if k_block_idx == num_k_blocks - 1:
+                                phase2_pipeline.consumer_release(phase2_cons_state)
+                                phase2_cons_state.advance()
+                            if k_next > 0:
+                                cute.copy(
+                                    smem_copy_B,
+                                    csB_phase2[None, None, k_next],
+                                    crB[None, None, k_next],
                                 )
-                                mma_atom.set(
-                                    WarpField.SFB,
-                                    tCrSFB_phase2[None, _nt, k_block_idx].iterator,
+                                f2 = cute.filter_zeros(csSFB_phase2)
+                                f4 = cute.filter_zeros(crSFB_phase2)
+                                cute.copy(
+                                    smem_copy_SFB,
+                                    f2[None, None, k_next],
+                                    f4[None, None, k_next],
                                 )
-                                cute.gemm(
-                                    mma_atom,
-                                    down_acc[None, _mt, _nt],
-                                    tCrA_tile[None, _mt, k_block_idx],
-                                    tCrB[None, _nt, k_block_idx],
-                                    down_acc[None, _mt, _nt],
-                                )
+                            for _mt in range(self.num_m_tiles):
+                                for _nt in range(self.num_n_tiles):
+                                    mma_atom.set(
+                                        WarpField.SFA,
+                                        tCrSFA_tile[None, _mt, k_block_idx].iterator,
+                                    )
+                                    mma_atom.set(
+                                        WarpField.SFB,
+                                        tCrSFB_phase2[None, _nt, k_block_idx].iterator,
+                                    )
+                                    cute.gemm(
+                                        mma_atom,
+                                        down_acc[None, _mt, _nt],
+                                        tCrA_tile[None, _mt, k_block_idx],
+                                        tCrB[None, _nt, k_block_idx],
+                                        down_acc[None, _mt, _nt],
+                                    )
 
                     # Scatter using precomputed metadata (no redundant gmem loads)
                     tile_n_base_cur = output_tile_idx * Int32(self.tile_shape_mnk[1])
@@ -2061,9 +2409,16 @@ class MoEStaticKernel:
                                 for elem_idx in cutlass.range_constexpr(
                                     cute.size(tRS_rD_slice)
                                 ):
-                                    tRS_rD_slice[elem_idx] = (
-                                        down_alpha_value * down_epi_acc_slice[elem_idx]
-                                    )
+                                    tRS_rD_slice[elem_idx] = down_epi_acc_slice[
+                                        elem_idx
+                                    ]
+
+                        # The prior output tile's scatter only needs to finish
+                        # before this tile overwrites sC.  Delay that barrier
+                        # until after the next FC2 GEMM so scatter and GEMM can
+                        # overlap; the final tile is closed by pass_sync below.
+                        if output_tile_idx > 0:
+                            self.epilog_sync_barrier.arrive_and_wait()
 
                         acc_vec = tRS_rD.load()
                         acc_vec = acc_vec.to(cutlass.BFloat16)
@@ -2082,123 +2437,82 @@ class MoEStaticKernel:
                         rows_offset = Int32(epi_m) * Int32(self.epi_tile[0])
 
                         # Per-warp scatter: each warp scatters its own quadrant
-                        # of sC (64 M-rows × 64 N-cols).
+                        # of sC (32 M-rows × 64 N-cols).
                         warp_epi_rows = (
                             valid_rows - tile_m_base - rows_offset - warp_m_base
                         )
-                        if warp_epi_rows > Int32(64):
-                            warp_epi_rows = Int32(64)
+                        if warp_epi_rows > warp_m_span:
+                            warp_epi_rows = warp_m_span
                         if warp_epi_rows < Int32(0):
                             warp_epi_rows = Int32(0)
 
-                        tile_vec_cols = Int32(64) // Int32(8)
-                        vec_idx = lane_id
-                        while vec_idx < warp_epi_rows * tile_vec_cols:
-                            local_row = vec_idx // tile_vec_cols
-                            local_vec_col = vec_idx - local_row * tile_vec_cols
-                            local_col = warp_n_base + local_vec_col * Int32(8)
-                            global_col = tile_n_base_cur + local_col
+                        # One lane owns two adjacent N8 reductions from the
+                        # same row.  The packed helper performs one shared
+                        # ld.v4.u32, BF16x2 scale, and one REDG per N8.
+                        tile_pair_cols = warp_n_span // Int32(16)
+                        pair_idx = lane_id
+                        while pair_idx < warp_epi_rows * tile_pair_cols:
+                            local_row = pair_idx // tile_pair_cols
+                            local_pair_col = pair_idx - local_row * tile_pair_cols
+                            local_col_base = warp_n_base + local_pair_col * Int32(16)
                             cached_row = rows_offset + warp_m_base + local_row
-                            tok = ld_shared_i32_relaxed(
-                                scatter_tok_base_addr + cached_row * Int32(4)
+                            route_idx, wv = load_shared_i32_f32_pair(
+                                scatter_meta_base_addr + cached_row * Int32(8)
                             )
-                            wv = _ld_shared_f32(
-                                scatter_weight_base_addr + cached_row * Int32(4)
-                            )
-                            sc_v0 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col,
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v1 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(1),
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v2 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(2),
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v3 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(3),
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v4 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(4),
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v5 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(5),
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v6 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(6),
-                                    epi_buffer,
-                                ]
-                            )
-                            sc_v7 = cutlass.Float32(
-                                sC[
-                                    warp_m_base + local_row,
-                                    local_col + Int32(7),
-                                    epi_buffer,
-                                ]
-                            )
-                            scatter_add_v4_bf16x2(
-                                get_ptr_as_int64(
-                                    scatter_output, tok * scatter_N + global_col
-                                ),
-                                wv * sc_v0,
-                                wv * sc_v1,
-                                wv * sc_v2,
-                                wv * sc_v3,
-                                wv * sc_v4,
-                                wv * sc_v5,
-                                wv * sc_v6,
-                                wv * sc_v7,
-                            )
-                            vec_idx += Int32(self.num_threads_per_warp)
-
-                        # Post-scatter barrier: needed to ensure all warps
-                        # finish scatter before next output tile's pipeline ops
-                        # (pipeline consumer is collective across all MMA warps).
-                        self.epilog_sync_barrier.arrive_and_wait()
+                            for pair_half in cutlass.range_constexpr(2):
+                                local_col = local_col_base + Int32(pair_half) * Int32(8)
+                                global_col = tile_n_base_cur + local_col
+                                sc_element_offset = Int32(
+                                    sC.layout(
+                                        (
+                                            warp_m_base + local_row,
+                                            local_col,
+                                            epi_buffer,
+                                        )
+                                    )
+                                )
+                                sc_element_offset = sc_element_offset ^ (
+                                    (sc_element_offset & Int32(0x1C0)) >> Int32(3)
+                                )
+                                sc_smem_addr = get_smem_ptr_as_int32(
+                                    sC,
+                                    sc_element_offset,
+                                )
+                                route_partial = intermediate_slice // Int32(2)
+                                store_weighted_bf16x8_route(
+                                    get_ptr_as_int64(
+                                        packed_a_storage,
+                                        route_scratch_base
+                                        + (
+                                            (
+                                                route_idx * retained_group_count
+                                                + route_partial
+                                            )
+                                            * scatter_N
+                                            + global_col
+                                        )
+                                        * Int32(2),
+                                    ),
+                                    sc_smem_addr,
+                                    wv,
+                                    down_alpha_value,
+                                )
+                            pair_idx += Int32(self.num_threads_per_warp)
 
                 # Final pass_sync: protect sA from next task's FC1 loads.
-                # DMA warp waits here too after finishing all B_down loads.
+                # DMA warp waits here too after finishing all B_down loads;
+                # this also closes the final output tile's scatter.
                 self.pass_sync_barrier.arrive_and_wait()
 
                 current_work_linear_idx += num_persistent_clusters
-                tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
-                    _compact_static_get_work_tile(
-                        row_counts,
-                        active_expert_count,
-                        tile_m=Int32(self.tile_shape_mnk[0]),
-                        num_tiles_n=Int32(self.output_tile_count_n),
-                        cluster_shape_mn=cluster_shape_mn,
-                        current_work_linear_idx=current_work_linear_idx,
-                        current_local_expert_idx=current_local_expert_idx,
-                        accum_tile_m=accum_tile_m,
-                        cta_id_in_cluster=cta_id_in_cluster,
-                    )
+                is_valid_tile = _ld_shared_i32(ctrl_base_addr + Int32(8)) != Int32(0)
+                tile_coord = (
+                    _ld_shared_i32(ctrl_base_addr + Int32(12)),
+                    _ld_shared_i32(ctrl_base_addr + Int32(16)),
+                    _ld_shared_i32(ctrl_base_addr + Int32(20)),
                 )
+                current_local_expert_idx = _ld_shared_i32(ctrl_base_addr + Int32(24))
+                accum_tile_m = _ld_shared_i32(ctrl_base_addr + Int32(28))
 
         # ===================================================================
         # DMA WARP (warp 4)
@@ -2219,12 +2533,13 @@ class MoEStaticKernel:
             current_work_linear_idx = Int32(bidz)
             current_local_expert_idx = Int32(0)
             accum_tile_m = Int32(0)
+            published_work_linear_idx = Int32(bidz)
             tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
-                _compact_static_get_work_tile(
+                _compact_static_get_single_m_tile_work(
                     row_counts,
                     active_expert_count,
                     tile_m=Int32(self.tile_shape_mnk[0]),
-                    num_tiles_n=Int32(self.output_tile_count_n),
+                    num_tiles_n=Int32((self.output_tile_count_n + 1) // 2),
                     cluster_shape_mn=cluster_shape_mn,
                     current_work_linear_idx=current_work_linear_idx,
                     current_local_expert_idx=current_local_expert_idx,
@@ -2235,101 +2550,73 @@ class MoEStaticKernel:
 
             while is_valid_tile:
                 tc = tile_coord
-                intermediate_slice = tc[1]
+                intermediate_slice = tc[1] * Int32(2)
                 local_expert_idx = tc[2]
                 weight_expert_idx = weight_expert_ids[local_expert_idx]
 
-                sa_tile_coord_m = tc[0] // self.sa_tiles_per_block
-                tAgA_mk = tAgA[(None, sa_tile_coord_m, None, local_expert_idx)]
-                sfa_tile_coord_m = tc[0] // self.sfa_tiles_per_block
-                tAgSFA_mk = tAgSFA[(None, sfa_tile_coord_m, None, local_expert_idx)]
-
-                # FC1 producer slice. Gated activation packs [up, gate] along N;
-                # relu2 uses a single FC1 pass over intermediate_slice.
-                tBgB_w13_up_nk = tBgB_w13[
-                    (None, intermediate_slice, None, weight_expert_idx)
-                ]
-                sfb_up_tile_coord = intermediate_slice // self.sfb_tiles_per_block
-                tBgSFB_w13_up_nk = tBgSFB_w13[
-                    (None, sfb_up_tile_coord, None, weight_expert_idx)
-                ]
-                gate_slice = (
-                    intermediate_slice + gate_tile_cnt
-                    if self.is_gated
-                    else intermediate_slice
-                )
-                tBgB_w13_gate_nk = tBgB_w13[(None, gate_slice, None, weight_expert_idx)]
-                sfb_gate_tile_coord = gate_slice // self.sfb_tiles_per_block
-                tBgSFB_w13_gate_nk = tBgSFB_w13[
-                    (None, sfb_gate_tile_coord, None, weight_expert_idx)
-                ]
-
-                # ---- FC1 gate pass ----
-                prod_state.reset_count()
-                for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
-                    ml_pipeline.producer_acquire(prod_state)
-                    cute.copy(
-                        tma_a,
-                        tAgA_mk[(None, k_tile)],
-                        tAsA[(None, prod_state.index)],
-                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
+                # Publish two adjacent N128 FC1 slices through the same paired
+                # Gate/Up pipeline.  Consumer releases make Stage0/1 reusable;
+                # no extra shared storage is needed.
+                for retained_slice_idx in cutlass.range_constexpr(2):
+                    current_slice = intermediate_slice + Int32(retained_slice_idx)
+                    tBgB_w13_up_nk = tBgB_w13[
+                        (None, current_slice, None, weight_expert_idx)
+                    ]
+                    sfb_up_tile_coord = current_slice // self.sfb_tiles_per_block
+                    tBgSFB_w13_up_nk = tBgSFB_w13[
+                        (None, sfb_up_tile_coord, None, weight_expert_idx)
+                    ]
+                    gate_slice = (
+                        current_slice + gate_tile_cnt
+                        if self.is_gated
+                        else current_slice
                     )
-                    cute.copy(
-                        tma_b_w13,
-                        tBgB_w13_gate_nk[(None, k_tile)],
-                        tBsB_w13[(None, prod_state.index)],
-                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
-                    )
-                    cute.copy(
-                        tma_sfa,
-                        tAgSFA_mk[(None, k_tile)],
-                        tAsSFA[(None, prod_state.index)],
-                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
-                    )
-                    cute.copy(
-                        tma_sfb_w13,
-                        tBgSFB_w13_gate_nk[(None, k_tile)],
-                        tBsSFB_w13[(None, prod_state.index)],
-                        tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
-                    )
-                    ml_pipeline.producer_commit(prod_state)
-                    prod_state.advance()
+                    tBgB_w13_gate_nk = tBgB_w13[
+                        (None, gate_slice, None, weight_expert_idx)
+                    ]
+                    sfb_gate_tile_coord = gate_slice // self.sfb_tiles_per_block
+                    tBgSFB_w13_gate_nk = tBgSFB_w13[
+                        (None, sfb_gate_tile_coord, None, weight_expert_idx)
+                    ]
 
-                # Wait for the MMA warps to finish the FC1 gate/only pass
-                # before reusing the gate staging buffers.
-                self.pass_sync_barrier.arrive_and_wait()
-
-                if cutlass.const_expr(self.is_gated):
-                    # ---- FC1 up pass ----
-                    up_prod_state.reset_count()
+                    prod_state.reset_count()
                     for k_tile in range(0, fc1_k_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
-                        up_pipeline.producer_acquire(up_prod_state)
-                        cute.copy(
-                            tma_a,
-                            tAgA_mk[(None, k_tile)],
-                            tAsA[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
+                        ml_pipeline.producer_acquire(prod_state)
                         cute.copy(
                             tma_b_w13,
-                            tBgB_w13_up_nk[(None, k_tile)],
-                            tBsB_w13_up[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
-                        )
-                        cute.copy(
-                            tma_sfa,
-                            tAgSFA_mk[(None, k_tile)],
-                            tAsSFA[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                            tBgB_w13_gate_nk[(None, k_tile)],
+                            tBsB_w13[(None, prod_state.index)],
+                            tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
                         )
                         cute.copy(
                             tma_sfb_w13,
-                            tBgSFB_w13_up_nk[(None, k_tile)],
-                            tBsSFB_w13_up[(None, up_prod_state.index)],
-                            tma_bar_ptr=up_pipeline.producer_get_barrier(up_prod_state),
+                            tBgSFB_w13_gate_nk[(None, k_tile)],
+                            tBsSFB_w13[(None, prod_state.index)],
+                            tma_bar_ptr=ml_pipeline.producer_get_barrier(prod_state),
                         )
-                        up_pipeline.producer_commit(up_prod_state)
-                        up_prod_state.advance()
+                        if cutlass.const_expr(self.is_gated):
+                            cute.copy(
+                                tma_b_w13,
+                                tBgB_w13_up_nk[(None, k_tile)],
+                                tBsB_w13_up[(None, prod_state.index)],
+                                tma_bar_ptr=ml_pipeline.producer_get_barrier(
+                                    prod_state
+                                ),
+                            )
+                            cute.copy(
+                                tma_sfb_w13,
+                                tBgSFB_w13_up_nk[(None, k_tile)],
+                                tBsSFB_w13_up[(None, prod_state.index)],
+                                tma_bar_ptr=ml_pipeline.producer_get_barrier(
+                                    prod_state
+                                ),
+                            )
+                        ml_pipeline.producer_commit(prod_state)
+                        prod_state.advance()
+
+                # FC2 reuses gate B/SFB storage, so wait until both branch MMA
+                # streams have drained the paired transaction.
+                self.pass_sync_barrier.arrive_and_wait()
 
                 # ---- FC2 B_down loads: continuous pipeline ----
                 # No barrier needed: sB/sSFB are free (gate done, up uses
@@ -2340,64 +2627,230 @@ class MoEStaticKernel:
                 # the gate staging buffers.
                 phase2_prod_state.reset_count()
                 for output_tile_idx in range(0, output_tile_cnt, 1, unroll=4):  # type: ignore[call-overload]
-                    phase2_pipeline.producer_acquire(phase2_prod_state)
-                    cute.copy(
-                        tma_b_down,
-                        tBgB_down[
-                            (
-                                None,
-                                output_tile_idx,
-                                intermediate_slice,
-                                weight_expert_idx,
-                            )
-                        ],
-                        tBsB_down[(None, phase2_prod_state.index)],
-                        tma_bar_ptr=phase2_pipeline.producer_get_barrier(
-                            phase2_prod_state
-                        ),
+                    for retained_slice_idx in cutlass.range_constexpr(2):
+                        current_slice = intermediate_slice + Int32(retained_slice_idx)
+                        phase2_pipeline.producer_acquire(phase2_prod_state)
+                        cute.copy(
+                            tma_b_down,
+                            tBgB_down[
+                                (
+                                    None,
+                                    output_tile_idx,
+                                    current_slice,
+                                    weight_expert_idx,
+                                )
+                            ],
+                            tBsB_down[(None, phase2_prod_state.index)],
+                            tma_bar_ptr=phase2_pipeline.producer_get_barrier(
+                                phase2_prod_state
+                            ),
+                        )
+                        cute.copy(
+                            tma_sfb_down,
+                            tBgSFB_down[
+                                (
+                                    None,
+                                    output_tile_idx // self.sfb_tiles_per_block,
+                                    current_slice,
+                                    weight_expert_idx,
+                                )
+                            ],
+                            tBsSFB_down[(None, phase2_prod_state.index)],
+                            tma_bar_ptr=phase2_pipeline.producer_get_barrier(
+                                phase2_prod_state
+                            ),
+                        )
+                        phase2_pipeline.producer_commit(phase2_prod_state)
+                        phase2_prod_state.advance()
+
+                if Int32(tidx) == Int32(self.tma_load_warp_id * 32):
+                    # Hybrid schedule: wave 2 is still statically strided,
+                    # every later task is claimed atomically. Work stealing
+                    # erases the tail's wave quantization and intra-wave
+                    # variance; claim order is nondeterministic but tasks
+                    # write disjoint route scratch and the finalize sums in
+                    # fixed token order, so output stays bitwise
+                    # deterministic.
+                    next_work_linear_idx = Int32(0)
+                    if published_work_linear_idx < num_persistent_clusters:
+                        next_work_linear_idx = (
+                            published_work_linear_idx + num_persistent_clusters
+                        )
+                    else:
+                        next_work_linear_idx = atomic_add_global_i32(
+                            get_ptr_as_int64(virt_route_scratch, claim_slot),
+                            Int32(1),
+                        )
+                    published_work_linear_idx = next_work_linear_idx
+                    (
+                        next_tile_coord,
+                        next_is_valid_tile,
+                        next_local_expert_idx,
+                        next_accum_tile_m,
+                    ) = _compact_static_get_single_m_tile_work(
+                        row_counts,
+                        active_expert_count,
+                        tile_m=Int32(self.tile_shape_mnk[0]),
+                        num_tiles_n=Int32((self.output_tile_count_n + 1) // 2),
+                        cluster_shape_mn=cluster_shape_mn,
+                        current_work_linear_idx=next_work_linear_idx,
+                        current_local_expert_idx=current_local_expert_idx,
+                        accum_tile_m=accum_tile_m,
+                        cta_id_in_cluster=cta_id_in_cluster,
                     )
-                    cute.copy(
-                        tma_sfb_down,
-                        tBgSFB_down[
-                            (
-                                None,
-                                output_tile_idx // self.sfb_tiles_per_block,
-                                intermediate_slice,
-                                weight_expert_idx,
-                            )
-                        ],
-                        tBsSFB_down[(None, phase2_prod_state.index)],
-                        tma_bar_ptr=phase2_pipeline.producer_get_barrier(
-                            phase2_prod_state
-                        ),
+                    _st_shared_i32(ctrl_base_addr + Int32(8), Int32(next_is_valid_tile))
+                    _st_shared_i32(
+                        ctrl_base_addr + Int32(12), Int32(next_tile_coord[0])
                     )
-                    phase2_pipeline.producer_commit(phase2_prod_state)
-                    phase2_prod_state.advance()
+                    _st_shared_i32(
+                        ctrl_base_addr + Int32(16), Int32(next_tile_coord[1])
+                    )
+                    _st_shared_i32(
+                        ctrl_base_addr + Int32(20), Int32(next_tile_coord[2])
+                    )
+                    _st_shared_i32(ctrl_base_addr + Int32(24), next_local_expert_idx)
+                    _st_shared_i32(ctrl_base_addr + Int32(28), next_accum_tile_m)
 
                 # Final pass_sync: match MMA warps' barrier after FC2 sweep.
                 # Ensures MMA warps finish scatter before DMA starts next task's FC1.
                 self.pass_sync_barrier.arrive_and_wait()
 
                 current_work_linear_idx += num_persistent_clusters
-                tile_coord, is_valid_tile, current_local_expert_idx, accum_tile_m = (
-                    _compact_static_get_work_tile(
-                        row_counts,
-                        active_expert_count,
-                        tile_m=Int32(self.tile_shape_mnk[0]),
-                        num_tiles_n=Int32(self.output_tile_count_n),
-                        cluster_shape_mn=cluster_shape_mn,
-                        current_work_linear_idx=current_work_linear_idx,
-                        current_local_expert_idx=current_local_expert_idx,
-                        accum_tile_m=accum_tile_m,
-                        cta_id_in_cluster=cta_id_in_cluster,
-                    )
+                is_valid_tile = _ld_shared_i32(ctrl_base_addr + Int32(8)) != Int32(0)
+                tile_coord = (
+                    _ld_shared_i32(ctrl_base_addr + Int32(12)),
+                    _ld_shared_i32(ctrl_base_addr + Int32(16)),
+                    _ld_shared_i32(ctrl_base_addr + Int32(20)),
                 )
+                current_local_expert_idx = _ld_shared_i32(ctrl_base_addr + Int32(24))
+                accum_tile_m = _ld_shared_i32(ctrl_base_addr + Int32(28))
 
             ml_pipeline.producer_tail(prod_state)
-            if cutlass.const_expr(self.is_gated):
-                up_pipeline.producer_tail(up_prod_state)
             phase2_pipeline.producer_tail(phase2_prod_state)
+
+        # Route-private stores are complete when this cooperative launch
+        # retires.  The stream-ordered finalize kernel performs the reduction.
         return
+
+    @cute.kernel
+    def finalize_kernel(
+        self,
+        packed_a_storage: cute.Tensor,
+        scatter_output: cute.Tensor,
+        topk_ids: cute.Tensor,
+        retained_group_count: cutlass.Constexpr,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        _, _, bidz = cute.arch.block_idx()
+        _, _, gdim_z = cute.arch.grid_dim()
+        flat_tid = Int32(bidz) * Int32(256) + Int32(tidx)
+        flat_stride = Int32(gdim_z) * Int32(256)
+
+        num_tokens = Int32(scatter_output.shape[0])
+        cols = Int32(scatter_output.shape[1])
+        total_pairs = Int32(topk_ids.shape[0])
+        num_topk = total_pairs // num_tokens
+        route_scratch_bytes = (
+            total_pairs * Int32(retained_group_count) * cols * Int32(2)
+        )
+        route_scratch_base = Int32(packed_a_storage.shape[0]) - route_scratch_bytes
+
+        vecs_per_token = cols // Int32(8)
+        final_vec_count = num_tokens * vecs_per_token
+        final_vec_idx = flat_tid
+        while final_vec_idx < final_vec_count:
+            final_token = final_vec_idx // vecs_per_token
+            final_col = (final_vec_idx - final_token * vecs_per_token) * Int32(8)
+            final_acc = cute.make_rmem_tensor((8,), cutlass.Float32)
+            final_acc.fill(0.0)
+            final_slot = Int32(0)
+            while final_slot < num_topk:
+                final_route = final_token * num_topk + final_slot
+                final_partial = Int32(0)
+                while final_partial < Int32(retained_group_count):
+                    route_values = load_global_bf16x8_to_f32x8(
+                        get_ptr_as_int64(
+                            packed_a_storage,
+                            route_scratch_base
+                            + (
+                                (
+                                    final_route * Int32(retained_group_count)
+                                    + final_partial
+                                )
+                                * cols
+                                + final_col
+                            )
+                            * Int32(2),
+                        )
+                    )
+                    for final_elem in cutlass.range_constexpr(8):
+                        final_acc[final_elem] += route_values[final_elem]
+                    final_partial += Int32(1)
+                final_slot += Int32(1)
+            store_global_f32x8_as_bf16(
+                get_ptr_as_int64(
+                    scatter_output,
+                    final_token * cols + final_col,
+                ),
+                final_acc[0],
+                final_acc[1],
+                final_acc[2],
+                final_acc[3],
+                final_acc[4],
+                final_acc[5],
+                final_acc[6],
+                final_acc[7],
+            )
+            final_vec_idx += flat_stride
+        return
+
+
+@cute.jit
+def _compact_static_get_work_tile(
+    row_counts: cute.Tensor,
+    active_expert_count: cute.Tensor,
+    *,
+    tile_m: Int32,
+    num_tiles_n: Int32,
+    cluster_shape_mn: Tuple[Int32, Int32],
+    current_work_linear_idx: Int32,
+    current_local_expert_idx: Int32,
+    accum_tile_m: Int32,
+    cta_id_in_cluster: cute.Coord,
+) -> Tuple[Tuple[Int32, Int32, Int32], Integer, Int32, Int32]:
+    num_active_experts = active_expert_count[Int32(0)]
+    scan_local_expert_idx = current_local_expert_idx
+    tile_m_minus_one = tile_m - Int32(1)
+
+    while scan_local_expert_idx < num_active_experts:
+        batch_rows = row_counts[scan_local_expert_idx]
+        batch_m_tiles = (batch_rows + tile_m_minus_one) // tile_m
+        if (accum_tile_m + batch_m_tiles) * num_tiles_n > current_work_linear_idx:
+            current_local_expert_idx = scan_local_expert_idx
+            scan_local_expert_idx = num_active_experts
+        else:
+            accum_tile_m += batch_m_tiles
+            scan_local_expert_idx += Int32(1)
+            current_local_expert_idx = scan_local_expert_idx
+
+    is_valid = current_local_expert_idx < num_active_experts
+    if is_valid:
+        batch_rows = row_counts[current_local_expert_idx]
+        is_valid = (
+            accum_tile_m + (batch_rows + tile_m_minus_one) // tile_m
+        ) * num_tiles_n > current_work_linear_idx
+
+    cur_cluster_coord = (
+        current_work_linear_idx // num_tiles_n - accum_tile_m,
+        current_work_linear_idx % num_tiles_n,
+        current_local_expert_idx,
+    )
+    cur_tile_coord = (
+        Int32(cur_cluster_coord[0]) * cluster_shape_mn[0] + cta_id_in_cluster[0],
+        Int32(cur_cluster_coord[1]) * cluster_shape_mn[1] + cta_id_in_cluster[1],
+        Int32(cur_cluster_coord[2]),
+    )
+    return cur_tile_coord, is_valid, current_local_expert_idx, accum_tile_m
 
 
 __all__ = ["MoEStaticKernel"]

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -305,6 +305,139 @@ def test_sm120_backend_cutovers_are_precision_specific(monkeypatch):
 
 
 @cute_dsl_available
+def test_static_workspace_uses_disjoint_route_output_scratch():
+    """Route partials must never alias live packed activations."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    workspace = moe_dispatch.allocate_sm120_static_workspace(
+        state_E=8,
+        weight_E=8,
+        max_rows=256,
+        k=1536,
+        n=768,
+        num_topk=2,
+        device=torch.device("cpu"),
+        quant_mode="nvfp4",
+    )
+
+    assert workspace.route_output_scratch.shape == (256, 3, 1536)
+    packed_begin = workspace.packed_input.data_ptr()
+    packed_end = packed_begin + workspace.packed_input.nbytes
+    route_begin = workspace.route_output_scratch.data_ptr()
+    route_end = route_begin + workspace.route_output_scratch.nbytes
+    assert max(packed_begin, route_begin) >= min(packed_end, route_end)
+
+
+@cute_dsl_available
+def test_static_workspace_pads_odd_retained_group_geometry():
+    """Five N128 slices are padded to six before retained2 scheduling."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    workspace = moe_dispatch.allocate_sm120_static_workspace(
+        state_E=2,
+        weight_E=2,
+        max_rows=8,
+        k=256,
+        n=640,
+        num_topk=2,
+        device=torch.device("cpu"),
+        quant_mode="nvfp4",
+    )
+
+    assert workspace.n == 768
+    assert workspace.route_output_scratch.shape == (8, 3, 256)
+
+
+@cute_dsl_available
+def test_dynamic_workspace_keeps_native_n128_geometry():
+    """Static retained-group padding must not leak into dynamic geometry."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    workspace = moe_dispatch.allocate_sm120_dynamic_workspace(
+        state_E=2,
+        weight_E=2,
+        routed_rows=2048,
+        k=256,
+        n=640,
+        num_topk=2,
+        device=torch.device("cpu"),
+        quant_mode="nvfp4",
+    )
+
+    assert workspace.n == 640
+
+
+@cute_dsl_available
+def test_static_workspace_rejects_undersized_shared_capacity():
+    """A legacy 640-row workspace cannot serve the widened 1024-row band."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    workspace = moe_dispatch.allocate_sm120_static_workspace(
+        state_E=8,
+        weight_E=8,
+        max_rows=640,
+        k=256,
+        n=256,
+        num_topk=8,
+        device=torch.device("cpu"),
+        quant_mode="nvfp4",
+    )
+
+    with pytest.raises(ValueError, match="capacity is too small"):
+        moe_dispatch._validate_static_workspace_for_launch(
+            workspace,
+            state_E=8,
+            weight_E=8,
+            routed_rows=1024,
+            k=256,
+            n=256,
+            num_topk=8,
+            device=torch.device("cpu"),
+            activation_precision="fp4",
+            quant_mode="nvfp4",
+        )
+
+
+@cute_dsl_available
+def test_static_workspace_rejects_wrong_type_and_geometry():
+    """Injected workspaces must match the selected static ABI exactly."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    validation_args = dict(
+        state_E=8,
+        weight_E=8,
+        routed_rows=256,
+        k=256,
+        n=256,
+        num_topk=8,
+        device=torch.device("cpu"),
+        activation_precision="fp4",
+        quant_mode="nvfp4",
+    )
+    with pytest.raises(ValueError, match="must be Sm120StaticMoEWorkspace"):
+        moe_dispatch._validate_static_workspace_for_launch(object(), **validation_args)
+
+    workspace = moe_dispatch.allocate_sm120_static_workspace(
+        state_E=8,
+        weight_E=8,
+        max_rows=256,
+        k=256,
+        n=256,
+        num_topk=8,
+        device=torch.device("cpu"),
+        quant_mode="nvfp4",
+    )
+    with pytest.raises(ValueError, match="workspace n mismatch"):
+        moe_dispatch._validate_static_workspace_for_launch(
+            workspace, **{**validation_args, "n": 512}
+        )
+
+    workspace.token_map = workspace.token_map[:, :-1]
+    with pytest.raises(ValueError, match="workspace token_map mismatch"):
+        moe_dispatch._validate_static_workspace_for_launch(workspace, **validation_args)
+
+
+@cute_dsl_available
 def test_w4a16_static_cutover_env_override_is_precision_scoped(monkeypatch):
     from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
 
@@ -1202,6 +1335,10 @@ class TestB12xFunctional:
             num_local_experts=num_experts,
             top_k=top_k,
         )
+        if num_tokens == 128:
+            # Reproduce the route distribution that used to overlap packed-A.
+            tensors["token_selected_experts"][:, 0].fill_(0)
+            tensors["token_selected_experts"][:, 1].fill_(1)
         result = b12x_fused_moe(
             x=tensors["x_bf16"],
             w1_weight=tensors["w1_weight"],
@@ -1241,13 +1378,15 @@ class TestB12xFunctional:
     @pytest.mark.parametrize(
         "activation", ["silu", "gelu_tanh", "swigluoai_uninterleave"]
     )
-    @pytest.mark.parametrize("num_tokens", [8, 128])
-    def test_intermediate_not_128_aligned(self, activation: str, num_tokens: int):
-        """NVFP4 transparently pads non-128-aligned intermediate sizes (e.g.
-        Gemma-4's 704) up to a tile multiple; result matches the unpadded ref."""
+    @pytest.mark.parametrize("intermediate_size", [640, 704])
+    @pytest.mark.parametrize("num_tokens", [8, 128, 2048])
+    def test_intermediate_padding_matches_selected_backend(
+        self, activation: str, intermediate_size: int, num_tokens: int
+    ):
+        """Odd N128 counts stay correct across static and dynamic dispatch."""
         from flashinfer import b12x_fused_moe
 
-        hidden_size, intermediate_size = 512, 704  # 704 = 128 * 5.5
+        hidden_size = 512
         num_experts, top_k = 8, 2
         swiglu_limit = 7.0 if activation == "swigluoai_uninterleave" else None
         tensors = create_moe_tensors(

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -258,9 +258,11 @@ def test_sm120_backend_cutovers_are_precision_specific(monkeypatch):
     _clear_static_cutover_env(monkeypatch)
     moe_dispatch._STATIC_COMPACT_CUTOVER_PAIRS_CACHE.clear()
     try:
+        # NVFP4's retained static implementation owns a wider band (1024
+        # routed pairs) than MXFP4's generic implementation (640 pairs).
         assert (
             moe_dispatch.select_sm120_moe_backend(
-                num_tokens=80,
+                num_tokens=128,
                 num_topk=8,
                 activation_precision="fp4",
             )
@@ -268,9 +270,17 @@ def test_sm120_backend_cutovers_are_precision_specific(monkeypatch):
         )
         assert (
             moe_dispatch.select_sm120_moe_backend(
-                num_tokens=81,
+                num_tokens=129,
                 num_topk=8,
                 activation_precision="fp4",
+            )
+            == "dynamic"
+        )
+        assert (
+            moe_dispatch.select_sm120_moe_backend(
+                num_tokens=81,
+                num_topk=8,
+                quant_mode="mxfp4",
             )
             == "dynamic"
         )
@@ -3135,7 +3145,7 @@ def _make_cpu_wrapper(monkeypatch, use_cuda_graph=True, **shared):
         hidden_size=256,
         intermediate_size=128,
         use_cuda_graph=use_cuda_graph,
-        max_num_tokens=1024,  # crosses the static/dynamic cutover
+        max_num_tokens=2048,  # crosses the NVFP4 static/dynamic cutover (1024)
         device="cpu",
         **shared,
     )
@@ -3217,7 +3227,7 @@ def test_wrapper_shared_buffers_require_cuda_graph(monkeypatch):
     monkeypatch.setattr(
         moe_dispatch, "allocate_sm120_moe_workspace", lambda **kw: object()
     )
-    output = torch.zeros((1024, 256), dtype=torch.bfloat16)
+    output = torch.zeros((2048, 256), dtype=torch.bfloat16)
     with pytest.raises(ValueError, match="use_cuda_graph"):
         _make_cpu_wrapper(monkeypatch, use_cuda_graph=False, shared_output=output)
 

--- a/tests/moe/test_b12x_fused_moe.py
+++ b/tests/moe/test_b12x_fused_moe.py
@@ -438,6 +438,124 @@ def test_static_workspace_rejects_wrong_type_and_geometry():
 
 
 @cute_dsl_available
+@pytest.mark.parametrize(
+    "field",
+    [
+        "barrier_count",
+        "barrier_epoch",
+        "active_expert_count",
+        "weight_expert_ids",
+        "global_to_local_expert",
+        "compact_topk_ids",
+        "virt_route_scratch",
+        "packed_a_view",
+        "packed_a_flat",
+        "scale_flat",
+        "dm_barrier_count",
+        "dm_barrier_epoch",
+        "dm_intermediate",
+        "dm_input_gs",
+        "dm_down_input_scale",
+    ],
+)
+def test_static_workspace_rejects_incomplete_kernel_tensor_contract(field):
+    """Every fixed-shape tensor consumed by a reachable static path is checked."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    validation_args = dict(
+        state_E=8,
+        weight_E=8,
+        routed_rows=256,
+        k=1536,
+        n=768,
+        num_topk=2,
+        device=torch.device("cpu"),
+        activation_precision="fp4",
+        quant_mode="nvfp4",
+    )
+    workspace = moe_dispatch.allocate_sm120_static_workspace(
+        state_E=8,
+        weight_E=8,
+        max_rows=256,
+        k=1536,
+        n=768,
+        num_topk=2,
+        device=torch.device("cpu"),
+        quant_mode="nvfp4",
+    )
+    value = getattr(workspace, field)
+    assert isinstance(value, torch.Tensor)
+    setattr(workspace, field, value.reshape(-1)[:-1])
+    with pytest.raises(ValueError, match=rf"workspace {field} mismatch"):
+        moe_dispatch._validate_static_workspace_for_launch(workspace, **validation_args)
+
+
+@cute_dsl_available
+def test_static_workspace_rejects_broken_derived_view_aliases():
+    """Shape-compatible replacement views may not point at unrelated storage."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    validation_args = dict(
+        state_E=8,
+        weight_E=8,
+        routed_rows=256,
+        k=256,
+        n=256,
+        num_topk=8,
+        device=torch.device("cpu"),
+        activation_precision="fp4",
+        quant_mode="nvfp4",
+    )
+    for field in ("packed_a_view", "packed_a_flat", "scale_flat"):
+        workspace = moe_dispatch.allocate_sm120_static_workspace(
+            state_E=8,
+            weight_E=8,
+            max_rows=256,
+            k=256,
+            n=256,
+            num_topk=8,
+            device=torch.device("cpu"),
+            quant_mode="nvfp4",
+        )
+        setattr(workspace, field, torch.empty_like(getattr(workspace, field)))
+        with pytest.raises(ValueError, match=rf"{field} must alias"):
+            moe_dispatch._validate_static_workspace_for_launch(
+                workspace, **validation_args
+            )
+
+
+@cute_dsl_available
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is required")
+def test_static_workspace_accepts_equivalent_cuda_device_forms():
+    """An index-less CUDA allocation matches its resolved current device."""
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
+
+    current_device = torch.cuda.current_device()
+    workspace = moe_dispatch.allocate_sm120_static_workspace(
+        state_E=8,
+        weight_E=8,
+        max_rows=256,
+        k=256,
+        n=256,
+        num_topk=8,
+        device=torch.device("cuda"),
+        quant_mode="nvfp4",
+    )
+    moe_dispatch._validate_static_workspace_for_launch(
+        workspace,
+        state_E=8,
+        weight_E=8,
+        routed_rows=256,
+        k=256,
+        n=256,
+        num_topk=8,
+        device=torch.device("cuda", current_device),
+        activation_precision="fp4",
+        quant_mode="nvfp4",
+    )
+
+
+@cute_dsl_available
 def test_w4a16_static_cutover_env_override_is_precision_scoped(monkeypatch):
     from flashinfer.fused_moe.cute_dsl.blackwell_sm12x import moe_dispatch
 


### PR DESCRIPTION
Optimize the SM12x static MoE path while keeping NVFP4 and MXFP4 in one
`MoEStaticKernel` implementation.

## What changed

- Fold the retained NVFP4 schedule into the existing `MoEStaticKernel`; no
  separate retained-kernel class or source file remains.
- Split oversized routed experts into 32-row virtual tasks, so skewed experts
  remain within the tile's computed M extent.
- Retain two FC1 N-slices per scheduled work group and use the compact
  O(1)-claim scheduler.
- Retune the static tile/MAC ladder and extend the default NVFP4 static cutover
  from 640 to 1024 routed rows (`M <= 128` for top-k 8).
- Keep MXFP4 on the same unified class with its original 640-row cutover.
- Update workspace sizing, compile/launch ABI, source tracking, and dispatch
  tests for the unified kernel.

The branch is rebased on current `origin/main`. Upstream #4603 now provides the
shared B12x workspace support that was previously a separate commit in this PR,
so this update deliberately drops that redundant commit. The PR is now one
commit touching four files.

## Why

The former static schedule could assign more rows from a skewed expert than a
tile64/tile128 launch computed, and it repeated scheduling/staging work across
the two FC1 N-slices. Virtual 32-row tasks bound each physical work item while
the retained schedule reuses pipeline state across both slices.

## Correctness

Validated source-exact against the upstream measurement base. The branch is
now rebased on the current upstream head; the intervening upstream commits do
not modify any of this PR's four changed files.

- Measurement upstream base: `083012d6819cf97128e559616b12acb666f2fffe`
- Current upstream base: `3bbfeba6218b6de32d1e894243c010c8d3aacb21`
- PR head: `e184523e35f59144132d750e085243d409a16cf4`
- Local SM120 GPU: `GPU-1c189c11-e797-a795-cefd-495b190afebc`
- Shape: Qwen3.5-35B TP1, `E=256`, `H=2048`, `I=512`, `topk=8`
- Routes: three exact-marginal Zipf-0.75 samples
- M: 32, 64, 96, 128, 256, 512
- Candidate repeats: three per `(M, route)`

Result: **18/18 cases passed**.

| Metric | Result |
|---|---:|
| Maximum relative L2 | 0.00791765 |
| Minimum cosine similarity | 0.99996866 |
| Maximum zero rows | 0 |
| Static candidate repeats | Bitwise equal |

The baseline dispatches M=96/128 to dynamic while this PR intentionally
dispatches them to static; those cross-backend cases are included in the 18/18.

MXFP4 targeted GPU tests also passed:

- static functional accuracy
- intermediate-size padding accuracy
- wrapper CUDA Graph accuracy

## Performance

Protocol: local SM120, A-B-B-A order, fresh cache per arm, exact-marginal
100-route replay, CUDA Graph event timing, 192 MiB L2 flush, and
warmup/iterations/repeats = 5/50/7. No kernel-selection override was used.

| M | Upstream main (us) | This PR (us) | Latency reduction | Dispatch |
|---:|---:|---:|---:|---|
| 1 | 28.408 | 28.548 | -0.49% | direct_micro → direct_micro |
| 2 | 43.077 | 43.103 | -0.06% | direct_micro → direct_micro |
| 4 | 79.381 | 78.937 | 0.56% | static → static |
| 8 | 111.938 | 95.736 | 14.47% | static → static |
| 16 | 176.482 | 150.483 | 14.73% | static → static |
| 24 | 245.054 | 204.748 | 16.45% | static → static |
| 32 | 289.707 | 228.786 | 21.03% | static → static |
| 48 | 339.848 | 281.051 | 17.30% | static → static |
| 64 | 383.466 | 325.493 | 15.12% | static → static |
| 96 | 394.043 | 377.587 | 4.18% | dynamic → static |
| 128 | 450.756 | 415.284 | 7.87% | dynamic → static |
| 256 | 464.900 | 465.468 | -0.12% | dynamic → dynamic |
| 512 | 463.755 | 465.730 | -0.43% | dynamic → dynamic |
| 1024 | 481.790 | 483.247 | -0.30% | dynamic → dynamic |
| 1536 | 538.665 | 539.207 | -0.10% | dynamic → dynamic |
| 2048 | 549.935 | 550.471 | -0.10% | dynamic → dynamic |
| 3072 | 599.754 | 597.256 | 0.42% | dynamic → dynamic |
| 4096 | 640.822 | 639.772 | 0.16% | dynamic → dynamic |
| 5120 | 694.750 | 693.507 | 0.18% | dynamic → dynamic |
| 6144 | 790.377 | 788.815 | 0.20% | dynamic → dynamic |
| 7168 | 935.373 | 937.726 | -0.25% | dynamic → dynamic |
| 8192 | 968.798 | 967.644 | 0.12% | dynamic → dynamic |

- Static-band geometric-mean latency reduction: **12.63%**
- M=32–128 geometric-mean latency reduction: **13.32%**
- Full 22-point geometric-mean latency reduction: **5.34%**
- Maximum upstream A-arm drift: **0.37%**
- Maximum PR B-arm drift: **0.21%**

Dynamic-only points are non-regression controls; differences there are within
the predeclared 1% maintenance threshold.

## Tests

```text
pytest tests/moe/test_b12x_fused_moe.py -k 'cutover or share_cached_workspace'
2 passed, 192 deselected

pytest \
  tests/moe/test_b12x_fused_moe.py::TestB12xFunctional::test_mxfp4_static_functional_accuracy \
  tests/moe/test_b12x_fused_moe.py::TestB12xFunctional::test_mxfp4_intermediate_padding_accuracy \
  tests/moe/test_b12x_fused_moe.py::TestB12xWrapper::test_mxfp4_wrapper_cuda_graph_accuracy
3 passed

pre-commit run --files <four changed files>
all hooks passed
```

## Relationship to #4329

#4329 optimized the gated dynamic NVFP4 path. This PR targets the complementary
small-token static path and leaves that merged dynamic implementation unchanged.

## Reviewer notes

Please pay particular attention to virtual-task allocation/publication ordering,
workspace sizing, the shared NVFP4/MXFP4 ABI, and the quant-mode-specific 1024
vs 640 routed-row cutover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reuse externally provided workspaces and output buffers during CUDA graph execution.
  * Improved NVFP4 performance and static execution support for larger workloads.
  * Maintained optimized MXFP4 execution selection across supported workload sizes.

* **Bug Fixes**
  * Improved workspace sizing, routing, and buffer handling for expanded workloads.
  * Added validation for incompatible shared buffers, output shapes, data types, devices, capacities, and execution modes.
  * Expanded regression coverage for buffer reuse, backend selection, and static/dynamic execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
