### PR TITLE
feat(prims-ts): CUDA graph mode for the prims-ts decode backend

### DIFF
--- a/flashinfer/attention/prims_ts/__init__.py
+++ b/flashinfer/attention/prims_ts/__init__.py
@@ -25,6 +25,7 @@ from .decode import (
     batch_decode_with_paged_kv_cache,
     get_prims_ts_batch_decode_workspace_size,
     prims_ts_batch_decode_with_kv_cache,
+    warm_prims_ts_batch_decode,
 )
 from .context import (
     BatchPrefillPagedTSWrapper,
@@ -52,6 +53,7 @@ __all__ = [
     "batch_decode_with_paged_kv_cache",
     "get_prims_ts_batch_decode_workspace_size",
     "prims_ts_batch_decode_with_kv_cache",
+    "warm_prims_ts_batch_decode",
     "BatchMLADecodePagedTSWrapper",
     "batch_decode_mla_with_paged_kv_cache",
     "get_prims_ts_batch_decode_mla_workspace_size",

--- a/flashinfer/attention/prims_ts/decode.py
+++ b/flashinfer/attention/prims_ts/decode.py
@@ -1674,6 +1674,69 @@ def get_prims_ts_batch_decode_workspace_size(
     ).total_bytes
 
 
+def warm_prims_ts_batch_decode(
+    batch_size: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    page_size: int,
+    max_seq_len: int,
+    *,
+    seq_len_q: int = 1,
+    q_dtype: torch.dtype = torch.float16,
+    kv_dtype: Optional[torch.dtype] = None,
+    out_dtype: Optional[torch.dtype] = None,
+    mask_type: Literal["dense", "causal"] = "dense",
+    window_left: int = -1,
+    kv_layout: Literal["HND"] = "HND",
+    device: Optional[Union[int, str, torch.device]] = None,
+) -> None:
+    """Compile the fixed-Q kernels that :func:`prims_ts_batch_decode_with_kv_cache`
+    would launch for this semantic key, so a later launch can be captured into a
+    CUDA graph without JIT work. Arguments mirror
+    :func:`get_prims_ts_batch_decode_workspace_size`."""
+
+    batch_size = _validate_positive_int(batch_size, "batch_size")
+    seq_len_q = _validate_seq_len_q(seq_len_q)
+    _validate_head_geometry(num_qo_heads, num_kv_heads)
+    _validate_decode_query_head_extent(
+        batch_size=batch_size,
+        num_qo_heads=num_qo_heads,
+        max_seq_len_q=seq_len_q,
+    )
+    head_dim = _validate_head_dim(head_dim)
+    page_size = _validate_page_size(page_size)
+    max_seq_len = _validate_max_kv_len(max_seq_len, "max_seq_len")
+    _validate_layout(kv_layout)
+    _validate_mask(mask_type)
+    window_left = _validate_window_left(window_left, mask_type)
+    if kv_dtype is None:
+        kv_dtype = q_dtype
+    if out_dtype is None:
+        out_dtype = q_dtype
+    _validate_dtype_pair(q_dtype, kv_dtype, out_dtype)
+    _, device_index = _resolve_cuda_device(device)
+    _get_compiled_decode(
+        device_index,
+        batch_size,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        max_seq_len,
+        seq_len_q,
+        _dtype_key(q_dtype),
+        _dtype_key(kv_dtype),
+        _dtype_key(out_dtype),
+        kv_layout,
+        mask_type,
+        False,
+        window_left,
+        "dynamic",
+        "dynamic",
+    )
+
+
 def _prepare_decode_runtime(
     q: torch.Tensor,
     paged_kv_cache: PagedKVCache,

--- a/flashinfer/attention/prims_ts/decode.py
+++ b/flashinfer/attention/prims_ts/decode.py
@@ -983,6 +983,34 @@ def _read_paged_kv_plan_values(
     )
 
 
+def _validate_planned_seq_lens(
+    seq_lens: torch.Tensor,
+    seq_lens_host: tuple[int, ...],
+    *,
+    expected_device: torch.device,
+) -> None:
+    if not isinstance(seq_lens, torch.Tensor):
+        raise TypeError("seq_lens must be a torch.Tensor")
+    if seq_lens.dtype != torch.int32:
+        raise TypeError(f"seq_lens must have dtype torch.int32, got {seq_lens.dtype}")
+    if seq_lens.dim() != 1 or seq_lens.numel() != len(seq_lens_host):
+        raise ValueError(
+            f"seq_lens must be a 1-D tensor with one entry per request "
+            f"({len(seq_lens_host)}), got shape {tuple(seq_lens.shape)}"
+        )
+    if seq_lens.device != expected_device:
+        raise ValueError(
+            f"seq_lens must be on {expected_device}, got {seq_lens.device}"
+        )
+    if not seq_lens.is_contiguous():
+        raise ValueError("seq_lens must be contiguous")
+    if tuple(int(value) for value in seq_lens.tolist()) != seq_lens_host:
+        raise ValueError(
+            "seq_lens values must equal the K/V lengths derived from "
+            "(paged_kv_indptr, paged_kv_last_page_len, page_size)"
+        )
+
+
 def _decode_output_shape(
     *,
     batch_size: int,
@@ -2166,6 +2194,7 @@ class BatchDecodePagedTSWrapper:
         _validate_layout(kv_layout)
         self._kv_layout = kv_layout
         self._planned = False
+        self._owned_workspace_buffer: Optional[torch.Tensor] = None
 
     @flashinfer_api
     def plan(
@@ -2187,6 +2216,8 @@ class BatchDecodePagedTSWrapper:
         mask_type: Literal["dense", "causal"] = "dense",
         window_left: int = -1,
         max_kv_len: Optional[int] = None,
+        seq_lens: Optional[torch.Tensor] = None,
+        workspace_buffer: Optional[torch.Tensor] = None,
     ) -> None:
         """Prepare native CSR metadata, policy, compiled callables, and scratch.
 
@@ -2225,6 +2256,9 @@ class BatchDecodePagedTSWrapper:
         be mutated concurrently with a run or replay that reads it. One wrapper
         instance supports only one in-flight run or captured-graph replay because
         it owns mutable scratch; use separate wrappers for concurrent execution.
+        Scratch is rebound and reinitialized in place by every plan, so a graph
+        captured against an earlier plan of this wrapper must not be replayed
+        after a re-plan.
 
         Parameters
         ----------
@@ -2246,6 +2280,18 @@ class BatchDecodePagedTSWrapper:
             Left sliding-window extent, or ``-1`` to disable the window.
         max_kv_len : int, optional
             Static K/V length bound; defaults to the metadata maximum.
+        seq_lens : torch.Tensor, optional
+            Caller-owned contiguous int32 device tensor of shape
+            ``[batch_size]`` holding the per-request K/V lengths. The values
+            must equal the lengths derived from ``(paged_kv_indptr,
+            paged_kv_last_page_len, page_size)``; planning validates that once
+            on the host. When omitted, the plan derives and owns the tensor.
+        workspace_buffer : torch.Tensor, optional
+            Caller-owned contiguous ``torch.int8``/``torch.uint8`` CUDA buffer
+            the plan binds its scratch into, holding at least the plan's
+            required bytes and exclusive to this wrapper. When omitted, the
+            wrapper owns one buffer and grows it as needed instead of
+            allocating per plan.
         """
 
         _validate_mask(mask_type)
@@ -2325,10 +2371,19 @@ class BatchDecodePagedTSWrapper:
                         "no greater than its K/V length; request "
                         f"{request_idx} has Q={q_len} and K/V={kv_len}"
                     )
-        # This is the only metadata-derived device tensor needed by the raw
-        # native path. It remains stable across every run of this plan.
-        num_pages = paged_kv_indptr[1:] - paged_kv_indptr[:-1]
-        seq_lens = ((num_pages - 1) * page_size + paged_kv_last_page_len).contiguous()
+        if seq_lens is None:
+            # This is the only metadata-derived device tensor needed by the
+            # raw native path. It remains stable across every run of this plan.
+            num_pages = paged_kv_indptr[1:] - paged_kv_indptr[:-1]
+            seq_lens = (
+                (num_pages - 1) * page_size + paged_kv_last_page_len
+            ).contiguous()
+        else:
+            _validate_planned_seq_lens(
+                seq_lens,
+                seq_lens_host,
+                expected_device=device,
+            )
         metadata_max_kv_len = max(seq_lens_host)
         if max_kv_len is None:
             exact_max_kv_len = metadata_max_kv_len
@@ -2403,9 +2458,24 @@ class BatchDecodePagedTSWrapper:
             o_data_type,
             use_separate_reduction_kernel=spec.config.use_separate_reduction_kernel,
         )
-        workspace_buffer = torch.empty(
-            workspace_layout.total_bytes, device=device, dtype=torch.int8
-        )
+        if workspace_buffer is not None:
+            _validate_workspace_buffer(
+                workspace_buffer,
+                device=device,
+                required_bytes=workspace_layout.total_bytes,
+            )
+        else:
+            owned = self._owned_workspace_buffer
+            if (
+                owned is None
+                or owned.device != device
+                or owned.numel() < workspace_layout.total_bytes
+            ):
+                owned = torch.empty(
+                    workspace_layout.total_bytes, device=device, dtype=torch.int8
+                )
+                self._owned_workspace_buffer = owned
+            workspace_buffer = owned
         workspace = _bind_decode_workspace(workspace_buffer, workspace_layout)
         workspace.split_kv_counter.zero_()
         workspace.cu_seqlens_q.zero_()

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
@@ -23,7 +23,7 @@ Import these entry points from `flashinfer.attention.prims_ts`:
 
 | API | Use |
 | --- | --- |
-| `BatchDecodePagedTSWrapper` | Reusable `plan()`/`run()` interface; owns compiled callables and scratch. |
+| `BatchDecodePagedTSWrapper` | Reusable `plan()`/`run()` interface; owns compiled callables and binds scratch from a caller-provided or wrapper-owned reusable buffer. |
 | `batch_decode_with_paged_kv_cache` | One-shot convenience interface. |
 | `get_prims_ts_batch_decode_workspace_size` | Size caller-owned scratch for the standalone launch. |
 | `prims_ts_batch_decode_with_kv_cache` | Standalone launch with caller-owned scratch and explicit `seq_lens`. |

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1035,6 +1035,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
             device="cpu",
             pin_memory=True,
         )
+        if self._backend == "prims-ts":
+            self._prims_ts_graph_key = None
+            self._prims_ts_workspace = None
 
     @flashinfer_api
     def workspace_size(

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -876,8 +876,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
             no RoPE/ALiBi/soft-cap).
             The ``prims-ts`` backend uses the task-scheduled decode kernel on SM100a/SM103a.
             It is the only backend that accepts ``is_causal=False`` with
-            ``q_len_per_req > 1``. It requires ``kv_layout="HND"`` and does not
-            support ``use_cuda_graph=True``.
+            ``q_len_per_req > 1`` and requires ``kv_layout="HND"``. Under
+            ``use_cuda_graph`` it runs the dynamic kernel variant, bounded by the
+            kv-token capacity of ``paged_kv_indices_buffer``, with scratch carved
+            from ``float_workspace_buffer``.
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -924,7 +926,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             device="cpu",
         )
         self._kv_lens_buffer: Optional[torch.Tensor] = None
