### PR TITLE
ci: pin nvidia-cutlass-dsl 4.6.2 on release-v0.6.18

### DIFF
--- a/docker/install/build_flashinfer_ep_pytorch.sh
+++ b/docker/install/build_flashinfer_ep_pytorch.sh
@@ -27,9 +27,9 @@ set -euo pipefail
 CUDA_MAJOR="${CUDA_MAJOR:-$(python -c 'import torch; v = torch.version.cuda or ""; print(v.split(".")[0])' 2>/dev/null || true)}"
 : "${CUDA_MAJOR:?could not detect CUDA major from torch.version.cuda; set CUDA_MAJOR explicitly}"
 CU="cu${CUDA_MAJOR}"
-CUTLASS_DSL_SPEC="nvidia-cutlass-dsl>=4.6.0"
+CUTLASS_DSL_SPEC="nvidia-cutlass-dsl==4.6.2"
 if [[ "${CUDA_MAJOR}" == "13" ]]; then
-    CUTLASS_DSL_SPEC="nvidia-cutlass-dsl[cu13]>=4.6.0"
+    CUTLASS_DSL_SPEC="nvidia-cutlass-dsl[cu13]==4.6.2"
 fi
 
 FI_SRC="${FI_SRC:-/host/flashinfer}"

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -61,10 +61,15 @@ pip3 install --upgrade "$CUDA_PYTHON"
 # Install cudnn package based on CUDA version
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
   pip3 install --upgrade nvidia-cudnn-cu13
-  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]==4.6.2"
+  CUTLASS_DSL_PKG="nvidia-cutlass-dsl[cu13]==4.6.2"
 else
   pip3 install --upgrade nvidia-cudnn-cu12
+  CUTLASS_DSL_PKG="nvidia-cutlass-dsl==4.6.2"
 fi
+pip3 uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base \
+  nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 \
+  nvidia-cutlass-dsl-libs-core -y 2>/dev/null || true
+pip3 install --upgrade "$CUTLASS_DSL_PKG"
 
 # Fail the build if torch or cuda-python drifted off this image's CUDA major.
 python3 -c "

--- a/docker/install/install_python_packages.sh
+++ b/docker/install/install_python_packages.sh
@@ -61,7 +61,7 @@ pip3 install --upgrade "$CUDA_PYTHON"
 # Install cudnn package based on CUDA version
 if [[ "$CUDA_VERSION" == *"cu13"* ]]; then
   pip3 install --upgrade nvidia-cudnn-cu13
-  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]==4.7.0"
+  pip3 install --upgrade "nvidia-cutlass-dsl[cu13]==4.6.2"
 else
   pip3 install --upgrade nvidia-cudnn-cu12
 fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
+# Same floor as requirements.txt (looser than main's >=4.7.0a0) so [cu12]/[cu13]
+# can resolve next to quack-kernels 0.6.4, which hard-pins ==4.6.2.
 cu12 = ["nvidia-cutlass-dsl>=4.6.2a0"]
 cu13 = ["nvidia-cutlass-dsl[cu13]>=4.6.2a0"]
 # DEPRECATED alias, kept so existing `pip install ".[nvep]"` commands keep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ urls = { Homepage = "https://github.com/flashinfer-ai/flashinfer" }
 license-files = ["LICENSE", "LICENSE*.txt"]
 
 [project.optional-dependencies]
-cu12 = ["nvidia-cutlass-dsl>=4.7.0a0"]
-cu13 = ["nvidia-cutlass-dsl[cu13]>=4.7.0a0"]
+cu12 = ["nvidia-cutlass-dsl>=4.6.2a0"]
+cu13 = ["nvidia-cutlass-dsl[cu13]>=4.6.2a0"]
 # DEPRECATED alias, kept so existing `pip install ".[nvep]"` commands keep
 # working. The moe_ep runtime deps (cuda-python, nccl4py) are now part of the
 # BASE dependencies (requirements.txt) and the NIXL-EP submodule build runs by

--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -128,7 +128,7 @@ uv pip install --python "${VENV}/bin/python" --no-deps \
 # nccl4py's cuda.core/cuda-bindings come along here.
 uv pip install --python "${VENV}/bin/python" \
     numpy einops ninja nvidia-ml-py click requests tabulate tqdm \
