### PR TITLE
ci: enable patched sccache for CUDA 13.4

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -181,6 +181,24 @@ jobs:
         with:
           submodules: true
 
+      - name: Build patched sccache (${{ matrix.arch }})
+        if: ${{ matrix.cuda.label == 'cu134' }}
+        env:
+          CUDA_VERSION: ${{ matrix.cuda.version }}
+          DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda.version) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda.version) }}
+          SCCACHE_PATCHED_BINARY_PATH: /ci-cache/sccache-cu134/${{ matrix.arch }}/sccache
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/ci-cache"
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -v "${GITHUB_WORKSPACE}/ci-cache:/ci-cache" \
+            -e CUDA_VERSION \
+            -e SCCACHE_PATCHED_BINARY_PATH \
+            -w /workspace \
+            "${DOCKER_IMAGE}" \
+            bash /workspace/scripts/build_patched_sccache.sh
+        timeout-minutes: 30
+
       - name: Build wheel in container
         env:
           ARCH: ${{ matrix.arch }}
@@ -195,6 +213,7 @@ jobs:
           FLASHINFER_LOCAL_VERSION: ${{ matrix.cuda.label }}
           PYTORCH_INDEX: ${{ matrix.cuda.pytorch_index }}
           SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          SCCACHE_PATCHED_BINARY_PATH: /ci-cache/sccache-cu134/${{ matrix.arch }}/sccache
           SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
         run: |
           # Extract CUDA major and minor versions
@@ -218,6 +237,7 @@ jobs:
             -e FLASHINFER_CUDA_ARCH_LIST \
             -e FLASHINFER_NVCC_THREADS="${FLASHINFER_NVCC_THREADS:-}" \
             -e SCCACHE_BUCKET \
+            -e SCCACHE_PATCHED_BINARY_PATH \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
             -e SCCACHE_REGION \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ on:
       - 'ci/cuda-versions.json'
       - 'ci/validate_cuda_versions.py'
       - 'scripts/build_flashinfer_jit_cache_whl.sh'
+      - 'scripts/build_patched_sccache.sh'
       - 'scripts/jit_cache_build_common.sh'
 
 jobs:
@@ -219,6 +220,24 @@ jobs:
           repository: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || github.repository }}
           submodules: true
 
+      - name: Build patched sccache (${{ matrix.arch }})
+        if: ${{ matrix.cuda.label == 'cu134' }}
+        env:
+          CUDA_VERSION: ${{ matrix.cuda.version }}
+          DOCKER_IMAGE: ${{ matrix.arch == 'aarch64' && format('pytorch/manylinuxaarch64-builder:cuda{0}', matrix.cuda.version) || format('pytorch/manylinux2_28-builder:cuda{0}', matrix.cuda.version) }}
+          SCCACHE_PATCHED_BINARY_PATH: /ci-cache/sccache-cu134/${{ matrix.arch }}/sccache
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/ci-cache"
+          docker run --rm \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            -v "${GITHUB_WORKSPACE}/ci-cache:/ci-cache" \
+            -e CUDA_VERSION \
+            -e SCCACHE_PATCHED_BINARY_PATH \
+            -w /workspace \
+            "${DOCKER_IMAGE}" \
+            bash /workspace/scripts/build_patched_sccache.sh
+        timeout-minutes: 30
+
       - name: Build wheel in container
         env:
           ARCH: ${{ matrix.arch }}
@@ -232,6 +251,7 @@ jobs:
           FLASHINFER_LOCAL_VERSION: ${{ matrix.cuda.label }}
           PYTORCH_INDEX: ${{ matrix.cuda.pytorch_index }}
           SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET || 'flashinfer-build-cache' }}
+          SCCACHE_PATCHED_BINARY_PATH: /ci-cache/sccache-cu134/${{ matrix.arch }}/sccache
           SCCACHE_REGION: ${{ vars.SCCACHE_REGION || 'us-west-2' }}
         run: |
           # Extract CUDA major and minor versions
@@ -254,6 +274,7 @@ jobs:
             -e FLASHINFER_CUDA_ARCH_LIST \
             -e FLASHINFER_NVCC_THREADS="${FLASHINFER_NVCC_THREADS:-}" \
             -e SCCACHE_BUCKET \
+            -e SCCACHE_PATCHED_BINARY_PATH \
             -e AWS_ACCESS_KEY_ID \
             -e AWS_SECRET_ACCESS_KEY \
             -e SCCACHE_REGION \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,9 @@ concurrency:
   group: release-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     runs-on: ubuntu-latest
