### PR TITLE
fix(cute_dsl): restore the GDN compile arch helper

### DIFF
--- a/flashinfer/cute_dsl/availability.py
+++ b/flashinfer/cute_dsl/availability.py
@@ -190,6 +190,27 @@ def _dsl_captured_arch() -> Optional[str]:
         return None
 
 
+def cute_dsl_compile_arch(major: int, minor: int) -> str:
+    r"""Return the arch name to pass to ``cute.GPUArch`` for a device."""
+    from cutlass.base_dsl.arch import Arch
+
+    for name in (f"sm_{major}{minor}a", f"sm_{major}{minor}"):
+        try:
+            Arch[name]
+            return name
+        except KeyError:
+            continue
+    if is_cute_dsl_arch_supported(major, minor):
+        family = _family_fallback_arch(major, minor)
+        if family is not None:
+            return family
+    raise NotImplementedError(
+        f"the installed CuTe DSL cannot target sm_{major}{minor}; export "
+        f"CUTE_DSL_ARCH=sm_{major}0f before starting the process to build "
+        f"family-portable kernels on this device"
+    )
+
+
 def require_cute_dsl_arch(device, native_only: bool = False) -> None:
     r"""Raise :class:`NotImplementedError` when the installed CuTe DSL cannot
     target ``device``'s architecture (see :func:`is_cute_dsl_arch_supported`)."""

--- a/flashinfer/cute_dsl/utils.py
+++ b/flashinfer/cute_dsl/utils.py
@@ -29,6 +29,7 @@ from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.cute.typing import AddressSpace, Numeric, Pointer, Type
 
 from .availability import (  # noqa: F401
+    cute_dsl_compile_arch,
     is_cute_dsl_arch_supported,
     is_cute_dsl_available,
     is_cute_dsl_experimental_available,


### PR DESCRIPTION
## Summary
- restore `cute_dsl_compile_arch` after the #4753 availability-module split deleted it while the SM100 GDN path still imported it
- keep the helper's CUTLASS imports lazy in the cutlass-free availability module and re-export it from `utils`
- fix CUDA 13 SM100/SM103 pytest collection seen in GitLab job 413622331

## Test plan
- [x] `python -m ruff check flashinfer/cute_dsl/availability.py flashinfer/cute_dsl/utils.py`
- [x] import `flashinfer.gdn_kernels.blackwell.gdn_cp_prefill`
- [x] `python -m pytest --collect-only -q tests/gdn/test_prefill_cp_delta_rule.py` (232 tests collected)
- [ ] GitLab SM100/SM103 CUDA 13 unit-test jobs