-        if backend in ("trtllm-gen", "cute-dsl"):
+        if backend in ("trtllm-gen", "cute-dsl", "prims-ts"):
             self._kv_lens_buffer = torch.empty(
                 (32768,), dtype=torch.int32, device=self.device
             )
@@ -986,15 +988,17 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 raise NotImplementedError(
                     "prims-ts decode backend requires kv_layout='HND'"
                 )
-            # The delegate snapshots seq_lens, scratch, and the compiled kernel
-            # at plan time, so a captured run() does not follow a later plan().
-            if use_cuda_graph:
-                raise NotImplementedError(
-                    "prims-ts decode backend does not support use_cuda_graph=True"
-                )
-            from .attention.prims_ts import BatchDecodePagedTSWrapper
+            # The delegate specializes its kernel on plan-time metadata, so it
+            # cannot back a captured run() that must follow later plan() calls.
+            # Under CUDA graph the wrapper drives the functional entry point
+            # with a static kv-length bound and wrapper-owned scratch instead.
+            self._prims_ts_graph_key = None
+            self._prims_ts_workspace: Optional[torch.Tensor] = None
+            self._prims_ts_max_kv_len: Optional[int] = None
+            if not use_cuda_graph:
+                from .attention.prims_ts import BatchDecodePagedTSWrapper
 