@@ -351,6 +354,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,12 @@ on:
       - 'scripts/build_patched_sccache.sh'
       - 'scripts/jit_cache_build_common.sh'
 
+concurrency:
+  # Superseded PR dry-runs only waste runner time; real release dispatches use
+  # unique groups so they remain independent and are never auto-cancelled.
+  group: release-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,8 +231,8 @@ jobs:
           FLASHINFER_CUDA_ARCH_LIST: ${{ matrix.arch == 'aarch64' && matrix.cuda.aarch64_arch_list || matrix.cuda.x86_64_arch_list }}
           FLASHINFER_LOCAL_VERSION: ${{ matrix.cuda.label }}
           PYTORCH_INDEX: ${{ matrix.cuda.pytorch_index }}
-          SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
-          SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
+          SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET || 'flashinfer-build-cache' }}
+          SCCACHE_REGION: ${{ vars.SCCACHE_REGION || 'us-west-2' }}
         run: |
           # Extract CUDA major and minor versions
           IFS=. read -r CUDA_MAJOR CUDA_MINOR <<< "${CUDA_VERSION}"

--- a/scripts/build_flashinfer_jit_cache_whl.sh
+++ b/scripts/build_flashinfer_jit_cache_whl.sh
@@ -119,10 +119,8 @@ echo "::endgroup::"
 
 # Optional: set up sccache for compiler caching with S3 backend
 if [ -n "$SCCACHE_BUCKET" ]; then
-  echo "::group::Install sccache"
   export SCCACHE_BUCKET
   setup_sccache "cuda${CUDA_MAJOR}${CUDA_MINOR}-$(uname -m)" "$(cd .. && pwd -P)"
-  echo "::endgroup::"
 fi
 
 # Clean any previous builds

--- a/scripts/build_patched_sccache.sh
+++ b/scripts/build_patched_sccache.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Build the pinned CUDA 13.4-compatible sccache binary in a dedicated GitHub
+# Actions step. The wheel build consumes the binary from the shared CI cache.
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/jit_cache_build_common.sh
+source "${SCRIPT_DIR}/jit_cache_build_common.sh"
+
+case "${CUDA_VERSION:-}" in
+  13.4|134)
+    ;;
+  *)
+    echo "ERROR: Patched sccache is only expected for CUDA 13.4, got ${CUDA_VERSION:-unset}"
+    exit 1
+    ;;
+esac
+
+if [ -z "${SCCACHE_PATCHED_BINARY_PATH:-}" ]; then
+  echo "ERROR: SCCACHE_PATCHED_BINARY_PATH must be set"
+  exit 1
+fi
+
+sccache_build_started_at=${SECONDS}
+report_sccache_build_duration() {
+  local exit_code=$?
+  trap - EXIT
+  echo "patched sccache step duration: $((SECONDS - sccache_build_started_at)) seconds"
+  exit "${exit_code}"
+}
+trap report_sccache_build_duration EXIT
+
+build_patched_sccache \
+  "${SCCACHE_CUDA_134_REVISION}" \
+  "${SCCACHE_CUDA_134_SOURCE_SHA256}" \
+  "${SCCACHE_PATCHED_BINARY_PATH}"
+
+"${SCCACHE_PATCHED_BINARY_PATH}" --version

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -115,12 +115,13 @@ install_released_sccache() {
   echo "sccache install duration: $((SECONDS - sccache_install_started_at)) seconds"
 }
 
