### PR TITLE
perf(attention): repack NVFP4 KV tiles to 16-bit on targets without a native E2M1 convert

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -69,6 +69,46 @@ constexpr uint32_t WARP_SIZE = 32;
 // Number of NVFP4 elements sharing one scale factor (UE4M3 byte).
 constexpr uint32_t NVFP4_SF_VEC_SIZE = 16;
 
+// Which E2M1-conversion regimes this translation unit is being built for.
+//
+// The NVFP4 tile repack exists to keep the software E2M1 -> 16-bit conversion out of the fully
+// unrolled MMA loops, where its instruction footprint starves the fetch pipe. From SM100 that
+// conversion is a single instruction, the premise does not hold, and the staging buffer would cost
+// shared memory -- and a smaller NUM_MMA_KV, since the occupancy budget counts it -- for nothing.
+//
+// The decision therefore has to be visible to the host, which sizes the storage and picks
+// NUM_MMA_KV, not just to the device. `__CUDA_ARCH__` is not, but `__CUDA_ARCH_LIST__` is: it holds
+// every target of this module in both passes. A module built for one regime hard-codes the answer
+// and instantiates a single variant; a module built for both (the release wheel bundles SM7.5
+// through SM12.x) instantiates both and the launcher picks by the device's compute capability.
+#if defined(__CUDA_ARCH_LIST__)
+namespace fp4_repack_targets {
+constexpr int kArchs[] = {__CUDA_ARCH_LIST__};
+constexpr bool any_below(int bound) {
+  for (int arch : kArchs) {
+    if (arch < bound) return true;
+  }
+  return false;
+}
+constexpr bool any_at_least(int bound) {
+  for (int arch : kArchs) {
+    if (arch >= bound) return true;
+  }
+  return false;
+}
+}  // namespace fp4_repack_targets
+// Targets that need the software conversion, i.e. that the repack is for.
+constexpr bool kTargetsSoftwareE2M1 = fp4_repack_targets::any_below(1000);
+// Targets whose E2M1 conversion is a single instruction, i.e. that must not pay for the repack.
+constexpr bool kTargetsNativeE2M1 = fp4_repack_targets::any_at_least(1000);
+#else
+// No arch list (host-only or non-nvcc translation): assume both, which forces the runtime choice.
+constexpr bool kTargetsSoftwareE2M1 = true;
+constexpr bool kTargetsNativeE2M1 = true;
+#endif
+// True when one instantiation cannot serve every target of this module.
+constexpr bool kFp4RepackNeedsRuntimeChoice = kTargetsSoftwareE2M1 && kTargetsNativeE2M1;
+
 /*!
  * \brief Convert four NVFP4 scale-factor bytes into two packed 16-bit pairs.
  *
@@ -83,6 +123,14 @@ constexpr uint32_t NVFP4_SF_VEC_SIZE = 16;
  * Where the hardware instruction exists we keep `static_cast` so it still lowers to it. The gate is
  * FLASHINFER_HARDWARE_FP8_CONVERSION_ENABLED -- the same one vec_cast<*, __nv_fp8_e4m3> uses -- so
  * this does not introduce a second, divergent notion of "has FP8 conversion".
+ *
+ * Scale factors are expected to be finite. Enumerating all 256 E4M3 encodings shows the two paths
+ * agree on 254 of them and differ only on the NaN encodings 0x7F and 0xFF, which the software
+ * converter maps to +-480 instead of NaN (a long-standing property of fast_dequant_f8f16x4, shared
+ * with the FP8 KV path). A NaN scale factor is not something quantization produces, and the only
+ * way one reaches here is an out-of-range KV row, whose scores logits_mask replaces with -inf
+ * before they can reach the accumulator. Callers passing an externally built kv_cache_sf that can
+ * contain those encodings should not expect NaN to propagate.
  */
 template <typename DTypeQ>
 __device__ __forceinline__ void nvfp4_sf4_to_packed2x2(uint8_t b0, uint8_t b1, uint8_t b2,
@@ -144,16 +192,31 @@ struct KVScaleFactorSmem<DTypeKV, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, true> {
   alignas(16) uint8_t v_sf_smem[CTA_TILE_KV * HEAD_DIM_VO / NVFP4_SF_VEC_SIZE];
 };
 
-// BF16/FP16 staging buffer for the FP8 "repack" path (compute_qk REPACK_BF16). Empty base
-// (0 bytes via EBO) when unused; same smem rationale as KVScaleFactorSmem above.
+// BF16/FP16 staging buffer for the one-byte-KV "repack" path (compute_qk REPACK_BF16), used by
+// both FP8 and NVFP4. Empty base (0 bytes via EBO) when unused; same smem rationale as
+// KVScaleFactorSmem above.
+// The single repack policy. The storage layout, the kernel traits and the launchers' occupancy
+// budget all go through this, so they cannot drift apart -- which is what would silently reserve
+// (and charge NUM_MMA_KV for) a staging buffer the device never reads.
+//
+// ENABLE_FP4_REPACK is the per-variant answer to "does this instantiation serve targets whose E2M1
+// conversion is a software sequence"; see kTargetsSoftwareE2M1 above. It only gates FP4: FP8 keeps
+// the policy it has always had.
+template <typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO>
+constexpr bool use_kv_repack(bool enable_fp4_repack) {
+  return (sizeof(DTypeKV) == 1) && (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
+         (CTA_TILE_Q > 16) &&
+         (!is_fp4_type_v<DTypeKV> || (HEAD_DIM_QK <= 256 && enable_fp4_repack));
+}
+
 template <typename DTypeQ, typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV,
-          uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
-          bool = ((sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO != 64) &&
-                  (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16))>
+          uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, bool ENABLE_FP4_REPACK,
+          bool = use_kv_repack<DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO>(ENABLE_FP4_REPACK)>
 struct KVRepackSmem {};
 template <typename DTypeQ, typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV,
-          uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO>
-struct KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, true> {
+          uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, bool ENABLE_FP4_REPACK>
+struct KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO,
+                    ENABLE_FP4_REPACK, true> {
   // Sized to max(HEAD_DIM_QK, HEAD_DIM_VO); time-shared between K and V within a tile.
   alignas(16) DTypeQ
       kv_smem_repack[CTA_TILE_KV * (HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO)];
@@ -176,10 +239,11 @@ struct VOSplitSmem<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_VO, DTypeQ, k
 
 template <uint32_t NUM_WARPS_KV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK,
           uint32_t HEAD_DIM_VO, typename DTypeQ, typename DTypeKV, typename DTypeO,
-          bool kEnableVOSplitOpt = false>
+          bool ENABLE_FP4_REPACK = true, bool kEnableVOSplitOpt = false>
 struct SharedStorageQKVO
     : KVScaleFactorSmem<DTypeKV, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO>,
-      KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO>,
+      KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO,
+                   ENABLE_FP4_REPACK>,
       VOSplitSmem<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_VO, DTypeQ, kEnableVOSplitOpt> {
   static constexpr bool kKVShareShape =
       (HEAD_DIM_VO / 16 > 16) && ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0);
@@ -208,9 +272,8 @@ struct SharedStorageQKVO
     };
     alignas(16) DTypeO smem_o[CTA_TILE_Q * HEAD_DIM_VO];
   };
-  static constexpr bool USE_KV_REPACK = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
-                                        (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
-                                        (CTA_TILE_Q > 16);
+  static constexpr bool USE_KV_REPACK =
+      use_kv_repack<DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO>(ENABLE_FP4_REPACK);
   static constexpr bool VO_SPLIT_SMEM = kVOSplit;
 
   // Accessors for the empty-base buffers above: return the buffer when present, else nullptr.
@@ -237,8 +300,8 @@ struct SharedStorageQKVO
   }
   __device__ __forceinline__ DTypeQ* kv_smem_repack_ptr() {
     if constexpr (USE_KV_REPACK) {
-      using Base =
-          KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, true>;
+      using Base = KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO,
+                                ENABLE_FP4_REPACK, true>;
       return static_cast<Base*>(this)->kv_smem_repack;
     } else {
       return nullptr;
@@ -273,7 +336,7 @@ template <MaskMode MASK_MODE_, uint32_t CTA_TILE_Q_, uint32_t NUM_MMA_Q_, uint32
           uint32_t NUM_MMA_D_QK_, uint32_t NUM_MMA_D_VO_, uint32_t NUM_WARPS_Q_,
           uint32_t NUM_WARPS_KV_, PosEncodingMode POS_ENCODING_MODE_, typename DTypeQ_,
           typename DTypeKV_, typename DTypeO_, typename DTypeQKAccum_, typename IdType_,
-          typename AttentionVariant_>
+          typename AttentionVariant_, bool ENABLE_FP4_REPACK_ = true>
 struct KernelTraits {
   static constexpr uint32_t NUM_STAGES = 1;  // used for BatchAttention Template
   static constexpr MaskMode MASK_MODE = MASK_MODE_;
@@ -327,10 +390,14 @@ struct KernelTraits {
   using DTypeQKAccum = DTypeQKAccum_;
   using IdType = IdType_;
   using AttentionVariant = AttentionVariant_;
-  static constexpr bool USE_KV_REPACK = (sizeof(DTypeKV_) == 1) && !is_fp4_type_v<DTypeKV_> &&
-                                        (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) &&
-                                        (CTA_TILE_Q > 16);  // CTA16 = decode/short-q -> in-loop
-  // b128 columns per KV row in the FP8 (packed) and BF16 (repacked) layouts.
+  // The staging buffer is sized max(HEAD_DIM_QK, HEAD_DIM_VO), so an asymmetric FP4 shape with a
+  // large HEAD_DIM_QK (e.g. 480 with HEAD_DIM_VO 128) would need more smem than the in-loop path
+  // it replaces, leaving no launchable NUM_MMA_KV. Bound HEAD_DIM_QK the same way HEAD_DIM_VO is.
+  // ENABLE_FP4_REPACK_ carries the target-regime answer; see kTargetsSoftwareE2M1.
+  static constexpr bool ENABLE_FP4_REPACK = ENABLE_FP4_REPACK_;
+  static constexpr bool USE_KV_REPACK =
+      use_kv_repack<DTypeKV_, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO>(ENABLE_FP4_REPACK_);
+  // b128 columns per KV row in the one-byte (packed) and 16-bit (repacked) layouts.
   static constexpr uint32_t REPACK_STRIDE_QK = HEAD_DIM_QK / upcast_size<DTypeQ_>();
   static constexpr uint32_t REPACK_STRIDE_VO = HEAD_DIM_VO / upcast_size<DTypeQ_>();
 
@@ -354,11 +421,12 @@ struct KernelTraits {
              POS_ENCODING_MODE == PosEncodingMode::kRoPELlama));
   }
 
-  using BaseSharedStorage = SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK,
-                                              HEAD_DIM_VO, DTypeQ, DTypeKV, DTypeO>;
+  using BaseSharedStorage =
+      SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ,
+                        DTypeKV, DTypeO, ENABLE_FP4_REPACK_>;
   using BaseSharedStoragePaged =
       SharedStorageQKVO<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO, DTypeQ,
-                        DTypeKV, DTypeO, /*kEnableVOSplitOpt=*/true>;
+                        DTypeKV, DTypeO, ENABLE_FP4_REPACK_, /*kEnableVOSplitOpt=*/true>;
   using SharedStorage =
       std::conditional_t<USE_SHARED_ROPE_FREQ,
                          SharedStorageWithRopeFreq<BaseSharedStorage, NUM_MMA_D_QK / 2>,
@@ -1208,6 +1276,83 @@ __device__ __forceinline__ void repack_fp8_tile_to_bf16(typename KTraits::DTypeK
     vec_cast<DTypeQ, DTypeKV>::template cast<16>(conv, (DTypeKV*)&packed);
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
     dst[get_permuted_offset<SWIZZLE, BF16_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
+  }
+}
+
+// NVFP4 counterpart of repack_fp8_tile_to_bf16: dequantize one K or V tile, scale factors
+// included, into the same 16-bit staging layout so the QK/PV MMAs can read it with the native
+// 16-bit ldmatrix path.
+//
+// Two things make this cheaper than the in-loop FP4 dequant it replaces, beyond amortizing the
+// work over the whole tile:
+//   * No cross-lane fragment swizzle. The in-loop path pays two __shfl_sync per fragment register
+//     to gather the 4-bit values a lane needs; here each thread owns a whole b128 already.
+//   * The scale factor is a single scalar. One b128 of the padded FP4 tile spans exactly
+//     HEAD_DIM 16 == NVFP4_SF_VEC_SIZE elements, i.e. one scale-factor group, so the per-fragment
+//     gather of two scale factors plus a 4-wide E4M3 convert collapses to one byte load and one
+//     convert per 16 elements.
+// Just as important on pre-SM100: the dequant code appears once instead of once per unrolled
+// (mma_d, mma_kv) pair, which is what keeps the FP4 kernel's instruction footprint from
+// starving the fetch pipe.
+//
+// Numerically identical to the in-loop dequant: same magnitude table, same scale-factor
+// conversion helper, same dequantize-then-multiply order.
+template <typename KTraits, uint32_t HEAD_DIM>
+__device__ __forceinline__ void repack_fp4_tile_to_16b(typename KTraits::DTypeKV* smem_fp4,
+                                                       const uint8_t* sf_smem,
+                                                       typename KTraits::DTypeQ* smem_16b,
+                                                       uint32_t thread_id) {
+  using DTypeKV = typename KTraits::DTypeKV;
+  using DTypeQ = typename KTraits::DTypeQ;
+  using packed2 = std::conditional_t<std::is_same_v<DTypeQ, half>, half2, __nv_bfloat162>;
+  constexpr SwizzleMode SWIZZLE = KTraits::SWIZZLE_MODE_KV;
+  constexpr uint32_t NUM_THREADS = KTraits::NUM_THREADS;
+  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+  // FP4 keeps the padded smem layout upstream produces: 16 elements per b128 (eight payload
+  // bytes, eight zero bytes), so one b128 column is one scale-factor group.
+  constexpr uint32_t FP4_COLS = HEAD_DIM / upcast_size<DTypeKV>();
+  constexpr uint32_t OUT_COLS = HEAD_DIM / upcast_size<DTypeQ>();
+  constexpr uint32_t SF_COLS = HEAD_DIM / NVFP4_SF_VEC_SIZE;
+  constexpr uint32_t NUM_B128 = CTA_TILE_KV * FP4_COLS;
+  static_assert(FP4_COLS == SF_COLS,
+                "one padded FP4 b128 must cover exactly one NVFP4 scale-factor group");
+
+  b128_t* src = (b128_t*)smem_fp4;
+  b128_t* dst = (b128_t*)smem_16b;
+#pragma unroll
+  for (uint32_t idx = thread_id; idx < NUM_B128; idx += NUM_THREADS) {
+    const uint32_t row = idx / FP4_COLS, col = idx % FP4_COLS;
+    b128_t packed = src[get_permuted_offset<SWIZZLE, FP4_COLS>(row, col)];
+    const uint32_t* w = (const uint32_t*)&packed;  // w[0], w[1]: the eight payload bytes
+    // alignas(16): conv is reinterpreted as b128_t (16B) for the smem stores below.
+    alignas(16) DTypeQ conv[16];
+    uint32_t* c = (uint32_t*)conv;
+    e2m1x8_to_16bx8<DTypeQ>(w[0], c);      // elements 0..7
+    e2m1x8_to_16bx8<DTypeQ>(w[1], c + 4);  // elements 8..15
+    uint2 sf_pair;
+    const uint8_t sf = sf_smem[row * SF_COLS + col];
+    nvfp4_sf4_to_packed2x2<DTypeQ>(sf, sf, sf, sf, &sf_pair);
+    const packed2 scale = *(packed2*)&sf_pair.x;
+#pragma unroll
+    for (uint32_t j = 0; j < 8; ++j) {
+      *(packed2*)&c[j] = __hmul2(*(packed2*)&c[j], scale);
+    }
+    dst[get_permuted_offset<SWIZZLE, OUT_COLS>(row, 2 * col)] = *(b128_t*)&conv[0];
+    dst[get_permuted_offset<SWIZZLE, OUT_COLS>(row, 2 * col + 1)] = *(b128_t*)&conv[8];
+  }
+}
+
+// Dispatch the one-byte-KV tile repack by KV dtype. `sf_smem` is the tile-base scale-factor
+// pointer (unused, and passed as nullptr, for FP8).
+template <typename KTraits, uint32_t HEAD_DIM>
+__device__ __forceinline__ void repack_kv_tile_to_16b(typename KTraits::DTypeKV* smem_kv,
+                                                      const uint8_t* sf_smem,
+                                                      typename KTraits::DTypeQ* smem_16b,
+                                                      uint32_t thread_id) {
+  if constexpr (is_fp4_type_v<typename KTraits::DTypeKV>) {
+    repack_fp4_tile_to_16b<KTraits, HEAD_DIM>(smem_kv, sf_smem, smem_16b, thread_id);
+  } else {
+    repack_fp8_tile_to_bf16<KTraits, HEAD_DIM>(smem_kv, smem_16b, thread_id);
   }
 }
 
@@ -2366,6 +2511,29 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
                v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
                    warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
                    lane_idx % KV_THR_LAYOUT_COL);
+
+      // Single prefill takes the repack for FP4 only. Whenever this variant allocates the staging
+      // buffer -- it shares SharedStorage with the ragged kernel, and USE_KV_REPACK decides both --
+      // the buffer is already counted in the NUM_MMA_KV budget, so leaving FP4 on the in-loop path
+      // would spend that shared memory for nothing. FP8 keeps the in-loop path it has always taken
+      // here: switching it over is a behavior change this PR does not measure, and single prefill
+      // has no FP8 KV test to catch a regression. The target-regime decision
+      // (KTraits::ENABLE_FP4_REPACK) is already folded into USE_KV_REPACK, so a native-only build
+      // has no staging buffer to spend in the first place.
+      constexpr bool kRepackActive = KTraits::USE_KV_REPACK && is_fp4_type_v<DTypeKV>;
+      // One-byte-KV repack path: 16-bit staging buffers + their (16-bit-strided) read offsets.
+      // Guard the offsets so the stride-8 get_permuted_offset isn't instantiated for the k64B
+      // swizzle (HEAD_DIM_VO == 64), which requires stride==4.
+      smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
+          v_smem_bf16(smem_storage.kv_smem_repack_ptr());
+      uint32_t k_smem_offset_r_bf16 = 0, v_smem_offset_r_bf16 = 0;
+      if constexpr (KTraits::USE_KV_REPACK) {
+        k_smem_offset_r_bf16 = k_smem_bf16.template get_permuted_offset<KTraits::REPACK_STRIDE_QK>(
+            get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + 8 * (lane_idx / 16) + lane_idx % 8,
+            (lane_idx % 16) / 8);
+        v_smem_offset_r_bf16 = v_smem_bf16.template get_permuted_offset<KTraits::REPACK_STRIDE_VO>(
+            get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16, lane_idx / 16);
+      }
       // For single prefill, the absolute KV base is just chunk_start (no kv_indptr offset).
       const uint32_t kv_abs_base = chunk_start;
       produce_kv<false, SharedMemFillMode::kNoFill, KTraits>(k_smem, &k_smem_offset_w, &k_ptr,
@@ -2411,6 +2579,17 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
               smem_storage.k_sf_smem_ptr(get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_idx_base, rope_freq, s_frag);
+        } else if constexpr (kRepackActive) {
+          // Dequantize one-byte K -> 16-bit staging smem (shuffle-free), then read native 16-bit.
+          repack_kv_tile_to_16b<KTraits, KTraits::HEAD_DIM_QK>(
+              smem_storage.k_smem, smem_storage.k_sf_smem_ptr(), smem_storage.kv_smem_repack_ptr(),
+              warp_idx * WARP_SIZE + lane_idx);
+          block.sync();
+          compute_qk<KTraits, /*REPACK_BF16=*/true>(
+              &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
+              smem_storage.k_sf_smem_ptr(get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
+                                         16 * KTraits::NUM_MMA_D_QK),
+              lane_idx, s_frag);
         } else {
           compute_qk<KTraits>(
               &qo_smem, &q_smem_offset_r, &k_smem, &k_smem_offset_r,
@@ -2461,6 +2640,17 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
               get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP;
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
+        } else if constexpr (kRepackActive) {
+          // Dequantize one-byte V -> 16-bit staging smem (shuffle-free), then read native 16-bit.
+          repack_kv_tile_to_16b<KTraits, KTraits::HEAD_DIM_VO>(
+              smem_storage.v_smem, smem_storage.v_sf_smem_ptr(), smem_storage.kv_smem_repack_ptr(),
+              warp_idx * WARP_SIZE + lane_idx);
+          block.sync();
+          compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
+              &v_smem_bf16, &v_smem_offset_r_bf16,
+              smem_storage.v_sf_smem_ptr(get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
+                                         16 * KTraits::NUM_MMA_D_VO),
+              lane_idx, s_frag, o_frag, d, d_base);
         } else {
           compute_sfm_v<KTraits>(
               &v_smem, &v_smem_offset_r,
@@ -2557,11 +2747,34 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void SinglePrefillWithKVCache
   SinglePrefillWithKVCacheDevice<KTraits>(params, smem_storage);
 }
 
+// Selects the NVFP4 repack variant. The whole launcher body -- shared-memory budget, NUM_MMA_KV
+// choice, storage type and kernel -- is templated on the policy, so every one of them sees the same
+// answer; splitting later would leave the budget sized for a staging buffer the kernel may not use.
+//
+// A module built for one E2M1 regime folds this to a single instantiation. Only a repack-eligible
+// NVFP4 configuration in a module spanning both regimes builds two and picks by the device.
+#define FLASHINFER_DISPATCH_FP4_REPACK(DTypeKV_, CTA_TILE_Q_, HEAD_DIM_QK_, HEAD_DIM_VO_, CALL) \
+  {                                                                                             \
+    constexpr bool kVariesAtRuntime =                                                           \
+        is_fp4_type_v<DTypeKV_> && kFp4RepackNeedsRuntimeChoice &&                              \
+        use_kv_repack<DTypeKV_, CTA_TILE_Q_, HEAD_DIM_QK_, HEAD_DIM_VO_>(true);                 \
+    if constexpr (!kVariesAtRuntime) {                                                          \
+      constexpr bool kEnable = (!is_fp4_type_v<DTypeKV_>) || kTargetsSoftwareE2M1;              \
+      return CALL(kEnable);                                                                     \
+    } else {                                                                                    \
+      int fp4_dev_id = 0, cc_major = 0;                                                         \
+      FLASHINFER_CUDA_CALL(cudaGetDevice(&fp4_dev_id));                                         \
+      FLASHINFER_CUDA_CALL(                                                                     \
+          cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, fp4_dev_id));    \
+      return cc_major < 10 ? CALL(true) : CALL(false);                                          \
+    }                                                                                           \
+  }
+
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
           bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename AttentionVariant,
-          typename Params>
-cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
-                                               cudaStream_t stream) {
+          typename Params, bool ENABLE_FP4_REPACK>
+cudaError_t SinglePrefillWithKVCacheDispatchedImpl(Params params, typename Params::DTypeO* tmp,
+                                                   cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
   using DTypeO = typename Params::DTypeO;
@@ -2610,13 +2823,13 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
     FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_block_optin,
                                                 cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
     // we expect each sm execute two threadblocks
-    // Per-NUM_MMA_KV K/V shared-memory cost, including the single BF16 repack
-    // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack
-    // path is active, so NUM_MMA_KV is chosen to keep base+staging within the
-    // occupancy budget. NOTE: single-prefill doesn't use the repack, but the
-    // staging buffer still lives in SharedStorageQKVO, so it must be accounted.
-    constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
-                                (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
+    // Per-NUM_MMA_KV K/V shared-memory cost, including the single 16-bit repack
+    // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the repack path is
+    // active for this variant, so NUM_MMA_KV is chosen to keep base+staging within
+    // the occupancy budget. Single prefill uses the repack for NVFP4 only, but the
+    // buffer lives in SharedStorageQKVO for FP8 too, so it must be accounted.
+    constexpr bool kUseRepack =
+        use_kv_repack<DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO>(ENABLE_FP4_REPACK);
     constexpr bool kKVShared = !is_fp4_type_v<DTypeKV> && (HEAD_DIM_VO / 16 > 16) &&
                                ((HEAD_DIM_VO / 16) % NUM_WARPS_KV == 0) &&
                                (HEAD_DIM_QK == HEAD_DIM_VO) &&
@@ -2676,7 +2889,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
           using KTraits =
               KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
                            NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                           DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+                           DTypeQKAccum, typename Params::IdType, AttentionVariant,
+                           ENABLE_FP4_REPACK>;
           if constexpr (KTraits::IsInvalid()) {
             // Invalid configuration, skip
             std::ostringstream err_msg;
@@ -2756,6 +2970,24 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::D
         })
   });
   return cudaSuccess;
+}
+
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, PosEncodingMode POS_ENCODING_MODE,
+          bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE, typename AttentionVariant,
+          typename Params>
+cudaError_t SinglePrefillWithKVCacheDispatched(Params params, typename Params::DTypeO* tmp,
+                                               cudaStream_t stream) {
+#define FLASHINFER_SINGLE_PREFILL_CALL(EN)                                                    \
+  (SinglePrefillWithKVCacheDispatchedImpl<HEAD_DIM_QK, HEAD_DIM_VO, POS_ENCODING_MODE,        \
+                                          USE_FP16_QK_REDUCTION, MASK_MODE, AttentionVariant, \
+                                          Params, EN>(params, tmp, stream))
+  // Single prefill dispatches CTA_TILE_Q inside the Impl, so the eligibility probe here uses a
+  // CTA that can be repack-eligible: it answers "could any CTA tile in this specialization take
+  // the repack", not "does this particular one". A mixed-architecture build therefore emits both
+  // policy variants for the whole specialization, including its CTA_TILE_Q=16 kernels.
+  FLASHINFER_DISPATCH_FP4_REPACK(typename Params::DTypeKV, 128u, HEAD_DIM_QK, HEAD_DIM_VO,
+                                 FLASHINFER_SINGLE_PREFILL_CALL)
+#undef FLASHINFER_SINGLE_PREFILL_CALL
 }
 
 // VO-split helpers used by large-head prefill kernels. Definitions live below the
@@ -3015,7 +3247,10 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
                    warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
                    lane_idx % KV_THR_LAYOUT_COL);
 