-            self._prims_ts_wrapper = BatchDecodePagedTSWrapper()
+                self._prims_ts_wrapper = BatchDecodePagedTSWrapper()
 
     @property
     def use_tensor_cores(self) -> bool:
@@ -1679,22 +1683,39 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         "(indptr, last_page_len, page_size); seq_lens must match them"
                     )
             self._max_kv_len = int(max(kv_lens_arr_host).item())
-            self._prims_ts_wrapper.plan(
-                self._paged_kv_indptr_buf,
-                self._paged_kv_indices_buf,
-                self._paged_kv_last_page_len_buf,
-                num_qo_heads=num_qo_heads,
-                num_kv_heads=num_kv_heads,
-                head_dim=head_dim,
-                page_size=page_size,
-                seq_len_q=q_len_per_req,
-                q_data_type=q_data_type,
-                kv_data_type=kv_data_type,
-                o_data_type=o_data_type,
-                mask_type="causal" if is_causal else "dense",
-                window_left=window_left,
-                max_kv_len=self._max_kv_len,
-            )
+            mask_type = "causal" if is_causal else "dense"
+            if self._use_cuda_graph:
+                self._plan_prims_ts_graph(
+                    kv_lens_arr_host,
+                    num_qo_heads=num_qo_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    page_size=page_size,
+                    q_len_per_req=q_len_per_req,
+                    q_data_type=q_data_type,
+                    kv_data_type=kv_data_type,
+                    o_data_type=o_data_type,
+                    mask_type=mask_type,
+                    window_left=window_left,
+                    non_blocking=non_blocking,
+                )
+            else:
+                self._prims_ts_wrapper.plan(
+                    self._paged_kv_indptr_buf,
+                    self._paged_kv_indices_buf,
+                    self._paged_kv_last_page_len_buf,
+                    num_qo_heads=num_qo_heads,
+                    num_kv_heads=num_kv_heads,
+                    head_dim=head_dim,
+                    page_size=page_size,
+                    seq_len_q=q_len_per_req,
+                    q_data_type=q_data_type,
+                    kv_data_type=kv_data_type,
+                    o_data_type=o_data_type,
+                    mask_type=mask_type,
+                    window_left=window_left,
+                    max_kv_len=self._max_kv_len,
+                )
         elif self._backend == "trtllm-gen":
             assert logits_soft_cap == 0.0
             self._max_kv_len = max(kv_lens_arr_host).item()
