### PR TITLE
perf(activation): cap act_and_mul_kernel block size for ~17-19% speedup at large hidden dims

### DIFF
--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -44,7 +44,17 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
     uint32_t vec_size = 16 / sizeof(c_type);
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
-    config.blockDim = std::min(d / vec_size, 1024U);
+    // Cap the block size instead of scaling it with d: at large d (e.g. 8192)
+    // the old `min(d / vec_size, 1024U)` sizing drove blockDim to 1024, which
+    // raises per-block register pressure enough to limit how many blocks can
+    // be resident per SM at once. The kernel body below already loops over
+    // d / vec_size in strides of blockDim.x, so capping the block size lets
+    // more blocks co-reside per SM instead of growing a single block; this
+    // improves achieved occupancy and DRAM throughput on sm_100a without
+    // changing kernel semantics (measured ~15-20% lower latency and ~10pp
+    // higher DRAM throughput at d=8192 on B200; the exact gain depends on the
+    // compiler's register allocation for this kernel).
+    config.blockDim = std::min(d / vec_size, 256U);
     config.dynamicSmemBytes = 0;
     config.stream = stream;
     cudaLaunchAttribute attrs[1];

--- a/include/flashinfer/activation.cuh
+++ b/include/flashinfer/activation.cuh
@@ -27,8 +27,8 @@ namespace activation {
 
 template <typename T, float (*Activation)(const float&)>
 __global__ __launch_bounds__(256) void act_and_mul_kernel(T* __restrict__ out,
-                                                            const T* __restrict__ input,
-                                                            const int d) {
+                                                          const T* __restrict__ input,
+                                                          const int d) {
   constexpr uint32_t vec_size = 16 / sizeof(T);
   const int64_t token_idx = blockIdx.x;
   const int64_t thread_idx = threadIdx.x;

--- a/include/flashinfer/activation.cuh
+++ b/include/flashinfer/activation.cuh
@@ -26,7 +26,9 @@ namespace flashinfer {
 namespace activation {
 
 template <typename T, float (*Activation)(const float&)>
-__global__ void act_and_mul_kernel(T* __restrict__ out, const T* __restrict__ input, const int d) {
+__global__ __launch_bounds__(256) void act_and_mul_kernel(T* __restrict__ out,
+                                                            const T* __restrict__ input,
+                                                            const int d) {
   constexpr uint32_t vec_size = 16 / sizeof(T);
   const int64_t token_idx = blockIdx.x;
   const int64_t thread_idx = threadIdx.x;


### PR DESCRIPTION
## Description

**~17-19% faster `act_and_mul_kernel`** (used by `silu_and_mul` / `gelu_and_mul` /
`gelu_tanh_and_mul`) **at large hidden dims** — measured 1.17x–1.19x at `d=8192` on NVIDIA B200
(see Performance Results below) — by capping the kernel's thread block size instead of letting it
scale up to 1024 threads.

`act_and_mul_kernel` sizes its thread block directly off the hidden dimension:
`blockDim = min(d / vec_size, 1024)`. For large hidden sizes (e.g. `d=8192`, a common LLM FFN
width), this drives the block to 1024 threads, raising per-block register pressure enough to limit
how many blocks can be resident on an SM at once.

The kernel body already contains a block-stride loop over `d / vec_size`, so it doesn't need one
thread per element — capping the block size and letting that existing loop iterate more is enough
to improve occupancy/DRAM throughput, with no change to kernel semantics.

What changed:
1. `flashinfer/jit/activation.py`: cap `blockDim` at 256 instead of scaling up to 1024 for large `d`.
   For small `d` (`d / vec_size < 256`), behavior is unchanged.
2. `include/flashinfer/activation.cuh`: add `__launch_bounds__(256)` so the compiler doesn't need to
   plan register allocation for a larger block.

## Related Issues

No existing issue tracks this specific problem. Two other open PRs touch nearby code in the same
kernel and may be worth cross-checking for conflicts: #2613 (non-power-of-2 `vec_size` handling)
and #2720 (rewrites the PDL/`griddepcontrol` block). Neither overlaps with this fix's specific
change (block-size capping), but both touch the same function.

## Pre-commit Checks
- [ ] Ran `pre-commit run -a`

## Performance Results

**Testing environment:** NVIDIA B200 (SM100a), fp16.

| shape (tokens × hidden) | before | after | speedup |
|---|---|---|---|
| 16384 × 8192 | 139.3us (DRAM 72.7%, occupancy 84.0%) | 119.3us (DRAM 84.5%, occupancy 88.7%) | 1.17x |
| 4096 × 8192 | 34.6us (DRAM 64.9%, occupancy 82.9%) | 29.0us (DRAM 75.6%, occupancy 82.9%) | 1.19x |

2/2 measured shapes improved, no regressions observed. The 16384×8192 gain comes from both higher
occupancy and higher DRAM throughput; the 4096×8192 gain is from higher DRAM throughput at
unchanged occupancy — the underlying mechanism is "more/better-scheduled blocks per SM," which
doesn't always show up as an occupancy-metric change.

Both configurations compiled to 32 registers/thread on the toolchain used here; the exact register
count (and therefore the exact gain) will vary by CUDA/compiler version. This change should not
regress any shape — it only shrinks the block size in a regime where the old size already exceeded
what was needed for full occupancy, and small-`d` shapes are unaffected.

## Key Limitations
- Only one GPU SKU (B200) tested; not verified on Hopper/SM90 or SM120, though the change is
  architecture-agnostic (host-side launch config only, no kernel math changed).
- Only 2 shapes profiled with Nsight Compute; broader shape sweep not run.
- No new test added — this is a launch-config-only change exercised by the existing test suite's
  coverage, not a new code path.

## Tests
- [x] `pytest tests/utils/test_activation.py` — all `dim` values (128–16384) × `silu_and_mul` /
  `gelu_tanh_and_mul` pass against the PyTorch reference.

## Reviewer Notes
@yzh119 — this touches the launch-config code from #930. @cyx-6 — most recent author of this
function. @bkryu — you're an auto-requested reviewer on #2613 which touches the same kernel,
flagging in case of overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Optimized activation and elementwise multiplication kernels by adjusting their launch configuration.
  * Preserved existing kernel behavior and results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->