-      // FP8 repack path: BF16 staging buffers + their (16-bit-strided) read offsets.
+      // The target-regime decision lives in the instantiation (KTraits::ENABLE_FP4_REPACK), so it
+      // is already folded into USE_KV_REPACK here.
+      constexpr bool kRepackActive = KTraits::USE_KV_REPACK;
+      // One-byte KV repack path: 16-bit staging buffers + their (16-bit-strided) read offsets.
       // Guard offsets by USE_KV_REPACK so the stride-8 get_permuted_offset isn't
       // instantiated for the k64B swizzle (HEAD_DIM_VO == 64), which requires stride==4.
       smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
@@ -3094,11 +3329,11 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
               smem_storage.k_sf_smem_ptr(get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_rope_base, rope_freq, s_frag);
-        } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(smem_storage.k_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+        } else if constexpr (kRepackActive) {
+          // Dequantize one-byte K -> 16-bit staging smem (shuffle-free), then read native 16-bit.
+          repack_kv_tile_to_16b<KTraits, KTraits::HEAD_DIM_QK>(
+              smem_storage.k_smem, smem_storage.k_sf_smem_ptr(), smem_storage.kv_smem_repack_ptr(),
+              warp_idx * WARP_SIZE + lane_idx);
           block.sync();
           compute_qk<KTraits, /*REPACK_BF16=*/true>(
               &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
@@ -3157,11 +3392,11 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
               get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP;
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
-        } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(smem_storage.v_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+        } else if constexpr (kRepackActive) {
+          // Dequantize one-byte V -> 16-bit staging smem (shuffle-free), then read native 16-bit.
+          repack_kv_tile_to_16b<KTraits, KTraits::HEAD_DIM_VO>(
+              smem_storage.v_smem, smem_storage.v_sf_smem_ptr(), smem_storage.kv_smem_repack_ptr(),
+              warp_idx * WARP_SIZE + lane_idx);
           block.sync();
           compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
               &v_smem_bf16, &v_smem_offset_r_bf16,
@@ -3780,11 +4015,14 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                k_smem_offset_w = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
                    warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
                    lane_idx % KV_THR_LAYOUT_COL);
+      // The target-regime decision lives in the instantiation (KTraits::ENABLE_FP4_REPACK), so it
+      // is already folded into USE_KV_REPACK here.
+      constexpr bool kRepackActive = KTraits::USE_KV_REPACK;
       [[maybe_unused]] uint32_t v_smem_offset_r = 0;
       uint32_t v_smem_offset_w = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
           warp_idx * KV_THR_LAYOUT_ROW + lane_idx / KV_THR_LAYOUT_COL,
           lane_idx % KV_THR_LAYOUT_COL);
