### PR TITLE
perf(cake_kda): add recurrence-piece persistent M128 prefill

### DIFF
--- a/csrc/kda/cake_flashkda_bf16_piece_persistent_m128.cu
+++ b/csrc/kda/cake_flashkda_bf16_piece_persistent_m128.cu
@@ -1,0 +1,3001 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Frozen generated kernel export; do not edit by hand.
+// Generated schedule 'flashkda_bf16_persistent_m128'; module
+// flashkda_bf16_persistent_m128_7fae17ef36.
+// clang-format off
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) FlashKDATensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) FlashKDATensorMapPack { FlashKDATensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+#define FLASH_KDA_INF CUDART_INF_F
+#define TMEM_NCOLS 256
+#define TMEM_TMEM_STATE_OFFSET 64
+#define TMEM_TMEM_STATE_INP_OFFSET 0
+#define TMEM_TMEM_U_ACC_OFFSET 224
+#define TMEM_TMEM_U2_INP_OFFSET 224
+#define TMEM_TMEM_U2_ACC_OFFSET 0
+#define TMEM_TMEM_OUT_OFFSET 192
+#define TMEM_TMEM_STATE_OUT_OFFSET 64
+#define NUM_CHUNK_PIPE_STAGES 5
+#define SMEM_SMEM_QD_OFF 1024
+#define SMEM_SMEM_QD_STAGE_BYTES 8192
+#define SMEM_SMEM_QD_STRIDE 41984
+#define SMEM_SMEM_G_RAW_OFF 1024
+#define SMEM_SMEM_G_RAW_STAGE_BYTES 8192
+#define SMEM_SMEM_G_RAW_STRIDE 41984
+#define SMEM_SMEM_G_RAW_ALL_OFF 1024
+#define SMEM_SMEM_G_RAW_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_G_RAW_ALL_STRIDE 176128
+#define SMEM_SMEM_KD_OFF 9216
+#define SMEM_SMEM_KD_STAGE_BYTES 8192
+#define SMEM_SMEM_KD_STRIDE 41984
+#define SMEM_SMEM_Q_RAW_PREFETCH_OFF 17408
+#define SMEM_SMEM_Q_RAW_PREFETCH_STAGE_BYTES 8192
+#define SMEM_SMEM_Q_RAW_PREFETCH_STRIDE 41984
+#define SMEM_SMEM_FINAL_TRANS_OFF 17408
+#define SMEM_SMEM_FINAL_TRANS_STAGE_BYTES 12288
+#define SMEM_SMEM_FINAL_TRANS_STRIDE 41984
+#define SMEM_SMEM_KR_TRANS_OFF 17408
+#define SMEM_SMEM_KR_TRANS_STAGE_BYTES 8192
+#define SMEM_SMEM_KR_TRANS_STRIDE 41984
+#define SMEM_SMEM_MQK_TRANS_OFF 25600
+#define SMEM_SMEM_MQK_TRANS_STAGE_BYTES 2048
+#define SMEM_SMEM_MQK_TRANS_STRIDE 41984
+#define SMEM_SMEM_INV_OFF 29696
+#define SMEM_SMEM_INV_STAGE_BYTES 2048
+#define SMEM_SMEM_INV_STRIDE 41984
+#define SMEM_SMEM_V_OFF 32384
+#define SMEM_SMEM_V_STAGE_BYTES 8192
+#define SMEM_SMEM_V_STRIDE 41984
+#define SMEM_SMEM_KI_OFF 17408
+#define SMEM_SMEM_KI_STAGE_BYTES 8192
+#define SMEM_SMEM_KI_STRIDE 41984
+#define SMEM_SMEM_GATE_OFF 25600
+#define SMEM_SMEM_GATE_STAGE_BYTES 16384
+#define SMEM_SMEM_GATE_STRIDE 41984
+#define SMEM_SMEM_BETA_RAW_OFF 41984
+#define SMEM_SMEM_BETA_RAW_STAGE_BYTES 512
+#define SMEM_SMEM_BETA_RAW_STRIDE 41984
+#define SMEM_SMEM_INV_WORK_OFF 32384
+#define SMEM_SMEM_INV_WORK_STAGE_BYTES 4096
+#define SMEM_SMEM_INV_WORK_STRIDE 41984
+#define SMEM_SMEM_OUT_OFF 210944
+#define SMEM_SMEM_OUT_STAGE_BYTES 8192
+#define SMEM_SMEM_OUT_STRIDE 8192
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_OFF 41984
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STAGE_BYTES 168452
+#define SMEM_SMEM_RESTORE_FACTOR_ALL_STRIDE 168452
+#define SMEM_SMEM_GT_PREFIX_ALL_OFF 41472
+#define SMEM_SMEM_GT_PREFIX_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_PREFIX_ALL_STRIDE 168448
+#define SMEM_SMEM_GT_ALL_OFF 31744
+#define SMEM_SMEM_GT_ALL_STAGE_BYTES 168448
+#define SMEM_SMEM_GT_ALL_STRIDE 168448
+#define SMEM_SMEM_PREP_BETA_ALL_OFF 42500
+#define SMEM_SMEM_PREP_BETA_ALL_STAGE_BYTES 168064
+#define SMEM_SMEM_PREP_BETA_ALL_STRIDE 168064
+#define SMEM_SMEM_GATE_RATE_ALL_OFF 42628
+#define SMEM_SMEM_GATE_RATE_ALL_STAGE_BYTES 167940
+#define SMEM_SMEM_GATE_RATE_ALL_STRIDE 167940
+#define SMEM_SMEM_GATE_BIAS_ALL_OFF 219136
+#define SMEM_SMEM_GATE_BIAS_ALL_STAGE_BYTES 2560
+#define SMEM_SMEM_GATE_BIAS_ALL_STRIDE 2560
+#define SMEM_SMEM_V_ALL_OFF 32384
+#define SMEM_SMEM_V_ALL_STAGE_BYTES 176128
+#define SMEM_SMEM_V_ALL_STRIDE 176128
+#define SMEM_SMEM_GATE_ALL_OFF 25600
+#define SMEM_SMEM_GATE_ALL_STAGE_BYTES 184320
+#define SMEM_SMEM_GATE_ALL_STRIDE 184320
+#define SMEM_TOTAL 221696
+#define THREADS 1024
+#define BINNED_TASKS 1
+#define PIECE_TASKS 1
+
+#include <math_constants.h>
+
+__device__ __forceinline__ uint32_t elect_sync() {
+    uint32_t pred = 0;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred %%px;\n\t"
+        "elect.sync _|%%px, %1;\n\t"
+        "@%%px mov.s32 %0, 1;\n\t"
+        "}\n"
+        : "+r"(pred)
+        : "r"(0xFFFFFFFF));
+    return pred;
+}
+
+
+__device__ __forceinline__ void mbarrier_init(int mbar_addr, int count) {
+    asm volatile("mbarrier.init.shared::cta.b64 [%0], %1;"
+        :: "r"(mbar_addr), "r"(count));
+}
+
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+__device__ __forceinline__ uint32_t mbarrier_try_wait_cluster(int mbar_addr, int phase) {
+    uint32_t token;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%1], %2;\n\t"
+        "selp.u32 %0, 1, 0, P1;\n\t"
+        "}\n"
+        : "=r"(token)
+        : "r"(mbar_addr), "r"(phase) : "memory");
+    return token;
+}
+
+// CTA-local pipelines have short, resident producer/consumer edges.  Omitting
+// suspendTimeHint keeps a miss on the lightweight TRYWAIT retry path; the
+// explicit loop still makes this helper blocking until acquire succeeds.
+__device__ __forceinline__ void mbarrier_wait(int mbar_addr, int phase) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT:\n\t"
+        "mbarrier.try_wait.parity.acquire.cta.shared::cta.b64"
+        " P1, [%0], %1;\n\t"
+        "@P1 bra.uni DONE;\n\t"
+        "bra.uni LAB_WAIT;\n\t"
+        "DONE:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_cluster(int mbar_addr, int phase) {
+    uint32_t ticks = 0x989680;
+    asm volatile(
+        "{\n\t"
+        ".reg .pred P1;\n\t"
+        "LAB_WAIT_CLUSTER:\n\t"
+        "mbarrier.try_wait.parity.acquire.cluster.shared::cta.b64"
+        " P1, [%0], %1, %2;\n\t"
+        "@P1 bra.uni DONE_CLUSTER;\n\t"
+        "bra.uni LAB_WAIT_CLUSTER;\n\t"
+        "DONE_CLUSTER:\n\t"
+        "}\n"
+        :: "r"(mbar_addr), "r"(phase), "r"(ticks) : "memory");
+}
+
+__device__ __forceinline__ void mbarrier_wait_token(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait(mbar_addr, phase);
+    }
+}
+
+__device__ __forceinline__ void mbarrier_wait_token_cluster(int mbar_addr, int phase, uint32_t token) {
+    if (token == 0) {
+        mbarrier_wait_cluster(mbar_addr, phase);
+    }
+}
+
+
+__device__ __forceinline__ void tcgen05_mma_f16(
+    int taddr, uint64_t a_desc, uint64_t b_desc,
+    uint32_t i_desc, int enable_input_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.cta_group::1.kind::f16 [%0], %1, %2, %3, p;\n\t"
+        "}\n"
+        :: "r"(taddr), "l"(a_desc), "l"(b_desc),
+           "r"(i_desc), "r"(enable_input_d));
+}
+
+
+__device__ __forceinline__ uint64_t desc_encode(uint64_t x) {
+    return (x & 0x3FFFFULL) >> 4ULL;
+}
+
+
+__device__ __forceinline__ void mma_ts_step(
+    int taddr_out, int taddr_a, int b_lo, uint32_t b_dhi,
+    uint32_t i_desc, int enable_d) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader, p;\n\t"
+        ".reg .b32 dhi;\n\t"
+        ".reg .b64 db;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "setp.ne.b32 p, %5, 0;\n\t"
+        "mov.b32 dhi, %3;\n\t"
+        "mov.b64 db, {%2, dhi};\n\t"
+        "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [%1], db, %4, p;\n\t"
+        "}\n"
+        :: "r"(taddr_out), "r"(taddr_a), "r"(b_lo), "r"(b_dhi),
+           "r"(i_desc), "r"(enable_d));
+}
+
+
+__device__ __forceinline__ void elect_commit(int mbar_addr) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "}\n"
+        :: "r"(mbar_addr));
+}
+
+
+__device__ __forceinline__ void mbarrier_arrive(int mbar_addr) {
+    asm volatile(
+        "mbarrier.arrive.release.cta.shared::cta.b64 _, [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void mbarrier_arrive_expect_tx(int mbar_addr, uint32_t bytes) {
+    asm volatile(
+        "mbarrier.arrive.expect_tx.release.cta.shared::cta.b64 _, [%0], %1;"
+        :: "r"(mbar_addr), "r"(bytes) : "memory");
+}
+
+
+__device__ __forceinline__ void tmem_ld_x32(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15,"
+        "  %16, %17, %18, %19, %20, %21, %22, %23,"
+        "  %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15]),
+          "=f"(dst[16]), "=f"(dst[17]), "=f"(dst[18]), "=f"(dst[19]),
+          "=f"(dst[20]), "=f"(dst[21]), "=f"(dst[22]), "=f"(dst[23]),
+          "=f"(dst[24]), "=f"(dst[25]), "=f"(dst[26]), "=f"(dst[27]),
+          "=f"(dst[28]), "=f"(dst[29]), "=f"(dst[30]), "=f"(dst[31])
+        : "r"(tmem_addr));
+}
+
+
+__device__ __forceinline__ void tmem_ld_x16(float* dst, int tmem_addr) {
+    asm volatile(
+        "tcgen05.ld.sync.aligned.32x32b.x16.b32"
+        " {%0, %1, %2, %3, %4, %5, %6, %7,"
+        "  %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+        : "=f"(dst[0]),  "=f"(dst[1]),  "=f"(dst[2]),  "=f"(dst[3]),
+          "=f"(dst[4]),  "=f"(dst[5]),  "=f"(dst[6]),  "=f"(dst[7]),
+          "=f"(dst[8]),  "=f"(dst[9]),  "=f"(dst[10]), "=f"(dst[11]),
+          "=f"(dst[12]), "=f"(dst[13]), "=f"(dst[14]), "=f"(dst[15])
+        : "r"(tmem_addr));
+}
+
+
+__device__ __forceinline__ void tmem_st_x32_f32(int tmem_addr, const float* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x32.b32"
+        " [%0], {%1, %2, %3, %4, %5, %6, %7, %8,"
+        "  %9, %10, %11, %12, %13, %14, %15, %16,"
+        "  %17, %18, %19, %20, %21, %22, %23, %24,"
+        "  %25, %26, %27, %28, %29, %30, %31, %32};"
+        :: "r"(tmem_addr),
+           "f"(src[0]),  "f"(src[1]),  "f"(src[2]),  "f"(src[3]),
+           "f"(src[4]),  "f"(src[5]),  "f"(src[6]),  "f"(src[7]),
+           "f"(src[8]),  "f"(src[9]),  "f"(src[10]), "f"(src[11]),
+           "f"(src[12]), "f"(src[13]), "f"(src[14]), "f"(src[15]),
+           "f"(src[16]), "f"(src[17]), "f"(src[18]), "f"(src[19]),
+           "f"(src[20]), "f"(src[21]), "f"(src[22]), "f"(src[23]),
+           "f"(src[24]), "f"(src[25]), "f"(src[26]), "f"(src[27]),
+           "f"(src[28]), "f"(src[29]), "f"(src[30]), "f"(src[31]));
+}
+
+
+__device__ __forceinline__ float approx_exp2(float x) {
+    float y;
+    asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(y) : "f"(x));
+    return y;
+}
+
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+    #pragma unroll
+    for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+
+__device__ __forceinline__ void elect_commit2(int mbar_addr0, int mbar_addr1) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred leader;\n\t"
+        "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];\n\t"
+        "@leader tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%1];\n\t"
+        "}\n"
+        :: "r"(mbar_addr0), "r"(mbar_addr1) : "memory");
+}
+
+
+__device__ __forceinline__ void fence_async_shared() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
+
+__device__ __forceinline__ uint64_t make_smem_desc(int addr) {
+    const int SBO = 1024;
+    return desc_encode(addr)
+         | (desc_encode(SBO) << 32ULL)
+         | (1ULL << 46ULL)
+         | (2ULL << 61ULL);
+}
+
+
+__device__ __forceinline__ void tma_3d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.3d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4}], [%5];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z),
+           "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tma_2d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.2d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3}], [%4];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y),
+           "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tma_4d_gmem2smem(
+    int dst, const void *tmap_ptr, int x, int y, int z, int w, int mbar_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.shared::cta.global"
+        ".mbarrier::complete_tx::bytes"
+        " [%0], [%1, {%2, %3, %4, %5}], [%6];"
+        :: "r"(dst), "l"(tmap_ptr), "r"(x), "r"(y), "r"(z), "r"(w),
+           "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tma_store_4d(
+    const void *tmap, int x, int y, int z, int w, unsigned smem_addr) {
+    asm volatile(
+        "cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group"
+        " [%0, {%1, %2, %3, %4}], [%5];"
+        :: "l"(tmap), "r"(x), "r"(y), "r"(z), "r"(w), "r"(smem_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tcgen05_commit(int mbar_addr) {
+    asm volatile(
+        "tcgen05.commit.cta_group::1.mbarrier::arrive::one"
+        ".shared::cluster.b64 [%0];"
+        :: "r"(mbar_addr) : "memory");
+}
+
+
+__device__ __forceinline__ void tmem_st_x8_u32(int addr, const uint32_t* src) {
+    asm volatile(
+        "tcgen05.st.sync.aligned.32x32b.x8.b32"
+        " [%0], {%1,%2,%3,%4,%5,%6,%7,%8};"
+        :: "r"(addr),
+           "r"(src[0]), "r"(src[1]), "r"(src[2]), "r"(src[3]),
+           "r"(src[4]), "r"(src[5]), "r"(src[6]), "r"(src[7]));
+}
+
+
+__device__ __forceinline__ uint32_t make_warp_uniform(uint32_t val) {
+    uint32_t result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1f, 0xffffffff;"
+        : "=r"(result) : "r"(val));
+    return result;
+}
+
+extern "C" {
+
+__global__ __launch_bounds__(1024) void
+kernel_flashkda_bf16_persistent_m128(__nv_bfloat16* __restrict__ q, FlashKDATensorMap const* q_tma, __nv_bfloat16* __restrict__ k, FlashKDATensorMap const* k_tma, __nv_bfloat16* __restrict__ v, FlashKDATensorMap const* v_tma, __nv_bfloat16* __restrict__ g, FlashKDATensorMap const* g_tma, __nv_bfloat16* __restrict__ beta, FlashKDATensorMap const* beta_tma, float* __restrict__ A_log, float* __restrict__ dt_bias, long long* __restrict__ cu_seqlens, int* __restrict__ seq_order, int* __restrict__ task_ids, int* __restrict__ task_offsets, int* __restrict__ task_token_starts, int* __restrict__ task_token_counts, int* __restrict__ task_state_sources, int* __restrict__ task_state_destinations, __nv_bfloat16* __restrict__ mid_state, unsigned int* __restrict__ mid_state_ready, __nv_bfloat16* __restrict__ initial_state, __nv_bfloat16* __restrict__ out, FlashKDATensorMap const* out_tma, __nv_bfloat16* __restrict__ final_state, int num_heads, int use_initial_state, int store_final_state, float scale, float lower_bound)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+    if (tid == 0) {
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(q_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(k_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(v_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(g_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(beta_tma)) : "memory");
+        asm volatile("fence.proxy.tensormap::generic.acquire.sys [%0], 128;" :: "l"((uint64_t)(out_tma)) : "memory");
+    }
+    __syncthreads();
+
+
+    // Kernel setup ops
+    __nv_bfloat16* smem_qd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_qd_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_addr = smem + 1024;
+    __nv_bfloat16* smem_g_raw_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 1024);
+    const int smem_g_raw_all_addr = smem + 1024;
+    __nv_bfloat16* smem_kd = reinterpret_cast<__nv_bfloat16*>(smem_raw + 9216);
+    const int smem_kd_addr = smem + 9216;
+    __nv_bfloat16* smem_q_raw_prefetch = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_q_raw_prefetch_addr = smem + 17408;
+    __nv_bfloat16* smem_final_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_final_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_kr_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_kr_trans_addr = smem + 17408;
+    __nv_bfloat16* smem_mqk_trans = reinterpret_cast<__nv_bfloat16*>(smem_raw + 25600);
+    const int smem_mqk_trans_addr = smem + 25600;
+    __nv_bfloat16* smem_inv = reinterpret_cast<__nv_bfloat16*>(smem_raw + 29696);
+    const int smem_inv_addr = smem + 29696;
+    __nv_bfloat16* smem_v = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_addr = smem + 32384;
+    __nv_bfloat16* smem_ki = reinterpret_cast<__nv_bfloat16*>(smem_raw + 17408);
+    const int smem_ki_addr = smem + 17408;
+    float* smem_gate = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_addr = smem + 25600;
+    __nv_bfloat16* smem_beta_raw = reinterpret_cast<__nv_bfloat16*>(smem_raw + 41984);
+    const int smem_beta_raw_addr = smem + 41984;
+    __nv_bfloat16* smem_inv_work = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_inv_work_addr = smem + 32384;
+    __nv_bfloat16* smem_out = reinterpret_cast<__nv_bfloat16*>(smem_raw + 210944);
+    const int smem_out_addr = smem + 210944;
+    float* smem_restore_factor_all = reinterpret_cast<float*>(smem_raw + 41984);
+    const int smem_restore_factor_all_addr = smem + 41984;
+    float* smem_gt_prefix_all = reinterpret_cast<float*>(smem_raw + 41472);
+    const int smem_gt_prefix_all_addr = smem + 41472;
+    float* smem_gt_all = reinterpret_cast<float*>(smem_raw + 31744);
+    const int smem_gt_all_addr = smem + 31744;
+    float* smem_prep_beta_all = reinterpret_cast<float*>(smem_raw + 42500);
+    const int smem_prep_beta_all_addr = smem + 42500;
+    float* smem_gate_rate_all = reinterpret_cast<float*>(smem_raw + 42628);
+    const int smem_gate_rate_all_addr = smem + 42628;
+    float* smem_gate_bias_all = reinterpret_cast<float*>(smem_raw + 219136);
+    const int smem_gate_bias_all_addr = smem + 219136;
+    __nv_bfloat16* smem_v_all = reinterpret_cast<__nv_bfloat16*>(smem_raw + 32384);
+    const int smem_v_all_addr = smem + 32384;
+    float* smem_gate_all = reinterpret_cast<float*>(smem_raw + 25600);
+    const int smem_gate_all_addr = smem + 25600;
+
+    // Mbarrier init (15 groups, 67 barriers)
+    // Mbarriers at smem_raw[0..536)
+
+    if (warp == 0) {
+        uint32_t leader = elect_sync();
+        if (leader) {
+            // --- pipeline 'chunk_pipe' ---
+            // qk_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 0, 1);
+            mbarrier_init(smem + 8, 1);
+            mbarrier_init(smem + 16, 1);
+            mbarrier_init(smem + 24, 1);
+            mbarrier_init(smem + 32, 1);
+            // gate_raw_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 40, 1);
+            mbarrier_init(smem + 48, 1);
+            mbarrier_init(smem + 56, 1);
+            mbarrier_init(smem + 64, 1);
+            mbarrier_init(smem + 72, 1);
+            // qk_raw_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 80, 1);
+            mbarrier_init(smem + 88, 1);
+            mbarrier_init(smem + 96, 1);
+            mbarrier_init(smem + 104, 1);
+            mbarrier_init(smem + 112, 1);
+            // v_full: 5 barriers, init_count=1
+            mbarrier_init(smem + 120, 1);
+            mbarrier_init(smem + 128, 1);
+            mbarrier_init(smem + 136, 1);
+            mbarrier_init(smem + 144, 1);
+            mbarrier_init(smem + 152, 1);
+            // v_free: 5 barriers, init_count=4
+            mbarrier_init(smem + 160, 4);
+            mbarrier_init(smem + 168, 4);
+            mbarrier_init(smem + 176, 4);
+            mbarrier_init(smem + 184, 4);
+            mbarrier_init(smem + 192, 4);
+            // smem_free: 5 barriers, init_count=1
+            mbarrier_init(smem + 200, 1);
+            mbarrier_init(smem + 208, 1);
+            mbarrier_init(smem + 216, 1);
+            mbarrier_init(smem + 224, 1);
+            mbarrier_init(smem + 232, 1);
+            // raw_inputs_free: 5 barriers, init_count=1
+            mbarrier_init(smem + 240, 1);
+            mbarrier_init(smem + 248, 1);
+            mbarrier_init(smem + 256, 1);
+            mbarrier_init(smem + 264, 1);
+            mbarrier_init(smem + 272, 1);
+            // state_inp_ready: 5 barriers, init_count=4
+            mbarrier_init(smem + 280, 4);
+            mbarrier_init(smem + 288, 4);
+            mbarrier_init(smem + 296, 4);
+            mbarrier_init(smem + 304, 4);
+            mbarrier_init(smem + 312, 4);
+            // old_out_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 320, 1);
+            mbarrier_init(smem + 328, 1);
+            mbarrier_init(smem + 336, 1);
+            mbarrier_init(smem + 344, 1);
+            mbarrier_init(smem + 352, 1);
+            // u_inp_ready: 5 barriers, init_count=4
+            mbarrier_init(smem + 360, 4);
+            mbarrier_init(smem + 368, 4);
+            mbarrier_init(smem + 376, 4);
+            mbarrier_init(smem + 384, 4);
+            mbarrier_init(smem + 392, 4);
+            // u2_acc_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 400, 1);
+            mbarrier_init(smem + 408, 1);
+            mbarrier_init(smem + 416, 1);
+            mbarrier_init(smem + 424, 1);
+            mbarrier_init(smem + 432, 1);
+            // u2_inp_ready: 5 barriers, init_count=4
+            mbarrier_init(smem + 440, 4);
+            mbarrier_init(smem + 448, 4);
+            mbarrier_init(smem + 456, 4);
+            mbarrier_init(smem + 464, 4);
+            mbarrier_init(smem + 472, 4);
+            // final_ready: 5 barriers, init_count=1
+            mbarrier_init(smem + 480, 1);
+            mbarrier_init(smem + 488, 1);
+            mbarrier_init(smem + 496, 1);
+            mbarrier_init(smem + 504, 1);
+            mbarrier_init(smem + 512, 1);
+            // out_empty: 1 barriers, init_count=1
+            mbarrier_init(smem + 520, 1);
+            // tmem_dealloc_ready: 1 barriers, init_count=2
+            mbarrier_init(smem + 528, 2);
+            asm volatile("fence.mbarrier_init.release.cluster;");
+        }
+    }
+
+    __syncwarp();
+
+    // TMEM alloc (256 columns, 256 used)
+    volatile int* tmem_addr_storage = (volatile int*)(smem_raw + 536);
+    if (warp == 0) {
+        int _tmem_hold = smem + 536;
+        asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;" :: "r"(_tmem_hold), "r"(256) : "memory");
+        asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;");
+    }
+
+    __syncthreads();
+    asm volatile("tcgen05.fence::after_thread_sync;");
+
+    const int mbar_base = smem;
+    #define qk_full_addr (mbar_base + 0)
+    #define gate_raw_full_addr (mbar_base + 40)
+    #define qk_raw_full_addr (mbar_base + 80)
+    #define v_full_addr (mbar_base + 120)
+    #define v_free_addr (mbar_base + 160)
+    #define smem_free_addr (mbar_base + 200)
+    #define raw_inputs_free_addr (mbar_base + 240)
+    #define state_inp_ready_addr (mbar_base + 280)
+    #define old_out_ready_addr (mbar_base + 320)
+    #define u_inp_ready_addr (mbar_base + 360)
+    #define u2_acc_ready_addr (mbar_base + 400)
+    #define u2_inp_ready_addr (mbar_base + 440)
+    #define final_ready_addr (mbar_base + 480)
+    #define out_empty_addr (mbar_base + 520)
+    #define tmem_dealloc_ready_addr (mbar_base + 528)
+    const int taddr = tmem_addr_storage[0];
+
+    // Kernel post-init ops
+    const int tmem_tmem_state = taddr + 64;
+    const int tmem_tmem_state_inp = taddr;
+    const int tmem_tmem_u_acc = taddr + 224;
+    const int tmem_tmem_u2_inp = taddr + 224;
+    const int tmem_tmem_u2_acc = taddr;
+    const int tmem_tmem_out = taddr + 192;
+    const int tmem_tmem_state_out = taddr + 64;
+
+    // ---- Ordered hardware-WG register redistribution ----
+    // Dec phase frees registers before any WG attempts inc.
+    if (warp >= 8 && warp <= 11) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+    }
+
+    // ---- Role: compute ----
+    if (warp <= 3) {
+        asm volatile("setmaxnreg.inc.sync.aligned.u32 168;");
+        { // compute_main
+            int warp_in_wg = warp % 4;
+            const int tmem_row_base = warp_in_wg * 32 << 16;
+            int state_row = warp_in_wg * 32 + lane;
+            int warp_id_in_role = (warp - 0);
+            int compute_local_warp = warp_id_in_role;
+            unsigned int compute_stage = 0;
+            unsigned int _phase_qk_full = 0;
+            unsigned int _phase_v_full = 0;
+            unsigned int _phase_old_out_ready = 0;
+            unsigned int _phase_u2_acc_ready = 0;
+            unsigned int _phase_final_ready = 0;
+            {
+                int task_begin = task_offsets[bid];
+                int task_end = task_offsets[bid + 1];
+                #pragma unroll 1
+                for (int task_pos = task_begin; task_pos < task_end; task_pos++) {
+                    int task_idx = task_ids[task_pos];
+                    int seq_idx = seq_order[task_idx / num_heads];
+                    int head_idx = task_idx % num_heads;
+                    long long seq_bos = cu_seqlens[seq_idx];
+                    long long bos = seq_bos;
+                    long long eos = cu_seqlens[seq_idx + 1];
+                    int task_state_source = -1;
+                    int task_state_destination = -1;
+                    {
+                        bos = seq_bos + (long long)task_token_starts[task_pos];
+                        eos = bos + (long long)task_token_counts[task_pos];
+                        task_state_source = task_state_sources[task_pos];
+                        task_state_destination = task_state_destinations[task_pos];
+                    }
+                    int seq_len = (int)(eos - bos);
+                    int num_chunks = (seq_len + 32 - 1) / 32;
+                    long long state_base = (((long long)seq_idx * (long long)num_heads + (long long)head_idx) * 128 + (long long)state_row) * 128;
+                    long long mid_state_source_base = ((long long)task_state_source * 128 + (long long)state_row) * 128;
+                    {
+                        if (task_state_source >= 0) {
+                            if (compute_local_warp == 0) {
+                                if (elect_sync()) {
+                                    {
+                                        unsigned int* _gca_p = reinterpret_cast<unsigned int*>(mid_state_ready) + (task_state_source);
+                                        while (true) {
+                                            unsigned int _gca_v;
+                                            asm volatile("ld.acquire.gpu.global.u32 %0, [%1];" : "=r"(_gca_v) : "l"(_gca_p));
+                                            if (_gca_v >= (unsigned int)(1)) break;
+                                        }
+                                    }
+                                }
+                            }
+                            asm volatile("barrier.sync 10, 128;" ::: "memory");
+                        }
+                    }
+                    #pragma unroll
+                    for (int state_col_block = 0; state_col_block < 4; state_col_block++) {
+                        float state_frag[32];
+                        state_frag[0] = 0.0f;
+                        state_frag[1] = 0.0f;
+                        state_frag[2] = 0.0f;
+                        state_frag[3] = 0.0f;
+                        state_frag[4] = 0.0f;
+                        state_frag[5] = 0.0f;
+                        state_frag[6] = 0.0f;
+                        state_frag[7] = 0.0f;
+                        state_frag[8] = 0.0f;
+                        state_frag[9] = 0.0f;
+                        state_frag[10] = 0.0f;
+                        state_frag[11] = 0.0f;
+                        state_frag[12] = 0.0f;
+                        state_frag[13] = 0.0f;
+                        state_frag[14] = 0.0f;
+                        state_frag[15] = 0.0f;
+                        state_frag[16] = 0.0f;
+                        state_frag[17] = 0.0f;
+                        state_frag[18] = 0.0f;
+                        state_frag[19] = 0.0f;
+                        state_frag[20] = 0.0f;
+                        state_frag[21] = 0.0f;
+                        state_frag[22] = 0.0f;
+                        state_frag[23] = 0.0f;
+                        state_frag[24] = 0.0f;
+                        state_frag[25] = 0.0f;
+                        state_frag[26] = 0.0f;
+                        state_frag[27] = 0.0f;
+                        state_frag[28] = 0.0f;
+                        state_frag[29] = 0.0f;
+                        state_frag[30] = 0.0f;
+                        state_frag[31] = 0.0f;
+                        {
+                            if (task_state_source >= 0) {
+                                {
+                                    const uint4* _vptr_0 = reinterpret_cast<const uint4*>(mid_state + mid_state_source_base + (long long)(state_col_block * 32));
+                                    uint4 _vld_0[2];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 2; _blk++) {
+                                        _vld_0[_blk] = _vptr_0[_blk];
+                                        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&state_frag[0 + _blk * 8 + _pair * 2])[0]), "=f"((&state_frag[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_0[_pair]));
+                                        }
+                                    }
+                                }
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(mid_state + mid_state_source_base + (long long)(state_col_block * 32) + 16);
+                                    uint4 _vld_1[2];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 2; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&state_frag[16 + _blk * 8 + _pair * 2])[0]), "=f"((&state_frag[16 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                            } else if (use_initial_state != 0) {
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(initial_state + state_base + (long long)(state_col_block * 32));
+                                    uint4 _vld_2[2];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 2; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&state_frag[0 + _blk * 8 + _pair * 2])[0]), "=f"((&state_frag[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(initial_state + state_base + (long long)(state_col_block * 32) + 16);
+                                    uint4 _vld_3[2];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 2; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&state_frag[16 + _blk * 8 + _pair * 2])[0]), "=f"((&state_frag[16 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        tmem_st_x32_f32(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block * 32), state_frag);
+                    }
+                    asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                    {
+                        if (task_state_source >= 0) {
+                            asm volatile("barrier.sync 10, 128;" ::: "memory");
+                            if (compute_local_warp == 0) {
+                                if (elect_sync()) {
+                                    {
+                                        unsigned int* _gcr_p = reinterpret_cast<unsigned int*>(mid_state_ready) + (task_state_source);
+                                        asm volatile("st.release.gpu.global.u32 [%0], %1;" : : "l"(_gcr_p), "r"(0u) : "memory");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    #pragma unroll 1
+                    for (int chunk_idx = 0; chunk_idx < num_chunks; chunk_idx++) {
+                        mbarrier_wait(qk_full_addr + (compute_stage) * 8, _phase_qk_full);
+                        #pragma unroll 1
+                        for (int state_col_block_1 = 0; state_col_block_1 < 4; state_col_block_1++) {
+                            int state_addr = taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 32);
+                            float _tmem_load_0[32];
+                            asm volatile(
+                                "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+                                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                                : "=f"(_tmem_load_0[0]), "=f"(_tmem_load_0[1]), "=f"(_tmem_load_0[2]), "=f"(_tmem_load_0[3]), "=f"(_tmem_load_0[4]), "=f"(_tmem_load_0[5]), "=f"(_tmem_load_0[6]), "=f"(_tmem_load_0[7]), "=f"(_tmem_load_0[8]), "=f"(_tmem_load_0[9]), "=f"(_tmem_load_0[10]), "=f"(_tmem_load_0[11]), "=f"(_tmem_load_0[12]), "=f"(_tmem_load_0[13]), "=f"(_tmem_load_0[14]), "=f"(_tmem_load_0[15]), "=f"(_tmem_load_0[16]), "=f"(_tmem_load_0[17]), "=f"(_tmem_load_0[18]), "=f"(_tmem_load_0[19]), "=f"(_tmem_load_0[20]), "=f"(_tmem_load_0[21]), "=f"(_tmem_load_0[22]), "=f"(_tmem_load_0[23]), "=f"(_tmem_load_0[24]), "=f"(_tmem_load_0[25]), "=f"(_tmem_load_0[26]), "=f"(_tmem_load_0[27]), "=f"(_tmem_load_0[28]), "=f"(_tmem_load_0[29]), "=f"(_tmem_load_0[30]), "=f"(_tmem_load_0[31])
+                                : "r"(state_addr));
+                            uint32_t _tmem_load_0_bf16[16];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 16; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_0[_lp*2 + 0], _tmem_load_0[_lp*2+1 + 0]));
+                                _tmem_load_0_bf16[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            asm volatile(
+                                "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                                " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                                :: "r"(taddr + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_1 * 16)), "r"(_tmem_load_0_bf16[0]), "r"(_tmem_load_0_bf16[1]), "r"(_tmem_load_0_bf16[2]), "r"(_tmem_load_0_bf16[3]), "r"(_tmem_load_0_bf16[4]), "r"(_tmem_load_0_bf16[5]), "r"(_tmem_load_0_bf16[6]), "r"(_tmem_load_0_bf16[7]), "r"(_tmem_load_0_bf16[8]), "r"(_tmem_load_0_bf16[9]), "r"(_tmem_load_0_bf16[10]), "r"(_tmem_load_0_bf16[11]), "r"(_tmem_load_0_bf16[12]), "r"(_tmem_load_0_bf16[13]), "r"(_tmem_load_0_bf16[14]), "r"(_tmem_load_0_bf16[15]));
+                            float state_scale[16];
+                            #pragma unroll
+                            for (int state_half = 0; state_half < 2; state_half++) {
+                                #pragma unroll
+                                for (int state_col = 0; state_col < 16; state_col++) {
+                                    state_scale[state_col] = smem_gt_all[compute_stage * 10496 + (unsigned int)(state_col_block_1 * 32) + (unsigned int)(state_half * 16) + (unsigned int)state_col];
+                                }
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 8; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>((_tmem_load_0 + state_half * 16))[_ls], reinterpret_cast<const float2*>(state_scale)[_ls]);
+                            }
+                            tmem_st_x32_f32(state_addr, _tmem_load_0);
+                        }
+                        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                        if (elect_sync()) {
+                            mbarrier_arrive(state_inp_ready_addr + (compute_stage) * 8);
+                        }
+                        mbarrier_wait(v_full_addr + (compute_stage) * 8, _phase_v_full);
+                        mbarrier_wait(old_out_ready_addr + (compute_stage) * 8, _phase_old_out_ready);
+                        float _tmem_load_1[32];
+                        asm volatile(
+                            "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+                            " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                            : "=f"(_tmem_load_1[0]), "=f"(_tmem_load_1[1]), "=f"(_tmem_load_1[2]), "=f"(_tmem_load_1[3]), "=f"(_tmem_load_1[4]), "=f"(_tmem_load_1[5]), "=f"(_tmem_load_1[6]), "=f"(_tmem_load_1[7]), "=f"(_tmem_load_1[8]), "=f"(_tmem_load_1[9]), "=f"(_tmem_load_1[10]), "=f"(_tmem_load_1[11]), "=f"(_tmem_load_1[12]), "=f"(_tmem_load_1[13]), "=f"(_tmem_load_1[14]), "=f"(_tmem_load_1[15]), "=f"(_tmem_load_1[16]), "=f"(_tmem_load_1[17]), "=f"(_tmem_load_1[18]), "=f"(_tmem_load_1[19]), "=f"(_tmem_load_1[20]), "=f"(_tmem_load_1[21]), "=f"(_tmem_load_1[22]), "=f"(_tmem_load_1[23]), "=f"(_tmem_load_1[24]), "=f"(_tmem_load_1[25]), "=f"(_tmem_load_1[26]), "=f"(_tmem_load_1[27]), "=f"(_tmem_load_1[28]), "=f"(_tmem_load_1[29]), "=f"(_tmem_load_1[30]), "=f"(_tmem_load_1[31])
+                            : "r"(taddr + 224 + (unsigned int)tmem_row_base));
+                        #pragma unroll
+                        for (int residual_half = 0; residual_half < 2; residual_half++) {
+                            float residual_v[16];
+                            float residual_beta[16];
+                            #pragma unroll
+                            for (int residual_col = 0; residual_col < 16; residual_col++) {
+                                int token_col = residual_half * 16 + residual_col;
+                                __nv_bfloat16 v_value = smem_v_all[compute_stage * 20992 + (unsigned int)(token_col * 128) + (unsigned int)state_row];
+                                float _cvt_f32_32 = __bfloat162float(v_value);
+                                residual_v[residual_col] = _cvt_f32_32;
+                                residual_beta[residual_col] = smem_prep_beta_all[compute_stage * 10496 + (unsigned int)token_col];
+                            }
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 8; _ls++)
+                                sub_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>((_tmem_load_1 + residual_half * 16))[_ls]);
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 8; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(residual_v)[_ls], reinterpret_cast<const float2*>(residual_beta)[_ls]);
+                            uint32_t residual_v_bf16[8];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 8; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(residual_v[_lp*2 + 0], residual_v[_lp*2+1 + 0]));
+                                residual_v_bf16[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            tmem_st_x8_u32(taddr + 224 + (unsigned int)tmem_row_base + (unsigned int)(residual_half * 8), (const uint32_t*)residual_v_bf16);
+                        }
+                        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                        if (elect_sync()) {
+                            mbarrier_arrive(v_free_addr + (compute_stage) * 8);
+                            mbarrier_arrive(u_inp_ready_addr + (compute_stage) * 8);
+                        }
+                        mbarrier_wait(u2_acc_ready_addr + (compute_stage) * 8, _phase_u2_acc_ready);
+                        float _tmem_load_2[32];
+                        asm volatile(
+                            "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+                            " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                            : "=f"(_tmem_load_2[0]), "=f"(_tmem_load_2[1]), "=f"(_tmem_load_2[2]), "=f"(_tmem_load_2[3]), "=f"(_tmem_load_2[4]), "=f"(_tmem_load_2[5]), "=f"(_tmem_load_2[6]), "=f"(_tmem_load_2[7]), "=f"(_tmem_load_2[8]), "=f"(_tmem_load_2[9]), "=f"(_tmem_load_2[10]), "=f"(_tmem_load_2[11]), "=f"(_tmem_load_2[12]), "=f"(_tmem_load_2[13]), "=f"(_tmem_load_2[14]), "=f"(_tmem_load_2[15]), "=f"(_tmem_load_2[16]), "=f"(_tmem_load_2[17]), "=f"(_tmem_load_2[18]), "=f"(_tmem_load_2[19]), "=f"(_tmem_load_2[20]), "=f"(_tmem_load_2[21]), "=f"(_tmem_load_2[22]), "=f"(_tmem_load_2[23]), "=f"(_tmem_load_2[24]), "=f"(_tmem_load_2[25]), "=f"(_tmem_load_2[26]), "=f"(_tmem_load_2[27]), "=f"(_tmem_load_2[28]), "=f"(_tmem_load_2[29]), "=f"(_tmem_load_2[30]), "=f"(_tmem_load_2[31])
+                            : "r"(taddr + (unsigned int)tmem_row_base));
+                        uint32_t _tmem_load_2_bf16[16];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 16; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_2[_lp*2 + 0], _tmem_load_2[_lp*2+1 + 0]));
+                            _tmem_load_2_bf16[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        asm volatile(
+                            "tcgen05.st.sync.aligned.32x32b.x16.b32"
+                            " [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16};"
+                            :: "r"(taddr + 224 + (unsigned int)tmem_row_base), "r"(_tmem_load_2_bf16[0]), "r"(_tmem_load_2_bf16[1]), "r"(_tmem_load_2_bf16[2]), "r"(_tmem_load_2_bf16[3]), "r"(_tmem_load_2_bf16[4]), "r"(_tmem_load_2_bf16[5]), "r"(_tmem_load_2_bf16[6]), "r"(_tmem_load_2_bf16[7]), "r"(_tmem_load_2_bf16[8]), "r"(_tmem_load_2_bf16[9]), "r"(_tmem_load_2_bf16[10]), "r"(_tmem_load_2_bf16[11]), "r"(_tmem_load_2_bf16[12]), "r"(_tmem_load_2_bf16[13]), "r"(_tmem_load_2_bf16[14]), "r"(_tmem_load_2_bf16[15]));
+                        asm volatile("tcgen05.wait::st.sync.aligned;" ::: "memory");
+                        if (elect_sync()) {
+                            mbarrier_arrive(u2_inp_ready_addr + (compute_stage) * 8);
+                        }
+                        mbarrier_wait(final_ready_addr + (compute_stage) * 8, _phase_final_ready);
+                        compute_stage += 1;
+                        if (compute_stage == 5) { compute_stage = 0; _phase_qk_full ^= 1; _phase_v_full ^= 1; _phase_old_out_ready ^= 1; _phase_u2_acc_ready ^= 1; _phase_final_ready ^= 1; }
+                    }
+                    {
+                        if (task_state_destination >= 0) {
+                            long long mid_state_destination_base = ((long long)task_state_destination * 128 + (long long)state_row) * 128;
+                            #pragma unroll
+                            for (int state_col_block_2 = 0; state_col_block_2 < 4; state_col_block_2++) {
+                                float _tmem_load_3[32];
+                                asm volatile(
+                                    "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+                                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                                    : "=f"(_tmem_load_3[0]), "=f"(_tmem_load_3[1]), "=f"(_tmem_load_3[2]), "=f"(_tmem_load_3[3]), "=f"(_tmem_load_3[4]), "=f"(_tmem_load_3[5]), "=f"(_tmem_load_3[6]), "=f"(_tmem_load_3[7]), "=f"(_tmem_load_3[8]), "=f"(_tmem_load_3[9]), "=f"(_tmem_load_3[10]), "=f"(_tmem_load_3[11]), "=f"(_tmem_load_3[12]), "=f"(_tmem_load_3[13]), "=f"(_tmem_load_3[14]), "=f"(_tmem_load_3[15]), "=f"(_tmem_load_3[16]), "=f"(_tmem_load_3[17]), "=f"(_tmem_load_3[18]), "=f"(_tmem_load_3[19]), "=f"(_tmem_load_3[20]), "=f"(_tmem_load_3[21]), "=f"(_tmem_load_3[22]), "=f"(_tmem_load_3[23]), "=f"(_tmem_load_3[24]), "=f"(_tmem_load_3[25]), "=f"(_tmem_load_3[26]), "=f"(_tmem_load_3[27]), "=f"(_tmem_load_3[28]), "=f"(_tmem_load_3[29]), "=f"(_tmem_load_3[30]), "=f"(_tmem_load_3[31])
+                                    : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_2 * 32)));
+                                {
+                                    __nv_bfloat162 _pk[8];
+                                    _pk[0] = __floats2bfloat162_rn(_tmem_load_3[0 + 0], _tmem_load_3[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(_tmem_load_3[0 + 2], _tmem_load_3[0 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(_tmem_load_3[0 + 4], _tmem_load_3[0 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(_tmem_load_3[0 + 6], _tmem_load_3[0 + 7]);
+                                    _pk[4] = __floats2bfloat162_rn(_tmem_load_3[0 + 8], _tmem_load_3[0 + 9]);
+                                    _pk[5] = __floats2bfloat162_rn(_tmem_load_3[0 + 10], _tmem_load_3[0 + 11]);
+                                    _pk[6] = __floats2bfloat162_rn(_tmem_load_3[0 + 12], _tmem_load_3[0 + 13]);
+                                    _pk[7] = __floats2bfloat162_rn(_tmem_load_3[0 + 14], _tmem_load_3[0 + 15]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(mid_state + (mid_state_destination_base + (long long)(state_col_block_2 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(mid_state + (mid_state_destination_base + (long long)(state_col_block_2 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                                }
+                                {
+                                    __nv_bfloat162 _pk[8];
+                                    _pk[0] = __floats2bfloat162_rn(_tmem_load_3[16 + 0], _tmem_load_3[16 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(_tmem_load_3[16 + 2], _tmem_load_3[16 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(_tmem_load_3[16 + 4], _tmem_load_3[16 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(_tmem_load_3[16 + 6], _tmem_load_3[16 + 7]);
+                                    _pk[4] = __floats2bfloat162_rn(_tmem_load_3[16 + 8], _tmem_load_3[16 + 9]);
+                                    _pk[5] = __floats2bfloat162_rn(_tmem_load_3[16 + 10], _tmem_load_3[16 + 11]);
+                                    _pk[6] = __floats2bfloat162_rn(_tmem_load_3[16 + 12], _tmem_load_3[16 + 13]);
+                                    _pk[7] = __floats2bfloat162_rn(_tmem_load_3[16 + 14], _tmem_load_3[16 + 15]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(mid_state + (mid_state_destination_base + (long long)(state_col_block_2 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(mid_state + (mid_state_destination_base + (long long)(state_col_block_2 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                                }
+                            }
+                            asm volatile("barrier.sync 10, 128;" ::: "memory");
+                            if (compute_local_warp == 0) {
+                                if (elect_sync()) {
+                                    {
+                                        unsigned int* _gc_p = reinterpret_cast<unsigned int*>(mid_state_ready) + (task_state_destination);
+                                        unsigned int _gc_old;
+                                        asm volatile("atom.release.gpu.global.add.u32 %0, [%1], 1;" : "=r"(_gc_old) : "l"(_gc_p) : "memory");
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if (store_final_state != 0) {
+                        if (task_state_destination < 0) {
+                            #pragma unroll
+                            for (int state_col_block_3 = 0; state_col_block_3 < 4; state_col_block_3++) {
+                                float _tmem_load_4[32];
+                                asm volatile(
+                                    "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+                                    " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                                    : "=f"(_tmem_load_4[0]), "=f"(_tmem_load_4[1]), "=f"(_tmem_load_4[2]), "=f"(_tmem_load_4[3]), "=f"(_tmem_load_4[4]), "=f"(_tmem_load_4[5]), "=f"(_tmem_load_4[6]), "=f"(_tmem_load_4[7]), "=f"(_tmem_load_4[8]), "=f"(_tmem_load_4[9]), "=f"(_tmem_load_4[10]), "=f"(_tmem_load_4[11]), "=f"(_tmem_load_4[12]), "=f"(_tmem_load_4[13]), "=f"(_tmem_load_4[14]), "=f"(_tmem_load_4[15]), "=f"(_tmem_load_4[16]), "=f"(_tmem_load_4[17]), "=f"(_tmem_load_4[18]), "=f"(_tmem_load_4[19]), "=f"(_tmem_load_4[20]), "=f"(_tmem_load_4[21]), "=f"(_tmem_load_4[22]), "=f"(_tmem_load_4[23]), "=f"(_tmem_load_4[24]), "=f"(_tmem_load_4[25]), "=f"(_tmem_load_4[26]), "=f"(_tmem_load_4[27]), "=f"(_tmem_load_4[28]), "=f"(_tmem_load_4[29]), "=f"(_tmem_load_4[30]), "=f"(_tmem_load_4[31])
+                                    : "r"(taddr + 64 + (unsigned int)tmem_row_base + (unsigned int)(state_col_block_3 * 32)));
+                                {
+                                    __nv_bfloat162 _pk[8];
+                                    _pk[0] = __floats2bfloat162_rn(_tmem_load_4[0 + 0], _tmem_load_4[0 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(_tmem_load_4[0 + 2], _tmem_load_4[0 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(_tmem_load_4[0 + 4], _tmem_load_4[0 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(_tmem_load_4[0 + 6], _tmem_load_4[0 + 7]);
+                                    _pk[4] = __floats2bfloat162_rn(_tmem_load_4[0 + 8], _tmem_load_4[0 + 9]);
+                                    _pk[5] = __floats2bfloat162_rn(_tmem_load_4[0 + 10], _tmem_load_4[0 + 11]);
+                                    _pk[6] = __floats2bfloat162_rn(_tmem_load_4[0 + 12], _tmem_load_4[0 + 13]);
+                                    _pk[7] = __floats2bfloat162_rn(_tmem_load_4[0 + 14], _tmem_load_4[0 + 15]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_3 * 32))))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_3 * 32))))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                                }
+                                {
+                                    __nv_bfloat162 _pk[8];
+                                    _pk[0] = __floats2bfloat162_rn(_tmem_load_4[16 + 0], _tmem_load_4[16 + 1]);
+                                    _pk[1] = __floats2bfloat162_rn(_tmem_load_4[16 + 2], _tmem_load_4[16 + 3]);
+                                    _pk[2] = __floats2bfloat162_rn(_tmem_load_4[16 + 4], _tmem_load_4[16 + 5]);
+                                    _pk[3] = __floats2bfloat162_rn(_tmem_load_4[16 + 6], _tmem_load_4[16 + 7]);
+                                    _pk[4] = __floats2bfloat162_rn(_tmem_load_4[16 + 8], _tmem_load_4[16 + 9]);
+                                    _pk[5] = __floats2bfloat162_rn(_tmem_load_4[16 + 10], _tmem_load_4[16 + 11]);
+                                    _pk[6] = __floats2bfloat162_rn(_tmem_load_4[16 + 12], _tmem_load_4[16 + 13]);
+                                    _pk[7] = __floats2bfloat162_rn(_tmem_load_4[16 + 14], _tmem_load_4[16 + 15]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_3 * 32) + 16)))[0]) = *reinterpret_cast<uint4*>(&_pk[0]);
+                                    *reinterpret_cast<uint4*>(&((__nv_bfloat16*)(final_state + (state_base + (long long)(state_col_block_3 * 32) + 16)))[8]) = *reinterpret_cast<uint4*>(&_pk[4]);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            asm volatile("barrier.sync 10, 128;" ::: "memory");
+            if (compute_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: epilogue ----
+    if (warp >= 4 && warp <= 7) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // epilogue_main
+            int warp_id_in_role_1 = (warp - 4);
+            int epilogue_local_warp = warp_id_in_role_1;
+            int warp_in_wg_1 = warp % 4;
+            const int tmem_row_base_1 = warp_in_wg_1 * 32 << 16;
+            int state_row_1 = warp_in_wg_1 * 32 + lane;
+            unsigned int epilogue_stage = 0;
+            unsigned int output_stage = 0;
+            unsigned int _phase_final_ready_1 = 0;
+            {
+                int task_begin_1 = task_offsets[bid];
+                int task_end_1 = task_offsets[bid + 1];
+                #pragma unroll 1
+                for (int task_pos_1 = task_begin_1; task_pos_1 < task_end_1; task_pos_1++) {
+                    int task_idx_1 = task_ids[task_pos_1];
+                    int seq_idx_1 = seq_order[task_idx_1 / num_heads];
+                    int head_idx_1 = task_idx_1 % num_heads;
+                    long long seq_bos_1 = cu_seqlens[seq_idx_1];
+                    long long bos_1 = seq_bos_1;
+                    long long eos_1 = cu_seqlens[seq_idx_1 + 1];
+                    {
+                        bos_1 = seq_bos_1 + (long long)task_token_starts[task_pos_1];
+                        eos_1 = bos_1 + (long long)task_token_counts[task_pos_1];
+                    }
+                    int seq_len_1 = (int)(eos_1 - bos_1);
+                    int num_chunks_1 = (seq_len_1 + 32 - 1) / 32;
+                    #pragma unroll 1
+                    for (int chunk_idx_1 = 0; chunk_idx_1 < num_chunks_1; chunk_idx_1++) {
+                        mbarrier_wait(final_ready_addr + (epilogue_stage) * 8, _phase_final_ready_1);
+                        int chunk_is_full = ((seq_len_1 >= (chunk_idx_1 + 1) * 32) ? 1 : 0);
+                        if (chunk_is_full != 0) {
+                            float _tmem_load_10[16];
+                            asm volatile(
+                                "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_10[15]))
+                                : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+                            float _tmem_load_11[16];
+                            asm volatile(
+                                "tcgen05.ld.sync.aligned.16x256b.x4.b32"
+                                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, [%16];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[0])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[1])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[2])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[3])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[4])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[5])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[6])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[7])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[8])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[9])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[10])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[11])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[12])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[13])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[14])), "=r"(*reinterpret_cast<uint32_t*>(&_tmem_load_11[15]))
+                                : "r"(taddr + 192 + (unsigned int)tmem_row_base_1 + 1048576));
+                            asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                            asm volatile("barrier.sync 9, 128;" ::: "memory");
+                            if (epilogue_local_warp == 0) {
+                                if (elect_sync()) {
+                                    mbarrier_arrive(out_empty_addr);
+                                }
+                            }
+                            if (epilogue_local_warp == 0) {
+                                if (chunk_idx_1 >= 1) {
+                                    asm volatile("cp.async.bulk.wait_group.read 0;");
+                                }
+                            }
+                            asm volatile("barrier.sync 9, 128;" ::: "memory");
+                            int out_stage_addr = smem_out_addr + output_stage * 8192;
+                            #pragma unroll
+                            for (int dim_half = 0; dim_half < 2; dim_half++) {
+                                unsigned int out_packed[8];
+                                if (dim_half == 0) {
+                                    #pragma unroll
+                                    for (int _lp = 0; _lp < 8; _lp++) {
+                                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_10[_lp*2 + 0], _tmem_load_10[_lp*2+1 + 0]));
+                                        out_packed[_lp] = *(uint32_t*)&_bf2;
+                                    }
+                                } else {
+                                    #pragma unroll
+                                    for (int _lp = 0; _lp < 8; _lp++) {
+                                        __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(_tmem_load_11[_lp*2 + 0], _tmem_load_11[_lp*2+1 + 0]));
+                                        out_packed[_lp] = *(uint32_t*)&_bf2;
+                                    }
+                                }
+                                #pragma unroll
+                                for (int token_group = 0; token_group < 2; token_group++) {
+                                    int mtx_idx = lane / 8;
+                                    int row_addr = lane & 7;
+                                    int dim_base = epilogue_local_warp * 32 + dim_half * 16 + (mtx_idx & 1) * 8;
+                                    int token_base = token_group * 16 + mtx_idx / 2 * 8;
+                                    int token_addr = token_base + row_addr;
+                                    int token_pair = token_addr / 2;
+                                    int token_parity = token_addr & 1;
+                                    int raw_row = token_pair + dim_base / 64 * 16;
+                                    int raw_col = (dim_base & 63 ^ (token_pair & 3) << 4 ^ token_parity << 3) + token_parity * 64;
+                                    int stsm_offset = (raw_row * 128 + raw_col) * 2;
+                                    const int pack_base = token_group * 4;
+                                    uint32_t _stmatrix_addr_0 = static_cast<uint32_t>((unsigned long long)(out_stage_addr + stsm_offset));
+                                    asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                        :: "r"(_stmatrix_addr_0), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 1])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 2])), "r"(*reinterpret_cast<const uint32_t*>(&out_packed[pack_base + 3]))
+                                        : "memory");
+                                }
+                            }
+                            asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                            asm volatile("barrier.sync 9, 128;" ::: "memory");
+                            if (epilogue_local_warp == 0) {
+                                if (elect_sync()) {
+                                    tma_store_4d(out_tma, 0, (int)(bos_1 + (long long)(chunk_idx_1 * 32)), head_idx_1, 0, smem_out_addr + output_stage * 8192);
+                                }
+                                asm volatile("cp.async.bulk.commit_group;");
+                            }
+                            output_stage = 0;
+                        } else {
+                            float _tmem_load_12[32];
+                            asm volatile(
+                                "tcgen05.ld.sync.aligned.32x32b.x32.b32"
+                                " {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
+                                : "=f"(_tmem_load_12[0]), "=f"(_tmem_load_12[1]), "=f"(_tmem_load_12[2]), "=f"(_tmem_load_12[3]), "=f"(_tmem_load_12[4]), "=f"(_tmem_load_12[5]), "=f"(_tmem_load_12[6]), "=f"(_tmem_load_12[7]), "=f"(_tmem_load_12[8]), "=f"(_tmem_load_12[9]), "=f"(_tmem_load_12[10]), "=f"(_tmem_load_12[11]), "=f"(_tmem_load_12[12]), "=f"(_tmem_load_12[13]), "=f"(_tmem_load_12[14]), "=f"(_tmem_load_12[15]), "=f"(_tmem_load_12[16]), "=f"(_tmem_load_12[17]), "=f"(_tmem_load_12[18]), "=f"(_tmem_load_12[19]), "=f"(_tmem_load_12[20]), "=f"(_tmem_load_12[21]), "=f"(_tmem_load_12[22]), "=f"(_tmem_load_12[23]), "=f"(_tmem_load_12[24]), "=f"(_tmem_load_12[25]), "=f"(_tmem_load_12[26]), "=f"(_tmem_load_12[27]), "=f"(_tmem_load_12[28]), "=f"(_tmem_load_12[29]), "=f"(_tmem_load_12[30]), "=f"(_tmem_load_12[31])
+                                : "r"(taddr + 192 + (unsigned int)tmem_row_base_1));
+                            asm volatile("tcgen05.wait::ld.sync.aligned;" ::: "memory");
+                            asm volatile("barrier.sync 9, 128;" ::: "memory");
+                            if (epilogue_local_warp == 0) {
+                                if (elect_sync()) {
+                                    mbarrier_arrive(out_empty_addr);
+                                }
+                            }
+                            #pragma unroll
+                            for (int token_col_1 = 0; token_col_1 < 32; token_col_1++) {
+                                long long out_token = bos_1 + (long long)(chunk_idx_1 * 32 + token_col_1);
+                                if (out_token < eos_1) {
+                                    long long out_idx = (out_token * (long long)num_heads + (long long)head_idx_1) * 128 + (long long)state_row_1;
+                                    out[out_idx] = _tmem_load_12[token_col_1];
+                                }
+                            }
+                        }
+                        epilogue_stage += 1;
+                        if (epilogue_stage == 5) { epilogue_stage = 0; _phase_final_ready_1 ^= 1; }
+                    }
+                    if (epilogue_local_warp == 0) {
+                        asm volatile("cp.async.bulk.wait_group 0;");
+                    }
+                    asm volatile("barrier.sync 9, 128;" ::: "memory");
+                }
+            }
+            if (epilogue_local_warp == 0) {
+                if (elect_sync()) {
+                    mbarrier_arrive(tmem_dealloc_ready_addr);
+                }
+            }
+        }
+    }
+    // ---- Role: mma ----
+    if (warp == 9) {
+        { // mma_main
+            unsigned int mma_stage = 0;
+            unsigned int _phase_qk_full_1 = 0;
+            unsigned int _phase_state_inp_ready = 0;
+            unsigned int _phase_out_empty_0 = 1;
+            unsigned int _phase_u_inp_ready = 0;
+            unsigned int _phase_u2_inp_ready = 0;
+            {
+                int task_begin_2 = task_offsets[bid];
+                int task_end_2 = task_offsets[bid + 1];
+                #pragma unroll 1
+                for (int task_pos_2 = task_begin_2; task_pos_2 < task_end_2; task_pos_2++) {
+                    int task_idx_2 = task_ids[task_pos_2];
+                    int seq_idx_2 = seq_order[task_idx_2 / num_heads];
+                    long long seq_bos_2 = cu_seqlens[seq_idx_2];
+                    long long bos_2 = seq_bos_2;
+                    long long eos_2 = cu_seqlens[seq_idx_2 + 1];
+                    {
+                        bos_2 = seq_bos_2 + (long long)task_token_starts[task_pos_2];
+                        eos_2 = bos_2 + (long long)task_token_counts[task_pos_2];
+                    }
+                    int seq_len_2 = (int)(eos_2 - bos_2);
+                    int num_chunks_2 = (seq_len_2 + 32 - 1) / 32;
+                    #pragma unroll 1
+                    for (int _chunk_idx = 0; _chunk_idx < num_chunks_2; _chunk_idx++) {
+                        mbarrier_wait(qk_full_addr + (mma_stage) * 8, _phase_qk_full_1);
+                        mbarrier_wait(state_inp_ready_addr + (mma_stage) * 8, _phase_state_inp_ready);
+                        mbarrier_wait(out_empty_addr, _phase_out_empty_0);
+                        _phase_out_empty_0 ^= 1;
+                        int _mma_b_lo_0 = make_warp_uniform((((smem_kd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u_acc), "r"(_mma_b_lo_0), "r"(tmem_tmem_state_inp), "r"(0));
+                        elect_commit(old_out_ready_addr + (mma_stage) * 8);
+                        int _mma_b_lo_1 = make_warp_uniform((((smem_qd_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 250;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 2;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_out), "r"(_mma_b_lo_1), "r"(tmem_tmem_state_inp), "r"(0));
+                        elect_commit(raw_inputs_free_addr + (mma_stage) * 8);
+                        mbarrier_wait(u_inp_ready_addr + (mma_stage) * 8, _phase_u_inp_ready);
+                        int _mma_b_lo_2 = make_warp_uniform((((smem_inv_addr) >> 4) & 0x3FFF) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0xC0004010;\n\t"
+                    "mov.b32 id, 134743184;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 64;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_u2_acc), "r"(_mma_b_lo_2), "r"(tmem_tmem_u2_inp), "r"(0));
+                        elect_commit(u2_acc_ready_addr + (mma_stage) * 8);
+                        mbarrier_wait(u2_inp_ready_addr + (mma_stage) * 8, _phase_u2_inp_ready);
+                        int _mma_b_lo_3 = make_warp_uniform(((((smem_final_trans_addr) >> 4) & 0x3FFF) | 0x1000000) + (mma_stage) * 2624);
+                        asm volatile(
+                    "{\n\t"
+                    ".reg .pred leader, p0, p1;\n\t"
+                    ".reg .b32 dhi, blo, ta, id;\n\t"
+                    ".reg .b64 db;\n\t"
+                    "elect.sync _|leader, 0xFFFFFFFF;\n\t"
+                    "setp.ne.b32 p0, %3, 0;\n\t"
+                    "setp.ne.b32 p1, 1, 0;\n\t"
+                    ""
+                    "mov.b32 dhi, 0x40004040;\n\t"
+                    "mov.b32 id, 136905872;\n\t"
+                    "mov.b32 ta, %2;\n\t"
+                    "mov.b32 blo, %1;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p0;\n\t"
+                    "add.u32 ta, ta, 8;\n\t"
+                    "add.u32 blo, blo, 128;\n\t"
+                    "mov.b64 db, {blo, dhi};\n\t"
+                    "@leader tcgen05.mma.cta_group::1.kind::f16 [%0], [ta], db, id, p1;\n\t"
+                    "}\n"
+                    :: "r"(tmem_tmem_state_out), "r"(_mma_b_lo_3), "r"(tmem_tmem_u2_inp), "r"(1));
+                        elect_commit2(final_ready_addr + (mma_stage) * 8, smem_free_addr + (mma_stage) * 8);
+                        mma_stage += 1;
+                        if (mma_stage == 5) { mma_stage = 0; _phase_qk_full_1 ^= 1; _phase_state_inp_ready ^= 1; _phase_u_inp_ready ^= 1; _phase_u2_inp_ready ^= 1; }
+                    }
+                }
+            }
+            unsigned int _phase_tmem_dealloc_ready_0 = 0;
+            mbarrier_wait(tmem_dealloc_ready_addr, _phase_tmem_dealloc_ready_0);
+            _phase_tmem_dealloc_ready_0 ^= 1;
+            int _tmem_dealloc_addr = *((volatile int*)tmem_addr_storage);
+            asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" :: "r"(_tmem_dealloc_addr), "r"(256));
+        }
+    }
+    // ---- Role: load ----
+    if (warp == 10) {
+        { // load_main
+            unsigned int load_stage = 0;
+            unsigned int _phase_v_free = 1;
+            unsigned int _phase_qk_full_2 = 0;
+            {
+                int task_begin_3 = task_offsets[bid];
+                int task_end_3 = task_offsets[bid + 1];
+                #pragma unroll 1
+                for (int task_pos_3 = task_begin_3; task_pos_3 < task_end_3; task_pos_3++) {
+                    int task_idx_3 = task_ids[task_pos_3];
+                    int seq_idx_3 = seq_order[task_idx_3 / num_heads];
+                    int head_idx_2 = task_idx_3 % num_heads;
+                    long long seq_bos_3 = cu_seqlens[seq_idx_3];
+                    long long bos_3 = seq_bos_3;
+                    long long eos_3 = cu_seqlens[seq_idx_3 + 1];
+                    {
+                        bos_3 = seq_bos_3 + (long long)task_token_starts[task_pos_3];
+                        eos_3 = bos_3 + (long long)task_token_counts[task_pos_3];
+                    }
+                    int seq_len_3 = (int)(eos_3 - bos_3);
+                    int num_chunks_3 = (seq_len_3 + 32 - 1) / 32;
+                    #pragma unroll 1
+                    for (int chunk_idx_2 = 0; chunk_idx_2 < num_chunks_3; chunk_idx_2++) {
+                        mbarrier_wait(v_free_addr + (load_stage) * 8, _phase_v_free);
+                        mbarrier_wait(qk_full_addr + (load_stage) * 8, _phase_qk_full_2);
+                        int chunk_is_full_1 = ((seq_len_3 >= (chunk_idx_2 + 1) * 32) ? 1 : 0);
+                        if (elect_sync()) {
+                            if (chunk_is_full_1 != 0) {
+                                mbarrier_arrive_expect_tx(v_full_addr + (load_stage) * 8, 8192);
+                                tma_3d_gmem2smem(smem_v_addr + load_stage * 41984, v_tma, 0, head_idx_2, (int)(bos_3 + (long long)(chunk_idx_2 * 32)), v_full_addr + (load_stage) * 8);
+                            }
+                        }
+                        if (chunk_is_full_1 == 0) {
+                            #pragma unroll
+                            for (int v_load_iter = 0; v_load_iter < 16; v_load_iter++) {
+                                int v_item = v_load_iter * 32 + lane;
+                                int row = v_item / 16;
+                                int segment = v_item % 16;
+                                long long token = bos_3 + (long long)(chunk_idx_2 * 32 + row);
+                                int token_valid = ((token < eos_3) ? 1 : 0);
+                                long long v_src = (token * (long long)num_heads + (long long)head_idx_2) * 128 + (long long)(segment * 8);
+                                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                                    :: "r"(smem_v_addr + load_stage * 41984 + (unsigned int)((row * 128 + segment * 8) * 2)), "l"(v + v_src), "r"((token_valid != 0) ? 16 : 0));
+                            }
+                            asm volatile("cp.async.commit_group;");
+                            asm volatile("cp.async.wait_group 0;");
+                        }
+                        asm volatile("barrier.sync 8, 32;" ::: "memory");
+                        if (elect_sync()) {
+                            if (chunk_is_full_1 == 0) {
+                                asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                                mbarrier_arrive(v_full_addr + (load_stage) * 8);
+                            }
+                        }
+                        load_stage += 1;
+                        if (load_stage == 5) { load_stage = 0; _phase_v_free ^= 1; _phase_qk_full_2 ^= 1; }
+                    }
+                }
+            }
+        }
+    }
+    // ---- Role: prep ----
+    if (warp >= 12 && warp <= 31) {
+        asm volatile("setmaxnreg.dec.sync.aligned.u32 48;");
+        { // prep_main
+            int instance_id = (warp - 12) / 4;
+            int prep_instance = instance_id;
+            int warp_id_in_role_2 = (warp - 12);
+            int prep_local_warp = warp_id_in_role_2 - prep_instance * 4;
+            int prep_tid = prep_local_warp * 32 + lane;
+            unsigned int prep_stage = (unsigned int)prep_instance;
+            int gate_rate_stage_f32 = prep_instance * 10496;
+            int gate_bias_instance_f32 = prep_instance * 128;
+            int last_gate_head_idx = -1;
+            unsigned int _phase_raw_inputs_free = 1;
+            unsigned int _phase_gate_raw_full = 0;
+            unsigned int _phase_smem_free = 1;
+            unsigned int _phase_qk_raw_full = 0;
+            {
+                int global_chunk_base = 0;
+                int task_begin_4 = task_offsets[bid];
+                int task_end_4 = task_offsets[bid + 1];
+                #pragma unroll 1
+                for (int task_pos_4 = task_begin_4; task_pos_4 < task_end_4; task_pos_4++) {
+                    int task_idx_4 = task_ids[task_pos_4];
+                    int prep_start = (prep_instance - global_chunk_base % 5 + 5) % 5;
+                    int seq_idx_4 = seq_order[task_idx_4 / num_heads];
+                    int head_idx_3 = task_idx_4 % num_heads;
+                    long long seq_bos_4 = cu_seqlens[seq_idx_4];
+                    long long bos_4 = seq_bos_4;
+                    long long eos_4 = cu_seqlens[seq_idx_4 + 1];
+                    {
+                        bos_4 = seq_bos_4 + (long long)task_token_starts[task_pos_4];
+                        eos_4 = bos_4 + (long long)task_token_counts[task_pos_4];
+                    }
+                    int seq_len_4 = (int)(eos_4 - bos_4);
+                    int num_chunks_4 = (seq_len_4 + 32 - 1) / 32;
+                    int num_prep_iters = (num_chunks_4 + 5 - 1 - prep_start) / 5;
+                    {
+                        if (head_idx_3 != last_gate_head_idx) {
+                            if (prep_tid == 0) {
+                                float _expf_0 = __expf(A_log[head_idx_3]);
+                                smem_gate_rate_all[gate_rate_stage_f32] = _expf_0;
+                            }
+                            if (prep_tid < 128) {
+                                smem_gate_bias_all[gate_bias_instance_f32 + prep_tid] = dt_bias[head_idx_3 * 128 + prep_tid];
+                            }
+                            asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                            if (prep_tid < 128) {
+                                smem_gate_bias_all[gate_bias_instance_f32 + prep_tid] = smem_gate_bias_all[gate_bias_instance_f32 + prep_tid] * smem_gate_rate_all[gate_rate_stage_f32];
+                            }
+                            asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                        }
+                        last_gate_head_idx = head_idx_3;
+                    }
+                    #pragma unroll 1
+                    for (int prep_iter = 0; prep_iter < num_prep_iters; prep_iter++) {
+                        int chunk_idx_3 = prep_iter * 5 + prep_start;
+                        int stage_f32 = prep_stage * 10496;
+                        int stage_bf16 = prep_stage * 20992;
+                        int chunk_is_full_2 = ((seq_len_4 >= (chunk_idx_3 + 1) * 32) ? 1 : 0);
+                        float early_beta_value = 0.0f;
+                        float early_gate0 = 0.0f;
+                        float early_gate_log2_values[8];
+                        {
+                            early_gate_log2_values[0] = 0.0f;
+                            early_gate_log2_values[1] = 0.0f;
+                            early_gate_log2_values[2] = 0.0f;
+                            early_gate_log2_values[3] = 0.0f;
+                            early_gate_log2_values[4] = 0.0f;
+                            early_gate_log2_values[5] = 0.0f;
+                            early_gate_log2_values[6] = 0.0f;
+                            early_gate_log2_values[7] = 0.0f;
+                        }
+                        if (chunk_is_full_2 != 0) {
+                            mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                        }
+                        if (chunk_is_full_2 == 0) {
+                            {
+                                mbarrier_wait(raw_inputs_free_addr + (prep_stage) * 8, _phase_raw_inputs_free);
+                            }
+                        }
+                        if (chunk_is_full_2 != 0) {
+                            if (prep_local_warp == 0) {
+                                if (elect_sync()) {
+                                    mbarrier_arrive_expect_tx(gate_raw_full_addr + (prep_stage) * 8, 8704);
+                                    tma_3d_gmem2smem(smem_g_raw_addr + prep_stage * 41984, g_tma, 0, head_idx_3, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                                    tma_2d_gmem2smem(smem_beta_raw_addr + prep_stage * 41984, beta_tma, head_idx_3 / 8 * 8, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), gate_raw_full_addr + (prep_stage) * 8);
+                                    mbarrier_arrive_expect_tx(qk_raw_full_addr + (prep_stage) * 8, 16384);
+                                    tma_4d_gmem2smem(smem_kd_addr + prep_stage * 41984, k_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_3, 0, qk_raw_full_addr + (prep_stage) * 8);
+                                }
+                            }
+                            mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                            if (prep_local_warp == 2 && lane < 32) {
+                                unsigned int beta_raw_pair[1];
+                                asm volatile("ld.shared.b32 %0, [%1];" : "=r"(*reinterpret_cast<uint32_t*>(&beta_raw_pair[0])) : "r"(smem_beta_raw_addr + prep_stage * 41984 + (unsigned int)(lane * 16) + (unsigned int)(head_idx_3 % 8 / 2 * 4)));
+                                float beta_raw_pair_f32[2];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 1; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&beta_raw_pair_f32[_pair * 2])[0]), "=f"((&beta_raw_pair_f32[_pair * 2])[1])
+                                        : "r"(beta_raw_pair[_pair]));
+                                }
+                                float beta_logit = beta_raw_pair_f32[0];
+                                if (head_idx_3 % 2 != 0) {
+                                    beta_logit = beta_raw_pair_f32[1];
+                                }
+                                float _tanh_approx_0;
+                                asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_0) : "f"(beta_logit * 0.5f));
+                                early_beta_value = _tanh_approx_0 * 0.5f + 0.5f;
+                            }
+                            if (prep_tid < 128) {
+                                float early_gate_rate = smem_gate_rate_all[stage_f32];
+                                float early_gate_bias = smem_gate_bias_all[gate_bias_instance_f32 + prep_tid];
+                                {
+                                    for (int early_gate_row = 0; early_gate_row < 8; early_gate_row++) {
+                                        __nv_bfloat16 early_gate_raw = smem_g_raw_all[stage_bf16 + early_gate_row * 128 + prep_tid];
+                                        float _cvt_f32_0 = __bfloat162float(early_gate_raw);
+                                        float _fma_0 = __fmaf_rn(_cvt_f32_0, early_gate_rate, early_gate_bias);
+                                        float early_gate_arg = _fma_0;
+                                        float _tanh_approx_1;
+                                        asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_1) : "f"(early_gate_arg * 0.5f));
+                                        float early_gate_tanh = _tanh_approx_1;
+                                        float half_gate_scale = lower_bound * 0.7213475204444817f;
+                                        float _fma_1 = __fmaf_rn(early_gate_tanh, half_gate_scale, half_gate_scale);
+                                        float early_gate_log2 = _fma_1;
+                                        early_gate_log2_values[early_gate_row] = early_gate_log2;
+                                    }
+                                }
+                            }
+                        }
+                        mbarrier_wait(smem_free_addr + (prep_stage) * 8, _phase_smem_free);
+                        if (chunk_is_full_2 != 0) {
+                            if (prep_local_warp == 0) {
+                                if (elect_sync()) {
+                                    tma_4d_gmem2smem(smem_q_raw_prefetch_addr + prep_stage * 41984, q_tma, 0, (int)(bos_4 + (long long)(chunk_idx_3 * 32)), head_idx_3, 0, qk_raw_full_addr + (prep_stage) * 8);
+                                }
+                            }
+                        }
+                        if (chunk_is_full_2 == 0) {
+                            #pragma unroll
+                            for (int gate_load_pass = 0; gate_load_pass < 4; gate_load_pass++) {
+                                int gate_load_item = gate_load_pass * 128 + prep_tid;
+                                int gate_load_row = gate_load_item / 16;
+                                int gate_load_segment = gate_load_item % 16;
+                                long long gate_load_token = bos_4 + (long long)(chunk_idx_3 * 32 + gate_load_row);
+                                long long gate_load_base = (gate_load_token * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)(gate_load_segment * 8);
+                                asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16, %2;"
+                                    :: "r"(smem_g_raw_addr + prep_stage * 41984 + (unsigned int)(gate_load_item * 16)), "l"(g + gate_load_base), "r"((gate_load_token < eos_4) ? 16 : 0));
+                            }
+                        }
+                        if (chunk_is_full_2 == 0) {
+                            asm volatile("cp.async.commit_group;");
+                            asm volatile("cp.async.wait_group 0;");
+                            asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                            {
+                                if (prep_local_warp == 0) {
+                                    if (elect_sync()) {
+                                        mbarrier_arrive(gate_raw_full_addr + (prep_stage) * 8);
+                                        mbarrier_arrive(qk_raw_full_addr + (prep_stage) * 8);
+                                    }
+                                }
+                                mbarrier_wait(gate_raw_full_addr + (prep_stage) * 8, _phase_gate_raw_full);
+                                mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                            }
+                        }
+                        if (prep_local_warp == 2 && lane < 32) {
+                            float beta_value = early_beta_value;
+                            if (chunk_is_full_2 == 0) {
+                                long long beta_token = bos_4 + (long long)(chunk_idx_3 * 32 + lane);
+                                if (beta_token < eos_4) {
+                                    float beta_logit_1 = (float)beta[beta_token * (long long)num_heads + (long long)head_idx_3];
+                                    float _tanh_approx_3;
+                                    asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_3) : "f"(beta_logit_1 * 0.5f));
+                                    beta_value = _tanh_approx_3 * 0.5f + 0.5f;
+                                }
+                            }
+                            smem_prep_beta_all[stage_f32 + lane] = beta_value;
+                        }
+                        if (prep_tid < 128) {
+                            int gate_col = prep_tid;
+                            float gate_rate = smem_gate_rate_all[stage_f32];
+                            float gate_bias = smem_gate_bias_all[gate_bias_instance_f32 + gate_col];
+                            float prefix_log2 = 0.0f;
+                            float2 _f2_0 = make_float2(gate_rate, gate_rate);
+                            float2 gate_rate_pair = _f2_0;
+                            float2 _f2_1 = make_float2(gate_bias, gate_bias);
+                            float2 gate_bias_pair = _f2_1;
+                            float half_gate_scale_1 = lower_bound * 0.7213475204444817f;
+                            float2 _f2_2 = make_float2(half_gate_scale_1, half_gate_scale_1);
+                            float2 half_gate_scale_pair = _f2_2;
+                            if (chunk_is_full_2 != 0) {
+                                for (int gate_row_pair = 0; gate_row_pair < 16; gate_row_pair++) {
+                                    const int gate_row0 = gate_row_pair * 2;
+                                    const int gate_row1 = gate_row0 + 1;
+                                    float gate_log0 = 0.0f;
+                                    float gate_log1 = 0.0f;
+                                    {
+                                        if (gate_row0 < 8) {
+                                            gate_log0 = early_gate_log2_values[gate_row0];
+                                            gate_log1 = early_gate_log2_values[gate_row1];
+                                        } else {
+                                            const int gate_row0_0 = gate_row_pair * 2;
+                                            const int gate_row1_1 = gate_row0_0 + 1;
+                                            __nv_bfloat16 gate_raw0 = smem_g_raw_all[stage_bf16 + gate_row0_0 * 128 + gate_col];
+                                            __nv_bfloat16 gate_raw1 = smem_g_raw_all[stage_bf16 + gate_row1_1 * 128 + gate_col];
+                                            float _cvt_f32_2 = __bfloat162float(gate_raw0);
+                                            float _cvt_f32_3 = __bfloat162float(gate_raw1);
+                                            float2 _f2_3 = make_float2(_cvt_f32_2, _cvt_f32_3);
+                                            float2 gate_raw_pair = _f2_3;
+                                            float2 gate_arg_pair = fma_f32x2(gate_raw_pair, gate_rate_pair, gate_bias_pair);
+                                            float _tanh_approx_4;
+                                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_4) : "f"(gate_arg_pair.x * 0.5f));
+                                            float _tanh_approx_5;
+                                            asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_5) : "f"(gate_arg_pair.y * 0.5f));
+                                            float2 _f2_4 = make_float2(_tanh_approx_4, _tanh_approx_5);
+                                            float2 gate_tanh_pair = _f2_4;
+                                            float2 gate_log_pair = fma_f32x2(gate_tanh_pair, half_gate_scale_pair, half_gate_scale_pair);
+                                            float gate_log0_2 = gate_log_pair.x;
+                                            float gate_log1_3 = gate_log_pair.y;
+                                            gate_log0 = gate_log0_2;
+                                            gate_log1 = gate_log1_3;
+                                        }
+                                    }
+                                    prefix_log2 += gate_log0;
+                                    smem_gate_all[stage_f32 + gate_row0 * 128 + gate_col] = prefix_log2;
+                                    prefix_log2 += gate_log1;
+                                    smem_gate_all[stage_f32 + gate_row1 * 128 + gate_col] = prefix_log2;
+                                }
+                            } else {
+                                for (int gate_row_pair_1 = 0; gate_row_pair_1 < 16; gate_row_pair_1++) {
+                                    const int gate_row0_1 = gate_row_pair_1 * 2;
+                                    const int gate_row1_2 = gate_row0_1 + 1;
+                                    const int gate_row0_0_1 = gate_row_pair_1 * 2;
+                                    const int gate_row1_1_1 = gate_row0_0_1 + 1;
+                                    __nv_bfloat16 gate_raw0_1 = smem_g_raw_all[stage_bf16 + gate_row0_0_1 * 128 + gate_col];
+                                    __nv_bfloat16 gate_raw1_1 = smem_g_raw_all[stage_bf16 + gate_row1_1_1 * 128 + gate_col];
+                                    float _cvt_f32_6 = __bfloat162float(gate_raw0_1);
+                                    float _cvt_f32_7 = __bfloat162float(gate_raw1_1);
+                                    float2 _f2_7 = make_float2(_cvt_f32_6, _cvt_f32_7);
+                                    float2 gate_raw_pair_1 = _f2_7;
+                                    float2 gate_arg_pair_1 = fma_f32x2(gate_raw_pair_1, gate_rate_pair, gate_bias_pair);
+                                    float _tanh_approx_8;
+                                    asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_8) : "f"(gate_arg_pair_1.x * 0.5f));
+                                    float _tanh_approx_9;
+                                    asm volatile("tanh.approx.f32 %0, %1;" : "=f"(_tanh_approx_9) : "f"(gate_arg_pair_1.y * 0.5f));
+                                    float2 _f2_8 = make_float2(_tanh_approx_8, _tanh_approx_9);
+                                    float2 gate_tanh_pair_1 = _f2_8;
+                                    float2 gate_log_pair_1 = fma_f32x2(gate_tanh_pair_1, half_gate_scale_pair, half_gate_scale_pair);
+                                    float gate_log0_1 = gate_log_pair_1.x;
+                                    float gate_log1_1 = gate_log_pair_1.y;
+                                    {
+                                        long long gate_token0 = bos_4 + (long long)(chunk_idx_3 * 32 + gate_row0_0_1);
+                                        long long gate_token1 = gate_token0 + 1;
+                                        if (gate_token0 >= eos_4) {
+                                            gate_log0_1 = 0.0f;
+                                        }
+                                        if (gate_token1 >= eos_4) {
+                                            gate_log1_1 = 0.0f;
+                                        }
+                                    }
+                                    prefix_log2 += gate_log0_1;
+                                    smem_gate_all[stage_f32 + gate_row0_1 * 128 + gate_col] = prefix_log2;
+                                    prefix_log2 += gate_log1_1;
+                                    smem_gate_all[stage_f32 + gate_row1_2 * 128 + gate_col] = prefix_log2;
+                                }
+                            }
+                        }
+                        asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                        if (chunk_is_full_2 != 0) {
+                            mbarrier_wait(qk_raw_full_addr + (prep_stage) * 8, _phase_qk_raw_full);
+                        }
+                        if (prep_tid < 128) {
+                            float total_log2 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                            float _exp2_0 = approx_exp2(total_log2 - lower_bound * 1.4426950408889634f * 16.0f);
+                            smem_restore_factor_all[stage_f32 + prep_tid] = _exp2_0;
+                        }
+                        if (prep_tid == 0) {
+                            float _exp2_1 = approx_exp2(lower_bound * 1.4426950408889634f * 16.0f);
+                            smem_restore_factor_all[stage_f32 + 128] = _exp2_1;
+                        }
+                        #pragma unroll 1
+                        for (int work_pass = 0; work_pass < 4; work_pass++) {
+                            int work_item = work_pass * 128 + prep_tid;
+                            int row_1 = work_item / 16;
+                            int segment_1 = work_item % 16;
+                            long long token_1 = bos_4 + (long long)(chunk_idx_3 * 32 + row_1);
+                            int token_valid_1 = ((token_1 < eos_4) ? 1 : 0);
+                            long long gmem_base = (token_1 * (long long)num_heads + (long long)head_idx_3) * 128 + (long long)(segment_1 * 8);
+                            float q_raw_vec[8];
+                            float k_raw_vec[8];
+                            q_raw_vec[0] = 0.0f;
+                            q_raw_vec[1] = 0.0f;
+                            q_raw_vec[2] = 0.0f;
+                            q_raw_vec[3] = 0.0f;
+                            q_raw_vec[4] = 0.0f;
+                            q_raw_vec[5] = 0.0f;
+                            q_raw_vec[6] = 0.0f;
+                            q_raw_vec[7] = 0.0f;
+                            k_raw_vec[0] = 0.0f;
+                            k_raw_vec[1] = 0.0f;
+                            k_raw_vec[2] = 0.0f;
+                            k_raw_vec[3] = 0.0f;
+                            k_raw_vec[4] = 0.0f;
+                            k_raw_vec[5] = 0.0f;
+                            k_raw_vec[6] = 0.0f;
+                            k_raw_vec[7] = 0.0f;
+                            if (chunk_is_full_2 != 0) {
+                                unsigned int packed[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed[(0) + 3]))
+                                    : "r"((smem_q_raw_prefetch_addr + prep_stage * 41984 + (unsigned int)(segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ (segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32[_pair * 2])[0]), "=f"((&packed_f32[_pair * 2])[1])
+                                        : "r"(packed[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx = 0; value_idx < 8; value_idx++) {
+                                    q_raw_vec[value_idx] = packed_f32[value_idx];
+                                }
+                                unsigned int packed_0[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0[(0) + 3]))
+                                    : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ (segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32[_pair * 2])[0]), "=f"((&packed_0_f32[_pair * 2])[1])
+                                        : "r"(packed_0[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_1 = 0; value_idx_1 < 8; value_idx_1++) {
+                                    k_raw_vec[value_idx_1] = packed_0_f32[value_idx_1];
+                                }
+                            } else if (token_valid_1 != 0) {
+                                {
+                                    const uint4* _vptr_0 = reinterpret_cast<const uint4*>(q + gmem_base);
+                                    uint4 _vld_0[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_0[_blk] = _vptr_0[_blk];
+                                        uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&q_raw_vec[0 + _blk * 8 + _pair * 2])[0]), "=f"((&q_raw_vec[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_0[_pair]));
+                                        }
+                                    }
+                                }
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(k + gmem_base);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&k_raw_vec[0 + _blk * 8 + _pair * 2])[0]), "=f"((&k_raw_vec[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                            }
+                            float q_sum = 0.0f;
+                            float k_sum = 0.0f;
+                            for (int elem_in_segment = 0; elem_in_segment < 8; elem_in_segment++) {
+                                float q_raw = q_raw_vec[elem_in_segment];
+                                float k_raw = k_raw_vec[elem_in_segment];
+                                float _fma_4 = __fmaf_rn(q_raw, q_raw, q_sum);
+                                q_sum = _fma_4;
+                                float _fma_5 = __fmaf_rn(k_raw, k_raw, k_sum);
+                                k_sum = _fma_5;
+                            }
+                            float _shfl_xor_0 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 8);
+                            q_sum += _shfl_xor_0;
+                            float _shfl_xor_1 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 8);
+                            k_sum += _shfl_xor_1;
+                            float _shfl_xor_2 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 4);
+                            q_sum += _shfl_xor_2;
+                            float _shfl_xor_3 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 4);
+                            k_sum += _shfl_xor_3;
+                            float _shfl_xor_4 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 2);
+                            q_sum += _shfl_xor_4;
+                            float _shfl_xor_5 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 2);
+                            k_sum += _shfl_xor_5;
+                            float _shfl_xor_6 = __shfl_xor_sync(0xFFFFFFFF, q_sum, 1);
+                            q_sum += _shfl_xor_6;
+                            float _shfl_xor_7 = __shfl_xor_sync(0xFFFFFFFF, k_sum, 1);
+                            k_sum += _shfl_xor_7;
+                            float _rsqrt_0 = rsqrtf(q_sum + 1e-06f);
+                            float q_inv = _rsqrt_0;
+                            float _rsqrt_1 = rsqrtf(k_sum + 1e-06f);
+                            float k_inv = _rsqrt_1;
+                            const float2 _scale2_2 = {q_inv, q_inv};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(q_raw_vec)[_ls], _scale2_2);
+                            const float2 _scale2_3 = {k_inv, k_inv};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(k_raw_vec)[_ls], _scale2_3);
+                            float qd_vec[8];
+                            float kd_vec[8];
+                            float ki_vec[8];
+                            for (int elem_in_segment_1 = 0; elem_in_segment_1 < 8; elem_in_segment_1++) {
+                                int col = segment_1 * 8 + elem_in_segment_1;
+                                float prefix = smem_gate_all[stage_f32 + row_1 * 128 + col];
+                                float common_log2 = lower_bound * 1.4426950408889634f * 16.0f;
+                                float _exp2_2 = approx_exp2(prefix - common_log2);
+                                float decay = _exp2_2;
+                                qd_vec[elem_in_segment_1] = decay;
+                                kd_vec[elem_in_segment_1] = decay;
+                                ki_vec[elem_in_segment_1] = k_raw_vec[elem_in_segment_1] / decay;
+                            }
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], reinterpret_cast<const float2*>(q_raw_vec)[_ls]);
+                            const float2 _scale2_4 = {scale, scale};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(qd_vec)[_ls], _scale2_4);
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(kd_vec)[_ls], reinterpret_cast<const float2*>(k_raw_vec)[_ls]);
+                            unsigned int packed_1[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(qd_vec[_lp*2 + 0], qd_vec[_lp*2+1 + 0]));
+                                packed_1[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word = 0; word < 4; word++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ (segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word * 4)), "r"((packed_1[word])));
+                            }
+                            unsigned int packed_0_1[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(kd_vec[_lp*2 + 0], kd_vec[_lp*2+1 + 0]));
+                                packed_0_1[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_1 = 0; word_1 < 4; word_1++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ (segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_1 * 4)), "r"((packed_0_1[word_1])));
+                            }
+                            unsigned int packed_1_1[4];
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(ki_vec[_lp*2 + 0], ki_vec[_lp*2+1 + 0]));
+                                packed_1_1[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            #pragma unroll
+                            for (int word_2 = 0; word_2 < 4; word_2++) {
+                                asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 ^ (segment_1 * 8 / 64 * 4096 + row_1 * 128 + segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_2 * 4)), "r"((packed_1_1[word_2])));
+                            }
+                        }
+                        asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                        int pair_row_base = prep_local_warp / 2 * 16;
+                        int pair_col_base = prep_local_warp % 2 * 16;
+                        unsigned int a_frag[4];
+                        unsigned int b_frag[4];
+                        float acc[8];
+                        if (pair_row_base >= pair_col_base) {
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_kd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            if (pair_row_base == pair_col_base) {
+                                float diagonal_inverse[8];
+                                int row0 = lane / 4;
+                                int row1 = row0 + 8;
+                                int col0 = lane % 4 * 2;
+                                float beta0 = smem_prep_beta_all[stage_f32 + pair_row_base + row0];
+                                float beta1 = smem_prep_beta_all[stage_f32 + pair_row_base + row1];
+                                float l_values[8];
+                                l_values[0] = 0.0f;
+                                l_values[1] = 0.0f;
+                                l_values[2] = 0.0f;
+                                l_values[3] = 0.0f;
+                                l_values[4] = 0.0f;
+                                l_values[5] = 0.0f;
+                                l_values[6] = 0.0f;
+                                l_values[7] = 0.0f;
+                                if (row0 > col0) {
+                                    __nv_bfloat16 _cvt_bf16_0 = __float2bfloat16(acc[0] * beta0);
+                                    float _cvt_f32_8 = __bfloat162float(_cvt_bf16_0);
+                                    l_values[0] = _cvt_f32_8;
+                                }
+                                if (row0 > col0 + 1) {
+                                    __nv_bfloat16 _cvt_bf16_1 = __float2bfloat16(acc[1] * beta0);
+                                    float _cvt_f32_9 = __bfloat162float(_cvt_bf16_1);
+                                    l_values[1] = _cvt_f32_9;
+                                }
+                                if (row1 > col0) {
+                                    __nv_bfloat16 _cvt_bf16_2 = __float2bfloat16(acc[2] * beta1);
+                                    float _cvt_f32_10 = __bfloat162float(_cvt_bf16_2);
+                                    l_values[2] = _cvt_f32_10;
+                                }
+                                if (row1 > col0 + 1) {
+                                    __nv_bfloat16 _cvt_bf16_3 = __float2bfloat16(acc[3] * beta1);
+                                    float _cvt_f32_11 = __bfloat162float(_cvt_bf16_3);
+                                    l_values[3] = _cvt_f32_11;
+                                }
+                                if (row0 > col0 + 8) {
+                                    __nv_bfloat16 _cvt_bf16_4 = __float2bfloat16(acc[4] * beta0);
+                                    float _cvt_f32_12 = __bfloat162float(_cvt_bf16_4);
+                                    l_values[4] = _cvt_f32_12;
+                                }
+                                if (row0 > col0 + 9) {
+                                    __nv_bfloat16 _cvt_bf16_5 = __float2bfloat16(acc[5] * beta0);
+                                    float _cvt_f32_13 = __bfloat162float(_cvt_bf16_5);
+                                    l_values[5] = _cvt_f32_13;
+                                }
+                                if (row1 > col0 + 8) {
+                                    __nv_bfloat16 _cvt_bf16_6 = __float2bfloat16(acc[6] * beta1);
+                                    float _cvt_f32_14 = __bfloat162float(_cvt_bf16_6);
+                                    l_values[6] = _cvt_f32_14;
+                                }
+                                if (row1 > col0 + 9) {
+                                    __nv_bfloat16 _cvt_bf16_7 = __float2bfloat16(acc[7] * beta1);
+                                    float _cvt_f32_15 = __bfloat162float(_cvt_bf16_7);
+                                    l_values[7] = _cvt_f32_15;
+                                }
+                                unsigned int l_frag[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(l_values[_lp*2 + 0], l_values[_lp*2+1 + 0]));
+                                    l_frag[_lp] = *(uint32_t*)&_h2;
+                                }
+                                unsigned int allmma_d_frag[4];
+                                allmma_d_frag[0] = 0;
+                                allmma_d_frag[1] = 0;
+                                allmma_d_frag[2] = 0;
+                                allmma_d_frag[3] = 0;
+                                allmma_d_frag[0] = l_frag[0];
+                                allmma_d_frag[3] = l_frag[3];
+                                float n_values[8];
+                                n_values[0] = 0.0f;
+                                n_values[1] = 0.0f;
+                                n_values[2] = 0.0f;
+                                n_values[3] = 0.0f;
+                                n_values[4] = 0.0f;
+                                n_values[5] = 0.0f;
+                                n_values[6] = 0.0f;
+                                n_values[7] = 0.0f;
+                                n_values[0] = -l_values[0];
+                                n_values[1] = -l_values[1];
+                                n_values[6] = -l_values[6];
+                                n_values[7] = -l_values[7];
+                                if (row0 == col0) {
+                                    n_values[0] = n_values[0] + 1.0f;
+                                }
+                                if (row0 == col0 + 1) {
+                                    n_values[1] = n_values[1] + 1.0f;
+                                }
+                                if (row1 == col0) {
+                                    n_values[2] = n_values[2] + 1.0f;
+                                }
+                                if (row1 == col0 + 1) {
+                                    n_values[3] = n_values[3] + 1.0f;
+                                }
+                                if (row0 == col0 + 8) {
+                                    n_values[4] = n_values[4] + 1.0f;
+                                }
+                                if (row0 == col0 + 9) {
+                                    n_values[5] = n_values[5] + 1.0f;
+                                }
+                                if (row1 == col0 + 8) {
+                                    n_values[6] = n_values[6] + 1.0f;
+                                }
+                                if (row1 == col0 + 9) {
+                                    n_values[7] = n_values[7] + 1.0f;
+                                }
+                                unsigned int n_frag[4];
+                                unsigned int low_word[1];
+                                unsigned int high_word[1];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(n_values[_lp*2 + 0], n_values[_lp*2+1 + 0]));
+                                    low_word[_lp] = *(uint32_t*)&_h2;
+                                }
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(n_values[_lp*2 + 6], n_values[_lp*2+1 + 6]));
+                                    high_word[_lp] = *(uint32_t*)&_h2;
+                                }
+                                n_frag[0] = 0;
+                                n_frag[1] = 0;
+                                n_frag[2] = 0;
+                                n_frag[3] = 0;
+                                n_frag[0] = low_word[0];
+                                n_frag[3] = high_word[0];
+                                float product[8];
+                                unsigned int rhs_trans_frag[4];
+                                #pragma unroll
+                                for (int word_3 = 0; word_3 < 4; word_3++) {
+                                    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                                        : "=r"(rhs_trans_frag[word_3])
+                                        : "r"(allmma_d_frag[word_3]));
+                                }
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+                                    : "r"(allmma_d_frag[0]), "r"(allmma_d_frag[1]), "r"(allmma_d_frag[2]), "r"(allmma_d_frag[3]), "r"(rhs_trans_frag[0]), "r"(rhs_trans_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]), "=f"(product[(4) + 3])
+                                    : "r"(allmma_d_frag[0]), "r"(allmma_d_frag[1]), "r"(allmma_d_frag[2]), "r"(allmma_d_frag[3]), "r"(rhs_trans_frag[2]), "r"(rhs_trans_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                unsigned int d2_frag[4];
+                                unsigned int low_word_0[1];
+                                unsigned int high_word_1[1];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(product[_lp*2 + 0], product[_lp*2+1 + 0]));
+                                    low_word_0[_lp] = *(uint32_t*)&_h2;
+                                }
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(product[_lp*2 + 6], product[_lp*2+1 + 6]));
+                                    high_word_1[_lp] = *(uint32_t*)&_h2;
+                                }
+                                d2_frag[0] = 0;
+                                d2_frag[1] = 0;
+                                d2_frag[2] = 0;
+                                d2_frag[3] = 0;
+                                d2_frag[0] = low_word_0[0];
+                                d2_frag[3] = high_word_1[0];
+                                unsigned int rhs_trans_frag_2[4];
+                                #pragma unroll
+                                for (int word_4 = 0; word_4 < 4; word_4++) {
+                                    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                                        : "=r"(rhs_trans_frag_2[word_4])
+                                        : "r"(d2_frag[word_4]));
+                                }
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+                                    : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]), "r"(rhs_trans_frag_2[0]), "r"(rhs_trans_frag_2[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]), "=f"(product[(4) + 3])
+                                    : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]), "r"(rhs_trans_frag_2[2]), "r"(rhs_trans_frag_2[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                #pragma unroll
+                                for (int value_idx_2 = 0; value_idx_2 < 8; value_idx_2++) {
+                                    n_values[value_idx_2] = n_values[value_idx_2] + product[value_idx_2];
+                                }
+                                unsigned int low_word_3[1];
+                                unsigned int high_word_4[1];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(n_values[_lp*2 + 0], n_values[_lp*2+1 + 0]));
+                                    low_word_3[_lp] = *(uint32_t*)&_h2;
+                                }
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(n_values[_lp*2 + 6], n_values[_lp*2+1 + 6]));
+                                    high_word_4[_lp] = *(uint32_t*)&_h2;
+                                }
+                                n_frag[0] = 0;
+                                n_frag[1] = 0;
+                                n_frag[2] = 0;
+                                n_frag[3] = 0;
+                                n_frag[0] = low_word_3[0];
+                                n_frag[3] = high_word_4[0];
+                                unsigned int rhs_trans_frag_5[4];
+                                #pragma unroll
+                                for (int word_5 = 0; word_5 < 4; word_5++) {
+                                    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                                        : "=r"(rhs_trans_frag_5[word_5])
+                                        : "r"(d2_frag[word_5]));
+                                }
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+                                    : "r"(d2_frag[0]), "r"(d2_frag[1]), "r"(d2_frag[2]), "r"(d2_frag[3]), "r"(rhs_trans_frag_5[0]), "r"(rhs_trans_frag_5[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]), "=f"(product[(4) + 3])
+                                    : "r"(d2_frag[0]), "r"(d2_frag[1]), "r"(d2_frag[2]), "r"(d2_frag[3]), "r"(rhs_trans_frag_5[2]), "r"(rhs_trans_frag_5[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                unsigned int d4_frag[4];
+                                unsigned int low_word_6[1];
+                                unsigned int high_word_7[1];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(product[_lp*2 + 0], product[_lp*2+1 + 0]));
+                                    low_word_6[_lp] = *(uint32_t*)&_h2;
+                                }
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(product[_lp*2 + 6], product[_lp*2+1 + 6]));
+                                    high_word_7[_lp] = *(uint32_t*)&_h2;
+                                }
+                                d4_frag[0] = 0;
+                                d4_frag[1] = 0;
+                                d4_frag[2] = 0;
+                                d4_frag[3] = 0;
+                                d4_frag[0] = low_word_6[0];
+                                d4_frag[3] = high_word_7[0];
+                                unsigned int rhs_trans_frag_8[4];
+                                #pragma unroll
+                                for (int word_6 = 0; word_6 < 4; word_6++) {
+                                    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                                        : "=r"(rhs_trans_frag_8[word_6])
+                                        : "r"(d4_frag[word_6]));
+                                }
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+                                    : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]), "r"(rhs_trans_frag_8[0]), "r"(rhs_trans_frag_8[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]), "=f"(product[(4) + 3])
+                                    : "r"(n_frag[0]), "r"(n_frag[1]), "r"(n_frag[2]), "r"(n_frag[3]), "r"(rhs_trans_frag_8[2]), "r"(rhs_trans_frag_8[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                #pragma unroll
+                                for (int value_idx_3 = 0; value_idx_3 < 8; value_idx_3++) {
+                                    n_values[value_idx_3] = n_values[value_idx_3] + product[value_idx_3];
+                                }
+                                unsigned int binv_frag[4];
+                                binv_frag[0] = 0;
+                                binv_frag[1] = 0;
+                                binv_frag[2] = 0;
+                                binv_frag[3] = 0;
+                                binv_frag[0] = n_frag[0];
+                                binv_frag[3] = n_frag[3];
+                                unsigned int a21_frag[4];
+                                a21_frag[0] = 0;
+                                a21_frag[1] = 0;
+                                a21_frag[2] = 0;
+                                a21_frag[3] = 0;
+                                a21_frag[1] = l_frag[1];
+                                unsigned int rhs_trans_frag_9[4];
+                                #pragma unroll
+                                for (int word_7 = 0; word_7 < 4; word_7++) {
+                                    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                                        : "=r"(rhs_trans_frag_9[word_7])
+                                        : "r"(a21_frag[word_7]));
+                                }
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+                                    : "r"(binv_frag[0]), "r"(binv_frag[1]), "r"(binv_frag[2]), "r"(binv_frag[3]), "r"(rhs_trans_frag_9[0]), "r"(rhs_trans_frag_9[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]), "=f"(product[(4) + 3])
+                                    : "r"(binv_frag[0]), "r"(binv_frag[1]), "r"(binv_frag[2]), "r"(binv_frag[3]), "r"(rhs_trans_frag_9[2]), "r"(rhs_trans_frag_9[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                float correction_values[2];
+                                correction_values[0] = -product[2];
+                                correction_values[1] = -product[3];
+                                unsigned int correction_word[1];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 1; _lp++) {
+                                    __half2 _h2 = __float22half2_rn(make_float2(correction_values[_lp*2 + 0], correction_values[_lp*2+1 + 0]));
+                                    correction_word[_lp] = *(uint32_t*)&_h2;
+                                }
+                                unsigned int correction_frag[4];
+                                correction_frag[0] = 0;
+                                correction_frag[1] = 0;
+                                correction_frag[2] = 0;
+                                correction_frag[3] = 0;
+                                correction_frag[1] = correction_word[0];
+                                unsigned int rhs_trans_frag_10[4];
+                                #pragma unroll
+                                for (int word_8 = 0; word_8 < 4; word_8++) {
+                                    asm volatile("movmatrix.sync.aligned.m8n8.trans.b16 %0, %1;\n"
+                                        : "=r"(rhs_trans_frag_10[word_8])
+                                        : "r"(binv_frag[word_8]));
+                                }
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[0]), "=f"(product[1]), "=f"(product[2]), "=f"(product[3])
+                                    : "r"(correction_frag[0]), "r"(correction_frag[1]), "r"(correction_frag[2]), "r"(correction_frag[3]), "r"(rhs_trans_frag_10[0]), "r"(rhs_trans_frag_10[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                    : "=f"(product[4]), "=f"(product[(4) + 1]), "=f"(product[(4) + 2]), "=f"(product[(4) + 3])
+                                    : "r"(correction_frag[0]), "r"(correction_frag[1]), "r"(correction_frag[2]), "r"(correction_frag[3]), "r"(rhs_trans_frag_10[2]), "r"(rhs_trans_frag_10[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                                n_values[2] = product[2];
+                                n_values[3] = product[3];
+                                #pragma unroll
+                                for (int value_idx_4 = 0; value_idx_4 < 8; value_idx_4++) {
+                                    diagonal_inverse[value_idx_4] = n_values[value_idx_4];
+                                }
+                                unsigned int inverse_packed[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(diagonal_inverse[_lp*2 + 0], diagonal_inverse[_lp*2+1 + 0]));
+                                    inverse_packed[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                int inverse_lane_row = lane % 16;
+                                int inverse_lane_col = lane / 16 * 8;
+                                int byte_off = (pair_row_base + inverse_lane_row) * 128 + (pair_row_base + inverse_lane_col) * 2;
+                                int swizzled_off = byte_off ^ (byte_off >> 7 & 7) << 4;
+                                int inverse_addr = smem_inv_work_addr + prep_stage * 41984 + (unsigned int)swizzled_off;
+                                uint32_t _stmatrix_addr_5 = static_cast<uint32_t>((unsigned long long)inverse_addr);
+                                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                    :: "r"(_stmatrix_addr_5), "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&inverse_packed[3]))
+                                    : "memory");
+                            } else {
+                                int row0_1 = pair_row_base + lane / 4;
+                                int row1_1 = row0_1 + 8;
+                                int col0_1 = pair_col_base + lane % 4 * 2;
+                                float beta0_1 = smem_prep_beta_all[stage_f32 + row0_1];
+                                float beta1_1 = smem_prep_beta_all[stage_f32 + row1_1];
+                                float seed[8];
+                                seed[0] = 0.0f;
+                                seed[1] = 0.0f;
+                                seed[2] = 0.0f;
+                                seed[3] = 0.0f;
+                                seed[4] = 0.0f;
+                                seed[5] = 0.0f;
+                                seed[6] = 0.0f;
+                                seed[7] = 0.0f;
+                                if (row0_1 > col0_1) {
+                                    seed[0] = acc[0] * beta0_1;
+                                }
+                                if (row0_1 > col0_1 + 1) {
+                                    seed[1] = acc[1] * beta0_1;
+                                }
+                                if (row1_1 > col0_1) {
+                                    seed[2] = acc[2] * beta1_1;
+                                }
+                                if (row1_1 > col0_1 + 1) {
+                                    seed[3] = acc[3] * beta1_1;
+                                }
+                                if (row0_1 > col0_1 + 8) {
+                                    seed[4] = acc[4] * beta0_1;
+                                }
+                                if (row0_1 > col0_1 + 9) {
+                                    seed[5] = acc[5] * beta0_1;
+                                }
+                                if (row1_1 > col0_1 + 8) {
+                                    seed[6] = acc[6] * beta1_1;
+                                }
+                                if (row1_1 > col0_1 + 9) {
+                                    seed[7] = acc[7] * beta1_1;
+                                }
+                                unsigned int seed_packed[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(seed[_lp*2 + 0], seed[_lp*2+1 + 0]));
+                                    seed_packed[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                int seed_lane_row = lane % 16;
+                                int seed_lane_col = lane / 16 * 8;
+                                int byte_off_1 = (pair_row_base + seed_lane_row) * 128 + (pair_col_base + seed_lane_col) * 2;
+                                int swizzled_off_1 = byte_off_1 ^ (byte_off_1 >> 7 & 7) << 4;
+                                int seed_addr = smem_inv_work_addr + prep_stage * 41984 + (unsigned int)swizzled_off_1;
+                                uint32_t _stmatrix_addr_6 = static_cast<uint32_t>((unsigned long long)seed_addr);
+                                asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                    :: "r"(_stmatrix_addr_6), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[0])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[1])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[2])), "r"(*reinterpret_cast<const uint32_t*>(&seed_packed[3]))
+                                    : "memory");
+                            }
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[0]), "=f"(acc[1]), "=f"(acc[2]), "=f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(acc[4]), "=f"(acc[(4) + 1]), "=f"(acc[(4) + 2]), "=f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a_frag[0]), "=r"(a_frag[1]), "=r"(a_frag[2]), "=r"(a_frag[3])
+                                : "r"(smem_qd_addr + prep_stage * 41984 + (unsigned int)(((lane / 16 / 8 * 256 + (pair_row_base + lane % 16) * 8 + (lane / 16 % 8 * 16 ^ (pair_row_base + lane % 16 & 7) << 4) / 16 ^ 2 ^ 6 ^ 2 ^ 6) + 256 ^ 2 ^ 6 ^ 2) * 16))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(b_frag[0]), "=r"(b_frag[1]), "=r"(b_frag[2]), "=r"(b_frag[3])
+                                : "r"(smem_ki_addr + prep_stage * 41984 + (unsigned int)(((((((((lane % 16 / 8 / 8 * 256 + (pair_col_base + 8 * (lane / 16) + lane % 8) * 8 + (lane % 16 / 8 % 8 * 16 ^ (pair_col_base + 8 * (lane / 16) + lane % 8 & 7) << 4) / 16 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256 + 256 ^ 6) + 256 - 256 + 256 ^ 2) - 256 + 256 ^ 6) - 256 + 256 ^ 2) - 256) * 16))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[0]), "+f"(acc[1]), "+f"(acc[2]), "+f"(acc[3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[0]), "r"(b_frag[1]));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%0, %1, %2, %3};\n"
+                                : "+f"(acc[4]), "+f"(acc[(4) + 1]), "+f"(acc[(4) + 2]), "+f"(acc[(4) + 3])
+                                : "r"(a_frag[0]), "r"(a_frag[1]), "r"(a_frag[2]), "r"(a_frag[3]), "r"(b_frag[2]), "r"(b_frag[(2) + 1]));
+                        } else {
+                            acc[0] = 0.0f;
+                            acc[1] = 0.0f;
+                            acc[2] = 0.0f;
+                            acc[3] = 0.0f;
+                            acc[4] = 0.0f;
+                            acc[5] = 0.0f;
+                            acc[6] = 0.0f;
+                            acc[7] = 0.0f;
+                        }
+                        int row0_2 = pair_row_base + lane / 4;
+                        int row1_2 = row0_2 + 8;
+                        int col0_2 = pair_col_base + lane % 4 * 2;
+                        float mqk[8];
+                        mqk[0] = 0.0f;
+                        mqk[1] = 0.0f;
+                        mqk[2] = 0.0f;
+                        mqk[3] = 0.0f;
+                        mqk[4] = 0.0f;
+                        mqk[5] = 0.0f;
+                        mqk[6] = 0.0f;
+                        mqk[7] = 0.0f;
+                        if (row0_2 >= col0_2) {
+                            mqk[0] = acc[0];
+                        }
+                        if (row0_2 >= col0_2 + 1) {
+                            mqk[1] = acc[1];
+                        }
+                        if (row1_2 >= col0_2) {
+                            mqk[2] = acc[2];
+                        }
+                        if (row1_2 >= col0_2 + 1) {
+                            mqk[3] = acc[3];
+                        }
+                        if (row0_2 >= col0_2 + 8) {
+                            mqk[4] = acc[4];
+                        }
+                        if (row0_2 >= col0_2 + 9) {
+                            mqk[5] = acc[5];
+                        }
+                        if (row1_2 >= col0_2 + 8) {
+                            mqk[6] = acc[6];
+                        }
+                        if (row1_2 >= col0_2 + 9) {
+                            mqk[7] = acc[7];
+                        }
+                        unsigned int mqk_packed[4];
+                        #pragma unroll
+                        for (int _lp = 0; _lp < 4; _lp++) {
+                            __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(mqk[_lp*2 + 0], mqk[_lp*2+1 + 0]));
+                            mqk_packed[_lp] = *(uint32_t*)&_bf2;
+                        }
+                        #pragma unroll
+                        for (int publish_pair = 0; publish_pair < 2; publish_pair++) {
+                            int publish_row = pair_col_base + publish_pair * 8 + (lane & 7);
+                            int publish_col = 128 + pair_row_base + lane / 8 * 8;
+                            uint32_t _stmatrix_addr_7 = static_cast<uint32_t>((unsigned long long)(smem_final_trans_addr + prep_stage * 41984 + (unsigned int)(publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 ^ (publish_col / 64 * 4096 + publish_row * 128 + publish_col % 64 * 2 >> 7 & 7) << 4)));
+                            asm volatile("stmatrix.sync.aligned.m8n8.x2.trans.shared.b16 [%0], {%1, %2};\n"
+                                :: "r"(_stmatrix_addr_7), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2])), "r"(*reinterpret_cast<const uint32_t*>(&mqk_packed[publish_pair * 2 + 1]))
+                                : "memory");
+                        }
+                        asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                        if (prep_tid < 128) {
+                            float total_log2_1 = smem_gt_prefix_all[stage_f32 + prep_tid];
+                            float _exp2_3 = approx_exp2(total_log2_1);
+                            smem_gt_all[stage_f32 + prep_tid] = _exp2_3;
+                        }
+                        if (prep_local_warp >= 2) {
+                            int stage_f32_0 = prep_stage * 10496;
+                            float restore_scale = smem_restore_factor_all[stage_f32_0 + 128];
+                            float restore_factor[8];
+                            int restore_segment = lane & 15;
+                            #pragma unroll
+                            for (int restore_elem = 0; restore_elem < 8; restore_elem++) {
+                                int restore_col = restore_segment * 8 + restore_elem;
+                                restore_factor[restore_elem] = smem_restore_factor_all[stage_f32_0 + restore_col];
+                            }
+                            #pragma unroll 1
+                            for (int restore_pass = 0; restore_pass < 6; restore_pass++) {
+                                int restore_row = 8 + (prep_local_warp - 2) * 12 + restore_pass * 2 + (lane >> 4);
+                                float restore_qd_values[8];
+                                float restore_kd_values[8];
+                                float restore_ki_values[8];
+                                unsigned int packed_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_2[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_1[_pair * 2])[0]), "=f"((&packed_f32_1[_pair * 2])[1])
+                                        : "r"(packed_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_5 = 0; value_idx_5 < 8; value_idx_5++) {
+                                    restore_qd_values[value_idx_5] = packed_f32_1[value_idx_5];
+                                }
+                                unsigned int packed_0_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_2[(0) + 3]))
+                                    : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_1[_pair * 2])[0]), "=f"((&packed_0_f32_1[_pair * 2])[1])
+                                        : "r"(packed_0_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_6 = 0; value_idx_6 < 8; value_idx_6++) {
+                                    restore_kd_values[value_idx_6] = packed_0_f32_1[value_idx_6];
+                                }
+                                unsigned int packed_1_2[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_2[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_1_f32[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_1_f32[_pair * 2])[0]), "=f"((&packed_1_f32[_pair * 2])[1])
+                                        : "r"(packed_1_2[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_7 = 0; value_idx_7 < 8; value_idx_7++) {
+                                    restore_ki_values[value_idx_7] = packed_1_f32[value_idx_7];
+                                }
+                                float restore_kr_values[8];
+                                #pragma unroll
+                                for (int restore_elem_1 = 0; restore_elem_1 < 8; restore_elem_1++) {
+                                    restore_kr_values[restore_elem_1] = restore_ki_values[restore_elem_1] * restore_factor[restore_elem_1];
+                                }
+                                const float2 _scale2_8 = {restore_scale, restore_scale};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values)[_ls], _scale2_8);
+                                const float2 _scale2_9 = {restore_scale, restore_scale};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_kd_values)[_ls], _scale2_9);
+                                unsigned int packed_2_1[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_qd_values[_lp*2 + 0], restore_qd_values[_lp*2+1 + 0]));
+                                    packed_2_1[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                #pragma unroll
+                                for (int word_9 = 0; word_9 < 4; word_9++) {
+                                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_9 * 4)), "r"((packed_2_1[word_9])));
+                                }
+                                unsigned int packed_3[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kd_values[_lp*2 + 0], restore_kd_values[_lp*2+1 + 0]));
+                                    packed_3[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                #pragma unroll
+                                for (int word_10 = 0; word_10 < 4; word_10++) {
+                                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_10 * 4)), "r"((packed_3[word_10])));
+                                }
+                                unsigned int packed_4[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values[_lp*2 + 0], restore_kr_values[_lp*2+1 + 0]));
+                                    packed_4[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                #pragma unroll
+                                for (int word_11 = 0; word_11 < 4; word_11++) {
+                                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 ^ (restore_segment * 8 / 64 * 4096 + restore_row * 128 + restore_segment * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_11 * 4)), "r"((packed_4[word_11])));
+                                }
+                            }
+                        }
+                        if (prep_local_warp == 0) {
+                            int lane_row = lane % 16;
+                            int lane_col = lane / 16 * 8;
+                            int byte_off_2 = (16 + lane_row) * 128 + (16 + lane_col) * 2;
+                            int swizzled_off_2 = byte_off_2 ^ (byte_off_2 >> 7 & 7) << 4;
+                            int d_addr = smem_inv_work_addr + prep_stage * 41984 + (unsigned int)swizzled_off_2;
+                            int byte_off_0 = (16 + lane_row) * 128 + lane_col * 2;
+                            int swizzled_off_1_1 = byte_off_0 ^ (byte_off_0 >> 7 & 7) << 4;
+                            int c_addr = smem_inv_work_addr + prep_stage * 41984 + (unsigned int)swizzled_off_1_1;
+                            int byte_off_2_1 = lane_row * 128 + lane_col * 2;
+                            int swizzled_off_3 = byte_off_2_1 ^ (byte_off_2_1 >> 7 & 7) << 4;
+                            int a_addr = smem_inv_work_addr + prep_stage * 41984 + (unsigned int)swizzled_off_3;
+                            unsigned int d32_frag[4];
+                            unsigned int c32_frag[4];
+                            float dc32_acc[8];
+                            unsigned int dc32_bf16[4];
+                            unsigned int a32_frag[4];
+                            float o32_acc[8];
+                            unsigned int o32_bf16[4];
+                            unsigned int zero32_bf16[4];
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(d32_frag[0]), "=r"(d32_frag[1]), "=r"(d32_frag[2]), "=r"(d32_frag[3])
+                                : "r"(d_addr)
+                                : "memory");
+                            int d_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + (16 + lane_row) * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + (16 + lane_row) * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                            uint32_t _stmatrix_addr_10 = static_cast<uint32_t>((unsigned long long)d_publish_addr);
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_10), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&d32_frag[3]))
+                                : "memory");
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(c32_frag[0]), "=r"(c32_frag[1]), "=r"(c32_frag[2]), "=r"(c32_frag[3])
+                                : "r"(c_addr)
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(dc32_acc[0]), "=f"(dc32_acc[1]), "=f"(dc32_acc[2]), "=f"(dc32_acc[3])
+                                : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[0]), "r"(c32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(dc32_acc[4]), "=f"(dc32_acc[(4) + 1]), "=f"(dc32_acc[(4) + 2]), "=f"(dc32_acc[(4) + 3])
+                                : "r"(d32_frag[0]), "r"(d32_frag[1]), "r"(d32_frag[2]), "r"(d32_frag[3]), "r"(c32_frag[2]), "r"(c32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            const float2 _scale2_11 = {-1.0f, -1.0f};
+                            #pragma unroll
+                            for (int _ls = 0; _ls < 4; _ls++)
+                                mul_f32x2_inplace(&reinterpret_cast<float2*>(dc32_acc)[_ls], _scale2_11);
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(dc32_acc[_lp*2 + 0], dc32_acc[_lp*2+1 + 0]));
+                                dc32_bf16[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            asm volatile("ldmatrix.sync.aligned.m8n8.x4.trans.shared.b16 {%0, %1, %2, %3}, [%4];\n"
+                                : "=r"(a32_frag[0]), "=r"(a32_frag[1]), "=r"(a32_frag[2]), "=r"(a32_frag[3])
+                                : "r"(a_addr)
+                                : "memory");
+                            int a_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + lane_row * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + lane_row * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                            uint32_t _stmatrix_addr_12 = static_cast<uint32_t>((unsigned long long)a_publish_addr);
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_12), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[0])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[1])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[2])), "r"(*reinterpret_cast<const uint32_t*>(&a32_frag[3]))
+                                : "memory");
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(o32_acc[0]), "=f"(o32_acc[1]), "=f"(o32_acc[2]), "=f"(o32_acc[3])
+                                : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[0]), "r"(a32_frag[1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            asm volatile("mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 {%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, {%10, %11, %12, %13};\n"
+                                : "=f"(o32_acc[4]), "=f"(o32_acc[(4) + 1]), "=f"(o32_acc[(4) + 2]), "=f"(o32_acc[(4) + 3])
+                                : "r"(dc32_bf16[0]), "r"(dc32_bf16[1]), "r"(dc32_bf16[2]), "r"(dc32_bf16[3]), "r"(a32_frag[2]), "r"(a32_frag[(2) + 1]), "f"(0.0f), "f"(0.0f), "f"(0.0f), "f"(0.0f));
+                            #pragma unroll
+                            for (int _lp = 0; _lp < 4; _lp++) {
+                                __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(o32_acc[_lp*2 + 0], o32_acc[_lp*2+1 + 0]));
+                                o32_bf16[_lp] = *(uint32_t*)&_bf2;
+                            }
+                            int o_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)(lane_col / 16 * 1024 + (16 + lane_row) * 32 + lane_col % 16 * 2 ^ (lane_col / 16 * 1024 + (16 + lane_row) * 32 + lane_col % 16 * 2 >> 7 & 1) << 4));
+                            uint32_t _stmatrix_addr_13 = static_cast<uint32_t>((unsigned long long)o_publish_addr);
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_13), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&o32_bf16[3]))
+                                : "memory");
+                            #pragma unroll
+                            for (int zero_word = 0; zero_word < 4; zero_word++) {
+                                zero32_bf16[zero_word] = 0;
+                            }
+                            int zero_publish_addr = (smem_inv_addr + prep_stage * 41984 + (unsigned int)((16 + lane_col) / 16 * 1024 + lane_row * 32 + (16 + lane_col) % 16 * 2 ^ ((16 + lane_col) / 16 * 1024 + lane_row * 32 + (16 + lane_col) % 16 * 2 >> 7 & 1) << 4));
+                            uint32_t _stmatrix_addr_14 = static_cast<uint32_t>((unsigned long long)zero_publish_addr);
+                            asm volatile("stmatrix.sync.aligned.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+                                :: "r"(_stmatrix_addr_14), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[0])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[1])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[2])), "r"(*reinterpret_cast<const uint32_t*>(&zero32_bf16[3]))
+                                : "memory");
+                        } else if (prep_local_warp == 1) {
+                            int stage_f32_0_1 = prep_stage * 10496;
+                            float restore_scale_1 = smem_restore_factor_all[stage_f32_0_1 + 128];
+                            float restore_factor_1[8];
+                            int restore_segment_1 = lane & 15;
+                            #pragma unroll
+                            for (int restore_elem_2 = 0; restore_elem_2 < 8; restore_elem_2++) {
+                                int restore_col_1 = restore_segment_1 * 8 + restore_elem_2;
+                                restore_factor_1[restore_elem_2] = smem_restore_factor_all[stage_f32_0_1 + restore_col_1];
+                            }
+                            #pragma unroll 1
+                            for (int restore_pass_1 = 0; restore_pass_1 < 4; restore_pass_1++) {
+                                int restore_row_1 = restore_pass_1 * 2 + (lane >> 4);
+                                float restore_qd_values_1[8];
+                                float restore_kd_values_1[8];
+                                float restore_ki_values_1[8];
+                                unsigned int packed_5[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_5[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_5[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_5[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_5[(0) + 3]))
+                                    : "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_f32_2[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_f32_2[_pair * 2])[0]), "=f"((&packed_f32_2[_pair * 2])[1])
+                                        : "r"(packed_5[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_8 = 0; value_idx_8 < 8; value_idx_8++) {
+                                    restore_qd_values_1[value_idx_8] = packed_f32_2[value_idx_8];
+                                }
+                                unsigned int packed_0_3[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_0_3[(0) + 3]))
+                                    : "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_0_f32_2[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_0_f32_2[_pair * 2])[0]), "=f"((&packed_0_f32_2[_pair * 2])[1])
+                                        : "r"(packed_0_3[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_9 = 0; value_idx_9 < 8; value_idx_9++) {
+                                    restore_kd_values_1[value_idx_9] = packed_0_f32_2[value_idx_9];
+                                }
+                                unsigned int packed_1_3[4];
+                                asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                    : "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[0])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&packed_1_3[(0) + 3]))
+                                    : "r"((smem_ki_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4))));
+                                float packed_1_f32_1[8];
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&packed_1_f32_1[_pair * 2])[0]), "=f"((&packed_1_f32_1[_pair * 2])[1])
+                                        : "r"(packed_1_3[_pair]));
+                                }
+                                #pragma unroll
+                                for (int value_idx_10 = 0; value_idx_10 < 8; value_idx_10++) {
+                                    restore_ki_values_1[value_idx_10] = packed_1_f32_1[value_idx_10];
+                                }
+                                float restore_kr_values_1[8];
+                                #pragma unroll
+                                for (int restore_elem_3 = 0; restore_elem_3 < 8; restore_elem_3++) {
+                                    restore_kr_values_1[restore_elem_3] = restore_ki_values_1[restore_elem_3] * restore_factor_1[restore_elem_3];
+                                }
+                                const float2 _scale2_15 = {restore_scale_1, restore_scale_1};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_qd_values_1)[_ls], _scale2_15);
+                                const float2 _scale2_16 = {restore_scale_1, restore_scale_1};
+                                #pragma unroll
+                                for (int _ls = 0; _ls < 4; _ls++)
+                                    mul_f32x2_inplace(&reinterpret_cast<float2*>(restore_kd_values_1)[_ls], _scale2_16);
+                                unsigned int packed_2_2[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_qd_values_1[_lp*2 + 0], restore_qd_values_1[_lp*2+1 + 0]));
+                                    packed_2_2[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                #pragma unroll
+                                for (int word_12 = 0; word_12 < 4; word_12++) {
+                                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_qd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_12 * 4)), "r"((packed_2_2[word_12])));
+                                }
+                                unsigned int packed_3_1[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kd_values_1[_lp*2 + 0], restore_kd_values_1[_lp*2+1 + 0]));
+                                    packed_3_1[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                #pragma unroll
+                                for (int word_13 = 0; word_13 < 4; word_13++) {
+                                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kd_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_13 * 4)), "r"((packed_3_1[word_13])));
+                                }
+                                unsigned int packed_4_1[4];
+                                #pragma unroll
+                                for (int _lp = 0; _lp < 4; _lp++) {
+                                    __nv_bfloat162 _bf2 = __float22bfloat162_rn(make_float2(restore_kr_values_1[_lp*2 + 0], restore_kr_values_1[_lp*2+1 + 0]));
+                                    packed_4_1[_lp] = *(uint32_t*)&_bf2;
+                                }
+                                #pragma unroll
+                                for (int word_14 = 0; word_14 < 4; word_14++) {
+                                    asm volatile("st.shared.b32 [%0], %1;" :: "r"((smem_kr_trans_addr + prep_stage * 41984 + (unsigned int)(restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 ^ (restore_segment_1 * 8 / 64 * 4096 + restore_row_1 * 128 + restore_segment_1 * 8 % 64 * 2 >> 7 & 7) << 4)) + (unsigned int)(word_14 * 4)), "r"((packed_4_1[word_14])));
+                                }
+                            }
+                        }
+                        asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+                        asm volatile("barrier.sync %0, 128;" :: "r"(11 + prep_instance) : "memory");
+                        if (prep_local_warp == 0) {
+                            if (elect_sync()) {
+                                mbarrier_arrive(qk_full_addr + (prep_stage) * 8);
+                            }
+                        }
+                        for (int _advance = 0; _advance < 5; _advance++) {
+                            prep_stage += 1;
+                            if (prep_stage == 5) { prep_stage = 0; _phase_raw_inputs_free ^= 1; _phase_gate_raw_full ^= 1; _phase_smem_free ^= 1; _phase_qk_raw_full ^= 1; }
+                        }
+                    }
+                    global_chunk_base = global_chunk_base + num_chunks_4;
+                }
+            }
+        }
+    }
+
+    // Cleanup
+}
+
+} // extern "C"

