### PR TITLE
Fix sm_constraint_gemm epilogue reading an uninitialized output buffer

### DIFF
--- a/flashinfer/triton/kernels/sm_constraint_gemm.py
+++ b/flashinfer/triton/kernels/sm_constraint_gemm.py
@@ -125,8 +125,12 @@ def gemm_kernel_persistent(
         c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
         c = accumulator.to(c_ptr.dtype.element_ty)
 
-        c = tl.fma(c, alpha, beta * tl.load(c_ptrs, mask=c_mask))
-        tl.store(c_ptrs, c, mask=c_mask)
+        # C is write-only when beta == 0, so it must not be read there.
+        if beta != 0:
+            res = tl.fma(c, alpha, beta * tl.load(c_ptrs, mask=c_mask))
+        else:
+            res = c * alpha
+        tl.store(c_ptrs, res, mask=c_mask)
 
 
 @triton.jit(launch_metadata=_matmul_launch_metadata)
@@ -205,18 +209,29 @@ def gemm_kernel_descriptor_persistent(
             acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
             acc = tl.permute(acc, (0, 2, 1))
             acc0, acc1 = tl.split(acc)
-            acc0 = tl.fma(acc0, alpha, beta * c_desc.load([offs_cm, offs_cn]))
-            acc1 = tl.fma(
-                acc1, alpha, beta * c_desc.load([offs_cm, offs_cn + BLOCK_SIZE_N // 2])
-            )
+            # C is write-only when beta == 0, so it must not be read there.
+            if beta != 0:
+                acc0 = tl.fma(acc0, alpha, beta * c_desc.load([offs_cm, offs_cn]))
+                acc1 = tl.fma(
+                    acc1,
+                    alpha,
+                    beta * c_desc.load([offs_cm, offs_cn + BLOCK_SIZE_N // 2]),
+                )
+            else:
+                acc0 = acc0 * alpha
+                acc1 = acc1 * alpha
             c0 = acc0.to(dtype)
             c_desc.store([offs_cm, offs_cn], c0)
             c1 = acc1.to(dtype)
             c_desc.store([offs_cm, offs_cn + BLOCK_SIZE_N // 2], c1)
         else:
-            accumulator = tl.fma(
-                accumulator, alpha, beta * c_desc.load([offs_cm, offs_cn])
-            )
+            # C is write-only when beta == 0, so it must not be read there.
+            if beta != 0:
+                accumulator = tl.fma(
+                    accumulator, alpha, beta * c_desc.load([offs_cm, offs_cn])
+                )
+            else:
+                accumulator = accumulator * alpha
             c = accumulator.to(dtype)
             c_desc.store([offs_cm, offs_cn], c)
 
@@ -286,5 +301,9 @@ def gemm_kernel(
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_cm[:, None] + stride_cn * offs_cn[None, :]
     c_mask = (offs_cm[:, None] < M) & (offs_cn[None, :] < N)
-    c = tl.fma(c, alpha, beta * tl.load(c_ptrs, mask=c_mask))
-    tl.store(c_ptrs, c, mask=c_mask)
+    # C is write-only when beta == 0, so it must not be read there.
+    if beta != 0:
+        res = tl.fma(c, alpha, beta * tl.load(c_ptrs, mask=c_mask))
+    else:
+        res = c * alpha
+    tl.store(c_ptrs, res, mask=c_mask)

--- a/flashinfer/triton/sm_constraint_gemm.py
+++ b/flashinfer/triton/sm_constraint_gemm.py
@@ -60,6 +60,9 @@ def gemm_persistent(a, b, c=None, alpha=1.0, beta=0.0, out_dtype=None, num_sms=N
         "Incompatible dtypes between c and out_dtype"
     )
 
+    # The kernel reads c only when beta != 0, and torch.empty does not initialize it.
+    assert c is not None or beta == 0, "c must be provided when beta != 0"
+
     # Allocates output.
     c = torch.empty((M, N), device=a.device, dtype=out_dtype) if c is None else c
 
@@ -142,6 +145,9 @@ def gemm(a, b, c=None, alpha=1.0, beta=0.0, out_dtype=None):
     assert c is None or c.dtype == out_dtype, (
         "Incompatible dtypes between c and out_dtype"
     )
+
+    # The kernel reads c only when beta != 0, and torch.empty does not initialize it.
+    assert c is not None or beta == 0, "c must be provided when beta != 0"
 
     # Allocates output.
     c = torch.empty((M, N), device=a.device, dtype=out_dtype) if c is None else c
@@ -239,6 +245,8 @@ def gemm_descriptor_persistent(
         assert K >= 8, "Least chunk size must be 16B"
         assert N >= 8, "Least chunk size must be 16B"
 
+    # The kernel reads c only when beta != 0, and torch.empty does not initialize it.
+    assert c is not None or beta == 0, "c must be provided when beta != 0"
     c = torch.empty((M, N), device=a.device, dtype=out_dtype) if c is None else c
 
     NUM_SMS = torch.cuda.get_device_properties("cuda").multi_processor_count

--- a/tests/gemm/test_sm_constraint_gemm.py
+++ b/tests/gemm/test_sm_constraint_gemm.py
@@ -155,6 +155,76 @@ def test_sm_constraint_gemm(M, N, K, alpha, beta, num_sms, dtype, EPILOGUE_SUBTI
         assert naive_vs_descriptor  # value is correct
 
 
+@pytest.mark.parametrize("kernel", ["naive", "persistent", "descriptor_persistent"])
+@pytest.mark.parametrize("alpha", [1.0, 2.0])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_sm_constraint_gemm_beta_zero_does_not_read_c(kernel, alpha, dtype):
+    # When c is not passed, the wrapper allocates it with torch.empty. With
+    # beta == 0 the epilogue must not read that buffer: 0.0 * NaN is NaN, so a
+    # single read turns the whole result into NaN.
+    if kernel == "descriptor_persistent" and dtype == torch.float32:
+        pytest.skip("descriptor persistent does not support float32")
+
+    M = N = K = 256
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16).to(dtype)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16).to(dtype)
+
+    if kernel == "naive":
+        run = lambda c: flashinfer.triton.sm_constraint_gemm.gemm(
+            a, b, c=c, alpha=alpha
+        )
+    elif kernel == "persistent":
+        run = lambda c: flashinfer.triton.sm_constraint_gemm.gemm_persistent(
+            a, b, c=c, alpha=alpha
+        )
+    else:
+        bT = b.T.contiguous()
+        run = lambda c: flashinfer.triton.sm_constraint_gemm.gemm_descriptor_persistent(
+            a, bT, c=c, alpha=alpha
+        )
+
+    # Leave NaN behind in a block of exactly the output's size and dtype, so the
+    # caching allocator hands it to the torch.empty inside the wrapper.
+    run(torch.zeros((M, N), device="cuda", dtype=dtype))  # warm up (compile)
+    stale = torch.full((M, N), float("nan"), device="cuda", dtype=dtype)
+    stale_ptr = stale.data_ptr()
+    del stale
+
+    out = run(None)  # c=None, beta=0.0
+    assert out.data_ptr() == stale_ptr  # the poisoned block was reused
+    assert torch.isfinite(out).all()
+    # Nothing about the buffer may reach the result.
+    assert torch.equal(out, run(torch.zeros((M, N), device="cuda", dtype=dtype)))
+
+
+@pytest.mark.parametrize("kernel", ["naive", "persistent", "descriptor_persistent"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_sm_constraint_gemm_beta_nonzero_reads_c(kernel, dtype):
+    # The other half of the contract: with beta != 0 the epilogue still folds c
+    # in. alpha = 0 zeroes the product, so the result must be exactly beta * c.
+    if kernel == "descriptor_persistent" and dtype == torch.float32:
+        pytest.skip("descriptor persistent does not support float32")
+
+    M = N = K = 256
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16).to(dtype)
+    b = torch.randn((K, N), device="cuda", dtype=torch.float16).to(dtype)
+    c = torch.randn((M, N), device="cuda", dtype=dtype)
+    expected = (0.5 * c.float()).to(dtype)
+
+    if kernel == "naive":
+        out = flashinfer.triton.sm_constraint_gemm.gemm(a, b, c=c, alpha=0.0, beta=0.5)
+    elif kernel == "persistent":
+        out = flashinfer.triton.sm_constraint_gemm.gemm_persistent(
+            a, b, c=c, alpha=0.0, beta=0.5
+        )
+    else:
+        out = flashinfer.triton.sm_constraint_gemm.gemm_descriptor_persistent(
+            a, b.T.contiguous(), c=c, alpha=0.0, beta=0.5
+        )
+
+    assert torch.equal(out, expected)
+
+
 def print_all_on_failure(
     a, b, c_unmodified, c_torch, c_naive, c_persistent, c_descriptor
 ):


### PR DESCRIPTION
## 📌 Description

The epilogue of all three Triton GEMMs reads `C` unconditionally, but the wrappers allocate `C` with `torch.empty` when the caller passes none. With the documented defaults (`c=None, beta=0.0`) the kernel therefore folds uninitialized memory into the result, and `0.0 * NaN` is `NaN`, so `gemm(a, b)` can return an all-NaN matrix.

- Kernels: read `C` only when `beta != 0`, at all four epilogue sites (`gemm_kernel:289`, `gemm_kernel_persistent:128`, and both branches of `gemm_kernel_descriptor_persistent`). `beta` is uniform across the grid, so this is a scalar branch. When `beta == 0` the result is `alpha * (A @ B)`, which is what the epilogue already computed.
- Wrappers: `assert c is not None or beta == 0`. Asking for `beta != 0` without supplying `C` has no defined meaning, and the internal `torch.empty` would otherwise be read as if it were `C`.

Results for `beta != 0` are unchanged — bit-identical on all three wrappers before and after (fp16, 512³, `alpha=1.5, beta=0.5`).

Performance, 4096³ fp16 on a B200, `do_bench(warmup=100, rep=500)`, caller-provided `c` on both sides so only the kernel differs (two independent rounds agreed to within 0.1 µs):

| kernel | beta | before | after |
|---|---|---|---|
| `gemm_kernel` (the `# only for testing` path) | 0.0 | 154.5 µs | 149.3 µs |
| `gemm_kernel` | 0.5 | 154.8 µs | 158.4 µs |
| `gemm_kernel_persistent` | 0.0 | 531.7 µs | 463.9 µs |
| `gemm_kernel_persistent` | 0.5 | 532.2 µs | 473.0 µs |
| `gemm_kernel_descriptor_persistent` | 0.0 | 218.7 µs | 210.5 µs |
| `gemm_kernel_descriptor_persistent` | 0.5 | 218.7 µs | 219.3 µs |

Skipping the load pays for itself on the `beta == 0` path everywhere. The persistent kernel also gets faster on the `beta != 0` path; there is a single autotune config, so that is codegen, not config selection. The one cost is `gemm_kernel` with `beta != 0` (+2.5% here, +5.7% at 1024³). A branch-free variant that folds the condition into the load mask (`mask=c_mask & (beta != 0), other=0.0`) removes that cost but also gives up the persistent kernel's gain (529.3 µs / 533.5 µs at 4096³); the branch is used because it applies unchanged to the descriptor path, whose TMA loads take no mask, and because the kernel it costs is the one the file marks as test-only. Happy to switch if you would rather keep the naive path untouched.

## 🔍 Related Issues

Fixes #4724

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`test_sm_constraint_gemm` always passes an explicit `c`, so the default `c=None` path — the one that breaks — was never exercised.

Two cases added to `tests/gemm/test_sm_constraint_gemm.py`, over all three wrappers:

- `test_sm_constraint_gemm_beta_zero_does_not_read_c` — frees a NaN-filled block of the output's exact size and dtype so the caching allocator returns it to the internal `torch.empty`, then requires the result to be finite and bit-identical to the same call with a caller-provided zeroed `c`.
- `test_sm_constraint_gemm_beta_nonzero_reads_c` — `alpha=0.0, beta=0.5` must return exactly `0.5 * c`, so the `beta != 0` branch cannot be dropped.

Both assert exact equality rather than tolerances, so they carry no architecture assumption. On this B200: 24 passed, 3 skipped (fp32 is not supported by the descriptor kernel). Reverting the two kernel/wrapper files while keeping the tests fails all 16 `beta_zero` cases and leaves the 8 `beta_nonzero` ones passing.

`compute-sanitizer --tool initcheck` on one `gemm(a, b)` call reports 2048 uninitialized-read errors at `sm_constraint_gemm.py:289` before the fix and 0 after.

The rest of the file is unaffected but cannot run here: `test_sm_constraint_gemm` skips unless the GPU is Hopper (`compute_capability[0] != 9`), so all 27648 of its cases skip on a B200.

## Reviewer Notes

The `beta != 0` branch needs a separate result variable in the pointer epilogues (`res`): `c` holds the accumulator cast to the output dtype, both branches produce fp32, and Triton rejects a branch that changes a live variable's type.

## Environment

- flashinfer `083012d6819cf97128e559616b12acb666f2fffe` (main), editable install
- 1× NVIDIA B200 (SM100), driver 595.71.05
- torch 2.13.0+cu130, triton 3.7.1, CUDA toolkit 13.1, Python 3.12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - GEMM operations with `beta = 0` no longer read uninitialized output data, producing reliable results.
  - GEMM operations with nonzero `beta` continue incorporating existing output values correctly.
  - Added validation to require output data when it is needed for nonzero-beta calculations.

- **Tests**
  - Added coverage for beta-zero safety and nonzero-beta accumulation across supported GEMM variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->