@@ -1859,6 +1880,95 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._rope_theta = rope_theta
         self._q_len_per_req = q_len_per_req
         self._is_causal = is_causal
+
+    def _plan_prims_ts_graph(
+        self,
+        kv_lens_arr_host: torch.Tensor,
+        *,
+        num_qo_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        page_size: int,
+        q_len_per_req: int,
+        q_data_type: torch.dtype,
+        kv_data_type: torch.dtype,
+        o_data_type: torch.dtype,
+        mask_type: str,
+        window_left: int,
+        non_blocking: bool,
+    ) -> None:
+        from .attention.prims_ts import (
+            get_prims_ts_batch_decode_workspace_size,
+            warm_prims_ts_batch_decode,
+        )
+        from .attention.prims_ts.decode import _DECODE_MAX_KV_LEN
+
+        # The functional path needs a static kv-length bound that is part of
+        # the compiled key. Policy and scratch do not depend on it, and any
+        # request whose pages fit the index buffer stays under its capacity,
+        # so the capacity is a free bound that never changes between plans.
+        max_kv_len = min(
+            int(self._paged_kv_indices_buf.numel()) * page_size, _DECODE_MAX_KV_LEN
+        )
+        batch_size = len(kv_lens_arr_host)
+        self._kv_lens_buffer[:batch_size].copy_(
+            kv_lens_arr_host, non_blocking=non_blocking
+        )
+        key = (
+            batch_size,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            max_kv_len,
+            q_len_per_req,
+            q_data_type,
+            kv_data_type,
+            o_data_type,
+            mask_type,
+            window_left,
+        )
+        if key != self._prims_ts_graph_key:
+            required = get_prims_ts_batch_decode_workspace_size(
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                max_kv_len,
+                seq_len_q=q_len_per_req,
+                q_dtype=q_data_type,
+                kv_dtype=kv_data_type,
+                out_dtype=o_data_type,
+                mask_type=mask_type,
+                window_left=window_left,
+                device=self.device,
+            )
+            if required > self._float_workspace_buffer.numel():
+                raise ValueError(
+                    f"prims-ts CUDA graph plan needs {required} workspace bytes, "
+                    f"float_workspace_buffer has {self._float_workspace_buffer.numel()}"
+                )
+            warm_prims_ts_batch_decode(
+                batch_size,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                max_kv_len,
+                seq_len_q=q_len_per_req,
+                q_dtype=q_data_type,
+                kv_dtype=kv_data_type,
+                out_dtype=o_data_type,
+                mask_type=mask_type,
+                window_left=window_left,
+                device=self.device,
+            )
+            workspace = self._float_workspace_buffer[:required].view(torch.int8)
+            workspace.zero_()
+            self._prims_ts_workspace = workspace
+            self._prims_ts_graph_key = key
+        self._prims_ts_max_kv_len = max_kv_len
 
     begin_forward = plan
 
@@ -2229,13 +2339,33 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 packed_shape = (actual_batch_size, q_len_per_req, q.size(1), q.size(2))
                 q = q.view(packed_shape)
                 out = out.view(packed_shape[:-1] + (out.size(-1),))
-            out = self._prims_ts_wrapper.run(
-                q,
-                (k_cache, v_cache),
-                bmm1_scale=sm_scale,
-                bmm2_scale=1.0 if v_scale is None else float(v_scale),
-                out=out,
-            )
+            bmm2_scale = 1.0 if v_scale is None else float(v_scale)
+            if self._use_cuda_graph:
+                from .attention.prims_ts import prims_ts_batch_decode_with_kv_cache
+
+                out = prims_ts_batch_decode_with_kv_cache(
+                    q,
+                    (k_cache, v_cache),
+                    self._prims_ts_workspace,
+                    self._paged_kv_indptr_buf,
+                    self._paged_kv_indices_buf,
+                    self._kv_lens_buffer[:actual_batch_size],
+                    self._prims_ts_max_kv_len,
+                    seq_len_q=q_len_per_req,
+                    mask_type="causal" if self._is_causal else "dense",
+                    window_left=self._window_left,
+                    bmm1_scale=sm_scale,
+                    bmm2_scale=bmm2_scale,
+                    out=out,
+                )
+            else:
+                out = self._prims_ts_wrapper.run(
+                    q,
+                    (k_cache, v_cache),
+                    bmm1_scale=sm_scale,
+                    bmm2_scale=bmm2_scale,
+                    out=out,
+                )
             return (
                 out.view(-1, out.size(-2), out.size(-1)) if q_len_per_req > 1 else out
             )

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1925,6 +1925,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
             int(self._paged_kv_indices_buf.numel()) * page_size, _DECODE_MAX_KV_LEN
         )
         batch_size = len(kv_lens_arr_host)