--- a/csrc/kda/cake_flashkda_bf16_piece_persistent_m128_binding.cu
+++ b/csrc/kda/cake_flashkda_bf16_piece_persistent_m128_binding.cu
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "flashkda_binding_common.cuh"
+
+#define uint8_t flashkda_generated_uint8_t
+#define uint16_t flashkda_generated_uint16_t
+#define uint32_t flashkda_generated_uint32_t
+#define uint64_t flashkda_generated_uint64_t
+#define int32_t flashkda_generated_int32_t
+#define int16_t flashkda_generated_int16_t
+#define FlashKDATensorMap flashkda_generated_FlashKDATensorMap
+#define FlashKDATensorMapPack flashkda_generated_FlashKDATensorMapPack
+#define CUtensorMap flashkda_generated_CUtensorMap
+#include "cake_flashkda_bf16_piece_persistent_m128.cu"
+#undef CUtensorMap
+#undef FlashKDATensorMapPack
+#undef FlashKDATensorMap
+#undef uint8_t
+#undef uint16_t
+#undef uint32_t
+#undef uint64_t
+#undef int32_t
+#undef int16_t
+
+namespace flashinfer {
+namespace flash_kda {
+
+static_assert(THREADS == 1024);
+static_assert(SMEM_TOTAL == 221696);
+
+void RunPiecePersistentM128(TensorView q, TensorView k, TensorView v, TensorView g, TensorView beta,
+                            TensorView beta_tma, TensorView A_log, TensorView dt_bias,
+                            TensorView cu_seqlens, TensorView seq_order, TensorView task_ids,
+                            TensorView task_offsets, TensorView task_token_starts,
+                            TensorView task_token_counts, TensorView task_state_sources,
+                            TensorView task_state_destinations, TensorView mid_state,
+                            TensorView mid_state_ready, TensorView initial_state, TensorView out,
+                            TensorView final_state, TensorView descriptor_storage,
+                            int64_t prepare_descriptors, int64_t num_heads,
+                            int64_t use_initial_state, int64_t store_final_state, double scale,
+                            double lower_bound, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+  TVM_FFI_ICHECK(q.device().device_type == kDLCUDA) << "q must be a CUDA tensor";
+  const int32_t device_id = q.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckFlashKDATarget(device_id);
+
+  const int64_t num_seqs =
+      CheckCommonInputs(q, k, v, g, beta, beta_tma, A_log, dt_bias, cu_seqlens, seq_order,
+                        initial_state, out, final_state, descriptor_storage, prepare_descriptors,
+                        num_heads, use_initial_state, store_final_state, scale, lower_bound);
+  for (const auto& named : {std::pair<const TensorView*, const char*>{&task_ids, "task_ids"},
+                            {&task_offsets, "task_offsets"},
+                            {&task_token_starts, "task_token_starts"},
+                            {&task_token_counts, "task_token_counts"},
+                            {&task_state_sources, "task_state_sources"},
+                            {&task_state_destinations, "task_state_destinations"},
+                            {&mid_state, "mid_state"},
+                            {&mid_state_ready, "mid_state_ready"}}) {
+    CheckCudaTensor(*named.first, named.second, device_id);
+  }
+  for (const auto& named : {std::pair<const TensorView*, const char*>{&task_ids, "task_ids"},
+                            {&task_offsets, "task_offsets"},
+                            {&task_token_starts, "task_token_starts"},
+                            {&task_token_counts, "task_token_counts"},
+                            {&task_state_sources, "task_state_sources"},
+                            {&task_state_destinations, "task_state_destinations"}}) {
+    CheckDtype(*named.first, named.second, dl_int32);
+  }
+  CheckDtype(mid_state, "mid_state", dl_bfloat16);
+  CheckDtype(mid_state_ready, "mid_state_ready", dl_uint32);
+
+  const int64_t total_tasks = num_seqs * num_heads;
+  const int64_t entry_count = task_ids.numel();
+  TVM_FFI_ICHECK(task_ids.ndim() == 1 && entry_count > total_tasks)
+      << "task_ids must contain more than N * H entries for split recurrence chains";
+  for (const auto& named :
+       {std::pair<const TensorView*, const char*>{&task_token_starts, "task_token_starts"},
+        {&task_token_counts, "task_token_counts"},
+        {&task_state_sources, "task_state_sources"},
+        {&task_state_destinations, "task_state_destinations"}}) {
+    TVM_FFI_ICHECK(named.first->ndim() == 1 && named.first->numel() == entry_count)
+        << named.second << " must contain one value per task entry";
+  }
+  TVM_FFI_ICHECK(task_offsets.ndim() == 1 && task_offsets.numel() >= 2)
+      << "task_offsets must contain one entry per worker plus its terminal offset";
+  const int64_t worker_count = task_offsets.numel() - 1;
+  int32_t sm_count = 0;
+  CheckCuda(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device_id),
+            "cudaDeviceGetAttribute(multiProcessorCount)");
+  TVM_FFI_ICHECK(sm_count == 148 || sm_count == 152)
+      << "piece-persistent FlashKDA is validated only on 148-SM or 152-SM Blackwell; got "
+      << sm_count << " SMs";
+  TVM_FFI_ICHECK(worker_count == sm_count)
+      << "piece-persistent FlashKDA requires one resident worker per physical SM";
+  TVM_FFI_ICHECK(use_initial_state == 1 && store_final_state == 1 &&
+                 initial_state.data_ptr() == final_state.data_ptr())
+      << "piece-persistent FlashKDA requires one caller-owned in-place state tensor";
+
+  const int64_t handoff_count = mid_state_ready.numel();
+  TVM_FFI_ICHECK(handoff_count > 0 && mid_state_ready.ndim() == 1)
+      << "mid_state_ready must contain at least one handoff counter";
+  TVM_FFI_ICHECK(mid_state.ndim() == 3 && mid_state.size(0) == handoff_count &&
+                 mid_state.size(1) == kHeadDim && mid_state.size(2) == kHeadDim)
+      << "mid_state must have shape [handoff_count, 128, 128]";
+
+  for (const auto& metadata : {std::pair<const TensorView*, const char*>{&task_ids, "task_ids"},
+                               {&task_offsets, "task_offsets"},
+                               {&task_token_starts, "task_token_starts"},
+                               {&task_token_counts, "task_token_counts"},
+                               {&task_state_sources, "task_state_sources"},
+                               {&task_state_destinations, "task_state_destinations"}}) {
+    CheckNoOverlap(*metadata.first, metadata.second, mid_state, "mid_state");
+    CheckNoOverlap(*metadata.first, metadata.second, mid_state_ready, "mid_state_ready");
+    CheckNoOverlap(*metadata.first, metadata.second, initial_state, "initial_state");
+    CheckNoOverlap(*metadata.first, metadata.second, out, "out");
+    CheckNoOverlap(*metadata.first, metadata.second, descriptor_storage, "descriptor_storage");
+  }
+  CheckNoOverlap(mid_state, "mid_state", mid_state_ready, "mid_state_ready");
+  CheckNoOverlap(mid_state, "mid_state", initial_state, "initial_state");
+  CheckNoOverlap(mid_state, "mid_state", out, "out");
+  CheckNoOverlap(mid_state, "mid_state", descriptor_storage, "descriptor_storage");
+  CheckNoOverlap(mid_state_ready, "mid_state_ready", initial_state, "initial_state");
+  CheckNoOverlap(mid_state_ready, "mid_state_ready", out, "out");
+  CheckNoOverlap(mid_state_ready, "mid_state_ready", descriptor_storage, "descriptor_storage");
+
+  constexpr int32_t kSmemBytes = SMEM_TOTAL;
+  CheckDynamicSmemCapacity(device_id, kSmemBytes);
+  CheckCuda(cudaFuncSetAttribute(kernel_flashkda_bf16_persistent_m128,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemBytes),
+            "cudaFuncSetAttribute(kernel_flashkda_bf16_persistent_m128)");
+
+  const dim3 grid(static_cast<uint32_t>(worker_count), 1, 1);
+  const dim3 block(THREADS, 1, 1);
+  const cudaStream_t stream = reinterpret_cast<cudaStream_t>(static_cast<uintptr_t>(cuda_stream));
+  const TmaPointers tma = EncodeTmaPointers<128, 32>(q, k, v, g, beta_tma, out, descriptor_storage,
+                                                     prepare_descriptors, stream);
+  PackBetaForTmaIfNeeded(beta, beta_tma, num_heads, beta.stride(beta.ndim() - 2), stream);
+
+  kernel_flashkda_bf16_persistent_m128<<<grid, block, kSmemBytes, stream>>>(
+      reinterpret_cast<__nv_bfloat16*>(q.data_ptr()),
+      reinterpret_cast<flashkda_generated_FlashKDATensorMap const*>(tma.q),
+      reinterpret_cast<__nv_bfloat16*>(k.data_ptr()),
+      reinterpret_cast<flashkda_generated_FlashKDATensorMap const*>(tma.k),
+      reinterpret_cast<__nv_bfloat16*>(v.data_ptr()),
+      reinterpret_cast<flashkda_generated_FlashKDATensorMap const*>(tma.v),
+      reinterpret_cast<__nv_bfloat16*>(g.data_ptr()),
+      reinterpret_cast<flashkda_generated_FlashKDATensorMap const*>(tma.g),
+      reinterpret_cast<__nv_bfloat16*>(beta.data_ptr()),
+      reinterpret_cast<flashkda_generated_FlashKDATensorMap const*>(tma.beta),
+      reinterpret_cast<float*>(A_log.data_ptr()), reinterpret_cast<float*>(dt_bias.data_ptr()),
+      reinterpret_cast<long long*>(cu_seqlens.data_ptr()),
+      reinterpret_cast<int*>(seq_order.data_ptr()), reinterpret_cast<int*>(task_ids.data_ptr()),
+      reinterpret_cast<int*>(task_offsets.data_ptr()),
+      reinterpret_cast<int*>(task_token_starts.data_ptr()),
+      reinterpret_cast<int*>(task_token_counts.data_ptr()),
+      reinterpret_cast<int*>(task_state_sources.data_ptr()),
+      reinterpret_cast<int*>(task_state_destinations.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(mid_state.data_ptr()),
+      reinterpret_cast<flashkda_generated_uint32_t*>(mid_state_ready.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(initial_state.data_ptr()),
+      reinterpret_cast<__nv_bfloat16*>(out.data_ptr()),
+      reinterpret_cast<flashkda_generated_FlashKDATensorMap const*>(tma.out),
+      reinterpret_cast<__nv_bfloat16*>(final_state.data_ptr()), static_cast<int32_t>(num_heads),
+      static_cast<int32_t>(use_initial_state), static_cast<int32_t>(store_final_state),
+      static_cast<float>(scale), static_cast<float>(lower_bound));
+  CheckCuda(cudaGetLastError(), "kernel_flashkda_bf16_persistent_m128 launch");
+}
+
+}  // namespace flash_kda
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::flash_kda::RunPiecePersistentM128);

--- a/docs/api/kda_prefill.rst
+++ b/docs/api/kda_prefill.rst
@@ -66,9 +66,22 @@ CUDA 12.8 predates the family target, so CC 10.0 uses legacy exact
 ``sm_100a`` modules. With CUDA 12.9 or newer, JIT and AOT compile one
 ``sm_100f`` module per schedule for both CC 10.0 and CC 10.3. Cache keys also
 include the frozen module identity so an older schedule cannot satisfy a
-refreshed request. Runtime routing remains device-specific: persistent M128
-is restricted to measured 148/152-SM CC 10.0 devices. CC 10.3 uses the direct
-schedules, with a tensor-core state-decay specialization for uniform, complete
+refreshed request. Runtime routing remains device-specific. The legacy
+head-grouped and mixed-length persistent M128 routes remain restricted to
+measured 148/152-SM CC 10.0 devices. On validated 148/152-SM CC 10.0 or CC 10.3
+devices, eligible uniform eager calls with a caller-owned in-place initial and
+final state may instead split only the recurrence chains that create a partial
+final device wave. An occupancy and roofline model
+uses the live SM count plus the frozen schedule's thread, shared-memory,
+tensor-memory, BF16, HBM, state-transfer, and refill costs; it selects
+recurrence pieces only when their dependency-DAG critical path is shorter than
+direct M128. Intermediate BF16 states use device-scope release/acquire
+handoffs, and each consumer CTA resets its ready counter before it completes so
+subsequent eager launches start from the same state. This route is not selected
+when the caller supplies an explicit workspace or ``seq_order``; CUDA Graph
+capture therefore continues through the existing non-piece routes.
+
+CC 10.3 also has a tensor-core state-decay specialization for uniform, complete
 N32 work when there are at least 64 heads, at least 96 sequence/head tasks,
 and the maximum sequence length is a multiple of 32 and at least 256. Mixed or
 partial N32 tails retain scalar state decay. On either capability, fixed-layout
@@ -130,9 +143,11 @@ BT16 prepare/chain route: dense fixed ``B=1,H=60..64`` inputs qualify from
 M128 shapes qualify from 65,536 tokens for one to eight sequence/head tasks,
 or from 4,096 tokens for nine to 32 tasks when two CTAs per task fit. N16
 alternatives additionally depend on SM count, chain waves, and sequence
-length. Supplying ``seq_order`` disables persistent host task-bin planning but
-does not suppress BT16 or otherwise force direct M128. Remaining eligible
-inputs select the shape-appropriate non-persistent or general M128 schedule.
+length. Uniform work may use the recurrence-piece route described above when
+its modeled critical path wins. Supplying ``seq_order`` disables persistent
+host task-bin planning but does not suppress BT16 or otherwise force direct
+M128. Remaining eligible inputs select the shape-appropriate non-persistent or
+general M128 schedule.
 The scalar-prepare/S8 BT16 pair is submitted by one native Cake binding, which
 performs both launch plans before enqueueing either kernel so the dependent
 launches do not expose a Python/FFI inter-kernel gap. CUDA Graph capture still

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -82,6 +82,7 @@ from .jit.flash_kda import (
     gen_flash_kda_m128_n16_checkpoint_module,
     gen_flash_kda_m128_n16_module,
     gen_flash_kda_m128_n16_short_module,
+    gen_flash_kda_piece_persistent_m128_module,
     gen_flash_kda_persistent_m128_module,
     gen_flash_kda_small_bh_m128_module,
 )
@@ -619,6 +620,7 @@ def gen_all_modules(
                     gen_flash_kda_m128_n16_module(flash_kda_target),
                     gen_flash_kda_m128_n16_checkpoint_module(flash_kda_target),
                     gen_flash_kda_m128_n16_short_module(flash_kda_target),
+                    gen_flash_kda_piece_persistent_m128_module(flash_kda_target),
                     gen_flash_kda_small_bh_m128_module(flash_kda_target),
                     gen_flash_kda_bt16_prepare_module(flash_kda_target),
                     gen_flash_kda_bt16_prepare_beta_tma_module(flash_kda_target),

--- a/flashinfer/jit/flash_kda.py
+++ b/flashinfer/jit/flash_kda.py
@@ -37,6 +37,7 @@ FlashKDAVariant = Literal[
     "m128_n16_checkpoint",
     "m128_n16_short",
     "persistent_m128",
+    "piece_persistent_m128",
     "small_bh_m128",
     "bt16_prepare",
     "bt16_prepare_beta_tma",
@@ -57,6 +58,7 @@ FLASH_KDA_VARIANTS: tuple[FlashKDAVariant, ...] = (
     "m128_n16_checkpoint",
     "m128_n16_short",
     "persistent_m128",
+    "piece_persistent_m128",
     "small_bh_m128",
     "bt16_prepare",
     "bt16_prepare_beta_tma",
@@ -91,6 +93,7 @@ _FLASH_KDA_MODULE_IDENTS = {
     "m128_n16_checkpoint": "2c3342ae17",
     "m128_n16_short": "71bc4450bf",
     "persistent_m128": "e57cec87a0",
+    "piece_persistent_m128": "3ac5764753",
     "small_bh_m128": "87ee851220",
     "bt16_prepare": "2c6cc4c1f6",
     "bt16_prepare_beta_tma": "d9394ce430",
@@ -110,6 +113,7 @@ _FLASH_KDA_BINDING_STEMS = {
     "m128_n16_checkpoint": "flashkda_bf16_fused_m128_n16_checkpoint",
     "m128_n16_short": "cake_flashkda_bf16_fused_m128_n16",
     "persistent_m128": "cake_flashkda_bf16_persistent_m128",
+    "piece_persistent_m128": "cake_flashkda_bf16_piece_persistent_m128",
     "small_bh_m128": "cake_flashkda_bf16_small_bh_m128",
     "bt16_prepare": "cake_flashkda_bf16_bt16_prepare",
     "bt16_prepare_beta_tma": "cake_flashkda_bf16_bt16_prepare_beta_tma",
@@ -281,6 +285,12 @@ def gen_flash_kda_persistent_m128_module(target: FlashKDATarget) -> JitSpec:
     return gen_flash_kda_module("persistent_m128", target)
 
 
+def gen_flash_kda_piece_persistent_m128_module(target: FlashKDATarget) -> JitSpec:
+    """Generate the recurrence-piece persistent M128 module."""
+
+    return gen_flash_kda_module("piece_persistent_m128", target)
+
+
 def gen_flash_kda_small_bh_m128_module(target: FlashKDATarget) -> JitSpec:
     """Generate the fixed-layout small-BH owner/helper M128 module."""
 
@@ -382,6 +392,12 @@ def load_flash_kda_persistent_m128_module(target: FlashKDATarget):
     return load_flash_kda_module("persistent_m128", target)
 
 
+def load_flash_kda_piece_persistent_m128_module(target: FlashKDATarget):
+    """Load the recurrence-piece persistent M128 module."""
+
+    return load_flash_kda_module("piece_persistent_m128", target)
+
+
 def load_flash_kda_small_bh_m128_module(target: FlashKDATarget):
     """Load the fixed-layout small-BH owner/helper M128 module."""
 
@@ -436,6 +452,7 @@ __all__ = [
     "gen_flash_kda_m128_n16_module",
     "gen_flash_kda_m128_n16_checkpoint_module",
     "gen_flash_kda_m128_n16_short_module",
+    "gen_flash_kda_piece_persistent_m128_module",
     "gen_flash_kda_persistent_m128_module",
     "gen_flash_kda_small_bh_m128_module",
     "gen_flash_kda_module",
@@ -448,6 +465,7 @@ __all__ = [
     "load_flash_kda_m128_h12_long_module",
     "load_flash_kda_m128_n16_module",
     "load_flash_kda_m128_n16_short_module",
+    "load_flash_kda_piece_persistent_m128_module",
     "load_flash_kda_persistent_m128_module",
     "load_flash_kda_small_bh_m128_module",
     "load_flash_kda_bt16_chain_m64_s7_module",

--- a/flashinfer/kda_prefill.py
+++ b/flashinfer/kda_prefill.py
@@ -24,8 +24,10 @@ support for recurrent KDA prefill.  The stable public dispatcher remains in
 """
 
 import functools
+import heapq
 import math
 import threading
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal, Optional
 
 import torch
@@ -77,9 +79,32 @@ _FLASH_KDA_H12_DIRECT_N32_EARLY_STATE_PACK_MAX_SEQUENCE_LENGTH = 128
 _FLASH_KDA_ROUTE_DIRECT_M128 = "direct_m128"
 _FLASH_KDA_ROUTE_DIRECT_M128_N16 = "direct_m128_n16"
 _FLASH_KDA_ROUTE_PERSISTENT_M128 = "persistent_m128"
+_FLASH_KDA_ROUTE_PIECE_PERSISTENT_M128 = "piece_persistent_m128"
 _FLASH_KDA_ROUTE_M64 = "independent_dvsplit_m64"
 _FLASH_KDA_ROUTE_SMALL_BH_M128 = "small_bh_owner_helper_m128"
 _FLASH_KDA_ROUTE_BT16_M64 = "bt16_prepare_chain_m64"
+
+# Physical contract for the frozen persistent-M128 schedule. The generated
+# launch reserves an additional aligned control prefix; the roofline uses the
+# schedule's data-pool footprint when resolving resident CTA count.
+_FLASH_KDA_M128_CHUNK = 32
+_FLASH_KDA_PERSISTENT_THREADS_PER_CTA = 1024
+_FLASH_KDA_PERSISTENT_SMEM_POOL_BYTES_PER_CTA = 220_672
+_FLASH_KDA_PERSISTENT_TMEM_COLS_PER_CTA = 256
+_FLASH_KDA_BLACKWELL_MAX_THREADS_PER_SM = 2048
+_FLASH_KDA_BLACKWELL_SMEM_BYTES_PER_SM = 228 * 1024
+_FLASH_KDA_BLACKWELL_TMEM_COLS_PER_SM = 512
+_FLASH_KDA_BLACKWELL_BF16_TFLOPS = 2250.0
+_FLASH_KDA_BLACKWELL_HBM_GBPS = 8000.0
+_FLASH_KDA_PERSISTENT_TENSOR_FLOPS_PER_CHUNK = (
+    3 * 2 * _FLASH_KDA_HEAD_DIM * _FLASH_KDA_M128_CHUNK * _FLASH_KDA_HEAD_DIM
+    + 2 * _FLASH_KDA_HEAD_DIM * _FLASH_KDA_M128_CHUNK * _FLASH_KDA_M128_CHUNK
+)
+_FLASH_KDA_PERSISTENT_STREAM_BYTES_PER_CHUNK = (
+    5 * _FLASH_KDA_M128_CHUNK * _FLASH_KDA_HEAD_DIM * 2 + _FLASH_KDA_M128_CHUNK * 2
+)
+_FLASH_KDA_PERSISTENT_STATE_BYTES = _FLASH_KDA_HEAD_DIM * _FLASH_KDA_HEAD_DIM * 2
+_FLASH_KDA_PERSISTENT_TASK_REFILL_CHUNKS = 2
 _flash_kda_tensor_cache: dict[tuple, torch.Tensor] = {}
 _flash_kda_tensor_cache_lock = threading.Lock()
 
@@ -92,6 +117,20 @@ _PackedTaskMetadata = tuple[
     tuple[int, ...],
     tuple[int, ...],
 ]
+
+
+@dataclass(frozen=True)
+class _PersistentM128Roofline:
+    """Resolved occupancy and critical-path lower bounds in nanoseconds."""
+
+    resident_ctas_per_sm: int
+    worker_count: int
+    handoff_count: int
+    chunk_ns: float
+    state_transfer_ns: float
+    task_refill_ns: float
+    direct_ns: float
+    piece_ns: float
 
 
 class _RecurrentKDAPrefillWorkspaceBase:
@@ -109,6 +148,8 @@ class _RecurrentKDAPrefillWorkspaceBase:
         self._small_bh_packet_ready: Optional[torch.Tensor] = None
         self._small_bh_packet_consumed: Optional[torch.Tensor] = None
         self._small_bh_helper_done: Optional[torch.Tensor] = None
+        self._piece_mid_state: Optional[torch.Tensor] = None
+        self._piece_mid_state_ready: Optional[torch.Tensor] = None
         self._bt16_cu_chunks: Optional[torch.Tensor] = None
         self._bt16_chunk_to_seq: Optional[torch.Tensor] = None
         self._bt16_qd: Optional[torch.Tensor] = None
@@ -139,6 +180,7 @@ class _RecurrentKDAPrefillWorkspaceBase:
                 "m128_n16_checkpoint",
                 "m128_n16_short",
                 "persistent_m128",
+                "piece_persistent_m128",
                 "small_bh_m128",
                 "bt16_prepare",
                 "bt16_prepare_beta_tma",
@@ -616,6 +658,8 @@ def _select_flash_kda_bf16_route(
     num_heads: int,
     uniform_sequences: bool,
     max_sequence_length: int,
+    use_initial_state: bool = True,
+    store_final_state: bool = True,
 ) -> str:
     """Mirror the measured Cake route policy for the frozen BF16 portfolio."""
 
@@ -696,6 +740,17 @@ def _select_flash_kda_bf16_route(
         and 2 * num_heads <= sm_count
     ):
         return _FLASH_KDA_ROUTE_M64
+    if _should_use_uniform_piece_persistent(
+        compute_capability=compute_capability,
+        sm_count=sm_count,
+        num_sequences=num_sequences,
+        num_heads=num_heads,
+        uniform_sequences=uniform_sequences,
+        max_sequence_length=max_sequence_length,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+    ):
+        return _FLASH_KDA_ROUTE_PIECE_PERSISTENT_M128
     return direct_route
 
 
@@ -827,6 +882,301 @@ def _lpt_bins_are_balanced(loads: tuple[int, ...]) -> bool:
         max(loads) * _FLASH_KDA_LPT_MAX_IMBALANCE_DENOMINATOR * len(loads)
         <= sum(loads) * _FLASH_KDA_LPT_MAX_IMBALANCE_NUMERATOR
     )
+
+
+@functools.lru_cache(maxsize=64)
+def _make_uniform_piece_task_bins(
+    *,
+    num_sequences: int,
+    num_heads: int,
+    sequence_length: int,
+    worker_count: int,
+) -> tuple[
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    tuple[int, ...],
+    int,
+    tuple[int, ...],
+]:
+    """Split quantization-bound uniform chains across persistent CTA bins."""
+
+    total_tasks = num_sequences * num_heads
+    if (
+        num_sequences <= 0
+        or num_heads <= 0
+        or sequence_length <= 0
+        or worker_count <= 0
+        or worker_count > total_tasks
+    ):
+        raise ValueError("uniform piece bins require positive resolved work")
+
+    chunk_count = (sequence_length + _FLASH_KDA_M128_CHUNK - 1) // _FLASH_KDA_M128_CHUNK
+    bins: list[list[tuple[int, int, int, int, int]]] = [[] for _ in range(worker_count)]
+    loads = [0] * worker_count
+    for task_idx in range(total_tasks):
+        worker_idx = min(
+            range(worker_count),
+            key=lambda index: (loads[index], index),
+        )
+        bins[worker_idx].append((task_idx, 0, sequence_length, -1, -1))
+        loads[worker_idx] += chunk_count
+
+    base_tasks, extra_tasks = divmod(total_tasks, worker_count)
+    piece_count = (
+        min(base_tasks, worker_count // extra_tasks, chunk_count) if extra_tasks else 1
+    )
+    if piece_count >= 2:
+        peak_load = (base_tasks + 1) * chunk_count
+        peak_slots = [
+            worker_idx for worker_idx, load in enumerate(loads) if load == peak_load
+        ]
+        if len(peak_slots) != extra_tasks:
+            raise RuntimeError("uniform LPT peak count did not match task remainder")
+        overflow_tasks = []
+        for worker_idx in peak_slots:
+            task = bins[worker_idx].pop()
+            loads[worker_idx] -= chunk_count
+            overflow_tasks.append(task[0])
+
+        handoff_count = 0
+        chunk_base = chunk_count // piece_count
+        chunk_remainder = chunk_count % piece_count
+        chunk_cuts = [0]
+        for piece_idx in range(piece_count):
+            # Put longer pieces last so every dependency gets at least the
+            # preceding whole-chain interval of scheduling slack.
+            piece_chunks = chunk_base + int(piece_idx >= piece_count - chunk_remainder)
+            chunk_cuts.append(chunk_cuts[-1] + piece_chunks)
+
+        for overflow_idx, task_idx in enumerate(overflow_tasks):
+            handoffs = tuple(range(handoff_count, handoff_count + piece_count - 1))
+            handoff_count += piece_count - 1
+            for piece_idx in range(piece_count):
+                chunk_start = chunk_cuts[piece_idx]
+                chunk_end = chunk_cuts[piece_idx + 1]
+                token_start = chunk_start * _FLASH_KDA_M128_CHUNK
+                token_end = min(sequence_length, chunk_end * _FLASH_KDA_M128_CHUNK)
+                source = -1 if piece_idx == 0 else handoffs[piece_idx - 1]
+                destination = (
+                    -1 if piece_idx + 1 == piece_count else handoffs[piece_idx]
+                )
+                worker_idx = piece_idx * extra_tasks + overflow_idx
+                insert_at = min(1 + piece_idx, len(bins[worker_idx]))
+                bins[worker_idx].insert(
+                    insert_at,
+                    (
+                        task_idx,
+                        token_start,
+                        token_end - token_start,
+                        source,
+                        destination,
+                    ),
+                )
+                loads[worker_idx] += chunk_end - chunk_start
+    else:
+        handoff_count = 0
+
+    task_ids: list[int] = []
+    task_token_starts: list[int] = []
+    task_token_counts: list[int] = []
+    task_state_sources: list[int] = []
+    task_state_destinations: list[int] = []
+    task_offsets = [0]
+    for worker_tasks in bins:
+        for task_idx, token_start, token_count, source, destination in worker_tasks:
+            task_ids.append(task_idx)
+            task_token_starts.append(token_start)
+            task_token_counts.append(token_count)
+            task_state_sources.append(source)
+            task_state_destinations.append(destination)
+        task_offsets.append(len(task_ids))
+    return (
+        tuple(task_ids),
+        tuple(task_offsets),
+        tuple(task_token_starts),
+        tuple(task_token_counts),
+        tuple(task_state_sources),
+        tuple(task_state_destinations),
+        handoff_count,
+        tuple(loads),
+    )
+
+
+@functools.lru_cache(maxsize=64)
+def _persistent_m128_roofline(
+    *,
+    compute_capability: tuple[int, int],
+    sm_count: int,
+    num_sequences: int,
+    num_heads: int,
+    sequence_length: int,
+    use_initial_state: bool,
+    store_final_state: bool,
+) -> Optional[_PersistentM128Roofline]:
+    """Compare direct and recurrence-piece persistent critical paths."""
+
+    if compute_capability not in _FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES:
+        return None
+    if sm_count not in (148, 152):
+        return None
+    if num_sequences <= 0 or num_heads <= 0 or sequence_length <= 0:
+        raise ValueError("persistent-M128 roofline requires resolved positive extents")
+
+    resident_ctas_per_sm = min(
+        _FLASH_KDA_BLACKWELL_MAX_THREADS_PER_SM
+        // _FLASH_KDA_PERSISTENT_THREADS_PER_CTA,
+        _FLASH_KDA_BLACKWELL_SMEM_BYTES_PER_SM
+        // _FLASH_KDA_PERSISTENT_SMEM_POOL_BYTES_PER_CTA,
+        _FLASH_KDA_BLACKWELL_TMEM_COLS_PER_SM
+        // _FLASH_KDA_PERSISTENT_TMEM_COLS_PER_CTA,
+    )
+    if resident_ctas_per_sm <= 0:
+        raise RuntimeError(
+            "persistent-M128 schedule is not resident on the selected device"
+        )
+    worker_count = sm_count * resident_ctas_per_sm
+    total_tasks = num_sequences * num_heads
+    if total_tasks <= worker_count:
+        return None
+
+    (
+        _task_ids,
+        task_offsets,
+        _token_starts,
+        token_counts,
+        state_sources,
+        state_destinations,
+        handoff_count,
+        _loads,
+    ) = _make_uniform_piece_task_bins(
+        num_sequences=num_sequences,
+        num_heads=num_heads,
+        sequence_length=sequence_length,
+        worker_count=worker_count,
+    )
+    if handoff_count == 0:
+        return None
+
+    worker_flops_per_ns = _FLASH_KDA_BLACKWELL_BF16_TFLOPS * 1_000.0 / worker_count
+    worker_bytes_per_ns = _FLASH_KDA_BLACKWELL_HBM_GBPS / worker_count
+    chunk_ns = max(
+        _FLASH_KDA_PERSISTENT_TENSOR_FLOPS_PER_CHUNK / worker_flops_per_ns,
+        _FLASH_KDA_PERSISTENT_STREAM_BYTES_PER_CHUNK / worker_bytes_per_ns,
+    )
+    state_transfer_ns = _FLASH_KDA_PERSISTENT_STATE_BYTES / worker_bytes_per_ns
+    task_refill_ns = _FLASH_KDA_PERSISTENT_TASK_REFILL_CHUNKS * chunk_ns
+    chunks_per_task = (
+        sequence_length + _FLASH_KDA_M128_CHUNK - 1
+    ) // _FLASH_KDA_M128_CHUNK
+    direct_task_ns = chunks_per_task * chunk_ns
+    if use_initial_state:
+        direct_task_ns += state_transfer_ns
+    if store_final_state:
+        direct_task_ns += state_transfer_ns
+    direct_ns = ((total_tasks + worker_count - 1) // worker_count) * direct_task_ns
+
+    entry_count = len(token_counts)
+    edges: list[set[int]] = [set() for _ in range(entry_count)]
+    indegree = [0] * entry_count
+
+    def add_edge(source: int, destination: int) -> None:
+        if destination not in edges[source]:
+            edges[source].add(destination)
+            indegree[destination] += 1
+
+    for worker_idx in range(worker_count):
+        begin = task_offsets[worker_idx]
+        end = task_offsets[worker_idx + 1]
+        for entry_idx in range(begin + 1, end):
+            add_edge(entry_idx - 1, entry_idx)
+    handoff_producers = {
+        destination: entry_idx
+        for entry_idx, destination in enumerate(state_destinations)
+        if destination >= 0
+    }
+    if len(handoff_producers) != handoff_count:
+        raise RuntimeError("piece roofline did not resolve every handoff producer")
+    for entry_idx, source in enumerate(state_sources):
+        if source >= 0:
+            try:
+                producer = handoff_producers[source]
+            except KeyError as exc:
+                raise RuntimeError(
+                    f"piece roofline did not resolve handoff source {source}"
+                ) from exc
+            add_edge(producer, entry_idx)
+
+    ready = [entry_idx for entry_idx, degree in enumerate(indegree) if degree == 0]
+    heapq.heapify(ready)
+    worker_first_entries = frozenset(task_offsets[:-1])
+    earliest_start = [0.0] * entry_count
+    finish = [0.0] * entry_count
+    visited = 0
+    while ready:
+        entry_idx = heapq.heappop(ready)
+        duration = (
+            (token_counts[entry_idx] + _FLASH_KDA_M128_CHUNK - 1)
+            // _FLASH_KDA_M128_CHUNK
+            * chunk_ns
+        )
+        if entry_idx not in worker_first_entries:
+            duration += task_refill_ns
+        if state_sources[entry_idx] >= 0 or use_initial_state:
+            duration += state_transfer_ns
+        if state_destinations[entry_idx] >= 0 or store_final_state:
+            duration += state_transfer_ns
+        finish[entry_idx] = earliest_start[entry_idx] + duration
+        visited += 1
+        for successor in edges[entry_idx]:
+            earliest_start[successor] = max(
+                earliest_start[successor], finish[entry_idx]
+            )
+            indegree[successor] -= 1
+            if indegree[successor] == 0:
+                heapq.heappush(ready, successor)
+    if visited != entry_count:
+        raise RuntimeError("piece roofline dependency graph contains a cycle")
+
+    return _PersistentM128Roofline(
+        resident_ctas_per_sm=resident_ctas_per_sm,
+        worker_count=worker_count,
+        handoff_count=handoff_count,
+        chunk_ns=chunk_ns,
+        state_transfer_ns=state_transfer_ns,
+        task_refill_ns=task_refill_ns,
+        direct_ns=direct_ns,
+        piece_ns=max(finish),
+    )
+
+
+def _should_use_uniform_piece_persistent(
+    *,
+    compute_capability: tuple[int, int],
+    sm_count: int,
+    num_sequences: int,
+    num_heads: int,
+    uniform_sequences: bool,
+    max_sequence_length: int,
+    use_initial_state: bool = True,
+    store_final_state: bool = True,
+) -> bool:
+    """Select recurrence pieces when their occupancy-aware roofline wins."""
+
+    if not uniform_sequences or max_sequence_length <= 0:
+        return False
+    estimate = _persistent_m128_roofline(
+        compute_capability=compute_capability,
+        sm_count=sm_count,
+        num_sequences=num_sequences,
+        num_heads=num_heads,
+        sequence_length=max_sequence_length,
+        use_initial_state=use_initial_state,
+        store_final_state=store_final_state,
+    )
+    return estimate is not None and estimate.piece_ns < estimate.direct_ns
 
 
 def _persistent_task_plan(
@@ -1256,6 +1606,37 @@ def _small_bh_workspace(
         zero_on_allocate=True,
     )
     return packet_workspace, packet_ready, packet_consumed, helper_done
+
+
+def _piece_persistent_workspace(
+    *,
+    workspace: _RecurrentKDAPrefillWorkspaceBase,
+    device: torch.device,
+    handoff_count: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if handoff_count <= 0:
+        raise ValueError("piece-persistent workspace requires a positive handoff count")
+    capture_error = (
+        "recurrent_kda piece-persistent workspace is not large enough for "
+        "CUDA graph capture; warm the largest shape on this stream before capture"
+    )
+    mid_state = _workspace_buffer(
+        workspace=workspace,
+        attribute="_piece_mid_state",
+        device=device,
+        numel=handoff_count * _FLASH_KDA_HEAD_DIM * _FLASH_KDA_HEAD_DIM,
+        capture_error=capture_error,
+    ).view(handoff_count, _FLASH_KDA_HEAD_DIM, _FLASH_KDA_HEAD_DIM)
+    mid_state_ready = _workspace_buffer(
+        workspace=workspace,
+        attribute="_piece_mid_state_ready",
+        device=device,
+        numel=handoff_count,
+        capture_error=capture_error,
+        dtype=torch.uint32,
+        zero_on_allocate=True,
+    )
+    return mid_state, mid_state_ready
 
 
 def _bt16_workspace(
@@ -1847,11 +2228,20 @@ def _run_flash_kda_prefill(
             != num_heads * _FLASH_KDA_HEAD_DIM * _FLASH_KDA_HEAD_DIM
         )
     )
-    persistent_candidate = (
+    legacy_persistent_candidate = (
         _uses_measured_sm100_persistent_policy(
             compute_capability=compute_capability,
             sm_count=sm_count,
         )
+        and not needs_direct_m128
+        and prefill_workspace is None
+        and seq_order is None
+        and initial_state is not None
+        and num_heads != 12
+        and num_sequences * num_heads > sm_count
+    )
+    piece_persistent_candidate = (
+        compute_capability in _FLASH_KDA_SUPPORTED_COMPUTE_CAPABILITIES
         and not needs_direct_m128
         and prefill_workspace is None
         and seq_order is None
@@ -1892,9 +2282,9 @@ def _run_flash_kda_prefill(
             total_tokens=batch_size * seq_len,
             num_heads=num_heads,
             sm_count=sm_count,
-            build_persistent_plan=persistent_candidate,
+            build_persistent_plan=legacy_persistent_candidate,
         )
-    if fixed_layout and persistent_candidate:
+    if fixed_layout and legacy_persistent_candidate:
         persistent_plan = _persistent_task_plan(
             sequence_lengths,
             num_heads=num_heads,
@@ -1929,7 +2319,17 @@ def _run_flash_kda_prefill(
             num_heads=num_heads,
             uniform_sequences=uniform_sequences,
             max_sequence_length=max_sequence_length,
+            use_initial_state=initial_state is not None,
+            store_final_state=initial_state is not None or output_final_state,
         )
+        if (
+            route == _FLASH_KDA_ROUTE_PIECE_PERSISTENT_M128
+            and not piece_persistent_candidate
+        ):
+            route = _direct_m128_route(
+                num_heads=num_heads,
+                max_sequence_length=max_sequence_length,
+            )
     use_bt16 = route == _FLASH_KDA_ROUTE_BT16_M64
     use_tensor_state_decay = (
         state_indices is None
@@ -1961,6 +2361,7 @@ def _run_flash_kda_prefill(
         "m128_n16_checkpoint",
         "m128_n16_short",
         "persistent_m128",
+        "piece_persistent_m128",
         "small_bh_m128",
     ]
     if use_bt16:
@@ -1971,6 +2372,8 @@ def _run_flash_kda_prefill(
         variant = "small_bh_m128"
     elif use_tensor_state_decay:
         variant = "m128_tensor_state_decay"
+    elif route == _FLASH_KDA_ROUTE_PIECE_PERSISTENT_M128:
+        variant = "piece_persistent_m128"
     elif persistent_plan is not None:
         variant = "persistent_m128"
     elif route == _FLASH_KDA_ROUTE_DIRECT_M128_N16:
@@ -1992,6 +2395,31 @@ def _run_flash_kda_prefill(
         variant = "m128"
     if checkpoint_every_n_tokens and variant == "m128_n16":
         variant = "m128_n16_checkpoint"
+    piece_plan = None
+    if variant == "piece_persistent_m128":
+        piece_roofline = _persistent_m128_roofline(
+            compute_capability=compute_capability,
+            sm_count=sm_count,
+            num_sequences=num_sequences,
+            num_heads=num_heads,
+            sequence_length=max_sequence_length,
+            use_initial_state=initial_state is not None,
+            store_final_state=initial_state is not None or output_final_state,
+        )
+        if (
+            piece_roofline is None
+            or piece_roofline.piece_ns >= piece_roofline.direct_ns
+        ):
+            raise RuntimeError(
+                "piece-persistent route selected without a resolved roofline advantage"
+            )
+        piece_plan = _make_uniform_piece_task_bins(
+            num_sequences=num_sequences,
+            num_heads=num_heads,
+            sequence_length=max_sequence_length,
+            worker_count=piece_roofline.worker_count,
+        )
+        persistent_plan = None
     persistent_task_ids = None
     persistent_task_offsets = None
     if persistent_plan is None:
@@ -2024,6 +2452,52 @@ def _run_flash_kda_prefill(
             device=q.device,
             kind="persistent_task_offsets",
             values=task_offsets,
+        )
+    piece_task_token_starts = None
+    piece_task_token_counts = None
+    piece_task_state_sources = None
+    piece_task_state_destinations = None
+    piece_handoff_count = 0
+    if piece_plan is not None:
+        (
+            task_ids,
+            task_offsets,
+            token_starts,
+            token_counts,
+            state_sources,
+            state_destinations,
+            piece_handoff_count,
+            _piece_loads,
+        ) = piece_plan
+        persistent_task_ids = _cached_int32_metadata(
+            device=q.device,
+            kind="piece_persistent_task_ids",
+            values=task_ids,
+        )
+        persistent_task_offsets = _cached_int32_metadata(
+            device=q.device,
+            kind="piece_persistent_task_offsets",
+            values=task_offsets,
+        )
+        piece_task_token_starts = _cached_int32_metadata(
+            device=q.device,
+            kind="piece_persistent_task_token_starts",
+            values=token_starts,
+        )
+        piece_task_token_counts = _cached_int32_metadata(
+            device=q.device,
+            kind="piece_persistent_task_token_counts",
+            values=token_counts,
+        )
+        piece_task_state_sources = _cached_int32_metadata(
+            device=q.device,
+            kind="piece_persistent_task_state_sources",
+            values=state_sources,
+        )
+        piece_task_state_destinations = _cached_int32_metadata(
+            device=q.device,
+            kind="piece_persistent_task_state_destinations",
+            values=state_destinations,
         )
     dummy_state = _dummy_bf16(q.device)
     dummy_i32 = _dummy_i32(q.device) if variant != "m64" else None
@@ -2132,6 +2606,8 @@ def _run_flash_kda_prefill(
         packet_ready = None
         packet_consumed = None
         helper_done = None
+        piece_mid_state = None
+        piece_mid_state_ready = None
         if variant == "small_bh_m128":
             (
                 packet_workspace,
@@ -2142,6 +2618,12 @@ def _run_flash_kda_prefill(
                 workspace=workspace,
                 device=q.device,
                 total_tasks=num_sequences * num_heads,
+            )
+        elif variant == "piece_persistent_m128":
+            piece_mid_state, piece_mid_state_ready = _piece_persistent_workspace(
+                workspace=workspace,
+                device=q.device,
+                handoff_count=piece_handoff_count,
             )
         if initial_state is None and output_final_state and explicit_workspace:
             final_state_arg = _state_scratch(
@@ -2281,6 +2763,46 @@ def _run_flash_kda_prefill(
                     seq_order_i32,
                     persistent_task_ids,
                     persistent_task_offsets,
+                    initial_state_arg,
+                    out_buf,
+                    final_state_arg,
+                    descriptor_storage,
+                    prepare_descriptors,
+                    num_heads,
+                    int(use_initial_state),
+                    int(store_final_state),
+                    scale_value,
+                    float(lower_bound),
+                    stream_ptr,
+                )
+            elif variant == "piece_persistent_m128":
+                assert persistent_task_ids is not None
+                assert persistent_task_offsets is not None
+                assert piece_task_token_starts is not None
+                assert piece_task_token_counts is not None
+                assert piece_task_state_sources is not None
+                assert piece_task_state_destinations is not None
+                assert piece_mid_state is not None
+                assert piece_mid_state_ready is not None
+                module.run(
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    beta_tma,
+                    A_log,
+                    dt_bias,
+                    cu_seqlens_i64,
+                    seq_order_i32,
+                    persistent_task_ids,
+                    persistent_task_offsets,
+                    piece_task_token_starts,
+                    piece_task_token_counts,
+                    piece_task_state_sources,
+                    piece_task_state_destinations,
+                    piece_mid_state,
+                    piece_mid_state_ready,
                     initial_state_arg,
                     out_buf,
                     final_state_arg,

--- a/tests/jit/test_flash_kda_prefill_jit.py
+++ b/tests/jit/test_flash_kda_prefill_jit.py
@@ -54,6 +54,10 @@ _COMMON_HEADER_VARIANT_BODIES = (
     ),
     ("m128_n16_short", "cake_flashkda_bf16_fused_m128_n16_short.cu"),
     ("persistent_m128", "cake_flashkda_bf16_persistent_m128.cu"),
+    (
+        "piece_persistent_m128",
+        "cake_flashkda_bf16_piece_persistent_m128.cu",
+    ),
     ("small_bh_m128", "cake_flashkda_bf16_small_bh_m128.cu"),
 )
 
@@ -135,6 +139,10 @@ def test_h12_prefill_jit_spec_and_frozen_source(
 def test_h12_prefill_variants_are_in_the_aot_inventory():
     assert "m128_h12_short" in flash_kda.FLASH_KDA_VARIANTS
     assert "m128_h12_long" in flash_kda.FLASH_KDA_VARIANTS
+
+
+def test_piece_persistent_prefill_variant_is_in_the_aot_inventory():
+    assert "piece_persistent_m128" in flash_kda.FLASH_KDA_VARIANTS
 
 
 @pytest.mark.parametrize(

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -1116,6 +1116,117 @@ def test_bt16_route_policy_matches_measured_crossovers(
     )
 
 
+def test_uniform_piece_bins_cover_tasks_and_match_h96_h64_bounds():
+    for num_heads, expected_handoffs, expected_max in (
+        (96, 32, 167),
+        (64, 56, 112),
+    ):
+        (
+            tasks,
+            offsets,
+            token_starts,
+            token_counts,
+            sources,
+            destinations,
+            handoff_count,
+            loads,
+        ) = kda_prefill_api._make_uniform_piece_task_bins(
+            num_sequences=8,
+            num_heads=num_heads,
+            sequence_length=1024,
+            worker_count=152,
+        )
+        assert len(offsets) == 153
+        assert len(tasks) == len(token_starts) == len(token_counts)
+        assert len(tasks) == len(sources) == len(destinations)
+        assert handoff_count == expected_handoffs
+        assert max(loads) == expected_max
+        assert sum(loads) == 8 * num_heads * 32
+
+        produced = sorted(value for value in destinations if value >= 0)
+        consumed = sorted(value for value in sources if value >= 0)
+        assert produced == consumed == list(range(handoff_count))
+        coverage = {}
+        for task, start, count in zip(tasks, token_starts, token_counts, strict=True):
+            coverage.setdefault(task, []).append((start, start + count))
+        assert set(coverage) == set(range(8 * num_heads))
+        for intervals in coverage.values():
+            ordered = sorted(intervals)
+            assert ordered[0][0] == 0
+            assert ordered[-1][1] == 1024
+            assert all(
+                left[1] == right[0]
+                for left, right in zip(ordered, ordered[1:], strict=False)
+            )
+
+
+def test_uniform_piece_policy_uses_occupancy_and_dependency_dag():
+    common = {
+        "compute_capability": (10, 3),
+        "sm_count": 152,
+        "num_sequences": 8,
+        "uniform_sequences": True,
+        "max_sequence_length": 1024,
+    }
+    for num_heads in (60, 64, 96, 104):
+        estimate = kda_prefill_api._persistent_m128_roofline(
+            compute_capability=common["compute_capability"],
+            sm_count=common["sm_count"],
+            num_sequences=common["num_sequences"],
+            num_heads=num_heads,
+            sequence_length=common["max_sequence_length"],
+            use_initial_state=True,
+            store_final_state=True,
+        )
+        assert estimate is not None
+        assert estimate.resident_ctas_per_sm == 1
+        assert estimate.worker_count == common["sm_count"]
+        assert estimate.handoff_count > 0
+        assert estimate.piece_ns < estimate.direct_ns
+        assert kda_prefill_api._should_use_uniform_piece_persistent(
+            num_heads=num_heads,
+            **common,
+        )
+        assert (
+            kda_prefill_api._select_flash_kda_bf16_route(
+                fixed_layout=False,
+                num_heads=num_heads,
+                **common,
+            )
+            == "piece_persistent_m128"
+        )
+
+    assert kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96,
+        **(common | {"compute_capability": (10, 0), "sm_count": 148}),
+    )
+    assert not kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96, **(common | {"num_sequences": 4})
+    )
+    assert not kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96, **(common | {"sm_count": 149})
+    )
+    assert kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96, **(common | {"max_sequence_length": 992})
+    )
+    assert not kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96, **(common | {"max_sequence_length": 32})
+    )
+    assert not kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=48, **common
+    )
+    assert not kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96, **(common | {"uniform_sequences": False})
+    )
+    assert kda_prefill_api._should_use_uniform_piece_persistent(
+        num_heads=96, **(common | {"num_sequences": 16})
+    )
+    for num_sequences in (32, 64):
+        assert not kda_prefill_api._should_use_uniform_piece_persistent(
+            num_heads=96, **(common | {"num_sequences": num_sequences})
+        )
+
+
 def test_bt16_prepare_walk_and_physical_variants_match_production_policy():
     assert (
         kda_prefill_api._direct_m128_route(num_heads=64, max_sequence_length=16)
@@ -1959,6 +2070,207 @@ def test_sm100_uniform_prefill_reaches_persistent_worker_abi(
     assert args[15].shape == (768,)
     assert args[16] == 1
     assert args[17] == 96
+
+
+def test_uniform_piece_prefill_reaches_extended_worker_abi(
+    cuda_device,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "get_compute_capability",
+        lambda device: (10, 3),
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_is_cuda_version_at_least",
+        lambda version: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_flash_kda_device_sm_count",
+        lambda device: 152,
+    )
+    monkeypatch.setattr(kda_prefill_api, "_flash_kda_stream_workspaces", {})
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_should_use_uniform_piece_persistent",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_persistent_m128_roofline",
+        lambda **kwargs: SimpleNamespace(
+            worker_count=152,
+            piece_ns=1.0,
+            direct_ns=2.0,
+        ),
+    )
+    module = _RecorderModule()
+    routes = []
+
+    def get_module(variant, target):
+        routes.append((variant, target))
+        return module
+
+    monkeypatch.setattr(kda_prefill_api, "_get_flash_kda_prefill_module", get_module)
+    inputs = _make_inputs(
+        seq_lens=[64] * 8,
+        num_heads=96,
+        packed=True,
+        initial_state=True,
+    )
+    output, state = recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output=torch.empty_like(inputs["q"]),
+        backend="cake",
+    )
+
+    assert output.shape == inputs["q"].shape
+    assert state is None
+    assert routes == [("piece_persistent_m128", "sm100f")]
+    (args,) = module.calls
+    assert len(args) == 29
+    assert args[9].tolist() == list(range(8))
+    assert args[10].numel() > 8 * 96
+    assert args[11].numel() == 153
+    assert args[10].numel() == args[12].numel() == args[13].numel()
+    assert args[10].numel() == args[14].numel() == args[15].numel()
+    assert args[16].shape[1:] == (128, 128)
+    assert args[17].dtype == torch.uint32
+    assert args[16].shape[0] == args[17].numel()
+    assert args[21].dtype == torch.uint8
+    assert args[21].shape == (768,)
+    assert args[22] == 1
+    assert args[23] == 96
+
+
+def test_explicit_workspace_keeps_uniform_piece_candidate_on_direct_abi(
+    cuda_device,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "get_compute_capability",
+        lambda device: (10, 3),
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_is_cuda_version_at_least",
+        lambda version: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_flash_kda_device_sm_count",
+        lambda device: 152,
+    )
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_should_use_uniform_piece_persistent",
+        lambda **kwargs: True,
+    )
+    module = _RecorderModule()
+    routes = []
+
+    def get_module(variant, target):
+        routes.append((variant, target))
+        return module
+
+    monkeypatch.setattr(kda_prefill_api, "_get_flash_kda_prefill_module", get_module)
+    inputs = _make_inputs(
+        seq_lens=[64] * 8,
+        num_heads=96,
+        packed=True,
+        initial_state=True,
+    )
+    workspace = RecurrentKDAPrefillWorkspace(cuda_device)
+    recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output=torch.empty_like(inputs["q"]),
+        prefill_workspace=workspace,
+        backend="cake",
+    )
+
+    assert routes == [("m128", "sm100f")]
+    assert len(module.calls[0]) == 28
+
+
+@pytest.mark.parametrize("num_heads", [40, 64, 96])
+def test_frozen_uniform_piece_prefill_repeats_and_matches_direct_control(
+    flash_kda_device,
+    monkeypatch,
+    num_heads,
+):
+    inputs = _make_inputs(
+        seq_lens=[1024] * 8,
+        num_heads=num_heads,
+        packed=True,
+        initial_state=True,
+        seed=102400 + num_heads,
+    )
+    initial_state_seed = inputs["initial_state"].clone()
+    routes = []
+    get_module = kda_prefill_api._get_flash_kda_prefill_module
+
+    def recording_get_module(variant, target):
+        routes.append((variant, target))
+        return get_module(variant, target)
+
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_get_flash_kda_prefill_module",
+        recording_get_module,
+    )
+
+    piece_results = []
+    for _ in range(2):
+        inputs["initial_state"].copy_(initial_state_seed)
+        piece_output, piece_state = recurrent_kda(
+            **_strict_prefill_kwargs(inputs),
+            output=torch.empty_like(inputs["q"]),
+            output_final_state=True,
+            backend="cake",
+        )
+        piece_results.append((piece_output.clone(), piece_state.clone()))
+
+    stream_workspace = kda_prefill_api._get_stream_workspace(flash_kda_device)
+    assert stream_workspace._piece_mid_state_ready is not None
+    assert not torch.count_nonzero(stream_workspace._piece_mid_state_ready).item()
+
+    inputs["initial_state"].copy_(initial_state_seed)
+    monkeypatch.setattr(
+        kda_prefill_api,
+        "_should_use_uniform_piece_persistent",
+        lambda **kwargs: False,
+    )
+    direct_output, direct_state = recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output=torch.empty_like(inputs["q"]),
+        output_final_state=True,
+        seq_order=torch.arange(8, dtype=torch.int32, device=flash_kda_device),
+        backend="cake",
+    )
+
+    expected_target = kda_prefill_api._select_flash_kda_prefill_target(flash_kda_device)
+    direct_variant = (
+        "m128_tensor_state_decay"
+        if get_compute_capability(flash_kda_device) == (10, 3) and num_heads >= 64
+        else "m128"
+    )
+    assert routes == [
+        ("piece_persistent_m128", expected_target),
+        ("piece_persistent_m128", expected_target),
+        (direct_variant, expected_target),
+    ]
+    for piece_output, piece_state in piece_results:
+        torch.testing.assert_close(
+            piece_output.float(), direct_output.float(), atol=1e-2, rtol=1e-2
+        )
+        torch.testing.assert_close(
+            piece_state.float(), direct_state.float(), atol=1e-2, rtol=1e-2
+        )
+    assert torch.equal(piece_results[0][0], piece_results[1][0])
+    assert torch.equal(piece_results[0][1], piece_results[1][1])
 
 
 def test_explicit_seq_order_keeps_direct_worker_and_reaches_ffi(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

This follow-up to #4675 adds a frozen recurrence-piece persistent M128
specialization to the explicit `recurrent_kda(..., backend="cake")` prefill
portfolio on validated 148/152-SM CC 10.0 and CC 10.3 devices.

For eligible uniform eager calls, the dispatcher uses the live SM count and a
physical occupancy/roofline model to split only recurrence chains responsible
for a partial final device wave. Device-scope release/acquire handoffs carry
intermediate BF16 state between persistent CTAs. The final consumer resets each
handoff counter before completing, so the same stream-local workspace can be
used by subsequent eager calls.

The new route requires a caller-owned in-place initial state and is not selected
with an explicit workspace or `seq_order`. Existing CUDA Graph paths therefore
continue to use the previously qualified non-piece variants.

<!-- recurrence-piece-performance:start -->
## Qualification and performance

Qualification completed at exact PR head
`48fc324fd6d64a89d4c4d21b5c10e41d19482de9`. Every GPU row below has passed its sealed
per-shape evidence audit.

### Original six H96/H64 cases

These are exactly the first six rows of the 29-shape ledger, not a separate
benchmark contract.

| GPU | hardware | exported API | FlashKDA | speedup vs FlashKDA | frozen #4605 | speedup vs #4605 | peer-normalized vs #4605 | correctness |
|---|---|---:|---:|---:|---:|---:|---:|---|
| B200 | NVIDIA B200 / sm100a / 148 SMs | 333.299 us | 791.432 us | 2.375x | 354.294 us | 1.063x | 1.063x | Cake 6/6; #4605 6/6 |
| B300 | NVIDIA B300 SXM6 AC / sm103a / 148 SMs | 309.099 us | 767.976 us | 2.485x | 345.601 us | 1.118x | 1.107x | Cake 6/6; #4605 6/6 |
| GB200 | NVIDIA GB200 / sm100a / 152 SMs | 307.208 us | 754.757 us | 2.457x | 328.716 us | 1.070x | 1.069x | Cake 6/6; #4605 6/6 |
| GB300 | NVIDIA GB300 / sm103a / 152 SMs | 296.361 us | 744.447 us | 2.512x | 329.459 us | 1.112x | 1.111x | Cake 6/6; #4605 6/6 |

### Full 29-shape production portfolio

| GPU | hardware | exported API | FlashKDA | speedup vs FlashKDA | frozen #4605 | speedup vs #4605 | peer-normalized vs #4605 | correctness |
|---|---|---:|---:|---:|---:|---:|---:|---|
| B200 | NVIDIA B200 / sm100a / 148 SMs | 474.631 us | 1218.852 us | 2.568x | 432.061 us | 1.018x | 1.019x | Cake 29/29; #4605 28 comparable + 1 N/A |
| B300 | NVIDIA B300 SXM6 AC / sm103a / 148 SMs | 452.939 us | 1228.177 us | 2.712x | 418.110 us | 1.030x | 1.026x | Cake 29/29; #4605 28 comparable + 1 N/A |
| GB200 | NVIDIA GB200 / sm100a / 152 SMs | 442.814 us | 1193.533 us | 2.695x | 406.954 us | 1.026x | 1.031x | Cake 29/29; #4605 28 comparable + 1 N/A |
| GB300 | NVIDIA GB300 / sm103a / 152 SMs | 431.695 us | 1176.178 us | 2.725x | 404.621 us | 1.045x | 1.046x | Cake 29/29; #4605 28 comparable + 1 N/A |

All times are geometric means of cold-L2 CUPTI GPU-activity medians from
`bench_gpu_time`. Timing covers the complete eager public API call and in-place
final-state update, not CPU wall time, a single-kernel-only span, CUDA Graph
replay, or end-to-end inference. Correctness uses BF16 `atol=rtol=1e-2`.

FlashKDA is frozen at `1ce47ea3bb22c84eb9cc665028399cf35e8ffb0b` and
CUTLASS at `5c149f52a436782210263fb2f19b354443a61c6a`. The exact
#4605 baseline is independently frozen at merge commit
`297d9b6506d3f278e419dd174b6094ce7c3177a2`. Every exported and FlashKDA
row must pass correctness and timing. Frozen-#4605 outcomes are fail-closed and
fully accounted: comparable rows must pass, while an explicitly recorded N/A is
excluded only from #4605 geomeans and shown in the correctness cell. No
unaccounted row is admitted. The frozen-#4605 latency and both #4605 speedups use
the same comparable subset.

For every full-29 row, the exported and FlashKDA columns cover all 29
shapes; frozen #4605 and both #4605 speedups cover its 28 comparable shapes.
`h96_uniform_n256` is the single recorded N/A on each GPU. The
29-shape ledger SHA256 is
`1143cd69fcc466eea98865cf2fe48e2c7e6ebc7e1b78a0f47f27caf0097b95d9`;
the first-six JSONL subset SHA256 is
`a476a70254b7b77c6fb0d5541e5286176ec548cfcda89e7a568a78795ebf9151`.

Exported and frozen-#4605 measurements each run with their own same-process
FlashKDA peer in the same GPU allocation. `speedup vs #4605` is the geometric
mean of per-shape direct latency ratios; `peer-normalized vs #4605` divides
out the two harnesses' FlashKDA peer ratio before taking that geometric mean,
exposing residual environment drift.
<!-- recurrence-piece-performance:end -->

## Related issues

- #4254

## Tests

- [x] targeted planner, route, JIT identity, AOT inventory, and binding tests
- [x] B200 and B300 JIT compile plus recurrence-piece correctness/repeat tests
- [x] public material safety audit and pre-commit
- [x] B200/B300/GB200/GB300 29-shape correctness and performance campaign


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optimized piece-persistent M128 execution path for eligible uniform FlashKDA prefill workloads.
  * Added automatic scheduling and fallback to direct M128 execution when the optimized path is unavailable or not beneficial.
  * Added support for generating and loading the new execution variant.

* **Documentation**
  * Updated prefill documentation to describe routing behavior, eligibility, and fallback conditions.

* **Tests**
  * Added coverage for scheduling, state handoffs, deterministic results, and AOT variant registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
