### PR TITLE
feat(gdn): expose MTP verify controls in pretranspose API

### DIFF
--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -187,6 +187,7 @@ def gated_delta_rule_decode_pretranspose(
         Requires ``initial_state`` to be provided.  If ``None``, the kernel
         writes the updated state back to the same slot it read from (i.e.
         ``initial_state_indices``).
+
         **Padding / inactive sequences**: set the index to ``-1`` for any
         batch entry that should be treated as padding.  The two backends
         handle ``-1`` differently:

--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -175,8 +175,8 @@ def gated_delta_rule_decode_pretranspose(
         K-contiguous, same layout as the per-batch ``state`` argument).
         When provided, the kernel gathers directly from the pool using
         ``initial_state_indices`` and writes updates back in-place,
-        eliminating the caller-side gather/scatter overhead.  Requires
-        bfloat16 state with K=V=128 (bf16 fast path).
+        eliminating the caller-side gather/scatter overhead. Bfloat16 state
+        uses the K=V=128 fast path; float32 state supports both T=1 and MTP.
     initial_state_indices : torch.Tensor, optional
         Per-batch indices of shape ``[B]`` (int32 or int64) mapping each
         batch entry to its slot in ``initial_state``.  Required when
@@ -199,18 +199,20 @@ def gated_delta_rule_decode_pretranspose(
           should not use it).  The caller must therefore allocate the pool
           with an extra leading slot (``pool_size = num_real_slots + 1``)
           and keep real slots at indices ``1..pool_size-1``.
-        - **float32 legacy path** (T=1): ``-1`` entries are skipped
-          entirely; neither the state pool nor the output are touched for
-          that batch entry; the output slot is written as **zero**.
+        - **float32 path**: ``-1`` entries are skipped entirely; neither the
+          state pool nor the output are touched for that batch entry. The
+          output slot remains caller-provided, or is **zero** when ``output``
+          is ``None``.
     intermediate_states_buffer : torch.Tensor, optional
-        Caller-owned BF16 intermediate-state cache of shape
-        ``[B, T, HV, V, K]``. Supported only by the BF16 ``T>1`` path.
-        Defaults to ``None``.
+        Caller-owned intermediate-state cache of shape
+        ``[B, T, HV, V, K]``. The cache must be bfloat16 for the BF16-state
+        backend and float32 for the FP32-state backend. Supported only when
+        ``T > 1``. Defaults to ``None``.
     disable_state_update : bool
-        If ``True``, the BF16 ``T>1`` path leaves the state pool unchanged.
-        This is used by speculative verification while intermediate states
-        are retained in ``intermediate_states_buffer``. Defaults to ``False``
-        to preserve the existing update behavior.
+        If ``True``, the ``T>1`` path leaves the state pool unchanged. This is
+        used by speculative verification while intermediate states are retained
+        in ``intermediate_states_buffer``. Defaults to ``False`` to preserve the
+        existing update behavior.
 
     Returns
     -------
@@ -222,14 +224,14 @@ def gated_delta_rule_decode_pretranspose(
     Notes
     -----
     - Requires SM90+ (Hopper, Blackwell, etc.).
-    - State is updated in-place by default; BF16 MTP verification can preserve
-      it with ``disable_state_update=True``.
+    - State is updated in-place by default; MTP verification can preserve it
+      with ``disable_state_update=True``.
     - State layout is v-major (K-last): ``[B, HV, V, K]``.  When state is
       bfloat16 and ``K = V = 128``, the BF16 state kernel is used (T=1 or
       MTP for T>1); the pool+indices path routes through the MTP kernel.
     - Pool+indices (``initial_state`` / ``initial_state_indices``) are
       supported on both the bf16 fast path (K=V=128) and the float32 legacy
-      path (T=1).  Both paths support ``-1`` padding indices (see
+      path (T=1 or MTP). Both paths support ``-1`` padding indices (see
       ``initial_state_indices`` above for per-backend semantics).
     - Legacy path (float32 state, T=1): ``K`` and ``V`` must each be
       ``>= 128``, and ``V`` must be a multiple of 8 (the pretranspose tile
@@ -242,7 +244,7 @@ def gated_delta_rule_decode_pretranspose(
     if (intermediate_states_buffer is not None or disable_state_update) and T == 1:
         raise ValueError(
             "intermediate_states_buffer and disable_state_update are supported "
-            "only by BF16 pretranspose decode with T > 1"
+            "only by pretranspose decode with T > 1"
         )
 
     use_pool = initial_state is not None
@@ -287,12 +289,15 @@ def gated_delta_rule_decode_pretranspose(
         and K == 128
         and V == 128
     )
+    supports_mtp_controls = use_bf16_state or (
+        state_dtype == torch.float32 and T > 1 and use_pool
+    )
     if (
         intermediate_states_buffer is not None or disable_state_update
-    ) and not use_bf16_state:
+    ) and not supports_mtp_controls:
         raise ValueError(
             "intermediate_states_buffer and disable_state_update are supported "
-            "only by BF16 pretranspose decode with T > 1"
+            "only by BF16 or pool-backed FP32 pretranspose decode with T > 1"
         )
     if use_bf16_state:
         assert q.dtype in (torch.float16, torch.bfloat16), (
@@ -409,8 +414,8 @@ def gated_delta_rule_decode_pretranspose(
             b=b,
             scale=scale,
             output=output,
-            intermediate_states_buffer=None,
-            disable_state_update=False,
+            intermediate_states_buffer=intermediate_states_buffer,
+            disable_state_update=disable_state_update,
             use_qk_l2norm=use_qk_l2norm,
             output_state_indices=output_state_indices,
         )

--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -130,22 +130,23 @@ def gated_delta_rule_decode_pretranspose(
     initial_state: Optional[torch.Tensor] = None,
     initial_state_indices: Optional[torch.Tensor] = None,
     output_state_indices: Optional[torch.Tensor] = None,
+    *,
     intermediate_states_buffer: Optional[torch.Tensor] = None,
     disable_state_update: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    r"""Gated Delta Rule Decode kernel for single-token generation.
+    r"""Gated Delta Rule Decode kernel for pretransposed state.
 
     Implements the decode phase of gated delta rule linear attention,
-    processing one token at a time and updating the recurrent state.
+    processing one or more tokens and updating the recurrent state by default.
 
     Parameters
     ----------
     q : torch.Tensor
-        Current query of shape ``[B, 1, H, K]``.  Must be float16/bfloat16.
+        Current query of shape ``[B, T, H, K]``.  Must be float16/bfloat16.
     k : torch.Tensor
-        Current key of shape ``[B, 1, H, K]``.  Must be float16/bfloat16.
+        Current key of shape ``[B, T, H, K]``.  Must be float16/bfloat16.
     v : torch.Tensor
-        Current value of shape ``[B, 1, HV, V]``.  Must be float16/bfloat16.
+        Current value of shape ``[B, T, HV, V]``.  Must be float16/bfloat16.
     state : torch.Tensor, optional
         Current state of shape ``[B, HV, V, K]`` (v-major / K-last layout).
         Float32: legacy kernel (T=1 only).  Bfloat16: BF16 state backend
@@ -154,18 +155,18 @@ def gated_delta_rule_decode_pretranspose(
     A_log : torch.Tensor
         Log decay parameter of shape ``[HV]``.  Must be float32.
     a : torch.Tensor
-        Input-dependent decay of shape ``[B, 1, HV]``.  Must be
+        Input-dependent decay of shape ``[B, T, HV]``.  Must be
         float16/bfloat16.
     dt_bias : torch.Tensor
         Decay bias of shape ``[HV]``.  Must be bfloat16 or float32.
     b : torch.Tensor
-        Update gate (beta) input of shape ``[B, 1, HV]``.  Must be
+        Update gate (beta) input of shape ``[B, T, HV]``.  Must be
         float16/bfloat16.
     scale : float, optional
         Scale factor for queries.  If ``None``, defaults to
         ``1 / sqrt(K)``.
     output : torch.Tensor, optional
-        Pre-allocated output tensor of shape ``[B, 1, HV, V]``.  Allocated
+        Pre-allocated output tensor of shape ``[B, T, HV, V]``.  Allocated
         automatically when ``None``.
     use_qk_l2norm : bool
         Whether to apply L2 normalization to q and k.  Default: ``True``.
@@ -201,26 +202,27 @@ def gated_delta_rule_decode_pretranspose(
           entirely; neither the state pool nor the output are touched for
           that batch entry; the output slot is written as **zero**.
     intermediate_states_buffer : torch.Tensor, optional
-        Caller-owned buffer of shape ``[B, cache_steps, HV, V, K]`` for
-        caching intermediate states on MTP paths (``T > 1``).  Its dtype
-        must match the selected state backend and ``cache_steps`` must be at
-        least ``T``.
+        Caller-owned BF16 intermediate-state cache of shape
+        ``[B, cache_steps, HV, V, K]``. Supported only by the BF16 ``T>1``
+        path; ``cache_steps`` must be at least ``T``. Defaults to ``None``.
     disable_state_update : bool
-        Whether to leave the state pool unchanged on MTP paths (``T > 1``).
-        Default: ``False``.
+        If ``True``, the BF16 ``T>1`` path leaves the state pool unchanged.
+        This is used by speculative verification while intermediate states
+        are retained in ``intermediate_states_buffer``. Defaults to ``False``
+        to preserve the existing update behavior.
 
     Returns
     -------
     Tuple[torch.Tensor, torch.Tensor]
         ``(output, state_or_initial_state)`` where ``output`` has shape
-        ``[B, 1, HV, V]`` and the second element is the updated state
-        (mutated in place).
+        ``[B, T, HV, V]`` and the second element is the caller-owned state.
+        The state is mutated in place unless state updates are disabled.
 
     Notes
     -----
     - Requires SM90+ (Hopper, Blackwell, etc.).
-    - State is updated in-place by default; the pool path writes directly
-      into ``initial_state`` memory (no separate scatter step needed).
+    - State is updated in-place by default; BF16 MTP verification can preserve
+      it with ``disable_state_update=True``.
     - State layout is v-major (K-last): ``[B, HV, V, K]``.  When state is
       bfloat16 and ``K = V = 128``, the BF16 state kernel is used (T=1 or
       MTP for T>1); the pool+indices path routes through the MTP kernel.
@@ -235,6 +237,12 @@ def gated_delta_rule_decode_pretranspose(
     # Validate input shapes
     B, T, H, K = q.shape
     _, _, HV, V = v.shape
+
+    if (intermediate_states_buffer is not None or disable_state_update) and T == 1:
+        raise ValueError(
+            "intermediate_states_buffer and disable_state_update are supported "
+            "only by BF16 pretranspose decode with T > 1"
+        )
 
     use_pool = initial_state is not None
     assert use_pool == (initial_state_indices is not None), (
@@ -278,6 +286,13 @@ def gated_delta_rule_decode_pretranspose(
         and K == 128
         and V == 128
     )
+    if (
+        intermediate_states_buffer is not None or disable_state_update
+    ) and not use_bf16_state:
+        raise ValueError(
+            "intermediate_states_buffer and disable_state_update are supported "
+            "only by BF16 pretranspose decode with T > 1"
+        )
     if use_bf16_state:
         assert q.dtype in (torch.float16, torch.bfloat16), (
             f"q must be float16/bfloat16, got {q.dtype}"
@@ -322,8 +337,6 @@ def gated_delta_rule_decode_pretranspose(
                 initial_state_source=bf16_pool,
                 initial_state_indices=bf16_indices,
                 output_state_indices=output_state_indices,
-                intermediate_states_buffer=intermediate_states_buffer,
-                disable_state_update=disable_state_update,
                 use_qk_l2norm_in_kernel=use_qk_l2norm,
                 scale=scale_val,
                 output=forward_output,
@@ -343,6 +356,8 @@ def gated_delta_rule_decode_pretranspose(
                 initial_state_source=bf16_pool,
                 initial_state_indices=bf16_indices,
                 output_state_indices=output_state_indices,
+                intermediate_states_buffer=intermediate_states_buffer,
+                disable_state_update=disable_state_update,
                 use_qk_l2norm_in_kernel=use_qk_l2norm,
                 scale=scale_val,
                 output=forward_output,
@@ -393,8 +408,8 @@ def gated_delta_rule_decode_pretranspose(
             b=b,
             scale=scale,
             output=output,
-            intermediate_states_buffer=intermediate_states_buffer,
-            disable_state_update=disable_state_update,
+            intermediate_states_buffer=None,
+            disable_state_update=False,
             use_qk_l2norm=use_qk_l2norm,
             output_state_indices=output_state_indices,
         )

--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -130,6 +130,8 @@ def gated_delta_rule_decode_pretranspose(
     initial_state: Optional[torch.Tensor] = None,
     initial_state_indices: Optional[torch.Tensor] = None,
     output_state_indices: Optional[torch.Tensor] = None,
+    intermediate_states_buffer: Optional[torch.Tensor] = None,
+    disable_state_update: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Gated Delta Rule Decode kernel for single-token generation.
 
@@ -184,7 +186,6 @@ def gated_delta_rule_decode_pretranspose(
         Requires ``initial_state`` to be provided.  If ``None``, the kernel
         writes the updated state back to the same slot it read from (i.e.
         ``initial_state_indices``).
-
         **Padding / inactive sequences**: set the index to ``-1`` for any
         batch entry that should be treated as padding.  The two backends
         handle ``-1`` differently:
@@ -199,6 +200,14 @@ def gated_delta_rule_decode_pretranspose(
         - **float32 legacy path** (T=1): ``-1`` entries are skipped
           entirely; neither the state pool nor the output are touched for
           that batch entry; the output slot is written as **zero**.
+    intermediate_states_buffer : torch.Tensor, optional
+        Caller-owned buffer of shape ``[B, cache_steps, HV, V, K]`` for
+        caching intermediate states on MTP paths (``T > 1``).  Its dtype
+        must match the selected state backend and ``cache_steps`` must be at
+        least ``T``.
+    disable_state_update : bool
+        Whether to leave the state pool unchanged on MTP paths (``T > 1``).
+        Default: ``False``.
 
     Returns
     -------
@@ -210,8 +219,8 @@ def gated_delta_rule_decode_pretranspose(
     Notes
     -----
     - Requires SM90+ (Hopper, Blackwell, etc.).
-    - State is always updated in-place; the pool path writes directly into
-      ``initial_state`` memory (no separate scatter step needed).
+    - State is updated in-place by default; the pool path writes directly
+      into ``initial_state`` memory (no separate scatter step needed).
     - State layout is v-major (K-last): ``[B, HV, V, K]``.  When state is
       bfloat16 and ``K = V = 128``, the BF16 state kernel is used (T=1 or
       MTP for T>1); the pool+indices path routes through the MTP kernel.
@@ -313,6 +322,8 @@ def gated_delta_rule_decode_pretranspose(
                 initial_state_source=bf16_pool,
                 initial_state_indices=bf16_indices,
                 output_state_indices=output_state_indices,
+                intermediate_states_buffer=intermediate_states_buffer,
+                disable_state_update=disable_state_update,
                 use_qk_l2norm_in_kernel=use_qk_l2norm,
                 scale=scale_val,
                 output=forward_output,
@@ -382,8 +393,8 @@ def gated_delta_rule_decode_pretranspose(
             b=b,
             scale=scale,
             output=output,
-            intermediate_states_buffer=None,
-            disable_state_update=False,
+            intermediate_states_buffer=intermediate_states_buffer,
+            disable_state_update=disable_state_update,
             use_qk_l2norm=use_qk_l2norm,
             output_state_indices=output_state_indices,
         )

--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -204,8 +204,8 @@ def gated_delta_rule_decode_pretranspose(
           that batch entry; the output slot is written as **zero**.
     intermediate_states_buffer : torch.Tensor, optional
         Caller-owned BF16 intermediate-state cache of shape
-        ``[B, cache_steps, HV, V, K]``. Supported only by the BF16 ``T>1``
-        path; ``cache_steps`` must be at least ``T``. Defaults to ``None``.
+        ``[B, T, HV, V, K]``. Supported only by the BF16 ``T>1`` path.
+        Defaults to ``None``.
     disable_state_update : bool
         If ``True``, the BF16 ``T>1`` path leaves the state pool unchanged.
         This is used by speculative verification while intermediate states

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -2050,16 +2050,15 @@ def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
     output = torch.empty(
         batch_size, seq_len, num_v_heads, head_size, dtype=dtype, device=device
     )
-    sentinel = 3.25
     cache_shape = (
         batch_size,
-        seq_len + 1,
+        seq_len,
         num_v_heads,
         head_size,
         head_size,
     )
-    public_cache = torch.full(cache_shape, sentinel, dtype=dtype, device=device)
-    direct_cache = torch.full(cache_shape, sentinel, dtype=dtype, device=device)
+    public_cache = torch.empty(cache_shape, dtype=dtype, device=device)
+    direct_cache = torch.empty(cache_shape, dtype=dtype, device=device)
     public_pool = initial_pool.clone()
     direct_pool = initial_pool.clone()
     scale = 1.0 / math.sqrt(head_size)
@@ -2104,15 +2103,7 @@ def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
     torch.testing.assert_close(public_output, direct_output, atol=1e-2, rtol=1e-2)
     torch.testing.assert_close(public_pool, initial_pool, atol=0.0, rtol=0.0)
     torch.testing.assert_close(direct_pool, initial_pool, atol=0.0, rtol=0.0)
-    torch.testing.assert_close(
-        public_cache[:, :seq_len], direct_cache[:, :seq_len], atol=1e-2, rtol=1e-2
-    )
-    torch.testing.assert_close(
-        public_cache[:, seq_len:],
-        torch.full_like(public_cache[:, seq_len:], sentinel),
-        atol=0.0,
-        rtol=0.0,
-    )
+    torch.testing.assert_close(public_cache, direct_cache, atol=1e-2, rtol=1e-2)
 
 
 # ============================================================================

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1984,6 +1984,120 @@ def test_pretranspose_api_uses_gdn_decode_bf16_state(
     )
 
 
+def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
+    """The public pretranspose API must preserve MTP verify state and cache controls."""
+    _skip_if_not_sm90_or_later()
+    if not GDN_DECODE_BF16_STATE_AVAILABLE:
+        pytest.skip("BF16 state kernel not available")
+
+    torch.random.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    batch_size, seq_len = 2, 2
+    num_q_heads = num_k_heads = 16
+    num_v_heads = 32
+    head_size = 128
+    pool_size = 5
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    q = torch.randn(
+        batch_size, seq_len, num_q_heads, head_size, dtype=dtype, device=device
+    )
+    k = torch.randn(
+        batch_size, seq_len, num_k_heads, head_size, dtype=dtype, device=device
+    )
+    v = torch.randn(
+        batch_size, seq_len, num_v_heads, head_size, dtype=dtype, device=device
+    )
+    a = (
+        torch.randn(
+            batch_size, seq_len, num_v_heads, dtype=dtype, device=device
+        )
+        * 0.1
+    )
+    b_tensor = torch.randn(
+        batch_size, seq_len, num_v_heads, dtype=dtype, device=device
+    )
+    A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    initial_state_indices = torch.tensor([1, 4], dtype=torch.int32, device=device)
+    initial_pool = torch.randn(
+        pool_size,
+        num_v_heads,
+        head_size,
+        head_size,
+        dtype=dtype,
+        device=device,
+    )
+    output = torch.empty(
+        batch_size, seq_len, num_v_heads, head_size, dtype=dtype, device=device
+    )
+    sentinel = 3.25
+    cache_shape = (
+        batch_size,
+        seq_len + 1,
+        num_v_heads,
+        head_size,
+        head_size,
+    )
+    public_cache = torch.full(cache_shape, sentinel, dtype=dtype, device=device)
+    direct_cache = torch.full(cache_shape, sentinel, dtype=dtype, device=device)
+    public_pool = initial_pool.clone()
+    direct_pool = initial_pool.clone()
+    scale = 1.0 / math.sqrt(head_size)
+
+    public_output, returned_pool = gated_delta_rule_decode_pretranspose(
+        q=q,
+        k=k,
+        v=v,
+        state=None,
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b_tensor,
+        scale=scale,
+        output=output,
+        use_qk_l2norm=True,
+        initial_state=public_pool,
+        initial_state_indices=initial_state_indices,
+        intermediate_states_buffer=public_cache,
+        disable_state_update=True,
+    )
+    direct_output = gdn_decode_bf16_state_mtp(
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        softplus_beta=1.0,
+        softplus_threshold=20.0,
+        q=q,
+        k=k,
+        v=v,
+        b=b_tensor,
+        initial_state_source=direct_pool,
+        initial_state_indices=initial_state_indices,
+        intermediate_states_buffer=direct_cache,
+        disable_state_update=True,
+        use_qk_l2norm_in_kernel=True,
+        scale=scale,
+    )
+
+    assert public_output is output
+    assert returned_pool is public_pool
+    torch.testing.assert_close(public_output, direct_output, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(public_pool, initial_pool, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(direct_pool, initial_pool, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(
+        public_cache[:, :seq_len], direct_cache[:, :seq_len], atol=1e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        public_cache[:, seq_len:],
+        torch.full_like(public_cache[:, seq_len:], sentinel),
+        atol=0.0,
+        rtol=0.0,
+    )
+
+
 # ============================================================================
 # Test BF16 state kernel (T=1)
 # ============================================================================

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 from __future__ import annotations
 
+import inspect
 import math
 import os
 import sys
@@ -1982,6 +1983,22 @@ def test_pretranspose_api_uses_gdn_decode_bf16_state(
     print(
         f"✓ API gdn_decode_bf16_state backend verified (batch={batch_size}, T={seq_len})"
     )
+
+
+def test_pretranspose_api_mtp_verify_controls_are_keyword_only():
+    parameters = inspect.signature(gated_delta_rule_decode_pretranspose).parameters
+
+    assert tuple(parameters)[-2:] == (
+        "intermediate_states_buffer",
+        "disable_state_update",
+    )
+    assert (
+        parameters["intermediate_states_buffer"].kind
+        is inspect.Parameter.KEYWORD_ONLY
+    )
+    assert parameters["disable_state_update"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["intermediate_states_buffer"].default is None
+    assert parameters["disable_state_update"].default is False
 
 
 def test_pretranspose_api_forwards_bf16_mtp_verify_controls():

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1992,10 +1992,7 @@ def test_pretranspose_api_mtp_verify_controls_are_keyword_only():
         "intermediate_states_buffer",
         "disable_state_update",
     )
-    assert (
-        parameters["intermediate_states_buffer"].kind
-        is inspect.Parameter.KEYWORD_ONLY
-    )
+    assert parameters["intermediate_states_buffer"].kind is inspect.Parameter.KEYWORD_ONLY
     assert parameters["disable_state_update"].kind is inspect.Parameter.KEYWORD_ONLY
     assert parameters["intermediate_states_buffer"].default is None
     assert parameters["disable_state_update"].default is False
@@ -2027,15 +2024,8 @@ def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
     v = torch.randn(
         batch_size, seq_len, num_v_heads, head_size, dtype=dtype, device=device
     )
-    a = (
-        torch.randn(
-            batch_size, seq_len, num_v_heads, dtype=dtype, device=device
-        )
-        * 0.1
-    )
-    b_tensor = torch.randn(
-        batch_size, seq_len, num_v_heads, dtype=dtype, device=device
-    )
+    a = torch.randn(batch_size, seq_len, num_v_heads, dtype=dtype, device=device) * 0.1
+    b_tensor = torch.randn(batch_size, seq_len, num_v_heads, dtype=dtype, device=device)
     A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
     dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
     initial_state_indices = torch.tensor([1, 4], dtype=torch.int32, device=device)

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -2154,9 +2154,7 @@ def test_pretranspose_api_forwards_fp32_mtp_verify_controls_with_noncompact_pool
         batch_size, seq_len, num_v_heads, head_size, dtype=io_dtype, device=device
     )
     a = (
-        torch.randn(
-            batch_size, seq_len, num_v_heads, dtype=io_dtype, device=device
-        )
+        torch.randn(batch_size, seq_len, num_v_heads, dtype=io_dtype, device=device)
         * 0.1
     )
     b_tensor = torch.randn(

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -2000,7 +2000,33 @@ def test_pretranspose_api_mtp_verify_controls_are_keyword_only():
     assert parameters["disable_state_update"].default is False
 
 
-def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
+@pytest.mark.parametrize("control", ["cache", "disable_state_update"])
+def test_pretranspose_api_rejects_mtp_controls_at_t1(control: str):
+    tensor = torch.empty(1, 1, 1, 1)
+    kwargs = (
+        {"intermediate_states_buffer": torch.empty(0)}
+        if control == "cache"
+        else {"disable_state_update": True}
+    )
+
+    with pytest.raises(ValueError, match="T > 1"):
+        gated_delta_rule_decode_pretranspose(
+            q=tensor,
+            k=tensor,
+            v=tensor,
+            state=tensor,
+            A_log=torch.empty(1),
+            a=torch.empty(1, 1, 1),
+            dt_bias=torch.empty(1),
+            b=torch.empty(1, 1, 1),
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("noncompact_pool", [False, True])
+def test_pretranspose_api_forwards_bf16_mtp_verify_controls(
+    noncompact_pool: bool,
+):
     """The public pretranspose API must preserve MTP verify state and cache controls."""
     _skip_if_not_sm90_or_later()
     if not GDN_DECODE_BF16_STATE_AVAILABLE:
@@ -2031,9 +2057,10 @@ def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
     A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
     dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
     initial_state_indices = torch.tensor([1, 4], dtype=torch.int32, device=device)
-    initial_pool = torch.randn(
+    padded_heads = 1 if noncompact_pool else 0
+    initial_backing = torch.randn(
         pool_size,
-        num_v_heads,
+        num_v_heads + padded_heads,
         head_size,
         head_size,
         dtype=dtype,
@@ -2051,8 +2078,12 @@ def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
     )
     public_cache = torch.empty(cache_shape, dtype=dtype, device=device)
     direct_cache = torch.empty(cache_shape, dtype=dtype, device=device)
-    public_pool = initial_pool.clone()
-    direct_pool = initial_pool.clone()
+    public_backing = initial_backing.clone()
+    direct_backing = initial_backing.clone()
+    public_pool = public_backing[:, :num_v_heads]
+    direct_pool = direct_backing[:, :num_v_heads]
+    assert public_pool.is_contiguous() == (not noncompact_pool)
+    assert direct_pool.is_contiguous() == (not noncompact_pool)
     scale = 1.0 / math.sqrt(head_size)
 
     public_output, returned_pool = gated_delta_rule_decode_pretranspose(
@@ -2093,9 +2124,119 @@ def test_pretranspose_api_forwards_bf16_mtp_verify_controls():
     assert public_output is output
     assert returned_pool is public_pool
     torch.testing.assert_close(public_output, direct_output, atol=1e-2, rtol=1e-2)
-    torch.testing.assert_close(public_pool, initial_pool, atol=0.0, rtol=0.0)
-    torch.testing.assert_close(direct_pool, initial_pool, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(public_backing, initial_backing, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(direct_backing, initial_backing, atol=0.0, rtol=0.0)
     torch.testing.assert_close(public_cache, direct_cache, atol=1e-2, rtol=1e-2)
+
+
+def test_pretranspose_api_forwards_fp32_mtp_verify_controls_with_noncompact_pool():
+    """FP32 MTP controls must survive public dtype dispatch for a padded pool."""
+    _skip_if_not_sm90_or_later()
+
+    torch.random.manual_seed(0)
+    torch.cuda.manual_seed(0)
+
+    batch_size, seq_len = 2, 2
+    num_q_heads = num_k_heads = 16
+    num_v_heads = 32
+    head_size = 128
+    pool_size = 5
+    device = torch.device("cuda")
+    io_dtype = torch.bfloat16
+
+    q = torch.randn(
+        batch_size, seq_len, num_q_heads, head_size, dtype=io_dtype, device=device
+    )
+    k = torch.randn(
+        batch_size, seq_len, num_k_heads, head_size, dtype=io_dtype, device=device
+    )
+    v = torch.randn(
+        batch_size, seq_len, num_v_heads, head_size, dtype=io_dtype, device=device
+    )
+    a = (
+        torch.randn(
+            batch_size, seq_len, num_v_heads, dtype=io_dtype, device=device
+        )
+        * 0.1
+    )
+    b_tensor = torch.randn(
+        batch_size, seq_len, num_v_heads, dtype=io_dtype, device=device
+    )
+    A_log = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    dt_bias = torch.randn(num_v_heads, dtype=torch.float32, device=device) * 0.1
+    initial_state_indices = torch.tensor([1, 4], dtype=torch.int32, device=device)
+    initial_backing = torch.randn(
+        pool_size,
+        num_v_heads + 1,
+        head_size,
+        head_size,
+        dtype=torch.float32,
+        device=device,
+    )
+    public_backing = initial_backing.clone()
+    direct_backing = initial_backing.clone()
+    public_pool = public_backing[:, :num_v_heads]
+    direct_pool = direct_backing[:, :num_v_heads]
+    assert not public_pool.is_contiguous()
+    assert not direct_pool.is_contiguous()
+
+    output = torch.empty(
+        batch_size, seq_len, num_v_heads, head_size, dtype=io_dtype, device=device
+    )
+    direct_output_buffer = torch.empty_like(output)
+    cache_shape = (
+        batch_size,
+        seq_len,
+        num_v_heads,
+        head_size,
+        head_size,
+    )
+    public_cache = torch.empty(cache_shape, dtype=torch.float32, device=device)
+    direct_cache = torch.empty(cache_shape, dtype=torch.float32, device=device)
+    scale = 1.0 / math.sqrt(head_size)
+
+    public_output, returned_pool = gated_delta_rule_decode_pretranspose(
+        q=q,
+        k=k,
+        v=v,
+        state=None,
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b_tensor,
+        scale=scale,
+        output=output,
+        use_qk_l2norm=True,
+        initial_state=public_pool,
+        initial_state_indices=initial_state_indices,
+        intermediate_states_buffer=public_cache,
+        disable_state_update=True,
+    )
+    direct_output, direct_returned_pool = gated_delta_rule_mtp(
+        q=q,
+        k=k,
+        v=v,
+        initial_state=direct_pool,
+        initial_state_indices=initial_state_indices,
+        A_log=A_log,
+        a=a,
+        dt_bias=dt_bias,
+        b=b_tensor,
+        scale=scale,
+        output=direct_output_buffer,
+        intermediate_states_buffer=direct_cache,
+        disable_state_update=True,
+        use_qk_l2norm=True,
+    )
+
+    assert public_output is output
+    assert returned_pool is public_pool
+    assert direct_output is direct_output_buffer
+    assert direct_returned_pool is direct_pool
+    torch.testing.assert_close(public_output, direct_output, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(public_backing, initial_backing, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(direct_backing, initial_backing, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(public_cache, direct_cache, atol=1e-3, rtol=1e-3)
 
 
 # ============================================================================

--- a/tests/gdn/test_decode_delta_rule.py
+++ b/tests/gdn/test_decode_delta_rule.py
@@ -1992,7 +1992,9 @@ def test_pretranspose_api_mtp_verify_controls_are_keyword_only():
         "intermediate_states_buffer",
         "disable_state_update",
     )
-    assert parameters["intermediate_states_buffer"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert (
+        parameters["intermediate_states_buffer"].kind is inspect.Parameter.KEYWORD_ONLY
+    )
     assert parameters["disable_state_update"].kind is inspect.Parameter.KEYWORD_ONLY
     assert parameters["intermediate_states_buffer"].default is None
     assert parameters["disable_state_update"].default is False


### PR DESCRIPTION
## Description

Expose the existing multi-token verification controls through the public
`gated_delta_rule_decode_pretranspose` entry point for both supported state
backends.

- Add keyword-only `intermediate_states_buffer` and `disable_state_update`
  parameters with backward-compatible defaults.
- Forward both controls to BF16 `T > 1` and pool-backed FP32 `T > 1` routes.
- Reject `T == 1` and unsupported routes instead of silently ignoring either
  control.
- Preserve the existing default update behavior, return values, generated
  kernels, and CUDA launch ABI.
- Document the dtype-specific cache contract.
- Cover indexed padded/noncompact state pools, including cache parity, returned
  pool identity, and full backing-store freeze (padding included) during
  verification.

This is independent of #4572, which handles padded intermediate-cache views.
Related to #4254.

## Tests

- B200 / SM100, exact `924418e284ce45a0083e8a3a323b68216d268680`:
  6 targeted cases passed with 0 failures, errors, or skips. Physical turnaround
  3m08s; allocation 2m17s; targeted gate 12s (pytest 7.08s).
- GB300 / SM103, exact `924418e284ce45a0083e8a3a323b68216d268680`:
  6 targeted cases passed with 0 failures, errors, or skips. Physical turnaround
  5m39s; allocation 5m37s; targeted gate 11s (pytest 8.07s).

Performance was not measured because this change is Python dispatch plumbing;
it does not modify generated CUDA, kernel schedules, or the launch ABI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended multi-token decoding support to FP32 state alongside BF16.
  * Added intermediate-state caching and state-update controls for FP32 decoding.
  * Improved handling of caller-provided output and storage buffers, including padded pools.
  * Updated padding-output behavior for FP32 multi-token decoding.

* **Bug Fixes**
  * Added validation for incompatible controls and single-token decoding paths.

* **Tests**
  * Added regression coverage for BF16 and FP32 multi-token behavior across pool layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