+        if batch_size > self._kv_lens_buffer.shape[0]:
+            self._kv_lens_buffer = torch.empty(
+                (batch_size,), dtype=torch.int32, device=self.device
+            )
         self._kv_lens_buffer[:batch_size].copy_(
             kv_lens_arr_host, non_blocking=non_blocking
         )

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -992,7 +992,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
             # cannot back a captured run() that must follow later plan() calls.
             # Under CUDA graph the wrapper drives the functional entry point
             # with a static kv-length bound and wrapper-owned scratch instead.
-            self._prims_ts_graph_key = None
+            self._prims_ts_graph_key: Optional[Tuple[Any, ...]] = None
             self._prims_ts_workspace: Optional[torch.Tensor] = None
             self._prims_ts_max_kv_len: Optional[int] = None
             if not use_cuda_graph:
@@ -1686,7 +1686,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         "(indptr, last_page_len, page_size); seq_lens must match them"
                     )
             self._max_kv_len = int(max(kv_lens_arr_host).item())
-            mask_type = "causal" if is_causal else "dense"
+            mask_type: Literal["dense", "causal"] = "causal" if is_causal else "dense"
             if self._use_cuda_graph:
                 self._plan_prims_ts_graph(
                     kv_lens_arr_host,
@@ -1896,7 +1896,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         q_data_type: torch.dtype,
         kv_data_type: torch.dtype,
         o_data_type: torch.dtype,
-        mask_type: str,
+        mask_type: Literal["dense", "causal"],
         window_left: int,
         non_blocking: bool,
     ) -> None:

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -876,10 +876,11 @@ class BatchDecodeWithPagedKVCacheWrapper:
             no RoPE/ALiBi/soft-cap).
             The ``prims-ts`` backend uses the task-scheduled decode kernel on SM100a/SM103a.
             It is the only backend that accepts ``is_causal=False`` with
-            ``q_len_per_req > 1`` and requires ``kv_layout="HND"``. Under
-            ``use_cuda_graph`` it runs the dynamic kernel variant, bounded by the
-            kv-token capacity of ``paged_kv_indices_buffer``, with scratch carved
-            from ``float_workspace_buffer``.
+            ``q_len_per_req > 1`` and requires ``kv_layout="HND"``. Both modes
+            carve scratch from ``float_workspace_buffer`` and stage the planned
+            KV lengths in a reusable device buffer. Under ``use_cuda_graph`` it
+            runs the dynamic kernel variant, bounded by the kv-token capacity of
+            ``paged_kv_indices_buffer``.
 
         jit_args : Optional[List[Any]]
             If provided, the wrapper will use the provided arguments to create the JIT module,
@@ -1703,6 +1704,14 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     non_blocking=non_blocking,
                 )
             else:
+                required_size = len(kv_lens_arr_host)
+                if required_size > self._kv_lens_buffer.shape[0]:
+                    self._kv_lens_buffer = torch.empty(
+                        (required_size,), dtype=torch.int32, device=self.device
+                    )
+                self._kv_lens_buffer[:required_size].copy_(
+                    kv_lens_arr_host, non_blocking=non_blocking
+                )
                 self._prims_ts_wrapper.plan(
                     self._paged_kv_indptr_buf,
                     self._paged_kv_indices_buf,
@@ -1718,6 +1727,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     mask_type=mask_type,
                     window_left=window_left,
                     max_kv_len=self._max_kv_len,
+                    seq_lens=self._kv_lens_buffer[:required_size],
+                    workspace_buffer=self._float_workspace_buffer,
                 )
         elif self._backend == "trtllm-gen":
             assert logits_soft_cap == 0.0

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1947,6 +1947,12 @@ class BatchDecodeWithPagedKVCacheWrapper:
             window_left,
         )
         if key != self._prims_ts_graph_key:
