### PR TITLE
perf(attention): cut NVFP4 KV dequant instructions on targets without native FP4/FP8 conversion

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -1228,11 +1228,25 @@ __device__ __forceinline__ void compute_qk(
           using packed2_ = std::conditional_t<std::is_same_v<DTypeQ_, half>, half2, __nv_bfloat162>;
           constexpr uint32_t SF_COLS_K = KTraits::NUM_MMA_D_QK;  // HEAD_DIM_QK / 16
           uint32_t sf_base = (mma_kv * 16 + lane_idx / 4) * SF_COLS_K + mma_d;
+          packed2_ scale_a, scale_b;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 1000
+          // Pre-SM100 has no hardware e4m3->f16 convert, so `static_cast` below expands to a
+          // software conversion *per scale byte, per fragment*. Pack both bytes duplicated into one
+          // word and reuse the prmt/lop3 converter already used on the V side, which handles four
+          // at once: {a,a,b,b} -> {half2(a,a), half2(b,b)} == {scale_a, scale_b}.
+          uint32_t sf_pack = __byte_perm(uint32_t(k_sf_smem[sf_base]),
+                                        uint32_t(k_sf_smem[sf_base + 8 * SF_COLS_K]), 0x4400u);
+          uint2 sf_pair;
+          fast_dequant_f8f16x4<__nv_fp8_e4m3, DTypeQ_>(&sf_pack, &sf_pair);
+          scale_a = *(packed2_*)&sf_pair.x;
+          scale_b = *(packed2_*)&sf_pair.y;
+#else
           __nv_fp8_e4m3 sf_a_fp8, sf_b_fp8;
           sf_a_fp8.__x = k_sf_smem[sf_base];
           sf_b_fp8.__x = k_sf_smem[sf_base + 8 * SF_COLS_K];
-          packed2_ scale_a{static_cast<DTypeQ_>(sf_a_fp8), static_cast<DTypeQ_>(sf_a_fp8)};
-          packed2_ scale_b{static_cast<DTypeQ_>(sf_b_fp8), static_cast<DTypeQ_>(sf_b_fp8)};
+          scale_a = packed2_{static_cast<DTypeQ_>(sf_a_fp8), static_cast<DTypeQ_>(sf_a_fp8)};
+          scale_b = packed2_{static_cast<DTypeQ_>(sf_b_fp8), static_cast<DTypeQ_>(sf_b_fp8)};
+#endif
           *(packed2_*)&b_frag[0] = __hmul2(*(packed2_*)&b_frag[0], scale_a);
           *(packed2_*)&b_frag[1] = __hmul2(*(packed2_*)&b_frag[1], scale_a);
           *(packed2_*)&b_frag[2] = __hmul2(*(packed2_*)&b_frag[2], scale_b);

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -69,6 +69,42 @@ constexpr uint32_t WARP_SIZE = 32;
 // Number of NVFP4 elements sharing one scale factor (UE4M3 byte).
 constexpr uint32_t NVFP4_SF_VEC_SIZE = 16;
 
+/*!
+ * \brief Convert four NVFP4 scale-factor bytes into two packed 16-bit pairs.
+ *
+ * Writes {pack(b0,b1), pack(b2,b3)} -- the two `half2`/`nv_bfloat162` operands that the
+ * per-fragment scale multiply consumes.
+ *
+ * Without a hardware e4m3->f16 convert, `static_cast<T>(__nv_fp8_e4m3)` expands to a software
+ * conversion whose denormal path is a data-dependent `while` loop: a divergent branch per scale
+ * byte, in the innermost loop. Packing the four bytes into one word lets the prmt/lop3 converter
+ * handle them together, branch-free.
+ *
+ * Where the hardware instruction exists we keep `static_cast` so it still lowers to it. The gate is
+ * FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED -- the same one vec_cast<*, __nv_fp8_e4m3> uses -- so
+ * this does not introduce a second, divergent notion of "has FP8 conversion".
+ */
+template <typename DTypeQ>
+__device__ __forceinline__ void nvfp4_sf4_to_packed2x2(uint8_t b0, uint8_t b1, uint8_t b2,
+                                                       uint8_t b3, uint2* out) {
+#if !defined(FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED)
+  uint32_t packed =
+      uint32_t(b0) | (uint32_t(b1) << 8) | (uint32_t(b2) << 16) | (uint32_t(b3) << 24);
+  fast_dequant_f8f16x4<__nv_fp8_e4m3, DTypeQ>(&packed, out);
+#else
+  using packed2 = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
+  __nv_fp8_e4m3 f0, f1, f2, f3;
+  f0.__x = b0;
+  f1.__x = b1;
+  f2.__x = b2;
+  f3.__x = b3;
+  packed2 lo{static_cast<DTypeQ>(f0), static_cast<DTypeQ>(f1)};
+  packed2 hi{static_cast<DTypeQ>(f2), static_cast<DTypeQ>(f3)};
+  out->x = *reinterpret_cast<uint32_t*>(&lo);
+  out->y = *reinterpret_cast<uint32_t*>(&hi);
+#endif
+}
+
 constexpr uint32_t get_num_warps_q(const uint32_t cta_tile_q) {
   if (cta_tile_q == 32) {
     return 1;  // HEAD_DIM_VO >= 512
@@ -1228,25 +1264,14 @@ __device__ __forceinline__ void compute_qk(
           using packed2_ = std::conditional_t<std::is_same_v<DTypeQ_, half>, half2, __nv_bfloat162>;
           constexpr uint32_t SF_COLS_K = KTraits::NUM_MMA_D_QK;  // HEAD_DIM_QK / 16
           uint32_t sf_base = (mma_kv * 16 + lane_idx / 4) * SF_COLS_K + mma_d;
-          packed2_ scale_a, scale_b;
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ < 1000
-          // Pre-SM100 has no hardware e4m3->f16 convert, so `static_cast` below expands to a
-          // software conversion *per scale byte, per fragment*. Pack both bytes duplicated into one
-          // word and reuse the prmt/lop3 converter already used on the V side, which handles four
-          // at once: {a,a,b,b} -> {half2(a,a), half2(b,b)} == {scale_a, scale_b}.
-          uint32_t sf_pack = __byte_perm(uint32_t(k_sf_smem[sf_base]),
-                                        uint32_t(k_sf_smem[sf_base + 8 * SF_COLS_K]), 0x4400u);
+          // b_frag[0,1] share KV row t/4 and b_frag[2,3] share row t/4+8, so each row's scale is
+          // duplicated across its half2: {a,a,b,b} -> {scale_a, scale_b}.
+          const uint8_t sf_a = k_sf_smem[sf_base];
+          const uint8_t sf_b = k_sf_smem[sf_base + 8 * SF_COLS_K];
           uint2 sf_pair;
-          fast_dequant_f8f16x4<__nv_fp8_e4m3, DTypeQ_>(&sf_pack, &sf_pair);
-          scale_a = *(packed2_*)&sf_pair.x;
-          scale_b = *(packed2_*)&sf_pair.y;
-#else
-          __nv_fp8_e4m3 sf_a_fp8, sf_b_fp8;
-          sf_a_fp8.__x = k_sf_smem[sf_base];
-          sf_b_fp8.__x = k_sf_smem[sf_base + 8 * SF_COLS_K];
-          scale_a = packed2_{static_cast<DTypeQ_>(sf_a_fp8), static_cast<DTypeQ_>(sf_a_fp8)};
-          scale_b = packed2_{static_cast<DTypeQ_>(sf_b_fp8), static_cast<DTypeQ_>(sf_b_fp8)};
-#endif
+          nvfp4_sf4_to_packed2x2<DTypeQ_>(sf_a, sf_a, sf_b, sf_b, &sf_pair);
+          const packed2_ scale_a = *(packed2_*)&sf_pair.x;
+          const packed2_ scale_b = *(packed2_*)&sf_pair.y;
           *(packed2_*)&b_frag[0] = __hmul2(*(packed2_*)&b_frag[0], scale_a);
           *(packed2_*)&b_frag[1] = __hmul2(*(packed2_*)&b_frag[1], scale_a);
           *(packed2_*)&b_frag[2] = __hmul2(*(packed2_*)&b_frag[2], scale_b);
@@ -1316,11 +1341,12 @@ __device__ __forceinline__ void load_fp4_k_frag_scaled(smem_t<KTraits::SWIZZLE_M
   using packed2 = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
   constexpr uint32_t SF_COLS_K = KTraits::NUM_MMA_D_QK;
   const uint32_t sf_base = (mma_kv * 16 + lane_idx / 4) * SF_COLS_K + mma_d;
-  __nv_fp8_e4m3 sf_a_fp8, sf_b_fp8;
-  sf_a_fp8.__x = k_sf_smem[sf_base];
-  sf_b_fp8.__x = k_sf_smem[sf_base + 8 * SF_COLS_K];
-  packed2 scale_a{static_cast<DTypeQ>(sf_a_fp8), static_cast<DTypeQ>(sf_a_fp8)};
-  packed2 scale_b{static_cast<DTypeQ>(sf_b_fp8), static_cast<DTypeQ>(sf_b_fp8)};
+  const uint8_t sf_a = k_sf_smem[sf_base];
+  const uint8_t sf_b = k_sf_smem[sf_base + 8 * SF_COLS_K];
+  uint2 sf_pair;
+  nvfp4_sf4_to_packed2x2<DTypeQ>(sf_a, sf_a, sf_b, sf_b, &sf_pair);
+  const packed2 scale_a = *(packed2*)&sf_pair.x;
+  const packed2 scale_b = *(packed2*)&sf_pair.y;
   *(packed2*)&b_frag[0] = __hmul2(*(packed2*)&b_frag[0], scale_a);
   *(packed2*)&b_frag[1] = __hmul2(*(packed2*)&b_frag[1], scale_a);
   *(packed2*)&b_frag[2] = __hmul2(*(packed2*)&b_frag[2], scale_b);
@@ -1776,13 +1802,12 @@ __device__ __forceinline__ void compute_sfm_v(
                 std::conditional_t<std::is_same_v<DTypeQ_, half>, half2, __nv_bfloat162>;
             constexpr uint32_t SF_COLS_V = KTraits::NUM_MMA_D_VO;  // HEAD_DIM_VO / 16
             uint32_t sf_base = (mma_kv * 16 + 2 * (lane_idx % 4)) * SF_COLS_V + mma_d;
-            __nv_fp8_e4m3 sf0_fp8, sf1_fp8, sf2_fp8, sf3_fp8;
-            sf0_fp8.__x = v_sf_smem[sf_base];
-            sf1_fp8.__x = v_sf_smem[sf_base + SF_COLS_V];
-            sf2_fp8.__x = v_sf_smem[sf_base + 8 * SF_COLS_V];
-            sf3_fp8.__x = v_sf_smem[sf_base + 9 * SF_COLS_V];
-            packed2_ scale_lo{static_cast<DTypeQ_>(sf0_fp8), static_cast<DTypeQ_>(sf1_fp8)};
-            packed2_ scale_hi{static_cast<DTypeQ_>(sf2_fp8), static_cast<DTypeQ_>(sf3_fp8)};
+            uint2 sf_pair;
+            nvfp4_sf4_to_packed2x2<DTypeQ_>(v_sf_smem[sf_base], v_sf_smem[sf_base + SF_COLS_V],
+                                            v_sf_smem[sf_base + 8 * SF_COLS_V],
+                                            v_sf_smem[sf_base + 9 * SF_COLS_V], &sf_pair);
+            const packed2_ scale_lo = *(packed2_*)&sf_pair.x;
+            const packed2_ scale_hi = *(packed2_*)&sf_pair.y;
             *(packed2_*)&b_frag[0] = __hmul2(*(packed2_*)&b_frag[0], scale_lo);
             *(packed2_*)&b_frag[1] = __hmul2(*(packed2_*)&b_frag[1], scale_hi);
             *(packed2_*)&b_frag[2] = __hmul2(*(packed2_*)&b_frag[2], scale_lo);
@@ -3455,13 +3480,13 @@ __device__ __forceinline__ void vosplit_compute_pv(
             } else {
               constexpr uint32_t SF_COLS_V = KTraits::NUM_MMA_D_VO;
               const uint32_t sf_base = (mma_kv * 16 + 2 * (lane_idx % 4)) * SF_COLS_V + global_d;
-              __nv_fp8_e4m3 sf0_fp8, sf1_fp8, sf2_fp8, sf3_fp8;
-              sf0_fp8.__x = smem_storage->v_sf_smem_ptr()[sf_base];
-              sf1_fp8.__x = smem_storage->v_sf_smem_ptr()[sf_base + SF_COLS_V];
-              sf2_fp8.__x = smem_storage->v_sf_smem_ptr()[sf_base + 8 * SF_COLS_V];
-              sf3_fp8.__x = smem_storage->v_sf_smem_ptr()[sf_base + 9 * SF_COLS_V];
-              packed2 scale_lo{static_cast<DTypeQ>(sf0_fp8), static_cast<DTypeQ>(sf1_fp8)};
-              packed2 scale_hi{static_cast<DTypeQ>(sf2_fp8), static_cast<DTypeQ>(sf3_fp8)};
+              const uint8_t* vsf = smem_storage->v_sf_smem_ptr();
+              uint2 sf_pair;
+              nvfp4_sf4_to_packed2x2<DTypeQ>(vsf[sf_base], vsf[sf_base + SF_COLS_V],
+                                             vsf[sf_base + 8 * SF_COLS_V],
+                                             vsf[sf_base + 9 * SF_COLS_V], &sf_pair);
+              const packed2 scale_lo = *(packed2*)&sf_pair.x;
+              const packed2 scale_hi = *(packed2*)&sf_pair.y;
               *(packed2*)&b_frag[0] = __hmul2(*(packed2*)&b_frag[0], scale_lo);
               *(packed2*)&b_frag[1] = __hmul2(*(packed2*)&b_frag[1], scale_hi);
               *(packed2*)&b_frag[2] = __hmul2(*(packed2*)&b_frag[2], scale_lo);

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -442,6 +442,41 @@ struct vec_cast<half, __nv_fp4x2_e2m1> {
       reinterpret_cast<uint32_t*>(dst)[i] = y;
     }
 #else
+#if defined(__CUDA_ARCH__)
+    // Fast path for arch < SM100: pure-ALU table lookup through `prmt`.
+    // The FP16 encodings of the eight E2M1 magnitudes {0,0.5,1,1.5,2,3,4,6} all have a zero low
+    // byte, so the whole magnitude table fits in the 8 bytes a single `prmt` can index and the
+    // conversion stays in registers. The `uint16_t lut[16]` array below instead lands in local
+    // memory: one dependent LDL per element, plus a 32-byte stack frame in every kernel that
+    // inlines this.
+    if constexpr (vec_size % 8 == 0) {
+      constexpr uint32_t kHi0 = 0x3E3C3800u;  // high bytes of +{0.0, 0.5, 1.0, 1.5}
+      constexpr uint32_t kHi1 = 0x46444240u;  // high bytes of +{2.0, 3.0, 4.0, 6.0}
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 8; ++i) {
+        const uint32_t* s = reinterpret_cast<const uint32_t*>(src) + i * 2;
+        // Payload bytes sit at stride 2; gather them into eight nibbles (nibble j == value j).
+        const uint32_t packed = __byte_perm(s[0], s[1], 0x6420u);
+        const uint32_t mag = packed & 0x77777777u;
+        const uint32_t sgn = packed & 0x88888888u;
+        uint32_t hi_a = __byte_perm(kHi0, kHi1, mag);        // magnitudes of values 0..3
+        uint32_t hi_b = __byte_perm(kHi0, kHi1, mag >> 16);  // magnitudes of values 4..7
+        // Move sign bit(4j+3) to the msb of byte j.
+        const uint32_t sa = sgn, sb = sgn >> 16;
+        hi_a |= ((sa & 0x8u) << 4) | ((sa & 0x80u) << 8) | ((sa & 0x800u) << 12) |
+                ((sa & 0x8000u) << 16);
+        hi_b |= ((sb & 0x8u) << 4) | ((sb & 0x80u) << 8) | ((sb & 0x800u) << 12) |
+                ((sb & 0x8000u) << 16);
+        // Expand each byte into a half whose low byte is zero.
+        uint32_t* d = reinterpret_cast<uint32_t*>(dst) + i * 4;
+        d[0] = __byte_perm(hi_a, 0u, 0x1404u);
+        d[1] = __byte_perm(hi_a, 0u, 0x3424u);
+        d[2] = __byte_perm(hi_b, 0u, 0x1404u);
+        d[3] = __byte_perm(hi_b, 0u, 0x3424u);
+      }
+      return;
+    }
+#endif
     // Software LUT fallback for arch < SM100.
     // e2m1 encoding: bit[3]=sign, bit[2:0]=magnitude index in {0,0.5,1,1.5,2,3,4,6}.
     // Each packed byte holds two fp4 values: bits[3:0]=first, bits[7:4]=second.
@@ -550,6 +585,42 @@ struct vec_cast<nv_bfloat16, __nv_fp4x2_e2m1> {
       reinterpret_cast<uint32_t*>(dst)[i] = y;
     }
 #else
+#if defined(__CUDA_ARCH__)
+    // Fast path for arch < SM100: pure-ALU table lookup through `prmt`. Unlike FP16, the BF16
+    // encodings of the E2M1 magnitudes have a varying low byte, so two 8-byte tables are indexed
+    // and then interleaved. Still register-only; see the FP16 specialization for why the
+    // `uint16_t lut[16]` array below is expensive.
+    if constexpr (vec_size % 8 == 0) {
+      constexpr uint32_t kHi0 = 0x3F3F3F00u;  // high bytes of +{0.0, 0.5, 1.0, 1.5}
+      constexpr uint32_t kHi1 = 0x40404040u;  // high bytes of +{2.0, 3.0, 4.0, 6.0}
+      constexpr uint32_t kLo0 = 0xC0800000u;  // low  bytes of +{0.0, 0.5, 1.0, 1.5}
+      constexpr uint32_t kLo1 = 0xC0804000u;  // low  bytes of +{2.0, 3.0, 4.0, 6.0}
+#pragma unroll
+      for (size_t i = 0; i < vec_size / 8; ++i) {
+        const uint32_t* s = reinterpret_cast<const uint32_t*>(src) + i * 2;
+        const uint32_t packed = __byte_perm(s[0], s[1], 0x6420u);
+        const uint32_t mag = packed & 0x77777777u;
+        const uint32_t sgn = packed & 0x88888888u;
+        const uint32_t mag_a = mag, mag_b = mag >> 16;
+        uint32_t hi_a = __byte_perm(kHi0, kHi1, mag_a);
+        uint32_t hi_b = __byte_perm(kHi0, kHi1, mag_b);
+        const uint32_t lo_a = __byte_perm(kLo0, kLo1, mag_a);
+        const uint32_t lo_b = __byte_perm(kLo0, kLo1, mag_b);
+        const uint32_t sa = sgn, sb = sgn >> 16;
+        hi_a |= ((sa & 0x8u) << 4) | ((sa & 0x80u) << 8) | ((sa & 0x800u) << 12) |
+                ((sa & 0x8000u) << 16);
+        hi_b |= ((sb & 0x8u) << 4) | ((sb & 0x80u) << 8) | ((sb & 0x800u) << 12) |
+                ((sb & 0x8000u) << 16);
+        // Interleave {low, high} byte pairs into bf16 lanes.
+        uint32_t* d = reinterpret_cast<uint32_t*>(dst) + i * 4;
+        d[0] = __byte_perm(lo_a, hi_a, 0x5140u);
+        d[1] = __byte_perm(lo_a, hi_a, 0x7362u);
+        d[2] = __byte_perm(lo_b, hi_b, 0x5140u);
+        d[3] = __byte_perm(lo_b, hi_b, 0x7362u);
+      }
+      return;
+    }
+#endif
     // Software LUT fallback for arch < SM100.
     // e2m1 encoding: bit[3]=sign, bit[2:0]=magnitude index in {0,0.5,1,1.5,2,3,4,6}.
     // Each packed byte holds two fp4 values: bits[3:0]=first, bits[7:4]=second.

--- a/include/flashinfer/vec_dtypes.cuh
+++ b/include/flashinfer/vec_dtypes.cuh
@@ -414,7 +414,82 @@ struct vec_cast<half, __nv_fp8_e5m2> {
   }
 };
 
+// E2M1 nibble decoding helpers. These are plain integer and 16-bit bit manipulation with no
+// FP4 type in their signatures, so they sit outside the FP4 feature guard below: the tile
+// repack in attention/prefill.cuh names them from a template whose FP4 branch is discarded,
+// not removed, and would otherwise fail to compile in builds without FP4 enabled.
+// `prmt` with the msb of a selector nibble set replicates the sign (msb) of the selected byte
+// across the whole output byte, giving 0x00 or 0xFF. `__byte_perm` discards that bit, so the
+// E2M1 sign spread below has to reach for the PTX instruction directly.
+__device__ __forceinline__ uint32_t prmt_b32(uint32_t a, uint32_t b, uint32_t sel) {
+  uint32_t r;
+  asm("prmt.b32 %0, %1, %2, %3;" : "=r"(r) : "r"(a), "r"(b), "r"(sel));
+  return r;
+}
+
+// Spread the four E2M1 sign bits of `packed`'s low/high half into byte msbs.
+//
+// `packed` holds eight fp4 values as eight nibbles; byte j carries value 2j in bits[3:0] and
+// value 2j+1 in bits[7:4], so bit 3 of byte j is an even value's sign and bit 7 is an odd
+// value's sign. Byte j's msb is therefore already the odd sign, and `packed << 4` puts the even
+// sign in the same place. One sign-replicating `prmt` then gathers the four signs in value order
+// as 0x00/0xFF bytes; the caller masks to 0x80 and merges, which `lop3` folds into one
+// instruction. Selector 0xD9C8 covers values 0..3, 0xFBEA covers values 4..7.
+__device__ __forceinline__ uint32_t e2m1_sign_bytes(uint32_t packed, uint32_t sel) {
+  return prmt_b32(packed << 4, packed, sel) & 0x80808080u;
+}
+
+// Dequantize eight E2M1 values, held as the eight nibbles of `packed` in value order, into four
+// packed 16-bit pairs. Pure ALU, register-only: the magnitude table is indexed by `prmt`.
+//
+// FP16: all eight E2M1 magnitudes {0,0.5,1,1.5,2,3,4,6} encode with a zero low byte, so the whole
+// table is eight high bytes -- exactly one `prmt` source window -- and the expansion just inserts
+// zero low bytes. BF16 magnitudes have varying low bytes, so two tables are indexed and the
+// {low, high} byte pairs are interleaved instead.
+__device__ __forceinline__ void e2m1x8_to_f16x8(uint32_t packed, uint32_t* d) {
+  constexpr uint32_t kHi0 = 0x3E3C3800u;  // high bytes of +{0.0, 0.5, 1.0, 1.5}
+  constexpr uint32_t kHi1 = 0x46444240u;  // high bytes of +{2.0, 3.0, 4.0, 6.0}
+  const uint32_t mag = packed & 0x77777777u;
+  uint32_t hi_a = __byte_perm(kHi0, kHi1, mag);        // magnitudes of values 0..3
+  uint32_t hi_b = __byte_perm(kHi0, kHi1, mag >> 16);  // magnitudes of values 4..7
+  hi_a |= e2m1_sign_bytes(packed, 0xD9C8u);
+  hi_b |= e2m1_sign_bytes(packed, 0xFBEAu);
+  d[0] = __byte_perm(hi_a, 0u, 0x1404u);
+  d[1] = __byte_perm(hi_a, 0u, 0x3424u);
+  d[2] = __byte_perm(hi_b, 0u, 0x1404u);
+  d[3] = __byte_perm(hi_b, 0u, 0x3424u);
+}
+
+__device__ __forceinline__ void e2m1x8_to_bf16x8(uint32_t packed, uint32_t* d) {
+  constexpr uint32_t kHi0 = 0x3F3F3F00u;  // high bytes of +{0.0, 0.5, 1.0, 1.5}
+  constexpr uint32_t kHi1 = 0x40404040u;  // high bytes of +{2.0, 3.0, 4.0, 6.0}
+  constexpr uint32_t kLo0 = 0xC0800000u;  // low  bytes of +{0.0, 0.5, 1.0, 1.5}
+  constexpr uint32_t kLo1 = 0xC0804000u;  // low  bytes of +{2.0, 3.0, 4.0, 6.0}
+  const uint32_t mag = packed & 0x77777777u;
+  const uint32_t mag_a = mag, mag_b = mag >> 16;
+  uint32_t hi_a = __byte_perm(kHi0, kHi1, mag_a);
+  uint32_t hi_b = __byte_perm(kHi0, kHi1, mag_b);
+  const uint32_t lo_a = __byte_perm(kLo0, kLo1, mag_a);
+  const uint32_t lo_b = __byte_perm(kLo0, kLo1, mag_b);
+  hi_a |= e2m1_sign_bytes(packed, 0xD9C8u);
+  hi_b |= e2m1_sign_bytes(packed, 0xFBEAu);
+  d[0] = __byte_perm(lo_a, hi_a, 0x5140u);
+  d[1] = __byte_perm(lo_a, hi_a, 0x7362u);
+  d[2] = __byte_perm(lo_b, hi_b, 0x5140u);
+  d[3] = __byte_perm(lo_b, hi_b, 0x7362u);
+}
+
+template <typename DType16>
+__device__ __forceinline__ void e2m1x8_to_16bx8(uint32_t packed, uint32_t* d) {
+  if constexpr (std::is_same_v<DType16, half>) {
+    e2m1x8_to_f16x8(packed, d);
+  } else {
+    e2m1x8_to_bf16x8(packed, d);
+  }
+}
+
 #if defined(FLASHINFER_ENABLE_FP4_E2M1) && CUDA_VERSION >= 12080
+
 // Convert __nv_fp4x2_e2m1 (2 fp4 values per byte) to fp16.
 // vec_size counts fp16 output elements; src has stride-2 layout:
 //   src[0] holds x0,x1  src[1] is padding
@@ -450,29 +525,11 @@ struct vec_cast<half, __nv_fp4x2_e2m1> {
     // memory: one dependent LDL per element, plus a 32-byte stack frame in every kernel that
     // inlines this.
     if constexpr (vec_size % 8 == 0) {
-      constexpr uint32_t kHi0 = 0x3E3C3800u;  // high bytes of +{0.0, 0.5, 1.0, 1.5}
-      constexpr uint32_t kHi1 = 0x46444240u;  // high bytes of +{2.0, 3.0, 4.0, 6.0}
 #pragma unroll
       for (size_t i = 0; i < vec_size / 8; ++i) {
         const uint32_t* s = reinterpret_cast<const uint32_t*>(src) + i * 2;
         // Payload bytes sit at stride 2; gather them into eight nibbles (nibble j == value j).
-        const uint32_t packed = __byte_perm(s[0], s[1], 0x6420u);
-        const uint32_t mag = packed & 0x77777777u;
-        const uint32_t sgn = packed & 0x88888888u;
-        uint32_t hi_a = __byte_perm(kHi0, kHi1, mag);        // magnitudes of values 0..3
-        uint32_t hi_b = __byte_perm(kHi0, kHi1, mag >> 16);  // magnitudes of values 4..7
-        // Move sign bit(4j+3) to the msb of byte j.
-        const uint32_t sa = sgn, sb = sgn >> 16;
-        hi_a |= ((sa & 0x8u) << 4) | ((sa & 0x80u) << 8) | ((sa & 0x800u) << 12) |
-                ((sa & 0x8000u) << 16);
-        hi_b |= ((sb & 0x8u) << 4) | ((sb & 0x80u) << 8) | ((sb & 0x800u) << 12) |
-                ((sb & 0x8000u) << 16);
-        // Expand each byte into a half whose low byte is zero.
-        uint32_t* d = reinterpret_cast<uint32_t*>(dst) + i * 4;
-        d[0] = __byte_perm(hi_a, 0u, 0x1404u);
-        d[1] = __byte_perm(hi_a, 0u, 0x3424u);
-        d[2] = __byte_perm(hi_b, 0u, 0x1404u);
-        d[3] = __byte_perm(hi_b, 0u, 0x3424u);
+        e2m1x8_to_f16x8(__byte_perm(s[0], s[1], 0x6420u), reinterpret_cast<uint32_t*>(dst) + i * 4);
       }
       return;
     }
@@ -591,32 +648,11 @@ struct vec_cast<nv_bfloat16, __nv_fp4x2_e2m1> {
     // and then interleaved. Still register-only; see the FP16 specialization for why the
     // `uint16_t lut[16]` array below is expensive.
     if constexpr (vec_size % 8 == 0) {
-      constexpr uint32_t kHi0 = 0x3F3F3F00u;  // high bytes of +{0.0, 0.5, 1.0, 1.5}
-      constexpr uint32_t kHi1 = 0x40404040u;  // high bytes of +{2.0, 3.0, 4.0, 6.0}
-      constexpr uint32_t kLo0 = 0xC0800000u;  // low  bytes of +{0.0, 0.5, 1.0, 1.5}
-      constexpr uint32_t kLo1 = 0xC0804000u;  // low  bytes of +{2.0, 3.0, 4.0, 6.0}
 #pragma unroll
       for (size_t i = 0; i < vec_size / 8; ++i) {
         const uint32_t* s = reinterpret_cast<const uint32_t*>(src) + i * 2;
-        const uint32_t packed = __byte_perm(s[0], s[1], 0x6420u);
-        const uint32_t mag = packed & 0x77777777u;
-        const uint32_t sgn = packed & 0x88888888u;
-        const uint32_t mag_a = mag, mag_b = mag >> 16;
-        uint32_t hi_a = __byte_perm(kHi0, kHi1, mag_a);
-        uint32_t hi_b = __byte_perm(kHi0, kHi1, mag_b);
-        const uint32_t lo_a = __byte_perm(kLo0, kLo1, mag_a);
-        const uint32_t lo_b = __byte_perm(kLo0, kLo1, mag_b);
-        const uint32_t sa = sgn, sb = sgn >> 16;
-        hi_a |= ((sa & 0x8u) << 4) | ((sa & 0x80u) << 8) | ((sa & 0x800u) << 12) |
-                ((sa & 0x8000u) << 16);
-        hi_b |= ((sb & 0x8u) << 4) | ((sb & 0x80u) << 8) | ((sb & 0x800u) << 12) |
-                ((sb & 0x8000u) << 16);
-        // Interleave {low, high} byte pairs into bf16 lanes.
-        uint32_t* d = reinterpret_cast<uint32_t*>(dst) + i * 4;
-        d[0] = __byte_perm(lo_a, hi_a, 0x5140u);
-        d[1] = __byte_perm(lo_a, hi_a, 0x7362u);
-        d[2] = __byte_perm(lo_b, hi_b, 0x5140u);
-        d[3] = __byte_perm(lo_b, hi_b, 0x7362u);
+        e2m1x8_to_bf16x8(__byte_perm(s[0], s[1], 0x6420u),
+                         reinterpret_cast<uint32_t*>(dst) + i * 4);
       }
       return;
     }


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

NVFP4 KV cache works on pre-SM100 but was never performance-tuned there. On sm_80 (head_dim 128, 32/8 heads, page_size 16) NVFP4 KV costs **6.8–8.2x FP8 KV in prefill and 4.4–5.4x in decode**, even though it reads *half* the bytes FP8 does. FP8 KV — which also dequantizes — is essentially free on the same hardware, so the gap is not "quantized KV is slow", it is specific to the FP4 path.

`ncu` says why. At identical shapes the NVFP4 and FP16 kernels have the **same launch config, same occupancy, same MMA instruction count, and the same number of `ldmatrix`**; the only difference is that NVFP4 executes **6.75x more instructions** (249.6M vs 36.97M). DRAM throughput is 0.36% of peak — it is not memory-bound, it is instruction-bound. The extra 212.7M instructions are 30% `LOP3`, 14% `PRMT`, 14% `IMAD`, 8% `SHF` — the bit-manipulation signature of dequantization — plus 13% branch opcodes (`ISETP`/`BRA`/`BSSY`/`BSYNC`), which turned out to be the most actionable part.

#4769 stacks on this PR: its NVFP4 tile repack calls the `e2m1x8_to_f16x8` / `e2m1x8_to_bf16x8` helpers and `nvfp4_sf4_to_packed2x2` added here, so its diff carries these commits until this one lands.

This PR is four changes, each gated to the targets that actually lack the corresponding hardware instruction. All of them produce bit-identical output, with one documented exception in the scale-factor conversion covered under "Known behavioral difference" below.

**1. `vec_dtypes.cuh`: the arch<SM100 `vec_cast<half|nv_bfloat16, __nv_fp4x2_e2m1>` fallback indexed a function-local `constexpr uint16_t lut[16]`.** nvcc puts that array in **local memory**: SASS shows `STL.128` x2 re-storing the table to the thread stack on *every inlined call*, one dependent `LDL.U16` per element, and a 32-byte stack frame in every kernel that inlines it.

Replaced with a register-only `prmt` path. The FP16 encodings of the eight E2M1 magnitudes {0, .5, 1, 1.5, 2, 3, 4, 6} are {0x0000, 0x3800, 0x3C00, 0x3E00, 0x4000, 0x4200, 0x4400, 0x4600} — **every low byte is zero**, so the whole magnitude table is eight distinct high bytes, which is exactly what one `prmt` indexes from its two source registers. BF16 magnitudes have a varying low byte, so that specialization indexes two 8-byte tables and interleaves them. Guarded by `if constexpr (vec_size % 8 == 0)`; every other size keeps the LUT, and SM100+ keeps `cvt.rn.f16x2.e2m1x2`.

Module-wide on the FA2 NVFP4-KV instantiation: **`LDL` 36202 → 128, `STL` 9602 → 190**, kernels with a zero-byte stack frame **0/72 → 54/72**, kernels at the 255-register ceiling **25 → 19**.

**2 + 3. `prefill.cuh`: every per-fragment E4M3 scale byte was converted with `static_cast<DTypeQ>(sf_fp8)`.** Where there is no hardware e4m3→f16 convert — below SM90 — that expands to a software conversion whose denormal path is a data-dependent

```
while ((mantissa & 0x0400U) == 0U) { ... }
```

renormalization loop. `ncu` source correlation put that single loop at the **top of the kernel's branch profile** — a divergent branch per scale byte, in the innermost loop.

Added `nvfp4_sf4_to_packed2x2()`, which packs four scale bytes into one word and hands them to the in-tree `fast_dequant_f8f16x4` (prmt/lop3, branch-free), producing exactly the two `half2`/`nv_bfloat162` operands the scale multiply needs. Applied at all four sites — the K path in `compute_qk`, the K path in `compute_qk_fp4_rope`, and both V paths. The helper is gated on `FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED` — the same macro `vec_cast<*, __nv_fp8_e4m3>` already uses — rather than a separate threshold, so SM90+ keeps `static_cast` and still lowers to the hardware instruction. Verified by SASS: sm_80 emits the `prmt` sequence, sm_90 emits `F2FP.F16.E4M3.UNPACK_B`.

After all three, branch opcodes drop out of the top of the profile entirely and instruction count falls 249.6M → 171.1M.

### 4. Spread the E2M1 signs with one `prmt` instead of a shift chain

The pre-SM100 e2m1 to 16-bit path built each value's sign by moving bit `4j+3` to the msb of byte `j` with four shift/mask/or chains per half of the vector — eight shifts and eight `lop3` per eight values, the largest part of the sequence.

`prmt`'s default mode replicates the sign of the selected byte across the output byte when the msb of a selector nibble is set. Byte `j` of the packed nibbles already carries an odd value's sign in its msb, and `packed << 4` puts the even value's sign in the same place, so one sign-replicating `prmt` gathers four signs in value order as `0x00`/`0xFF` bytes. Masking to `0x80` and merging folds into a single `lop3`. `__byte_perm()` discards the mode bit, so this reaches for the PTX instruction directly.

Per eight values the sequence drops from 25 to 14 instructions (half; bf16 26 to 15). Across the NVFP4 prefill module on sm_80, `cuobjdump` counts 501575 instructions before and 448209 after.

This one is exhaustively checked rather than sampled: all 2^32 four-payload-byte inputs against the plain-LUT reference, for both half and bf16, zero mismatches. The magnitude-table body is also lifted into `e2m1x8_to_f16x8` / `e2m1x8_to_bf16x8` so a caller holding contiguous nibbles can convert without the stride-2 gather `vec_cast` has to do.

### Results

Kernel latency, sm_80, head_dim 128, 32/8 heads, page_size 16, seeded KV, no D2H sync in the timed loop. **FP8 KV is the meaningful yardstick**: it also dequantizes, its dequant is already optimized upstream, and NVFP4 moves half its bytes — so the fair target is <1.0x, not 1.0x.

| case | FP8 KV | NVFP4 before | NVFP4 after | before/FP8 | **after/FP8** |
|---|---|---|---|---|---|
| prefill b1 4096² | 1.866 ms | 12.616 | **4.531** | 6.76x | **2.43x** |
| prefill b4 2048² | 1.489 | 12.157 | **4.427** | 8.17x | **2.97x** |
| prefill b8 1024² | 0.937 | 6.351 | **2.399** | 6.78x | **2.56x** |
| decode b8 kv8192 | 0.172 | 0.921 | **0.295** | 5.36x | **1.72x** |
| decode b32 kv8192 | 0.673 | 3.298 | **1.146** | 4.90x | **1.70x** |
| decode b64 kv8192 40h | 1.544 | 6.815 | **2.347** | 4.41x | **1.52x** |

Speedup over the current NVFP4 path: **prefill 2.65–2.78x, decode 2.88–3.12x**.

**Measurement caveat.** At this commit `_nvfp4_kv_requires_disabled_split_kv()` force-disables split-KV for NVFP4 KV on every architecture, while FP8 KV keeps it. The FP8 column above is therefore *unfair to NVFP4* in the decode rows — NVFP4 is running without flash-decoding and FP8 is not. The before/after columns are unaffected, since both sides carry the same gate. #4747 narrows that gate to the architecture it was found on; NVFP4 decode improves further once it lands.

End-to-end serving numbers are omitted for the same reason: with the gate in place, NVFP4 decode at low batch is up to 3x off its own achievable latency, so an end-to-end table taken here would measure the gate rather than this change.

An isolated microbenchmark of change 1 alone gives 6.82x on the conversion when ALU-bound and 3.69x when streaming from HBM (322 → 1187 GB/s) — the old path could not saturate HBM at all.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed. *(No new tests: every change is an arithmetic-identity replacement, so the existing suite plus a bit-identity check is the stronger assertion. See the head_dim gap below, which is why I did add coverage there manually rather than as a committed test.)*
- [x] All tests are passing — the NVFP4/FP4 selection of the attention and quantization suites on SM80, not the full suite.

```bash
pytest tests/attention/test_batch_prefill_kernels.py \
       tests/attention/test_batch_decode_kernels.py \
       tests/attention/test_single_prefill.py \
       tests/attention/test_batch_attention.py \
       tests/utils/test_fp4_kv_quantization.py -k "nvfp4 or fp4"
# 425 passed, 25 skipped in 1837s
```

**Bit-identity.** Every change replaces an arithmetic expression with an equal one, so the oracle is byte equality against the unpatched build rather than a tolerance. Captured attention output before and after across `head_dim {64,128,256,512}` × `page_size {1,16,64}` × `{NHD,HND}` × `{float16,bfloat16}` × `causal {True,False}`, prefill and decode: **bit-identical everywhere** (`torch.equal` true, max abs diff 0). The one exception is `page_size=1`, which is **already non-deterministic upstream** — two runs of the *same* build differ by up to 7.3e-1 — so it cannot be compared this way in either direction.

The `prmt` conversion tables were also verified exhaustively in isolation: all 16 nibble values × 8 fragment positions against the previous LUT, both dtypes, on sm_80 hardware — 0 mismatches.

## Reviewer Notes

**Known behavioral difference, pre-existing, not introduced here.** `fast_dequant_f8f16x4` is not bit-equivalent to `static_cast<DTypeQ>(__nv_fp8_e4m3)` on the two E4M3 NaN encodings:

| byte | fast path (FP16) | fast path (BF16) | `static_cast` |
|---|---|---|---|
| `0x7F` | `0x5F80` = +480 | `0x43F0` = +480 | `0x7FFF` NaN |
| `0xFF` | `0xDF80` = −480 | `0xC3F0` = −480 | `0x7FFF` NaN |

The other 254 byte values are bit-identical, including every E4M3 denormal, ±0, and all finite negatives. This is a property of `fast_dequant_f8f16x4` itself, which the `USE_VEC_V_SCALE` path already used before this PR — so the behavior is not new, but this PR does extend it to the other four sites. The in-tree append quantizer never emits a NaN scale; an externally supplied `kv_cache_sf` tensor is not validated, so it is reachable in principle. Making it exact would put a `(byte & 0x7F) == 0x7F` test back into the innermost loop — i.e. re-introduce the branch this PR removes — so I left it and am flagging it instead. Fixing `fast_dequant_f8f16x4` itself would be a separate change affecting the whole FP8 KV path.

**Why the scale multiply still scales K rather than the accumulator.** Hoisting the per-block scale onto the MMA accumulator looks attractive (it is what SM100 block-scaled MMA does in hardware) but is *worse* at this geometry: for `m16n8` a thread holds 8 halves of `b_frag` (4 `__hmul2`) versus 8 accumulator floats (8 `FFMA`), and the K fragment is reused across every `mma_q`. The existing arrangement is already the cheaper side, so it is unchanged.

What I verified and what I did not: I have sm_80 hardware, so every runtime result above is sm_80. The arch split was checked by compilation and SASS rather than execution — sm_80 emits the `prmt` sequence, sm_90 emits `F2FP.F16.E4M3.UNPACK_B`, and a host pass plus `sm_100a` compile both succeed — but I have not run sm_86, sm_89, sm_90 or SM100 at runtime. Change 1 takes the `prmt` path on every target below SM100, so sm_86/89/90 exercise code I could not execute; changes 2 and 3 leave SM90+ on `static_cast`, so those targets keep the current behavior by construction. Hopper coverage in particular would be worth a second pair of eyes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved NVFP4 scale-factor dequantization during attention processing.
  * Added faster FP4-to-FP16 and FP4-to-BF16 conversion paths on supported CUDA hardware.
  * Reduced conversion overhead for FP4 attention and vector operations while preserving existing behavior and fallback support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



