### PR TITLE
feat(decode): add prims-ts backend and is_causal to paged decode

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -876,7 +876,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
             no RoPE/ALiBi/soft-cap).
             The ``prims-ts`` backend uses the task-scheduled decode kernel on SM100a/SM103a.
             It is the only backend that accepts ``is_causal=False`` with
-            ``q_len_per_req > 1``, and it requires ``kv_layout="HND"``.
+            ``q_len_per_req > 1``. It requires ``kv_layout="HND"`` and does not
+            support ``use_cuda_graph=True``.
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -984,6 +985,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
             if kv_layout != "HND":
                 raise NotImplementedError(
                     "prims-ts decode backend requires kv_layout='HND'"
+                )
+            # The delegate snapshots seq_lens, scratch, and the compiled kernel
+            # at plan time, so a captured run() does not follow a later plan().
+            if use_cuda_graph:
+                raise NotImplementedError(
+                    "prims-ts decode backend does not support use_cuda_graph=True"
                 )
             from .attention.prims_ts import BatchDecodePagedTSWrapper
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1667,6 +1667,17 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     "prims-ts decode backend requires q_data_type == kv_data_type, "
                     f"got {q_data_type} and {kv_data_type}"
                 )
+            # The delegate derives kv lengths from the page table and has no
+            # seq_lens input, so a divergent seq_lens would be silently ignored.
+            if seq_lens is not None:
+                derived_kv_lens = get_seq_lens(
+                    indptr_host, last_page_len_host, page_size
+                ).to(torch.int64)
+                if not torch.equal(kv_lens_arr_host.to(torch.int64), derived_kv_lens):
+                    raise ValueError(
+                        "prims-ts decode backend derives kv lengths from "
+                        "(indptr, last_page_len, page_size); seq_lens must match them"
+                    )
             self._max_kv_len = int(max(kv_lens_arr_host).item())
             self._prims_ts_wrapper.plan(
                 self._paged_kv_indptr_buf,
@@ -2210,6 +2221,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 )
             # The kernel takes token-major [B, SQ, Hq, D], or [B, Hq, D] at SQ=1.
             if q_len_per_req > 1:
+                if not q.is_contiguous() or not out.is_contiguous():
+                    raise ValueError(
+                        "prims-ts decode backend requires contiguous q and out "
+                        "when q_len_per_req > 1"
+                    )
                 packed_shape = (actual_batch_size, q_len_per_req, q.size(1), q.size(2))
                 q = q.view(packed_shape)
                 out = out.view(packed_shape[:-1] + (out.size(-1),))
