### PR TITLE
perf(sparse mla): Update sparse MLA half-Q-tile heuristic to apply to short queries only

### DIFF
--- a/.claude/skills/benchmark-kernel/SKILL.md
+++ b/.claude/skills/benchmark-kernel/SKILL.md
@@ -63,7 +63,7 @@ If you don't install CUPTI, the framework will:
 ### Step 1: Choose Your Test Routine
 
 Available routines:
-- **Attention**: `BatchDecodeWithPagedKVCacheWrapper`, `BatchPrefillWithPagedKVCacheWrapper`, `BatchPrefillWithRaggedKVCacheWrapper`, `BatchMLAPagedAttentionWrapper`
+- **Attention**: `BatchDecodeWithPagedKVCacheWrapper`, `BatchPrefillWithPagedKVCacheWrapper`, `BatchPrefillWithRaggedKVCacheWrapper`, `BatchMLAPagedAttentionWrapper`, `trtllm_batch_decode_sparse_mla_dsv4`
 - **GEMM**: `bmm_fp8`, `gemm_fp8_nt_groupwise`, `group_gemm_fp8_nt_groupwise`, `mm_fp4`
 - **MOE**: `trtllm_fp4_block_scale_moe`, `trtllm_fp8_block_scale_moe`, `trtllm_fp8_per_tensor_scale_moe`, `cutlass_fused_moe`
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -36,6 +36,7 @@ Currently supports testing attention, gemm, fused MOE, normalization, quantizati
         - Also supports computationally similar `cudnn_batch_prefill_with_kv_cache` (cudnn-native) and  `trtllm_ragged_attention_deepseek`.
     - `BatchMLAPagedAttentionWrapper` - MLA attention proposed in DeepSeek series of models.
         - Also supports computationally similar `trtllm_batch_decode_with_kv_cache_mla` (trtllm-native) and CuTe DSL MLA decode kernel (cute-dsl, SM100+).
+    - `trtllm_batch_decode_sparse_mla_dsv4` - DeepSeek-V4 sparse MLA using the public TRTLLM-GEN API on SM100/SM103. Supports varlen prefill-style query lengths, causal SWA and compressed-cache sparse tables, FP8/BF16 inputs, sampled FP32 reference checking, and hot-path Q-tile selector benchmarks.
     - All four attention routines accept `--backends prims-ts` on SM100/SM103 to benchmark the experimental task-scheduled attention implementation. `prims_ts` is accepted as an alias.
 - GEMM:
     - `gemm_fp8_nt_groupwise` - GEMM with FP8 data types using groupwise scaling.
@@ -239,6 +240,11 @@ The output CSV will contain detailed metrics including:
 | `--out_dtype`            | Data type for the output tensor. Default: same as q_dtype. Backend-dependent; PrimTS context accepts bfloat16, float16, or fp8_e4m3, while PrimTS FP8 decode accepts float16 or fp8_e4m3. FP8 ragged comparisons with non-PrimTS backends require bfloat16 or float16. |
 | `--causal`               | Use causal attention masking for context/prefill. Multi-query FMHA and MLA decode use bottom-right causal masking automatically. |
 | `--random_actual_seq_len`| Use random sequence lengths up to max length. If False, use max length.                                    |
+| `--swa_topk`             | DSV4 sparse MLA only: sliding-window segment width. Must be 128.                                           |
+| `--compressed_topk`      | DSV4 sparse MLA only: maximum compressed-cache rows selected per query. Default: 1920.                    |
+| `--compressed_kv_len`    | DSV4 sparse MLA only: compressed-cache rows per request. Default: `ceil(s_kv / 4)`.                       |
+| `--compressed_page_size` | DSV4 sparse MLA only: compressed-cache page size. Default: 64.                                             |
+| `--kv_layout`            | DSV4 sparse MLA only: `HND` (default) or `NHD` for both KV-cache pools.                                    |
 
 ### GEMM Flags
 | Flag                     | Description                                                                                                 |
@@ -526,6 +532,7 @@ Legend:
 | **BatchPrefillWithPagedKVCacheWrapper** |  | fa2, cudnn, cudnn-native | fa2, cudnn, cudnn-native | fa2, cudnn, cudnn-native | fa2, fa3, cudnn, cudnn-native | fa2, cudnn, cudnn-native, trtllm-gen, trtllm-native, prims-ts | fa2, cudnn, cudnn-native, trtllm-gen, trtllm-native, prims-ts | fa2, cudnn, cudnn-native |
 | **BatchPrefillWithRaggedKVCacheWrapper** |  | fa2, cudnn, cudnn-native | fa2, cudnn, cudnn-native | fa2, cudnn, cudnn-native | fa2, fa3, cudnn, cudnn-native | fa2, cudnn, cudnn-native, cutlass, trtllm-native, prims-ts | fa2, cudnn, cudnn-native, cutlass, trtllm-native, prims-ts | fa2, cudnn, cudnn-native |
 | **BatchMLAPagedAttentionWrapper** |  | fa2 | fa2 | fa2 | fa2, fa3 | fa2, cutlass, trtllm-native, cute-dsl, prims-ts | fa2, cutlass, trtllm-native, prims-ts | fa2 |
+| **trtllm_batch_decode_sparse_mla_dsv4** |  |  |  |  |  | trtllm-gen | trtllm-gen |  |
 | **gemm_fp8_nt_groupwise** |  |  |  |  |  | cutlass | cutlass |  |
 | **group_gemm_fp8_nt_groupwise** |  |  |  |  |  | cutlass | cutlass |  |
 | **bmm_fp8** |  |  |  | cudnn, cublas | cudnn, cublas | cudnn, cublas, cutlass | cudnn, cublas, cutlass | cudnn, cublas |

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -37,7 +37,7 @@ Currently supports testing attention, gemm, fused MOE, normalization, quantizati
     - `BatchMLAPagedAttentionWrapper` - MLA attention proposed in DeepSeek series of models.
         - Also supports computationally similar `trtllm_batch_decode_with_kv_cache_mla` (trtllm-native) and CuTe DSL MLA decode kernel (cute-dsl, SM100+).
     - `trtllm_batch_decode_sparse_mla_dsv4` - DeepSeek-V4 sparse MLA using the public TRTLLM-GEN API on SM100/SM103. Supports varlen prefill-style query lengths, causal SWA and compressed-cache sparse tables, FP8/BF16 inputs, sampled FP32 reference checking, and hot-path Q-tile selector benchmarks.
