### PR TITLE
perf(mla): optimize SM120 sparse MLA with swapped MMA operands

### DIFF
--- a/benchmarks/bench_sparse_mla_sm120.py
+++ b/benchmarks/bench_sparse_mla_sm120.py
@@ -307,11 +307,15 @@ def bench_sparse_mla_sm120_dsv4_dual(
     return ms * 1e3, kv_bw_gbps, tflops
 
 
-def bench_sparse_mla_sm120_dsv3_2(num_heads, num_tokens, with_sink=False, seed=0):
+def bench_sparse_mla_sm120_dsv3_2(
+    num_heads, num_tokens, with_sink=False, seed=0, kv_scale_format="arbitrary_fp32"
+):
     """Returns (median_us, kv_bw_gbps, attn_tflops) for DSv3.2.
 
     Fixed: topk=2048, page_block_size=64 (= _DECODE_DSV3_2_PAGE_BLOCK_SIZE),
-    d_qk=576, d_v=512.
+    d_qk=576, d_v=512. ``kv_scale_format`` picks the power-of-2 inline-scale
+    path (``"auto"``) or the GLM arbitrary-FP32 path (software fold with
+    dual-limb weights).
     """
     torch.manual_seed(seed)
     device = torch.device("cuda")
@@ -351,7 +355,7 @@ def bench_sparse_mla_sm120_dsv3_2(num_heads, num_tokens, with_sink=False, seed=0
     runner = _SparseMLAPagedAttentionRunner(
         max_num_tokens=num_tokens,
         max_num_heads=num_heads,
-        kv_scale_format="arbitrary_fp32",
+        kv_scale_format=kv_scale_format,
         device=device,
     )
 
@@ -513,3 +517,18 @@ if __name__ == "__main__":
         print(
             f"{h:>10}  {2048:>6}  {t:>11}  {lat_us:>10.1f}  {kvbw:>13.1f}  {tfl:>12.2f}"
         )
+
+    # DSv3.2 prefill: topk fixed at 2048, num_tokens > 64. Sweep is num_heads ×
+    # num_tokens × kv_scale_format; 64/128 heads run the swapAB kernel.
+    dsv3_2_prefill_configs = [(h, t) for t in (128, 512) for h in (64, 128)]
+
+    for fmt in ("auto", "arbitrary_fp32"):
+        print()
+        print(f"DSv3.2 prefill path (num_tokens > 64, kv_scale_format={fmt}):")
+        print(header)
+        print("-" * len(header))
+        for h, t in dsv3_2_prefill_configs:
+            lat_us, kvbw, tfl = bench_sparse_mla_sm120_dsv3_2(h, t, kv_scale_format=fmt)
+            print(
+                f"{h:>10}  {2048:>6}  {t:>11}  {lat_us:>10.1f}  {kvbw:>13.1f}  {tfl:>12.2f}"
+            )

--- a/csrc/sparse_mla_sm120_prefill.cu
+++ b/csrc/sparse_mla_sm120_prefill.cu
@@ -28,6 +28,8 @@
 
 // Sparse-MLA SM120 prefill. Single raw-pointer entry point that dispatches:
 //   - DSV3_2 / DSV4 model split
+//   - swapAB (warp specialized, 64 heads/CTA) for the DSV3_2 family at
+//     num_heads 64 / 128
 //   - SG (single-group, 16 heads/CTA) for num_heads <= 16
 //   - MG (multi-group, 32 heads/CTA) for num_heads > 16
 //   - Dual-cache MG variants (DSV4 only)
@@ -83,6 +85,39 @@ void launch_prefill_sg(const bf16* Q, const uint8_t* KV_cache, const int32_t* in
   configure_dynamic_smem_per_device(kernel, smem_bytes, configured);
 
   // SG is single-cache only.
+  PrefillColdParams cold{sm_scale,
+                         num_tokens,
+                         stride_kv_block,
+                         /*stride_kv_block_extra=*/(size_t)0,
+                         /*topk_extra=*/0,
+                         attn_sink,
+                         topk_length_ptr,
+                         /*topk_length_extra=*/(const int*)nullptr};
+  cudaLaunchConfig_t config{grid, block, smem_bytes, stream, nullptr, 0};
+  void* args[] = {(void*)&Q,      (void*)&KV_cache, (void*)&indices, (void*)&attn_sink,
+                  (void*)&output, (void*)&out_lse,  (void*)&cold};
+  CUDA_CHECK(cudaLaunchKernelExC(&config, (const void*)kernel, args));
+}
+
+// Warp-specialized swapAB dispatcher (DSV3_2 family, 64 heads/CTA, single cache).
+template <ModelType MT, int NUM_HEADS, int TOPK>
+void launch_prefill_swapab(const bf16* Q, const uint8_t* KV_cache, const int32_t* indices,
+                           const float* attn_sink, bf16* output, float* out_lse, float sm_scale,
+                           int num_tokens, size_t stride_kv_block, const int* topk_length_ptr,
+                           cudaStream_t stream) {
+  using CT = ComputeTraitsSwapAB<MT>;
+  using L = SmemLayoutSwapAB<MT>;
+  static_assert(KVCacheTraits<MT>::SCALE_IN_KV_SMEM && KVCacheTraits<MT>::D_NOPE == D_V,
+                "swapAB prefill is DSV3_2 family only: inline scales, V spans the nope half");
+  constexpr size_t smem_bytes = L::TOTAL;
+  constexpr int REPLICATE_H = NUM_HEADS / CT::HEADS_PER_CTA;
+  dim3 grid(num_tokens * REPLICATE_H);
+  dim3 block(BLOCK_THREADS);
+
+  auto kernel = sparse_mla_prefill_swapab_kernel<MT, NUM_HEADS, TOPK>;
+  static bool configured[kMaxCachedCudaDevices] = {};
+  configure_dynamic_smem_per_device(kernel, smem_bytes, configured);
+
   PrefillColdParams cold{sm_scale,
                          num_tokens,
                          stride_kv_block,
@@ -211,13 +246,43 @@ void launch_prefill_mg_dual(const bf16* Q, const uint8_t* KV_cache, const int32_
   CUDA_CHECK(cudaLaunchKernelExC(&config, (const void*)kernel, args));
 }
 
+// swapAB covers the head counts that fill whole 64-head CTAs; the rest fall
+// through to SG/MG below.
+template <ModelType MT>
+inline bool dispatch_v32_swapab(int num_heads, const bf16* Q, const uint8_t* KV,
+                                const int32_t* indices, const float* attn_sink, bf16* output,
+                                float* out_lse, float sm_scale, int num_tokens,
+                                size_t stride_kv_block, const int* topk_length_ptr,
+                                cudaStream_t stream) {
+#define DISPATCH_DSV3_2_SWAPAB(NH)                                                          \
+  launch_prefill_swapab<MT, NH, 2048>(Q, KV, indices, attn_sink, output, out_lse, sm_scale, \
+                                      num_tokens, stride_kv_block, topk_length_ptr, stream)
+
+  switch (num_heads) {
+    case 64:
+      DISPATCH_DSV3_2_SWAPAB(64);
+      return true;
+    case 128:
+      DISPATCH_DSV3_2_SWAPAB(128);
+      return true;
+    default:
+      return false;
+  }
+#undef DISPATCH_DSV3_2_SWAPAB
+}
+
 template <ModelType MT>
 inline bool dispatch_v32(int num_heads, int topk, const bf16* Q, const uint8_t* KV,
                          const int32_t* indices, const float* attn_sink, bf16* output,
                          float* out_lse, float sm_scale, int num_tokens, size_t stride_kv_block,
                          const int* topk_length_ptr, cudaStream_t stream) {
   static_assert(KVCacheTraits<MT>::D_QK == 576);
+
   if (topk != 2048) return false;
+
+  if (dispatch_v32_swapab<MT>(num_heads, Q, KV, indices, attn_sink, output, out_lse, sm_scale,
+                              num_tokens, stride_kv_block, topk_length_ptr, stream))
+    return true;
 
   // PBS=64 matches the V32 decode (`decode_dsv3_2_kernel.cuh`). NH=8 covers
   // small-TP shards; the SG kernel zero-pads invalid head slots up to HPB=16

--- a/include/flashinfer/attention/sparse_mla_sm120/arch/common.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/arch/common.cuh
@@ -84,6 +84,41 @@ __device__ __forceinline__ float warp_reduce_sum(float val) {
   return val;
 }
 
+// Reductions over the 8 lanes sharing `lane & 3` — one swapAB softmax row.
+__device__ __forceinline__ float warp8_reduce_max(float val) {
+#pragma unroll
+  for (int offset = 4; offset <= 16; offset <<= 1)
+    val = fmaxf(val, __shfl_xor_sync(0xffffffff, val, offset));
+  return val;
+}
+
+__device__ __forceinline__ float warp8_reduce_sum(float val) {
+#pragma unroll
+  for (int offset = 4; offset <= 16; offset <<= 1) val += __shfl_xor_sync(0xffffffff, val, offset);
+  return val;
+}
+
+// 4 × FP32 → one register of packed E4M3.
+__device__ __forceinline__ uint32_t cvt_e4m3x4(float a, float b, float c, float d) {
+  uint16_t lo, hi;
+  asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" : "=h"(lo) : "f"(b), "f"(a));
+  asm volatile("cvt.rn.satfinite.e4m3x2.f32 %0, %1, %2;" : "=h"(hi) : "f"(d), "f"(c));
+  return static_cast<uint32_t>(lo) | (static_cast<uint32_t>(hi) << 16);
+}
+
+// Residual limb of a packed E4M3 quad: what the first rounding dropped, so the
+// two limbs together widen the mantissa. F16x2 unpacks a pair per conversion.
+__device__ __forceinline__ uint32_t cvt_e4m3x4_residual(float a, float b, float c, float d,
+                                                        uint32_t high) {
+  uint32_t ab, cd;
+  asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;" : "=r"(ab) : "h"(static_cast<uint16_t>(high)));
+  asm volatile("cvt.rn.f16x2.e4m3x2 %0, %1;" : "=r"(cd) : "h"(static_cast<uint16_t>(high >> 16)));
+  const __half2 h_ab = *reinterpret_cast<const __half2*>(&ab);
+  const __half2 h_cd = *reinterpret_cast<const __half2*>(&cd);
+  return cvt_e4m3x4(a - __low2float(h_ab), b - __high2float(h_ab), c - __low2float(h_cd),
+                    d - __high2float(h_cd));
+}
+
 #ifndef CUDA_CHECK
 #define CUDA_CHECK(call)                                                                         \
   do {                                                                                           \

--- a/include/flashinfer/attention/sparse_mla_sm120/arch/cp_async.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/arch/cp_async.cuh
@@ -90,6 +90,13 @@ __device__ __forceinline__ uint64_t create_l2_evict_first_policy() {
   return policy;
 }
 
+// Create L2 evict-last cache policy, for data reused across query tokens.
+__device__ __forceinline__ uint64_t create_l2_evict_last_policy() {
+  uint64_t policy;
+  asm volatile("createpolicy.fractional.L2::evict_last.b64 %0, 1.0;" : "=l"(policy));
+  return policy;
+}
+
 // Store 8 floats (256-bit) with L2::evict_last hint.
 // L2::evict_last requires .v8.b32 or .v4.b64 — 128-bit stores are not supported.
 __device__ __forceinline__ void store_8f_evict_last(float* addr, float4 v0, float4 v1) {

--- a/include/flashinfer/attention/sparse_mla_sm120/arch/ldmatrix_sm120.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/arch/ldmatrix_sm120.cuh
@@ -102,3 +102,20 @@ __device__ __forceinline__ void ldmatrix_load_A_bf16(uint32_t& a0, uint32_t& a1,
   int col = (lane >> 4) * 8;
   ldmatrix_x4(a0, a1, a2, a3, smem_base + row * stride_elems + col);
 }
+
+// FP8 [32×16] → the [16×32] A operand: lane l addresses row l, 16B aligned
+__device__ __forceinline__ void ldmatrix_x2_trans_b8(uint32_t& d0, uint32_t& d1, uint32_t& d2,
+                                                     uint32_t& d3, const void* smem_ptr) {
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m16n16.x2.trans.shared.b8 {%0, %1, %2, %3}, [%4];\n"
+               : "=r"(d0), "=r"(d1), "=r"(d2), "=r"(d3)
+               : "r"(addr));
+}
+
+// FP8 A operand [16×32] transposed, straight out of a [candidate, dim] tile
+template <int KV_STRIDE>
+__device__ __forceinline__ void ldmatrix_load_A_fp8_trans(uint32_t& a0, uint32_t& a1, uint32_t& a2,
+                                                          uint32_t& a3, const uint8_t* smem_base,
+                                                          int k_start, int dim, int lane) {
+  ldmatrix_x2_trans_b8(a0, a1, a2, a3, smem_base + (size_t)(k_start + lane) * KV_STRIDE + dim);
+}

--- a/include/flashinfer/attention/sparse_mla_sm120/arch/stmatrix_sm120.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/arch/stmatrix_sm120.cuh
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "common.cuh"
+
+__device__ __forceinline__ void stmatrix_x4_trans_b8(void* smem_ptr, uint32_t r0, uint32_t r1,
+                                                     uint32_t r2, uint32_t r3) {
+  uint32_t addr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("stmatrix.sync.aligned.m16n8.x4.trans.shared.b8 [%0], {%1, %2, %3, %4};\n"
+               :
+               : "r"(addr), "r"(r0), "r"(r1), "r"(r2), "r"(r3)
+               : "memory");
+}
+
+template <int HEADS_PER_WARP, int N_CAND>
+struct StMatrixTransB8Tile {
+  static constexpr int BYTES = HEADS_PER_WARP * N_CAND;
+  static_assert(HEADS_PER_WARP == 8, "load_b's 16 * gid + 4 * tid addressing assumes 8 heads");
+  __device__ static __forceinline__ void store(uint8_t* dst, const uint32_t* regs, int lane) {
+    stmatrix_x4_trans_b8(dst + 16 * lane, regs[0], regs[1], regs[2], regs[3]);
+  }
+  __device__ static __forceinline__ void load_b(uint32_t* b, const uint8_t* src, int lane) {
+    const int gid = lane >> 2, tid = lane & 3;
+#pragma unroll
+    for (int i = 0; i < BYTES / 128; i++)
+      b[i] = *reinterpret_cast<const uint32_t*>(src + 128 * i + 16 * gid + 4 * tid);
+  }
+};

--- a/include/flashinfer/attention/sparse_mla_sm120/common/fp8_quant.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/fp8_quant.cuh
@@ -64,6 +64,71 @@ __device__ __forceinline__ void load_q_bf16_to_smem(bf16* q_nope_bf16, bf16* q_r
   bar_sync_t<2, _MATH_THREADS>();
 }
 
+// swapAB Q quantization: the four B-fragment lanes of a head partition its
+// D_NOPE dims exactly, so Q is quantized into registers and never reaches smem.
+template <ModelType MT>
+struct QSwapABRegs {
+  using KV = KVCacheTraits<MT>;
+  uint32_t nope[KV::D_NOPE / 32][2];
+  float scale[KV::NUM_SCALES];  // of head (lane >> 2)
+};
+
+template <ModelType MT>
+__device__ __forceinline__ QSwapABRegs<MT> quantize_q_to_regs_swapab(const bf16* q_base, int lane) {
+  using KV = KVCacheTraits<MT>;
+  constexpr int NOPE_KSTEPS = KV::D_NOPE / 32;
+  constexpr int STEPS_PER_GRP = KV::QUANT_TILE / 32;
+  const int tid = lane & 3;
+  QSwapABRegs<MT> q;
+
+#pragma unroll
+  for (int g = 0; g < KV::NUM_SCALES; g++) q.scale[g] = 0.f;
+
+#pragma unroll
+  for (int ik = 0; ik < NOPE_KSTEPS; ik++) {
+    const bf16* p = q_base + ik * 32 + tid * 4;
+    uint2 lo = *reinterpret_cast<const uint2*>(p);
+    uint2 hi = *reinterpret_cast<const uint2*>(p + 16);
+    const bf16* el = reinterpret_cast<const bf16*>(&lo);
+    const bf16* eh = reinterpret_cast<const bf16*>(&hi);
+    float a = 0.f;
+#pragma unroll
+    for (int j = 0; j < 4; j++) a = fmaxf(a, fmaxf(fabsf(to_float(el[j])), fabsf(to_float(eh[j]))));
+    q.scale[ik / STEPS_PER_GRP] = fmaxf(q.scale[ik / STEPS_PER_GRP], a);
+  }
+
+#pragma unroll
+  for (int g = 0; g < KV::NUM_SCALES; g++) {
+    float amax = q.scale[g];
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, 1));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, 2));
+    const float s = fmaxf(amax, 1e-4f) / FP8_MAX;
+    if constexpr (KV::SCALE_FORMAT == ScaleFormat::ARBITRARY_FP32) {
+      q.scale[g] = s;  // the software fold takes FP32, so keep the exact amax
+    } else {
+      // Round up to a power of 2 so the UE8M0 block-scaled MMA is exact.
+      uint32_t bits = __float_as_uint(s);
+      if (bits & 0x007FFFFF) bits = (bits + 0x00800000) & 0x7F800000;
+      q.scale[g] = __uint_as_float(bits);
+    }
+  }
+
+#pragma unroll
+  for (int ik = 0; ik < NOPE_KSTEPS; ik++) {
+    const float si = 1.f / q.scale[ik / STEPS_PER_GRP];
+    const bf16* p = q_base + ik * 32 + tid * 4;
+    uint2 lo = *reinterpret_cast<const uint2*>(p);
+    uint2 hi = *reinterpret_cast<const uint2*>(p + 16);
+    const bf16* el = reinterpret_cast<const bf16*>(&lo);
+    const bf16* eh = reinterpret_cast<const bf16*>(&hi);
+    q.nope[ik][0] = cvt_e4m3x4(to_float(el[0]) * si, to_float(el[1]) * si, to_float(el[2]) * si,
+                               to_float(el[3]) * si);
+    q.nope[ik][1] = cvt_e4m3x4(to_float(eh[0]) * si, to_float(eh[1]) * si, to_float(eh[2]) * si,
+                               to_float(eh[3]) * si);
+  }
+  return q;
+}
+
 template <ModelType MT, int _MATH_THREADS>
 __device__ __forceinline__ void quantize_q_to_smem(uint8_t* q_nope_fp8, float* q_nope_sc,
                                                    bf16* q_rope, const bf16* q_base,

--- a/include/flashinfer/attention/sparse_mla_sm120/common/q_rope.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/q_rope.cuh
@@ -87,3 +87,24 @@ __device__ __forceinline__ void compute_qk_rope(float qk[4], const QRopeRegs& qr
   qk[2] += ra[2];
   qk[3] += ra[3];
 }
+
+template <int KV_STRIDE>
+__device__ __forceinline__ void compute_qk_rope_swapab(float qk[4], const bf16* kv_rope_smem,
+                                                       const KVRopePrefetch& qr, int lane) {
+  float ra[4] = {0.f, 0.f, 0.f, 0.f};
+#pragma unroll
+  for (int ks = 0; ks < N_ROPE_CHUNKS; ks++) {
+    uint32_t a0, a1, a2, a3;
+    ldmatrix_load_A_bf16(a0, a1, a2, a3, kv_rope_smem + ks * 16, KV_STRIDE / 2, lane);
+    MmaBf16Result r =
+        mma_bf16_m16n8k16(a0, a1, a2, a3, qr.b[ks][0], qr.b[ks][1], ra[0], ra[1], ra[2], ra[3]);
+    ra[0] = r.d0;
+    ra[1] = r.d1;
+    ra[2] = r.d2;
+    ra[3] = r.d3;
+  }
+  qk[0] += ra[0];
+  qk[1] += ra[1];
+  qk[2] += ra[2];
+  qk[3] += ra[3];
+}

--- a/include/flashinfer/attention/sparse_mla_sm120/common/smem_layout.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/smem_layout.cuh
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "../model/kv_cache_traits.cuh"
+#include "scale_mma.cuh"
 
 // Smem layout: constexpr offset computation for each buffer.
 // Parameterized by ModelType and ComputeMode.
@@ -207,6 +208,88 @@ struct SmemPtrsMG {
   }
   __device__ __forceinline__ uint64_t* mbar_kv(int i) const {
     return reinterpret_cast<uint64_t*>(base + LMG::OFF_MBAR_KV) + i;
+  }
+};
+
+// swapAB (warp specialized) tiling and layout: candidates on the MMA M axis and
+// heads on N, so one warp owns HEADS_PER_WARP heads and Q stays in registers.
+
+template <ModelType MT>
+struct ComputeTraitsSwapAB {
+  using KV = KVCacheTraits<MT>;
+
+  static constexpr int HEADS_PER_WARP = 8;
+  static constexpr int HEADS_PER_CTA = N_MATH_WARPS * HEADS_PER_WARP;  // 64
+  static constexpr int MTILES = BI / 16;                               // 4
+  static constexpr int NOPE_KSTEPS = KV::D_NOPE / 32;                  // 16
+  static constexpr int STEPS_PER_GRP = KV::QUANT_TILE / 32;            // 4
+  // Candidate M-tiles per QK pass: two independent MMA chains, bounded A live set.
+  static constexpr int MPASS = 2;
+  static constexpr int MPASSES = MTILES / MPASS;  // 2
+  // V dims per XV pass; sizes the V fragment, not the total MMA count.
+  static constexpr int V_CHUNK = 64;
+  static constexpr int N_V_CHUNKS = D_V / V_CHUNK;                 // 8
+  static constexpr int CHUNKS_PER_GRP = KV::QUANT_TILE / V_CHUNK;  // 2
+  static constexpr int XV_MTILES = V_CHUNK / 16;                   // 4
+  static constexpr int XV_KSTEPS = BI / 32;                        // 2
+  static constexpr int P_PASSES = WeightFp8PassTraits<KV::SCALE_FORMAT>::PASSES;
+
+  static_assert(KV::QUANT_TILE % V_CHUNK == 0, "a dequant group must cover whole V chunks");
+};
+
+template <ModelType MT>
+struct SmemLayoutSwapAB {
+  using KV = KVCacheTraits<MT>;
+  using CT = ComputeTraitsSwapAB<MT>;
+
+  static constexpr int KV_STRIDE = KV::KV_GMEM_STRIDE;          // 656
+  static constexpr int P_TILE_BYTES = CT::HEADS_PER_WARP * BI;  // 512
+
+  // nope + inline scales + rope, one linear tile per candidate.
+  static constexpr size_t SMEM_KV_BUF = BI * KV_STRIDE;  // 41984
+
+  // The epilogue's [dim, head] to [head, dim] transpose stays inside a warp, one
+  // V chunk at a time. Padding keeps each head row aligned for the uint4 readback.
+  static constexpr int O_STAGE_STRIDE = CT::V_CHUNK + OUT_VEC;  // 72 bf16
+  static constexpr size_t SMEM_O_WARP = CT::HEADS_PER_WARP * O_STAGE_STRIDE * sizeof(bf16);
+
+  // P and O staging are both warp private and never live at once: one slot each.
+  static constexpr size_t SMEM_SCRATCH_WARP = (size_t)CT::P_PASSES * P_TILE_BYTES > SMEM_O_WARP
+                                                  ? (size_t)CT::P_PASSES* P_TILE_BYTES
+                                                  : SMEM_O_WARP;
+  static constexpr size_t SMEM_SCRATCH = N_MATH_WARPS * SMEM_SCRATCH_WARP;
+  static constexpr size_t SMEM_MBAR = 2 * sizeof(uint64_t);
+
+  static constexpr size_t OFF_KV0 = 0;
+  static constexpr size_t OFF_KV1 = OFF_KV0 + SMEM_KV_BUF;
+  static constexpr size_t OFF_SCRATCH = OFF_KV1 + SMEM_KV_BUF;
+  static constexpr size_t OFF_MBAR_KV = (OFF_SCRATCH + SMEM_SCRATCH + 7) / 8 * 8;
+  static constexpr size_t OFF_MBAR_WR = OFF_MBAR_KV + SMEM_MBAR;
+  static constexpr size_t TOTAL = OFF_MBAR_WR + SMEM_MBAR;
+
+  static_assert(TOTAL <= 101376, "swapAB smem exceeds 99KB per-block limit");
+};
+
+template <ModelType MT>
+struct SmemPtrsSwapAB {
+  using L = SmemLayoutSwapAB<MT>;
+
+  uint8_t* kv_bufs[2];
+  uint8_t* p_buf;  // this warp's stmatrix tile (P_PASSES × P_TILE_BYTES)
+  bf16* o_buf;     // same slot, reused by the epilogue for one V chunk
+  uint64_t* mbar_kv;
+  uint64_t* mbar_wr;
+
+  __device__ static SmemPtrsSwapAB init(char* base, int mwarp) {
+    SmemPtrsSwapAB s;
+    s.kv_bufs[0] = (uint8_t*)(base + L::OFF_KV0);
+    s.kv_bufs[1] = (uint8_t*)(base + L::OFF_KV1);
+    uint8_t* scratch = (uint8_t*)(base + L::OFF_SCRATCH) + mwarp * L::SMEM_SCRATCH_WARP;
+    s.p_buf = scratch;
+    s.o_buf = (bf16*)scratch;
+    s.mbar_kv = (uint64_t*)(base + L::OFF_MBAR_KV);
+    s.mbar_wr = (uint64_t*)(base + L::OFF_MBAR_WR);
+    return s;
   }
 };
 

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_kernel.cuh
@@ -33,6 +33,7 @@
 #include "arch/cp_async.cuh"
 #include "arch/ldmatrix_sm120.cuh"
 #include "arch/mma_sm120.cuh"
+#include "arch/stmatrix_sm120.cuh"
 #include "common/d2_load_b.cuh"
 #include "common/fp8_quant.cuh"
 #include "common/kv_cache_io.cuh"
@@ -1684,4 +1685,427 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1) sparse_mla_prefill_mg_dual_f
   prefill_mg_impl<MT, ComputeMode::BF16, NUM_HEADS, TOPK, PAGE_BLOCK_SIZE, /*DUAL_CACHE=*/true,
                   PAGE_BLOCK_SIZE_EXTRA, MG_N_HG_T, /*ASSUME_FULL_TILES=*/true>(
       Q, KV_cache, indices, KV_cache_extra, indices_extra, output, out_lse, attn_sink, cold);
+}
+
+// ============================================================================
+// Sparse MLA Prefill Kernel — swapAB, warp specialized (DSV3_2 family)
+//
+// Single pass over all TOPK/BI tiles, with the MMA operands swapped:
+//   - Candidates on M, heads on N, so one warp owns HEADS_PER_WARP heads and
+//     softmax reduces inside the warp
+//   - Q is register resident, so the KV ring gets the whole smem budget
+//   - 8 math warps gather-fed by 4 IO warps
+//   - A CTA covers HEADS_PER_CTA = 64 heads of one query token, so NUM_HEADS
+//     128 launches two CTAs per token
+//
+// Template params (all constexpr):
+//   MT:        ModelType (DSV3_2 / GLM_NSA)
+//   NUM_HEADS: 64, 128
+//   TOPK:      2048
+// ============================================================================
+
+// Unlike io_bulk_gather_tile this copies the whole gmem row, rope included, so
+// the inline-scale ABI needs no rope buffer and the smem stride matches gmem.
+template <ModelType MT>
+__device__ __forceinline__ void io_bulk_gather_tile_swapab(uint8_t* dst, const int32_t* indices,
+                                                           const uint8_t* __restrict__ kv_ptr,
+                                                           uint64_t* mbar, int io_tid,
+                                                           uint64_t cache_policy) {
+  constexpr int STRIDE = SmemLayoutSwapAB<MT>::KV_STRIDE;
+
+  if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * STRIDE);
+
+#pragma unroll 1
+  for (int bi = io_tid; bi < BI; bi += IO_THREADS) {
+    const int idx = indices[bi];
+    const uint8_t* src = kv_ptr + (size_t)(idx >= 0 ? idx : 0) * STRIDE;
+    cp_async_bulk_g2s_l2hint(dst + bi * STRIDE, src, STRIDE, mbar, cache_policy);
+  }
+}
+
+template <ModelType MT, int NUM_HEADS, int TOPK>
+__global__ void __launch_bounds__(BLOCK_THREADS, 1)
+    sparse_mla_prefill_swapab_kernel(const bf16* __restrict__ Q,
+                                     const uint8_t* __restrict__ KV_cache,
+                                     const int32_t* __restrict__ indices,
+                                     const float* __restrict__ attn_sink,  // [NUM_HEADS], nullable
+                                     bf16* __restrict__ output, float* __restrict__ out_lse,
+                                     __grid_constant__ const PrefillColdParams cold) {
+  using KV = KVCacheTraits<MT>;
+  using CT = ComputeTraitsSwapAB<MT>;
+  using L = SmemLayoutSwapAB<MT>;
+
+  static constexpr int REPLICATE_H = NUM_HEADS / CT::HEADS_PER_CTA;
+  static constexpr int HPW = CT::HEADS_PER_WARP;
+  static constexpr bool SOFT_SCALE = (KV::SCALE_FORMAT == ScaleFormat::ARBITRARY_FP32);
+
+  const int s_i = blockIdx.x / REPLICATE_H;
+  const int h_start = (blockIdx.x % REPLICATE_H) * CT::HEADS_PER_CTA;
+  if (s_i >= cold.num_tokens) return;
+
+  int topk_len = cold.topk_length ? __ldg(cold.topk_length + s_i) : TOPK;
+  topk_len = topk_len < 0 ? 0 : (topk_len > TOPK ? TOPK : topk_len);
+  const int actual_ni = (topk_len + BI - 1) / BI;
+
+  const int warp_rank = threadIdx.x / 32;
+  const int lane = threadIdx.x & 31;
+  const int32_t* idx_base = indices + (size_t)s_i * TOPK;
+
+  extern __shared__ char smem_raw[];
+  auto sm = SmemPtrsSwapAB<MT>::init(smem_raw, warp_rank < N_MATH_WARPS ? warp_rank : 0);
+
+  if (threadIdx.x == 0) {
+#pragma unroll
+    for (int s = 0; s < 2; s++) {
+      mbarrier_init(sm.mbar_kv + s, 1);             // the bulk gather signals once per tile
+      mbarrier_init(sm.mbar_wr + s, N_MATH_WARPS);  // one release per math warp
+    }
+  }
+  bar_sync_t<3, BLOCK_THREADS>();
+
+  // ── IO warps ────────────────────────────────────────────────────
+  if (warp_rank >= N_MATH_WARPS) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" ::"n"(24));
+
+    const int io_tid = threadIdx.x - MATH_THREADS;
+    const uint64_t kv_l2_policy = create_l2_evict_last_policy();
+
+    int wr_phase = 1;
+#pragma unroll 1
+    for (int ti = 0; ti < actual_ni; ti++) {
+      const int buf = ti & 1;
+      mbarrier_wait_parity(sm.mbar_wr + buf, wr_phase);
+      io_bulk_gather_tile_swapab<MT>(sm.kv_bufs[buf], idx_base + ti * BI, KV_cache,
+                                     sm.mbar_kv + buf, io_tid, kv_l2_policy);
+      if (buf == 1) wr_phase ^= 1;
+    }
+
+    // ── Math warps ──────────────────────────────────────────────────
+  } else {
+    asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" ::"n"(240));
+
+    const int mwarp = warp_rank;
+    const int gid = lane >> 2, tid = lane & 3;
+    const float sm_scale_log2e = cold.sm_scale * LOG2E;
+    // B fragment column n == gid, so this lane feeds head h_base + gid; the C
+    // fragment hands back heads h_base + 2*tid and h_base + 2*tid + 1.
+    const int h_base = h_start + mwarp * HPW;
+    const bf16* q_base = Q + ((size_t)s_i * NUM_HEADS + h_base + gid) * KV::D_QK;
+
+    QSwapABRegs<MT> q = quantize_q_to_regs_swapab<MT>(q_base, lane);
+    KVRopePrefetch q_rope = prefetch_kv_rope(q_base + KV::D_NOPE, lane);
+
+    uint8_t sfb[KV::NUM_SCALES];
+    float q_sc[2][KV::NUM_SCALES];
+    if constexpr (SOFT_SCALE) {
+#pragma unroll
+      for (int g = 0; g < KV::NUM_SCALES; g++) {
+        q_sc[0][g] = __shfl_sync(0xffffffff, q.scale[g], 8 * tid);
+        q_sc[1][g] = __shfl_sync(0xffffffff, q.scale[g], 8 * tid + 4);
+      }
+    } else {
+#pragma unroll
+      for (int g = 0; g < KV::NUM_SCALES; g++) sfb[g] = fp32_to_ue8m0(q.scale[g]);
+    }
+
+    float acc_o[CT::N_V_CHUNKS][CT::XV_MTILES][4];
+#pragma unroll
+    for (int c = 0; c < CT::N_V_CHUNKS; c++)
+#pragma unroll
+      for (int t = 0; t < CT::XV_MTILES; t++)
+        acc_o[c][t][0] = acc_o[c][t][1] = acc_o[c][t][2] = acc_o[c][t][3] = 0.f;
+
+    float warp_m[2] = {-1e30f, -1e30f};
+    float warp_l[2] = {0.f, 0.f};
+    int kv_phase = 0;
+
+// ── Main loop — QK + softmax + XV ───────────────────────────
+#pragma unroll 1
+    for (int ti = 0; ti < actual_ni; ti++) {
+      const int buf = ti & 1;
+      mbarrier_wait_parity(sm.mbar_kv + buf, kv_phase);
+      const uint8_t* kv_smem = sm.kv_bufs[0] + buf * L::SMEM_KV_BUF;
+      const int32_t* ib = idx_base + ti * BI;
+      auto kv_scale = [&](int slot) {
+        return reinterpret_cast<const float*>(kv_smem + (size_t)slot * L::KV_STRIDE + KV::D_NOPE);
+      };
+
+      const uint32_t vm_lo =
+          __ballot_sync(0xffffffff, ib[lane] >= 0 && (ti * BI + lane) < topk_len);
+      const uint32_t vm_hi =
+          __ballot_sync(0xffffffff, ib[32 + lane] >= 0 && (ti * BI + 32 + lane) < topk_len);
+      const uint64_t vmask = (uint64_t)vm_lo | ((uint64_t)vm_hi << 32);
+
+      // ── QK nope MMA (A = candidates, B = heads) ─────────
+      float qk[CT::MTILES][4];
+#pragma unroll
+      for (int m = 0; m < CT::MTILES; m++) qk[m][0] = qk[m][1] = qk[m][2] = qk[m][3] = 0.f;
+
+#pragma unroll
+      for (int mh = 0; mh < CT::MPASSES; mh++) {
+        const int m0 = mh * CT::MPASS;
+        uint32_t a[2][CT::MPASS][4];
+#pragma unroll
+        for (int mi = 0; mi < CT::MPASS; mi++)
+          ldmatrix_load_A_fp8(a[0][mi][0], a[0][mi][1], a[0][mi][2], a[0][mi][3],
+                              kv_smem + (size_t)((m0 + mi) * 16) * L::KV_STRIDE, L::KV_STRIDE,
+                              lane);
+
+#pragma unroll
+        for (int g = 0; g < KV::NUM_SCALES; g++) {
+          [[maybe_unused]] uint8_t sfa[CT::MPASS];
+          [[maybe_unused]] float ks[CT::MPASS][2];
+          [[maybe_unused]] float acc[CT::MPASS][4];
+          if constexpr (SOFT_SCALE) {
+#pragma unroll
+            for (int mi = 0; mi < CT::MPASS; mi++) {
+              ks[mi][0] = kv_scale((m0 + mi) * 16 + gid)[g];
+              ks[mi][1] = kv_scale((m0 + mi) * 16 + gid + 8)[g];
+              acc[mi][0] = acc[mi][1] = acc[mi][2] = acc[mi][3] = 0.f;
+            }
+          } else {
+#pragma unroll
+            for (int mi = 0; mi < CT::MPASS; mi++)
+              sfa[mi] = KV::scale_to_ue8m0(kv_scale((m0 + mi) * 16 + gid + (lane & 1) * 8)[g]);
+          }
+
+#pragma unroll
+          for (int j = 0; j < CT::STEPS_PER_GRP; j++) {
+            const int ik = g * CT::STEPS_PER_GRP + j;
+            if (ik + 1 < CT::NOPE_KSTEPS) {
+#pragma unroll
+              for (int mi = 0; mi < CT::MPASS; mi++)
+                ldmatrix_load_A_fp8(
+                    a[(ik + 1) & 1][mi][0], a[(ik + 1) & 1][mi][1], a[(ik + 1) & 1][mi][2],
+                    a[(ik + 1) & 1][mi][3],
+                    kv_smem + (size_t)((m0 + mi) * 16) * L::KV_STRIDE + (ik + 1) * 32, L::KV_STRIDE,
+                    lane);
+            }
+#pragma unroll
+            for (int mi = 0; mi < CT::MPASS; mi++) {
+              const uint32_t* av = a[ik & 1][mi];
+              if constexpr (SOFT_SCALE) {
+                MmaFp8Result r =
+                    mma_fp8_m16n8k32(av[0], av[1], av[2], av[3], q.nope[ik][0], q.nope[ik][1],
+                                     acc[mi][0], acc[mi][1], acc[mi][2], acc[mi][3]);
+                acc[mi][0] = r.d0;
+                acc[mi][1] = r.d1;
+                acc[mi][2] = r.d2;
+                acc[mi][3] = r.d3;
+              } else {
+                float* o = qk[m0 + mi];
+                MmaFp8Result r = mma_fp8_block_scaled_m16n8k32(av[0], av[1], av[2], av[3],
+                                                               q.nope[ik][0], q.nope[ik][1], o[0],
+                                                               o[1], o[2], o[3], sfa[mi], sfb[g]);
+                o[0] = r.d0;
+                o[1] = r.d1;
+                o[2] = r.d2;
+                o[3] = r.d3;
+              }
+            }
+          }
+
+          if constexpr (SOFT_SCALE) {
+#pragma unroll
+            for (int mi = 0; mi < CT::MPASS; mi++) {
+              float* o = qk[m0 + mi];
+              o[0] = fmaf(acc[mi][0] * ks[mi][0], q_sc[0][g], o[0]);
+              o[1] = fmaf(acc[mi][1] * ks[mi][0], q_sc[1][g], o[1]);
+              o[2] = fmaf(acc[mi][2] * ks[mi][1], q_sc[0][g], o[2]);
+              o[3] = fmaf(acc[mi][3] * ks[mi][1], q_sc[1][g], o[3]);
+            }
+          }
+        }
+      }
+
+      // ── QK rope: stored raw, so it lands in the real domain ──
+#pragma unroll
+      for (int m = 0; m < CT::MTILES; m++)
+        compute_qk_rope_swapab<L::KV_STRIDE>(
+            qk[m],
+            reinterpret_cast<const bf16*>(kv_smem + (size_t)(m * 16) * L::KV_STRIDE +
+                                          KV::KV_ROPE_GMEM_OFFSET),
+            q_rope, lane);
+
+      // ── Masking + online softmax (warp-local) ───────────────
+      float s[CT::MTILES][4];
+#pragma unroll
+      for (int m = 0; m < CT::MTILES; m++) {
+        const bool v0 = (vmask >> (m * 16 + gid)) & 1ull;
+        const bool v1 = (vmask >> (m * 16 + gid + 8)) & 1ull;
+        s[m][0] = v0 ? qk[m][0] * sm_scale_log2e : -1e30f;
+        s[m][1] = v0 ? qk[m][1] * sm_scale_log2e : -1e30f;
+        s[m][2] = v1 ? qk[m][2] * sm_scale_log2e : -1e30f;
+        s[m][3] = v1 ? qk[m][3] * sm_scale_log2e : -1e30f;
+      }
+
+      float alpha[2];
+      float smax[2];
+#pragma unroll
+      for (int ih = 0; ih < 2; ih++) {
+        float rm = -1e30f;
+#pragma unroll
+        for (int m = 0; m < CT::MTILES; m++) rm = fmaxf(rm, fmaxf(s[m][ih], s[m][2 + ih]));
+        rm = warp8_reduce_max(rm);
+
+        const float nm = fmaxf(warp_m[ih], rm);
+        alpha[ih] = exp2f(warp_m[ih] - nm);
+        smax[ih] = exp2f(rm - nm);
+        warp_m[ih] = nm;
+
+        float rs = 0.f;
+#pragma unroll
+        for (int m = 0; m < CT::MTILES; m++) {
+          s[m][ih] = exp2f(s[m][ih] - nm);
+          s[m][2 + ih] = exp2f(s[m][2 + ih] - nm);
+          rs += s[m][ih] + s[m][2 + ih];
+        }
+        warp_l[ih] = fmaf(warp_l[ih], alpha[ih], rs);
+      }
+
+      // ── XV: fold V's group scale into the weights, quantize, MMA ──
+#pragma unroll
+      for (int g = 0; g < KV::NUM_SCALES; g++) {
+        float vsc[CT::MTILES][2];
+        float vsc_max = 0.f;
+#pragma unroll
+        for (int m = 0; m < CT::MTILES; m++) {
+          vsc[m][0] = kv_scale(m * 16 + gid)[g];
+          vsc[m][1] = kv_scale(m * 16 + gid + 8)[g];
+          vsc_max = fmaxf(vsc_max, fmaxf(vsc[m][0], vsc[m][1]));
+        }
+        vsc_max = warp8_reduce_max(vsc_max);
+
+        float wsc[2], si[2];
+#pragma unroll
+        for (int ih = 0; ih < 2; ih++) {
+          const float pmax = smax[ih] * vsc_max;
+          wsc[ih] = pmax * FP8_MAX_INV;
+          si[ih] = pmax > 0.f ? (FP8_MAX / pmax) : 0.f;
+        }
+
+        uint32_t pq[CT::P_PASSES][CT::MTILES];
+#pragma unroll
+        for (int m = 0; m < CT::MTILES; m++) {
+          const float ws00 = s[m][0] * vsc[m][0] * si[0], ws10 = s[m][1] * vsc[m][0] * si[1];
+          const float ws01 = s[m][2] * vsc[m][1] * si[0], ws11 = s[m][3] * vsc[m][1] * si[1];
+          pq[0][m] = cvt_e4m3x4(ws00, ws10, ws01, ws11);
+          if constexpr (CT::P_PASSES == 2)
+            pq[1][m] = cvt_e4m3x4_residual(ws00, ws10, ws01, ws11, pq[0][m]);
+        }
+
+        __syncwarp();
+#pragma unroll
+        for (int p = 0; p < CT::P_PASSES; p++)
+          StMatrixTransB8Tile<HPW, BI>::store(sm.p_buf + p * L::P_TILE_BYTES, pq[p], lane);
+        __syncwarp();
+
+        uint32_t pb[CT::P_PASSES][BI / 16];
+#pragma unroll
+        for (int p = 0; p < CT::P_PASSES; p++)
+          StMatrixTransB8Tile<HPW, BI>::load_b(pb[p], sm.p_buf + p * L::P_TILE_BYTES, lane);
+
+#pragma unroll
+        for (int jc = 0; jc < CT::CHUNKS_PER_GRP; jc++) {
+          const int vc = g * CT::CHUNKS_PER_GRP + jc;
+          uint32_t v[CT::XV_MTILES][CT::XV_KSTEPS][4];
+#pragma unroll
+          for (int mt = 0; mt < CT::XV_MTILES; mt++)
+#pragma unroll
+            for (int kt = 0; kt < CT::XV_KSTEPS; kt++)
+              ldmatrix_load_A_fp8_trans<L::KV_STRIDE>(v[mt][kt][0], v[mt][kt][1], v[mt][kt][2],
+                                                      v[mt][kt][3], kv_smem, kt * 32,
+                                                      vc * CT::V_CHUNK + mt * 16, lane);
+
+          float xv[CT::XV_MTILES][4] = {};
+#pragma unroll
+          for (int kt = 0; kt < CT::XV_KSTEPS; kt++)
+#pragma unroll
+            for (int p = 0; p < CT::P_PASSES; p++)
+#pragma unroll
+              for (int mt = 0; mt < CT::XV_MTILES; mt++) {
+                MmaFp8Result r = mma_fp8_m16n8k32(v[mt][kt][0], v[mt][kt][1], v[mt][kt][2],
+                                                  v[mt][kt][3], pb[p][2 * kt], pb[p][2 * kt + 1],
+                                                  xv[mt][0], xv[mt][1], xv[mt][2], xv[mt][3]);
+                xv[mt][0] = r.d0;
+                xv[mt][1] = r.d1;
+                xv[mt][2] = r.d2;
+                xv[mt][3] = r.d3;
+              }
+
+#pragma unroll
+          for (int mt = 0; mt < CT::XV_MTILES; mt++) {
+            float* o = acc_o[vc][mt];
+            o[0] = fmaf(xv[mt][0], wsc[0], o[0] * alpha[0]);
+            o[1] = fmaf(xv[mt][1], wsc[1], o[1] * alpha[1]);
+            o[2] = fmaf(xv[mt][2], wsc[0], o[2] * alpha[0]);
+            o[3] = fmaf(xv[mt][3], wsc[1], o[3] * alpha[1]);
+          }
+        }
+      }
+
+      if (lane == 0) mbarrier_arrive(sm.mbar_wr + buf);
+      if (buf == 1) kv_phase ^= 1;
+    }
+
+    // ── Write BF16 output and LSE ────────────────────────────────
+    // attn_sink convention (FlashMLA V4): output[h] *= sigmoid(lse_h - sink_h)
+    // is folded directly into the normalizer:
+    //   il = exp(lse) / (exp(lse) + exp(sink)) / exp(lse)
+    //      = 1 / (l + exp(sink - m))   in log2 space
+    // (working in log2 space: sum_l is in exp-domain of m, multiply sink by LOG2E).
+    // A row whose candidates are all masked keeps m at -1e30f, where every slot
+    // would contribute exp2(0)=1; drop l so it collapses to il=0, lse=-1e30f.
+    float il[2];
+    float lse[2];
+#pragma unroll
+    for (int ih = 0; ih < 2; ih++) {
+      const bool empty = (warp_m[ih] <= -1e29f);
+      const float l = warp8_reduce_sum(empty ? 0.f : warp_l[ih]);
+      const float m = empty ? -1e30f : warp_m[ih];
+      lse[ih] = softmax_lse(m, l);
+      if (cold.attn_sink != nullptr) {
+        const float sink_log2 = __ldg(cold.attn_sink + h_base + 2 * tid + ih) * LOG2E;
+        const float denom = l + exp2f(sink_log2 - m);
+        il[ih] = (denom > 0.f) ? (1.f / denom) : 0.f;
+        lse[ih] =
+            (lse[ih] != -1e30f) ? (lse[ih] + log2f(1.f + exp2f(sink_log2 - lse[ih]))) : sink_log2;
+      } else {
+        il[ih] = (l > 0.f) ? (1.f / l) : 0.f;
+      }
+    }
+
+    // Write LSE (merged with attn_sink if present)
+    if (gid == 0) {
+#pragma unroll
+      for (int ih = 0; ih < 2; ih++)
+        out_lse[(size_t)s_i * NUM_HEADS + h_base + 2 * tid + ih] = lse[ih];
+    }
+
+    const size_t out_base = ((size_t)s_i * NUM_HEADS + h_base) * D_V;
+    constexpr int O_VECS_PER_CHUNK = CT::V_CHUNK / OUT_VEC;
+#pragma unroll
+    for (int vc = 0; vc < CT::N_V_CHUNKS; vc++) {
+      __syncwarp();
+#pragma unroll
+      for (int mt = 0; mt < CT::XV_MTILES; mt++) {
+        const int d0 = mt * 16 + gid;
+        const int row0 = (2 * tid) * L::O_STAGE_STRIDE;
+        const int row1 = row0 + L::O_STAGE_STRIDE;
+        const float* o = acc_o[vc][mt];
+        sm.o_buf[row0 + d0] = to_bf16(o[0] * il[0]);
+        sm.o_buf[row1 + d0] = to_bf16(o[1] * il[1]);
+        sm.o_buf[row0 + d0 + 8] = to_bf16(o[2] * il[0]);
+        sm.o_buf[row1 + d0 + 8] = to_bf16(o[3] * il[1]);
+      }
+      __syncwarp();
+#pragma unroll
+      for (int i = lane; i < HPW * O_VECS_PER_CHUNK; i += 32) {
+        const int h = i / O_VECS_PER_CHUNK;
+        const int d8 = (i - h * O_VECS_PER_CHUNK) * OUT_VEC;
+        uint4 v = *reinterpret_cast<const uint4*>(&sm.o_buf[h * L::O_STAGE_STRIDE + d8]);
+        *reinterpret_cast<uint4*>(&output[out_base + (size_t)h * D_V + vc * CT::V_CHUNK + d8]) = v;
+      }
+    }
+  }
 }

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -911,7 +911,7 @@ def test_sparse_mla_sm120_decode_glm_nsa_arbitrary_fp32() -> None:
     torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
 
 
