### PR TITLE
fix(ci): skip source-only CUDA config test in nightlies

### DIFF
--- a/tests/cli/test_cli_cmds.py
+++ b/tests/cli/test_cli_cmds.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import sys
 
 from packaging.version import Version
+import pytest
 
 from flashinfer.artifacts import ArtifactPath
 
@@ -26,6 +27,8 @@ from .cli_cmd_helpers import (
     _assert_output_contains_all,
     _assert_output_contains_any,
 )
+
+_SOURCE_CUDA_CONFIG_PATH = Path(__file__).parents[2] / "ci" / "cuda-versions.json"
 
 
 def test_show_config_cmd_real():
@@ -468,11 +471,14 @@ def test_download_jit_cache_alias_cmd_mocked(monkeypatch):
     assert recorded["cmd"][-1] == "flashinfer-jit-cache==0.4.2+cu129"
 
 
+@pytest.mark.skipif(
+    not _SOURCE_CUDA_CONFIG_PATH.is_file(),
+    reason="requires the source-tree CUDA configuration",
+)
 def test_supported_jit_cache_versions_match_cuda_config():
     from flashinfer.__main__ import _SUPPORTED_JIT_CACHE_CUDA_VERSIONS
 
-    config_path = Path(__file__).parents[2] / "ci" / "cuda-versions.json"
-    config = json.loads(config_path.read_text())
+    config = json.loads(_SOURCE_CUDA_CONFIG_PATH.read_text())
 
     assert [str(version) for version in _SUPPORTED_JIT_CACHE_CUDA_VERSIONS] == [
         entry["version"] for entry in config["jit_cache"]


### PR DESCRIPTION
## 📌 Description

Keep `test_supported_jit_cache_versions_match_cuda_config` active in source-tree presubmit runs, but skip it when `ci/cuda-versions.json` is intentionally absent from the isolated installed-package layout used by Nightly Release.

This fixes the identical cu129/cu130 shard 5 failures in Nightly Release #360 without copying repository-only CI metadata into the installed-package test directory.

## 🔍 Related Issues

- Nightly Release #360: https://github.com/flashinfer-ai/flashinfer/actions/runs/32920335499

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation performed:

- `python3 -m compileall -q tests/cli/test_cli_cmds.py`
- `pre-commit run --files tests/cli/test_cli_cmds.py`
- `git diff --check`

Targeted pytest was not run locally because the existing repository virtualenv does not contain a usable pytest installation. PR CI should confirm both the source-tree pass and isolated-nightly skip behavior.

## Reviewer Notes

The test still protects the duplicated CLI/config CUDA-version invariant during presubmit. The skip applies only when the repository-only `ci/cuda-versions.json` file is unavailable, as it is in the Nightly Release installed-wheel test directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CUDA version consistency testing.
  * Tests now skip gracefully when the required configuration file is unavailable.
  * Added support for running tests with `pytest`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->