### PR TITLE
feat(mla): support variable-Q decode with DCP in CuTeDSL

### DIFF
--- a/flashinfer/cute_dsl/attention/mla_dispatch.py
+++ b/flashinfer/cute_dsl/attention/mla_dispatch.py
@@ -10,7 +10,8 @@ controlled by the ``cute_dsl_impl`` kwarg, with three valid values:
 * ``"auto"`` (default) — library picks the right implementation.
   Monolithic by default, automatically promoted to modular when the call
   uses a feature monolithic doesn't support (currently: ``sinks``).
-  Compact variable Q and DCP select the monolithic implementation.
+  Compact variable Q, DCP, and their combination select the monolithic
+  implementation.
 * ``"modular"`` — strict.  Always run the modular implementation; reject
   monolithic-only features such as compact variable Q and DCP.
 * ``"monolithic"`` — strict.  Always run the monolithic implementation;
@@ -140,9 +141,6 @@ def _resolve_impl(*, requested: str, kwargs: dict) -> str:
             "monolithic CuTeDSL MLA implementation, while the requested feature "
             "requires the modular implementation."
         )
-    if enable_dcp and needs_monolithic is not None:
-        raise ValueError("DCP does not support cum_seq_lens_q / max_q_len")
-
     if requested == "auto":
         if needs_modular is not None:
             return "modular"
@@ -183,7 +181,7 @@ def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
     :func:`flashinfer.cute_dsl.attention.wrappers.batch_mla.cute_dsl_mla_decode`
     (modular, supports ``sinks=``) and
     :func:`flashinfer.cute_dsl.attention.monolithic.mla_decode.cute_dsl_mla_decode`
-    (monolithic, supports compact variable Q and static DCP).
+    (monolithic, supports compact variable Q, static DCP, and their combination).
     Implementation-specific keyword
     arguments are validated before dispatch and stripped only when their
     default values make them irrelevant to the selected implementation.
@@ -193,7 +191,8 @@ def cute_dsl_mla_decode(*args, cute_dsl_impl: str = "auto", **kwargs):
     cute_dsl_impl : str, default ``"auto"``
         ``"auto"`` (default) lets the dispatcher pick: monolithic by
         default, modular when the call uses a modular-only feature
