### PR TITLE
fix(attention): count NVFP4 scale-factor staging in the batch smem budget

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -4207,6 +4207,11 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
+      // NVFP4 also stages one UE4M3 scale factor per NVFP4_SF_VEC_SIZE elements for K and for V
+      // (KVScaleFactorSmem), which grows with NUM_MMA_KV like the K/V tiles do.
+      (is_fp4_type_v<DTypeKV>
+           ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+           : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;
@@ -4406,6 +4411,11 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
+      // NVFP4 also stages one UE4M3 scale factor per NVFP4_SF_VEC_SIZE elements for K and for V
+      // (KVScaleFactorSmem), which grows with NUM_MMA_KV like the K/V tiles do.
+      (is_fp4_type_v<DTypeKV>
+           ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
+           : 0u) +
       (kVOSplitDispatch ? (CTA_TILE_Q * NUM_WARPS_KV * 16 * sizeof(DTypeQ)) : 0u);
   constexpr uint32_t kVOSplitFixedSmem =
       kVOSplitDispatch ? (NUM_WARPS_KV * CTA_TILE_Q * 8u + 2048u) : 0u;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The batch prefill launchers pick `NUM_MMA_KV` by sizing a per-`NUM_MMA_KV` shared-memory cost (`kKVSmemPerMmaKV`) against the occupancy budget, so the kernel keeps two blocks per SM. For NVFP4 KV that cost left out the scale-factor staging entirely.

`SharedStorageQKVO` inherits `KVScaleFactorSmem`, which stakes out one UE4M3 byte per `NVFP4_SF_VEC_SIZE` elements, for K and for V:

```cpp
// include/flashinfer/attention/prefill.cuh
alignas(16) uint8_t k_sf_smem[CTA_TILE_KV * HEAD_DIM_QK / NVFP4_SF_VEC_SIZE];
alignas(16) uint8_t v_sf_smem[CTA_TILE_KV * HEAD_DIM_VO / NVFP4_SF_VEC_SIZE];
```

`CTA_TILE_KV` is `NUM_MMA_KV * NUM_WARPS_KV * 16`, so those two planes grow with `NUM_MMA_KV` exactly like the K/V tiles sitting next to them. The single-prefill launcher already carries the term; the ragged and paged launchers did not, so their chooser could settle on a `NUM_MMA_KV` whose real storage exceeds the budget it was selected against, and the later hard check against `max_smem_per_threadblock` is left to reject a configuration that a smaller tile would have satisfied.

This adds the missing term to the two launchers, matching the single-prefill one. Non-FP4 KV dtypes are unaffected: the term is `0` for them.

#4769 stacks on this PR: its repack condition is only correct once the scale-factor planes are inside the budget, so its diff carries this commit until this one lands.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed. — this is a launch-configuration arithmetic fix with no new reachable behavior to assert on; it is covered by the existing NVFP4 prefill/decode tests continuing to pass.
- [ ] All tests are passing (`unittest`, etc.) — I ran the NVFP4 subset on sm_80, not the full suite.

```bash
pytest -q tests/attention/test_batch_prefill_kernels.py \
          tests/attention/test_batch_decode_kernels.py \
          tests/attention/test_single_prefill.py -k "nvfp4 or fp4"
# 355 passed, 9 skipped
```

I also checked that `plan()` still finds a launchable configuration across asymmetric and large head dims on sm_80, since those are the shapes where the budget is tightest:

```
qk128 vo128, qk192 vo128, qk256 vo128, qk256 vo256, qk320 vo128, qk384 vo128,
qk448 vo128, qk480 vo128, qk512 vo128, qk512 vo256, qk512 vo512   -> all plan OK
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4 attention performance and reliability by accounting for scale-factor staging memory when selecting kernel execution parameters.
  * Updated both ragged and paged KV-cache prefill paths to better manage shared-memory usage.
  * Reduced the risk of inefficient execution or resource-related issues during FP4 workloads, particularly when processing larger or more complex attention requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
