### PR TITLE
fix: test nightly should copy ci/cuda-versions.json from test sources

### DIFF
--- a/scripts/task_test_nightly_build.sh
+++ b/scripts/task_test_nightly_build.sh
@@ -53,10 +53,13 @@ echo "Verifying installation..."
 # Run from /tmp to avoid importing local flashinfer/ source directory
 (cd /tmp && python -m flashinfer show-config)
 
-# Copy only test sources into an isolated directory so package tests exercise the
-# installed flashinfer distribution instead of shadowing it with /workspace.
+# Copy test sources and repository-owned test data into an isolated directory so
+# package tests exercise the installed flashinfer distribution instead of
+# shadowing it with /workspace.
 cp -a "${SOURCE_WORKSPACE}/tests" "${TEST_RUN_DIR}/"
 cp -a "${SOURCE_WORKSPACE}/pytest.ini" "${TEST_RUN_DIR}/"
+mkdir -p "${TEST_RUN_DIR}/ci"
+cp -a "${SOURCE_WORKSPACE}/ci/cuda-versions.json" "${TEST_RUN_DIR}/ci/"
 
 # Run test shard
 echo "Running test shard ${TEST_SHARD}..."


### PR DESCRIPTION
## 📌 Description

Recent nightly test failure was due to missing cuda-versions.json. This commit is to copy over this file from the test source before the test is launched.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly build test reliability by ensuring CUDA version configuration is available in the isolated test environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->