### PR TITLE
build(jit): reduce JIT-cache wheel size

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -188,8 +188,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
           CUDA_VERSION: ${{ matrix.cuda.version }}
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda.version) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda.version) }}
-          # Keep 12.1a on CUDA 13.x aarch64 only: including it in cu129 made
-          # that wheel exceed GitHub's 2 GiB release-asset limit (#4519).
+          # Keep size-constrained architecture coverage centralized in
+          # ci/cuda-versions.json so release and nightly wheels stay aligned.
           FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.arch == 'aarch64' && matrix.cuda.aarch64_arch_list || matrix.cuda.x86_64_arch_list }}
           FLASHINFER_DEV_RELEASE_SUFFIX: ${{ needs.setup.outputs.dev_suffix }}
           FLASHINFER_LOCAL_VERSION: ${{ matrix.cuda.label }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,8 +226,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SCCACHE_AWS_SECRET_ACCESS_KEY }}
           CUDA_VERSION: ${{ matrix.cuda.version }}
           DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda.version) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda.version) }}
-          # Keep 12.1a on CUDA 13.x aarch64 only: including it in cu129 made
-          # that wheel exceed GitHub's 2 GiB release-asset limit (#4519).
+          # Keep size-constrained architecture coverage centralized in
+          # ci/cuda-versions.json so release and nightly wheels stay aligned.
           FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.arch == 'aarch64' && matrix.cuda.aarch64_arch_list || matrix.cuda.x86_64_arch_list }}
           FLASHINFER_LOCAL_VERSION: ${{ matrix.cuda.label }}
           PYTORCH_INDEX: ${{ matrix.cuda.pytorch_index }}

--- a/ci/cuda-versions.json
+++ b/ci/cuda-versions.json
@@ -30,15 +30,15 @@
       "label": "cu129",
       "version": "12.9",
       "pytorch_index": "cu129",
-      "x86_64_arch_list": "7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f",
-      "aarch64_arch_list": "7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f"
+      "x86_64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 12.0f",
+      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 12.0f"
     },
     {
       "label": "cu130",
       "version": "13.0",
       "pytorch_index": "cu130",
-      "x86_64_arch_list": "7.5 8.0 8.9 9.0a 10.0a 10.3a 12.0f",
-      "aarch64_arch_list": "7.5 8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a"
+      "x86_64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 12.0f",
+      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a"
     },
     {
       "label": "cu134",

--- a/ci/cuda-versions.json
+++ b/ci/cuda-versions.json
@@ -38,14 +38,14 @@
       "version": "13.0",
       "pytorch_index": "cu130",
       "x86_64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 12.0f",
-      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f 12.1a"
+      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 11.0a 12.0f"
     },
     {
       "label": "cu134",
       "version": "13.4",
       "pytorch_index": "nightly/cu134",
       "x86_64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 10.7a 12.0f",
-      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 10.7a 11.0a 12.0f 12.1a"
+      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 10.7a 11.0a 12.0f"
     }
   ]
 }

--- a/ci/cuda-versions.json
+++ b/ci/cuda-versions.json
@@ -44,8 +44,8 @@
       "label": "cu134",
       "version": "13.4",
       "pytorch_index": "nightly/cu134",
-      "x86_64_arch_list": "7.5 8.0 8.9 9.0a 10.0a 10.3a 10.7a 12.0f",
-      "aarch64_arch_list": "7.5 8.0 8.9 9.0a 10.0a 10.3a 10.7a 11.0a 12.0f 12.1a"
+      "x86_64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 10.7a 12.0f",
+      "aarch64_arch_list": "8.0 8.9 9.0a 10.0a 10.3a 10.7a 11.0a 12.0f 12.1a"
     }
   ]
 }

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -543,6 +543,7 @@ def gen_jit_spec(
         *get_nvcc_parallelism_flags(),
         "-use_fast_math",
         "-Xfatbin=-compress-all",  # Ensure all device binaries are compressed
+        "--compress-mode=size",
         "-DFLASHINFER_ENABLE_F16",
         "-DFLASHINFER_ENABLE_BF16",
         "-DFLASHINFER_ENABLE_FP8_E4M3",

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -28,6 +28,16 @@ def test_nvcc_parallelism_flags_ignore_sccache_launcher(monkeypatch):
     assert cpp_ext.get_nvcc_parallelism_flags() == ["--threads=4"]
 
 
+def test_jit_uses_size_optimized_fatbin_compression(monkeypatch):
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(core, "get_nvcc_parallelism_flags", lambda: ["--threads=1"])
+
+    spec = core.gen_jit_spec(name="test_module", sources=[])
+
+    assert "-Xfatbin=-compress-all" in spec.extra_cuda_cflags
+    assert "--compress-mode=size" in spec.extra_cuda_cflags
+
+
 def test_generate_ninja_uses_sccache_compatible_nvcc_depfile_flag(
     monkeypatch, tmp_path
 ):


### PR DESCRIPTION
## 📌 Description

Reduce JIT-cache wheel size by:

- Removing SM75 from every cu129, cu130, and cu134 x86_64 and AArch64 JIT-cache architecture list.
- Removing SM121a from the cu130 and cu134 AArch64 JIT-cache architecture lists while retaining the other newer targets, including Rubin.
- Adding nvcc --compress-mode=size to every CUDA JIT build while retaining -Xfatbin=-compress-all.
- Adding focused coverage that verifies both fatbin compression flags remain enabled.

The latest cu134 AArch64 nightly wheel measured 2,382,841,917 bytes, which is 235,358,269 bytes over the GitHub 2 GiB release-asset limit. SM75 accounted for an estimated 125,281,650 bytes of that wheel, and a representative CUDA 13.4 cubin sample was 17.6% smaller with size mode than with the current default compression mode. Removing SM121a provides additional headroom. The release workflow will provide the exact end-to-end measurement.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed pre-commit by running pip install pre-commit (or used your preferred method).
- [ ] I have installed the hooks with pre-commit install.
- [x] I have run the hooks manually with pre-commit run --all-files and fixed any reported issues.

> If you are unsure about how to set up pre-commit, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (unittest, etc.).

Validation performed:

- pre-commit run --all-files
- python3 ci/validate_cuda_versions.py --config ci/cuda-versions.json
- Explicit assertion that SM75 and SM121a are absent from every JIT-cache architecture list
- Python syntax compilation for the changed Python files

The local Python 3.14 environment does not include pytest, so the focused unit test was not executed locally. The CUDA wheel size and compatibility require release CI validation.

## Reviewer Notes

Please confirm the CUDA driver compatibility expectation for applying --compress-mode=size to every supported CUDA version. The current JIT-cache matrix begins at CUDA 12.9, newer than the CUDA 12.4 driver support boundary for compressed fatbins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced the size of compiled CUDA binaries through size-optimized compilation.
  - Improved efficiency for applications using generated CUDA extensions.

- **Compatibility**
  - Updated supported GPU compilation targets for CUDA 12.9, 13.0, and 13.4 configurations.
  - Aligned release and nightly builds with the updated architecture coverage.

- **Tests**
  - Added coverage to verify that size-optimized CUDA compilation is enabled.
  - Confirmed the expected compiler settings are applied during JIT builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->