-    - All four attention routines accept `--backends prims-ts` on SM100/SM103 to benchmark the experimental task-scheduled attention implementation. `prims_ts` is accepted as an alias.
+    - All four wrapper attention routines above accept `--backends prims-ts` on SM100/SM103. The standalone `trtllm_batch_decode_sparse_mla_dsv4` routine supports only `trtllm-gen`.
 - GEMM:
     - `gemm_fp8_nt_groupwise` - GEMM with FP8 data types using groupwise scaling.
     - `group_gemm_fp8_nt_groupwise` - Group GEMM with FP8 data types using groupwise scaling.

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import math
 
 import numpy as np
 import torch
@@ -281,6 +282,8 @@ def run_attention_test(args):
         return testBatchPrefillWithRaggedKVCacheWrapper(args)
     elif args.routine == "BatchMLAPagedAttentionWrapper":
         return testBatchMLAPagedAttentionWrapper(args)
+    elif args.routine == "trtllm_batch_decode_sparse_mla_dsv4":
+        return testTrtllmBatchDecodeSparseMlaDsv4(args)
     else:
         print(f"[ERROR] Unsupported routine: {args.routine}")
         return []
@@ -302,7 +305,7 @@ def parse_attention_args(line, parser):
         type=str,
         required=False,
         nargs="+",
-        default=["fa2"],
+        default=None,
         choices=[
             "fa2",
             "fa2_tc",
@@ -319,7 +322,7 @@ def parse_attention_args(line, parser):
             "prims-ts",
             "prims_ts",  # Accepted alias for the Python module spelling.
         ],
-        help="Kernel backends to test. Default: fa2. prims-ts selects the experimental task-scheduled Blackwell backend for all attention routines. backend=auto is supported for BatchDecodeWithPagedKVCacheWrapper, BatchPrefillWithPagedKVCacheWrapper, and BatchMLAPagedAttentionWrapper (where it pairs with --autotune to select between trtllm-gen and cute-dsl).",
+        help="Kernel backends to test. Default: fa2, except DSV4 sparse MLA defaults to trtllm-gen. prims-ts selects the experimental task-scheduled Blackwell backend for the wrapper attention routines. backend=auto is supported for BatchDecodeWithPagedKVCacheWrapper, BatchPrefillWithPagedKVCacheWrapper, and BatchMLAPagedAttentionWrapper (where it pairs with --autotune to select between trtllm-gen and cute-dsl).",
     )
     parser.add_argument(
         "--page_size",
@@ -458,8 +461,55 @@ def parse_attention_args(line, parser):
             "preserving existing behavior and perf baselines."
         ),
     )
+    parser.add_argument(
+        "--swa_topk",
+        type=int,
+        default=128,
+        help="DSV4 sparse MLA only: fixed sliding-window segment width.",
+    )
+    parser.add_argument(
+        "--compressed_topk",
+        type=int,
+        default=1920,
+        help="DSV4 sparse MLA only: maximum selected compressed-cache rows per query.",
+    )
+    parser.add_argument(
+        "--compressed_kv_len",
+        type=int,
+        default=None,
+        help=(
+            "DSV4 sparse MLA only: logical compressed-cache rows per request "
+            "(default: ceil(s_kv / 4))."
+        ),
+    )
+    parser.add_argument(
+        "--compressed_page_size",
+        type=int,
+        default=64,
+        help="DSV4 sparse MLA only: compressed-cache page size.",
+    )
+    parser.add_argument(
+        "--kv_layout",
+        choices=["HND", "NHD"],
+        default="HND",
+        help="DSV4 sparse MLA only: layout of both KV-cache pools.",
+    )
 
     args = parser.parse_args(line)
+
+    if args.backends is None:
+        args.backends = (
+            ["trtllm-gen"]
+            if args.routine == "trtllm_batch_decode_sparse_mla_dsv4"
+            else ["fa2"]
+        )
+
+    if args.routine == "trtllm_batch_decode_sparse_mla_dsv4" and args.page_size == 0:
+        args.page_size = 256
+    if args.routine == "trtllm_batch_decode_sparse_mla_dsv4":
+        # The sparse tables encode causal visibility; there is no non-causal
+        # mode in this DSV4 generation-form API.
+        args.causal = True
 
     # Normalize backend names (handle deprecated names)
     args.backends = normalize_backends(args.backends)
@@ -3773,3 +3823,429 @@ def testBatchMLAPagedAttentionWrapper(args):
                 cur_res["case_tag"] = args.case_tag
                 res.append(cur_res)
     return res
