### PR TITLE
ci: keep Rubin cute-dsl pins after the 4.6.2 CI pin

### DIFF
--- a/docker/install/build_flashinfer_ep_pytorch.sh
+++ b/docker/install/build_flashinfer_ep_pytorch.sh
@@ -31,6 +31,11 @@ CUTLASS_DSL_SPEC="nvidia-cutlass-dsl==4.6.2"
 if [[ "${CUDA_MAJOR}" == "13" ]]; then
     CUTLASS_DSL_SPEC="nvidia-cutlass-dsl[cu13]==4.6.2"
 fi
+# Rubin jobs keep the image / public-stack DSL (see test_utils.sh).
+if [ "${PREPARE_RUBIN_TEST_IMAGE:-0}" = "1" ] || \
+   [ "${PREPARE_PUBLIC_RUBIN_STACK:-0}" = "1" ]; then
+    CUTLASS_DSL_SPEC=""
+fi
 
 FI_SRC="${FI_SRC:-/host/flashinfer}"
 NCCL_VERSION="${FI_NCCL_VERSION:-2.30.7}"
@@ -60,12 +65,19 @@ PIP_CONSTRAINT="" pip install --no-cache-dir \
 python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep + nccl4py import OK')"
 
 echo "== install DeepGEMM + NVSHMEM / CUTLASS DSL deps =="
-PIP_CONSTRAINT="" python -m pip install --no-cache-dir \
-    "nvshmem4py-${CU}" \
-    pytest \
-    "nvidia-nvshmem-${CU}" \
-    filelock \
-    "${CUTLASS_DSL_SPEC}"
+_ep_pip_args=(
+    "nvshmem4py-${CU}"
+    pytest
+    "nvidia-nvshmem-${CU}"
+    filelock
+)
+if [ -n "${CUTLASS_DSL_SPEC}" ]; then
+    _ep_pip_args+=("${CUTLASS_DSL_SPEC}")
+else
+    echo "Keeping installed nvidia-cutlass-dsl for Rubin job"
+fi
+PIP_CONSTRAINT="" python -m pip install --no-cache-dir "${_ep_pip_args[@]}"
+unset _ep_pip_args
 (
     if [ ! -d "${DEEPGEMM_SRC}/.git" ]; then
         git clone --recursive https://github.com/deepseek-ai/DeepGEMM.git "${DEEPGEMM_SRC}"

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -295,18 +295,25 @@ install_and_verify() {
         # version skew between libs-base and libs-cu13.  requirements.txt
         # cannot add the extra conditionally, hence the separate install.
         #
-        # Exact 4.6.2: existing CI images bake 4.7.0, and a >= floor would
-        # still resolve to 4.7.x. This also downgrades Rubin images that
-        # ship 4.8.0a0 (SM107 cute-dsl stays gated off for the job).
-        pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base \
-            nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 \
-            nvidia-cutlass-dsl-libs-core -y 2>/dev/null || true
-        if [[ "${CUDA_VERSION}" == *"cu13"* || "${CUDA_VERSION}" == 13.* ]]; then
-            pip install "nvidia-cutlass-dsl[cu13]==4.6.2"
+        # Exact 4.6.2 on default CI images (they bake 4.7.0; a >= floor still
+        # resolves to 4.7.x). Rubin jobs keep the image/prep DSL: gr100/vr200
+        # on adshen/rubin-unit-test-pdx use rubin-latest (4.8.0a0) with
+        # PREPARE_RUBIN_TEST_IMAGE=1; public-stack Rubin jobs set
+        # PREPARE_PUBLIC_RUBIN_STACK=1 after installing 4.7.0.
+        if [ "${PREPARE_RUBIN_TEST_IMAGE:-0}" = "1" ] || \
+           [ "${PREPARE_PUBLIC_RUBIN_STACK:-0}" = "1" ]; then
+            python -c "import importlib.metadata as m; print('nvidia-cutlass-dsl', m.version('nvidia-cutlass-dsl'), '(left in place for Rubin job)')"
         else
-            pip install "nvidia-cutlass-dsl==4.6.2"
+            pip uninstall nvidia-cutlass-dsl nvidia-cutlass-dsl-libs-base \
+                nvidia-cutlass-dsl-libs-cu12 nvidia-cutlass-dsl-libs-cu13 \
+                nvidia-cutlass-dsl-libs-core -y 2>/dev/null || true
+            if [[ "${CUDA_VERSION}" == *"cu13"* || "${CUDA_VERSION}" == 13.* ]]; then
+                pip install "nvidia-cutlass-dsl[cu13]==4.6.2"
+            else
+                pip install "nvidia-cutlass-dsl==4.6.2"
+            fi
+            python -c "import importlib.metadata as m; print('nvidia-cutlass-dsl', m.version('nvidia-cutlass-dsl'))"
         fi
-        python -c "import importlib.metadata as m; print('nvidia-cutlass-dsl', m.version('nvidia-cutlass-dsl'))"
 
         # Install local python sources. The env var keeps --no-build-isolation
         # from activating the build hooks' own downloads (see setup_test_env.sh).


### PR DESCRIPTION
## Summary

Follow-up to #4758. 

- Default B200/B300 (and moe_ep) jobs still uninstall and install `==4.6.2`.
- other internal jobs on the laternate branch skip the pin and leave the image/prep package.
- Same skip in `docker/install/build_flashinfer_ep_pytorch.sh` so CUDA 13 moe_ep setup does not re-pin those jobs.

A global `>=4.6.2` would leave default CI on the baked 4.7.0; this keeps the exact pin everywhere except the Rubin env flags GitLab already passes into the container.