+            # The functional launch validates its scratch at 32 bytes, stricter
+            # than the 16-byte wrapper check, so fail at plan rather than at
+            # graph capture.
+            _check_workspace_buffer_alignment(
+                self._float_workspace_buffer, "float_workspace_buffer", alignment=32
+            )
             required = get_prims_ts_batch_decode_workspace_size(
                 batch_size,
                 num_qo_heads,

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -149,20 +149,32 @@ def test_rejects_jit_args():
         _make_wrapper("prims-ts", jit_args=[1])
 
 
-@requires_cuda
-def test_rejects_cuda_graph():
-    batch_size = 2
-    buffers = dict(
+def _graph_buffers(batch_size, max_pages, device="cuda"):
+    return dict(
         paged_kv_indptr_buffer=torch.zeros(
-            batch_size + 1, dtype=torch.int32, device="cuda"
+            batch_size + 1, dtype=torch.int32, device=device
         ),
-        paged_kv_indices_buffer=torch.zeros(16, dtype=torch.int32, device="cuda"),
+        paged_kv_indices_buffer=torch.zeros(
+            max_pages, dtype=torch.int32, device=device
+        ),
         paged_kv_last_page_len_buffer=torch.zeros(
-            batch_size, dtype=torch.int32, device="cuda"
+            batch_size, dtype=torch.int32, device=device
         ),
     )
-    with pytest.raises(NotImplementedError, match="use_cuda_graph"):
-        _make_wrapper("prims-ts", use_cuda_graph=True, **buffers)
+
+
+@requires_prims_ts_gpu
+def test_graph_plan_rejects_small_workspace():
+    workspace = torch.zeros(64, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        "HND",
+        backend="prims-ts",
+        use_cuda_graph=True,
+        **_graph_buffers(2, max_pages=64),
+    )
+    with pytest.raises(ValueError, match="workspace bytes"):
+        wrapper.plan(*_plan_args([32, 48], "cuda"), q_data_type=torch.bfloat16)
 
 
 @requires_cuda
@@ -472,12 +484,75 @@ def test_rejects_noncontiguous_multi_q_tensors():
 
 
 @requires_prims_ts_gpu
-def test_graph_capture_of_fixed_plan_replays():
-    """Capturing run() after a plan replays that plan; re-planning is not covered.
+@pytest.mark.parametrize("q_len_per_req,is_causal", [(1, False), (4, False), (4, True)])
+def test_cuda_graph_replan_then_replay(q_len_per_req, is_causal):
+    kv_lens_sets = [[64, 96], [40, 200], [128, 128]]
+    max_pages = 64
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(
+        [max_pages * PAGE_SIZE // 2] * 2, torch.bfloat16, "cuda"
+    )
+    q = torch.randn(
+        2 * q_len_per_req, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda"
+    )
+    wrapper = _make_wrapper(
+        "prims-ts", use_cuda_graph=True, **_graph_buffers(2, max_pages=max_pages)
+    )
 
-    The wrapper-level ``use_cuda_graph=True`` flow (re-plan then replay) is
-    rejected for this backend, see ``test_rejects_cuda_graph``.
-    """
+    def plan(kv_lens):
+        wrapper.plan(
+            *_plan_args(kv_lens, "cuda"),
+            q_data_type=torch.bfloat16,
+            q_len_per_req=q_len_per_req,
+            is_causal=is_causal,
+        )
+
+    def reference(kv_lens):
+        return _reference_decode(
+            q, k_cache, v_cache, kv_lens, q_len_per_req, is_causal, PAGE_SIZE
+        )
+
+    plan(kv_lens_sets[0])
+    out = torch.empty_like(q)
+    wrapper.run(q, (k_cache, v_cache), out=out)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        wrapper.run(q, (k_cache, v_cache), out=out)
+
+    for kv_lens in kv_lens_sets:
+        plan(kv_lens)
+        out.fill_(float("nan"))
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            out.float(), reference(kv_lens), rtol=2e-2, atol=2e-2
+        )
+
+
+@requires_prims_ts_gpu
+def test_cuda_graph_matches_eager_path():
+    kv_lens = [64, 96]
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(2, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    plan_args = _plan_args(kv_lens, "cuda")
+
+    eager = _make_wrapper("prims-ts")
+    eager.plan(*plan_args, q_data_type=torch.bfloat16)
+    expected = eager.run(q, (k_cache, v_cache))
+
+    graph_wrapper = _make_wrapper(
+        "prims-ts", use_cuda_graph=True, **_graph_buffers(2, max_pages=32)
+    )
+    graph_wrapper.plan(*plan_args, q_data_type=torch.bfloat16)
+    got = graph_wrapper.run(q, (k_cache, v_cache))
+    torch.testing.assert_close(got, expected, rtol=1e-2, atol=1e-2)
+
+
+@requires_prims_ts_gpu
+def test_graph_capture_of_fixed_plan_replays():
+    """Eager-mode wrapper: capturing run() after a plan replays that plan."""
 
     kv_lens = [64, 96]
     q_len_per_req = 4

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -531,6 +531,37 @@ def test_cuda_graph_replan_then_replay(q_len_per_req, is_causal):
 
 
 @requires_prims_ts_gpu
+def test_graph_plan_rebinds_after_workspace_reset():
+    kv_lens = [64, 96]
+    plan_args = _plan_args(kv_lens, "cuda")
+    wrapper = _make_wrapper(
+        "prims-ts", use_cuda_graph=True, **_graph_buffers(2, max_pages=32)
+    )
+    wrapper.plan(*plan_args, q_data_type=torch.bfloat16)
+    old_workspace = wrapper._prims_ts_workspace
+
+    new_float = torch.zeros(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    new_int = torch.zeros(8 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper.reset_workspace_buffer(new_float, new_int)
+    wrapper.plan(*plan_args, q_data_type=torch.bfloat16)
+
+    workspace = wrapper._prims_ts_workspace
+    assert workspace.data_ptr() != old_workspace.data_ptr()
+    assert workspace.data_ptr() == new_float.data_ptr()
+
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(2, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    out = wrapper.run(q, (k_cache, v_cache))
+    torch.testing.assert_close(
+        out.float(),
+        _reference_decode(q, k_cache, v_cache, kv_lens, 1, False, PAGE_SIZE),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
+@requires_prims_ts_gpu
 def test_cuda_graph_matches_eager_path():
     kv_lens = [64, 96]
     torch.manual_seed(0)

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -178,6 +178,27 @@ def test_graph_plan_rejects_small_workspace():
 
 
 @requires_prims_ts_gpu
+def test_graph_plan_grows_kv_lens_buffer():
+    # One page per request; the batch exceeds the 32768-slot default buffer.
+    # The tiny workspace stops plan() right after the kv-lens staging, so the
+    # test never reaches kernel warming.
+    batch_size = 32769
+    kv_lens = [PAGE_SIZE] * batch_size
+    workspace = torch.zeros(64, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        "HND",
+        backend="prims-ts",
+        use_cuda_graph=True,
+        **_graph_buffers(batch_size, max_pages=batch_size),
+    )
+    with pytest.raises(ValueError, match="workspace bytes"):
+        wrapper.plan(*_plan_args(kv_lens, "cuda"), q_data_type=torch.bfloat16)
+    assert wrapper._kv_lens_buffer.shape[0] == batch_size
+    assert wrapper._kv_lens_buffer[-1].item() == PAGE_SIZE
+
+
+@requires_prims_ts_gpu
 def test_eager_plan_binds_caller_buffers():
     kv_lens = [64, 96]
     workspace = torch.zeros(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -177,6 +177,75 @@ def test_graph_plan_rejects_small_workspace():
         wrapper.plan(*_plan_args([32, 48], "cuda"), q_data_type=torch.bfloat16)
 
 
+@requires_prims_ts_gpu
+def test_eager_plan_binds_caller_buffers():
+    kv_lens = [64, 96]
+    workspace = torch.zeros(64 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "HND", backend="prims-ts"
+    )
+    wrapper.plan(*_plan_args(kv_lens, "cuda"), q_data_type=torch.bfloat16)
+    delegate = wrapper._prims_ts_wrapper
+    assert delegate._workspace_buffer.data_ptr() == workspace.data_ptr()
+    assert delegate._seq_lens.data_ptr() == wrapper._kv_lens_buffer.data_ptr()
+
+    torch.manual_seed(0)
+    k_cache, v_cache = _make_cache(kv_lens, torch.bfloat16, "cuda")
+    q = torch.randn(2, NUM_QO_HEADS, HEAD_DIM, dtype=torch.bfloat16, device="cuda")
+    out = wrapper.run(q, (k_cache, v_cache))
+    torch.testing.assert_close(
+        out.float(),
+        _reference_decode(q, k_cache, v_cache, kv_lens, 1, False, PAGE_SIZE),
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+    wrapper.plan(*_plan_args([48, 96], "cuda"), q_data_type=torch.bfloat16)
+    assert delegate._workspace_buffer.data_ptr() == workspace.data_ptr()
+
+
+@requires_prims_ts_gpu
+def test_eager_plan_rejects_small_workspace():
+    workspace = torch.zeros(16, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace, "HND", backend="prims-ts"
+    )
+    with pytest.raises(ValueError, match="workspace_buffer is too small"):
+        wrapper.plan(*_plan_args([32, 48], "cuda"), q_data_type=torch.bfloat16)
+
+
+@requires_prims_ts_gpu
+def test_delegate_plan_rejects_mismatched_seq_lens():
+    from flashinfer.attention.prims_ts import BatchDecodePagedTSWrapper
+
+    indptr, indices, last_page_len = _make_page_table([32, 48], PAGE_SIZE, "cuda")
+    wrong = torch.tensor([32, 40], dtype=torch.int32, device="cuda")
+    with pytest.raises(ValueError, match="seq_lens values must equal"):
+        BatchDecodePagedTSWrapper().plan(
+            indptr,
+            indices,
+            last_page_len,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=torch.bfloat16,
+            seq_lens=wrong,
+        )
+
+
+@requires_prims_ts_gpu
+def test_delegate_plan_reuses_owned_workspace():
+    from flashinfer.attention.prims_ts import BatchDecodePagedTSWrapper
+
+    wrapper = BatchDecodePagedTSWrapper()
+    args = _plan_args([32, 48], "cuda")
+    wrapper.plan(*args, q_data_type=torch.bfloat16)
+    first = wrapper._workspace_buffer.data_ptr()
+    wrapper.plan(*args, q_data_type=torch.bfloat16)
+    assert wrapper._workspace_buffer.data_ptr() == first
+
+
 @requires_cuda
 def test_rejects_fast_decode_plan():
     wrapper = _make_wrapper("prims-ts")

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -177,6 +177,26 @@ def test_graph_plan_rejects_small_workspace():
         wrapper.plan(*_plan_args([32, 48], "cuda"), q_data_type=torch.bfloat16)
 
 
+@requires_cuda
+def test_graph_plan_rejects_misaligned_workspace():
+    # 16-byte aligned but not 32-byte aligned; the wrapper-level check passes
+    # and the functional launch would reject it only at graph capture. The
+    # alignment check fires before the arch-gated sizing helper, so any CUDA
+    # device can run this.
+    backing = torch.zeros(64 * 1024 * 1024 + 16, dtype=torch.uint8, device="cuda")
+    workspace = backing[16:]
+    assert workspace.data_ptr() % 32 == 16
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        "HND",
+        backend="prims-ts",
+        use_cuda_graph=True,
+        **_graph_buffers(2, max_pages=64),
+    )
+    with pytest.raises(ValueError, match="32-byte aligned"):
+        wrapper.plan(*_plan_args([32, 48], "cuda"), q_data_type=torch.bfloat16)
+
+
 @requires_prims_ts_gpu
 def test_graph_plan_grows_kv_lens_buffer():
     # One page per request; the batch exceeds the 32768-slot default buffer.


### PR DESCRIPTION
## 📌 Description

`BatchDecodeWithPagedKVCacheWrapper(backend="prims-ts", use_cuda_graph=True)` is rejected since #4739. This PR enables it.

The wrapper's CUDA graph contract is re-plan then replay: `plan()` runs outside the graph each step and writes into fixed buffers, and `replay()` picks up the new metadata. `BatchDecodePagedTSWrapper.plan()` does not fit that contract. It snapshots `seq_lens`, allocates scratch, and specializes the compiled kernel on plan-time values, so a captured `run()` would keep the tensors and kernel of the plan it was captured under.

The functional `prims_ts_batch_decode_with_kv_cache` path already fits. It compiles the dynamic variant only, reads kv lengths from a caller-owned device tensor, takes caller scratch, and does no device-to-host reads. Under `use_cuda_graph` the wrapper now routes to it:

- kv lengths are staged into the existing `_kv_lens_buffer`, the same pattern trtllm-gen and cute-dsl use
- scratch is carved from the front of `float_workspace_buffer`, sized by `get_prims_ts_batch_decode_workspace_size`, and re-zeroed when the compile key changes
- the static kv-length bound is the kv-token capacity of `paged_kv_indices_buffer`. Any request whose pages fit the index buffer stays under it, so it never changes between plans
- `plan()` compiles the key through the new `warm_prims_ts_batch_decode` so capture does not JIT

Eager mode is unchanged and keeps the plan-specialized delegate.

### Bound choice

The functional path needs a static `max_seq_len` for its compile key. Measured on B200 (bf16, Hq 32, Hkv 8, D 128, page 16), the automatic policy (`splits_kv`, persistent scheduling, kv tile) and the scratch size are identical for bounds from the exact length up to the 2,147,483,392 cap, at batch 8, 64, and 256. Latency is identical within 0.1%. So the bound costs nothing and an explicit `plan(max_kv_len=...)` knob is not needed.

### Cost of the dynamic variant

The eager delegate specializes on plan-time metadata (`planned_uniform_max`, `planned_full`). The graph path gives that up. Same shapes, median of CUDA event timing:

| batch | kv_len | eager ms | graph ms | ratio | policy |
|---|---|---|---|---|---|
| 64 | 2048 | 0.1012 | 0.1024 | 1.011 | 1 split, persistent |
| 64 | 8192 | 0.3237 | 0.3237 | 1.000 | 1 split, persistent |
| 64 | 32768 | 1.2298 | 1.2309 | 1.001 | 1 split, persistent |
| 8 | 8192 | 0.0595 | 0.0615 | 1.034 | 2 splits |
| 256 | 4096 | 0.6113 | 0.6116 | 1.000 | 1 split, persistent |

## 🔍 Related Issues

#4770 

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/attention/test_prims_ts_decode_backend.py`: re-plan then replay across three kv-length sets for dense SQ=1, dense SQ=4, and causal SQ=4 against the paged reference; graph output equals the eager delegate; scratch is rebound after `reset_workspace_buffer()`; rejection of an undersized `float_workspace_buffer`. The rejection and rebind cases are gated on SM100a because the prims-ts sizing helper is architecture-gated and raises `NotImplementedError` first on other GPUs. The previous `use_cuda_graph` rejection test is removed.

Run on B200 (SM100a), `nvidia-cutlass-dsl` 4.7.0:

```
tests/attention/test_prims_ts_decode_backend.py    33 passed
tests/attention/test_batch_decode_kernels.py      742 passed   (-k "uniform_multi_token or fast_plan or workspace", with test_workspace_size.py)
tests/attention/test_attention_ts_decode.py        10 passed   (-k "workspace or functional or graph")
```
## Reviewer Notes

`warm_prims_ts_batch_decode` is the only prims-ts side change. It mirrors `get_prims_ts_batch_decode_workspace_size` and compiles the dynamic kernels for the key. Happy to fold it into the sizing helper or keep it private if that is preferred.

`_plan_prims_ts_graph` imports `_DECODE_MAX_KV_LEN` to clamp the capacity bound. A public constant would avoid the private import if reviewers prefer.

cc:@PerkzZheng @saltyminty
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CUDA Graph support for prims-ts batch decoding, including replay after re-planning and workspace reset.
  - Added a helper to warm and precompile batch decode kernels without running inference.
  - Added support for caller-provided sequence-length and workspace buffers during planning.
  - Added validation for decode configuration, data types, layouts, masking, and device compatibility.

- **Bug Fixes**
  - Improved workspace sizing, reuse, validation, and rebinding during planning and reset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->