+
+
+_DSV4_HEAD_DIM = 512
+_DSV4_SWA_TOPK = 128
+_DSV4_WORKSPACE_BYTES = 128 * 1024 * 1024
+
+
+def _dsv4_cache_to_flat_rows(cache, kv_layout):
+    if kv_layout == "HND":
+        cache = cache.transpose(1, 2)
+    return cache.reshape(-1, cache.shape[-1])
+
+
+def _dsv4_coprime_strides(lengths):
+    """Choose deterministic, non-unit strides for sparse-index permutations."""
+    strides = []
+    for length in lengths.to("cpu").tolist():
+        if length <= 1:
+            strides.append(1)
+            continue
+        candidate = max(1, length // 2 + 1)
+        if candidate >= length:
+            candidate = 1
+        while math.gcd(candidate, length) != 1:
+            candidate += 1
+            if candidate >= length:
+                candidate = 1
+        strides.append(candidate)
+    return torch.tensor(strides, dtype=torch.int64, device=lengths.device)
+
+
+def _dsv4_make_sparse_indices(
+    *,
+    batch_size,
+    s_qo,
+    s_kv,
+    swa_topk,
+    swa_page_size,
+    compressed_topk,
+    compressed_kv_len,
+    compressed_page_size,
+    device,
+):
+    """Build causal SWA rows plus causal compressed-cache selections."""
+    query_positions = torch.arange(s_kv - s_qo, s_kv, dtype=torch.int64, device=device)
+
+    swa_valid_lens = torch.minimum(
+        query_positions + 1,
+        torch.tensor(swa_topk, dtype=torch.int64, device=device),
+    )
+    swa_columns = torch.arange(swa_topk, dtype=torch.int64, device=device)
+    swa_starts = query_positions - swa_valid_lens + 1
+    swa_local = swa_starts[:, None] + swa_columns[None, :]
+    swa_local = torch.where(
+        swa_columns[None, :] < swa_valid_lens[:, None], swa_local, -1
+    )
+
+    # DSV4's compressed pool stores one row per four raw KV tokens. The active
+    # top-k grows causally during a full-prompt prefill and saturates at the
+    # configured maximum.
+    compressed_available = torch.minimum(
+        torch.div(query_positions + 4, 4, rounding_mode="floor"),
+        torch.tensor(compressed_kv_len, dtype=torch.int64, device=device),
+    ).clamp_min(1)
+    compressed_active_lens = torch.minimum(
+        compressed_available,
+        torch.tensor(compressed_topk, dtype=torch.int64, device=device),
+    )
+    compressed_columns = torch.arange(compressed_topk, dtype=torch.int64, device=device)
+    compressed_strides = _dsv4_coprime_strides(compressed_available)
+    compressed_local = (
+        compressed_columns[None, :] * compressed_strides[:, None]
+        + query_positions[:, None] * 29
+    ) % compressed_available[:, None]
+    compressed_local = torch.where(
+        compressed_columns[None, :] < compressed_active_lens[:, None],
+        compressed_local,
+        -1,
+    )
+
+    swa_rows_per_request = math.ceil(s_kv / swa_page_size) * swa_page_size
+    compressed_rows_per_request = (
+        math.ceil(compressed_kv_len / compressed_page_size) * compressed_page_size
+    )
+    swa_bases = (
+        torch.arange(batch_size, dtype=torch.int64, device=device)
+        * swa_rows_per_request
+    )
+    compressed_bases = (
+        torch.arange(batch_size, dtype=torch.int64, device=device)
+        * compressed_rows_per_request
+    )
+    swa_indices = torch.where(
+        swa_local[None, :, :] >= 0,
+        swa_local[None, :, :] + swa_bases[:, None, None],
+        -1,
+    )
+    compressed_indices = torch.where(
+        compressed_local[None, :, :] >= 0,
+        compressed_local[None, :, :] + compressed_bases[:, None, None],
+        -1,
+    )
+    sparse_indices = torch.cat((swa_indices, compressed_indices), dim=-1)
+    sparse_indices = sparse_indices.reshape(
+        batch_size * s_qo, swa_topk + compressed_topk
+    ).to(torch.int32)
+
+    compressed_active_lens = compressed_active_lens.repeat(batch_size)
+    sparse_topk_lens = (compressed_active_lens + swa_topk).to(torch.int32)
+    active_kv_lens = (swa_valid_lens + compressed_active_lens[:s_qo]).repeat(batch_size)
+    return sparse_indices.contiguous(), sparse_topk_lens.contiguous(), active_kv_lens
+
+
+@torch.inference_mode()
+def _validate_dsv4_sparse_mla_samples(
+    *,
+    query,
+    swa_kv_cache,
+    compressed_kv_cache,
+    sparse_indices,
+    sparse_topk_lens,
+    output,
+    swa_topk,
+    bmm1_scale,
+    bmm2_scale,
+    kv_layout,
+    sample_limit=8,
+):
+    """Check sampled query rows against an independent FP32 attention oracle."""
+    if not torch.isfinite(output.float()).all():
+        raise AssertionError("DSV4 sparse MLA output contains nonfinite values")
+
+    total_q = query.shape[0]
+    sample_rows = sorted(
+        {
+            0,
+            total_q - 1,
+            total_q // 4,
+            total_q // 2,
+            (3 * total_q) // 4,
+        }
+    )[:sample_limit]
+    swa_rows = _dsv4_cache_to_flat_rows(swa_kv_cache, kv_layout)
+    compressed_rows = _dsv4_cache_to_flat_rows(compressed_kv_cache, kv_layout)
+    scale_qk = float(bmm1_scale.item()) if torch.is_tensor(bmm1_scale) else bmm1_scale
+    scale_out = float(bmm2_scale.item()) if torch.is_tensor(bmm2_scale) else bmm2_scale
+    max_abs_error = 0.0
+
+    for query_row in sample_rows:
+        active_len = int(sparse_topk_lens[query_row].item())
+        row_indices = sparse_indices[query_row]
+        swa_indices = row_indices[:swa_topk]
+        swa_indices = swa_indices[swa_indices >= 0].to(torch.int64)
+        compressed_len = max(0, active_len - swa_topk)
+        compressed_indices = row_indices[swa_topk : swa_topk + compressed_len].to(
+            torch.int64
+        )
+        selected_kv = torch.cat(
+            (
+                swa_rows.index_select(0, swa_indices),
+                compressed_rows.index_select(0, compressed_indices),
+            ),
+            dim=0,
+        ).float()
+        scores = torch.matmul(query[query_row].float(), selected_kv.T) * scale_qk
+        expected = torch.matmul(torch.softmax(scores, dim=-1), selected_kv) * scale_out
+        actual = output[query_row].float()
+        max_abs_error = max(
+            max_abs_error, float((actual - expected).abs().max().item())
+        )
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-1)
+    return len(sample_rows), max_abs_error
+
+
+def testTrtllmBatchDecodeSparseMlaDsv4(args):
+    """Benchmark the public DSV4 sparse-MLA API on SM100/SM103."""
+    if args.verbose >= 1:
+        print("[INFO] Running testTrtllmBatchDecodeSparseMlaDsv4")
+        print(f"[INFO] FlashInfer version: {flashinfer.__version__}")
+
+    device = get_device(args)
+    if args.generate_repro_command:
+        print(
+            "[INFO] To reproduce this test case, run the following command: "
+            f"{args.repro_command}"
+        )
+
+    backends = filter_backends_by_compute_capability(
+        list(args.backends), args.routine, device
+    )
+    if not backends:
+        print("[ERROR] No backends to test. Exiting.")
+        return []
+    if args.random_actual_seq_len:
+        raise ValueError(
+            "trtllm_batch_decode_sparse_mla_dsv4 does not support "
+            "--random_actual_seq_len"
+        )
+    if args.batch_size <= 0 or args.s_qo <= 0 or args.s_kv <= 0:
+        raise ValueError("batch_size, s_qo, and s_kv must be positive")
+    if args.s_qo > args.s_kv:
+        raise ValueError("DSV4 sparse MLA requires s_qo <= s_kv")
+    if args.num_qo_heads not in (8, 16, 32, 64, 128):
+        raise ValueError("DSV4 sparse MLA num_qo_heads must be one of 8,16,32,64,128")
+    if args.num_kv_heads != 1:
+        raise ValueError("DSV4 sparse MLA requires num_kv_heads=1")
+    if args.head_dim_qk != _DSV4_HEAD_DIM:
+        raise ValueError("DSV4 sparse MLA requires head_dim_qk=512")
+    head_dim_vo = args.head_dim_qk if args.head_dim_vo is None else args.head_dim_vo
+    if head_dim_vo != _DSV4_HEAD_DIM:
+        raise ValueError("DSV4 sparse MLA requires head_dim_vo=512")
+    if args.swa_topk != _DSV4_SWA_TOPK:
+        raise ValueError("DSV4 sparse MLA requires swa_topk=128")
+    if args.page_size <= 0 or args.compressed_page_size <= 0:
+        raise ValueError("page sizes must be positive")
+    compressed_kv_len = (
+        math.ceil(args.s_kv / 4)
+        if args.compressed_kv_len is None
+        else args.compressed_kv_len
+    )
+    if args.compressed_topk <= 0 or compressed_kv_len < args.compressed_topk:
+        raise ValueError("compressed_kv_len must be >= compressed_topk > 0")
+
+    q_dtype = dtype_str_to_torch_dtype(args.q_dtype)
+    kv_dtype = dtype_str_to_torch_dtype(args.kv_dtype)
+    if q_dtype not in (torch.bfloat16, torch.float8_e4m3fn):
+        raise ValueError("DSV4 sparse MLA Q supports bfloat16 or fp8_e4m3")
+    if kv_dtype != q_dtype:
+        raise ValueError("DSV4 sparse MLA requires matching Q and KV dtypes")
+    if args.out_dtype not in (None, "bfloat16"):
+        raise ValueError("DSV4 sparse MLA output dtype is bfloat16")
+
+    batch_size = args.batch_size
+    total_q = batch_size * args.s_qo
+    query = (
+        torch.randn(
+            total_q,
+            args.num_qo_heads,
+            _DSV4_HEAD_DIM,
+            dtype=torch.float32,
+            device=device,
+        )
+        .mul_(0.05)
+        .clamp_(-1.0, 1.0)
+        .to(q_dtype)
+    )
+
+    def make_cache(logical_len, page_size):
+        pages_per_request = math.ceil(logical_len / page_size)
+        cache = (
+            torch.randn(
+                batch_size * pages_per_request,
+                page_size,
+                1,
+                _DSV4_HEAD_DIM,
+                dtype=torch.float32,
+                device=device,
+            )
+            .mul_(0.05)
+            .clamp_(-1.0, 1.0)
+            .to(kv_dtype)
+        )
+        if args.kv_layout == "HND":
+            cache = cache.transpose(1, 2).contiguous()
+        return cache
+
+    swa_kv_cache = make_cache(args.s_kv, args.page_size)
+    compressed_kv_cache = make_cache(compressed_kv_len, args.compressed_page_size)
+    sparse_indices, sparse_topk_lens, active_kv_lens = _dsv4_make_sparse_indices(
+        batch_size=batch_size,
+        s_qo=args.s_qo,
+        s_kv=args.s_kv,
+        swa_topk=args.swa_topk,
+        swa_page_size=args.page_size,
+        compressed_topk=args.compressed_topk,
+        compressed_kv_len=compressed_kv_len,
+        compressed_page_size=args.compressed_page_size,
+        device=device,
+    )
+    seq_lens = torch.full((batch_size,), args.s_kv, dtype=torch.int32, device=device)
+    cum_seq_lens_q = torch.arange(
+        0,
+        (batch_size + 1) * args.s_qo,
+        args.s_qo,
+        dtype=torch.int32,
+        device=device,
+    )
+    workspace = torch.empty(_DSV4_WORKSPACE_BYTES, dtype=torch.uint8, device=device)
+    output = torch.empty(
+        total_q,
+        args.num_qo_heads,
+        _DSV4_HEAD_DIM,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    qk_scale_value = _DSV4_HEAD_DIM**-0.55
+    bmm1_scale = (
+        torch.tensor([qk_scale_value], dtype=torch.float32, device=device)
+        if q_dtype == torch.float8_e4m3fn
+        else qk_scale_value
+    )
+    bmm2_scale = (
+        torch.tensor([1.0], dtype=torch.float32, device=device)
+        if q_dtype == torch.float8_e4m3fn
+        else 1.0
+    )
+
+    def run_backend(
+        query_arg,
+        swa_cache_arg,
+        compressed_cache_arg,
+        sparse_indices_arg,
+        sparse_topk_lens_arg,
+        seq_lens_arg,
+        cum_seq_lens_q_arg,
+        output_arg,
+    ):
+        return flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+            query=query_arg,
+            swa_kv_cache=swa_cache_arg,
+            workspace_buffer=workspace,
+            sparse_indices=sparse_indices_arg,
+            compressed_kv_cache=compressed_cache_arg,
+            sparse_topk_lens=sparse_topk_lens_arg,
+            seq_lens=seq_lens_arg,
+            out=output_arg,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=bmm2_scale,
+            kv_layout=args.kv_layout,
+            cum_seq_lens_q=cum_seq_lens_q_arg,
+            max_q_len=args.s_qo,
+            enable_pdl=args.enable_pdl,
+            backend="trtllm-gen",
+        )
+
+    runtime_args = (
+        query,
+        swa_kv_cache,
+        compressed_kv_cache,
+        sparse_indices,
+        sparse_topk_lens,
+        seq_lens,
+        cum_seq_lens_q,
+        output,
+    )
+    if args.refcheck:
+        run_backend(*runtime_args)
+        try:
+            sample_count, max_abs_error = _validate_dsv4_sparse_mla_samples(
+                query=query,
+                swa_kv_cache=swa_kv_cache,
+                compressed_kv_cache=compressed_kv_cache,
+                sparse_indices=sparse_indices,
+                sparse_topk_lens=sparse_topk_lens,
+                output=output,
+                swa_topk=args.swa_topk,
+                bmm1_scale=bmm1_scale,
+                bmm2_scale=bmm2_scale,
+                kv_layout=args.kv_layout,
+            )
+            if args.verbose >= 1:
+                print(
+                    f"[INFO] DSV4 sampled FP32 reference passed: {sample_count} "
+                    f"query rows, max_abs_error={max_abs_error:.6g}"
+                )
+        except AssertionError as error:
+            print(f"[ERROR] DSV4 sampled FP32 reference mismatch: {error}")
+            if not args.allow_output_mismatch:
+                raise
+
+    times = bench_gpu_time(
+        fn=run_backend,
+        dry_run_iters=args.dry_run_iters,
+        repeat_iters=args.num_iters,
+        sleep_after_run=False,
+        enable_cupti=args.use_cupti,
+        use_cuda_graph=not args.no_cuda_graph,
+        cold_l2_cache=True,
+        input_args=runtime_args,
+    )
+    median_time = float(np.median(times))
+    std_time = float(np.std(times))
+    active_pairs = int(active_kv_lens.sum().item())
+    flops = 4 * active_pairs * args.num_qo_heads * _DSV4_HEAD_DIM
+    logical_bytes = (
+        query.numel() * query.element_size()
+        + active_pairs * _DSV4_HEAD_DIM * torch.empty((), dtype=kv_dtype).element_size()
+        + output.numel() * output.element_size()
+    )
+    tflops = flops / (median_time * 1e9)
+    tb_per_sec = logical_bytes / (median_time * 1e9)
+    print_perf_metrics("trtllm-gen", median_time, std_time, tflops, tb_per_sec)
+
+    result = defaultdict(str)
+    result.update(
+        {
+            "routine": args.routine,
+            "median_time": median_time,
+            "std_time": std_time,
+            "tflops": tflops,
+            "tb_per_sec": tb_per_sec,
+            "backend": "trtllm-gen",
+            "resolved_backend": "trtllm-gen",
+            "page_size": args.page_size,
+            "batch_size": batch_size,
+            "s_qo": args.s_qo,
+            "s_kv": args.s_kv,
+            "num_qo_heads": args.num_qo_heads,
+            "num_kv_heads": args.num_kv_heads,
+            "head_dim_qk": _DSV4_HEAD_DIM,
+            "head_dim_vo": _DSV4_HEAD_DIM,
+            "causal": True,
+            "q_dtype": args.q_dtype,
+            "kv_dtype": args.kv_dtype,
+            "out_dtype": "bfloat16",
+            "avg_actual_seq_len": args.s_kv,
+            "random_actual_seq_len": False,
+            "swa_topk": args.swa_topk,
+            "compressed_topk": args.compressed_topk,
+            "compressed_kv_len": compressed_kv_len,
+            "compressed_page_size": args.compressed_page_size,
+            "kv_layout": args.kv_layout,
+            "case_tag": args.case_tag,
+        }
+    )
+    return [result]

