### PR TITLE
chore(aot): exclude single prefill/decode modules from jit-cache prebuilds

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -41,8 +41,6 @@ from .jit.attention import (
     gen_batch_prefill_module,
     gen_cudnn_fmha_module,
     gen_fmha_cutlass_sm100a_module,
-    gen_single_decode_module,
-    gen_single_prefill_module,
     gen_trtllm_gen_fmha_module,
     gen_trtllm_fmha_v2_sm120_module,
 )
@@ -173,19 +171,6 @@ def gen_fa2(
     if dtype_qo.itemsize == 1:
         return  # fp8 tensor cores not supported in fa2
 
-    yield gen_single_prefill_module(
-        backend="fa2",
-        dtype_q=dtype_qo,
-        dtype_kv=dtype_kv,
-        dtype_o=dtype_qo,
-        head_dim_qk=head_dim_qk,
-        head_dim_vo=head_dim_vo,
-        pos_encoding_mode=0,
-        use_sliding_window=use_sliding_window,
-        use_logits_soft_cap=use_logits_soft_cap,
-        use_fp16_qk_reduction=False,
-    )
-
     yield gen_batch_prefill_module(
         backend="fa2",
         dtype_q=dtype_qo,
@@ -201,17 +186,6 @@ def gen_fa2(
     )
 
     if not prefill_only:
-        yield gen_single_decode_module(
-            dtype_q=dtype_qo,
-            dtype_kv=dtype_kv,
-            dtype_o=dtype_qo,
-            head_dim_qk=head_dim_qk,
-            head_dim_vo=head_dim_vo,
-            pos_encoding_mode=0,
-            use_sliding_window=use_sliding_window,
-            use_logits_soft_cap=use_logits_soft_cap,
-        )
-
         yield gen_batch_decode_module(
             dtype_q=dtype_qo,
             dtype_kv=dtype_kv,


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

The `single_prefill_with_kv_cache` / `single_decode_with_kv_cache` module families account for ~280–400 MB per `flashinfer-jit-cache` wheel (12–16%;  measured on v0.6.17: fa2 single prefill 233–322 MB, fa2 single decode 47–82 MB across cu129/cu130 × x86_64/aarch64), contributing to the 2 GiB  GitHub release-asset limit problem (#4519).

These modules are fully disjoint from the ones used by `BatchPrefillWithPagedKVCacheWrapper` / `BatchDecodeWithPagedKVCacheWrapper`, and neither vLLM nor SGLang calls the single-request APIs. This PR drops them from AOT prebuilds (96 modules); the APIs remain fully functional and JIT-compile on first use.

**No kernel or API changes — AOT module list only.**

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * AOT builds now generate only batched FA2 attention kernels.
  * Single-request FA2 prefill and decode kernels are no longer included in generated builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->