### PR TITLE
Fix TRTLLM MOE per-token NVFP4 TileN 192 and update cubins

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -239,6 +239,13 @@ TrtllmGenBatchedGemmRunner::TrtllmGenBatchedGemmRunner(
   FLASHINFER_CHECK(!mPassingConfigIndices.empty(), error_msg.str());
 }
 
+batchedGemm::trtllm::gen::SfLayout TrtllmGenBatchedGemmRunner::getSfLayoutB(
+    int32_t configIndex) const {
+  checkPassingConfigIndex(mPassingConfigIndices, configIndex);
+  auto const configs = BatchedGemmInterface().getBatchedGemmConfigs();
+  return configs[configIndex].mOptions.mSfLayoutB;
+}
+
 size_t TrtllmGenBatchedGemmRunner::getWorkspaceSizeInBytes(
     int32_t m, int32_t n, int32_t k, std::vector<int32_t> const& batchedTokens, int32_t numTokens,
     int32_t numBatches, int32_t maxNumCtasInBatchDim, int32_t configIndex) const {

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -2922,8 +2922,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
  public:
   static constexpr std::array<int32_t, 4> mBaseSupportedTileNums = {8, 16, 32, 64};
 
-  static std::vector<int32_t> getSupportedTileNums(btg::Dtype dtype_act, btg::Dtype dtype_weights,
-                                                   bool use_per_token_scaling) {
+  static std::vector<int32_t> getSupportedTileNums(btg::Dtype dtype_act, btg::Dtype dtype_weights) {
     std::vector<int32_t> tiles(mBaseSupportedTileNums.begin(), mBaseSupportedTileNums.end());
     if (dtype_act != btg::Dtype::Bfloat16) {
       tiles.push_back(128);
@@ -2934,9 +2933,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
       // advertised tile, so advertising 192 there failed runner construction
       // outright. The consolidated multi-arch BMM pin does ship sm107a 192-tile
       // FP4 kernels, so this guard can be dropped once Rubin is re-verified.
-      // The exported per-token NVFP4 tile-192 path produces non-finite outputs (#4486).
-      if ((dtype_weights == btg::Dtype::E2m1 && dtype_act == btg::Dtype::E2m1 &&
-           !use_per_token_scaling) ||
+      if ((dtype_weights == btg::Dtype::E2m1 && dtype_act == btg::Dtype::E2m1) ||
           (dtype_weights == btg::Dtype::MxE2m1 && dtype_act == btg::Dtype::MxE4m3)) {
         tiles.push_back(192);
       }
@@ -3335,8 +3332,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
                                                batchedGemm::gemm::BiasType gemm1_bias_type) {
     Array<Array<int64_t>> valid_configs;
 
-    std::vector<int32_t> tile_sizes =
-        getSupportedTileNums(dtype_act, dtype_weights, use_per_token_scaling);
+    std::vector<int32_t> tile_sizes = getSupportedTileNums(dtype_act, dtype_weights);
     std::set<int32_t> selected_tile_nums =
         computeSelectedTileN(tile_sizes, num_tokens, top_k, num_local_experts);
 
@@ -3983,8 +3979,8 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
   }
 
   // Determine supported tile sizes
-  std::vector<int32_t> mSupportedTileN = FP4BlockScaleLauncher::getSupportedTileNums(
-      mDtypeAct, mDtypeWeights, per_token_scales.has_value());
+  std::vector<int32_t> mSupportedTileN =
+      FP4BlockScaleLauncher::getSupportedTileNums(mDtypeAct, mDtypeWeights);
   // Build launchers for ALL supported tiles so autotuner-cached tactics always find their tile_N.
 
   // Create a map of launchers for each tile size

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -578,9 +578,19 @@ void Runner::run(MoERunnerArgs const& args, MoEWorkspace const& workspace, int d
     FLASHINFER_CHECK(
         workspace.token_scales_fc2 != nullptr,
         "workspace.token_scales_fc2 must be provided When using explicit quantization.");
-    // FIXME(siyuan): Detect from the kernel config. Currently only tile size >= 128 will use R128c4
-    auto sfLayout = mGemm2.mTileTokensDim >= 128 ? QuantizationSFLayout::SWIZZLED_128x4
-                                                 : QuantizationSFLayout::SWIZZLED_8x4;
+    auto const sfLayoutB = mGemm2.mRunner.getSfLayoutB(config.gemm2Config);
+    auto sfLayout = QuantizationSFLayout::LINEAR;
+    switch (sfLayoutB) {
+      case btg::SfLayout::R8c4:
+        sfLayout = QuantizationSFLayout::SWIZZLED_8x4;
+        break;
+      case btg::SfLayout::R128c4:
+        sfLayout = QuantizationSFLayout::SWIZZLED_128x4;
+        break;
+      default:
+        FLASHINFER_CHECK(false, "Unsupported FC2 block scale layout ",
+                         btg::sfLayoutToString(sfLayoutB));
+    }
 
     float globalScaleInv = 1.f / (448.f * 6.f);
     if (tensorrt_llm::common::getEnvNVFP4Use4Over6() &&

--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -139,7 +139,7 @@ class ArtifactPath:
     # publish carries the Blackwell (sm100f/sm103a) and Rubin (sm107a) cubins.
     TRTLLM_GEN_FMHA: str = "2d6a5a029eefcc388ec0ceb87efb55d8bcce5c3c/fmha/trtllm-gen/"
     TRTLLM_GEN_BMM: str = (
-        "8ec29a98612c3670f9f28825d1ed19f09496073b/batched_gemm-fa419f4-31ee4e5/"
+        "1d145b82ac60add55ea213863523f12d63005651/batched_gemm-09795a1-31ee4e5/"
     )
     TRTLLM_GEN_GEMM: str = (
         "2d6a5a029eefcc388ec0ceb87efb55d8bcce5c3c/gemm-fa419f4-25754e6/"
@@ -167,7 +167,7 @@ class CheckSumHash:
         "d79b5c51fc8597fac57dae0da4afa114fb2014575e4ec3df099ad856d97cabc3"
     )
     TRTLLM_GEN_BMM: str = (
-        "011635d3c36756addcdc148eea90c984f2d7611ba375626aaaf466d355c80e50"
+        "e071273ce357ee3e8d40ce905dac03d2a6078f6c5869ca3b7d1f1d146643f009"
     )
     DEEPGEMM: str = "09e961d4e3852a6cf81b3482d0604c09dcb1f69c1b7936f535c9ee2f53335184"
     TRTLLM_GEN_GEMM: str = (

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -458,13 +458,17 @@ def get_w2_permute_indices_with_cache(
     dst_w2_weight: torch.Tensor,
     epilogue_tile_m: int,
     num_elts_per_sf: Union[None, int] = None,
+    is_gated_act_gemm: bool | None = None,
 ) -> torch.Tensor:
-    # Include every parameter that changes the generated permutation.
+    # Keep gated and non-gated preparation in separate cache namespaces. The
+    # row mapping is currently identical, but the cached tensor is device-resident
+    # and must not be shared across activation-specific preparation lifetimes.
     cache_key = (
         "w2",
         dst_w2_weight.shape,
         epilogue_tile_m,
         num_elts_per_sf,
+        is_gated_act_gemm,
     )
     if cache_key not in _cache_permute_indices:
         if num_elts_per_sf is None:

--- a/flashinfer/fused_moe/prepare.py
+++ b/flashinfer/fused_moe/prepare.py
@@ -607,7 +607,12 @@ def prepare_trtllm_fp4_weights(
             )
         )
 
-        p = get_w2_permute_indices_with_cache(permute_cache, g2_w[i], epilogue_tile_m)
+        p = get_w2_permute_indices_with_cache(
+            permute_cache,
+            g2_w[i],
+            epilogue_tile_m,
+            is_gated_act_gemm=activation.is_gated,
+        )
         g2_w_sh.append(g2_w[i][p.to(device)].contiguous())
 
         p_sf = get_w2_permute_indices_with_cache(
@@ -615,6 +620,7 @@ def prepare_trtllm_fp4_weights(
             g2_s[i].view(torch.uint8),
             epilogue_tile_m,
             num_elts_per_sf=16,
+            is_gated_act_gemm=activation.is_gated,
         )
         g2_s_sh.append(
             block_scale_interleave(
@@ -856,13 +862,17 @@ def prepare_trtllm_fp8_block_weights(
             q, sf = mxfp8_quantize(w2_bf16[expert], is_sf_swizzled_layout=False)
             sf = sf.view(torch.uint8).reshape(hidden_size, intermediate_size // 32)
             permute = get_w2_permute_indices_with_cache(
-                _TRTLLM_FP8_PERMUTE_CACHE, q.view(torch.uint8), 128
+                _TRTLLM_FP8_PERMUTE_CACHE,
+                q.view(torch.uint8),
+                128,
+                is_gated_act_gemm=activation.is_gated,
             )
             permute_sf = get_w2_permute_indices_with_cache(
                 _TRTLLM_FP8_PERMUTE_CACHE,
                 sf,
                 128,
                 num_elts_per_sf=32,
+                is_gated_act_gemm=activation.is_gated,
             )
             w2_q.append(q.view(torch.uint8)[permute.to(device)].view(q.dtype))
             w2_sf.append(
@@ -1015,6 +1025,7 @@ def prepare_trtllm_fp8_per_tensor_weights(
             _TRTLLM_FP8_PER_TENSOR_PERMUTE_CACHE,
             w2_q[expert].view(torch.uint8),
             128,
+            is_gated_act_gemm=activation.is_gated,
         )
         w2_shuffled.append(
             w2_q[expert]
@@ -1162,7 +1173,10 @@ def prepare_trtllm_mxint4_weights(
             is_gated_act_gemm=activation.is_gated,
         )
         w2_permute = get_w2_permute_indices_with_cache(
-            permute_cache, w2_q[expert], epilogue_tile_m
+            permute_cache,
+            w2_q[expert],
+            epilogue_tile_m,
+            is_gated_act_gemm=activation.is_gated,
         )
         # Keep the established flat-test MxInt4 scale permutation contract;
         # preparation parity tests cover this asymmetric GEMM1/GEMM2 setting.
@@ -1171,6 +1185,7 @@ def prepare_trtllm_mxint4_weights(
             w2_sf[expert],
             epilogue_tile_m,
             num_elts_per_sf=16,
+            is_gated_act_gemm=activation.is_gated,
         )
 
         w1_views.append(
@@ -1295,7 +1310,12 @@ def prepare_trtllm_bf16_weights(
         )
 
         w2_u8 = w2_bf16[i].view(torch.uint8)
-        p2 = get_w2_permute_indices_with_cache(permute_cache, w2_u8, epilogue_tile_m)
+        p2 = get_w2_permute_indices_with_cache(
+            permute_cache,
+            w2_u8,
+            epilogue_tile_m,
+            is_gated_act_gemm=activation.is_gated,
+        )
         w2_views.append(
             convert_to_block_layout(w2_u8[p2.to(device)].contiguous(), block_k)
         )

--- a/include/flashinfer/trtllm/batched_gemm/KernelRunner.h
+++ b/include/flashinfer/trtllm/batched_gemm/KernelRunner.h
@@ -113,6 +113,8 @@ class TrtllmGenBatchedGemmRunner {
  public:
   explicit TrtllmGenBatchedGemmRunner(TrtllmGenBatchedGemmRunnerOptions const& options);
 
+  [[nodiscard]] batchedGemm::trtllm::gen::SfLayout getSfLayoutB(int32_t configIndex) const;
+
   [[nodiscard]] size_t getWorkspaceSizeInBytes(int32_t m, int32_t n, int32_t k,
                                                std::vector<int32_t> const& batchedTokens,
                                                int32_t numTokens, int32_t numBatches,

--- a/tests/moe/test_trtllm_gen_per_token_moe.py
+++ b/tests/moe/test_trtllm_gen_per_token_moe.py
@@ -276,6 +276,7 @@ def test_routed_fused_moe(
             cache_permute_indices,
             w2[i].view(torch.uint8),
             epilogue_tile_m,
+            is_gated_act_gemm=is_gated,
         )
         w2_shuffled.append(
             w2[i].view(torch.uint8)[permute_indices.to(device)].contiguous()
@@ -285,6 +286,7 @@ def test_routed_fused_moe(
             w2_scale[i].view(torch.uint8),
             epilogue_tile_m,
             num_elts_per_sf=16,
+            is_gated_act_gemm=is_gated,
         )
         w2_scale_shuffled.append(
             block_scale_interleave(

--- a/tests/moe/trtllm_gen_fused_moe_utils.py
+++ b/tests/moe/trtllm_gen_fused_moe_utils.py
@@ -683,6 +683,7 @@ class FP4Moe(Moe):
                 self._cache_permute_indices,
                 gemm2_weights_fp4[i].view(torch.uint8),
                 epilogue_tile_m,
+                is_gated_act_gemm=is_gated_activation(args.activation_type),
             )
             gemm2_weights_fp4_shuffled.append(
                 gemm2_weights_fp4[i]
@@ -695,6 +696,7 @@ class FP4Moe(Moe):
                 gemm2_scales_linear_fp4[i].view(torch.uint8),
                 epilogue_tile_m,
                 num_elts_per_sf=16,
+                is_gated_act_gemm=is_gated_activation(args.activation_type),
             )
             gemm2_scales_fp4_shuffled.append(
                 block_scale_interleave(
@@ -711,6 +713,7 @@ class FP4Moe(Moe):
                     self._cache_permute_indices,
                     gemm2_bias_for_kernel[i].reshape(-1, 1),
                     epilogue_tile_m,
+                    is_gated_act_gemm=is_gated_activation(args.activation_type),
                 )
                 gemm2_bias_shuffled.append(
                     gemm2_bias_for_kernel[i]
@@ -1086,6 +1089,7 @@ class MxInt4BlockScaleMoe(Moe):
                 self._cache_permute_indices,
                 args.gemm2_weights[i].view(torch.uint8),
                 epilogue_tile_m,
+                is_gated_act_gemm=True,
             )
             gemm2_weights_shuffled = (
                 args.gemm2_weights[i]
@@ -1098,6 +1102,7 @@ class MxInt4BlockScaleMoe(Moe):
                 args.gemm2_scales[i].view(torch.bfloat16),
                 epilogue_tile_m,
                 num_elts_per_sf=16,
+                is_gated_act_gemm=True,
             )
             gemm2_scales_shuffled.append(
                 block_scale_interleave(
@@ -1946,6 +1951,7 @@ class BF16Moe(Moe):
                     self._cache_permute_indices,
                     args.gemm2_weights[i].view(torch.uint8),
                     epilogue_tile_m,
+                    is_gated_act_gemm=is_gated_activation(args.activation_type),
                 )
                 tmp_weights2 = (
                     args.gemm2_weights[i]


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. Fix TRTLLM MOE per-token NVFP4 TileN 192 accuracy
2. Update cubins to fix MXFP8 Quant

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved NVFP4 mixture-of-experts support by enabling additional tile configurations, including tile size 192.
  * Improved scale-factor layout handling for quantized matrix multiplication and mixture-of-experts execution.

* **Bug Fixes**
  * Corrected scale-factor layout selection to reflect the active kernel configuration.
  * Improved weight preparation cache separation for gated and non-gated activation paths.

* **Chores**
  * Updated the bundled TRTLLM generated matrix multiplication artifact and its integrity verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->