-# Build and install a pinned sccache revision natively. Building inside each
-# manylinux builder produces the matching x86_64 or aarch64 binary without
-# relying on an unpublished binary artifact.
-install_patched_sccache() {
+# Build a pinned sccache revision natively. Building inside each manylinux
+# builder produces the matching x86_64 or aarch64 binary without relying on an
+# unpublished binary artifact.
+build_patched_sccache() {
   local sccache_revision=$1
   local expected_sha256=$2
+  local output_path=$3
   local sccache_package="sccache-${sccache_revision}"
   local sccache_archive="${sccache_package}.tar.gz"
   local sccache_url="https://github.com/mozilla/sccache/archive/${sccache_revision}.tar.gz"
@@ -128,9 +129,7 @@ install_patched_sccache() {
   local required_command
   local sccache_build_started_at=${SECONDS}
 
-  echo "::group::Build patched sccache (cu134, $(uname -m))"
-
-  for required_command in cargo curl env sha256sum tar; do
+  for required_command in cargo curl env install make perl sha256sum tar; do
     if ! command -v "${required_command}" >/dev/null 2>&1; then
       echo "ERROR: ${required_command} is required to build patched sccache"
       exit 1
@@ -153,14 +152,37 @@ install_patched_sccache() {
     --locked \
     --release \
     --no-default-features \
-    --features s3 \
+    --features s3,vendored-openssl \
     --bin sccache \
     --manifest-path "${sccache_tmpdir}/${sccache_package}/Cargo.toml"
-  mv "${sccache_tmpdir}/${sccache_package}/target/release/sccache" /usr/local/bin/
+  mkdir -p "$(dirname "${output_path}")"
+  install -m 0755 \
+    "${sccache_tmpdir}/${sccache_package}/target/release/sccache" \
+    "${output_path}"
   rm -rf "${sccache_tmpdir}"
-  chmod +x /usr/local/bin/sccache
-  echo "::endgroup::"
   echo "patched sccache build duration: $((SECONDS - sccache_build_started_at)) seconds"
+}
+
+# Install the pinned source build, reusing a binary produced by a dedicated
+# workflow step when available. Other call sites retain a self-contained
+# fallback that builds directly into /usr/local/bin.
+install_patched_sccache() {
+  local sccache_revision=$1
+  local expected_sha256=$2
+
+  if [ -n "${SCCACHE_PATCHED_BINARY_PATH:-}" ]; then
+    if [ ! -x "${SCCACHE_PATCHED_BINARY_PATH}" ]; then
+      echo "ERROR: Prebuilt patched sccache not found: ${SCCACHE_PATCHED_BINARY_PATH}"
+      exit 1
+    fi
+    echo "Installing prebuilt patched sccache from ${SCCACHE_PATCHED_BINARY_PATH}"
+    install -m 0755 "${SCCACHE_PATCHED_BINARY_PATH}" /usr/local/bin/sccache
+  else
+    build_patched_sccache \
+      "${sccache_revision}" \
+      "${expected_sha256}" \
+      /usr/local/bin/sccache
+  fi
 }
 
 # Install the official release by default. CUDA 13.4 uses the first upstream

--- a/scripts/jit_cache_build_common.sh
+++ b/scripts/jit_cache_build_common.sh
@@ -5,6 +5,8 @@
 #   - scripts/task_test_jit_cache_package_build_import.sh (PR tests)
 
 SCCACHE_VERSION="0.17.0"
+SCCACHE_CUDA_134_REVISION="e9b15a35f7240a7edd1b9644583edb388c6cb5f9"
+SCCACHE_CUDA_134_SOURCE_SHA256="9e444cc5097a839f03c81c59c5cadebc20090aad1fc699e398d5c1c18c44118c"
 # The v0.17 client-side architecture remains opt-in while this change isolates
 # the version upgrade from a separate execution-mode change.
 
@@ -76,9 +78,9 @@ compute_jit_cache_parallelism() {
   export MEM_PER_JOB=$mem_per_job
 }
 
-# Download and install sccache to /usr/local/bin/sccache, verifying the
-# upstream sha256 checksum.
-install_sccache() {
+# Download and install a released sccache binary to /usr/local/bin/sccache,
+# verifying the upstream sha256 checksum.
+install_released_sccache() {
   local sccache_version=$1
   local sccache_arch=$2
   local sccache_package="sccache-v${sccache_version}-${sccache_arch}-unknown-linux-musl"
@@ -86,6 +88,9 @@ install_sccache() {
   local sccache_url="https://github.com/mozilla/sccache/releases/download/v${sccache_version}/${sccache_archive}"
   local sccache_tmpdir
   local sccache_sha256
+  local sccache_install_started_at=${SECONDS}
+
+  echo "::group::Install sccache v${sccache_version} (${sccache_arch})"
 
   if ! command -v sha256sum >/dev/null 2>&1; then
     echo "ERROR: sha256sum is required to verify sccache downloads"
@@ -106,6 +111,88 @@ install_sccache() {
   mv "${sccache_tmpdir}/${sccache_package}/sccache" /usr/local/bin/
   rm -rf "${sccache_tmpdir}"
   chmod +x /usr/local/bin/sccache
+  echo "::endgroup::"
+  echo "sccache install duration: $((SECONDS - sccache_install_started_at)) seconds"
+}
+
+# Build and install a pinned sccache revision natively. Building inside each
+# manylinux builder produces the matching x86_64 or aarch64 binary without
+# relying on an unpublished binary artifact.
+install_patched_sccache() {
+  local sccache_revision=$1
+  local expected_sha256=$2
+  local sccache_package="sccache-${sccache_revision}"
+  local sccache_archive="${sccache_package}.tar.gz"
+  local sccache_url="https://github.com/mozilla/sccache/archive/${sccache_revision}.tar.gz"
+  local sccache_tmpdir
+  local required_command
+  local sccache_build_started_at=${SECONDS}
+
+  echo "::group::Build patched sccache (cu134, $(uname -m))"
+
+  for required_command in cargo curl env sha256sum tar; do
+    if ! command -v "${required_command}" >/dev/null 2>&1; then
+      echo "ERROR: ${required_command} is required to build patched sccache"
+      exit 1
+    fi
+  done
+
+  sccache_tmpdir=$(mktemp -d)
+  curl -fsSL "${sccache_url}" -o "${sccache_tmpdir}/${sccache_archive}"
+  printf '%s  %s\n' "${expected_sha256}" "${sccache_tmpdir}/${sccache_archive}" | sha256sum -c -
+  tar xzf "${sccache_tmpdir}/${sccache_archive}" -C "${sccache_tmpdir}"
+
+  echo "Building sccache revision ${sccache_revision} for $(uname -m)"
+  # Do not expose cache credentials to third-party Cargo build scripts.
+  env \
+    -u AWS_ACCESS_KEY_ID \
+    -u AWS_SECRET_ACCESS_KEY \
+    -u AWS_SESSION_TOKEN \
+    CARGO_INCREMENTAL=0 \
+    cargo build \
+    --locked \
+    --release \
+    --no-default-features \
+    --features s3 \
+    --bin sccache \
+    --manifest-path "${sccache_tmpdir}/${sccache_package}/Cargo.toml"
+  mv "${sccache_tmpdir}/${sccache_package}/target/release/sccache" /usr/local/bin/
+  rm -rf "${sccache_tmpdir}"
+  chmod +x /usr/local/bin/sccache
+  echo "::endgroup::"
+  echo "patched sccache build duration: $((SECONDS - sccache_build_started_at)) seconds"
+}
+
+# Install the official release by default. CUDA 13.4 uses the first upstream
+# revision containing the CUDA 13.3+ dry-run parser fix while that fix remains
+# unreleased: https://github.com/mozilla/sccache/pull/2722
+install_sccache() {
+  local sccache_version=$1
+  local sccache_arch=$2
+
+  case "${sccache_arch}" in
+    x86_64|aarch64)
+      ;;
+    *)
+      echo "ERROR: Unsupported sccache build architecture: ${sccache_arch}"
+      exit 1
+      ;;
+  esac
+
+  case "${CUDA_VERSION:-}" in
+    13.4|134)
+      install_patched_sccache \
+        "${SCCACHE_CUDA_134_REVISION}" \
+        "${SCCACHE_CUDA_134_SOURCE_SHA256}"
+      export FLASHINFER_SCCACHE_INSTALL_SOURCE="github-source"
+      export FLASHINFER_SCCACHE_REVISION="${SCCACHE_CUDA_134_REVISION}"
+      ;;
+    *)
+      install_released_sccache "${sccache_version}" "${sccache_arch}"
+      export FLASHINFER_SCCACHE_INSTALL_SOURCE="github-release"
+      export FLASHINFER_SCCACHE_REVISION="v${sccache_version}"
+      ;;
+  esac
 }
 
 # Install sccache (if missing), configure environment, and start the server.
@@ -130,19 +217,7 @@ setup_sccache() {
   export SCCACHE_S3_KEY_PREFIX="${key_prefix}"
   export SCCACHE_IDLE_TIMEOUT=0
   export FLASHINFER_CXX_LAUNCHER="sccache"
-
-  # sccache v0.17 cannot parse CUDA 13.3+ nvcc dry-run output, which can leave
-  # fatbinary without its input cubins. Keep host C++ caching enabled, but run
-  # cu134 nvcc directly until a release includes the upstream fix:
-  # https://github.com/mozilla/sccache/pull/2722
-  case "${CUDA_VERSION:-}" in
-    13.4|134)
-      unset FLASHINFER_NVCC_LAUNCHER
-      ;;
-    *)
-      export FLASHINFER_NVCC_LAUNCHER="sccache"
-      ;;
-  esac
+  export FLASHINFER_NVCC_LAUNCHER="sccache"
 
   # Avoid leaking AWS credentials under set -x.
   local _sccache_xtrace=0
@@ -163,6 +238,8 @@ setup_sccache() {
   sccache --zero-stats
   export FLASHINFER_SCCACHE_ACTIVE=true
   echo "sccache version: $(sccache --version)"
+  echo "sccache install source: ${FLASHINFER_SCCACHE_INSTALL_SOURCE}"
+  echo "sccache revision: ${FLASHINFER_SCCACHE_REVISION}"
   echo "sccache bucket: ${SCCACHE_BUCKET}"
   echo "sccache region: ${SCCACHE_REGION}"
   echo "sccache prefix: ${SCCACHE_S3_KEY_PREFIX}"
@@ -177,6 +254,8 @@ setup_sccache() {
     {
       printf 'git_commit=%s\n' "${git_commit:-unknown}"
       printf 'sccache_version=%s\n' "$(sccache --version)"
+      printf 'sccache_install_source=%s\n' "${FLASHINFER_SCCACHE_INSTALL_SOURCE}"
+      printf 'sccache_revision=%s\n' "${FLASHINFER_SCCACHE_REVISION}"
       printf 'sccache_cache_mode=%s\n' "${FLASHINFER_SCCACHE_CACHE_MODE}"
       printf 'sccache_bucket=%s\n' "${SCCACHE_BUCKET}"
       printf 'sccache_region=%s\n' "${SCCACHE_REGION}"


### PR DESCRIPTION
## 📌 Description

Enable NVCC caching for CUDA 13.4 by building sccache from pinned upstream merge commit `e9b15a35f7240a7edd1b9644583edb388c6cb5f9`, which contains the CUDA 13.3+ dry-run parser fix.

- Build the checksum-verified source natively in the existing x86_64 and aarch64 manylinux builders.
- Keep CUDA 12.9 and 13.0 on the official sccache v0.17.0 binaries.
- Build only the S3-enabled sccache feature set with the locked dependency graph and its supported vendored OpenSSL option.
- Remove AWS cache credentials from the Cargo build environment.
- Default the Release workflow to the public sccache bucket and region when fork PR variables are unavailable, enabling anonymous read-only caching and exercising the patched build in PR CI.
- Re-enable `FLASHINFER_NVCC_LAUNCHER=sccache` for CUDA 13.4.
- Build cu134 sccache in a dedicated `Build patched sccache (<arch>)` Actions step in both Release and Nightly Release, preserving elapsed timing even when the step fails.
- Pass the resulting native binary into the subsequent wheel-build container through the shared CI cache mount.
- Cancel superseded Release dry-runs per PR while keeping real release dispatches independent.
- Default the workflow token to contents: read, with actions: read and contents: write granted only to create-release.
- Record the sccache install source and exact revision in the existing stats artifact.

This is intended as a temporary bridge until an official sccache release contains the upstream parser fix.

## 🔍 Related Issues

- https://github.com/mozilla/sccache/pull/2722

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation completed locally:

- `pre-commit run --all-files`
- `bash -n scripts/build_patched_sccache.sh scripts/jit_cache_build_common.sh scripts/build_flashinfer_jit_cache_whl.sh scripts/task_test_jit_cache_package_build_import.sh`
- `shellcheck scripts/build_patched_sccache.sh scripts/jit_cache_build_common.sh scripts/build_flashinfer_jit_cache_whl.sh`
- YAML parsing for both Release workflows
- Mocked routing checks for CUDA 13.4 on x86_64 and aarch64 and unchanged release routing for CUDA 12.9/13.0
- Mocked launcher check confirming cu134 enables both C++ and NVCC sccache launchers
- Reverified the pinned GitHub source archive SHA256
- Verified the pinned Cargo lockfile contains the vendored OpenSSL dependency
- Rebased onto current `main` and reran the changed-file validations

Native Linux builds remain for the PR release workflow matrix, which covers both x86_64 and aarch64.

## Reviewer Notes

Please compare the dedicated patched-sccache Actions step duration and the resulting NVCC cache statistics for both cu134 architectures. The source build intentionally remains scoped to cu134; other CUDA variants continue using the published v0.17.0 artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build-cache reliability for CUDA 13.4 environments.
  * Ensured the CUDA compiler consistently uses the configured cache.
  * Added build metadata identifying the cache implementation and revision.

* **Chores**
  * Added validated, reproducible cache builds for CUDA 13.4.
  * Added support for released or pinned cache binaries.
  * Added automated verification for patched cache binaries.
  * Improved release workflow handling and pull request checks.
  * Added fallback cache storage settings when release configuration is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