-@pytest.mark.parametrize("num_heads", [8, 32])
+@pytest.mark.parametrize("num_heads", [8, 32, 64, 128])
 def test_sparse_mla_sm120_prefill_glm_nsa_arbitrary_fp32(num_heads: int) -> None:
     torch.manual_seed(2)
     device = torch.device("cuda")


### PR DESCRIPTION

## 📌 Description

### Performance summary
Compared with the existing MG prefill kernel, the swapAB(swapped MMA operands) kernel delivers a **1.31–2.16× speedup** across the tested configurations (64/128 heads and 128–8192 query tokens). It achieves up to **1.95×** speedup with the `auto`
scale format and up to **2.16×** with `arbitrary_fp32`.


### Performance
GPU: NVidia RTX PRO5000, SM120
CUDA: 13.0

`python benchmarks/bench_sparse_mla_sm120.py
`(2048/8192 query tokens are not included in benchmark script)

| KV scale format | Heads | Tokens | Before (µs) | After (µs) | Speedup |
|---|---:|---:|---:|---:|---:|
| auto | 64 | 128 | 424.6 | 324.2 | 1.31× |
| auto | 128 | 128 | 682.7 | 420.4 | 1.62× |
| auto | 64 | 512 | 1377.3 | 802.8 | 1.72× |
| auto | 128 | 512 | 2522.8 | 1321.0 | 1.91× |
| auto | 64 | 2048 | 5169.7 | 2945.0 | 1.76× |
| auto | 128 | 2048 | 9784.6 | 5023.6 | 1.95× |
| auto | 64 | 8192 | 20320.3 | 11403.0 | 1.78× |
| auto | 128 | 8192 | 38686.8 | 19896.3 | 1.94× |
| arbitrary_fp32 | 64 | 128 | 553.6 | 356.9 | 1.55× |
| arbitrary_fp32 | 128 | 128 | 912.0 | 494.1 | 1.85× |
| arbitrary_fp32 | 64 | 512 | 1814.1 | 864.8 | 2.10× |
| arbitrary_fp32 | 128 | 512 | 3422.9 | 1601.5 | 2.14× |
| arbitrary_fp32 | 64 | 2048 | 6835.8 | 3264.5 | 2.09× |
| arbitrary_fp32 | 128 | 2048 | 13437.5 | 6220.8 | 2.16× |
| arbitrary_fp32 | 64 | 8192 | 26861.1 | 13077.9 | 2.05× |
| arbitrary_fp32 | 128 | 8192 | 53355.0 | 24661.7 | 2.16× |

