### PR TITLE
fix(jit): prefer system CUB/Thrust over bundled CCCL 3.0.3 (sampling.cu fails to compile under nvcc 12/SM89)

### DIFF
--- a/flashinfer/jit/env.py
+++ b/flashinfer/jit/env.py
@@ -171,7 +171,17 @@ CUTLASS_INCLUDE_DIRS: list[pathlib.Path] = [
 ]
 SPDLOG_INCLUDE_DIR: pathlib.Path = _package_root / "data" / "spdlog" / "include"
 CCCL_INCLUDE_DIRS: list[pathlib.Path] = [
-    _package_root / "data" / "cccl" / "cub",
+    # Prefer system CUB/Thrust when present: the bundled CCCL 3.0.3 headers fail to
+    # compile sampling.cuh under nvcc 12 / CUDA 12 (SM89) with 100 errors, e.g.
+    # cub::_V_300302_SM_890::BlockAdjacentDifference<...> has no member ... .
+    # System CUB 2.0.1 compiles fine. Fall back to the bundle otherwise.
+    *(
+        [pathlib.Path("/usr/include")]
+        if (pathlib.Path("/usr/include") / "cub" / "cub.cuh").exists()
+        else [
+            _package_root / "data" / "cccl" / "cub",
+            _package_root / "data" / "cccl" / "thrust",
+        ]
+    ),
     _package_root / "data" / "cccl" / "libcudacxx" / "include",
-    _package_root / "data" / "cccl" / "thrust",
 ]


### PR DESCRIPTION
## Problem

flashinfer's JIT compilation of `data/csrc/sampling.cu` fails on nvcc 12 / CUDA 12 toolchains (SM89, RTX 40-series) with the **bundled CCCL 3.0.3** headers:

```
/home/.../flashinfer/data/include/flashinfer/sampling.cuh(623): error: class "cub::_V_300302_SM_890::BlockAdjacentDifference<__nv_bool, ...>" has no member ...
...
Error limit reached. 100 errors detected in the compilation of "sampling.cu".
```

The bundled CUB 3.0.3 headers are incompatible with this code path when compiled with nvcc 12 / system libcub-dev 2.0.1. Consequences at runtime: the JIT build fails on the first request, the backend worker dies without a Python traceback, and every following request fails (empty reply / 400).

## Reproducer

- RTX 4070 Ti SUPER (SM89), Pop!_OS 24.04, NVIDIA 595.84, nvcc 12.0, libcub-dev 2.0.1
- flashinfer-python 0.6.17 (bundled CCCL 3.0.3), FreeToken 0.1.2 with `--attn triton` (sampling still goes through the flashinfer JIT)
- First `/v1/chat/completions` request triggers the JIT build of `sampling.cu` -> compile failure -> worker dies
- Isolated repro before fix (same failure, no engine needed):

```python
import torch
from flashinfer.sampling import top_k_top_p_sampling_from_probs

probs = torch.rand(4, 32000, device="cuda", dtype=torch.float32)
probs = probs / probs.sum(dim=-1, keepdim=True)
out = top_k_top_p_sampling_from_probs(probs, top_k=20, top_p=0.95)
```

## Fix

Prefer the **system CUB/Thrust** installation when present (detected via `cub/cub.cuh`); keep the bundled CCCL as a fallback for environments without a system CUB. With system CUB 2.0.1 + the bundled libcudacxx headers, `sampling.cu` compiles cleanly under nvcc 12 / SM89.

## Validation

- Isolated kernel test with a **completely empty JIT cache** (fresh `nvcc` build of `sampling.cu` with the patched `env.py`): `KERNEL-OK: [30701, 7894, 29451]` (valid token indices)
- Full engine (FreeToken 0.1.2, Qwen3.6-35B-A3B-NVFP4 offload): weight rebuild + CUDA-graph capture + prefill warmup complete, real inference responses
- 30/30 sequential chat requests return HTTP 200 across configurations (current constrained config, `--cuda-graph-max-bs 1`, default graph batch size, historical failing config), fresh TCP connections and keep-alive reuse

## Regression / build test

- With the JIT cache removed, the first kernel call recompiles `sampling.cu` from scratch and succeeds
- The bundled-CCCL fallback path is preserved for systems without a system CUB (no behavioral change for those environments)

## Related

- FreeToken issue [FlashML-org/FreeToken#220](https://github.com/FlashML-org/FreeToken/issues/220) documents the full investigation: the 100-error compile failure, the resulting worker death, and the historical "9 ms empty reply on request #2" symptom that was traced to this JIT instability (no longer reproducible after this fix; exact mechanism of the historical EOF remains unproven).