-    "nvidia-cutlass-dsl[cu13]==4.7.0" "nvidia-cudnn-frontend>=1.13.0" \
+    "nvidia-cutlass-dsl[cu13]==4.6.2" "nvidia-cudnn-frontend>=1.13.0" \
     "cuda-tile>=1.4.0" "cuda-python>=13.0" "nccl4py>=0.3.1" \
     "nvidia-nccl-cu13>=2.30.7"   # B200 NCCL-EP needs >=2.30.7; load this first on LD_LIBRARY_PATH
 

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -295,13 +295,16 @@ install_and_verify() {
         # version skew between libs-base and libs-cu13.  requirements.txt
         # cannot add the extra conditionally, hence the separate install.
         #
-        # Keep this a floor, not an exact pin: an exact ==4.7.0 downgrades a
-        # newer CuTe DSL that the test image may ship (the Rubin image ships
-        # 4.8.0a0), which removes cutlass.utils.rubin_helpers and the sm_107a
-        # Arch member and so disables every SM107 path for the whole run.
-        # The a0 suffix is required for pip to consider pre-releases at all.
+        # Exact 4.6.2: existing CI images bake 4.7.0, and a >= floor would
+        # still resolve to 4.7.x. This also downgrades Rubin images that
+        # ship 4.8.0a0 (SM107 cute-dsl stays gated off for the job).
+        pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base \
+            nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 \
+            nvidia-cutlass-dsl-libs-core -y 2>/dev/null || true
         if [[ "${CUDA_VERSION}" == *"cu13"* || "${CUDA_VERSION}" == 13.* ]]; then
-            pip install --upgrade "nvidia-cutlass-dsl[cu13]>=4.7.0a0"
+            pip install "nvidia-cutlass-dsl[cu13]==4.6.2"
+        else
+            pip install "nvidia-cutlass-dsl==4.6.2"
         fi
 
         # Install local python sources. The env var keeps --no-build-isolation

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -306,6 +306,7 @@ install_and_verify() {
         else
             pip install "nvidia-cutlass-dsl==4.6.2"
         fi
+        python -c "import importlib.metadata as m; print('nvidia-cutlass-dsl', m.version('nvidia-cutlass-dsl'))"
 
         # Install local python sources. The env var keeps --no-build-isolation
         # from activating the build hooks' own downloads (see setup_test_env.sh).


### PR DESCRIPTION
## Summary

Make 4.6.2 the DSL that **default** 0.6.18 CI actually runs, matching the published `requirements.txt` floor (`>=4.6.2a0` from #4715). Today that floor is only theoretical: CI images bake `==4.7.0`, `test_utils.sh` then upgrades to `>=4.7.0a0`, and the `[cu12]`/`[cu13]` extras still require `>=4.7.0a0`.

Do **not** use a global `>=4.6.2` pin: existing B200/B300 images already have 4.7.0, so a floor would never install 4.6.2.

- `pyproject.toml` extras: `>=4.6.2a0` (same floor as base deps). This is an **intentional divergence from `main`**, which still has `>=4.7.0a0` / `ci/cuda-versions.json`. #4715 left extras at 4.7 on purpose; 0.6.18 extras need to be able to resolve next to `quack-kernels==0.6.4` (`==4.6.2`). Unconstrained pip still picks 4.7.1.
- `scripts/test_utils.sh`: exact `==4.6.2` (with `[cu13]` on CUDA 13, plain pin on CUDA 12) on **non-Rubin** jobs, then prints `importlib.metadata.version`. Rubin jobs skip the uninstall/reinstall when `PREPARE_RUBIN_TEST_IMAGE=1` or `PREPARE_PUBLIC_RUBIN_STACK=1` (GitLab `adshen/rubin-unit-test-pdx` already passes the former into the container for `unit_test_gr100` / `unit_test_vr200`).
- `docker/install/install_python_packages.sh`: bake `==4.6.2` on **both** CUDA 12 and CUDA 13 (uninstall libs first).
- `scripts/build_in_container.sh`: `==4.6.2`.
- `docker/install/build_flashinfer_ep_pytorch.sh`: `==4.6.2` instead of `>=4.6.0`, skipped when the same Rubin env flags are set.

## Expected CI deltas vs rc8 at 4.7.0

- PrimTS attention suites skip (`pytest.importorskip(..., minversion="4.7.0")` in `test_attention_ts_*.py`)
- Default B200/B300 jobs run cute-dsl **4.6.2**; Rubin `rubin-latest` jobs keep baked **4.8.0a0**
- quack-kernels 0.6.4's `==4.6.2` pin is now aligned on non-Rubin jobs (still installed `--no-deps`)
- SM100/SM103/SM12x cute-dsl arch members (`sm_100a`, `sm_121a`, …) exist in 4.6.2

`CUTLASS_DSL_VERSION` in `ci/setup_python.env` still overrides after this install on jobs that set it.

## Test plan

- [ ] GitLab unit-test pipeline: job logs show `nvidia-cutlass-dsl 4.6.2` after `install_and_verify` on B200/B300 **and** on a CUDA 13 `moe_ep` job
- [ ] Expect PrimTS files skipped, not failed
- [ ] B200/B300 cute-dsl GEMM/MoE still collect and run
- [ ] Rubin (`PREPARE_RUBIN_TEST_IMAGE=1`): log shows left-in-place DSL (4.8.0a0), not 4.6.2

Do not rebuild CI images before the first run — `test_utils.sh` downgrades the existing 4.7.0 bake on non-Rubin jobs.