### PR TITLE
fix: SM107 (Rubin) MoE tactic guard and batched-GEMM cubin pin

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -143,7 +143,7 @@ class ArtifactPath:
         "10f64528a1172dae8e29601a3b99ab9dc78d37be/gemm-91e0ba0-2710384/"
     )
     TRTLLM_GEN_BMM_RUBIN: str = (
-        "46d3f3561e3336c131a141191ee6aaa0690723bb/batched_gemm-17629de-61f1bc7/"
+        "2d6a5a029eefcc388ec0ceb87efb55d8bcce5c3c/batched_gemm-fa419f4-22202a7/"
     )
     TRTLLM_GEN_GEMM_RUBIN: str = (
         "46d3f3561e3336c131a141191ee6aaa0690723bb/gemm-17629de-25754e6/"
@@ -183,7 +183,7 @@ class CheckSumHash:
         "f97f90f9ce1dab73eb3d7c90fca4bbd52687642dd87a79dd10b77d7802b25c33"
     )
     TRTLLM_GEN_BMM_RUBIN: str = (
-        "31c9f4cdd59299fc6a9a6f3a31b403b817a1fea63238eec2cbcd3009d2feb3f7"
+        "d4e146217239c53aadbc40a35e86b289c74e0f5886e8ba9d5f12b990c20edecc"
     )
     TRTLLM_GEN_GEMM_RUBIN: str = (
         "2174e60bc8248a8af41a3d0afdc4cac8f2b04893ac983f654065dd14c77ec139"

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -694,6 +694,20 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
                 if not gated:
                     return False
 
+                # Those kernels are also built on ``cutlass.utils.rubin_helpers``,
+                # which only exists from CuTe DSL 4.8. The ``.rubin`` package
+                # imports them eagerly, so on an older DSL the import below raises
+                # ModuleNotFoundError instead of merely declining the tactic.
+                #
+                # Imported inside the function because ``cute_dsl/utils`` pulls in
+                # cutlass at module scope and this module deliberately does not.
+                # Once the probes live in a cutlass-free module this can move to
+                # module scope and import from there instead.
+                from ...cute_dsl.utils import is_rubin_cute_dsl_available
+
+                if not is_rubin_cute_dsl_available():
+                    return False
+
                 from .rubin import (
                     Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel,
                     Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel,


### PR DESCRIPTION
## Summary

Two independent SM107 (Rubin) fixes found while triaging the v0.6.18 Rubin CI failures. They are unrelated to each other and can be reviewed separately.

**Draft** — neither commit has been validated on hardware yet. See *Validation status* below.

### 1. `fix(moe)` — decline Rubin tactics when the CuTe DSL lacks `rubin_helpers`

`_tactic_ok` in `flashinfer/fused_moe/cute_dsl/tuner.py` checks that a Rubin tactic is gated, then does `from .rubin import (...)` without checking whether the installed CuTe DSL can actually provide those kernels. The `.rubin` package imports both SM107 kernel modules eagerly, and each does a module-scope `import cutlass.utils.rubin_helpers` — a module that only exists from CuTe DSL 4.8.

On an older DSL that import raises `ModuleNotFoundError` instead of the tactic simply being declined:

```
ModuleNotFoundError: No module named 'cutlass.utils.rubin_helpers'
```

Every other consumer of these kernels already gates on `is_rubin_cute_dsl_available()` — `_sm107_swiglu_kernel_cls`, the finalize-fusion equivalent, `bmm_fp8_wrapper`, and `gemm/kernels/__init__.py` (whose comment describes this exact hazard). `tuner.py` is the only unguarded path.

The fix returns `False` rather than raising, matching `_tactic_ok`'s contract and the adjacent `if not gated: return False` — raising would abort autotuning instead of falling back to the other backends.

The guard is imported lazily because `cute_dsl/utils.py` imports `cutlass` at module scope and `tuner.py` deliberately does not. If the probes later move to a cutlass-free module, this can become a module-scope import.

### 2. `fix(artifacts)` — bump the Rubin batched-GEMM pin to the multi-arch package

The pinned Rubin batched-GEMM package omits the `geGlu` and `siTu` fused activations across every MXFP8/MXFP4 dtype family. Those kernels exist for Blackwell but were never generated for sm107, so MoE calls requesting them find no match:

```
No kernel found for the given options: mDtypeA: MxE4m3, mDtypeB: MxE4m3,
mDtypeC: MxE4m3, ... mActType: 1 ...
```

This is a kernel-generation gap in the package — option matching, tile sizes and arch handling are all correct.

Verified against the published artifact repository:

| | old pin | new pin |
|---|---|---|
| `sm107a` | 2,552 | **3,386** (+834, none lost) |
| `sm100f` | 2,552 | **3,386** |
| `sm103a` | 90 | 90 |

The five previously-empty families are now populated on `sm107a`: `E2m1E2m1 siTu` 74, `MxE2m1MxE4m3 geGlu` 208, `MxE2m1MxE4m3 siTu` 110, `MxE4m3MxE4m3 geGlu` 208, `MxE4m3MxE4m3 siTu` 110.

The checksum method was validated by recomputing the **old** package's hash, which reproduces the value already in `artifacts.py` exactly.

`TRTLLM_GEN_GEMM_RUBIN` is deliberately left alone — its old and new kernel sets are identical (93 `sm107a`, 93 `sm100f`), so bumping it would be pure churn.

**This one is a stopgap.** #4648 supersedes it by deleting `TRTLLM_GEN_BMM_RUBIN` entirely and serving both architectures from a single pin. This change keeps the existing split and repoints only the Rubin half so it can land independently of that refactor. **If #4648 merges first, drop this commit rather than merging it.**

## Validation status

Neither commit has been run on hardware. Kept as a draft for that reason.

* **`fix(moe)`** — static analysis only: `py_compile`, plus a grep confirming `tuner.py` is the only unguarded path. The correct validator is a CI job running a public build against public CuTe DSL 4.7.0, which is the configuration that produced the failure.
* **`fix(artifacts)`** — manifest analysis only. Proving the fix means running the two Geglu MoE cases against the new pin:
  * `tests/moe/test_trtllm_gen_fused_moe.py::test_sigmoid_routing_Geglu_Shuffled_MajorK_Sigmoid_128e_top8_FP8_Block_MxFp8_1024_1024_8_`
  * `tests/moe/test_trtllm_gen_routed_fused_moe.py::test_trtllm_gen_routed_fused_moe_geglu_packed_MxFP4xMxFP8_1_4_128_1024_1024_1_`

One caveat on the evidence for the second commit: the kernel counts are parsed from arch suffixes in kernel names (`_sm100f` / `_sm107a`) rather than from a structured field, because the config struct does not expose the arch directly. Arch is a safer inference from a kernel name than most attributes, but it is not verified to the same standard as the checksum.

## Not included

A related fix widening `isArchCompatible`'s `Sm100f` case to accept SM107 is still being investigated and will follow separately if it holds up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with older CuTe DSL versions by safely skipping unavailable Rubin tactics instead of raising import errors.
  * Updated the TRTLLM GEN BMM Rubin backend artifact reference and verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->