### PR TITLE
[bug fix] Issue 3700 sparse mla sm121 hang

### DIFF
--- a/include/flashinfer/attention/sparse_mla_sm120/arch/barrier.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/arch/barrier.cuh
@@ -41,6 +41,25 @@ __device__ __forceinline__ void bar_sync_t() {
   asm volatile("barrier.cta.sync %0, %1;\n" ::"n"(ID), "n"(CNT) : "memory");
 }
 
+// Producer/consumer handshakes where the arriving side does not block must alternate
+// between two barrier ids: the non-blocking side may be one iteration ahead, and
+// arriving twice in one phase is invalid and desynchronizes the barrier (#3700).
+template <int ID_EVEN, int ID_ODD, int CNT>
+__device__ __forceinline__ void bar_arrive_alt(int parity) {
+  if (parity)
+    bar_arrive_t<ID_ODD, CNT>();
+  else
+    bar_arrive_t<ID_EVEN, CNT>();
+}
+
+template <int ID_EVEN, int ID_ODD, int CNT>
+__device__ __forceinline__ void bar_sync_alt(int parity) {
+  if (parity)
+    bar_sync_t<ID_ODD, CNT>();
+  else
+    bar_sync_t<ID_EVEN, CNT>();
+}
+
 // mbarrier (SM90+) for async copy tracking
 __device__ __forceinline__ void mbarrier_init(uint64_t* mbar, uint32_t count) {
   uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(mbar));

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -71,6 +71,9 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, const int32_t*
   constexpr int SMEM_STRIDE = KV::KV_SMEM_STRIDE;
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * COPY_BYTES);
+  // Execution barrier the caller's __threadfence_block cannot provide; without it the
+  // CTA deadlocks on sm_121 (#3700).
+  bar_sync_t<4, IO_THREADS>();
 
 #pragma unroll 1
   for (int bi = io_tid; bi < BI; bi += IO_THREADS) {

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -71,9 +71,11 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, const int32_t*
   constexpr int SMEM_STRIDE = KV::KV_SMEM_STRIDE;
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * COPY_BYTES);
-  // Execution barrier the caller's __threadfence_block cannot provide; without it the
-  // CTA deadlocks on sm_121 (#3700).
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 1210)
+  // sm_121 (GB10) deadlocks the CTA here without an IO-warp rendezvous (#3700); the
+  // mechanism is unresolved, so other archs keep the unmodified path.
   bar_sync_t<4, IO_THREADS>();
+#endif
 
 #pragma unroll 1
   for (int bi = io_tid; bi < BI; bi += IO_THREADS) {

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -71,11 +71,6 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, const int32_t*
   constexpr int SMEM_STRIDE = KV::KV_SMEM_STRIDE;
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * COPY_BYTES);
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 1210)
-  // sm_121 (GB10) deadlocks the CTA here without an IO-warp rendezvous (#3700); the
-  // mechanism is unresolved, so other archs keep the unmodified path.
-  bar_sync_t<4, IO_THREADS>();
-#endif
 
 #pragma unroll 1
   for (int bi = io_tid; bi < BI; bi += IO_THREADS) {

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
@@ -154,7 +154,7 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
             sm.kv_bufs[(ti + 1) & 1], idx_base + (ti + 1) * BI, KV_cache,
             sm.mbar_kv + ((ti + 1) & 1), io_tid, stride_kv_block, kv_l2_policy);
       }
-      bar_sync_t<1, BLOCK_THREADS>();
+      bar_sync_alt<1, 5, BLOCK_THREADS>(ti & 1);
     }
 
     // ── Math warps ──────────────────────────────────────────────────
@@ -519,7 +519,7 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
                                          stride_kv_block, reinterpret_cast<bf16*>(sm.w_fp8));
       }
 
-      bar_arrive_t<1, BLOCK_THREADS>();
+      bar_arrive_alt<1, 5, BLOCK_THREADS>(ti & 1);
       if (ti + 1 < actual_ni) {
         const int next_phase = ((ti + 1) >> 1) & 1;
         mbarrier_wait_parity(sm.mbar_kv + ((ti + 1) & 1), next_phase);
@@ -782,7 +782,7 @@ __device__ __forceinline__ void prefill_mg_impl(
                                                            io_tid, stride_kv_block, kv_l2_policy);
           }
         }
-        bar_sync_t<1, BLOCK_THREADS>();
+        bar_sync_alt<1, 5, BLOCK_THREADS>(ti & 1);
       }
     } else {
       auto issue_tile = [&](int logical_ti, int buf) {
@@ -823,7 +823,7 @@ __device__ __forceinline__ void prefill_mg_impl(
         if (ti + 1 < loop_bound) {
           issue_tile(ti + 1, (ti + 1) & 1);
         }
-        bar_sync_t<1, BLOCK_THREADS>();
+        bar_sync_alt<1, 5, BLOCK_THREADS>(ti & 1);
       }
     }
 
@@ -1514,7 +1514,7 @@ __device__ __forceinline__ void prefill_mg_impl(
                                                        reinterpret_cast<bf16*>(sm.w_fp8()));
         }
       }
-      bar_arrive_t<1, BLOCK_THREADS>();
+      bar_arrive_alt<1, 5, BLOCK_THREADS>(ti & 1);
       if (ti + 1 < loop_bound) {
         const int next_phase = ((ti + 1) >> 1) & 1;
         mbarrier_wait_parity(sm.mbar_kv((ti + 1) & 1), next_phase);


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Sparse-MLA SM120 prefill uses CTA barrier 1 as an asymmetric handshake (count 384): 256 math threads `barrier.cta.arrive` (non-blocking), 128 IO threads `barrier.cta.sync`. Math can arrive for tile `ti`, run `ti+1`, and arrive **again** before IO syncs `ti`. The PTX ISA warns against exactly that (`arrive` then another `barrier.cta` on the same id before reset). The surplus arrival completes the phase without IO; a later phase starves. Captured on GB10: IO warps parked on `BAR.SYNC 1, 384` after math had exited.

Fix: alternate the handshake between ids **1 and 5** by tile parity (`bar_arrive_alt` / `bar_sync_alt`) at all five call sites. A run-ahead tile lands on the other id. Two ids suffice because math cannot start tile `ti` until IO has returned from the sync for `ti-2`, so at most one arrival is outstanding per id.

Ungated: this is an invalid arrival pattern, not an sm_121 quirk. The hang is only demonstrated on GB10; the kernel is SM12x-only.

## 🔍 Related Issues

Closes #3700

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

GB10 / sm_121: `pytest tests/attention/test_sparse_mla_sm120.py` → **309 passed**. Single-process soak on `heads=128, topk=1024, tokens=256`: baseline **5/5 hung** (usually tens of iterations, sometimes a few hundred); fix **5/5 × 30k, 0 hangs**. Two concurrent pytest (`-k "prefill_glm_nsa_arbitrary_fp32 or prefill_dsv4"`): baseline wedged in round 3; fix **12/12 clean**. All four instantiated prefill variants soaked 30k each (with `assert_close`); 30k bitwise-identical iterations vs a golden result (fix does not turn the hang into silent corruption). No new unit test — the race is a soak, not a unit.

Header-only change: ninja may serve a stale `.so` (no `.d` depfiles). Delete `csrc_sparse_mla_sm120_prefill.cuda.o` and `sparse_mla_sm120.so` and confirm the `.so` mtime advances before A/B. Wedged processes ignore `SIGTERM`; use `timeout -s KILL`.