### Motivation
SM12x GPUs provide a limited shared-memory capacity of 99 KiB per CTA and do not provide a WGMMA-style instruction that can issue matrix multiplication directly from shared-memory operands. These constraints create significant register-pressure challenges for MLA kernels.

The MLA output dimension is 512. In a conventional FlashAttention-style kernel, warps are partitioned along the query-head dimension. Because SM12x still uses MMA instructions with an fp8 `m16n8k32` shape, each warp would need to hold a `16 × 512` output tile. With FP32 accumulators, this requires 256 accumulator registers per thread, exceeding the practical per-thread register limit and causing extensive register spilling.

Existing FlashInfer sparse MLA kernels avoid this issue by partitioning warps along the KV dimension. However, this design requires:
- Cross-warp synchronization during softmax.
- Writing the probability matrix `P` to shared memory, then synchronizing and reading `P` back before the PV computation.

The overhead is even larger in the FP8 path. The quantization scale of `V` must first be folded into the softmax probability matrix `P`, after which `P` is quantized again. This introduces additional cross-warp synchronization and shared-memory traffic.

### SwapAB design
The new kernel retains FlashAttention-style warp partitioning along the query-head dimension, but swaps the MMA operands:
- `Q` is used as the B operand.
- `K` is used as the A operand.
- `P` is used as the B operand.
- `V` is used as the A operand.

