### PR TITLE
fix(moe): static-wrap SM12x W4A16 weight banks to fix >2 GiB host marshalling overflow

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell_sm12x/moe_w4a16_kernel.py
@@ -5976,6 +5976,14 @@ def _w4a16_fused_moe_launch_flat(
         # identical cache entry instead of silently recompiling with auto tiles.
         force_tile_config=(fc1_tile_k, fc1_tile_n, fc2_tile_k, fc2_tile_n),
     )
+    # Expert weight banks can exceed 2**31 elements. The implicit TensorAdapter
+    # conversion marks their layout dynamic, and the DSL runtime packs dynamic
+    # sizes 32-bit, so a >2 GiB flat bank overflows during host-side argument
+    # marshalling. The kernel is compiled against static-shape fakes for these
+    # parameters, so wrap the banks in a static-layout from_dlpack instead:
+    # identical MLIR type to the compiled signature, and sizes stay 64-bit.
+    w13_arg = cute.runtime.from_dlpack(w13_arg, assumed_align=16)
+    w2_arg = cute.runtime.from_dlpack(w2_arg, assumed_align=16)
     fused.compiled(
         make_ptr(
             _cutlass_element_dtype(element_dtype),

--- a/tests/moe/test_b12x_w4a16_large_bank.py
+++ b/tests/moe/test_b12x_w4a16_large_bank.py
@@ -1,0 +1,146 @@
+"""Regression test: SM12x W4A16 MoE with a flat expert weight bank > 2**31
+elements must not overflow during host-side argument marshalling.
+
+The fused-MoE launch flattens each expert weight bank to a rank-1 tensor. In
+the "modelopt" weight layout that flat view is uint8, so a bank larger than
+2 GiB exceeds int32 range; the implicit TensorAdapter conversion marks the
+layout dynamic, and dynamic sizes are packed 32-bit by the DSL runtime,
+raising ``OverflowError: Value overflow: ... exceeds range of l`` before the
+kernel ever launches. The launch now wraps the banks in a static-layout
+``from_dlpack`` (matching the static-shape fakes the kernel is compiled
+against), which keeps sizes 64-bit.
+"""
+
+import pytest
+import torch
+
+
+def _is_sm12x_supported():
+    if not torch.cuda.is_available():
+        return False
+    from flashinfer.utils import is_sm120a_supported, is_sm121a_supported
+
+    device = torch.device("cuda")
+    return is_sm120a_supported(device) or is_sm121a_supported(device)
+
+
+def _free_vram_bytes():
+    if not torch.cuda.is_available():
+        return 0
+    free, _total = torch.cuda.mem_get_info()
+    return free
+
+
+sm120_required = pytest.mark.skipif(
+    not _is_sm12x_supported(),
+    reason="W4A16 fused MoE requires SM120/SM121",
+)
+
+# w13 bank 2.5 GiB + w2 bank 1.25 GiB + scales/activations head-room.
+_REQUIRED_VRAM = 6 * 1024**3
+
+
+@sm120_required
+@pytest.mark.skipif(
+    _free_vram_bytes() < _REQUIRED_VRAM,
+    reason="needs ~6 GiB free VRAM for a >2 GiB expert weight bank",
+)
+def test_w4a16_moe_flat_bank_over_int32_max():
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_host import (
+        plan_w4a16_buffers,
+    )
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_kernel import (
+        _scale_fake_int32_elements,
+        run_w4a16_moe,
+    )
+    from flashinfer.fused_moe.cute_dsl.blackwell_sm12x.moe_w4a16_prepare import (
+        W4A16PackedWeights,
+        _make_workspace,
+    )
+
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+    # E * (2 * n) * (k // 2) = 64 * 8192 * 5120 = 2,684,354,560 uint8 elements:
+    # the smallest realistic bank past int32 max (matches the report in the
+    # linked issue, Qwen3.6-35B-A3B-NVFP4 on GB10).
+    num_experts, hidden_size, intermediate_size = 64, 10240, 4096
+    m, top_k = 4, 2
+    fc1_cols = 2 * intermediate_size
+    bank_elements = num_experts * fc1_cols * (hidden_size // 2)
+    assert bank_elements > 2**31 - 1
+
+    w13 = torch.randint(
+        0,
+        256,
+        (num_experts, fc1_cols, hidden_size // 2),
+        dtype=torch.uint8,
+        device=device,
+    )
+    w2 = torch.randint(
+        0,
+        256,
+        (num_experts, hidden_size, intermediate_size // 2),
+        dtype=torch.uint8,
+        device=device,
+    )
+    n13 = _scale_fake_int32_elements(
+        num_experts=num_experts,
+        size_k=hidden_size,
+        size_n=fc1_cols,
+        scale_format="e4m3_k16",
+    )
+    n2 = _scale_fake_int32_elements(
+        num_experts=num_experts,
+        size_k=intermediate_size,
+        size_n=hidden_size,
+        scale_format="e4m3_k16",
+    )
+    prepared = W4A16PackedWeights(
+        w13=w13,
+        w13_scale=torch.full((n13,), 0x3C3C3C3C, dtype=torch.int32, device=device),
+        w13_global_scale=torch.ones(num_experts, dtype=torch.float32, device=device),
+        w2=w2,
+        w2_scale=torch.full((n2,), 0x3C3C3C3C, dtype=torch.int32, device=device),
+        w2_global_scale=torch.ones(num_experts, dtype=torch.float32, device=device),
+        workspace=_make_workspace(device),
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        is_gated=True,
+        params_dtype=torch.bfloat16,
+        source_format="modelopt",
+        w13_layout="w13",
+        weight_layout="modelopt",
+        scale_format="e4m3_k16",
+    )
+
+    a = torch.randn(m, hidden_size, dtype=torch.bfloat16, device=device)
+    logits = torch.randn(m, num_experts, dtype=torch.float32, device=device)
+    topk_weights, topk_ids = torch.topk(torch.softmax(logits, -1), top_k)
+    props = torch.cuda.get_device_properties(device)
+    plan = plan_w4a16_buffers(
+        prepared,
+        m=m,
+        topk=top_k,
+        route_num_experts=num_experts,
+        sms=int(props.multi_processor_count),
+    )
+    output = torch.zeros(m, hidden_size, dtype=torch.bfloat16, device=device)
+
+    # Overflowed at host-side argument marshalling before the fix.
+    run_w4a16_moe(
+        a,
+        prepared,
+        topk_weights.float().contiguous(),
+        topk_ids.to(torch.int32).contiguous(),
+        activation="silu",
+        intermediate_cache13=torch.empty(
+            plan.intermediate_cache13_elements, dtype=torch.bfloat16, device=device
+        ),
+        intermediate_cache2=torch.empty(
+            plan.intermediate_cache2_elements, dtype=torch.bfloat16, device=device
+        ),
+        output=output,
+    )
+    torch.cuda.synchronize()
+    assert torch.isfinite(output).all()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

A flat expert weight bank larger than 2 GiB kills the SM12x W4A16 fused MoE on
the host side, before the kernel is ever launched:

```
OverflowError: Value overflow: 2684354560 exceeds range of l
```

### What happens

`_w4a16_fused_moe_launch_flat` flattens each expert bank to rank-1 and hands
the raw torch tensor to `fused.compiled(...)`:

```python
w13_arg = prepared.w13.view(torch.uint8).view(-1)   # 2,684,354,560 elements
...
fused.compiled(make_ptr(a...), w13_arg, w2_arg, ...)
```

A raw tensor at that boundary is converted implicitly by the DSL's
`TensorAdapter`, which does `from_dlpack(arg).mark_layout_dynamic()`. Dynamic
sizes are packed 32-bit by the runtime when the memref descriptor is built, so
any bank past `2**31 - 1` overflows in `build_memref_desc`.

### Why it went unnoticed

Two things have to line up:

* **The uint8 view.** `prepare_w4a16_packed_weights` always produces
  `weight_layout="packed"`, whose flat view is int32 — a 2.5 GiB bank is only
  671M elements there. The `modelopt` layout flattens to uint8, so the element
  count *is* the byte count. That is the path in the report (b12x / modelopt
  weights consumed zero-copy).
* **A bank that big.** Consumer SM120 cards usually shard below the boundary;
  the report is on GB10 with 128 GB unified memory, where the full bank for
  Qwen3.6-35B-A3B-NVFP4 (256 experts) crosses it.

### Why the fix is a type correction, not a workaround

The kernel is compiled against **static-shape** fakes for exactly these two
parameters — the geometry is part of the compile cache key:

```python
w13_fake = cute.runtime.make_fake_compact_tensor(
    cutlass.Uint8,
    (num_experts * fc1_cols * (hidden_size // 2),),   # compile-time int
    assumed_align=16,
)
```

So the compiled signature and what the call site actually passes are different
MLIR types:

```
fake / compiled signature : !cute.memref<i8, gmem, align<16>, "(N):(1)">
static from_dlpack        : !cute.memref<i8, gmem, align<16>, "(N):(1)">   # matches
implicit TensorAdapter    : !cute.memref<i8, gmem, align<16>, "(?):(1)">   # mismatch
```

The dynamic wrapper was never type-accurate here; it only worked because the
descriptors are ABI-compatible and the kernel indexes with compile-time
constants rather than reading the runtime size slot. The 2 GiB boundary is
where that coincidence runs out.

The fix wraps the two banks explicitly:

```python
w13_arg = cute.runtime.from_dlpack(w13_arg, assumed_align=16)
w2_arg = cute.runtime.from_dlpack(w2_arg, assumed_align=16)
```

This restores the type the kernel was compiled for, and as a consequence the
size never goes through the 32-bit packing path at all — it stays a
compile-time constant, as the fakes already declared. `assumed_align=16`
mirrors the fake declaration.

### Scope

Only `w13_arg` / `w2_arg` are wrapped. Their runtime shape is a deterministic
function of the compile cache key (`num_experts`, `hidden_size`,
`intermediate_size`, `weight_layout`, `scale_format`), so pinning them static
costs no flexibility.

The scratch and intermediate-cache arguments are also passed flat and could in
principle cross `2**31` at extreme batch sizes, but their runtime size is only
required to be *at least* the compile-time sample (`numel() >= ...`), so
static-wrapping them would assert a shape that may not hold. Left untouched
deliberately; happy to follow up if maintainers want a guard there.

## 🔍 Related Issues

Fixes #4706

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added `tests/moe/test_b12x_w4a16_large_bank.py`. It builds a `modelopt`-layout
`W4A16PackedWeights` whose w13 bank is exactly 2,684,354,560 uint8 elements
(`E=64`, `2n=8192`, `k/2=5120` — the value from the report) and runs
`run_w4a16_moe` end to end. It skips unless SM120/SM121 and ~6 GiB of free
VRAM are available.

Verified on an RTX 5090 (SM120), flashinfer 0.6.17 / nvidia-cutlass-dsl 4.6.2:

| layout | bank | before | after |
| --- | --- | --- | --- |
| modelopt | 2,684,354,560 (2.5 GiB) | `OverflowError`, traceback frame-for-frame identical to the report | passes |
| modelopt | 8,388,608 (8 MiB) | passes | passes |
| packed | 2,147,483,648 (2 GiB) | passes | passes |
| packed | 8,388,608 (8 MiB) | passes | passes |

Output equivalence: for the two small configurations I captured the output
tensors before and after the change and compared them bit-for-bit (viewed as
uint16) — identical, as expected since the kernel body and its compile cache
key are untouched.

## Reviewer Notes

* The root cause — dynamic sizes packed 32-bit in `build_memref_desc` — lives
  in the CUTLASS DSL runtime, not in FlashInfer. This PR fixes the call site so
  it stops relying on the dynamic path for parameters that were declared
  static; it does not change or work around the DSL itself.
* The regression test needs a real >2 GiB allocation, so it is gated on free
  VRAM as well as architecture. On a 32 GB SM120 card it runs in a few seconds
  once the kernel is cached.
* The reporter offered to validate on DGX Spark (GB10). This PR was confirmed
  on consumer SM120 with the exact bank size from the report; an independent
  check on GB10 would be welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could prevent large fused mixture-of-experts models from running when expert weight banks exceeded 2 GiB.
  * Large expert weight banks now retain their full size during processing, avoiding overflow errors.

* **Tests**
  * Added regression coverage for large-bank W4A16 fused mixture-of-experts workloads.
  * The test verifies successful execution and finite output on supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->