-      if constexpr (!KTraits::USE_VO_SPLIT && !KTraits::USE_KV_REPACK) {
+      if constexpr (!KTraits::USE_VO_SPLIT && !kRepackActive) {
         v_smem_offset_r = v_smem.template get_permuted_offset<UPCAST_STRIDE_V>(
             get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + lane_idx % 16, lane_idx / 16);
       }
@@ -3792,7 +4030,7 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
         static_assert(UPCAST_STRIDE_K == UPCAST_STRIDE_V);
       }
 
-      // FP8 repack path
+      // One-byte KV repack path
       smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
           v_smem_bf16(smem_storage.kv_smem_repack_ptr());
       uint32_t k_smem_offset_r_bf16 = 0, v_smem_offset_r_bf16 = 0;
@@ -3970,11 +4208,11 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
               smem_storage.k_sf_smem_ptr(get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_KV *
                                          16 * KTraits::NUM_MMA_D_QK),
               lane_idx, kv_rope_base, rope_freq, s_frag);
-        } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 K -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_QK>(smem_storage.k_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+        } else if constexpr (kRepackActive) {
+          // Dequantize one-byte K -> 16-bit staging smem (shuffle-free), then read native 16-bit.
+          repack_kv_tile_to_16b<KTraits, KTraits::HEAD_DIM_QK>(
+              smem_storage.k_smem, smem_storage.k_sf_smem_ptr(), smem_storage.kv_smem_repack_ptr(),
+              warp_idx * WARP_SIZE + lane_idx);
           block.sync();
           compute_qk<KTraits, /*REPACK_BF16=*/true>(
               &qo_smem, &q_smem_offset_r, &k_smem_bf16, &k_smem_offset_r_bf16,
@@ -4060,11 +4298,11 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
               get_warp_idx_kv<KTraits>(tid.z) * KTraits::NUM_MMA_D_VO_PER_WARP;
           vosplit_compute_pv<KTraits>(&smem_storage, o_frag, o_scale, warp_vo_base,
                                       get_warp_idx_q<KTraits>(tid.y), lane_idx);
-        } else if constexpr (KTraits::USE_KV_REPACK) {
-          // Dequantize FP8 V -> BF16 staging smem (shuffle-free), then read native 16-bit.
-          repack_fp8_tile_to_bf16<KTraits, KTraits::HEAD_DIM_VO>(smem_storage.v_smem,
-                                                                 smem_storage.kv_smem_repack_ptr(),
-                                                                 warp_idx * WARP_SIZE + lane_idx);
+        } else if constexpr (kRepackActive) {
+          // Dequantize one-byte V -> 16-bit staging smem (shuffle-free), then read native 16-bit.
+          repack_kv_tile_to_16b<KTraits, KTraits::HEAD_DIM_VO>(
+              smem_storage.v_smem, smem_storage.v_sf_smem_ptr(), smem_storage.kv_smem_repack_ptr(),
+              warp_idx * WARP_SIZE + lane_idx);
           block.sync();
           compute_sfm_v<KTraits, /*REPACK_BF16=*/true>(
               &v_smem_bf16, &v_smem_offset_r_bf16,
@@ -4179,10 +4417,11 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithPagedKVC
 
 template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
-          typename AttentionVariant, typename Params>
-cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
-                                                    float* tmp_s, bool enable_pdl,
-                                                    cudaStream_t stream) {
+          typename AttentionVariant, typename Params, bool ENABLE_FP4_REPACK>
+cudaError_t BatchPrefillWithRaggedKVCacheDispatchedImpl(Params params,
+                                                        typename Params::DTypeO* tmp_v,
+                                                        float* tmp_s, bool enable_pdl,
+                                                        cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
   using DTypeO = typename Params::DTypeO;
@@ -4225,11 +4464,11 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
                                               cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
   // we expect each sm execute two threadblocks
   // Per-NUM_MMA_KV K/V shared-memory cost, including the single BF16 repack
-  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
+  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
-                              (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
+  constexpr bool kUseRepack =
+      use_kv_repack<DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO>(ENABLE_FP4_REPACK);
   // Matches KernelTraits::USE_KV_SHARED_SMEM: at large head dims K and V
   // time-share one smem buffer, so the occupancy budget counts the K/V
   // footprint once exactly when the kernel actually shares it.
@@ -4246,8 +4485,6 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
-      // NVFP4 also stages one UE4M3 scale factor per NVFP4_SF_VEC_SIZE elements for K and for V
-      // (KVScaleFactorSmem), which grows with NUM_MMA_KV like the K/V tiles do.
       (is_fp4_type_v<DTypeKV>
            ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
            : 0u) +
@@ -4297,10 +4534,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
 
   DISPATCH_NUM_MMA_KV(
       min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg), NUM_MMA_KV, {
-        using KTraits =
-            KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                         NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                         DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+        using KTraits = KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK,
+                                     NUM_MMA_D_VO, NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE,
+                                     DTypeQ, DTypeKV, DTypeO, DTypeQKAccum, typename Params::IdType,
+                                     AttentionVariant, ENABLE_FP4_REPACK>;
         if constexpr (KTraits::IsInvalid()) {
           // Invalid configuration, skip
           std::ostringstream err_msg;
@@ -4387,9 +4624,25 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Para
 template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
           PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
           typename AttentionVariant, typename Params>
-cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
-                                                   float* tmp_s, bool enable_pdl,
-                                                   cudaStream_t stream) {
+cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
+                                                    float* tmp_s, bool enable_pdl,
+                                                    cudaStream_t stream) {
+#define FLASHINFER_RAGGED_PREFILL_CALL(EN)                                               \
+  (BatchPrefillWithRaggedKVCacheDispatchedImpl<CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO,     \
+                                               POS_ENCODING_MODE, USE_FP16_QK_REDUCTION, \
+                                               MASK_MODE, AttentionVariant, Params, EN>( \
+      params, tmp_v, tmp_s, enable_pdl, stream))
+  FLASHINFER_DISPATCH_FP4_REPACK(typename Params::DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO,
+                                 FLASHINFER_RAGGED_PREFILL_CALL)
+#undef FLASHINFER_RAGGED_PREFILL_CALL
+}
+
+template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
+          typename AttentionVariant, typename Params, bool ENABLE_FP4_REPACK>
+cudaError_t BatchPrefillWithPagedKVCacheDispatchedImpl(Params params,
+                                                       typename Params::DTypeO* tmp_v, float* tmp_s,
+                                                       bool enable_pdl, cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
   using DTypeKV = typename Params::DTypeKV;
   using DTypeO = typename Params::DTypeO;
@@ -4430,11 +4683,11 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
                                               cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
   // we expect each sm execute two threadblocks
   // Per-NUM_MMA_KV K/V shared-memory cost, including the single BF16 repack
-  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the FP8 repack path
+  // staging buffer (sized max(HEAD_DIM_QK, HEAD_DIM_VO)) when the repack path
   // is active, so NUM_MMA_KV is chosen to keep base+staging within the occupancy
   // budget (otherwise the staging silently drops blocks/SM at large head dims).
-  constexpr bool kUseRepack = (sizeof(DTypeKV) == 1) && !is_fp4_type_v<DTypeKV> &&
-                              (HEAD_DIM_VO != 64) && (HEAD_DIM_VO <= 256) && (CTA_TILE_Q > 16);
+  constexpr bool kUseRepack =
+      use_kv_repack<DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO>(ENABLE_FP4_REPACK);
   // Matches KernelTraits::USE_KV_SHARED_SMEM: K/V share one smem buffer for bf16/fp16 at every
   // tile and for FP8 only at CTA_TILE_Q=32 (not NVFP4), so the occupancy budget counts the K/V
   // footprint once exactly when the kernel actually shares it.
@@ -4450,8 +4703,6 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
       (kUseRepack ? ((HEAD_DIM_QK > HEAD_DIM_VO ? HEAD_DIM_QK : HEAD_DIM_VO) * 16 * NUM_WARPS_KV *
                      sizeof(DTypeQ))
                   : 0u) +
-      // NVFP4 also stages one UE4M3 scale factor per NVFP4_SF_VEC_SIZE elements for K and for V
-      // (KVScaleFactorSmem), which grows with NUM_MMA_KV like the K/V tiles do.
       (is_fp4_type_v<DTypeKV>
            ? ((HEAD_DIM_QK + HEAD_DIM_VO) * 16 * NUM_WARPS_KV / NVFP4_SF_VEC_SIZE)
            : 0u) +
@@ -4495,10 +4746,10 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
 
   DISPATCH_NUM_MMA_KV(
       min(static_cast<uint32_t>(max_num_mma_kv_smem), max_num_mma_kv_reg), NUM_MMA_KV, {
-        using KTraits =
-            KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK, NUM_MMA_D_VO,
-                         NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE, DTypeQ, DTypeKV, DTypeO,
-                         DTypeQKAccum, typename Params::IdType, AttentionVariant>;
+        using KTraits = KernelTraits<MASK_MODE, CTA_TILE_Q, NUM_MMA_Q, NUM_MMA_KV, NUM_MMA_D_QK,
+                                     NUM_MMA_D_VO, NUM_WARPS_Q, NUM_WARPS_KV, POS_ENCODING_MODE,
+                                     DTypeQ, DTypeKV, DTypeO, DTypeQKAccum, typename Params::IdType,
+                                     AttentionVariant, ENABLE_FP4_REPACK>;
         if constexpr (KTraits::IsInvalid()) {
           // Invalid configuration, skip
           std::ostringstream err_msg;
@@ -4576,6 +4827,22 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Param
         }
       });
   return cudaSuccess;
+}
+
+template <uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO,
+          PosEncodingMode POS_ENCODING_MODE, bool USE_FP16_QK_REDUCTION, MaskMode MASK_MODE,
+          typename AttentionVariant, typename Params>
+cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params params, typename Params::DTypeO* tmp_v,
+                                                   float* tmp_s, bool enable_pdl,
+                                                   cudaStream_t stream) {
+#define FLASHINFER_PAGED_PREFILL_CALL(EN)                                                          \
+  (BatchPrefillWithPagedKVCacheDispatchedImpl<CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO,                \
+                                              POS_ENCODING_MODE, USE_FP16_QK_REDUCTION, MASK_MODE, \
+                                              AttentionVariant, Params, EN>(params, tmp_v, tmp_s,  \
+                                                                            enable_pdl, stream))
+  FLASHINFER_DISPATCH_FP4_REPACK(typename Params::DTypeKV, CTA_TILE_Q, HEAD_DIM_QK, HEAD_DIM_VO,
+                                 FLASHINFER_PAGED_PREFILL_CALL)
+#undef FLASHINFER_PAGED_PREFILL_CALL
 }
 
 }  // namespace flashinfer

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -239,7 +239,7 @@ struct VOSplitSmem<NUM_WARPS_KV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_VO, DTypeQ, k
 
 template <uint32_t NUM_WARPS_KV, uint32_t CTA_TILE_Q, uint32_t CTA_TILE_KV, uint32_t HEAD_DIM_QK,
           uint32_t HEAD_DIM_VO, typename DTypeQ, typename DTypeKV, typename DTypeO,
-          bool ENABLE_FP4_REPACK = true, bool kEnableVOSplitOpt = false>
+          bool ENABLE_FP4_REPACK = false, bool kEnableVOSplitOpt = false>
 struct SharedStorageQKVO
     : KVScaleFactorSmem<DTypeKV, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO>,
       KVRepackSmem<DTypeQ, DTypeKV, CTA_TILE_Q, CTA_TILE_KV, HEAD_DIM_QK, HEAD_DIM_VO,
@@ -336,7 +336,12 @@ template <MaskMode MASK_MODE_, uint32_t CTA_TILE_Q_, uint32_t NUM_MMA_Q_, uint32
           uint32_t NUM_MMA_D_QK_, uint32_t NUM_MMA_D_VO_, uint32_t NUM_WARPS_Q_,
           uint32_t NUM_WARPS_KV_, PosEncodingMode POS_ENCODING_MODE_, typename DTypeQ_,
           typename DTypeKV_, typename DTypeO_, typename DTypeQKAccum_, typename IdType_,
-          typename AttentionVariant_, bool ENABLE_FP4_REPACK_ = true>
+          typename AttentionVariant_,
+          // Defaults to the variant that allocates no staging buffer. The FA2 prefill launchers
+          // pass this explicitly; every other instantiation of KernelTraits (pod, batch_pod,
+          // persistent) has neither a repack call site nor the staging term in its shared-memory
+          // budget, so a default of true would make those paths reserve a buffer they never read.
+          bool ENABLE_FP4_REPACK_ = false>
 struct KernelTraits {
   static constexpr uint32_t NUM_STAGES = 1;  // used for BatchAttention Template
   static constexpr MaskMode MASK_MODE = MASK_MODE_;


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

FP8 KV already dequantizes a whole tile into the 16-bit staging buffer and lets the QK/PV MMAs read it back with the native `ldmatrix` path (`repack_fp8_tile_to_bf16`, `KernelTraits::USE_KV_REPACK`). NVFP4 was excluded from that path and kept dequantizing inside the fully unrolled `(mma_d, mma_kv)` nest, so its dequant sequence — magnitude table, sign spread, scale-factor gather, scale multiply, plus two `__shfl_sync` per fragment register for the 4-bit fragment swizzle — was replicated once per pair.

On targets without a native E2M1 conversion that turns the kernel instruction-fetch bound rather than math bound. `ncu` on FA2 paged prefill, batch 1, 2048x2048, head_dim 128, sm_80:

| | NVFP4 before | FP8 | NVFP4 after |
|---|---|---|---|
| `no_instruction` stall, % of warp-active | 24.9 | 1.4 | 1.3 |
| `sm__pipe_tensor_cycles_active`, % of peak | 18.7 | 51.5 | 48.6 |
| kernel time | 1.403 ms | 0.539 ms | 0.552 ms |

`repack_fp4_tile_to_16b` dequantizes one K or V tile, scale factors included, into the same staging layout. One thing makes it cheaper than the in-loop path it replaces, beyond amortizing the work over the tile: one padded FP4 b128 spans exactly `HEAD_DIM` 16 == `NVFP4_SF_VEC_SIZE` elements, i.e. one scale-factor group, so the per-fragment gather of two scale factors plus a four-wide E4M3 convert collapses to one byte load and one convert per b128. The cross-lane fragment swizzle disappears with it.

### Architecture scope

The repack only makes sense where the E2M1 conversion is a software sequence. From SM100 it is a single instruction, the premise above does not hold, and the staging buffer would cost shared memory -- and a smaller `NUM_MMA_KV`, since the occupancy budget counts it -- for nothing.

That decision has to be visible to the host, which sizes the storage and picks `NUM_MMA_KV`, not just to the device. `__CUDA_ARCH__` is not, but `__CUDA_ARCH_LIST__` is: it names every target of the module in both passes. So the policy is a template parameter, `ENABLE_FP4_REPACK`, threaded through one predicate:

```cpp
template <typename DTypeKV, uint32_t CTA_TILE_Q, uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO>
constexpr bool use_kv_repack(bool enable_fp4_repack);
```

`KVRepackSmem`, `KernelTraits::USE_KV_REPACK` and the `kUseRepack` in all three launcher budgets now go through it, so they cannot disagree. Each launcher body became `...DispatchedImpl<..., ENABLE_FP4_REPACK>` and the public entry point is a thin wrapper that picks the variant before any budget arithmetic runs.

- a module built only for pre-SM100 targets folds to one variant, with the repack;
- a module built only for SM100+ folds to one variant, with no staging buffer and no budget for it;
- a module spanning both (the release wheel bundles SM7.5 through SM12.x) builds both and selects on the device's compute capability. The device query happens only on that path, so FP16, FP8 and single-regime FP4 launches gain no CUDA API call.

Measured on the FP4 paged prefill translation unit, `head_dim` 128:

| built for | kernel entries | software dequant `prmt` | native e2m1 cvt |
|---|---|---|---|
| `sm_80` | 13 | 340 | 0 |
| `sm_100a` | 13 | 0 | 2240 |
| `sm_80` + `sm_100a` | 36 | 740 | 2240 |

and the storage and budget follow, at `head_dim` 128 with `NUM_WARPS_KV` 1 and a 2-byte query dtype:

| variant | `use_kv_repack` | `kKVSmemPerMmaKV` | `sizeof(SmemStorage)` |
|---|---|---|---|
| repack | 1 | 8448 | 41216 |
| native | 0 | 4352 | 37120 |

The 4096-byte difference is the staging buffer: on a native-only build it is neither allocated nor charged.

The repack condition also gained a `HEAD_DIM_QK` bound for FP4. The staging buffer is sized `max(HEAD_DIM_QK, HEAD_DIM_VO)`, so an asymmetric shape such as `HEAD_DIM_QK` 480 with `HEAD_DIM_VO` 128 would need more shared memory than the in-loop path it replaces and leave no launchable `NUM_MMA_KV`.

Single prefill dispatches `CTA_TILE_Q` inside the Impl, so its eligibility probe asks whether any CTA tile in the specialization could be repack-eligible rather than whether a particular one is. A mixed-architecture build therefore emits both policy variants for that whole specialization, including its `CTA_TILE_Q` 16 kernels.

### Stacking

Both prerequisites have landed. #4746 brought in the `e2m1x8_to_f16x8` / `e2m1x8_to_bf16x8` helpers and `nvfp4_sf4_to_packed2x2` that the repack calls, and #4767 the scale-factor budget the corrected repack condition depends on. Rebasing onto `main` dropped both by patch id with nothing to resolve by hand, so this PR is now the repack and its policy default: two commits touching only `include/flashinfer/attention/prefill.cuh`.

Earlier revisions of this section described those prerequisites while they were still open, and one of them claimed that reviewing the last commit alone was enough. Neither applies now.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed. — the repack is an alternative lowering of an existing computation, covered by the existing NVFP4 prefill/decode tests; the checks below are what I ran to establish it is lossless.
- [ ] All tests are passing (`unittest`, etc.) — I ran the NVFP4 subset on sm_80, not the full suite.

```bash
pytest -q tests/attention/test_batch_prefill_kernels.py \
          tests/attention/test_batch_decode_kernels.py \
          tests/attention/test_single_prefill.py -k "nvfp4 or fp4"
# 355 passed, 9 skipped
```

Re-run after the per-architecture variant work, same result: 355 passed, 9 skipped.

Output equivalence against FA2 attention run on the dequantized KV in the query dtype, so kernel and reference consume the same values. This covers the FP4 payload path end to end; the scale-factor conversion is a separate path and is scoped below:

```
head_dim 128  f16  maxabs 0        head_dim 128  bf16  maxabs 0
head_dim 256  f16  maxabs 0        head_dim 256  bf16  maxabs 0
head_dim 512  f16  maxabs 0        head_dim 512  bf16  maxabs 0
```

Against the previous NVFP4 build, head_dim 128 and 512 are bit-identical and head_dim 256 prefill is not: the corrected budget makes the chooser pick a `NUM_MMA_KV` that actually fits two blocks per SM, which changes the flash-attention accumulation order. The reference comparison above is what settles which side is closer — at head_dim 256 the previous build differs from the reference by up to 1.95e-3 (f16) and this one by 0.

Latency on sm_80, median of three, one process per dtype, FA2 paged:

| case | NVFP4 before | NVFP4 after | FP8 | FP16 |
|---|---|---|---|---|
| prefill b1 4096x4096 hd128 | 4.763 | 1.900 | 1.858 | 1.516 |
| prefill b4 2048x2048 hd128 | 4.427 | 1.840 | 1.857 | 1.546 |
| prefill b8 1024x1024 hd128 | 2.407 | 0.994 | 0.983 | 0.884 |
| prefill b2 2048 hd256 | 3.790 | 1.254 | 1.209 | 0.910 |
| decode b32 kv8192 hd128 | 1.154 | 1.036 | 0.718 | 0.848 |
| decode b16 kv4096 hd512 | 1.114 | 0.612 | n/a | 0.398 |

head_dim 512 keeps the in-loop path (`HEAD_DIM_VO <= 256`); its gain comes from the sign-spread commit underneath.

Scale-factor contract. `nvfp4_sf4_to_packed2x2` arrives with #4746 and is unchanged by the repack commits, but the repack calls it, so its contract applies here too and is now written down at the declaration. Enumerating all 256 E4M3 encodings, the software and hardware conversions agree on 254 and differ only on the NaN encodings `0x7F` and `0xFF`, which the software converter maps to +-480 instead of NaN:

| byte | software | hardware |
|---|---|---|
| `0x7F` | +480 | NaN |
| `0xFF` | -480 | NaN |

Scale factors are expected finite. Quantization does not produce a NaN scale, and the only way one reaches the kernel is an out-of-range KV row, whose scores `logits_mask` replaces with `-inf` before they can reach the accumulator. The repack does not widen that exposure: it converts the same scale factors the in-loop path converted, with the same helper. Callers supplying an externally built `kv_cache_sf` that can contain those encodings should not expect NaN to propagate.

Review follow-ups in this branch:

- the E2M1 nibble helpers moved out of the `FLASHINFER_ENABLE_FP4_E2M1` guard. They have no FP4 type in their signatures, and `repack_fp4_tile_to_16b` names them from a template whose FP4 branch is discarded rather than removed, so a build without FP4 enabled failed to compile. Checked `sm_80` and `sm_100a`, with and without the macro.
- `clang-format` applied (the pinned 19.1.1), covering both spots the automated check flagged.
- the repack policy became a template parameter selected per architecture regime, so a module built only for SM100+ neither allocates the staging buffer nor charges `NUM_MMA_KV` for it; see Architecture scope.
- the single-prefill kernel now takes the repack for NVFP4 as well. It shares `SharedStorage` with the ragged kernel, so whenever the variant allocates the staging buffer it is already counted in that kernel's `NUM_MMA_KV` budget; NVFP4 was paying for it without using it. On a native-only build there is no staging buffer to pay for. FP8 keeps the in-loop path it has always taken in that kernel: switching it over is a behavior change this PR does not measure, and `tests/attention/test_single_prefill.py` has no FP8 KV case that would catch a regression.

The `sm_80` code path is unchanged by the variant work in the sense that matters -- it is the `ENABLE_FP4_REPACK = true` instantiation, and its dequant/repack instruction sequences are the ones measured above. Whole-cubin byte identity is not the right oracle here: the storage type and its size differ per variant, so the comparison is per-path, plus the functional checks below.

Additional runs for the single-prefill change and for the shared-memory budget arithmetic:

```bash
pytest -q tests/attention/test_single_prefill.py \
       tests/attention/test_batch_prefill_kernels.py::test_batch_prefill_paged_cta_tile_q_smem_probe_qk448_vo256
# 207 passed, 13 skipped
```

The second one pins the `FA2DetermineCtaTileQ` probe at `(head_dim_qk, head_dim_vo) = (448, 256)` for both a 2-byte and a 1-byte KV dtype, which is the shape class the corrected budget and the new `HEAD_DIM_QK` bound act on.

Not verified: the mixed-module runtime selection on an SM100+ device, and latency on sm_89 and sm_90 -- no hardware for either. The numbers above are local measurements; the fork's CI test matrix is permission-gated and did not run them. Both compile, and `ptxas -v` shows register spilling on the FP4 prefill kernels drops there too — 424 B to 28 B of spill stores on sm_89, 376 B to 28 B on sm_90a, against 392 B to 8 B on sm_80.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optimized NVFP4 support for single, ragged, and paged prefill attention workflows.
  * Added automatic GPU architecture-aware selection of FP4 data repacking.
  * Added FP4 scale conversion and tile dequantization for attention processing.
  * Added faster FP4 conversion to FP16 and BF16 for supported vector sizes.
* **Compatibility**
  * Preserved FP8 behavior and fallback conversion paths across supported configurations.
  * Added support for consistent operation across older and newer GPU architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


