### PR TITLE
fix(moe): disable PDL in the trtllm-gen fused-MoE path on SM107 (Rubin)

### DIFF
--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -252,6 +252,25 @@ class TrtllmDaBodyCaptureStream:
 
 
 @functools.cache
+def _device_support_moe_pdl(device: torch.device) -> bool:
+    """PDL gate for the trtllm-gen fused-MoE pipeline.
+
+    On SM107 (Rubin), PDL in this pipeline intermittently fails with
+    "unspecified launch failure" and occasional hangs. A/B stress runs on Rubin
+    hardware isolated the trigger: with PDL enabled the renormalize-routing
+    tests crash across routing modes (split-topK on/off), dtypes
+    (BF16/MxFP4/MxInt4) and autotune on/off -- 4 crashes in ~21 full-file runs
+    -- while the same loop with PDL fully disabled ran clean.
+
+    Disable PDL here until the launch-dependency chain is audited for Rubin
+    timing. The CUTLASS MoE path is deliberately left alone: it has soaked with
+    PDL enabled on Rubin for 9+ nights without a crash.
+    """
+    if get_compute_capability(device) == (10, 7):
+        return False
+    return device_support_pdl(device)
+
+
 def _get_trtllm_da_body_capture_stream(
     device_index: int,
 ) -> TrtllmDaBodyCaptureStream:
@@ -2629,6 +2648,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         )
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
+        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
@@ -2907,6 +2927,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ) -> List[torch.Tensor]:
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
+        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
 
@@ -3145,6 +3166,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         assert topk_ids.dtype == torch.int32, "topk_ids must be an int32 tensor."
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
+        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
 
@@ -3416,6 +3438,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
 
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
+        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
@@ -3794,6 +3817,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 )
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
+        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
         if output is None:
             output = _alloc_trtllm_moe_output(
                 num_tokens, hidden_size, do_finalize, hidden_states.device
@@ -4110,6 +4134,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             )
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
+        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
         if output is None:
             output = _alloc_trtllm_moe_output(
                 num_tokens, hidden_size, do_finalize, hidden_states.device

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -271,6 +271,7 @@ def _device_support_moe_pdl(device: torch.device) -> bool:
     return device_support_pdl(device)
 
 
+@functools.cache
 def _get_trtllm_da_body_capture_stream(
     device_index: int,
 ) -> TrtllmDaBodyCaptureStream:
@@ -2648,7 +2649,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         )
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
-        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
+        if not _device_support_moe_pdl(hidden_states.device):
+            enable_pdl = False
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
@@ -2927,7 +2929,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
     ) -> List[torch.Tensor]:
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
-        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
+        if not _device_support_moe_pdl(hidden_states.device):
+            enable_pdl = False
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
 
@@ -3166,7 +3169,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         assert topk_ids.dtype == torch.int32, "topk_ids must be an int32 tensor."
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
-        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
+        if not _device_support_moe_pdl(hidden_states.device):
+            enable_pdl = False
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
 
@@ -3438,7 +3442,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
 
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
-        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
+        if not _device_support_moe_pdl(hidden_states.device):
+            enable_pdl = False
 
         # Use AutoTuner to select the best tactic
         tuner = AutoTuner.get()
@@ -3817,7 +3822,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 )
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
-        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
+        if not _device_support_moe_pdl(hidden_states.device):
+            enable_pdl = False
         if output is None:
             output = _alloc_trtllm_moe_output(
                 num_tokens, hidden_size, do_finalize, hidden_states.device
@@ -4134,7 +4140,8 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             )
         if enable_pdl is None:
             enable_pdl = device_support_pdl(hidden_states.device)
-        enable_pdl = enable_pdl and _device_support_moe_pdl(hidden_states.device)
+        if not _device_support_moe_pdl(hidden_states.device):
+            enable_pdl = False
         if output is None:
             output = _alloc_trtllm_moe_output(
                 num_tokens, hidden_size, do_finalize, hidden_states.device


### PR DESCRIPTION
## 📌 Description

PDL in the trtllm-gen fused-MoE pipeline intermittently fails on SM107 (Rubin) with
`unspecified launch failure`, and occasionally hangs. The crash surfaces at the
`routingIndicesClusterKernel` launch in `trtllm_fused_moe_routing_custom.cu`.

A/B stress runs on SM107 hardware isolated the trigger. With PDL enabled the
renormalize-routing tests crash across routing modes (split-topK on and off), dtypes
(BF16 / MxFP4 / MxInt4) and autotune on/off — **4 crashes in ~21 full-file runs**. The
same loop with PDL fully disabled ran clean.

This clamps `enable_pdl` to off on SM107 at the six trtllm-gen MoE entry points,
**including when the caller passes `enable_pdl=True` explicitly**: an illegal memory
access is not something a caller should be able to opt into while the underlying
launch-dependency chain is unaudited for Rubin timing.

### Scope is deliberately narrow

* **Only compute capability `(10, 7)`.** `device_support_pdl()` returns `True` for every
  `major >= 9`, so gating there instead would cost Hopper and Blackwell for a
  Rubin-only defect.
* **Only the trtllm-gen path.** The three CUTLASS MoE sites are untouched — that path
  has soaked with PDL enabled on Rubin for 9+ nights without a crash.

## 🧪 Performance impact

Measured on SM107, trtllm-gen `NvFP4xNvFP4` routed MoE (128 experts, top-k 8,
hidden 2048, intermediate 768), autotuned:

| tokens | PDL on | PDL off | cost |
|--------|--------|---------|------|
| 8      | 0.027 ms | 0.028 ms | +3.7% |
| 64     | 0.046 ms | 0.048 ms | +4.3% |
| 512    | 0.055 ms | 0.061 ms | **+10.9%** |
| 4096   | 0.156 ms | 0.158 ms | +1.3% |

The cost is launch-overlap latency, so it is largest mid-range and negligible at 4096
tokens where the kernels are long enough that overlap stops mattering.

**Caveat on the numbers:** single run per arm with CUDA-event timing (CUPTI
unavailable), so the 1–4% points are within noise. The 512-token gap is the one to
trust — it reproduces in both the autotuned (+10.9%) and untuned (+6.0%) columns, so it
is not an autotuner artifact.

## 🔍 Related Issues

Mitigates the SM107 MoE routing illegal-memory-access reported against the v0.6.18
release candidates. **This is a mitigation, not a root-cause fix** — revert it once the
PDL launch-dependency chain is audited for Rubin timing.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks
- [x] `pre-commit` installed and hooks run (`ruff check`, `ruff format` clean)

### 🧪 Tests
- [x] Verified on SM107 hardware; the A/B above was run on-device
- [ ] No new tests added — this changes a dispatch default, and the existing MoE suite
      exercises both paths

AI-assisted (Claude Code).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for fused Mixture-of-Experts operations on Rubin GPUs.
  * Automatically disables unsupported performance behavior for affected MoE execution paths while preserving existing behavior elsewhere.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->