With this layout, each warp independently owns eight attention heads. Softmax and the requantization of `P` are therefore entirely warp-local, eliminating all cross-warp synchronization from these stages.
The MMA B operand has an eight-column output dimension, so each thread only needs 128 FP32 accumulator registers for the final 512-dimensional output. This substantially reduces register pressure and avoids the severe spilling of the conventional layout.

### Kernel organization
The kernel retains double-buffered KV loading and uses a larger `TileKV = 64` to better amortize and hide the softmax overhead. Given the limited shared-memory capacity, `Q` and its quantization scales remain resident in registers. This also reduces shared-memory bandwidth consumption.

The CTA consists of:
- Eight math warps.
- Four I/O warps.
- Eight attention heads per math warp.
- 64 attention heads per CTA.
As a result, the specialized path supports 64 heads with one CTA and 128 heads with two CTAs per query token.

For the PV GEMM:
- Quantized FP8 `P` is stored with the SM120 8-bit transposed `stmatrix` (`STSM_T`) instruction.
- FP8 `V` is loaded with the SM120 8-bit transposed `ldmatrix` (`LDSM_T`) instruction.
- Each warp performs its PV GEMM independently.
- The shared-memory transpose of `P` requires only warp-local synchronization and no cross-warp synchronization.
Overall, the swapAB layout removes cross-warp synchronization and shared-memory round trips from softmax and probability requantization while substantially reducing register pressure.

