### PR TITLE
fix(jit): avoid invalidating bgmv_moe cache on source staging

### DIFF
--- a/flashinfer/jit/bgmv_moe.py
+++ b/flashinfer/jit/bgmv_moe.py
@@ -97,7 +97,8 @@ def gen_bgmv_moe_module():
         if not src_path.exists():
             raise FileNotFoundError(f"BGMV MoE source file not found: {src_path}")
         dest_path = gen_directory / fname
-        shutil.copy(src_path, dest_path)
+        # copy2 keeps source mtimes; a fresh mtime forces a full ninja rebuild (#4782)
+        shutil.copy2(src_path, dest_path)
         sources.append(dest_path)
 
     # Copy headers to gen directory
@@ -105,7 +106,7 @@ def gen_bgmv_moe_module():
         src_path = csrc_dir / fname
         if not src_path.exists():
             raise FileNotFoundError(f"BGMV MoE header file not found: {src_path}")
-        shutil.copy(src_path, gen_directory / fname)
+        shutil.copy2(src_path, gen_directory / fname)
 
     # Get nvcc flags for supported architectures (SM70+)
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(

--- a/tests/jit/test_bgmv_moe_jit_cache.py
+++ b/tests/jit/test_bgmv_moe_jit_cache.py
@@ -1,0 +1,121 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Regression test for https://github.com/flashinfer-ai/flashinfer/issues/4782
+
+The JIT path delegates .so freshness entirely to ninja's dependency scan
+(JitSpecNvcc.try_load returns None for non-AOT modules), so staging must not
+touch the mtime of unchanged sources: if gen_bgmv_moe_module() re-stages an
+unchanged source with a fresh timestamp, every new process makes the staged
+sources newer than the already-built objects and ninja rebuilds from scratch.
+"""
+
+import os
+
+import pytest
+
+import flashinfer.jit.bgmv_moe as bgmv_moe_jit
+from flashinfer.jit import core as jit_core
+from flashinfer.jit import env as jit_env
+
+# Filenames gen_bgmv_moe_module() expects in the bgmv_moe csrc directory.
+_SOURCE_FILES = [
+    "moe_bgmv_binding.cu",
+    "moe_bgmv_bf16_bf16_bf16.cu",
+    "moe_bgmv_bf16_fp32_bf16.cu",
+    "moe_bgmv_fp16_fp16_fp16.cu",
+    "moe_bgmv_fp16_fp32_fp16.cu",
+    "moe_bgmv_fp32_bf16_bf16.cu",
+    "moe_bgmv_fp32_fp16_fp16.cu",
+]
+_HEADER_FILES = [
+    "moe_bgmv_impl.cuh",
+    "moe_bgmv_config.h",
+    "moe_bgmv_ops.h",
+    "moe_bgmv_ops.cu",
+    "kernel_config.h",
+]
+
+# A fixed timestamp far in the past (2020-09-13T12:26:40Z), so that any staging
+# step that stamps "now" onto a copy is unambiguously detectable without sleeps.
+_OLD_MTIME_NS = 1_600_000_000_000_000_000
+
+
+class _StubCompilationContext:
+    """No-GPU stand-in so the generation pass needs no CUDA device."""
+
+    TARGET_CUDA_ARCHS = [(9, "0a")]
+
+    def get_nvcc_flags_list(self, supported_major_versions=None):
+        return []
+
+
+@pytest.fixture
+def bgmv_moe_workspace(tmp_path, monkeypatch):
+    """Fake csrc dir with old mtimes plus a redirected JIT workspace."""
+    csrc_dir = tmp_path / "csrc" / "bgmv_moe"
+    csrc_dir.mkdir(parents=True)
+    for fname in _SOURCE_FILES + _HEADER_FILES:
+        path = csrc_dir / fname
+        path.write_text(f"// fake {fname} for issue #4782 regression test\n")
+        os.utime(path, ns=(_OLD_MTIME_NS, _OLD_MTIME_NS))
+
+    monkeypatch.setattr(bgmv_moe_jit, "_get_bgmv_moe_csrc_dir", lambda: csrc_dir)
+    monkeypatch.setattr(jit_env, "FLASHINFER_GEN_SRC_DIR", tmp_path / "generated")
+    monkeypatch.setattr(jit_env, "FLASHINFER_JIT_DIR", tmp_path / "cached_ops")
+    stub_ctx = _StubCompilationContext()
+    monkeypatch.setattr(bgmv_moe_jit, "current_compilation_context", stub_ctx)
+    monkeypatch.setattr(jit_core, "current_compilation_context", stub_ctx)
+
+    bgmv_moe_jit.gen_bgmv_moe_module.cache_clear()
+    yield tmp_path
+    # Drop specs whose paths point into the (now gone) tmp workspace.
+    bgmv_moe_jit.gen_bgmv_moe_module.cache_clear()
+
+
+def test_restaging_unchanged_sources_keeps_built_artifact_fresh(
+    bgmv_moe_workspace,
+):
+    # First generation pass: a fresh process stages sources for the build.
+    spec = bgmv_moe_jit.gen_bgmv_moe_module()
+    gen_directory = jit_env.FLASHINFER_GEN_SRC_DIR / bgmv_moe_jit.get_bgmv_moe_uri()
+    staged_files = [gen_directory / f for f in _SOURCE_FILES + _HEADER_FILES]
+    for staged in staged_files:
+        assert staged.exists(), f"staging did not produce {staged}"
+
+    # Simulate the .so a completed build would leave behind: newer than the
+    # staged sources it was built from, but still in the past relative to now.
+    so_path = spec.jit_library_path
+    so_path.parent.mkdir(parents=True, exist_ok=True)
+    so_path.write_bytes(b"")
+    artifact_mtime_ns = _OLD_MTIME_NS + 3600 * 10**9
+    os.utime(so_path, ns=(artifact_mtime_ns, artifact_mtime_ns))
+
+    # A new process re-runs module generation over the unchanged sources.
+    bgmv_moe_jit.gen_bgmv_moe_module.cache_clear()
+    bgmv_moe_jit.gen_bgmv_moe_module()
+
+    # Freshness invariant: re-staging unchanged inputs must not make any
+    # staged source/header newer than the existing artifact, or ninja's
+    # dependency scan sees stale objects and rebuilds every kernel.
+    stale = [
+        staged.name
+        for staged in staged_files
+        if staged.stat().st_mtime_ns > artifact_mtime_ns
+    ]
+    assert not stale, (
+        "re-staging unchanged bgmv_moe inputs made these staged files newer "
+        f"than the already-built artifact, forcing a full JIT rebuild: {stale}"
+    )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Every new process that JIT-loads `bgmv_moe` rebuilt all kernels from scratch, even with a fully warm cache. `gen_bgmv_moe_module()` stages its sources and headers into `FLASHINFER_GEN_SRC_DIR` with `shutil.copy`, which stamps a fresh mtime on every copy. Since the JIT path delegates `.so` freshness entirely to ninja's dependency scan (`JitSpecNvcc.try_load()` returns `None` for non-AOT modules), the re-staged inputs always looked newer than the cached objects, so ninja recompiled the whole module on every warm start. #4782 reports 216–218 s per process on Blackwell versus 4.3 s once mtimes are preserved (as measured by the reporter).

**Fix:** stage with `shutil.copy2`, which preserves source mtimes, so unchanged inputs stay older than the built artifact and ninja no-ops. `shutil.copy` already propagated permission bits, so the only staging behavior that changes is timestamp preservation.

**Regression test:** `tests/jit/test_bgmv_moe_jit_cache.py` is deterministic and needs no GPU, nvcc, or sleeps. It runs `gen_bgmv_moe_module()` against a fake csrc tree with fixed old mtimes in a redirected workspace, simulates an already-built `.so` newer than the sources, clears the `functools.cache` to model a fresh process, re-stages, and asserts the JIT-cache freshness invariant: no staged source/header may become newer than the existing build artifact. It fails on current `main` (all 12 staged files get fresh mtimes) and passes with this change.

**Validation**
- Regression test: fails on `main`, passes with the fix.
- `tests/jit/test_jit_cpp_ext.py`: 18 passed; the 3 failures reproduce identically on unmodified `main` in my CPU-only environment (no CUDA toolkit installed) and are unrelated to this change.
- Warm-cache ninja check over the actual staged output of `gen_bgmv_moe_module()` (using a `cp` stand-in build graph, since nvcc is unavailable locally): after re-staging unchanged sources, `ninja -n` reports "no work to do" with this change, while on `main` it rebuilds all targets.
- `pre-commit run --files <changed files>`: all hooks pass (mypy, ruff check, ruff format, whitespace hooks).

## 🔍 Related Issues

Fixes #4782

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues. *(ran `pre-commit run --files <changed files>` instead — all hooks pass; see Reviewer Notes)*

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.). *(Targeted regression and changed-file checks pass; 3 CUDA-toolkit-dependent failures reproduce identically on unmodified main.)*

## Reviewer Notes

Hooks were run as `pre-commit run --files flashinfer/jit/bgmv_moe.py tests/jit/test_bgmv_moe_jit_cache.py` (the changed files) rather than `--all-files`, to avoid churning unrelated files. GPU kernel tests for bgmv_moe were not run locally (no CUDA device available); the added regression test is GPU-free by design.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JIT compilation caching by preserving CUDA source and header file timestamps.
  * Prevented unnecessary full rebuilds when generating BGMV MoE modules from unchanged files.

* **Tests**
  * Added regression coverage to verify cached builds do not trigger avoidable recompilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->