### PR TITLE
Add bias support to cublast gemm backend and as fallback backend for cutedsl gemm backend

### DIFF
--- a/csrc/mm_bf16_cublaslt.cu
+++ b/csrc/mm_bf16_cublaslt.cu
@@ -37,14 +37,26 @@ cudaDataType_t get_d_type(DLDataType dtype) {
   }
 }
 
+const __nv_bfloat16* get_bias_ptr(const ffi::Optional<TensorView>& bias, int64_t n) {
+  if (!bias.has_value()) {
+    return nullptr;
+  }
+  const auto& tensor = bias.value();
+  CHECK_CUDA(tensor);
+  CHECK_INPUT_AND_TYPE(tensor, dl_bfloat16);
+  CHECK_DIM(1, tensor);
+  TVM_FFI_ICHECK_EQ(tensor.size(0), n) << "bias N dimension mismatch";
+  return static_cast<const __nv_bfloat16*>(tensor.data_ptr());
+}
+
 }  // namespace
 
 // Serialize all heuristic algorithms into a CPU uint8 tensor for caching.
 // algo_buffer: CPU uint8 tensor of size >= kMaxAlgorithms * kAlgoBytes.
 // Returns number of algorithms written.
-int64_t mm_bf16_cublaslt_get_algos(TensorView mat1, TensorView mat2, TensorView out,
-                                   TensorView workspace_buffer, int64_t cublas_handle,
-                                   TensorView algo_buffer) {
+int64_t mm_bf16_cublaslt_get_algos(TensorView mat1, TensorView mat2, ffi::Optional<TensorView> bias,
+                                   TensorView out, TensorView workspace_buffer,
+                                   int64_t cublas_handle, TensorView algo_buffer) {
   CHECK_CUDA(mat1);
   CHECK_CUDA(mat2);
   CHECK_CUDA(out);
@@ -65,21 +77,22 @@ int64_t mm_bf16_cublaslt_get_algos(TensorView mat1, TensorView mat2, TensorView 
       << "mat2 K dimension mismatch: expected " << k << ", got " << mat2.size(1);
   TVM_FFI_ICHECK_EQ(out.size(0), m) << "out M dimension mismatch";
   TVM_FFI_ICHECK_EQ(out.size(1), n) << "out N dimension mismatch";
-
   cudaDataType_t d_type = get_d_type(out.dtype());
+  const auto* bias_ptr = get_bias_ptr(bias, n);
 
   ffi::CUDADeviceGuard device_guard(mat1.device().device_id);
   auto lt_handle = reinterpret_cast<cublasLtHandle_t>(cublas_handle);
   int max_algos = static_cast<int>(algo_buffer.numel() * get_element_size(algo_buffer) /
                                    flashinfer::mm_bf16_cublaslt::kAlgoBytes);
   return static_cast<int64_t>(flashinfer::mm_bf16_cublaslt::get_algorithms(
-      static_cast<int>(m), static_cast<int>(n), static_cast<int>(k), d_type,
+      static_cast<int>(m), static_cast<int>(n), static_cast<int>(k), d_type, bias_ptr,
       workspace_buffer.numel() * get_element_size(workspace_buffer), lt_handle,
       algo_buffer.data_ptr(), max_algos));
 }
 
 // Run matmul using a pre-cached algorithm — zero heuristic overhead.
-void mm_bf16_cublaslt_run_with_algo(TensorView mat1, TensorView mat2, TensorView out,
+void mm_bf16_cublaslt_run_with_algo(TensorView mat1, TensorView mat2,
+                                    ffi::Optional<TensorView> bias, TensorView out,
                                     TensorView workspace_buffer, int64_t cublas_handle,
                                     TensorView algo_buffer, int64_t algo_idx) {
   CHECK_CUDA(mat1);
@@ -102,7 +115,6 @@ void mm_bf16_cublaslt_run_with_algo(TensorView mat1, TensorView mat2, TensorView
       << "mat2 K dimension mismatch: expected " << k << ", got " << mat2.size(1);
   TVM_FFI_ICHECK_EQ(out.size(0), m) << "out M dimension mismatch";
   TVM_FFI_ICHECK_EQ(out.size(1), n) << "out N dimension mismatch";
-
   int64_t max_algos = algo_buffer.numel() * get_element_size(algo_buffer) /
                       flashinfer::mm_bf16_cublaslt::kAlgoBytes;
   TVM_FFI_ICHECK(algo_idx >= 0 && algo_idx < max_algos)
@@ -112,12 +124,14 @@ void mm_bf16_cublaslt_run_with_algo(TensorView mat1, TensorView mat2, TensorView
   ffi::CUDADeviceGuard device_guard(mat1.device().device_id);
   auto stream = get_stream(mat1.device());
   cudaDataType_t d_type = get_d_type(out.dtype());
+  const auto* bias_ptr = get_bias_ptr(bias, n);
 
   auto status = flashinfer::mm_bf16_cublaslt::run_with_algo(
       static_cast<__nv_bfloat16*>(mat1.data_ptr()), static_cast<__nv_bfloat16*>(mat2.data_ptr()),
-      out.data_ptr(), static_cast<int>(m), static_cast<int>(n), static_cast<int>(k), d_type,
-      workspace_buffer.data_ptr(), workspace_buffer.numel() * get_element_size(workspace_buffer),
-      lt_handle, stream, algo_buffer.data_ptr(), static_cast<int>(algo_idx));
+      out.data_ptr(), bias_ptr, static_cast<int>(m), static_cast<int>(n), static_cast<int>(k),
+      d_type, workspace_buffer.data_ptr(),
+      workspace_buffer.numel() * get_element_size(workspace_buffer), lt_handle, stream,
+      algo_buffer.data_ptr(), static_cast<int>(algo_idx));
   TVM_FFI_ICHECK(status == CUBLAS_STATUS_SUCCESS)
       << "mm_bf16_cublaslt_run_with_algo failed: " << cublasGetStatusString(status);
 }

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -345,9 +345,16 @@ def _cublaslt_mm_bf16_requirement(
     backend: Literal["cudnn", "cutlass", "tgv", "cublaslt", "auto"] = "cudnn",
 ):
     if bias is not None:
-        raise ValueError(
-            "You cannot use the cuBLASLt backend with a bias. Use the TGV backend instead."
-        )
+        if out_dtype != torch.bfloat16:
+            raise ValueError("cuBLASLt fused bias requires bfloat16 output.")
+        if bias.shape != (b.shape[1],):
+            raise ValueError(
+                f"cuBLASLt bias must have shape {(b.shape[1],)}, got {bias.shape}."
+            )
+        if bias.device != a.device:
+            raise ValueError("cuBLASLt bias must be on the same CUDA device as A.")
+        if not bias.is_contiguous():
+            raise ValueError("cuBLASLt bias must be contiguous.")
     if pdl:
         raise ValueError(
             "The cuBLASLt backend does not support PDL. Use the TGV backend instead."
@@ -447,6 +454,10 @@ def _cute_dsl_mm_bf16_requirement(
     ):
         raise ValueError(
             f"Bias must be contiguous on A's device with shape {(b.shape[1],)}."
+        )
+    if a.shape[0] > 32:
+        return _cublaslt_mm_bf16_requirement(
+            a, b, out, out_dtype, bias, False, "cublaslt"
         )
 
     from flashinfer.cute_dsl.utils import is_cute_dsl_available
@@ -583,6 +594,8 @@ def _heuristic_func_mm_bf16(
             heuristic_backends.append("tgv")
         if "cudnn" in suitable_backends:
             heuristic_backends.append("cudnn")
+        if bias is not None and not pdl and "cublaslt" in suitable_backends:
+            heuristic_backends.append("cublaslt")
     else:
         if "cutlass" in suitable_backends:
             heuristic_backends.append("cutlass")
@@ -643,11 +656,13 @@ def mm_bf16(
 
     bias: Optional[torch.Tensor]
         Optional bias tensor, shape (n,). Enabled for TGV, TinyGEMM, and
-        CuTeDSL backends. Defaults to ``None``.
+        CuTeDSL backends; cuBLASLt supports bias with BF16 output. Defaults to
+        ``None``.
 
     pdl: bool
         Whether to use Programmatic Dependent Launch. Enabled for TGV,
-        TinyGEMM, and CuTeDSL backends. Defaults to ``False``.
+        TinyGEMM, and CuTeDSL backends. The CuTeDSL M > 32 fallback ignores
+        PDL because cuBLASLt does not expose it. Defaults to ``False``.
 
     out: Optional[torch.Tensor]
         Out tensor, shape (m, n), bf16, fp16, or fp32. FP16 and FP32 output are enabled
@@ -663,14 +678,16 @@ def mm_bf16(
         ``"cudnn"`` uses the cuDNN backend.
         ``"cutlass"`` uses the CUTLASS backend.
         ``"tgv"`` uses the TGV backend.
-        ``"cublaslt"`` uses the cuBLASLt backend with heuristic algorithm search.
+        ``"cublaslt"`` uses the cuBLASLt backend with heuristic algorithm
+        search and an optional fused BF16 bias epilogue for BF16 output.
         ``"tinygemm"`` uses the TinyGEMM backend for small-M BF16 GEMM.
         ``"cutile"`` uses the cuTile (cuda.tile Python) backend. Pure-Python
             persistent-scheduled GEMM with per-shape exhaustive autotune; ignores
             ``bias`` / ``pdl``. Requires SM >= 90.
         ``"cute-dsl"`` uses standalone Blackwell low-M direct and split-K
-        kernels for M <= 32. It is never auto-selected; serving frameworks
-        must select it explicitly. Without autotuning, a measured shape
+        kernels for M <= 32 and falls back to cuBLASLt for larger M. It is
+        never auto-selected; serving frameworks must select it explicitly.
+        Without autotuning, a measured shape
         heuristic chooses between the algorithms. With autotuning, both tactic
         spaces are profiled when bias is disabled; bias uses split-K only.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
@@ -750,14 +767,16 @@ def mm_bf16(
         )
     elif backend == "cublaslt":
         backends = _heuristic_func_mm_bf16(
-            ["cublaslt"], a, b, None, False, out, out_dtype, backend
+            ["cublaslt"], a, b, bias, pdl, out, out_dtype, backend
         )
     elif backend == "tinygemm":
         backends = _heuristic_func_mm_bf16(
             ["tinygemm"], a, b, bias, pdl, out, out_dtype, backend
         )
     elif backend == "cute-dsl":
-        backends = ["cute-dsl"]
+        # The low-M kernels cap M at 32. Use cuBLASLt above that range;
+        # pdl is intentionally ignored because cuBLASLt has no PDL API.
+        backends = ["cute-dsl"] if a.shape[0] <= 32 else ["cublaslt"]
     else:
         backends = [backend]
 
@@ -1275,13 +1294,21 @@ def get_mm_bf16_cublaslt_module():
                 self._algo_cache: dict = {}
 
             def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
-                a, b, _, _, out, _ = inputs
+                a, b, bias, _, out, _ = inputs
                 return (
                     a.shape[0],
                     b.shape[1],
                     a.shape[1],
                     self._compute_dtype(out.dtype),
+                    self._pointer_alignment(bias),
                 )
+
+            @staticmethod
+            def _pointer_alignment(tensor):
+                if tensor is None:
+                    return 0
+                address = tensor.data_ptr()
+                return min(address & -address, 256)
 
             @staticmethod
             def _compute_dtype(out_dtype):
@@ -1293,7 +1320,7 @@ def get_mm_bf16_cublaslt_module():
                 return out_dtype
 
             def _get_algos(self, inputs):
-                a, b, _, _, out, workspace_buffer = inputs
+                a, b, bias, _, out, workspace_buffer = inputs
                 compute_dt = self._compute_dtype(out.dtype)
                 key = self.get_cache_key_extras(inputs)
                 cached = self._algo_cache.get(key)
@@ -1314,6 +1341,7 @@ def get_mm_bf16_cublaslt_module():
                 count = module.mm_bf16_cublaslt_get_algos(
                     a,
                     b.transpose(-2, -1),
+                    bias,
                     proxy_out,
                     workspace_buffer,
                     cublas_handle,
@@ -1338,7 +1366,7 @@ def get_mm_bf16_cublaslt_module():
                 do_preparation: bool = False,
                 **kwargs,
             ) -> torch.Tensor:
-                a, b, _, _, out, workspace_buffer = inputs
+                a, b, bias, _, out, workspace_buffer = inputs
                 with torch.cuda.device(a.device):
                     cublas_handle = torch.cuda.current_blas_handle()
                 b_t = b.transpose(-2, -1)
@@ -1369,6 +1397,7 @@ def get_mm_bf16_cublaslt_module():
                 module.mm_bf16_cublaslt_run_with_algo(
                     a,
                     b_t,
+                    bias,
                     compute_out,
                     workspace_buffer,
                     cublas_handle,

--- a/include/flashinfer/gemm/mm_bf16_cublaslt.cuh
+++ b/include/flashinfer/gemm/mm_bf16_cublaslt.cuh
@@ -56,13 +56,18 @@ struct GemmDescriptors {
   CuBlasLtMatrixLayout b_layout;  // mat1
   CuBlasLtMatrixLayout d_layout;  // out
 
-  GemmDescriptors(int m, int n, int k, cudaDataType_t d_type)
+  GemmDescriptors(int m, int n, int k, cudaDataType_t d_type, const __nv_bfloat16* bias = nullptr)
       : matmul_desc(CUBLAS_COMPUTE_32F, CUDA_R_32F),
         a_layout(CUDA_R_16BF, n, k, k, /*t=*/true),
         b_layout(CUDA_R_16BF, k, m, k),
         d_layout(d_type, n, m, n) {
     matmul_desc.setAttribute(CUBLASLT_MATMUL_DESC_TRANSA, CUBLAS_OP_T);
     matmul_desc.setAttribute(CUBLASLT_MATMUL_DESC_TRANSB, CUBLAS_OP_N);
+    if (bias != nullptr) {
+      matmul_desc.setAttribute(CUBLASLT_MATMUL_DESC_EPILOGUE, CUBLASLT_EPILOGUE_BIAS);
+      matmul_desc.setAttribute(CUBLASLT_MATMUL_DESC_BIAS_POINTER, bias);
+      matmul_desc.setAttribute(CUBLASLT_MATMUL_DESC_BIAS_DATA_TYPE, CUDA_R_16BF);
+    }
   }
 };
 
@@ -76,10 +81,10 @@ struct GemmDescriptors {
  * \param max_algos Maximum number of algorithms to retrieve.
  * \return Number of algorithms written to algo_buf.
  */
-inline int get_algorithms(int m, int n, int k, cudaDataType_t d_type,
+inline int get_algorithms(int m, int n, int k, cudaDataType_t d_type, const __nv_bfloat16* bias,
                           size_t workspace_size_in_bytes, cublasLtHandle_t lt_handle,
                           void* algo_buf, int max_algos) {
-  GemmDescriptors desc(m, n, k, d_type);
+  GemmDescriptors desc(m, n, k, d_type, bias);
 
   CuBlasLtMatmulPreference preference;
   preference.setAttribute(CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES, workspace_size_in_bytes);
@@ -107,10 +112,11 @@ inline int get_algorithms(int m, int n, int k, cudaDataType_t d_type,
  * \param algo_idx  Index into algo_buf selecting which algorithm to use.
  */
 inline cublasStatus_t run_with_algo(const __nv_bfloat16* mat1, const __nv_bfloat16* mat2, void* out,
-                                    int m, int n, int k, cudaDataType_t d_type, void* workspace,
+                                    const __nv_bfloat16* bias, int m, int n, int k,
+                                    cudaDataType_t d_type, void* workspace,
                                     size_t workspace_size_in_bytes, cublasLtHandle_t lt_handle,
                                     cudaStream_t stream, const void* algo_buf, int algo_idx) {
-  GemmDescriptors desc(m, n, k, d_type);
+  GemmDescriptors desc(m, n, k, d_type, bias);
 
   cublasLtMatmulAlgo_t algo;
   std::memcpy(&algo, static_cast<const uint8_t*>(algo_buf) + algo_idx * kAlgoBytes, kAlgoBytes);

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -28,10 +28,13 @@ _SMOKE_CASES = [
     (1, 2048, 1024, torch.bfloat16, True, True, "tgv", False),
     (64, 1024, 2048, torch.bfloat16, False, True, "tgv", True),
     (16, 2048, 2048, torch.bfloat16, False, False, "cublaslt", True),
+    (16, 2048, 2048, torch.bfloat16, True, False, "cublaslt", True),
     (8, 4096, 3072, torch.float16, False, False, "cublaslt", False),
     (1, 1024, 3072, torch.bfloat16, True, False, "tinygemm", False),
     (32, 1024, 1024, torch.bfloat16, False, False, "cutile", False),
     (25, 2048, 1024, torch.bfloat16, False, False, "cute-dsl", False),
+    (33, 256, 512, torch.bfloat16, True, True, "cute-dsl", False),
+    (64, 256, 512, torch.bfloat16, True, True, "cute-dsl", False),
     (64, 4096, 2048, torch.bfloat16, False, False, "auto", True),
     (1, 2048, 3072, torch.float16, False, False, "auto", False),
 ]
@@ -76,12 +79,11 @@ def test_mm_bf16(
         if not is_sm100a_supported(torch.device("cuda")):
             pytest.skip("CuTeDSL low-M backend requires SM100/SM103 with CUDA 12.8+.")
 
-        from flashinfer.cute_dsl.utils import is_cute_dsl_available
+        if m <= 32:
+            from flashinfer.cute_dsl.utils import is_cute_dsl_available
 
-        if not is_cute_dsl_available():
-            pytest.skip("nvidia-cutlass-dsl is not available.")
-        if m > 32:
-            pytest.skip("CuTeDSL low-M backend requires M <= 32.")
+            if not is_cute_dsl_available():
+                pytest.skip("nvidia-cutlass-dsl is not available.")
         if res_dtype != torch.bfloat16:
             pytest.skip("CuTeDSL low-M backend requires BF16 output.")
 
@@ -92,10 +94,8 @@ def test_mm_bf16(
         pytest.skip(
             "mm_bf16 with CUTLASS backend does not support bias or pdl arguments."
         )
-    if backend == "cublaslt" and (enable_bias or pdl):
-        pytest.skip(
-            "mm_bf16 with cuBLASLt backend does not support bias or pdl arguments."
-        )
+    if backend == "cublaslt" and pdl:
+        pytest.skip("mm_bf16 with cuBLASLt backend does not support pdl arguments.")
     if backend == "cutile" and (enable_bias or pdl):
         pytest.skip(
             "mm_bf16 with cuTile backend does not support bias or pdl arguments."


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

1. Add  bias support to cublast gemm backend 
2. Add cublast backend as the fallback backend of cutedsl because cutedsl backend only supports M<=32

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional fused bias support for BF16 matrix multiplication with the cuBLASLt backend.
  * Added automatic cuBLASLt fallback for larger CuTeDSL BF16 workloads, including fused-bias operations.

* **Bug Fixes**
  * Improved validation and handling of BF16 bias tensors.
  * Bias-enabled operations now work where previously they were rejected.
  * Improved backend selection for supported large-`M` workloads.

* **Tests**
  * Added coverage for fused bias, invalid output types, and large-`M` fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->