### feature
- Keep the existing KV-cache layout and all input parameters unchanged.
- Support both UE8M0 block scaling and arbitrary FP32 KV scales.
- Preserve attention-sink and variable `topk_length` behavior.
- Dispatch the new kernel for DSv3.2/GLM sparse MLA prefill with 64 or 128 heads.
- Extend tests and benchmarks to cover the new path.


## 🔍 Related Issues

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [✅  ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [✅  ] I have installed the hooks with `pre-commit install`.
- [✅  ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [✅  ] Tests have been added or updated as needed.
- [✅  ] All tests are passing (`unittest`, etc.).

The existing DSv3.2 prefill test already covers 64/128 heads with the `auto` scale format, including multiple token counts and optional attention sinks.
This PR extends the `arbitrary_fp32` prefill test from `[8, 32]` to `[8, 32, 64, 128]`, covering the new swapAB path for both supported scale formats. Outputs and LSE are validated against the PyTorch reference.

```bash
pytest tests/attention/test_sparse_mla_sm120.py -v
311 passed, 2 warnings 
```

## Reviewer Notes

The main design choice is to swap the MMA operands so that each warp owns eight heads. This reduces the FP32 output accumulators from 256 to 128 registers per thread and removes cross-warp synchronization from softmax and P
requantization.
The new dispatch only affects DSv3.2/GLM prefill with `topk=2048` and 64/128 heads(the kernel design can naturally support any multiple of 64 heads, but the current dispatch specializes 64 and 128 because they are the most common configurations). All other configurations continue using the existing kernels.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optimized prefill support for selected DSv3.2 and GLM-NSA configurations with 64 or 128 heads.
  - Added support for configurable KV scale formats, including arbitrary FP32 scaling.
  - Improved handling of variable token counts, invalid entries, attention sinks, and empty rows.

- **Tests**
  - Expanded coverage for arbitrary-FP32 prefill configurations with 64- and 128-head models.

- **Benchmarks**
  - Added DSv3.2 prefill benchmark sweeps across supported head and token counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->