--- a/benchmarks/routines/attention.py
+++ b/benchmarks/routines/attention.py
@@ -3993,7 +3993,7 @@ def _validate_dsv4_sparse_mla_samples(
         max_abs_error = max(
             max_abs_error, float((actual - expected).abs().max().item())
         )
-        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-1)
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
     return len(sample_rows), max_abs_error
 
 

--- a/benchmarks/routines/flashinfer_benchmark_utils.py
+++ b/benchmarks/routines/flashinfer_benchmark_utils.py
@@ -30,6 +30,12 @@ output_column_dict = {
         "is_var_seq",
         "cute_dsl_impl",
     ],
+    "dsv4_sparse_mla": [
+        "swa_topk",
+        "compressed_topk",
+        "compressed_kv_len",
+        "compressed_page_size",
+    ],
     "gemm": [
         "n",
         "group_size",
@@ -197,6 +203,7 @@ output_column_dict = {
 full_output_columns = (
     output_column_dict["perf"]
     + output_column_dict["attention"]
+    + output_column_dict["dsv4_sparse_mla"]
     + output_column_dict["gemm"]
     + output_column_dict["moe"]
     + output_column_dict["moe_comm"]
@@ -220,6 +227,7 @@ benchmark_apis = {
         "BatchPrefillWithPagedKVCacheWrapper",
         "BatchPrefillWithRaggedKVCacheWrapper",
         "BatchMLAPagedAttentionWrapper",
+        "trtllm_batch_decode_sparse_mla_dsv4",
     ],
     "gemm": [
         "gemm_fp8_nt_groupwise",
@@ -493,6 +501,18 @@ routine_cc_to_supported_backends = {
         "10.7": ["fa2", "cutlass", "trtllm-native"],
         "12.0": ["fa2"],
         "12.1": ["fa2"],
+    },
+    "trtllm_batch_decode_sparse_mla_dsv4": {
+        "7.5": [],
+        "8.0": [],
+        "8.6": [],
+        "8.9": [],
+        "9.0": [],
+        "10.0": ["trtllm-gen"],
+        "10.3": ["trtllm-gen"],
+        "10.7": [],
+        "12.0": [],
+        "12.1": [],
     },
     # GEMM
     "gemm_fp8_nt_groupwise": {

--- a/benchmarks/samples/sample_testlist.txt
+++ b/benchmarks/samples/sample_testlist.txt
@@ -21,6 +21,9 @@
 # PrimTS speculative MLA decode
 --routine BatchMLAPagedAttentionWrapper --backends prims-ts trtllm-native --page_size 32 --batch_size 4 --s_qo 4 --s_kv 4096 --num_qo_heads 32 --num_kv_heads 1 --head_dim_ckv 512 --head_dim_kpe 64 -vv --refcheck --q_dtype bfloat16 --kv_dtype bfloat16 --case_tag "PrimTS-MLA-decode-SQ4"
 
+# DeepSeek-V4 sparse MLA long-query prefill on SM100/SM103
+--routine trtllm_batch_decode_sparse_mla_dsv4 --backends trtllm-gen --page_size 256 --compressed_page_size 64 --batch_size 1 --s_qo 16384 --s_kv 16384 --num_qo_heads 16 --num_kv_heads 1 --head_dim_qk 512 --head_dim_vo 512 --swa_topk 128 --compressed_topk 1920 --q_dtype fp8_e4m3 --kv_dtype fp8_e4m3 --out_dtype bfloat16 --no_cuda_graph --refcheck -vv --generate_repro_command --case_tag "DeepSeek-V4-sparse-MLA-prefill"
+
 ## FP8 bmm
 --routine bmm_fp8 --batch_size 64 --m 4 --n 1024 --k 7168 --input_dtype fp8_e4m3 --mat2_dtype fp8_e4m3 --out_dtype bfloat16 --backends cudnn cublas cutlass --refcheck -vv --generate_repro_command
 

--- a/benchmarks/test_flashinfer_benchmark.py
+++ b/benchmarks/test_flashinfer_benchmark.py
@@ -141,6 +141,103 @@ def test_prims_ts_backend_is_blackwell_only(routine):
     )
 
 
+def test_dsv4_sparse_mla_backend_is_sm100_or_sm103_only():
+    support = routine_cc_to_supported_backends["trtllm_batch_decode_sparse_mla_dsv4"]
+    assert support["10.0"] == ["trtllm-gen"]
+    assert support["10.3"] == ["trtllm-gen"]
+    assert all(
+        not backends
+        for compute_capability, backends in support.items()
+        if compute_capability not in ("10.0", "10.3")
+    )
+
+
+def test_dsv4_sparse_mla_adapter_contract(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(
+        attention_routine, "get_device", lambda _args: torch.device("cpu")
+    )
+    monkeypatch.setattr(
+        attention_routine,
+        "filter_backends_by_compute_capability",
+        lambda backends, *_args: list(backends),
+    )
+    monkeypatch.setattr(attention_routine, "print_perf_metrics", lambda *_args: None)
+    monkeypatch.setattr(attention_routine, "_DSV4_WORKSPACE_BYTES", 1)
+    monkeypatch.setattr(
+        attention_routine.torch,
+        "randn",
+        lambda *shape, **kwargs: torch.ones(*shape, **kwargs),
+    )
+
+    def fake_sparse_mla(**kwargs):
+        calls.append(kwargs)
+        kwargs["out"].fill_(0.05)
+        return kwargs["out"]
+
+    monkeypatch.setattr(
+        attention_routine.flashinfer.mla,
+        "trtllm_batch_decode_sparse_mla_dsv4",
+        fake_sparse_mla,
+    )
+
+    def fake_bench_gpu_time(*, fn, input_args, **_kwargs):
+        fn(*input_args)
+        return np.array([1.0, 1.0])
+
+    monkeypatch.setattr(attention_routine, "bench_gpu_time", fake_bench_gpu_time)
+    args = flashinfer_benchmark.parse_args(
+        [
+            "--routine",
+            "trtllm_batch_decode_sparse_mla_dsv4",
+            "--batch_size",
+            "1",
+            "--s_qo",
+            "2",
+            "--s_kv",
+            "256",
+            "--num_qo_heads",
+            "16",
+            "--num_kv_heads",
+            "1",
+            "--head_dim_qk",
+            "512",
+            "--head_dim_vo",
+            "512",
+            "--compressed_topk",
+            "16",
+            "--q_dtype",
+            "bfloat16",
+            "--kv_dtype",
+            "bfloat16",
+            "--refcheck",
+        ]
+    )
+
+    assert args.backends == ["trtllm-gen"]
+    assert args.page_size == 256
+    assert args.causal is True
+    results = attention_routine.testTrtllmBatchDecodeSparseMlaDsv4(args)
+
+    assert len(calls) == 2
+    call = calls[0]
+    assert call["query"].shape == (2, 16, 512)
+    assert call["swa_kv_cache"].shape == (1, 1, 256, 512)
+    assert call["compressed_kv_cache"].shape == (1, 1, 64, 512)
+    assert call["sparse_indices"].shape == (2, 144)
+    assert call["sparse_topk_lens"].tolist() == [144, 144]
+    assert call["seq_lens"].tolist() == [256]
+    assert call["cum_seq_lens_q"].tolist() == [0, 2]
+    assert call["max_q_len"] == 2
+    assert call["backend"] == "trtllm-gen"
+    assert call["kv_layout"] == "HND"
+    assert call["out"].dtype == torch.bfloat16
+    assert results[0]["median_time"] == 1.0
+    assert results[0]["compressed_kv_len"] == 64
+    assert results[0]["causal"] is True
+
+
 @pytest.mark.parametrize(
     ("backend", "out_dtype", "message"),
     [

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -779,10 +779,11 @@ class TllmGenFmhaKernel {
                                        SelectKernelParams& selectKernelParams) const {
     // numHeadsQ <= 32 : SwapsMmaAbForGeneration
     //   Non-power-of-two head counts use one padded Q8/Q16/Q32 tile. Power-of-two head counts use
-    //   tileSizeQ = numHeadsQPerKv/2 at batch=1 or numHeadsQPerKv at batch>=2.
-    //   Threshold: batchSize * maxNumCtasPerSeqKv <= MP/8  (crossover at batch=1->2 on B200).
-    //   Benchmarks (seqLen=8192, topK=2048): half tileSizeQ wins by 2-6% at batch=1;
-    //     full tileSizeQ wins by 2-11% at batch>=2.
+    //   tileSizeQ = numHeadsQPerKv/2 for short queries at batch=1, otherwise numHeadsQPerKv.
+    //   Threshold: maxSeqLenQ <= 16 and batchSize * maxNumCtasPerSeqKv <= MP/8
+    //   (crossover at batch=1->2 on B200).
+    //   Short-query benchmarks (seqLenKv=8192, topK=2048): half tileSizeQ wins by 2-6% at
+    //     batch=1; full tileSizeQ wins by 2-11% at batch>=2.
     // numHeadsQ > 32 : KeepsMmaAbForGeneration, tileSizeQ = 64
     //   numHeadsQ=128 at large batch : 2CTA (clusterDimX=2, headDimPerCtaV=256)
     //   otherwise                    : 1CTA, headDimPerCtaV fine-tuned later
@@ -799,8 +800,10 @@ class TllmGenFmhaKernel {
       // mMultiCtasKvMode defaults to GmemReduction from the constructor. computeCtaAndClusterConfig
       // may upgrade it to CgaSmemReduction; that update is preserved naturally across
       // re-selections. The base tileSizeQ is numHeadsQPerKv (one CTA covers all Q heads per token).
-      // At batch=1 the GPU is under-utilized, so we halve tileSizeQ to create 2x more
-      // head-splitting CTAs. Threshold: batchSize * maxNumCtasPerSeqKv <= MP/8.
+      // At batch=1 short queries under-utilize the GPU, so halve tileSizeQ to create 2x more
+      // head-splitting CTAs. Long-query prefill already has Q-axis parallelism; halving the tile
+      // duplicates the KV loads for each token.
+      // Threshold: maxSeqLenQ <= 16 and batchSize * maxNumCtasPerSeqKv <= MP/8.
       //   effectiveSeqLenKv = min(seqLen, topK) = 2048 -> maxNumCtasPerSeqKv = 16.
       //   Condition: batchSize * 16 <= MP/8 -> batchSize <= 1 (crossover at batch=1->2).
       // Only halve when half tileSizeQ >= 8 (no valid SwapsMmaAb kernel below tileSizeQ=8).
@@ -809,8 +812,10 @@ class TllmGenFmhaKernel {
       int const effectiveSeqLenKv = std::min(params.mMaxSeqLenKv, params.mSparseMlaTopK);
       int const maxNumCtasPerSeqKv =
           flashinfer::ceil_div(effectiveSeqLenKv, selectKernelParams.mTileSizeKv);
-      bool const useHalfTileSizeQ = halfTileSizeQ >= 8 && params.mBatchSize * maxNumCtasPerSeqKv <=
-                                                              params.mMultiProcessorCount / 8;
+      bool const useHalfTileSizeQ =
+          halfTileSizeQ >= 8 &&
+          params.mBatchSize * maxNumCtasPerSeqKv <= params.mMultiProcessorCount / 8 &&
+          params.mMaxSeqLenQ <= 16;
       tileSizeQ = useHalfTileSizeQ ? halfTileSizeQ : fullTileSizeQ;
     } else {
       // numHeadsQ > 32: use KeepsMmaAbForGeneration.


### PR DESCRIPTION
## 📌 Description

### Summary

This PR restricts the sparse-MLA half-Q-tile heuristic to short queries
(`mMaxSeqLenQ <= 16`). Short decode/MTP queries retain the existing Q8 choice,
while long-query DeepSeek-V4 prefill uses Q16.

The existing heuristic considers the number of KV-split CTAs and batch size,
but not the amount of Q-axis parallelism. For the DeepSeek-V4 prefill case on
B200:

- `numHeadsQPerKv = 16`, so the full and half Q tiles are Q16 and Q8.
- `maxNumCtasPerSeqKv = ceil(min(maxSeqLenKv, sparseMlaTopK) / tileSizeKv)`.
- With `sparseMlaTopK = 2048` and `tileSizeKv = 128`,
  `maxNumCtasPerSeqKv = 16`.
- At batch 1 on a 148-SM B200, `1 * 16 <= 148 / 8`, so the current condition
  selects Q8 even when `maxSeqLenQ = 16384`.

Q8 is useful for short batch-1 queries because it creates more head-splitting
CTAs. A 16K query already supplies 16K-way Q-axis parallelism. In that case Q8
changes the main-kernel grid from `(16384, 1, 1)` to `(16384, 2, 1)` and makes
two CTAs load the same sparse KV set for the two eight-head groups. Q16 avoids
that duplicated KV traffic.

No new cubin is required: both Q8 and Q16 variants are already shipped. The
change only narrows the host-side selector condition.

### vLLM DeepSeek-V4 prefill call site

vLLM invokes this generation-form FlashInfer API from its DeepSeek-V4
`_forward_prefill` path: [`flashinfer_sparse.py:L781-L886`](https://github.com/vllm-project/vllm/blob/728d3ad09/vllm/models/deepseek_v4/nvidia/flashinfer_sparse.py#L781-L886).
Specifically, `_forward_prefill` calls
`flashinfer_trtllm_batch_decode_sparse_mla_dsv4(query=q_chunk, ...)`, which is
why prefill reaches `selectSparseMlaGenerationKernel()`.

### Native FlashInfer B200 benchmark

This PR adds `trtllm_batch_decode_sparse_mla_dsv4` as a first-class attention
routine in the repository's canonical `benchmarks/flashinfer_benchmark.py`
driver. It uses the public FlashInfer API and the driver's existing backend
filtering, common CLI flags, `bench_gpu_time`, cold-L2 handling, CSV schema,
test-list execution, and generated reproduction commands. Correctness is
checked before timing against an independent sampled FP32 attention oracle.

Native benchmark contract:

- 1x NVIDIA B200; PyTorch `2.13.0+cu130`; FlashInfer `0.6.16.post3`.
- Batch 1, 16 Q heads, head dim 512, FP8 E4M3 Q/KV, BF16 output.
- KV sequence length 16,384; 128 SWA + 1,920 compressed entries per query
  (`sparseMlaTopK=2048`); HND cache layout; PDL disabled.
- Query lengths `1,8,16,17,32,256,4096,16384` cover both sides of the guard
  and the target long-prefill case.
- Canonical `bench_gpu_time`: cold L2, 20 untimed warmups and 100 measured
  iterations per case. `cupti-python` was absent in the application image, so
  the driver used its documented CUDA-event fallback.
- Sampled FP32 reference checking ran before timing for every case. All BF16
  outputs were finite and the maximum absolute error was `1.81e-4`.

From the FlashInfer repository root, the target 16K case can be reproduced
with the canonical benchmark driver as follows:

```bash
python3 benchmarks/flashinfer_benchmark.py \
  --routine trtllm_batch_decode_sparse_mla_dsv4 \
  --backends trtllm-gen \
  --batch_size 1 \
  --s_qo 16384 \
  --s_kv 16384 \
  --num_qo_heads 16 \
  --num_kv_heads 1 \
  --head_dim_qk 512 \
  --head_dim_vo 512 \
  --page_size 256 \
  --swa_topk 128 \
  --compressed_kv_len 4096 \
  --compressed_page_size 64 \
  --compressed_topk 1920 \
  --kv_layout HND \
  --q_dtype fp8_e4m3 \
  --kv_dtype fp8_e4m3 \
  --out_dtype bfloat16 \
  --no_cuda_graph \
  --refcheck \
  --dry_run_iters 20 \
  --num_iters 100 \
  --generate_repro_command \
  --case_tag dsv4-q16384 \
  -vv
```

For the full boundary sweep, repeat the same command with
`--s_qo 1, 8, 16, 17, 32, 256, 4096, 16384` individually. Parent and PR
measurements must be run from their respective source checkouts with a freshly
built `fmha_gen` host launcher; an installed AOT launcher can otherwise hide
the selector change.

| Q length | Parent tile | PR tile | Parent (ms) | PR (ms) | Speedup |
|---:|:---:|:---:|---:|---:|---:|
| 1 | Q8 | Q8 | 0.027616 | 0.027616 | 1.000x |
| 8 | Q8 | Q8 | 0.027648 | 0.027584 | 1.002x |
| 16 | Q8 | Q8 | 0.029696 | 0.029680 | 1.001x |
| 17 | Q8 | Q16 | 0.029696 | 0.025568 | 1.162x |
| 32 | Q8 | Q16 | 0.037920 | 0.029696 | 1.277x |
| 256 | Q8 | Q16 | 0.134144 | 0.080736 | 1.662x |
| 4,096 | Q8 | Q16 | 1.565744 | 0.825200 | **1.897x** |
| 16,384 | Q8 | Q16 | 4.931104 | 2.614256 | **1.886x** |

The canonical-run logs show that the kernel name stays Q8 through `Q=16` and
changes to Q16 at `Q=17`, exactly matching the new boundary. At the target
`Q=16384`, the native API result is a 46.99% latency reduction. The `Q<=16`
arms use the same Q8 selector path and agree within 0.23%.

### vLLM DeepSeek-V4 B200 benchmark

Hardware and software:

- 8x NVIDIA B200, TP=8
- DeepSeek-V4-Pro, FP8 KV cache, block size 256
- vLLM `0.1.dev19908+g728d3ad09`
- FlashInfer `0.6.16.post3`
- Image `vllm/vllm-openai:nightly-dev-x86_64-cu13.0.1-728d3ad`
  (SHA-256 `9d812de47e34568de2a945635dd29cf2d6784fee62e3a602283d2665a9459cac`)
- `FLASHINFER_MLA_SPARSE_DSV4`, prefill-query quantization enabled, FP4
  indexer cache enabled, MTP=3
- Concurrency 16, ISL=16,384, OSL=1, seed 42,
  `max_num_batched_tokens=16384`, prefix caching disabled

The server used the DeepSeek-V4 configuration with the workload changes above.
The relevant launch arguments were:

```bash
vllm serve /models/DeepSeek-V4-Pro \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --trust-remote-code --tensor-parallel-size 8 \
  --kv-cache-dtype fp8 --block-size 256 --max-model-len 1048576 \
  --max-num-seqs 32 --max-num-batched-tokens 16384 \
  --attention-config '{"backend":"FLASHINFER_MLA_SPARSE_DSV4","use_prefill_query_quantization":true,"use_fp4_indexer_cache":true}' \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"synthetic","synthetic_acceptance_length":2.49}' \
  --no-enable-flashinfer-autotune --no-enable-prefix-caching --enforce-eager
```

Each arm ran four unprofiled repeats of 16 requests. The first repeat used 16
warmup requests; the server remained warm for the other repeats. The client
command was:

```bash
python utils/bench_serving/benchmark_serving.py \
  --model deepseek-ai/DeepSeek-V4-Pro \
  --served-model-name deepseek-ai/DeepSeek-V4-Pro \
  --backend vllm --base-url http://127.0.0.1:8888 \
  --dataset-name random --random-input-len 16384 --random-output-len 1 \
  --random-range-ratio 1.0 --max-concurrency 16 --request-rate inf \
  --num-prompts 16 --ignore-eos --seed 42 --trust-remote-code \
  --tokenizer-mode deepseek_v4 --use-chat-template --dsv4
```

Q8 is the parent selector. Q16 is the same image and workload with only this
query-length guard applied and the AOT host launcher rebuilt.

| Metric | Q8 (parent) | Q16 (this PR) | Change |
|---|---:|---:|---:|
| Four throughput repeats (tok/s) | 25,292.38; 25,286.59; 25,308.48; 25,294.95 | 27,892.23; 27,939.74; 27,923.39; 27,938.74 | -- |
| Mean total throughput | 25,295.60 tok/s | 27,923.53 tok/s | **+10.39%** |
| Mean throughput per GPU | 3,161.95 tok/s | 3,490.44 tok/s | **+10.39%** |
| Exact main sparse-MLA kernel | 142.38 ms/step | 75.89 ms/step | **1.88x faster; -46.70%** |
| Overlap-accounted attention | 198.72 ms/step | 132.66 ms/step | **-33.24%** |
| Iteration wall time | 648.73 ms/step | 589.02 ms/step | **-9.20%** |
| Main-kernel grid | `(16384, 2, 1)` | `(16384, 1, 1)` | **2x fewer CTAs** |

The throughput coefficient of variation was 0.037% for Q8 and 0.079% for Q16.
The wall-time ratio implies +10.14% throughput, consistent with the independent
unprofiled +10.39% result.

A 64-step profile validated the selector on all eight ranks. Per rank, all
`62 layers * 64 steps = 3968` main sparse-MLA calls used the Q16 kernel, with
zero main-path Q8 calls. The two short MTP calls per step remained Q8
(`128` calls per rank), as intended.

The Q8 and Q16 throughput arms used different B200 nodes. The image, framework,
model, and workload were identical; non-attention categories agreed within
about 2.4%, and the exact main FMHA reduction (66.48 ms/step) accounts for the
full raw-attention reduction (66.10 ms/step). A same-node rerun would provide
the strictest hardware-controlled A/B.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation performed:

- `pre-commit run --all-files`: passed.
- Canonical `benchmarks/flashinfer_benchmark.py` public-API benchmark on one
  B200: 20 warmups + 100 measured iterations for each of eight Q lengths and
  both selector variants; all sampled FP32 correctness checks passed.
  Long-prefill Q16 was 1.886x faster at `Q=16384` with cold L2.
- 4x unprofiled B200 throughput repeats per arm: passed, 16/16 requests each.
- 64-step, eight-rank B200 selector profile: Q16 on all 3968 main-layer calls
  per rank; short MTP remained Q8.

## Reviewer Notes

- This deliberately changes only the host-side tile selector. It does not
  modify numerical code or cubin artifacts.
- The `<= 16` boundary matches the existing short-query/DSv3 min-latency
  boundary in this runner and covers decode plus the configured MTP length.
- The benchmarked package used an AOT host launcher, so the validation rebuilt
  that launcher after editing the header. Normal source/CI builds will compile
  the updated selector into the launcher.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added benchmarking support for DeepSeek-V4 sparse MLA attention with configurable sparse-window, compressed-cache, paging, and cache-length settings.
  * Added performance metrics, support-matrix coverage, documentation, and sample configurations for supported hardware and the TensorRT-LLM generation backend.
* **Bug Fixes**
  * Improved sparse MLA tile selection for long-query prefill workloads.
* **Tests**
  * Added validation for availability, configuration, tensor layouts, execution behavior, and reported metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->