### PR TITLE
fix: skip SM107 low-latency GEMM cubins on Blackwell (#4773)

### DIFF
--- a/csrc/trtllm_low_latency_gemm_runner.cu
+++ b/csrc/trtllm_low_latency_gemm_runner.cu
@@ -19,6 +19,7 @@
 #include <tvm/ffi/error.h>
 #include <tvm_ffi_utils.h>
 
+#include <algorithm>
 #include <vector>
 
 #include "flashinfer/exception.h"
@@ -179,11 +180,24 @@ class TrtllmLowLatencyGemmRunner {
         "No valid low latency TRTLLM-GEN GEMM kernel was found for the given data types.");
   }
 
+  // Tactic ids are indices into the cubin manifest, which spans several
+  // architectures. A tactic that never came from getValidTactics() (a config
+  // file saved on other hardware, an explicit FFI argument) would otherwise
+  // reach cuModuleLoadData and fault instead of erroring.
+  void checkPassingConfigIndex(int64_t tactic) const {
+    auto it = std::find(mPassingConfigIndices.begin(), mPassingConfigIndices.end(), tactic);
+    TVM_FFI_ICHECK(it != mPassingConfigIndices.end())
+        << "Tactic " << tactic
+        << " is not in this runner's compatible config set (device architecture or GEMM options "
+           "mismatch)";
+  }
+
   void run(int64_t m, int64_t n, int64_t k, void const* a, void const* b, void* c, void* cScale,
            void* workspace, CUstream stream, int32_t device_index, int64_t tactic) {
     auto gemm = gemm::gemm::GemmInterface();
     auto const configs = gemm.getGemmConfigs();
     TVM_FFI_ICHECK(tactic >= 0 && tactic < gemm.getNumGemmConfigs()) << "Invalid tactic id in run";
+    checkPassingConfigIndex(tactic);
     auto const& config = configs[tactic];
 
     gemm::gemm::GemmData gemmData = createGemmData(m, n, k);

--- a/csrc/trtllm_low_latency_gemm_runner.cu
+++ b/csrc/trtllm_low_latency_gemm_runner.cu
@@ -37,6 +37,28 @@ namespace flashinfer {
 using tvm::ffi::Array;
 using tvm::ffi::Optional;
 
+namespace {
+
+bool isArchCompatible(int smVersion, gemm::trtllm::gen::CudaArch cubinArch) {
+  using CudaArch = gemm::trtllm::gen::CudaArch;
+  switch (cubinArch) {
+    case CudaArch::Sm100a:
+      return smVersion == 100;
+    case CudaArch::Sm100f:
+      return smVersion == 100 || smVersion == 103;
+    case CudaArch::Sm103a:
+      return smVersion == 103;
+#ifdef TLLM_RUBIN_FEATURES
+    case CudaArch::Sm107a:
+      return smVersion == 107;
+#endif
+    default:
+      return false;
+  }
+}
+
+}  // namespace
+
 struct TrtllmLowLatencyGemmRunnerOptions {
   gemm::trtllm::gen::Dtype eltType;
   gemm::trtllm::gen::Dtype outputType;
@@ -137,6 +159,7 @@ class TrtllmLowLatencyGemmRunner {
     auto const configs = gemm.getGemmConfigs();
 
     mPassingConfigIndices.clear();
+    int const sv = getSMVersion();
 
     for (size_t i = 0; i < gemm.getNumGemmConfigs(); ++i) {
       auto const configOptions = configs[i].mOptions;
@@ -146,6 +169,7 @@ class TrtllmLowLatencyGemmRunner {
           configOptions.mTransposeMmaOutput == true &&
           configOptions.mLayoutA == gemm::gemm::MatrixLayout::BlockMajorK &&
           configOptions.mUseShuffledMatrix) {
+        if (!isArchCompatible(sv, configs[i].mSm)) continue;
         mPassingConfigIndices.push_back(i);
       }
     }


### PR DESCRIPTION
## Summary
Fixes #4773: `mm_fp8` / `test_mm_fp8_replay` SIGSEGV in `cuModuleGetFunction` during low-latency GEMM autotune on SM100 (B200/GB200) and SM103 (B300).

After #4648 the trtllm-gen GEMM pack is a single multi-arch publish, so `flashinferMetaInfo.h` now lists sm100f **and** sm107a configs in the manifest the Blackwell module compiles against. Previously the Rubin cubins lived in a separate `TRTLLM_GEN_GEMM_RUBIN` pin, so the non-Rubin manifest was sm100-only.

`trtllm_low_latency_gemm_runner.cu` was the one trtllm-gen runner without the arch filter that #4280 added to its siblings. With the consolidated pack, `getValidTactics()` returned 16 tactics on Blackwell (8 sm100f + 8 sm107a); `cuModuleLoadData` fails on the first sm107a cubin, the `CUresult` is ignored by the generated `GemmInterface`, and `cuModuleGetFunction` faults on the uninitialised `CUmodule`.

Two commits, no cubin regeneration:

1. **`isArchCompatible` filter** when building `mPassingConfigIndices`, identical to `csrc/trtllm_gemm_runner.cu` (`Sm107a` only under `TLLM_RUBIN_FEATURES`, `Sm100f` allowed on sm100 and sm103).
2. **`checkPassingConfigIndex` in `run()`**, also mirroring `trtllm_gemm_runner.cu`. Tactic ids are manifest indices, and the autotuner's file-config key (`custom_op`, `runner_class_name`, `nearest_profile`, `extras`) does not include the device arch, so a config saved via `save_configs()` / `autotune(cache=...)` on other hardware — or an explicit FFI tactic — could still hand a foreign-arch index straight to the cubin loader. It now raises instead of faulting.

Other ops touched by #4648 already have the equivalent guard, so no further coverage is needed:

| Consumer | Arch filter |
|---|---|
| `trtllm_gemm_runner.cu` | `isArchCompatible` + `checkPassingConfigIndex` (#4280) |
| `trtllm_batched_gemm_runner.cu` (trtllm-gen MoE backend) | `isArchCompatible` + `checkPassingConfigIndex` (#4280) |
| trtllm-gen FMHA | `isSMCompatible()` in `fmhaKernels.cuh`, with explicit sm107 rules |
| `trtllm_low_latency_gemm_runner.cu` | **missing — this PR** |

## Test plan
Local B200 (SM100, CUDA 13.0, Python 3.10), on `release-v0.6.18` + these commits:

- [x] Before the filter: 16 valid tactics (sm100f indices `0,2,3,4,5,7,10,11` + sm107a `93,95,96,97,101,102,104,109`); SIGSEGV on the first sm107a cubin load.
- [x] After: 8 sm100f tactics only; `mm_fp8` passes under `autotune()` and on the heuristic `tactic=-1` path.
- [x] Forced sm107a tactic (`93`) now raises `RuntimeError: Tactic 93 is not in this runner's compatible config set` instead of SIGSEGV.
- [x] `pytest tests/gemm/test_mm_fp8.py tests/utils/test_logging_replay.py` → 44 passed, 2 skipped (includes `test_mm_fp8_replay`, the test that crashed in CI).
- [ ] GitLab `unit_test_b300` / GB200 jobs covering `tests/gemm/test_mm_fp8.py` and `tests/utils/test_logging_replay.py`.