-        (currently ``sinks``); compact variable Q and DCP require monolithic.
+        (currently ``sinks``); compact variable Q, DCP, and their combination
+        require monolithic.
         ``"modular"`` and
         ``"monolithic"`` are strict — the dispatcher will not silently switch
         implementations, and raises :class:`ValueError` for an incompatible

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
@@ -551,6 +551,8 @@ def cute_dsl_mla_decode(
     enable_dcp : bool
         Enable static cyclic decode context-parallel masking. DCP returns a
         rank-local attention state and therefore requires ``return_lse=True``.
+        Compact variable-Q input is supported when ``cum_seq_lens_q`` and
+        ``max_q_len`` are provided.
     cp_world : int
         Compile-time context-parallel world size. The local cache owns global
         token positions ``cp_world * local_k + cp_rank``.
@@ -604,8 +606,6 @@ def cute_dsl_mla_decode(
         raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
 
     if enable_dcp:
-        if is_var_q:
-            raise ValueError("DCP does not support cum_seq_lens_q / max_q_len")
         if not 0 <= cp_rank < cp_world:
             raise ValueError(
                 f"cp_rank must satisfy 0 <= cp_rank < cp_world, got "

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -1599,7 +1599,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                         mAccO,
                         mAccLSE,
                         blk_coord,
-                        self.get_valid_q_rows(blk_coord[1]),
+                        q_begin,
+                        valid_q_rows,
                         tidx,
                     )
                 tile_sched.advance_to_next_work()
@@ -1615,6 +1616,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         mAccO: Optional[cute.Tensor],
         mAccLSE: Optional[cute.Tensor],
         blk_coord: cute.Coord,
+        q_begin: cutlass.Int32,
         valid_q_rows: cutlass.Int32,
         tidx: cutlass.Int32,
     ):
@@ -1632,7 +1634,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             q_row = cta_row_base + cta_row
             if cute.elem_less(q_row, valid_q_rows):
                 if cutlass.const_expr(mAccO is None):
-                    mO[q_row, d_idx, blk_coord[1], blk_coord[2]] = self.o_dtype(0.0)
+                    if cutlass.const_expr(self.is_var_q):
+                        compact_q_row = (
+                            q_begin * self.num_heads
+                            + blk_coord[1] * self.mma_qk_tiler[0]
+                            + q_row
+                        )
+                        mO[compact_q_row, d_idx, 0] = self.o_dtype(0.0)
+                    else:
+                        mO[q_row, d_idx, blk_coord[1], blk_coord[2]] = self.o_dtype(0.0)
                 else:
                     mAccO[
                         q_row,
@@ -1646,7 +1656,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             q_row = cta_row_base + local_tidx
             if cute.elem_less(q_row, valid_q_rows):
                 if cutlass.const_expr(mAccLSE is None):
-                    mLSE[q_row, blk_coord[1], blk_coord[2]] = -self.lse_dtype.inf
+                    if cutlass.const_expr(self.is_var_q):
+                        compact_q_row = (
+                            q_begin * self.num_heads
+                            + blk_coord[1] * self.mma_qk_tiler[0]
+                            + q_row
+                        )
+                        mLSE[compact_q_row, 0, 0] = -self.lse_dtype.inf
+                    else:
+                        mLSE[q_row, blk_coord[1], blk_coord[2]] = -self.lse_dtype.inf
                 else:
                     mAccLSE[
                         q_row, blk_coord[3], blk_coord[1], blk_coord[2]

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -1852,7 +1852,8 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                         mAccO,
                         mAccLSE,
                         blk_coord,
-                        self.get_valid_q_rows(blk_coord[1]),
+                        q_begin,
+                        valid_q_rows,
                         tidx,
                     )
                 tile_sched.advance_to_next_work()
@@ -1867,6 +1868,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         mAccO: Optional[cute.Tensor],
         mAccLSE: Optional[cute.Tensor],
         blk_coord: cute.Coord,
+        q_begin: cutlass.Int32,
         valid_q_rows: cutlass.Int32,
         tidx: cutlass.Int32,
     ):
@@ -1884,7 +1886,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             q_row = cta_row_base + cta_row
             if cute.elem_less(q_row, valid_q_rows):
                 if cutlass.const_expr(mAccO is None):
-                    mO[q_row, d_idx, blk_coord[1], blk_coord[2]] = self.o_dtype(0.0)
+                    if cutlass.const_expr(self.is_var_q):
+                        compact_q_row = (
+                            q_begin * self.num_heads
+                            + blk_coord[1] * self.mma_qk_tiler[0]
+                            + q_row
+                        )
+                        mO[compact_q_row, d_idx, 0] = self.o_dtype(0.0)
+                    else:
+                        mO[q_row, d_idx, blk_coord[1], blk_coord[2]] = self.o_dtype(0.0)
                 else:
                     mAccO[
                         q_row,
@@ -1898,7 +1908,15 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             q_row = cta_row_base + local_tidx
             if cute.elem_less(q_row, valid_q_rows):
                 if cutlass.const_expr(mAccLSE is None):
-                    mLSE[q_row, blk_coord[1], blk_coord[2]] = -self.lse_dtype.inf
+                    if cutlass.const_expr(self.is_var_q):
+                        compact_q_row = (
+                            q_begin * self.num_heads
+                            + blk_coord[1] * self.mma_qk_tiler[0]
+                            + q_row
+                        )
+                        mLSE[compact_q_row, 0, 0] = -self.lse_dtype.inf
+                    else:
+                        mLSE[q_row, blk_coord[1], blk_coord[2]] = -self.lse_dtype.inf
                 else:
                     mAccLSE[
                         q_row, blk_coord[3], blk_coord[1], blk_coord[2]
@@ -4110,7 +4128,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             self.cp_world * first_local_key
             + common_params.cp_rank
             - common_params.causal_seq_len
-            + self.seq_len_q
+            + common_params.q_len
         )
         return cute.elem_less(first_local_key, common_params.K) and not cute.elem_less(
             flat_q_row, mask_threshold

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2767,11 +2767,26 @@ def _validate_mla_dcp_args(
             )
         return backend
 
-    if query.ndim != 4:
-        raise ValueError(
-            "DCP requires a dense query with shape "
-            "[batch_size, q_len_per_request, num_heads, head_dim_qk]"
-        )
+    is_var_q = cum_seq_lens_q is not None
+    if is_var_q:
+        if not isinstance(cum_seq_lens_q, torch.Tensor):
+            raise TypeError(
+                "cum_seq_lens_q must be a torch.Tensor when DCP is enabled, got "
+                f"{type(cum_seq_lens_q).__name__}"
+            )
+        if query.ndim != 3:
+            raise ValueError(
+                "DCP with cum_seq_lens_q requires a compact query with shape "
+                "[total_q, num_heads, head_dim_qk]"
+            )
+        batch_size = cum_seq_lens_q.numel() - 1
+    else:
+        if query.ndim != 4:
+            raise ValueError(
+                "DCP without cum_seq_lens_q requires a dense query with shape "
+                "[batch_size, q_len_per_request, num_heads, head_dim_qk]"
+            )
+        batch_size = query.shape[0]
     if not 0 <= cp_rank < cp_world:
         raise ValueError(
             f"cp_rank must satisfy 0 <= cp_rank < cp_world, got "
@@ -2792,8 +2807,6 @@ def _validate_mla_dcp_args(
             "DCP cannot be combined with sinks: DCP requires monolithic "
             "CuTeDSL MLA, while sinks require the modular implementation"
         )
-    if cum_seq_lens_q is not None or max_q_len is not None:
-        raise ValueError("DCP does not support cum_seq_lens_q / max_q_len")
     if causal_seqlens_kv_global is None:
         raise ValueError("causal_seqlens_kv_global is required when enable_dcp=True")
     if not isinstance(causal_seqlens_kv_global, torch.Tensor):
@@ -2813,10 +2826,10 @@ def _validate_mla_dcp_args(
             "causal_seqlens_kv_global must be on the query device "
             f"{query.device}, got {causal_seqlens_kv_global.device}"
         )
-    if tuple(causal_seqlens_kv_global.shape) != (query.shape[0],):
+    if tuple(causal_seqlens_kv_global.shape) != (batch_size,):
         raise ValueError(
             "causal_seqlens_kv_global must have shape "
-            f"({query.shape[0]},), got {tuple(causal_seqlens_kv_global.shape)}"
+            f"({batch_size},), got {tuple(causal_seqlens_kv_global.shape)}"
         )
     if not causal_seqlens_kv_global.is_contiguous():
         raise ValueError("causal_seqlens_kv_global must be contiguous")
@@ -3725,6 +3738,8 @@ def trtllm_batch_decode_with_kv_cache_mla(
         Statically enable cyclic decode context parallelism in the monolithic
         CuTeDSL MLA kernel. DCP returns a rank-local output/LSE state, so
         ``return_lse=True`` is required and the caller must merge rank states.
+        Both fixed-Q input and compact variable-Q input described by
+        ``cum_seq_lens_q`` are supported.
     cp_world : int = 1
         Compile-time context-parallel world size. Rank ``r`` stores global KV
         positions whose token index modulo ``cp_world`` equals ``r``.
@@ -4032,6 +4047,8 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 cute_dsl_impl=cute_dsl_impl,
                 cum_seq_lens_q=cum_seq_lens_q,
                 max_q_len=max_q_len,
+                enable_dcp=enable_dcp,
+                cp_world=cp_world,
             )
 
         selected_var_q_backend: str
@@ -4130,6 +4147,10 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 cute_dsl_impl=cute_dsl_impl,
                 cum_seq_lens_q=cum_seq_lens_q,
                 max_q_len=max_q_len,
+                enable_dcp=enable_dcp,
+                cp_world=cp_world,
+                cp_rank=cp_rank,
+                causal_seqlens_kv_global=causal_seqlens_kv_global,
             )
 
         multi_ctas_kv_counter_buffer = _resolve_trtllm_gen_multi_ctas_kv_counter_buffer(

--- a/tests/attention/test_cute_dsl_mla_dcp.py
+++ b/tests/attention/test_cute_dsl_mla_dcp.py
@@ -246,6 +246,34 @@ def _reference_attention(
     return out, lse
 
 
+def _reference_variable_q_attention(
+    query: torch.Tensor,
+    cum_seq_lens_q: torch.Tensor,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int = 1,
+    cp_rank: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Reference compact variable-Q attention one request at a time."""
+    outputs = []
+    lses = []
+    offsets = cum_seq_lens_q.tolist()
+    for batch_idx, (q_begin, q_end) in enumerate(
+        zip(offsets[:-1], offsets[1:], strict=True)
+    ):
+        request_out, request_lse = _reference_attention(
+            query[q_begin:q_end].unsqueeze(0),
+            global_kv[batch_idx : batch_idx + 1],
+            global_lens[batch_idx : batch_idx + 1],
+            cp_world=cp_world,
+            cp_rank=cp_rank,
+        )
+        outputs.append(request_out.squeeze(0))
+        lses.append(request_lse.squeeze(0))
+    return torch.cat(outputs), torch.cat(lses)
+
+
 def _merge_rank_outputs_natural_log(
     rank_outputs: list[torch.Tensor],
     rank_lses: list[torch.Tensor],
@@ -366,6 +394,61 @@ def _launch_rank(
     return out, lse, split_kv
 
 
+def _launch_variable_q_rank(
+    query: torch.Tensor,
+    cum_seq_lens_q: torch.Tensor,
+    max_q_len: int,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int,
+    cp_rank: int,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    """Launch one compact variable-Q DCP rank."""
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+        cute_dsl_mla_decode,
+    )
+    from flashinfer.cute_dsl.utils import get_num_sm
+
+    kv_cache, block_tables, local_lens, max_local_len = _pack_cyclic_rank_pages(
+        global_kv, global_lens, cp_world, cp_rank
+    )
+    batch_size = cum_seq_lens_q.numel() - 1
+    num_heads = query.shape[1]
+    split_kv, workspace_size = _get_split_kv_and_workspace_size(
+        batch_size,
+        max_q_len,
+        num_heads,
+        _LATENT_DIM,
+        get_num_sm(query.device),
+        max_local_len,
+    )
+    workspace = torch.empty(
+        max(workspace_size, 1), dtype=torch.int8, device=query.device
+    )
+    out, lse = cute_dsl_mla_decode(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace,
+        kv_lora_rank=_LATENT_DIM,
+        qk_rope_head_dim=_ROPE_DIM,
+        block_tables=block_tables,
+        seq_lens=local_lens,
+        max_seq_len=max_local_len,
+        softmax_scale=1.0 / math.sqrt(_LATENT_DIM),
+        is_var_seq=True,
+        return_lse=True,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=max_q_len,
+        enable_dcp=True,
+        cp_world=cp_world,
+        cp_rank=cp_rank,
+        causal_seqlens_kv_global=global_lens,
+    )
+    return out, lse, split_kv
+
+
 def _assert_close_to_reference(
     out: torch.Tensor,
     lse: torch.Tensor,
@@ -419,6 +502,51 @@ def _assert_dcp_rank_merge_matches_reference(
 
     merged_out, merged_lse = _merge_rank_outputs_natural_log(rank_outputs, rank_lses)
     ref_out, ref_lse = _reference_attention(query, global_kv, global_lens)
+    _assert_close_to_reference(merged_out, merged_lse, ref_out, ref_lse, dtype)
+    return split_kvs
+
+
+def _assert_variable_q_dcp_rank_merge_matches_reference(
+    query: torch.Tensor,
+    cum_seq_lens_q: torch.Tensor,
+    max_q_len: int,
+    global_kv: torch.Tensor,
+    global_lens: torch.Tensor,
+    *,
+    cp_world: int,
+    dtype: torch.dtype,
+) -> list[int]:
+    """Check compact rank-local states and the final cross-rank merge."""
+    rank_outputs = []
+    rank_lses = []
+    split_kvs = []
+    for cp_rank in range(cp_world):
+        out, lse, split_kv = _launch_variable_q_rank(
+            query,
+            cum_seq_lens_q,
+            max_q_len,
+            global_kv,
+            global_lens,
+            cp_world=cp_world,
+            cp_rank=cp_rank,
+        )
+        ref_out, ref_lse = _reference_variable_q_attention(
+            query,
+            cum_seq_lens_q,
+            global_kv,
+            global_lens,
+            cp_world=cp_world,
+            cp_rank=cp_rank,
+        )
+        _assert_close_to_reference(out, lse, ref_out, ref_lse, dtype)
+        rank_outputs.append(out)
+        rank_lses.append(lse)
+        split_kvs.append(split_kv)
+
+    merged_out, merged_lse = _merge_rank_outputs_natural_log(rank_outputs, rank_lses)
+    ref_out, ref_lse = _reference_variable_q_attention(
+        query, cum_seq_lens_q, global_kv, global_lens
+    )
     _assert_close_to_reference(merged_out, merged_lse, ref_out, ref_lse, dtype)
     return split_kvs
 
@@ -572,6 +700,19 @@ def test_cute_dsl_mla_dcp_dispatch_is_strictly_monolithic():
         )
         == "monolithic"
     )
+    assert (
+        _resolve_impl(
+            requested="auto",
+            kwargs={
+                "enable_dcp": True,
+                "cp_world": 2,
+                "cp_rank": 0,
+                "cum_seq_lens_q": torch.tensor([0, 2, 3], dtype=torch.int32),
+                "max_q_len": 2,
+            },
+        )
+        == "monolithic"
+    )
     with pytest.raises(ValueError, match="only supported by the monolithic"):
         _resolve_impl(
             requested="modular",
@@ -666,6 +807,134 @@ def test_cute_dsl_mla_dcp_packed_head_counts(num_heads):
         dtype=torch.bfloat16,
     )
     assert split_kvs == [1, 1]
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_variable_q_dcp_rank_merge(dtype):
+    """Compose compact ragged Q with DCP, empty ranks, and split-KV."""
+    _skip_if_unsupported()
+    torch.manual_seed(70)
+    q_lens = (4, 1, 0, 3)
+    max_q_len = 8
+    dense_query, global_kv, global_lens = _make_batched_inputs(
+        global_lengths=(1, 130, 3, 4101),
+        q_len=max_q_len,
+        num_heads=24,
+        dtype=dtype,
+    )
+    query = torch.cat(
+        [dense_query[batch_idx, :q_len] for batch_idx, q_len in enumerate(q_lens)]
+    )
+    cum_seq_lens_q = torch.tensor(
+        (0, 4, 5, 5, 8), dtype=torch.int32, device=query.device
+    )
+
+    split_kvs = _assert_variable_q_dcp_rank_merge_matches_reference(
+        query,
+        cum_seq_lens_q,
+        max_q_len,
+        global_kv,
+        global_lens,
+        cp_world=4,
+        dtype=dtype,
+    )
+    assert all(split_kv > 1 for split_kv in split_kvs)
+
+
+def test_cute_dsl_mla_variable_q_dcp_fp8_direct_empty_rank():
+    """Cover FP8 direct epilogue with short requests and empty local ranks."""
+    _skip_if_unsupported()
+    torch.manual_seed(72)
+    q_lens = (4, 1, 0, 3)
+    max_q_len = 8
+    dense_query, global_kv, global_lens = _make_batched_inputs(
+        global_lengths=(1, 130, 3, 129),
+        q_len=max_q_len,
+        num_heads=24,
+        dtype=torch.float8_e4m3fn,
+    )
+    query = torch.cat(
+        [dense_query[batch_idx, :q_len] for batch_idx, q_len in enumerate(q_lens)]
+    )
+    cum_seq_lens_q = torch.tensor(
+        (0, 4, 5, 5, 8), dtype=torch.int32, device=query.device
+    )
+
+    split_kvs = _assert_variable_q_dcp_rank_merge_matches_reference(
+        query,
+        cum_seq_lens_q,
+        max_q_len,
+        global_kv,
+        global_lens,
+        cp_world=4,
+        dtype=torch.float8_e4m3fn,
+    )
+    assert split_kvs == [1] * 4
+
+
+def test_cute_dsl_mla_variable_q_dcp_public_api():
+    """Route compact DCP through the public MLA backend selector."""
+    _skip_if_unsupported()
+    from flashinfer.cute_dsl.attention.monolithic.mla_decode import (
+        _get_split_kv_and_workspace_size,
+    )
+    from flashinfer.cute_dsl.utils import get_num_sm
+    from flashinfer.mla._core import trtllm_batch_decode_with_kv_cache_mla
+
+    torch.manual_seed(71)
+    dense_query, global_kv, global_lens = _make_batched_inputs(
+        global_lengths=(256, 130),
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    query = torch.cat((dense_query[0, :4], dense_query[1, :1]))
+    cum_seq_lens_q = torch.tensor((0, 4, 5), dtype=torch.int32, device=query.device)
+    kv_cache, block_tables, local_lens, max_local_len = _pack_cyclic_rank_pages(
+        global_kv, global_lens, cp_world=2, cp_rank=0
+    )
+    _, workspace_size = _get_split_kv_and_workspace_size(
+        2, 4, 96, _LATENT_DIM, get_num_sm(query.device), max_local_len
+    )
+    workspace = torch.empty(
+        max(workspace_size, 1), dtype=torch.int8, device=query.device
+    )
+
+    out, lse = trtllm_batch_decode_with_kv_cache_mla(
+        query=query,
+        kv_cache=kv_cache,
+        workspace_buffer=workspace,
+        qk_nope_head_dim=128,
+        kv_lora_rank=_LATENT_DIM,
+        qk_rope_head_dim=_ROPE_DIM,
+        block_tables=block_tables,
+        seq_lens=local_lens,
+        max_seq_len=max_local_len,
+        bmm1_scale=1.0 / math.sqrt(_LATENT_DIM),
+        bmm2_scale=1.0,
+        backend="auto",
+        is_var_seq=True,
+        return_lse=True,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=4,
+        enable_dcp=True,
+        cp_world=2,
+        cp_rank=0,
+        causal_seqlens_kv_global=global_lens,
+    )
+    ref_out, ref_lse = _reference_variable_q_attention(
+        query,
+        cum_seq_lens_q,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        cp_rank=0,
+    )
+    _assert_close_to_reference(out, lse, ref_out, ref_lse, torch.bfloat16)
 
 
 def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Enable `cum_seq_lens_q` / `max_q_len` for CuTeDSL MLA decode with DCP.

  - Route variable-Q DCP to monolithic CuTeDSL
  - Fix compact O/LSE writes for empty DCP ranks
  - Use request-local Q length in the FP8 DCP mask
  - Add BF16/FP8 correctness tests

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/4658

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for compact variable-length queries with distributed context parallelism (DCP).
  * Enabled this support across monolithic MLA attention paths, including BF16 and FP8 execution.
  * Improved handling of varying query lengths, empty workloads, split-KV processing, and causal visibility.
  * Updated compatibility checks and documentation to reflect support for both fixed-length and compact variable-length inputs.

* **Bug Fixes**
  * Corrected output and log-sum-exp handling for empty DCP work with compact queries.
  * Improved request-specific query addressing for variable-length batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->