### PR TITLE
test(moe): use scale-aware tolerance for NVFP4 padding safety

### DIFF
--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -2572,17 +2572,19 @@ def test_moe_nvfp4_ndim_padding_safety(
         ActivationType.Swiglu,
     )
     # Two-tier tolerance for FP4 at larger K dimensions (2048 vs 128 in existing tests):
-    # 1. Tight: most elements within atol=0.5. SM100/SM120 use a 95% bar; SM107
-    #    uses 90% because hardware-dependent reduction order shifts the
-    #    batch_size=1 match rate. If N-dim padding corruption occurs, this drops
-    #    dramatically either way.
+    # 1. Tight: most elements within atol=0.5 plus 5% of the reference magnitude.
+    #    SM100/SM120 use a 95% bar; SM107 uses 90% because hardware-dependent
+    #    reduction order shifts the batch_size=1 match rate. If N-dim padding
+    #    corruption occurs, this drops dramatically either way.
     # 2. Relaxed: 100% within atol=2.0. Catches catastrophic NaN/corruption.
     abs_diff = (ref_output - flash_output).abs()
-    tight_match_rate = (abs_diff <= 0.5).float().mean().item()
+    tight_tolerance = 0.5 + 0.05 * ref_output.abs()
+    tight_match_rate = (abs_diff <= tight_tolerance).float().mean().item()
     is_sm107 = get_compute_capability(torch.device("cuda")) == (10, 7)
     tight_bar = 0.90 if is_sm107 else 0.95
     assert tight_match_rate >= tight_bar, (
-        f"Only {tight_match_rate * 100:.1f}% of elements within tight tolerance (0.5). "
+        f"Only {tight_match_rate * 100:.1f}% of elements within tight tolerance "
+        f"(atol=0.5, rtol=0.05). "
         f"Expected >={tight_bar * 100:.0f}%."
     )
     assert abs_diff.max().item() <= 2.0, (


### PR DESCRIPTION
## Description

The NVFP4 N-dimension padding safety test currently measures large-K outputs with a fixed `atol=0.5`. On the reported case, 91.345% of values meet that bound even though the maximum error remains 1.648 and the error grows with the reference magnitude.

This change makes the tight check scale-aware by using `0.5 + 5% * abs(reference)`. It keeps the existing 95% match-rate gate and the independent `max_abs <= 2.0` guard, so broad numerical corruption and isolated large errors are still rejected.

## Related Issues

Fixes #4578.

## Pull Request Checklist

### Pre-commit Checks

- [x] Targeted pre-commit hooks pass for the modified file.

## Tests

- [x] Baseline exact reproduction on RTX 5090: both reported variants fail at 91.345% with fixed `atol=0.5`.
- [x] Historical parent of #3761 reproduces the same 91.345%, ruling out that kernel optimization as the source.
- [x] Patched exact cases: 2 passed.
- [x] Full NVFP4 N-dimension padding matrix: 12 passed.
- [x] Scale-aware match rate: 96.265%; maximum absolute error: 1.648.
- [x] Corruption sensitivity: a zeroed output reaches only 6.055% tight matches; adding 3.0 to one element raises max error to 3.219 and trips the relaxed guard.
- [x] `git diff --check` passes.

## Reviewer Notes

The 5% relative component is applied only to this large-K NVFP4 safety test. The 95% coverage threshold and the absolute catastrophic-error bound are unchanged.

AI assisted with investigation and test preparation. I reviewed and verified the submitted change and will maintain it and address reviewer feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of NVFP4 padding behavior by using a tolerance that accounts for both fixed and value-relative error.
  * Retained architecture-specific accuracy thresholds and relaxed maximum-error validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->