### PR TITLE
fix(attention): scope the NVFP4 split-KV workaround to the arch it was found on

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -36,6 +36,7 @@ from .jit import (
     get_single_prefill_uri,
     setup_cubin_loader,
 )
+from .jit.attention.utils import _is_nvfp4_kv_dtype
 from .page import get_seq_lens
 from .quantization import packbits, segment_packbits
 from .trace.templates.attention import (
@@ -1510,16 +1511,9 @@ def _compute_page_mask_indptr(
     return mask_indptr
 
 
-def _is_nvfp4_kv_dtype(kv_data_type: torch.dtype) -> bool:
-    """Whether ``kv_data_type`` denotes an NVFP4 KV cache."""
-    if kv_data_type == torch.uint8:  # packed NVFP4 (the run path's convention)
-        return True
-    native_fp4 = getattr(torch, "float4_e2m1fn_x2", None)
-    return native_fp4 is not None and kv_data_type == native_fp4
-
-
 # Architectures on which the NVFP4 split-KV corruption was actually observed. Keep this as narrow
-# as the evidence: every target added here loses up to 3x on low-batch decode.
+# as the evidence: every target added here pays the gate on low-batch decode. Measured on SM90 at
+# batch 1, qo_len 1, head_dim 128, page_size 16, bf16: 3.98x at kv_len 8192, 8.14x at kv_len 32768.
 _NVFP4_SPLIT_KV_BROKEN_ARCHS = ((12, 0), (12, 1))
 
 
@@ -1545,9 +1539,12 @@ def _nvfp4_kv_requires_disabled_split_kv(
     asymmetric VO-split NVFP4 paged prefill path added for those targets, so
     the gate is scoped to them. Pre-SM100 has no native FP4 conversion, so
     every such target runs the same generic 1-byte-KV FA2 path; on that path
-    split-KV yields output indistinguishable from the gated result while being
-    up to 3x faster at low batch. FP8 and 16-bit KV caches were never gated and
-    keep split-KV everywhere.
+    split-KV yields output indistinguishable from the gated result. Review
+    reproduced that on SM90 as well, over symmetric ``head_dim`` 128, the
+    asymmetric 512/256 path and a needle retrieval swept across split
+    boundaries, with the gate-on/gate-off difference staying at output-dtype
+    rounding scale. FP8 and 16-bit KV caches were never gated and keep split-KV
+    everywhere.
     """
     if not _is_nvfp4_kv_dtype(kv_data_type):
         return False

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1510,29 +1510,48 @@ def _compute_page_mask_indptr(
     return mask_indptr
 
 
-def _nvfp4_kv_requires_disabled_split_kv(kv_data_type: torch.dtype) -> bool:
-    """Whether split-KV must be disabled because the KV cache is NVFP4.
+def _is_nvfp4_kv_dtype(kv_data_type: torch.dtype) -> bool:
+    """Whether ``kv_data_type`` denotes an NVFP4 KV cache."""
+    if kv_data_type == torch.uint8:  # packed NVFP4 (the run path's convention)
+        return True
+    native_fp4 = getattr(torch, "float4_e2m1fn_x2", None)
+    return native_fp4 is not None and kv_data_type == native_fp4
+
+
+# Architectures on which the NVFP4 split-KV corruption was actually observed. Keep this as narrow
+# as the evidence: every target added here loses up to 3x on low-batch decode.
+_NVFP4_SPLIT_KV_BROKEN_ARCHS = ((12, 0), (12, 1))
+
+
+def _nvfp4_kv_requires_disabled_split_kv(
+    kv_data_type: torch.dtype, device: torch.device
+) -> bool:
+    """Whether split-KV must be disabled because the KV cache is NVFP4 on an affected arch.
 
     This gate is an *empirical workaround*: with split-KV (flash-decoding)
     enabled, NVFP4 paged KV was observed to produce corrupted outputs whenever
     a short query attends a long KV range (``qo_len << kv_len``, i.e. decode
     and prefix-cache extend), while dense full-prefill was unaffected.
-    Disabling split-KV removes the corruption, and decode-throughput
-    measurements showed no cost from the gate.
+    Disabling split-KV removes the corruption.
 
     The root cause has not been confirmed. The FP8 scale-factor blocks
     themselves cannot be the mechanism: NVFP4 scales group 16 consecutive
     *head-dim* elements of a single token, whereas split-KV partitions the
     *token* axis, so a split boundary never slices a scale block. The current
     hypothesis (unconfirmed) is that the small per-split KV chunks interact
-    badly with the ``NUM_MMA_KV`` tile floor of the 1-byte-KV FA2 path. Until
-    the failure is root-caused and fixed, force split-KV off for NVFP4 KV.
-    FP8 and 16-bit KV caches are unaffected and keep split-KV.
+    badly with the ``NUM_MMA_KV`` tile floor of the 1-byte-KV FA2 path.
+
+    The corruption was only ever reported on SM120/121, alongside the
+    asymmetric VO-split NVFP4 paged prefill path added for those targets, so
+    the gate is scoped to them. Pre-SM100 has no native FP4 conversion, so
+    every such target runs the same generic 1-byte-KV FA2 path; on that path
+    split-KV yields output indistinguishable from the gated result while being
+    up to 3x faster at low batch. FP8 and 16-bit KV caches were never gated and
+    keep split-KV everywhere.
     """
-    if kv_data_type == torch.uint8:  # packed NVFP4 (the run path's convention)
-        return True
-    native_fp4 = getattr(torch, "float4_e2m1fn_x2", None)
-    return native_fp4 is not None and kv_data_type == native_fp4
+    if not _is_nvfp4_kv_dtype(kv_data_type):
+        return False
+    return get_compute_capability(device) in _NVFP4_SPLIT_KV_BROKEN_ARCHS
 
 
 class BatchPrefillWithPagedKVCacheWrapper:
@@ -2596,7 +2615,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             if self._backend == "fa2":
                 args.append(fixed_split_size or -1)  # fixed_split_size
                 if not disable_split_kv and _nvfp4_kv_requires_disabled_split_kv(
-                    kv_data_type
+                    kv_data_type, self.device
                 ):
                     # Empirical workaround: split-KV corrupted NVFP4 KV reads
                     # when qo_len << kv_len (decode / prefix-cache extend); see
@@ -3915,7 +3934,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             if self._backend == "fa2":
                 args.append(fixed_split_size or -1)  # fixed_split_size
                 if not disable_split_kv and _nvfp4_kv_requires_disabled_split_kv(
-                    kv_data_type
+                    kv_data_type, self.device
                 ):
                     # Empirical workaround: split-KV corrupted NVFP4 KV reads
                     # when qo_len << kv_len (decode / prefix-cache extend); see

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -780,28 +780,76 @@ def test_nvfp4_attention_sm120_unpadded_k_len_masks_tail_garbage():
 
 
 def test_nvfp4_split_kv_gate_dtype_logic():
-    """The split-KV gate must fire for NVFP4 KV and only for NVFP4 KV.
+    """The split-KV gate's dtype classification must accept NVFP4 KV and only NVFP4 KV.
 
     Split-KV was empirically observed to corrupt NVFP4 KV reads when a short
     query attends a long KV range (decode / prefix-cache extend), so plan()
-    force-disables split-KV when the KV cache is NVFP4 as a workaround (see
-    _nvfp4_kv_requires_disabled_split_kv for the state of the root-cause
-    analysis). FP8 / 16-bit KV are unaffected and must keep split-KV. This is
-    a pure dtype-classification check (no GPU required) guarding that contract.
+    force-disables split-KV for NVFP4 KV on the affected architectures as a
+    workaround (see _nvfp4_kv_requires_disabled_split_kv for the state of the
+    root-cause analysis). FP8 / 16-bit KV are unaffected and must keep split-KV.
+    This is a pure dtype-classification check (no GPU required) guarding that
+    half of the contract; the architecture scoping is covered by
+    test_nvfp4_split_kv_gate_arch_scope.
     """
-    from flashinfer.prefill import _nvfp4_kv_requires_disabled_split_kv
+    from flashinfer.jit.attention.utils import _is_nvfp4_kv_dtype
 
-    # packed NVFP4 (uint8 is the run-path convention) and native fp4 -> gated
-    assert _nvfp4_kv_requires_disabled_split_kv(torch.uint8)
+    # packed NVFP4 (uint8 is the run-path convention) and native fp4 -> NVFP4 KV
+    assert _is_nvfp4_kv_dtype(torch.uint8)
     native_fp4 = getattr(torch, "float4_e2m1fn_x2", None)
     if native_fp4 is not None:
-        assert _nvfp4_kv_requires_disabled_split_kv(native_fp4)
+        assert _is_nvfp4_kv_dtype(native_fp4)
 
-    # 16-bit and FP8 KV split-KV is fine -> not gated
+    # 16-bit and FP8 KV split-KV is fine -> never NVFP4 KV
     for dtype in (
         torch.float16,
         torch.bfloat16,
         torch.float8_e4m3fn,
         torch.float8_e5m2,
     ):
-        assert not _nvfp4_kv_requires_disabled_split_kv(dtype)
+        assert not _is_nvfp4_kv_dtype(dtype)
+
+
+def test_nvfp4_split_kv_gate_arch_scope(monkeypatch):
+    """The gate must fire only on the architectures the corruption was seen on.
+
+    SM120/121 stay gated; every other target keeps split-KV, at the low-batch
+    decode saving quantified in the comment above
+    _NVFP4_SPLIT_KV_BROKEN_ARCHS. The compute capability is faked, so this runs
+    without a GPU.
+    """
+    from flashinfer import prefill
+
+    device = torch.device("cuda:0")
+
+    def gated_at(compute_capability):
+        monkeypatch.setattr(
+            prefill, "get_compute_capability", lambda _device: compute_capability
+        )
+        return prefill._nvfp4_kv_requires_disabled_split_kv(torch.uint8, device)
+
+    for compute_capability in ((12, 0), (12, 1)):
+        assert gated_at(compute_capability)
+    for compute_capability in (
+        (8, 0),
+        (8, 9),
+        (9, 0),
+        (10, 0),
+        (10, 3),
+        (10, 7),
+        (11, 0),
+    ):
+        assert not gated_at(compute_capability)
+
+    # A non-NVFP4 KV cache is never gated, and must not cost an architecture
+    # query to establish that: the dtype test comes first for every plan() call.
+    def _unexpected_query(_device):
+        raise AssertionError("architecture queried for a non-NVFP4 KV cache")
+
+    monkeypatch.setattr(prefill, "get_compute_capability", _unexpected_query)
+    for dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float8_e4m3fn,
+        torch.float8_e5m2,
+    ):
+        assert not prefill._nvfp4_kv_requires_disabled_split_kv(dtype, device)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`_nvfp4_kv_requires_disabled_split_kv()` force-disables split-KV (flash-decoding) for **every** NVFP4 KV cache on **every** architecture. The corruption it works around was reported only on SM120/121 — in `8f9ad200`, alongside the asymmetric VO-split NVFP4 paged prefill path added for those targets — but the predicate looks only at `kv_data_type`, so it also disables flash-decoding on pre-SM100, which never had the problem and never had the gate before that commit.

This PR scopes the predicate to the compute capabilities the failure was actually observed on.

Pre-SM100 has no native FP4 conversion, so every such target runs the same generic 1-byte-KV FA2 path — the one the gate's own hypothesis points at (`NUM_MMA_KV` tile floor). On sm_80 that path does not reproduce the corruption, and the gate is expensive there.

The docstring's "decode-throughput measurements showed no cost from the gate" is also removed: it does not hold at low batch, which is exactly where flash-decoding exists to help. The cost vanishes once the batch alone supplies enough CTAs, which is presumably why it can look free when measured only at high batch.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed. — `test_nvfp4_split_kv_gate_arch_scope` covers the scoping with a faked compute capability, and `test_nvfp4_split_kv_gate_dtype_logic` keeps the dtype classification hardware-free; both run with no GPU visible. The correctness sweep below stays out of CI: it needs an affected GPU to be meaningful and would be vacuous everywhere else.
- [x] All tests are passing — the NVFP4/FP4 selection of the attention and quantization suites on SM80.

**Does the corruption reproduce on sm_80?** No. For each shape the paged prefill wrapper was run twice — gate on (split-KV forced off) and gate off (split-KV allowed) — and both scored against a dense reference built from the dequantized KV:

| qo_len | kv_len | gate on, rel err | gate off, rel err |
|---|---|---|---|
| 1 | 8192 | 7.06e-04 | 7.06e-04 |
| 16 | 8192 | 8.40e-04 | 8.40e-04 |
| 16 | 4096 | 4.07e-04 | 8.14e-04 |
| 64 | 8192 | 7.32e-04 | 7.32e-04 |
| 256 | 8192 | 6.69e-04 | 6.69e-04 |
| 2048 | 2048 | 0.0 | 0.0 |

`qo_len=1` against `kv_len=8192` is the exact `qo_len << kv_len` regime the gate was introduced for, and it is bit-identical with split-KV enabled. The residual ~7e-4 is NVFP4 quantization granularity — the same value with and without the gate — not corruption. The `2048×2048` row is dense full-prefill, exact either way, matching the original report that dense prefill was unaffected.

**What the gate costs.** sm_80, paged decode, head_dim 128:

| case | gate on | gate off | speedup |
|---|---|---|---|
| b1 kv8192 32/8 | 0.5787 ms | **0.1876 ms** | **3.09x** |
| b8 kv8192 32/8 | 0.6661 | **0.4747** | **1.40x** |
| b16 kv8192 32/8 | 0.7955 | 0.7908 | 1.01x |
| b32 kv8192 32/8 | 1.3252 | 1.2792 | 1.04x |
| b64 kv8192 40/8 | 2.5050 | 2.5047 | 1.00x |

```bash
pytest tests/attention/test_batch_prefill_kernels.py \
       tests/attention/test_batch_decode_kernels.py \
       tests/attention/test_single_prefill.py \
       tests/attention/test_batch_attention.py \
       tests/utils/test_fp4_kv_quantization.py -k "nvfp4 or fp4"
# 425 passed, 25 skipped
```

## Reviewer Notes

**What I verified and what I did not.** I have sm_80 hardware, so the sweep above is sm_80 only. sm_86 has been exercised separately and shows the same benefit with no corruption. I have not run sm_89/sm_90/SM100, which this change also un-gates. The argument for including them is provenance rather than measurement: before `8f9ad200` no architecture had this gate, that commit added it globally from an SM120/121 observation, and narrowing it restores the prior behavior everywhere else. If you would rather see the un-gating limited to the capabilities that have actually been measured, `_NVFP4_SPLIT_KV_BROKEN_ARCHS` is the single place to widen.

**The root cause is still unknown.** This PR does not fix it; it stops charging pre-SM100 for it. SM120/121 keep the workaround unchanged. The gate's own reasoning about why the scale-factor blocks cannot be the mechanism — NVFP4 scales group 16 consecutive head-dim elements of one token while split-KV partitions the token axis, so a split boundary never slices a scale block — still stands, and is worth keeping in the docstring for whoever does root-cause it.

**Why the arch check is a runtime device query.** `get_compute_capability(device)` is already imported in this module and already used this way (the SM107 NVFP4 rejection a few hundred lines down), so this follows the existing pattern rather than introducing a second mechanism. Both call sites had `self.device` in scope.

**Interaction with dequant work.** This gate also confounds any NVFP4-vs-FP8 kernel comparison, because FP8 KV keeps split-KV and NVFP4 does not — so NVFP4 decode numbers measured against FP8 before this change understate NVFP4. That is measurement hygiene rather than a reason for this PR, but it is worth knowing if you are reading NVFP4 decode benchmarks taken at this commit.

On the native-FP4 output-width question: pre-existing and not reachable. The predicate on `main` already tested both `torch.uint8` and `float4_e2m1fn_x2`; this PR only lifted that test into `_is_nvfp4_kv_dtype`. The run path keys on `uint8` throughout — the `kv_cache_sf must be provided` check included — so a native-FP4 tensor never enters the NVFP4 branch at all and the output-width doubling is skipped consistently with everything else, not incorrectly. The real asymmetry (plan-time predicate accepts both spellings, run path understands only packed uint8) predates this PR; closing it is a design call about whether native FP4 becomes supported end-to-end or is rejected at `plan()`. Left out to keep this a single-predicate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 attention handling on SM120 and SM121 GPU architectures.
  * Added support for packed and native FP4 data formats.
  * Updated paged and ragged attention planning for architecture-specific split-KV behavior.
  * Preserved split-KV support on other architectures and for non-NVFP4 data types, avoiding unnecessary hardware checks.

* **Tests**
  * Added validation for supported architectures and NVFP4 data formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
