### PR TITLE
fix(benchmark): preserve padded MXFP4 MoE scales

### DIFF
--- a/benchmarks/routines/moe.py
+++ b/benchmarks/routines/moe.py
@@ -650,16 +650,14 @@ def testTrtllmFp4BlockScaleMoe(args):
     gemm1_weights_fp4 = gemm1_weights_fp4_bytes.view(torch.uint8).reshape(
         num_experts, 2 * intermediate_size, hidden_size // 2
     )
-    gemm1_weights_scale = gemm1_scales_fp4_bytes.view(torch.float8_e4m3fn).reshape(
-        num_experts, 2 * intermediate_size, hidden_size // sf_vec_size
-    )
+    # Keep the shape returned by quantize_fp4_batched: swizzled scale storage
+    # pads rows to 128 and scale columns to 4 independently for each expert.
+    gemm1_weights_scale = gemm1_scales_fp4_bytes.view(torch.float8_e4m3fn)
 
     gemm2_weights_fp4 = gemm2_weights_fp4_bytes.view(torch.uint8).reshape(
         num_experts, hidden_size, intermediate_size // 2
     )
-    gemm2_weights_scale = gemm2_scales_fp4_bytes.view(torch.float8_e4m3fn).reshape(
-        num_experts, hidden_size, intermediate_size // sf_vec_size
-    )
+    gemm2_weights_scale = gemm2_scales_fp4_bytes.view(torch.float8_e4m3fn)
 
     gemm1_bias = None
     gemm1_alpha = None


### PR DESCRIPTION
## Description

`quantize_fp4_batched` returns each expert's scale factors in the swizzled storage layout expected by the kernel. That storage pads scale rows to 128 and scale columns to 4. The benchmark then reshapes the buffer back to logical dimensions, which discards neither padding nor data and therefore fails whenever those element counts differ.

For the GPT-OSS-120B shape, GEMM1 has 90 logical scale columns but 92 stored columns. GEMM2 additionally stores 2944 padded rows for 2880 logical rows. This change keeps the three-dimensional scale tensors returned by the quantizer instead of forcing logical shapes.

## Related Issues

Fixes #4729.

## Pull Request Checklist

### Pre-commit Checks

- [x] Targeted pre-commit hooks pass for the modified file.

## Tests

- [x] The issue already provides full benchmark failures on B300 and GB300 for both MXFP4 modes.
- [x] RTX 5090 scale-layout reproduction with `hidden_size=intermediate_size=2880`:
  - GEMM1: old reshape `[2, 5760, 90]` fails for stored shape `[2, 5760, 92]`.
  - GEMM2: old reshape `[2, 2880, 90]` fails for stored shape `[2, 2944, 92]`.
- [x] Patched benchmark preprocessing reaches the kernel call boundary in both `mxfp4_bf16` and `mxfp4_mxfp8` modes; both scale tensors remain contiguous and retain their expected padded shapes.
- [x] `git diff --check` passes.

## Reviewer Notes

The benchmark's packed FP4 weight shapes are unchanged. Only the already-swizzled scale tensors keep the shape produced by `quantize_fp4_batched`; the native launcher consumes their data pointer and element count.

AI assisted with investigation and test preparation. I reviewed and verified the submitted change and will maintain it and address reviewer feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated FP4 mixture-of-experts benchmarking to use the correct swizzled and padded weight-scale layout.
  * Improved accuracy and consistency of benchmark results for FP4 workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->