@@ -3959,6 +3975,10 @@ def fast_decode_plan(
     - Remove unnecessary host-to-device copy for the metadata buffers.
     """
     batch_size = len(last_page_len)
+    if getattr(self, "_backend", None) == "prims-ts":
+        raise NotImplementedError(
+            "fast_decode_plan is not supported by the prims-ts decode backend"
+        )
     if q_len_per_req < 1:
         raise ValueError(f"q_len_per_req must be >= 1, got {q_len_per_req}")
     if q_len_per_req > 1 and not self.use_tensor_cores:

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -866,13 +866,16 @@ class BatchDecodeWithPagedKVCacheWrapper:
             Only needed when ``use_cuda_graph`` is ``True``.
 
         backend : str
-            The implementation backend, could be ``auto``/``fa2``/``fa3``/``trtllm-gen``
-            or ``cute-dsl``. Defaults to ``auto``.
+            The implementation backend, could be ``auto``/``fa2``/``fa3``/``trtllm-gen``/
+            ``cute-dsl`` or ``prims-ts``. Defaults to ``auto``.
             If set to ``auto``, the wrapper will automatically choose the backend based on the
             device architecture and kernel availability.
             The ``cute-dsl`` backend uses the CuTe DSL GQA decode kernel for Blackwell
             (SM100+) and only supports a subset of features (equal head_dim_qk/vo,
             no RoPE/ALiBi/soft-cap).
+            The ``prims-ts`` backend uses the task-scheduled decode kernel on SM100a/SM103a.
+            It is the only backend that accepts ``is_causal=False`` with
+            ``q_len_per_req > 1``, and it requires ``kv_layout="HND"``.
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -883,9 +886,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
         )
         _check_kv_layout(kv_layout)
 
-        if backend == "cute-dsl" and jit_args is not None:
+        if backend in ("cute-dsl", "prims-ts") and jit_args is not None:
             raise NotImplementedError(
-                "cute-dsl backend does not support jit_args customization"
+                f"{backend} backend does not support jit_args customization"
             )
         if jit_args is not None:
             if use_tensor_cores:
@@ -952,6 +955,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._use_tensor_cores = use_tensor_cores or backend in (
             "trtllm-gen",
             "cute-dsl",
+            "prims-ts",
         )
         self._use_cuda_graph = use_cuda_graph
 
@@ -973,6 +977,16 @@ class BatchDecodeWithPagedKVCacheWrapper:
             self._cute_dsl_wrapper = BatchDecodePagedCuteDSLWrapper(
                 float_workspace_buffer, use_cuda_graph=use_cuda_graph
             )
+
+        self._prims_ts_wrapper = None
+        if backend == "prims-ts":
+            if kv_layout != "HND":
+                raise NotImplementedError(
+                    "prims-ts decode backend requires kv_layout='HND'"
+                )
+            from .attention.prims_ts import BatchDecodePagedTSWrapper
+
+            self._prims_ts_wrapper = BatchDecodePagedTSWrapper()
 
     @property
     def use_tensor_cores(self) -> bool:
@@ -1367,6 +1381,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
             Under ``use_cuda_graph``, this value is part of the frozen
             shape (like the batch size): once the wrapper has been
             planned, re-planning with a different value raises.
+        is_causal : Optional[bool]
+            Whether the mask is causal within each request block. Defaults to ``None``,
+            which derives it from ``q_len_per_req > 1``. Only the ``prims-ts`` backend
+            honors a value that differs from that default; the other backends raise.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -1441,6 +1459,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
         q_len_per_req: int = 1,
+        is_causal: Optional[bool] = None,
     ) -> None:
         _check_workspace_buffer_alignment(
             self._float_workspace_buffer, "float_workspace_buffer"
@@ -1464,9 +1483,14 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         if q_len_per_req < 1:
             raise ValueError(f"q_len_per_req must be >= 1, got {q_len_per_req}")
-        # Multi-token requests are causal within each request's block;
-        # DFlash-style non-causal multi-token is not wired up yet.
-        is_causal = q_len_per_req > 1
+        if is_causal is None:
+            is_causal = q_len_per_req > 1
+        elif self._backend != "prims-ts" and is_causal != (q_len_per_req > 1):
+            raise NotImplementedError(
+                f"backend={self._backend!r} derives the decode mask from "
+                "q_len_per_req; an explicit is_causal is only honored by "
+                "backend='prims-ts'"
+            )
         qo_indptr_host = _get_range_buf(batch_size + 1, "cpu")
         if q_len_per_req > 1:
             if not self.use_tensor_cores:
@@ -1556,7 +1580,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             kv_lens_arr_host = get_seq_lens(indptr_host, last_page_len_host, page_size)
         else:
             kv_lens_arr_host = seq_lens.cpu()
-        if q_len_per_req > 1:
+        if q_len_per_req > 1 and is_causal:
             min_kv_len = int(kv_lens_arr_host.min())
             if min_kv_len < q_len_per_req:
                 raise ValueError(
@@ -1611,6 +1635,42 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 window_right=(None if window_right < 0 else window_right),
                 max_kv_len=self._max_kv_len,
                 non_blocking=non_blocking,
+            )
+        elif self._backend == "prims-ts":
+            if logits_soft_cap > 0:
+                raise NotImplementedError(
+                    "prims-ts decode backend does not support logits_soft_cap"
+                )
+            if pos_encoding_mode != "NONE":
+                raise NotImplementedError(
+                    f"prims-ts decode backend does not support "
+                    f"pos_encoding_mode={pos_encoding_mode!r}"
+                )
+            if fixed_split_size > 0 or disable_split_kv:
+                raise NotImplementedError(
+                    "prims-ts decode backend selects the split-kv policy internally"
+                )
+            if q_data_type != kv_data_type:
+                raise NotImplementedError(
+                    "prims-ts decode backend requires q_data_type == kv_data_type, "
+                    f"got {q_data_type} and {kv_data_type}"
+                )
+            self._max_kv_len = int(max(kv_lens_arr_host).item())
+            self._prims_ts_wrapper.plan(
+                self._paged_kv_indptr_buf,
+                self._paged_kv_indices_buf,
+                self._paged_kv_last_page_len_buf,
+                num_qo_heads=num_qo_heads,
+                num_kv_heads=num_kv_heads,
+                head_dim=head_dim,
+                page_size=page_size,
+                seq_len_q=q_len_per_req,
+                q_data_type=q_data_type,
+                kv_data_type=kv_data_type,
+                o_data_type=o_data_type,
+                mask_type="causal" if is_causal else "dense",
+                window_left=window_left,
+                max_kv_len=self._max_kv_len,
             )
         elif self._backend == "trtllm-gen":
             assert logits_soft_cap == 0.0
@@ -1775,6 +1835,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
         self._q_len_per_req = q_len_per_req
+        self._is_causal = is_causal
 
     begin_forward = plan
 
@@ -2118,6 +2179,38 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 enable_pdl=enable_pdl,
             )
             return (out, lse) if return_lse else out
+
+        if self._backend == "prims-ts":
+            if kv_cache_sf is not None:
+                raise NotImplementedError(
+                    "prims-ts decode backend does not support NVFP4 KV cache"
+                )
+            if sinks is not None:
+                raise NotImplementedError(
+                    "prims-ts decode backend does not support attention sinks"
+                )
+            if return_lse:
+                raise NotImplementedError("prims-ts decode backend does not return LSE")
+            if skip_softmax_threshold_scale_factor is not None:
+                raise NotImplementedError(
+                    "prims-ts decode backend does not support "
+                    "skip_softmax_threshold_scale_factor"
+                )
+            # The kernel takes token-major [B, SQ, Hq, D], or [B, Hq, D] at SQ=1.
+            if q_len_per_req > 1:
+                packed_shape = (actual_batch_size, q_len_per_req, q.size(1), q.size(2))
+                q = q.view(packed_shape)
+                out = out.view(packed_shape[:-1] + (out.size(-1),))
+            out = self._prims_ts_wrapper.run(
+                q,
+                (k_cache, v_cache),
+                bmm1_scale=sm_scale,
+                bmm2_scale=1.0 if v_scale is None else float(v_scale),
+                out=out,
+            )
+            return (
+                out.view(-1, out.size(-2), out.size(-1)) if q_len_per_req > 1 else out
+            )
 
         if self._backend == "trtllm-gen":
             q = q.view(q.size(0) // q_len_per_req, q_len_per_req, q.size(1), q.size(2))

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -25,6 +25,7 @@ import torch
 from .api_logging import flashinfer_api
 from .trace.templates.attention import (
     gqa_paged_decode_trace,
+    gqa_paged_decode_plan_trace,
     single_decode_with_kv_cache_trace,
     trtllm_batch_decode_trace_dispatch,
     xqa_batch_decode_trace,
@@ -1131,6 +1132,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
             self._float_workspace_buffer, "float_workspace_buffer"
         )
         del block_tables, rope_scale, rope_theta, sm_scale
+        backend = self._backend
+        if backend == "prims-ts":
+            raise NotImplementedError(
+                f"workspace_size is not available for decode backend {backend!r}"
+            )
         batch_size = len(last_page_len)
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
@@ -1183,7 +1189,6 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     "would attend to an empty KV range."
                 )
 
-        backend = self._backend
         if backend in ("cute-dsl", "trtllm-gen"):
             raise NotImplementedError(
                 f"workspace_size is not available for decode backend {backend!r}"
@@ -1290,7 +1295,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         float_workspace_size, int_workspace_size = module.workspace_size(*args)
         return int(float_workspace_size), int(int_workspace_size)
 
-    @flashinfer_api
+    @flashinfer_api(trace=gqa_paged_decode_plan_trace)
     def plan(
         self,
         indptr: torch.Tensor,

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -245,6 +245,89 @@ gqa_paged_decode_trace = TraceTemplate(
 )
 
 
+class _BatchDecodePlanTraceTemplate(TraceTemplate):
+    """Trace batch-decode planning metadata, including compatibility kwargs."""
+
+    def build_fi_trace_fn(self, fi_api):
+        build_definition = super().build_fi_trace_fn(fi_api)
+
+        def fi_trace(save_dir=None, name=None, **kwargs):
+            kwargs = dict(kwargs)
+            nested_kwargs = kwargs.pop("kwargs", None)
+            if isinstance(nested_kwargs, dict):
+                kwargs.update(nested_kwargs)
+            return build_definition(save_dir=save_dir, name=name, **kwargs)
+
+        return fi_trace
+
+
+gqa_paged_decode_plan_trace = _BatchDecodePlanTraceTemplate(
+    op_type="gqa_paged_plan",
+    name_prefix="gqa_paged_decode_plan",
+    description=(
+        "Batch-decode planning metadata for a paged KV cache, including "
+        "query length and explicit causal-mode request."
+    ),
+    axes={
+        "batch_size": Var(description="Number of requests."),
+        "num_qo_heads": Const(abbrev="h"),
+        "num_kv_heads": Const(abbrev="kv"),
+        "head_dim": Const(abbrev="d"),
+        "page_size": Const(abbrev="ps"),
+        "len_indptr": Var(description="Length of indptr array."),
+        "num_kv_indices": Var(description="Total number of KV page indices."),
+        "max_num_blocks_per_seq": Var(
+            description="Maximum number of block-table entries per request."
+        ),
+    },
+    inputs={
+        "indptr": Tensor(["len_indptr"], dtype="int32"),
+        "indices": Tensor(["num_kv_indices"], dtype="int32"),
+        "last_page_len": Tensor(["batch_size"], dtype="int32"),
+        "num_qo_heads": Scalar("int32"),
+        "num_kv_heads": Scalar("int32"),
+        "head_dim": Scalar("int32"),
+        "page_size": Scalar("int32"),
+        "q_len_per_req": Scalar(
+            "int32",
+            optional=True,
+            description="Uniform query tokens per request.",
+        ),
+        "is_causal": Scalar(
+            "bool",
+            optional=True,
+            description="Whether the planned attention mask is causal.",
+        ),
+        "pos_encoding_mode": Scalar("string", optional=True),
+        "window_left": Scalar("int32", optional=True),
+        "window_right": Scalar("int32", optional=True),
+        "logits_soft_cap": Scalar("float32", optional=True),
+        "q_data_type": Scalar("dtype", optional=True),
+        "kv_data_type": Scalar("dtype", optional=True),
+        "o_data_type": Scalar("dtype", optional=True),
+        "data_type": Scalar("dtype", optional=True),
+        "sm_scale": Scalar("float32", optional=True),
+        "rope_scale": Scalar("float32", optional=True),
+        "rope_theta": Scalar("float32", optional=True),
+        "non_blocking": Scalar("bool", optional=True),
+        "fixed_split_size": Scalar("int32", optional=True),
+        "disable_split_kv": Scalar("bool", optional=True),
+        "seq_lens": Tensor(["batch_size"], dtype="int32", optional=True),
+        "block_tables": Tensor(
+            ["batch_size", "max_num_blocks_per_seq"],
+            dtype="int32",
+            optional=True,
+        ),
+    },
+    outputs={},
+    constraints=[
+        "len_indptr == batch_size + 1",
+        "num_qo_heads % num_kv_heads == 0",
+    ],
+    tags=["stage:decode", "phase:plan", "status:experimental"],
+)
+
+
 # PrimTS block-sparse schema. Only the one-shot API can fully express its BSR
 # metadata and block geometry in a trace definition.
 

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -149,6 +149,22 @@ def test_rejects_jit_args():
         _make_wrapper("prims-ts", jit_args=[1])
 
 
+@requires_cuda
+def test_rejects_cuda_graph():
+    batch_size = 2
+    buffers = dict(
+        paged_kv_indptr_buffer=torch.zeros(
+            batch_size + 1, dtype=torch.int32, device="cuda"
+        ),
+        paged_kv_indices_buffer=torch.zeros(16, dtype=torch.int32, device="cuda"),
+        paged_kv_last_page_len_buffer=torch.zeros(
+            batch_size, dtype=torch.int32, device="cuda"
+        ),
+    )
+    with pytest.raises(NotImplementedError, match="use_cuda_graph"):
+        _make_wrapper("prims-ts", use_cuda_graph=True, **buffers)
+
+
 def test_plan_trace_captures_explicit_causal_mode():
     """The plan trace includes kwargs passed through compatibility API."""
 
@@ -389,7 +405,13 @@ def test_run_rejects_unsupported_options(run_kwargs, match):
 
 
 @requires_prims_ts_gpu
-def test_cuda_graph_replay():
+def test_graph_capture_of_fixed_plan_replays():
+    """Capturing run() after a plan replays that plan; re-planning is not covered.
+
+    The wrapper-level ``use_cuda_graph=True`` flow (re-plan then replay) is
+    rejected for this backend, see ``test_rejects_cuda_graph``.
+    """
+
     kv_lens = [64, 96]
     q_len_per_req = 4
     torch.manual_seed(0)

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -165,6 +165,29 @@ def test_rejects_cuda_graph():
         _make_wrapper("prims-ts", use_cuda_graph=True, **buffers)
 
 
+@requires_cuda
+def test_rejects_fast_decode_plan():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(NotImplementedError, match="fast_decode_plan"):
+        flashinfer.decode.fast_decode_plan(
+            wrapper,
+            *_plan_args([32, 48], "cuda"),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+        )
+
+
+@requires_cuda
+def test_rejects_mismatched_seq_lens():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(ValueError, match="seq_lens must match"):
+        wrapper.plan(
+            *_plan_args([32, 48], "cuda"),
+            q_data_type=torch.bfloat16,
+            seq_lens=torch.tensor([32, 40], dtype=torch.int32, device="cuda"),
+        )
+
+
 def test_plan_trace_captures_explicit_causal_mode():
     """The plan trace includes kwargs passed through compatibility API."""
 
@@ -402,6 +425,50 @@ def test_run_rejects_unsupported_options(run_kwargs, match):
     wrapper.plan(*_plan_args(kv_lens, "cuda"), q_data_type=torch.bfloat16)
     with pytest.raises(NotImplementedError, match=match):
         wrapper.run(q, (k_cache, v_cache), **run_kwargs)
+
+
+@requires_prims_ts_gpu
+def test_matching_seq_lens_accepted():
+    kv_lens = [32, 48]
+    wrapper = _make_wrapper("prims-ts")
+    wrapper.plan(
+        *_plan_args(kv_lens, "cuda"),
+        q_data_type=torch.bfloat16,
+        seq_lens=torch.tensor(kv_lens, dtype=torch.int32, device="cuda"),
+    )
+    q = torch.randn(
+        len(kv_lens), NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    out = wrapper.run(q, (k_cache, v_cache))
+    assert out.shape == q.shape
+
+
+@requires_prims_ts_gpu
+def test_rejects_noncontiguous_multi_q_tensors():
+    kv_lens = [64, 96]
+    q_len_per_req = 4
+    wrapper = _make_wrapper("prims-ts")
+    wrapper.plan(
+        *_plan_args(kv_lens, "cuda"),
+        q_data_type=torch.bfloat16,
+        q_len_per_req=q_len_per_req,
+        is_causal=False,
+    )
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    num_tokens = len(kv_lens) * q_len_per_req
+    q = torch.randn(
+        num_tokens, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+    q_strided = torch.randn(
+        num_tokens, HEAD_DIM, NUM_QO_HEADS, dtype=torch.bfloat16, device="cuda"
+    ).transpose(1, 2)
+    assert not q_strided.is_contiguous()
+    with pytest.raises(ValueError, match="contiguous"):
+        wrapper.run(q_strided, (k_cache, v_cache))
+    out_strided = torch.empty_like(q_strided)
+    with pytest.raises(ValueError, match="contiguous"):
+        wrapper.run(q, (k_cache, v_cache), out=out_strided)
 
 
 @requires_prims_ts_gpu

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -149,6 +149,44 @@ def test_rejects_jit_args():
         _make_wrapper("prims-ts", jit_args=[1])
 
 
+def test_plan_trace_captures_explicit_causal_mode():
+    """The plan trace includes kwargs passed through compatibility API."""
+
+    plan_trace = flashinfer.BatchDecodeWithPagedKVCacheWrapper.plan.fi_trace
+    indptr, indices, last_page_len, *_ = _plan_args([2, 3], "cpu")
+    definition = plan_trace(
+        indptr=indptr,
+        indices=indices,
+        last_page_len=last_page_len,
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim=128,
+        page_size=PAGE_SIZE,
+        kwargs={"q_len_per_req": 4, "is_causal": False},
+    )
+
+    assert definition["op_type"] == "gqa_paged_plan"
+    assert definition["inputs"]["q_len_per_req"]["optional"] is True
+    assert definition["inputs"]["is_causal"] == {
+        "shape": None,
+        "dtype": "bool",
+        "optional": True,
+        "description": "Whether the planned attention mask is causal.",
+    }
+
+
+@requires_cuda
+def test_workspace_size_rejects_prims_ts():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(NotImplementedError, match="prims-ts"):
+        wrapper.workspace_size(
+            *_plan_args([2, 3], "cuda"),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.bfloat16,
+            q_len_per_req=4,
+        )
+
+
 @requires_cuda
 def test_rejects_logits_soft_cap():
     wrapper = _make_wrapper("prims-ts")

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -1,0 +1,383 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the ``backend="prims-ts"`` path of BatchDecodeWithPagedKVCacheWrapper.
+
+The rejection tests run on any CUDA device because they fire before the kernel
+is planned. The numerical tests need SM100a, where the kernel is qualified.
+"""
+
+import math
+
+import pytest
+import torch
+
+pytest.importorskip(
+    "cutlass",
+    minversion="4.7.0",
+    reason="prims-ts decode requires nvidia-cutlass-dsl==4.7.0",
+)
+
+import flashinfer  # noqa: E402
+from flashinfer.utils import is_sm100a_supported  # noqa: E402
+
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA device"
+)
+
+requires_prims_ts_gpu = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.cuda.get_device_capability() != (10, 0)
+    or not is_sm100a_supported(torch.device("cuda")),
+    reason="prims-ts decode is qualified on SM100a",
+)
+
+
+NUM_QO_HEADS = 8
+NUM_KV_HEADS = 2
+HEAD_DIM = 128
+PAGE_SIZE = 16
+
+
+def _make_page_table(kv_lens, page_size, device):
+    """Build contiguous CSR page metadata covering the given kv lengths."""
+
+    pages_per_req = [(kv_len + page_size - 1) // page_size for kv_len in kv_lens]
+    offsets = [0]
+    for num_pages in pages_per_req:
+        offsets.append(offsets[-1] + num_pages)
+    indptr = torch.tensor(offsets, dtype=torch.int32, device=device)
+    indices = torch.arange(sum(pages_per_req), dtype=torch.int32, device=device)
+    last_page_len = torch.tensor(
+        [
+            kv_len - (n - 1) * page_size
+            for kv_len, n in zip(kv_lens, pages_per_req, strict=True)
+        ],
+        dtype=torch.int32,
+        device=device,
+    )
+    return indptr, indices, last_page_len
+
+
+def _make_wrapper(backend, kv_layout="HND", device="cuda", **kwargs):
+    workspace = torch.zeros(64 * 1024 * 1024, dtype=torch.uint8, device=device)
+    return flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, kv_layout, backend=backend, **kwargs
+    )
+
+
+def _plan_args(kv_lens, device, page_size=PAGE_SIZE):
+    indptr, indices, last_page_len = _make_page_table(kv_lens, page_size, device)
+    return (
+        indptr,
+        indices,
+        last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        page_size,
+    )
+
+
+def _reference_decode(
+    q, k_cache, v_cache, kv_lens, q_len_per_req, is_causal, page_size
+):
+    """Dense or bottom-right causal paged decode over HND k/v pages."""
+
+    batch_size = len(kv_lens)
+    group_size = NUM_QO_HEADS // NUM_KV_HEADS
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    q = q.view(batch_size, q_len_per_req, NUM_QO_HEADS, HEAD_DIM).float()
+    out = torch.empty_like(q)
+    page_id = 0
+    for b, kv_len in enumerate(kv_lens):
+        num_pages = (kv_len + page_size - 1) // page_size
+        pages = slice(page_id, page_id + num_pages)
+        page_id += num_pages
+        # HND pages are [num_pages, num_kv_heads, page_size, head_dim].
+        k = k_cache[pages].permute(1, 0, 2, 3).reshape(NUM_KV_HEADS, -1, HEAD_DIM)
+        v = v_cache[pages].permute(1, 0, 2, 3).reshape(NUM_KV_HEADS, -1, HEAD_DIM)
+        k = k[:, :kv_len].float()
+        v = v[:, :kv_len].float()
+        for h in range(NUM_QO_HEADS):
+            kv_h = h // group_size
+            scores = (q[b, :, h] @ k[kv_h].transpose(0, 1)) * sm_scale
+            if is_causal:
+                rows = torch.arange(q_len_per_req, device=q.device).unsqueeze(1)
+                cols = torch.arange(kv_len, device=q.device).unsqueeze(0)
+                scores = scores.masked_fill(
+                    cols > kv_len - q_len_per_req + rows, float("-inf")
+                )
+            out[b, :, h] = torch.softmax(scores, dim=-1) @ v[kv_h]
+    return out.view(batch_size * q_len_per_req, NUM_QO_HEADS, HEAD_DIM)
+
+
+def _make_cache(kv_lens, dtype, device, page_size=PAGE_SIZE):
+    num_pages = sum((kv_len + page_size - 1) // page_size for kv_len in kv_lens)
+    shape = (num_pages, NUM_KV_HEADS, page_size, HEAD_DIM)
+    k = torch.randn(shape, device=device).to(dtype)
+    v = torch.randn(shape, device=device).to(dtype)
+    return k, v
+
+
+# ---------------------------------------------------------------------------
+# Rejections
+# ---------------------------------------------------------------------------
+
+
+@requires_cuda
+def test_rejects_nhd_layout():
+    with pytest.raises(NotImplementedError, match="kv_layout"):
+        _make_wrapper("prims-ts", kv_layout="NHD")
+
+
+@requires_cuda
+def test_rejects_jit_args():
+    with pytest.raises(NotImplementedError, match="jit_args"):
+        _make_wrapper("prims-ts", jit_args=[1])
+
+
+@requires_cuda
+def test_rejects_logits_soft_cap():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(NotImplementedError, match="logits_soft_cap"):
+        wrapper.plan(*_plan_args([64, 96], "cuda"), logits_soft_cap=30.0)
+
+
+@requires_cuda
+def test_rejects_pos_encoding_mode():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(NotImplementedError, match="pos_encoding_mode"):
+        wrapper.plan(*_plan_args([64, 96], "cuda"), pos_encoding_mode="ROPE_LLAMA")
+
+
+@requires_cuda
+@pytest.mark.parametrize(
+    "kwargs", [{"fixed_split_size": 4}, {"disable_split_kv": True}]
+)
+def test_rejects_split_kv_knobs(kwargs):
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(NotImplementedError, match="split-kv"):
+        wrapper.plan(*_plan_args([64, 96], "cuda"), **kwargs)
+
+
+@requires_cuda
+def test_rejects_mixed_q_kv_dtype():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(NotImplementedError, match="q_data_type == kv_data_type"):
+        wrapper.plan(
+            *_plan_args([64, 96], "cuda"),
+            q_data_type=torch.bfloat16,
+            kv_data_type=torch.float8_e4m3fn,
+        )
+
+
+@requires_cuda
+@pytest.mark.parametrize("q_len_per_req,is_causal", [(4, False), (1, True)])
+def test_explicit_is_causal_rejected_on_other_backends(q_len_per_req, is_causal):
+    wrapper = _make_wrapper("fa2", kv_layout="NHD")
+    with pytest.raises(NotImplementedError, match="is_causal"):
+        wrapper.plan(
+            *_plan_args([64, 96], "cuda"),
+            q_data_type=torch.bfloat16,
+            q_len_per_req=q_len_per_req,
+            is_causal=is_causal,
+        )
+
+
+@requires_cuda
+def test_default_is_causal_leaves_other_backends_unchanged():
+    kv_lens = [64, 96]
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    kv_cache = (
+        k_cache.transpose(-3, -2).contiguous(),
+        v_cache.transpose(-3, -2).contiguous(),
+    )
+    q = torch.randn(
+        len(kv_lens), NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+
+    outs = []
+    for is_causal in (None, False):
+        wrapper = _make_wrapper("fa2", kv_layout="NHD")
+        wrapper.plan(
+            *_plan_args(kv_lens, "cuda"),
+            q_data_type=torch.bfloat16,
+            is_causal=is_causal,
+        )
+        outs.append(wrapper.run(q, kv_cache))
+    torch.testing.assert_close(outs[0], outs[1], rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+@requires_prims_ts_gpu
+@pytest.mark.parametrize("q_len_per_req", [1, 4])
+@pytest.mark.parametrize("is_causal", [True, False])
+def test_matches_reference(q_len_per_req, is_causal):
+    kv_lens = [64, 96, 128]
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(
+        len(kv_lens) * q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    wrapper = _make_wrapper("prims-ts")
+    wrapper.plan(
+        *_plan_args(kv_lens, "cuda"),
+        q_data_type=torch.bfloat16,
+        q_len_per_req=q_len_per_req,
+        is_causal=is_causal,
+    )
+    out = wrapper.run(q, (k_cache, v_cache))
+
+    reference = _reference_decode(
+        q, k_cache, v_cache, kv_lens, q_len_per_req, is_causal, PAGE_SIZE
+    )
+    torch.testing.assert_close(out.float(), reference, rtol=2e-2, atol=2e-2)
+
+
+@requires_prims_ts_gpu
+def test_dense_and_causal_differ():
+    kv_lens = [128, 128]
+    q_len_per_req = 4
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(
+        len(kv_lens) * q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    outs = []
+    for is_causal in (True, False):
+        wrapper = _make_wrapper("prims-ts")
+        wrapper.plan(
+            *_plan_args(kv_lens, "cuda"),
+            q_data_type=torch.bfloat16,
+            q_len_per_req=q_len_per_req,
+            is_causal=is_causal,
+        )
+        outs.append(wrapper.run(q, (k_cache, v_cache)))
+    # Only the last query row shares the same visible range under both masks.
+    assert not torch.allclose(outs[0][0], outs[1][0], rtol=1e-2, atol=1e-2)
+
+
+@requires_prims_ts_gpu
+def test_dense_allows_kv_len_below_q_len():
+    kv_lens = [2, 3]
+    q_len_per_req = 4
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(
+        len(kv_lens) * q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    wrapper = _make_wrapper("prims-ts")
+    wrapper.plan(
+        *_plan_args(kv_lens, "cuda"),
+        q_data_type=torch.bfloat16,
+        q_len_per_req=q_len_per_req,
+        is_causal=False,
+    )
+    out = wrapper.run(q, (k_cache, v_cache))
+
+    reference = _reference_decode(
+        q, k_cache, v_cache, kv_lens, q_len_per_req, False, PAGE_SIZE
+    )
+    torch.testing.assert_close(out.float(), reference, rtol=2e-2, atol=2e-2)
+
+
+@requires_cuda
+def test_sliding_window_requires_causal():
+    wrapper = _make_wrapper("prims-ts")
+    with pytest.raises(ValueError, match="window_left"):
+        wrapper.plan(
+            *_plan_args([64, 96], "cuda"),
+            q_data_type=torch.bfloat16,
+            q_len_per_req=4,
+            is_causal=False,
+            window_left=16,
+        )
+
+
+@requires_prims_ts_gpu
+@pytest.mark.parametrize(
+    "run_kwargs,match",
+    [
+        ({"return_lse": True}, "LSE"),
+        ({"skip_softmax_threshold_scale_factor": 1.0}, "skip_softmax"),
+        ({"sinks": torch.zeros(NUM_QO_HEADS)}, "sinks"),
+    ],
+)
+def test_run_rejects_unsupported_options(run_kwargs, match):
+    kv_lens = [64, 96]
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(
+        len(kv_lens), NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+
+    wrapper = _make_wrapper("prims-ts")
+    wrapper.plan(*_plan_args(kv_lens, "cuda"), q_data_type=torch.bfloat16)
+    with pytest.raises(NotImplementedError, match=match):
+        wrapper.run(q, (k_cache, v_cache), **run_kwargs)
+
+
+@requires_prims_ts_gpu
+def test_cuda_graph_replay():
+    kv_lens = [64, 96]
+    q_len_per_req = 4
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(
+        len(kv_lens) * q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    wrapper = _make_wrapper("prims-ts")
+    wrapper.plan(
+        *_plan_args(kv_lens, "cuda"),
+        q_data_type=torch.bfloat16,
+        q_len_per_req=q_len_per_req,
+        is_causal=False,
+    )
+    eager = wrapper.run(q, (k_cache, v_cache))
+
+    out = torch.empty_like(eager)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        wrapper.run(q, (k_cache, v_cache), out=out)
+    out.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, eager, rtol=0, atol=0)


### PR DESCRIPTION
## 📌 Description

`BatchDecodeWithPagedKVCacheWrapper` derives the attention mask from `q_len_per_req`, so a multi-token request is always causal:

```python
is_causal = q_len_per_req > 1
```

Non-causal multi-token decode is therefore not reachable from the public API, even though the task-scheduled decode kernel in `flashinfer.attention.prims_ts` takes `mask_type` as a plan argument and supports `"dense"` for GQA, FP8 KV, and fixed `SQ > 1`. This PR connects the two.

Two changes:

1. `backend="prims-ts"` on the paged decode wrapper, following the `cute-dsl` backend structure: a delegate wrapper built in `__init__`, a `plan()` branch, and a `run()` branch that returns before the tensor-core argument assembly.
2. `is_causal: Optional[bool] = None` on `plan()`. `None` keeps the existing derivation, so the other backends behave exactly as before. An explicit value is honored only by `prims-ts`; the other backends raise, because their mask mode is baked into the planned `qo_indptr` and JIT key.

The `kv_len >= q_len_per_req` plan check now applies only under causal masking. Dense attention places no such constraint, and the kernel accepts `kv_len < q_len_per_req` in that mode.

The `prims-ts` kernel exposes a narrow surface, so unsupported wrapper options are rejected rather than silently ignored:

| Option | Reason |
| --- | --- |
| `kv_layout="NHD"` | The kernel takes HND pages with compact inner strides. |
| `use_cuda_graph=True` | The delegate re-allocates `seq_lens` and scratch and re-specializes the kernel on every `plan()`, so a captured `run()` does not follow a re-plan. Graph support needs a graph mode on the prims-ts side and is left to a follow-up. |
| `jit_args` | No JIT customization hook. |
| `logits_soft_cap`, `pos_encoding_mode` | Not in the kernel contract. |
| `fixed_split_size`, `disable_split_kv` | Split-kv topology is chosen internally. |
| `q_data_type != kv_data_type` | The kernel requires them equal. |
| `kv_cache_sf` | No block-scale path for NVFP4 KV. |
| `sinks` | Not in the kernel contract. |
| `return_lse` | LSE and split-kv partials are internal scratch. |
| `skip_softmax_threshold_scale_factor` | Not in the kernel contract. |

A sliding window under a dense mask is rejected by the kernel itself, since `window_left >= 0` requires `mask_type="causal"`.

Automatic backend selection is untouched. `prims-ts` stays opt-in until it is benchmarked against `trtllm-gen` on the causal path.

The `gqa_paged_decode` trace template is unaffected: it is scoped to one query per sequence, where dense and causal masking coincide.

## 🔍 Related Issues

#3570, #3335

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New file `tests/attention/test_prims_ts_decode_backend.py`. The rejection tests run on any CUDA device because they fire before the kernel is planned. The numerical tests are gated on SM100a, where the kernel is qualified.

Numerical coverage: dense and causal against a paged reference at `q_len_per_req` 1 and 4, dense output differing from causal on the same inputs, dense with `kv_len < q_len_per_req`, and graph capture of a fixed plan. The graph test only covers capture and replay of one plan; the wrapper-level `use_cuda_graph=True` flow (re-plan then replay) is rejected for this backend, see above.

Run on B200 (SM100a) with `nvidia-cutlass-dsl` 4.7.0:

```
tests/attention/test_prims_ts_decode_backend.py    24 passed
tests/attention/test_batch_decode_kernels.py       16 passed   (-k uniform_multi_token)
tests/attention/test_workspace_size.py              6 passed
```

## Reviewer Notes

`is_causal` is the spelling at the wrapper boundary because it replaces the variable of that name; the branch translates it to the kernel's `mask_type`.

NVFP4 KV under a dense mask is deliberately out of scope. It needs a block-scale data path inside the kernel rather than wrapper plumbing, so it belongs in a separate PR.

cc:@PerkzZheng

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tracing support for paged key-value cache decode planning, capturing configuration and request metadata for improved analysis.
  * Expanded paged decode coverage across causal, dense, sliding-window, and split-KV scenarios.

* **Bug Fixes**
  * Added clearer validation for unsupported backend and runtime-option combinations.
  * Prevented incompatible CUDA Graph planning configurations from being accepted.
  * Improved validation for sequence metadata, grouped-query attention dimensions, tensor contiguity, and sliding-window settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->