### PR TITLE
feat(topk): self-sampling GVR V2 backend (SM100/103/107), oracle-tracking auto, and the V1 threshold repair

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
       -   id: mypy
           args: ["--config-file", "pyproject.toml", "--exclude", "flashinfer-cubin/"]
           files: ^flashinfer/
-          exclude: ^(flashinfer-cubin/|flashinfer/attention/prims_ts/kernels/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/)|flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107\.py|flashinfer/fused_moe/cute_dsl/rubin/(blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion\.py|blockscaled_contiguous_grouped_gemm_finalize_fusion\.py)|flashinfer/topk_varlen/kernels/filtered_topk_(util|decode)\.py)
+          exclude: ^(flashinfer-cubin/|flashinfer/attention/prims_ts/kernels/|3rdparty/|build/|flashinfer/cute_dsl/attention/fmha/(fmha\.py|fmha_blockscaled\.py|helpers/)|flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107\.py|flashinfer/fused_moe/cute_dsl/rubin/(blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion\.py|blockscaled_contiguous_grouped_gemm_finalize_fusion\.py)|flashinfer/topk_varlen/kernels/filtered_topk_(util|decode)\.py|flashinfer/topk_varlen/kernels/(gvr2_topk_decode\.py|gvr2_topk_host\.py))
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.

--- a/benchmarks/bench_topk_varlen_gvr2.py
+++ b/benchmarks/bench_topk_varlen_gvr2.py
@@ -59,7 +59,7 @@ def parse_args():
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument("--batch-sizes", type=str, default="1,4,16,32,64,128,256")
     p.add_argument("--n-vals", type=str, default="4096,8192,16384,32768,65536,131072")
-    p.add_argument("--top-k", type=int, default=1024, choices=[512, 1024, 2048])
+    p.add_argument("--top-k", type=int, default=1024)
     p.add_argument(
         "--scenarios",
         type=str,
@@ -69,6 +69,14 @@ def parse_args():
     )
     p.add_argument("--next-n", type=int, default=1)
     p.add_argument("--compress-ratio", type=int, default=1, choices=[1, 4])
+    p.add_argument(
+        "--dtype",
+        type=str,
+        default="fp32",
+        choices=["fp32", "bf16", "fp16"],
+        help="logits dtype; gvr_2/trtllm_gvr2 are fp32-only and are dropped "
+        "for bf16/fp16",
+    )
     p.add_argument("--hint-quality", type=float, default=0.6)
     p.add_argument("--oracle", action="store_true", help="perfect pre_idx hints")
     p.add_argument(
@@ -84,11 +92,13 @@ def parse_args():
     return p.parse_args()
 
 
-def make_inputs(scenario, batch, N, K, nn, cr, hint_quality, oracle, seed):
-    """fp32 logits [batch*nn, N] (compressed space), uncompressed seq_lens."""
+def make_inputs(scenario, batch, N, K, nn, cr, hint_quality, oracle, seed, dtype):
+    """Logits [batch*nn, N] (compressed space), uncompressed seq_lens."""
     gen = torch.Generator(device="cuda").manual_seed(seed)
     rows = batch * nn
-    logits = torch.randn(rows, N, generator=gen, device="cuda", dtype=torch.float32)
+    logits = torch.randn(rows, N, generator=gen, device="cuda", dtype=torch.float32).to(
+        dtype
+    )
     if scenario == "uniform":
         seq_lens = torch.full((batch,), N * cr, dtype=torch.int32, device="cuda")
     elif scenario == "mixed":
@@ -265,6 +275,16 @@ def main():
     scenarios = args.scenarios.split(",")
     backends = args.backends.split(",")
     K, nn, cr = args.top_k, args.next_n, args.compress_ratio
+    dtype = {
+        "fp32": torch.float32,
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+    }[args.dtype]
+    if args.dtype != "fp32":
+        dropped = [b for b in backends if b in ("fi_gvr2", "trtllm_gvr2")]
+        if dropped:
+            print(f"[WARN] {dropped} are fp32-only; dropping for {args.dtype}")
+            backends = [b for b in backends if b not in dropped]
 
     trt_host = None
     if "trtllm_gvr2" in backends:
@@ -281,7 +301,7 @@ def main():
 
     print(f"device: {torch.cuda.get_device_name(0)}")
     print(
-        f"top_k={K} next_n={nn} cr={cr} hint_quality="
+        f"dtype={args.dtype} top_k={K} next_n={nn} cr={cr} hint_quality="
         f"{'oracle' if args.oracle else args.hint_quality} "
         f"timing=cuda-graph median, repeat_ms={args.repeat_ms}"
     )
@@ -307,6 +327,7 @@ def main():
                     args.hint_quality,
                     args.oracle,
                     seed=args.seed + B * 7 + N // 64,
+                    dtype=dtype,
                 )
                 row = {}
                 for backend in backends:

--- a/benchmarks/bench_topk_varlen_gvr2.py
+++ b/benchmarks/bench_topk_varlen_gvr2.py
@@ -101,20 +101,27 @@ def make_inputs(scenario, batch, N, K, nn, cr, hint_quality, oracle, seed, dtype
     )
     if scenario == "uniform":
         seq_lens = torch.full((batch,), N * cr, dtype=torch.int32, device="cuda")
-    elif scenario == "mixed":
-        seq_lens = torch.randint(
-            K * cr + nn, N * cr + 1, (batch,), generator=gen, device="cuda"
-        ).int()
-    elif scenario == "short":
-        seq_lens = torch.randint(
-            K * cr + nn,
-            max(N * cr // 8, K * cr + nn + 1),
-            (batch,),
-            generator=gen,
-            device="cuda",
-        ).int()
-        n_long = max(batch // 4, 1)
-        seq_lens[:n_long] = N * cr
+    elif scenario in ("mixed", "short"):
+        # Smallest uncompressed kv whose EVERY next_n row is a long row
+        # (n_r = (kv - nn + j + 1) // cr >= K + 1 for all j): keeps the
+        # documented domains ("mixed" = rows in [K+1, N]) so no row silently
+        # bypasses refcheck's n <= K skip.
+        lo = (K + 1) * cr + nn - 1
+        if scenario == "mixed":
+            hi = N * cr + 1
+        else:
+            hi = N * cr // 8
+            if hi <= lo:
+                print(
+                    f"[NOTE] short scenario is degenerate for N={N}, K={K}: "
+                    "N/8 <= K+1, so the 'short' rows are not short",
+                    flush=True,
+                )
+        hi = max(hi, lo + 1)
+        seq_lens = torch.randint(lo, hi, (batch,), generator=gen, device="cuda").int()
+        if scenario == "short":
+            n_long = max(batch // 4, 1)
+            seq_lens[:n_long] = N * cr
     else:
         raise ValueError(scenario)
 
@@ -142,6 +149,13 @@ def make_backend_fns(backend, logits, seq_lens, pre_idx, K, nn, cr, trt_host):
     or None if the backend cannot run this config."""
     rows = logits.shape[0]
     out_i = torch.empty(rows, K, dtype=torch.int32, device="cuda")
+
+    if backend in ("fi_gvr2", "fi_gvr", "fi_gvr_nolb", "trtllm_gvr2") and K not in (
+        512,
+        1024,
+        2048,
+    ):
+        return None, None  # outside the GVR-family top_k domain: n/a, not an error
 
     if backend == "fi_gvr2":
 
@@ -369,16 +383,17 @@ def main():
                     if msg and msg != "n/a":
                         print(f"    [{b}] {msg}", flush=True)
 
-    # ---- summary ----------------------------------------------------------
-    if "fi_gvr2" not in backends:
+    # ---- summary (relative to gvr_2 when present, else the first backend) ---
+    if not backends:
         return
-    print("\n================ SUMMARY (ratios are other/gvr_2; >1 = gvr_2 faster)")
+    base = "fi_gvr2" if "fi_gvr2" in backends else backends[0]
+    print(f"\n================ SUMMARY (ratios are other/{base}; >1 = {base} faster)")
     for other in backends:
-        if other == "fi_gvr2":
+        if other == base:
             continue
         ratios, wins, total = [], 0, 0
         for _, _, _, row in results:
-            g2, g2_ok, _ = row["fi_gvr2"]
+            g2, g2_ok, _ = row[base]
             ot, ot_ok, _ = row.get(other, (float("nan"), False, ""))
             if math.isnan(g2) or math.isnan(ot) or not (g2_ok and ot_ok):
                 continue
@@ -388,7 +403,7 @@ def main():
         if total:
             print(
                 f"  vs {other:<17} geomean {geomean(ratios):5.2f}x   "
-                f"gvr_2 wins {wins}/{total}"
+                f"{base} wins {wins}/{total}"
             )
     print("\nper-config winner:")
     for scenario, B, N, row in results:

--- a/benchmarks/bench_topk_varlen_gvr2.py
+++ b/benchmarks/bench_topk_varlen_gvr2.py
@@ -82,7 +82,7 @@ def parse_args():
     p.add_argument(
         "--backends",
         type=str,
-        default="fi_gvr2,fi_gvr,fi_gvr_nolb,fi_radix,fi_radix_cutlass",
+        default="fi_gvr2,fi_gvr,fi_gvr_nolb,fi_radix,fi_radix_cutlass,fi_radix_filter",
         help="comma list; add trtllm_gvr2 for the upstream port-parity twin",
     )
     p.add_argument("--trtllm-path", type=str, default=_DEFAULT_TRTLLM_TOPK)
@@ -226,6 +226,22 @@ def make_backend_fns(backend, logits, seq_lens, pre_idx, K, nn, cr, trt_host):
                 compress_ratio=cr,
                 out_indices=out_i,
                 backend="radix_cutlass",
+            )
+
+        return fn, out_i
+    if backend == "fi_radix_filter":
+        if cr != 1:
+            return None, None  # the vendored DKG kernel has no compress_ratio
+
+        def fn():
+            flashinfer.top_k_varlen(
+                logits,
+                seq_lens,
+                K,
+                next_n=nn,
+                compress_ratio=cr,
+                out_indices=out_i,
+                backend="radix_filter",
             )
 
         return fn, out_i

--- a/benchmarks/bench_topk_varlen_gvr2.py
+++ b/benchmarks/bench_topk_varlen_gvr2.py
@@ -1,0 +1,381 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Benchmark the gvr_2 (self-sampling GVR V2) top_k_varlen backend.
+
+Compares, on identical fp32 inputs (gvr_2 is fp32-only):
+
+* ``fi_gvr2``          — the new self-sampling GVR V2 backend (this PR)
+* ``fi_gvr``           — existing GVR, load-balance path (production default)
+* ``fi_gvr_nolb``      — existing GVR, single-CTA path
+* ``fi_radix``         — CuTe DSL single-pass multi-CTA radix
+* ``fi_radix_cutlass`` — masked CUTLASS radix fallback
+* ``trtllm_gvr2``      — upstream TRT-LLM run_varlen (port-parity check;
+                         needs a local TRT-LLM checkout, see --trtllm-path)
+
+Timing: ``bench_gpu_time(..., use_cuda_graph=True)`` — decode top-k kernels
+are microsecond-scale, so graph replay removes launch-overhead noise (same
+method as bench_topk_varlen_vs_trtllm.py). Every backend's output is
+validated (tie-aware value multiset per row) before timing; a wrong backend
+is reported as WRONG and excluded from win statistics.
+
+Hints: ``pre_idx`` mixes a ``--hint-quality`` fraction of the true top-K with
+random valid indices (hint quality shifts GVR-family perf but never
+exactness). ``--oracle`` uses perfect hints (GVR-favorable upper bound).
+
+Example:
+    python benchmarks/bench_topk_varlen_gvr2.py \
+        --batch-sizes 1,16,64,256 --n-vals 8192,32768,131072 --top-k 1024
+"""
+
+import argparse
+import math
+import os
+import sys
+
+import torch
+
+import flashinfer
+from flashinfer.testing import bench_gpu_time
+
+# Directory holding TRT-LLM's top_k CuTe-DSL kernels (a local checkout's
+# tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k), used only by the
+# optional trtllm_gvr2 port-parity twin. No path ships as a default — pass
+# --trtllm-path or set TRTLLM_TOPK_DIR.
+_DEFAULT_TRTLLM_TOPK = os.environ.get("TRTLLM_TOPK_DIR", "")
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--batch-sizes", type=str, default="1,4,16,32,64,128,256")
+    p.add_argument("--n-vals", type=str, default="4096,8192,16384,32768,65536,131072")
+    p.add_argument("--top-k", type=int, default=1024, choices=[512, 1024, 2048])
+    p.add_argument(
+        "--scenarios",
+        type=str,
+        default="uniform,mixed",
+        help="comma list of: uniform (all rows = N), mixed (ragged in "
+        "[K+1, N]), short (75%% of rows <= N/8)",
+    )
+    p.add_argument("--next-n", type=int, default=1)
+    p.add_argument("--compress-ratio", type=int, default=1, choices=[1, 4])
+    p.add_argument("--hint-quality", type=float, default=0.6)
+    p.add_argument("--oracle", action="store_true", help="perfect pre_idx hints")
+    p.add_argument(
+        "--backends",
+        type=str,
+        default="fi_gvr2,fi_gvr,fi_gvr_nolb,fi_radix,fi_radix_cutlass",
+        help="comma list; add trtllm_gvr2 for the upstream port-parity twin",
+    )
+    p.add_argument("--trtllm-path", type=str, default=_DEFAULT_TRTLLM_TOPK)
+    p.add_argument("--repeat-ms", type=int, default=200)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--no-refcheck", action="store_true")
+    return p.parse_args()
+
+
+def make_inputs(scenario, batch, N, K, nn, cr, hint_quality, oracle, seed):
+    """fp32 logits [batch*nn, N] (compressed space), uncompressed seq_lens."""
+    gen = torch.Generator(device="cuda").manual_seed(seed)
+    rows = batch * nn
+    logits = torch.randn(rows, N, generator=gen, device="cuda", dtype=torch.float32)
+    if scenario == "uniform":
+        seq_lens = torch.full((batch,), N * cr, dtype=torch.int32, device="cuda")
+    elif scenario == "mixed":
+        seq_lens = torch.randint(
+            K * cr + nn, N * cr + 1, (batch,), generator=gen, device="cuda"
+        ).int()
+    elif scenario == "short":
+        seq_lens = torch.randint(
+            K * cr + nn,
+            max(N * cr // 8, K * cr + nn + 1),
+            (batch,),
+            generator=gen,
+            device="cuda",
+        ).int()
+        n_long = max(batch // 4, 1)
+        seq_lens[:n_long] = N * cr
+    else:
+        raise ValueError(scenario)
+
+    # request-level hints: hint_quality fraction of the true top-K of the
+    # request's first row, rest random valid indices
+    pre_idx = torch.zeros(batch, K, dtype=torch.int32, device="cuda")
+    sl = seq_lens.cpu().tolist()
+    for b in range(batch):
+        n0 = min(max((sl[b] - nn + 1) // cr, 1), N)
+        k_eff = min(K, n0)
+        true_top = torch.topk(logits[b * nn, :n0], k_eff).indices.int()
+        if oracle:
+            pre_idx[b, :k_eff] = true_top
+        else:
+            n_hit = int(k_eff * hint_quality)
+            pre_idx[b] = torch.randint(
+                0, n0, (K,), generator=gen, device="cuda", dtype=torch.int32
+            )
+            pre_idx[b, :n_hit] = true_top[:n_hit]
+    return logits, seq_lens, pre_idx
+
+
+def make_backend_fns(backend, logits, seq_lens, pre_idx, K, nn, cr, trt_host):
+    """Return a zero-arg closure running the backend into preallocated outputs,
+    or None if the backend cannot run this config."""
+    rows = logits.shape[0]
+    out_i = torch.empty(rows, K, dtype=torch.int32, device="cuda")
+
+    if backend == "fi_gvr2":
+
+        def fn():
+            flashinfer.top_k_varlen(
+                logits,
+                seq_lens,
+                K,
+                pre_idx=pre_idx,
+                next_n=nn,
+                compress_ratio=cr,
+                out_indices=out_i,
+                backend="gvr_2",
+            )
+
+        return fn, out_i
+    if backend in ("fi_gvr", "fi_gvr_nolb"):
+        lb = backend == "fi_gvr"
+        ws = None
+        if lb:
+            if seq_lens.shape[0] > 1024:
+                return None, None  # LB prepare kernel cap
+            mbs = 64
+            while mbs < seq_lens.shape[0]:
+                mbs *= 2
+            ws = {
+                "gvr_order_row": torch.empty(mbs, dtype=torch.int32, device="cuda"),
+                "gvr_counters": torch.empty(2, dtype=torch.int32, device="cuda"),
+            }
+
+        def fn():
+            flashinfer.top_k_varlen(
+                logits,
+                seq_lens,
+                K,
+                pre_idx=pre_idx,
+                next_n=nn,
+                compress_ratio=cr,
+                out_indices=out_i,
+                backend="gvr",
+                load_balance=lb,
+                workspace=ws,
+            )
+
+        return fn, out_i
+    if backend == "fi_radix":
+
+        def fn():
+            flashinfer.top_k_varlen(
+                logits,
+                seq_lens,
+                K,
+                next_n=nn,
+                compress_ratio=cr,
+                out_indices=out_i,
+                backend="radix",
+            )
+
+        return fn, out_i
+    if backend == "fi_radix_cutlass":
+
+        def fn():
+            flashinfer.top_k_varlen(
+                logits,
+                seq_lens,
+                K,
+                next_n=nn,
+                compress_ratio=cr,
+                out_indices=out_i,
+                backend="radix_cutlass",
+            )
+
+        return fn, out_i
+    if backend == "trtllm_gvr2":
+        if trt_host is None:
+            return None, None
+
+        msl = logits.shape[1] * cr
+
+        def fn():
+            trt_host.run_varlen(
+                logits,
+                pre_idx,
+                seq_lens,
+                out_i,
+                next_n=nn,
+                compress_ratio=cr,
+                max_seq_len=msl,
+            )
+
+        return fn, out_i
+    raise ValueError(backend)
+
+
+def refcheck(logits, seq_lens, out_i, K, nn, cr):
+    """Tie-aware per-row check; rows with n<=K only checked for -1 padding
+    conventions loosely (backends differ there). Returns (ok, msg)."""
+    rows = logits.shape[0]
+    sl = seq_lens.cpu().tolist()
+    for r in range(rows):
+        n = min(max((sl[r // nn] - nn + (r % nn) + 1) // cr, 0), logits.shape[1])
+        if n <= K:
+            continue  # short-row pad conventions differ across backends
+        idx = out_i[r].to(torch.int64)
+        if int(idx.min()) < 0 or int(idx.max()) >= n:
+            return False, f"row {r}: index out of range"
+        if int(torch.unique(idx).numel()) != K:
+            return False, f"row {r}: duplicate indices"
+        got = torch.sort(logits[r].gather(0, idx) + 0.0, descending=True).values
+        ref = torch.sort(
+            torch.topk(logits[r, :n], K).values + 0.0, descending=True
+        ).values
+        if not torch.equal(got, ref):
+            nbad = int((got != ref).sum())
+            return False, f"row {r}: value multiset mismatch ({nbad}/{K} slots)"
+    return True, ""
+
+
+def geomean(xs):
+    xs = [x for x in xs if x > 0]
+    if not xs:
+        return float("nan")
+    return math.exp(sum(math.log(x) for x in xs) / len(xs))
+
+
+def main():
+    args = parse_args()
+    torch.manual_seed(args.seed)
+    batch_sizes = [int(x) for x in args.batch_sizes.split(",")]
+    n_vals = [int(x) for x in args.n_vals.split(",")]
+    scenarios = args.scenarios.split(",")
+    backends = args.backends.split(",")
+    K, nn, cr = args.top_k, args.next_n, args.compress_ratio
+
+    trt_host = None
+    if "trtllm_gvr2" in backends:
+        if not args.trtllm_path:
+            print("[WARN] trtllm_gvr2 needs --trtllm-path or TRTLLM_TOPK_DIR; dropping")
+            backends = [b for b in backends if b != "trtllm_gvr2"]
+        else:
+            sys.path.insert(0, args.trtllm_path)
+            try:
+                import gvr_topk_decode_self_sampling_host as trt_host  # noqa: N813
+            except ImportError as e:
+                print(f"[WARN] trtllm_gvr2 unavailable ({e}); dropping")
+                backends = [b for b in backends if b != "trtllm_gvr2"]
+
+    print(f"device: {torch.cuda.get_device_name(0)}")
+    print(
+        f"top_k={K} next_n={nn} cr={cr} hint_quality="
+        f"{'oracle' if args.oracle else args.hint_quality} "
+        f"timing=cuda-graph median, repeat_ms={args.repeat_ms}"
+    )
+    header = f"{'scenario':<8} {'B':>4} {'N':>7} " + "".join(
+        f"{b:>17}" for b in backends
+    )
+    print(header)
+    print("-" * len(header))
+
+    results = []  # (scenario, B, N, {backend: (us, ok)})
+    for scenario in scenarios:
+        for B in batch_sizes:
+            for N in n_vals:
+                if N <= K:
+                    continue
+                logits, seq_lens, pre_idx = make_inputs(
+                    scenario,
+                    B,
+                    N,
+                    K,
+                    nn,
+                    cr,
+                    args.hint_quality,
+                    args.oracle,
+                    seed=args.seed + B * 7 + N // 64,
+                )
+                row = {}
+                for backend in backends:
+                    fn, out_i = make_backend_fns(
+                        backend, logits, seq_lens, pre_idx, K, nn, cr, trt_host
+                    )
+                    if fn is None:
+                        row[backend] = (float("nan"), False, "n/a")
+                        continue
+                    try:
+                        fn()  # warmup / JIT outside timing
+                        torch.cuda.synchronize()
+                        ok, msg = (True, "")
+                        if not args.no_refcheck:
+                            ok, msg = refcheck(logits, seq_lens, out_i, K, nn, cr)
+                        timings = bench_gpu_time(
+                            fn,
+                            dry_run_time_ms=50,
+                            repeat_time_ms=args.repeat_ms,
+                            use_cuda_graph=True,
+                            num_iters_within_graph=10,
+                        )
+                        med_us = float(torch.tensor(timings).median()) * 1e3
+                        row[backend] = (med_us, ok, msg)
+                    except Exception as e:  # noqa: BLE001 — report and move on
+                        row[backend] = (float("nan"), False, f"{type(e).__name__}: {e}")
+                results.append((scenario, B, N, row))
+                cells = ""
+                for b in backends:
+                    us, ok, msg = row[b]
+                    if math.isnan(us):
+                        cells += f"{'—':>17}"
+                    else:
+                        tag = "" if ok else "!WRONG"
+                        cells += f"{us:>11.1f}us{tag:<5}"
+                print(f"{scenario:<8} {B:>4} {N:>7} {cells}", flush=True)
+                for b in backends:
+                    us, ok, msg = row[b]
+                    if msg and msg != "n/a":
+                        print(f"    [{b}] {msg}", flush=True)
+
+    # ---- summary ----------------------------------------------------------
+    if "fi_gvr2" not in backends:
+        return
+    print("\n================ SUMMARY (ratios are other/gvr_2; >1 = gvr_2 faster)")
+    for other in backends:
+        if other == "fi_gvr2":
+            continue
+        ratios, wins, total = [], 0, 0
+        for _, _, _, row in results:
+            g2, g2_ok, _ = row["fi_gvr2"]
+            ot, ot_ok, _ = row.get(other, (float("nan"), False, ""))
+            if math.isnan(g2) or math.isnan(ot) or not (g2_ok and ot_ok):
+                continue
+            ratios.append(ot / g2)
+            wins += ot > g2
+            total += 1
+        if total:
+            print(
+                f"  vs {other:<17} geomean {geomean(ratios):5.2f}x   "
+                f"gvr_2 wins {wins}/{total}"
+            )
+    print("\nper-config winner:")
+    for scenario, B, N, row in results:
+        valid = {b: us for b, (us, ok, _) in row.items() if ok and not math.isnan(us)}
+        if valid:
+            w = min(valid, key=valid.get)
+            print(f"  {scenario:<8} B={B:<4} N={N:<7} -> {w} ({valid[w]:.1f}us)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/routines/topk_varlen.py
+++ b/benchmarks/routines/topk_varlen.py
@@ -29,12 +29,12 @@ from .flashinfer_benchmark_utils import (
     print_perf_metrics,
 )
 
-# top_k_varlen's three runners. Per-CC support is NOT hard-coded here; it is
+# top_k_varlen's runners. Per-CC support is NOT hard-coded here; it is
 # resolved at runtime from top_k_varlen's @backend_requirement decorator via
 # ``flashinfer.top_k_varlen.is_backend_supported(backend, cc)`` (the single
 # source of truth), mirroring how the GEMM routines rely on their support
 # checkers (e.g. mm_fp4 / bmm_fp8) instead of a compute-capability table.
-_TOP_K_VARLEN_BACKENDS = ("radix", "gvr", "radix_cutlass")
+_TOP_K_VARLEN_BACKENDS = ("radix", "gvr", "gvr_2", "radix_cutlass")
 
 
 def parse_topk_varlen_args(line, parser):
@@ -96,7 +96,7 @@ def run_topk_varlen_test(args):
 
 
 def testTopKVarlen(args):
-    """Benchmark top_k_varlen with three runners: 'radix', 'radix_cutlass', 'gvr'.
+    """Benchmark top_k_varlen with its runners: 'radix', 'radix_cutlass', 'gvr', 'gvr_2'.
 
     Runners
     -------
@@ -107,6 +107,9 @@ def testTopKVarlen(args):
                      (sm_100/103) only. Per-CC support is resolved via
                      ``top_k_varlen.is_backend_supported`` (its
                      ``@backend_requirement`` decorator).
+    gvr_2          — self-sampling GVR V2 (TRT-LLM PR #17821 port); passes the
+                     same ``pre_idx``. Blackwell (sm_100/103) + fp32 logits +
+                     top_k in {512, 1024, 2048} only; skipped otherwise.
 
     Reference check compares the *set* of selected indices against ``torch.topk``
     applied to logits masked to ``seq_lens``.
@@ -143,6 +146,16 @@ def testTopKVarlen(args):
                 f"[WARNING] {backend} for routine {args.routine} is not supported "
                 f"on compute capability {major}.{minor}. Skipping."
             )
+    # gvr_2's CC check passes on sm_100/103, but the backend is fp32-only with
+    # a fixed top_k domain — drop it up front instead of failing the call.
+    if "gvr_2" in backends and (
+        args.input_dtype != "float32" or top_k not in (512, 1024, 2048)
+    ):
+        backends.remove("gvr_2")
+        print(
+            "[WARNING] gvr_2 requires float32 logits and top_k in {512, 1024, "
+            "2048}. Skipping."
+        )
     if len(backends) == 0:
         print("[ERROR] No backends to test. Exiting.")
         return res
@@ -176,6 +189,10 @@ def testTopKVarlen(args):
         elif backend == "gvr":
             return flashinfer.top_k_varlen(
                 logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr"
+            )
+        elif backend == "gvr_2":
+            return flashinfer.top_k_varlen(
+                logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr_2"
             )
         else:
             raise ValueError(f"Unsupported backend: {backend}")

--- a/benchmarks/routines/topk_varlen.py
+++ b/benchmarks/routines/topk_varlen.py
@@ -146,15 +146,19 @@ def testTopKVarlen(args):
                 f"[WARNING] {backend} for routine {args.routine} is not supported "
                 f"on compute capability {major}.{minor}. Skipping."
             )
-    # gvr_2's CC check passes on sm_100/103, but the backend is fp32-only with
-    # a fixed top_k domain — drop it up front instead of failing the call.
+    # gvr_2's CC check passes on sm_100/103/107, but the backend is fp32-only,
+    # has a fixed top_k domain and needs a 4-aligned row stride (float4 loads;
+    # for these contiguous logits the stride is max_seq_len) — drop it up
+    # front instead of failing the call.
     if "gvr_2" in backends and (
-        args.input_dtype != "float32" or top_k not in (512, 1024, 2048)
+        args.input_dtype != "float32"
+        or top_k not in (512, 1024, 2048)
+        or max_seq_len % 4 != 0
     ):
         backends.remove("gvr_2")
         print(
-            "[WARNING] gvr_2 requires float32 logits and top_k in {512, 1024, "
-            "2048}. Skipping."
+            "[WARNING] gvr_2 requires float32 logits, top_k in {512, 1024, "
+            "2048} and max_seq_len % 4 == 0. Skipping."
         )
     if len(backends) == 0:
         print("[ERROR] No backends to test. Exiting.")

--- a/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/filtered_topk_decode.py
@@ -501,6 +501,10 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             _batch = row_id // self.next_n
             _off = row_id % self.next_n
             _eff = seqlen[_batch] - self.next_n + _off + 1
+            # FlashInfer-local: clamp the dynamic row length to the physical row
+            # width (input.shape[1] is symbolic, the compile bucket is wider); a
+            # length past the width used to read into the next rows.
+            _eff = min(_eff, input.shape[1])
             chunk_start = self.chunk_size_per_cta * cta_in_group
             row_start = chunk_start
             row_end = min(_eff, chunk_start + self.chunk_size_per_cta)
@@ -534,6 +538,8 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             if not cutlass.const_expr(self.merge_blocks):
                 seq_len = seqlen[bidx // self.next_n]
                 row_end = seq_len - self.next_n + (bidx % self.next_n) + 1
+                # FlashInfer-local: same clamp to the physical row width
+                row_end = min(row_end, input.shape[1])
                 length = row_end - row_start
 
         if cutlass.const_expr(self.enable_multi_cta):
@@ -575,6 +581,7 @@ class FilteredTopKKernelVarlenDecode(FilteredTopKKernelVarlen):
             _batch_check = bidx // self.next_n
             _off_check = bidx % self.next_n
             _eff_check = seqlen[_batch_check] - self.next_n + _off_check + 1
+            _eff_check = min(_eff_check, input.shape[1])  # FlashInfer-local clamp
             _needed_ctas = (
                 _eff_check + self.chunk_size_per_cta - 1
             ) // self.chunk_size_per_cta

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -32,12 +32,13 @@ collision symbols carry a ``__<family>`` suffix.
 Provenance: ported near-verbatim from TensorRT-LLM
 ``tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_self_sampling.py``
 (PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf), plus two register-family
-fixes ported verbatim into ``GvrTopkRegKernel.kern``: PR
-NVIDIA/TensorRT-LLM#18501 (count-crossing enforcement when the histogram
-total never reaches k, radix-descent escape, -inf fill-lane bound) and PR
-NVIDIA/TensorRT-LLM#18625 (an infinite bracket width from an in-window +inf
-fails the collapse guard and takes the key-space escape instead of folding
-the row into bin 0 and dropping the +inf).  FlashInfer-local changes: module
+fixes ported verbatim: PR NVIDIA/TensorRT-LLM#18501 (``GvrTopkRegKernel.kern``:
+count-crossing enforcement when the histogram total never reaches k,
+radix-descent escape, -inf fill-lane bound) and PR NVIDIA/TensorRT-LLM#18625
+(an infinite bracket width from a sampled +inf fails the collapse guard;
+``GvrTopkRegKernel.kern`` then takes the key-space escape and
+``GvrRegClusKernel.kern`` the whole-row ``degen`` fallback, instead of the
+collapsed histogram dropping the +inf).  FlashInfer-local changes: module
 rename, this note, the ``_persist`` hook that routes the four
 ``get_compiled*`` builders through FlashInfer's on-disk CuTe-DSL kernel
 cache, ``_base_compile_opts`` (explicit ``--gpu-arch`` for the current
@@ -6198,10 +6199,13 @@ class GvrRegClusKernel:
             Tv = invkey(lmin)
             GMAX = invkey(lmax)
 
-            # ---- collapse guard, NaN-safe
+            # ---- collapse guard, NaN-safe. Reject infinite width as well:
+            # otherwise SC becomes zero and can collapse +inf into a finite
+            # histogram bin.
             okc = cutlass.Int32(0)
             if Tv < GMAX:
-                if (GMAX - Tv) > cutlass.Float32(1e-30):
+                w_ = GMAX - Tv
+                if w_ > cutlass.Float32(1e-30) and w_ < cutlass.Float32(3.5e38):
                     okc = cutlass.Int32(1)
             if okc == cutlass.Int32(0):
                 Tv = cutlass.Float32(SENT_LO)
@@ -6262,6 +6266,12 @@ class GvrRegClusKernel:
                 whole = cutlass.Int32(1)
             degen = cutlass.Int32(0)
             if m > cutlass.Int32(CS * CMPC):
+                degen = cutlass.Int32(1)
+            # The sentinel bracket also has infinite width. Bypass its
+            # collapsed histogram and enter the exact whole-row key-space
+            # fallback on rank 0, where fkey(+inf) is the maximum key.
+            if okc == cutlass.Int32(0):
+                whole = cutlass.Int32(0)
                 degen = cutlass.Int32(1)
             for z in cutlass.range_constexpr(NB__regclus // self.blk):
                 i = tid + cutlass.Int32(z * self.blk)

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -31,13 +31,19 @@ collision symbols carry a ``__<family>`` suffix.
 
 Provenance: ported near-verbatim from TensorRT-LLM
 ``tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_self_sampling.py``
-(PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf), plus the register-family
-escape fix from PR NVIDIA/TensorRT-LLM#18501 (count-crossing enforcement when
-the histogram total never reaches k, radix-descent escape, -inf fill-lane
-bound) ported verbatim into ``GvrTopkRegKernel.kern``.  FlashInfer-local
-changes: module rename, this note, and the ``_persist`` hook that routes the
-four ``get_compiled*`` builders through FlashInfer's on-disk CuTe-DSL kernel
-cache.  Keep future diffs against upstream mechanical.
+(PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf), plus two register-family
+fixes ported verbatim into ``GvrTopkRegKernel.kern``: PR
+NVIDIA/TensorRT-LLM#18501 (count-crossing enforcement when the histogram
+total never reaches k, radix-descent escape, -inf fill-lane bound) and PR
+NVIDIA/TensorRT-LLM#18625 (an infinite bracket width from an in-window +inf
+fails the collapse guard and takes the key-space escape instead of folding
+the row into bin 0 and dropping the +inf).  FlashInfer-local changes: module
+rename, this note, the ``_persist`` hook that routes the four
+``get_compiled*`` builders through FlashInfer's on-disk CuTe-DSL kernel
+cache, ``_base_compile_opts`` (explicit ``--gpu-arch`` for the current
+device), and the main-family varlen prologue clamping each row's length to
+the envelope in launch slot ``n`` instead of the row stride.  Keep future
+diffs against upstream mechanical.
 """
 
 import contextlib
@@ -3772,10 +3778,16 @@ class GvrTopkRegKernel:
             Tv = invkey(lmin)
             GMAX = invkey(lmax)
 
-            # ---- collapse guard, NaN-safe
+            # ---- collapse guard, NaN-safe. An infinite bracket width
+            # (GMAX=+inf from an in-window +inf, or Tv=-inf) makes SC=rcp(w)=0
+            # and folds every value into bin 0, dropping the +inf; reject it
+            # here (okc=0) and force the key-space escape below.
+            # (upstream TensorRT-LLM PR #18625, ported verbatim.)
             okc = cutlass.Int32(0)
             if Tv < GMAX:
-                if (GMAX - Tv) > cutlass.Float32(1e-30):
+                w_ = GMAX - Tv
+                # w_ < 3.5e38 (> FLT_MAX) rejects an infinite bracket width.
+                if w_ > cutlass.Float32(1e-30) and w_ < cutlass.Float32(3.5e38):
                     okc = cutlass.Int32(1)
             if okc == cutlass.Int32(0):
                 Tv = cutlass.Float32(SENT_LO)
@@ -3864,6 +3876,13 @@ class GvrTopkRegKernel:
                 if m > cmp_:
                     esc = cutlass.Int32(1)
             if tot < k:
+                esc = cutlass.Int32(1)
+            # Degenerate bracket (okc==0: infinite/collapsed width, e.g. an
+            # in-window +inf) makes SC=0 and folds every value into bin 0, so
+            # the histogram cannot rank the row; take the bracket-independent
+            # key-space escape, where fkey(+inf) is the maximum key.
+            # (upstream TensorRT-LLM PR #18625, ported verbatim.)
+            if okc == cutlass.Int32(0):
                 esc = cutlass.Int32(1)
             if esc == cutlass.Int32(1):
                 if tid == cutlass.Int32(0):

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -1,0 +1,6606 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-sampling GVR top-K decode kernels (CuTe DSL, Blackwell sm_100a).
+
+Sample-calibrated threshold ladders for exact single-pass top-K: the kernel
+derives its selection threshold from an in-kernel sample of the row itself
+(one sample histogram yields a bracketed ladder of candidate thresholds,
+resolved and harvested in a single streaming pass); exactness is guaranteed
+by count-crossing invariants, never by the estimate; the temporal hint
+(pre_idx) survives only as a degenerate-case anchor.
+
+Four kernel families -- sampling-ladder slab/streaming (main),
+register-resident (reg), cluster streaming (clus), clustered
+register-resident (regclus) -- merged into a single device module;
+collision symbols carry a ``__<family>`` suffix.
+
+Provenance: ported near-verbatim from TensorRT-LLM
+``tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_self_sampling.py``
+(PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf). FlashInfer-local changes:
+module rename, this note, and the ``_persist`` hook that routes the four
+``get_compiled*`` builders through FlashInfer's on-disk CuTe-DSL kernel cache.
+Keep future diffs against upstream mechanical.
+"""
+
+import contextlib
+import sys
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.cute.math as cmath
+from cutlass._mlir.dialects import arith as mlir_arith
+from cutlass._mlir.dialects import llvm, nvvm
+from cutlass._mlir.dialects import llvm as mlir_llvm
+from cutlass._mlir.dialects import math as mlir_math
+from cutlass.cute import runtime as _crt
+from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass.utils.smem_allocator import SmemAllocator
+
+# `C.` references throughout resolve against this module itself.
+C = sys.modules[__name__]
+
+
+def _persist(kernel_name: str, compile_fn):
+    """Route a ``cute.compile`` closure through FlashInfer's persistent
+    CuTe-DSL kernel cache (one ``gvr2_topk`` module directory shared by all
+    four families; artifacts reload via TVM-FFI, so the closures MUST compile
+    with ``--enable-tvm-ffi`` — they all do). Falls back to a plain in-process
+    compile when the FlashInfer JIT layer is unavailable (standalone use)."""
+    try:
+        from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
+    except ImportError:
+        return compile_fn()
+    return build_and_load_cute_dsl_kernel(
+        "gvr2_topk", kernel_name, compile_fn, extra_key_files=(__file__,)
+    )
+
+
+# ===========================================================================
+# ==== shared device units =====================================
+# ===========================================================================
+"""Device-helper library shared by the main / reg / clus / regclus families.
+
+Conventions
+-----------
+* Crossing-scan helpers write their scalar outputs into an Int32 smem tensor
+  `s_res` using the slot map RES_B=0, RES_M=1, RES_ABOVE=2, RES_TOT=3,
+  RES_B2=4, RES_B3=5. Slots are written ONLY on a pin.
+* Histograms are Int32 smem tensors: adds/scans are bit-identical mod 2^32,
+  and totals stay below 2^31 by dispatch domain.
+* Warp-0-only helpers (find_cross / scan_cross0 / merge_scan0) contain NO
+  barrier; scan_cross and scan_cross_w contain EXACTLY ONE internal barrier;
+  gather_hint contains EXACTLY TWO. Do not add or drop any.
+* All warp collectives use the full mask FULLM = 0xffffffff.
+"""
+
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
+FULLM = 0xFFFFFFFF
+NB = 1024  # register-family base bin count
+SNB = 256  # streaming-path bin count — MUST stay 256
+MAXC = 160  # multi-CTA SPLIT row cap
+GCAP = 16384  # per-row slab capacity in int2
+QUADC = 96  # O(mc^2) rank gate, streaming/reg
+QUADC_CLUS = 288  # clus + gvr_main gate
+IDXB = 22  # packed candidate index bits
+IDXM = (1 << IDXB) - 1
+GVR_WS_OFF_OFF = MAXC * 8  # workspace g_off byte offset
+GVR_WS_BUF_OFF = 2048  # workspace g_buf byte offset
+
+# degenerate-hint sentinels (exact-equality flag values)
+SENT_LO = -3.0e38
+SENT_HI = 3.0e38
+
+# s_res slot map (see module docstring)
+RES_B = 0
+RES_M = 1
+RES_ABOVE = 2
+RES_TOT = 3
+RES_B2 = 4
+RES_B3 = 5
+
+
+# ---------------------------------------------------------------------------
+# float <-> u32 bitcasts
+# ---------------------------------------------------------------------------
+def u32_of_f32(v):
+    """Raw fp32 bits as Uint32 (bit-cast, no conversion)."""
+    return cutlass.Uint32(llvm.bitcast(cutlass.Uint32.mlir_type, v.ir_value()))
+
+
+def f32_of_u32(u):
+    """Uint32 bit pattern as Float32 (bit-cast)."""
+    return cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, u.ir_value()))
+
+
+def f32_of_i32(i):
+    return cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, i.ir_value()))
+
+
+def i32_of_f32(v):
+    return cutlass.Int32(llvm.bitcast(cutlass.Int32.mlir_type, v.ir_value()))
+
+
+# ---------------------------------------------------------------------------
+# fkey / invkey — order-preserving float->u32 radix key.
+# fkey:   u ^ (((int32)u >> 31) | 0x80000000)  [arithmetic-shift sign trick,
+#         spelled 0 - (u >> 31) on Uint32]
+# invkey: (K & 0x80000000) ? K ^ 0x80000000 : ~K   [exact inverse]
+# Monotone over all finite floats and +-inf; min identity 0xffffffff, max 0.
+# ---------------------------------------------------------------------------
+def fkey_bits(u):
+    """fkey on raw fp32 bits already held as Uint32."""
+    neg = cutlass.Uint32(0) - (u >> cutlass.Uint32(31))  # 0 or 0xFFFFFFFF
+    return u ^ (neg | cutlass.Uint32(0x80000000))
+
+
+def fkey(x):
+    """CUDA fkey(float). x: dynamic Float32 -> Uint32 key."""
+    return fkey_bits(u32_of_f32(x))
+
+
+def invkey_bits(K):
+    """CUDA invkey without the final bitcast: key -> fp32 bits."""
+    s = K >> cutlass.Uint32(31)  # 1 iff key top bit set
+    m = (s - cutlass.Uint32(1)) | cutlass.Uint32(0x80000000)
+    # s==1 -> m=0x80000000 (K^0x80000000); s==0 -> m=0xFFFFFFFF (~K)
+    return K ^ m
+
+
+def invkey(K):
+    """CUDA invkey(uint32). K: dynamic Uint32 key -> Float32."""
+    return f32_of_u32(invkey_bits(K))
+
+
+# ---------------------------------------------------------------------------
+# warp redux wrappers. Values passed to the u32 forms MUST be genuine
+# cutlass.Uint32 — an Int32 silently lowers to redux.sync.{min,max}.s32.
+# ---------------------------------------------------------------------------
+def warp_min_u32(v):
+    """__reduce_min_sync(FULLM, v) -> redux.sync.min.u32 (single inst)."""
+    return cute.arch.warp_redux_sync(v, "min")
+
+
+def warp_max_u32(v):
+    """__reduce_max_sync(FULLM, v) -> redux.sync.max.u32."""
+    return cute.arch.warp_redux_sync(v, "max")
+
+
+def warp_add_u32(v):
+    """__reduce_add_sync(FULLM, v) -> redux.sync.add.s32 (bit-identical u32)."""
+    return cute.arch.warp_redux_sync(v, "add")
+
+
+def warp_add_i32(v):
+    """__reduce_add_sync on Int32 (scan_cross_w two-redux stage)."""
+    return cute.arch.warp_redux_sync(v, "add")
+
+
+def fmin_f32(a, b):
+    """fminf -> native min.f32."""
+    return cute.arch.fmin(a, b)
+
+
+def fmax_f32(a, b):
+    """fmaxf -> max.f32."""
+    return cute.arch.fmax(a, b)
+
+
+# ---------------------------------------------------------------------------
+# ballot / popc / clz / ffs wrappers
+# ---------------------------------------------------------------------------
+def ballot(pred):
+    """__ballot_sync(FULLM, pred) -> Int32 mask."""
+    return cute.arch.vote_ballot_sync(pred)
+
+
+def popc(x):
+    return cute.arch.popc(x)
+
+
+def clz_i32(x):
+    """__clz as Int32."""
+    return cutlass.Int32(cute.arch.clz(x))
+
+
+def ffs_m1(x):
+    """__ffs(x) - 1 for x != 0 (bit index of lowest set bit).
+
+    Spelled popc((x & -x) - 1). Caller must guarantee x != 0 (every use is
+    inside a mask-walk loop).
+    """
+    return cutlass.Int32(cute.arch.popc((x & (cutlass.Int32(0) - x)) - cutlass.Int32(1)))
+
+
+@cute.jit
+def hi_bit_or_zero(msk):
+    """CUDA `msk ? (31 - __clz(msk)) : 0`."""
+    r = cutlass.Int32(0)
+    if msk != cutlass.Int32(0):
+        r = cutlass.Int32(31) - clz_i32(msk)
+    return r
+
+
+# ---------------------------------------------------------------------------
+# warp shfl scans (plus the TWO-interleaved variant gvr_topk_reg needs)
+# ---------------------------------------------------------------------------
+@cute.jit
+def _shfl_up_add(val, lane, offset: cutlass.Constexpr):
+    """Inclusive-scan step: val += shfl_up(val, offset) gated lane >= offset.
+
+    Native shfl.sync.up (mask_and_clamp=0, the __shfl_up_sync lowering):
+    hardware clamps the source lane, deleting the VIMNMX+VIADD software
+    clamp of the previous idx-kind spelling. Lanes < offset receive an
+    undefined-but-discarded value (the gate keeps the result identical).
+    """
+    other = cute.arch.shuffle_sync_up(val, offset, mask_and_clamp=0)
+    if lane >= cutlass.Int32(offset):
+        val = val + other
+    return val
+
+
+@cute.jit
+def _shfl_down_add(val, lane, offset: cutlass.Constexpr):
+    """Suffix-scan step: val += shfl_down(val, offset) gated lane+offset < 32.
+
+    Native shfl.sync.down (mask_and_clamp=31 = __shfl_down_sync lowering);
+    hardware clamps, gate discards out-of-range lanes as before.
+    """
+    other = cute.arch.shuffle_sync_down(val, offset, mask_and_clamp=31)
+    if lane + cutlass.Int32(offset) < cutlass.Int32(32):
+        val = val + other
+    return val
+
+
+@cute.jit
+def warp_incl_scan_add(val, lane):
+    """5-step inclusive __shfl_up_sync add scan."""
+    for o in [1, 2, 4, 8, 16]:
+        val = _shfl_up_add(val, lane, o)
+    return val
+
+
+@cute.jit
+def warp_incl_scan_add2(v1, v2, lane):
+    """TWO interleaved inclusive shfl_up scans.
+
+    Per step o: shfl(v1); gated add; shfl(v2); gated add — the two dependency
+    chains interleave so the second scan hides under the first's shfl latency
+    exactly as the CUDA dual-scan loop does.
+    """
+    for o in [1, 2, 4, 8, 16]:
+        z1 = cute.arch.shuffle_sync_up(v1, o, mask_and_clamp=0)
+        if lane >= cutlass.Int32(o):
+            v1 = v1 + z1
+        z2 = cute.arch.shuffle_sync_up(v2, o, mask_and_clamp=0)
+        if lane >= cutlass.Int32(o):
+            v2 = v2 + z2
+    return v1, v2
+
+
+@cute.jit
+def warp_suffix_scan_add(val, lane):
+    """5-step __shfl_down_sync suffix add scan."""
+    for o in [1, 2, 4, 8, 16]:
+        val = _shfl_down_add(val, lane, o)
+    return val
+
+
+# ---------------------------------------------------------------------------
+# CTA-scope shared-memory atomics (return the OLD value; never sys scope)
+# ---------------------------------------------------------------------------
+def atomic_add_cta(ptr, val):
+    """shared atomicAdd returning old value. ptr: cute Pointer
+
+    (e.g. `s_hist.iterator + bin_idx`), val: Int32.
+    """
+    return cutlass.Int32(cute.arch.atomic_add(ptr, val, sem="relaxed", scope="cta"))
+
+
+def atomic_min_cta(ptr, val):
+    """shared atomicMin (s_kmin seeds). Unsigned iff val is Uint32."""
+    return cute.arch.atomic_min(ptr, val, sem="relaxed", scope="cta")
+
+
+def atomic_max_cta(ptr, val):
+    """shared atomicMax (s_kmax seeds)."""
+    return cute.arch.atomic_max(ptr, val, sem="relaxed", scope="cta")
+
+
+def atomic_or_cta(ptr, val):
+    """shared atomicOr (gvr_topk_reg bitmap path)."""
+    return cute.arch.atomic_or(ptr, val, sem="relaxed", scope="cta")
+
+
+# ---------------------------------------------------------------------------
+# gpu-scope fences + global u64 atomicAdd (SPLIT slab protocol)
+# ---------------------------------------------------------------------------
+def threadfence_gpu():
+    """__threadfence() == fence.acq_rel.gpu — required on BOTH the release and
+    acquire sides of the slab hand-off."""
+    cute.arch.fence_acq_rel_gpu()
+
+
+def atomic_add_u64_gpu(ptr, val):
+    """atom.global.add.u64 returning the OLD value (arrival RMW).
+
+    ptr: cute Pointer to an Int64 gmem word; val: cutlass.Int64.
+    Packed arrival word: `cutlass.Int64(1 << 32) + cutlass.Int64(myn)`.
+    """
+    return cutlass.Int64(cute.arch.atomic_add(ptr, val))
+
+
+# ---------------------------------------------------------------------------
+# saturating converts (native ctors emit cvt.rzi.{u32,s32}.f32)
+# ---------------------------------------------------------------------------
+def f2u_rz(v):
+    """__float2uint_rz: saturating (neg/-inf -> 0, huge -> 0xffffffff, NaN -> 0).
+
+    Dynamic values only — host constants raise OverflowError on inf.
+    """
+    return cutlass.Uint32(v)
+
+
+def f2s_rz(v):
+    """__float2int_rz: saturating (-inf -> INT_MIN, huge -> INT_MAX, NaN -> 0)."""
+    return cutlass.Int32(v)
+
+
+# ---------------------------------------------------------------------------
+# L2 prefetch escape hatch
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _prefetch_l2(gaddr, *, loc=None, ip=None):
+    """prefetch.global.L2 [gaddr]; gaddr is a byte address (Int64)."""
+    llvm.inline_asm(
+        res=None,
+        operands_=[gaddr.ir_value(loc=loc, ip=ip)],
+        asm_string="prefetch.global.L2 [$0];",
+        constraints="l",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+# ---------------------------------------------------------------------------
+# global loads: 128-bit ldg (read-only) / plain, scalar forms, and __ldcg
+# (L2-direct) vector forms for the slab consume
+# ---------------------------------------------------------------------------
+def g2r_atom_f32(bits: int, invariant: bool = True):
+    """CopyG2ROp atom: bits=128 -> LDG.E.128[.CONSTANT], bits=32 -> scalar."""
+    return cute.make_copy_atom(
+        cute.nvgpu.CopyG2ROp(), cutlass.Float32, num_bits_per_copy=bits, invariant=invariant
+    )
+
+
+def g2r_atom_i32(bits: int, invariant: bool = False):
+    return cute.make_copy_atom(
+        cute.nvgpu.CopyG2ROp(), cutlass.Int32, num_bits_per_copy=bits, invariant=invariant
+    )
+
+
+@dsl_user_op
+def _ld_g_nc_v4_f32(gaddr, *, loc=None, ip=None):
+    """Pinned `ld.global.nc.v4.f32` (CUDA `__ldg(const float4*)`).
+
+    The asm boundary pins the four-scalar-f32 shape: NVVM otherwise rewrites
+    adjacent 128-bit f32 copy-atom loads into v2.b64 register-pair loads,
+    whose even-aligned pair constraint fragments allocation at the
+    64-register wall and induces spills."""
+    from cutlass._mlir import ir as _ir
+
+    st = _ir.Type.parse("!llvm.struct<(f32, f32, f32, f32)>")
+    r = mlir_llvm.inline_asm(
+        st,
+        [gaddr.ir_value(loc=loc, ip=ip)],
+        "ld.global.nc.v4.f32 {$0, $1, $2, $3}, [$4];",
+        "=f,=f,=f,=f,l",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=mlir_llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(
+        cutlass.Float32(mlir_llvm.extractvalue(T.f32(), r, [i], loc=loc, ip=ip)) for i in range(4)
+    )
+
+
+def ld_g_f32x4(copy_atom, base_addr, v_idx, frag):
+    """Load float4 #v_idx (16B units) from gmem byte base into frag[0..3].
+
+    base_addr: Int64 byte address; frag: (4,) f32 fragment. Issue ALL batch
+    members before consuming any. Pinned-asm form (see _ld_g_nc_v4_f32);
+    copy_atom kept for call-site compatibility.
+    """
+    v0, v1, v2, v3 = _ld_g_nc_v4_f32(base_addr + cutlass.Int64(v_idx) * cutlass.Int64(16))
+    frag[0] = v0
+    frag[1] = v1
+    frag[2] = v2
+    frag[3] = v3
+
+
+def ldg_f32(base_addr, idx):
+    """__ldg(X + idx): scalar read-only 4B gather."""
+    atom = g2r_atom_f32(32, invariant=True)
+    p = cute.make_ptr(
+        cutlass.Float32,
+        base_addr + cutlass.Int64(idx) * cutlass.Int64(4),
+        cute.AddressSpace.gmem,
+        assumed_align=4,
+    )
+    frag = cute.make_rmem_tensor((1,), cutlass.Float32)
+    cute.copy(atom, cute.make_tensor(p, cute.make_layout((1,))), frag)
+    return frag[0]
+
+
+def ld_g_i32(base_addr, idx):
+    """plain P[idx] scalar int32 load."""
+    p = cute.make_ptr(
+        cutlass.Int32,
+        base_addr + cutlass.Int64(idx) * cutlass.Int64(4),
+        cute.AddressSpace.gmem,
+        assumed_align=4,
+    )
+    return cutlass.Int32(cute.arch.load(p, cutlass.Int32))
+
+
+@dsl_user_op
+def _ldcg_v2_i32(gaddr, *, loc=None, ip=None):
+    """__ldcg on an int2 (8B slab word): ld.global.cg.v2.u32 -> (x, y).
+
+    x = value bits, y = index (workspace g_buf layout).
+    gaddr: Int64 byte address, 8B-aligned.
+    """
+    ret = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32()]),
+        [gaddr.ir_value(loc=loc, ip=ip)],
+        "ld.global.cg.v2.u32 {$0, $1}, [$2];",
+        "=r,=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Int32(llvm.extractvalue(T.i32(), ret, [0])),
+        cutlass.Int32(llvm.extractvalue(T.i32(), ret, [1])),
+    )
+
+
+@dsl_user_op
+def _ldcg_v4_i32(gaddr, *, loc=None, ip=None):
+    """ld.global.cg.v4.b32 (16B L2-direct load), returns 4 Int32."""
+    ret = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [gaddr.ir_value(loc=loc, ip=ip)],
+        "ld.global.cg.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return tuple(cutlass.Int32(llvm.extractvalue(T.i32(), ret, [i])) for i in range(4))
+
+
+# ---------------------------------------------------------------------------
+# 128-bit shared-memory ld/st (copy-atom spelling) + ulonglong2 read
+# ---------------------------------------------------------------------------
+def smem_atom_i32_128():
+    """CopyUniversalOp atom for ld/st.shared.v4.b32 on Int32 smem."""
+    return cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Int32, num_bits_per_copy=128)
+
+
+def _smem_v4_tensor(base_addr, byte_off):
+    """4-elt Int32 smem tensor at 16B-aligned base_addr+byte_off (Int32 addr)."""
+    p = cute.make_ptr(cutlass.Int32, base_addr + byte_off, cute.AddressSpace.smem, assumed_align=16)
+    return cute.make_tensor(p, cute.make_layout((4,)))
+
+
+def lds128_i32(copy_atom, base_addr, byte_off, frag):
+    """ld.shared.v4.b32 -> frag(4, Int32)."""
+    cute.copy(copy_atom, _smem_v4_tensor(base_addr, byte_off), frag)
+
+
+def sts128_i32(copy_atom, frag, base_addr, byte_off):
+    """st.shared.v4.b32 <- frag(4, Int32)."""
+    cute.copy(copy_atom, frag, _smem_v4_tensor(base_addr, byte_off))
+
+
+@dsl_user_op
+def _lds_v2_u64(saddr, *, loc=None, ip=None):
+    """ulonglong2 16B smem read (quad-rank path): (lo, hi)."""
+    ret = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i64(), T.i64()]),
+        [saddr.ir_value(loc=loc, ip=ip)],
+        "ld.shared.v2.u64 {$0, $1}, [$2];",
+        "=l,=l,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Uint64(llvm.extractvalue(T.i64(), ret, [0])),
+        cutlass.Uint64(llvm.extractvalue(T.i64(), ret, [1])),
+    )
+
+
+# ---------------------------------------------------------------------------
+# DSMEM op set. mapa returns a byte-addressed Int32 in the PEER's shared
+# window; offset arithmetic is applied after one mapa per rank.
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _mapa_shared_cluster(smem_ptr, peer_rank, *, loc=None, ip=None):
+    """mapa.shared::cluster of a local smem Pointer -> Int32 peer byte addr."""
+    smem_ptr_i32 = smem_ptr.toint(loc=loc, ip=ip).ir_value()
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [smem_ptr_i32, peer_rank.ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _mapa_shared_cluster_addr(addr_i32, peer_rank, *, loc=None, ip=None):
+    """mapa of a raw Int32 shared-window byte address (already .toint()'d)."""
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [addr_i32.ir_value(loc=loc, ip=ip), peer_rank.ir_value(loc=loc, ip=ip)],
+            "mapa.shared::cluster.u32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_shared_cluster_i32(mapped_addr, *, loc=None, ip=None):
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [mapped_addr.ir_value(loc=loc, ip=ip)],
+            "ld.shared::cluster.u32 $0, [$1];",
+            "=r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_shared_cluster_f32(mapped_addr, *, loc=None, ip=None):
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [mapped_addr.ir_value(loc=loc, ip=ip)],
+            "ld.shared::cluster.f32 $0, [$1];",
+            "=f,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _ld_shared_cluster_v4_u32(mapped_addr, *, loc=None, ip=None):
+    """Single-shot remote 16B DSMEM load."""
+    ret = llvm.inline_asm(
+        llvm.StructType.get_literal([T.i32(), T.i32(), T.i32(), T.i32()]),
+        [mapped_addr.ir_value(loc=loc, ip=ip)],
+        "ld.shared::cluster.v4.u32 {$0, $1, $2, $3}, [$4];",
+        "=r,=r,=r,=r,r",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return (
+        cutlass.Int32(llvm.extractvalue(T.i32(), ret, [0])),
+        cutlass.Int32(llvm.extractvalue(T.i32(), ret, [1])),
+        cutlass.Int32(llvm.extractvalue(T.i32(), ret, [2])),
+        cutlass.Int32(llvm.extractvalue(T.i32(), ret, [3])),
+    )
+
+
+@dsl_user_op
+def _st_shared_cluster_i32(mapped_addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        res=None,
+        operands_=[mapped_addr.ir_value(loc=loc, ip=ip), val.ir_value(loc=loc, ip=ip)],
+        asm_string="st.shared::cluster.u32 [$0], $1;",
+        constraints="r,r",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _st_shared_cluster_f32(mapped_addr, val, *, loc=None, ip=None):
+    llvm.inline_asm(
+        res=None,
+        operands_=[mapped_addr.ir_value(loc=loc, ip=ip), val.ir_value(loc=loc, ip=ip)],
+        asm_string="st.shared::cluster.f32 [$0], $1;",
+        constraints="r,f",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _st_shared_cluster_u64(mapped_addr, val, *, loc=None, ip=None):
+    """ONE packed 8B DSMEM candidate push (never split into two 4B stores).
+
+    val = (Uint64(key) << 32) | Uint64(idx_bits).
+    """
+    llvm.inline_asm(
+        res=None,
+        operands_=[mapped_addr.ir_value(loc=loc, ip=ip), val.ir_value(loc=loc, ip=ip)],
+        asm_string="st.shared::cluster.u64 [$0], $1;",
+        constraints="r,l",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _atom_shared_cluster_add_i32(mapped_addr, val, *, loc=None, ip=None):
+    """Remote CTA smem atomicAdd (cluster scope), returns old value."""
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [mapped_addr.ir_value(loc=loc, ip=ip), val.ir_value(loc=loc, ip=ip)],
+            "atom.relaxed.cluster.shared::cluster.add.u32 $0, [$1], $2;",
+            "=r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# aligned cluster barrier (cg::cluster.sync() ==
+# barrier.cluster.{arrive,wait}.aligned). Writers use the FULL (releasing)
+# arrive — cluster_arrive_relaxed has NO release and races DSMEM. Never
+# substitute the non-aligned cute.arch forms.
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _cluster_arrive_aligned(*, loc=None, ip=None):
+    nvvm.cluster_arrive(aligned=True, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def _cluster_wait_aligned(*, loc=None, ip=None):
+    nvvm.cluster_wait(aligned=True, loc=loc, ip=ip)
+
+
+@cute.jit
+def _cluster_sync_aligned():
+    """cg::cluster_group::sync()."""
+    _cluster_arrive_aligned()
+    _cluster_wait_aligned()
+
+
+# ===========================================================================
+# find_cross<NB_=1024>
+# highest bin B with sum_{j>=B} hist[j] >= target; also total, m = hist[B],
+# above = sum_{j>B}. Warp-parallel (warp 0 only), bank-conflict free via the
+# rotated indexing hist[lane*BPL + ((j+lane) & (BPL-1))] — DO NOT drop it.
+# Non-destructive. NO barrier inside.
+# Writes s_res[RES_B/RES_M/RES_ABOVE] from the single pinning lane and
+# s_res[RES_TOT] from lane 0.
+# ===========================================================================
+@cute.jit
+def find_cross(s_hist, target, tidx, s_res, nb: cutlass.Constexpr):
+    BPL = nb // 32  # python int at trace time
+    if tidx < cutlass.Int32(32):
+        lane = tidx
+        # per-lane span sum with rotated bank-skew indexing
+        part = cutlass.Int32(0)
+        for j in cutlass.range_constexpr(BPL):
+            idx = lane * cutlass.Int32(BPL) + ((cutlass.Int32(j) + lane) & cutlass.Int32(BPL - 1))
+            part = part + s_hist[idx]
+        # 5-step suffix scan: v = sum of part over lanes >= lane
+        v = warp_suffix_scan_add(part, lane)
+        if lane == cutlass.Int32(0):
+            s_res[RES_TOT] = v
+        # level 1: highest lane whose suffix still reaches target
+        msk = ballot(v >= target)
+        L = hi_bit_or_zero(msk)
+        aboveL = cute.arch.shuffle_sync(v - part, L)
+        # level 2: one bin per lane inside lane L's span
+        h = cutlass.Int32(0)
+        if lane < cutlass.Int32(BPL):
+            h = s_hist[L * cutlass.Int32(BPL) + lane]
+        w = warp_suffix_scan_add(h, lane)
+        msk2 = ballot((aboveL + w) >= target)
+        J = hi_bit_or_zero(msk2)
+        if lane == J:  # pinning lane
+            s_res[RES_B] = L * cutlass.Int32(BPL) + J
+            s_res[RES_M] = h
+            s_res[RES_ABOVE] = aboveL + (w - h)
+
+
+# ===========================================================================
+# scan_cross0<NB_, ZERO, TWO, THREE, ADD>
+# Warp-0-only vectorized suffix scan (streaming workhorse, NB_=256 at every
+# production call site). Contains NO barrier — the caller pays exactly one
+# after it. Leaves hist[j] = per-bin OUTPUT CURSOR (count strictly above
+# bin j), or ZEROS when zero=True (folds the next phase's histogram clear).
+# two/three pin extra crossing bins for target2/target3 into RES_B2/RES_B3.
+# addf folds the per-rank bin-offset vector s_addv into the cursors.
+# HOLD register guard: NV<=2 holds the span in regs across the scan; wider
+# instantiations re-READ their span (no barrier needed — each lane only
+# touches its own span).
+# ===========================================================================
+@cute.jit
+def scan_cross0(
+    s_hist,
+    target,
+    tidx,
+    s_res,
+    target2,
+    target3,
+    s_addv,
+    nb: cutlass.Constexpr,
+    zero: cutlass.Constexpr,
+    two: cutlass.Constexpr = False,
+    three: cutlass.Constexpr = False,
+    addf: cutlass.Constexpr = False,
+):
+    BPT = nb // 32  # bins per lane (trace-time int)
+    NV = BPT // 4  # 16B vectors per lane
+    HOLD = NV <= 2  # register-pressure guard
+    if tidx < cutlass.Int32(32):
+        lane = tidx
+        atom = smem_atom_i32_128()
+        hbase = s_hist.iterator.toint()
+        # pass 1: span sum via NV uint4 LDS.128
+        frags = [cute.make_rmem_tensor((4,), cutlass.Int32) for _ in range(NV)]
+        sm = cutlass.Int32(0)
+        for q in cutlass.range_constexpr(NV):
+            boff = (lane * cutlass.Int32(NV) + cutlass.Int32(q)) * cutlass.Int32(16)
+            lds128_i32(atom, hbase, boff, frags[q])
+            sm = sm + frags[q][0] + frags[q][1] + frags[q][2] + frags[q][3]
+        # 5-step inclusive shfl_up scan
+        w = warp_incl_scan_add(sm, lane)
+        tot = cute.arch.shuffle_sync(w, cutlass.Int32(31))
+        after = tot - w  # bins strictly above my span
+        if lane == cutlass.Int32(0):
+            s_res[RES_TOT] = tot
+        base = lane * cutlass.Int32(BPT)
+        # pass 2: descending vector walk
+        for q in cutlass.range_constexpr(NV - 1, -1, -1):
+            if cutlass.const_expr(HOLD):
+                vv = frags[q]
+            else:
+                vv = cute.make_rmem_tensor((4,), cutlass.Int32)  # re-read span
+                boff = (lane * cutlass.Int32(NV) + cutlass.Int32(q)) * cutlass.Int32(16)
+                lds128_i32(atom, hbase, boff, vv)
+            o4 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            for j in cutlass.range_constexpr(3, -1, -1):
+                cq = vv[j]
+                if cutlass.const_expr(zero):
+                    o4[j] = cutlass.Int32(0)
+                else:
+                    o4[j] = after
+                gb = base + cutlass.Int32(4 * q + j)
+                cross = cutlass.Int32(0)
+                if after < target:
+                    if (after + cq) >= target:
+                        cross = cutlass.Int32(1)
+                    if gb == cutlass.Int32(0):
+                        cross = cutlass.Int32(1)
+                if cross != cutlass.Int32(0):
+                    s_res[RES_B] = gb
+                    s_res[RES_ABOVE] = after
+                    s_res[RES_M] = cq
+                if cutlass.const_expr(two):
+                    cross2 = cutlass.Int32(0)
+                    if after < target2:
+                        if (after + cq) >= target2:
+                            cross2 = cutlass.Int32(1)
+                        if gb == cutlass.Int32(0):
+                            cross2 = cutlass.Int32(1)
+                    if cross2 != cutlass.Int32(0):
+                        s_res[RES_B2] = gb
+                if cutlass.const_expr(three):
+                    cross3 = cutlass.Int32(0)
+                    if after < target3:
+                        if (after + cq) >= target3:
+                            cross3 = cutlass.Int32(1)
+                        if gb == cutlass.Int32(0):
+                            cross3 = cutlass.Int32(1)
+                    if cross3 != cutlass.Int32(0):
+                        s_res[RES_B3] = gb
+                after = after + cq
+            if cutlass.const_expr(addf):  # fold per-rank bin offset
+                av = cute.make_rmem_tensor((4,), cutlass.Int32)
+                aoff = (lane * cutlass.Int32(NV) + cutlass.Int32(q)) * cutlass.Int32(16)
+                lds128_i32(atom, s_addv.iterator.toint(), aoff, av)
+                for j in cutlass.range_constexpr(4):
+                    o4[j] = o4[j] + av[j]
+            boff = (lane * cutlass.Int32(NV) + cutlass.Int32(q)) * cutlass.Int32(16)
+            sts128_i32(atom, o4, hbase, boff)
+
+
+# ===========================================================================
+# scan_cross<BLK, NB_, TWO>
+# Block-parallel suffix scan over NB_ (<= BLK) bins. Leaves hist[j] = OUTPUT
+# CURSOR (count in bins > j) and pins the crossing bin. Warps that hold no
+# bin skip the body. EXACTLY ONE internal barrier; the caller pays its usual
+# publish barrier after. Used by the gvr_clus whole-row degenerate path.
+# ===========================================================================
+@cute.jit
+def scan_cross(
+    s_hist,
+    s_ws,
+    target,
+    tidx,
+    s_res,
+    target2,
+    blk: cutlass.Constexpr,
+    nb: cutlass.Constexpr,
+    two: cutlass.Constexpr = False,
+):
+    NWU = nb // 32
+    lane = tidx & cutlass.Int32(31)
+    wid = tidx >> cutlass.Int32(5)
+    c = cutlass.Int32(0)
+    w = cutlass.Int32(0)
+    if tidx < cutlass.Int32(nb):
+        c = s_hist[tidx]
+        w = warp_incl_scan_add(c, lane)
+        if lane == cutlass.Int32(31):
+            s_ws[wid] = w
+    cute.arch.barrier()  # the ONE internal barrier
+    if tidx < cutlass.Int32(nb):
+        v2 = cutlass.Int32(0)
+        if lane < cutlass.Int32(NWU):
+            v2 = s_ws[lane]
+        pre = warp_incl_scan_add(v2, lane)
+        tot = cute.arch.shuffle_sync(pre, cutlass.Int32(31))
+        off = cute.arch.shuffle_sync(pre - v2, wid)
+        after = tot - (off + w)
+        if tidx == cutlass.Int32(0):
+            s_res[RES_TOT] = tot
+        s_hist[tidx] = after  # output cursor
+        cross = cutlass.Int32(0)
+        if after < target:
+            if (after + c) >= target:
+                cross = cutlass.Int32(1)
+            if tidx == cutlass.Int32(0):
+                cross = cutlass.Int32(1)
+        if cross != cutlass.Int32(0):
+            s_res[RES_B] = tidx
+            s_res[RES_ABOVE] = after
+            s_res[RES_M] = c
+        if cutlass.const_expr(two):
+            cross2 = cutlass.Int32(0)
+            if after < target2:
+                if (after + c) >= target2:
+                    cross2 = cutlass.Int32(1)
+                if tidx == cutlass.Int32(0):
+                    cross2 = cutlass.Int32(1)
+            if cross2 != cutlass.Int32(0):
+                s_res[RES_B2] = tidx
+
+
+# ===========================================================================
+# scan_cross_w<BLK, NB_>
+# Register-path block-parallel suffix scan for NB_ >= BLK: every thread owns
+# a private contiguous BPT = NB_/BLK span, so its read->write needs no
+# barrier. EXACTLY ONE internal barrier. The second stage is TWO REDUCTIONS,
+# not a scan: tot = redux_add(vv), off = redux_add((lane < wid) ? vv : 0) —
+# wid is warp-uniform so the masked operand stays convergent.
+# ===========================================================================
+@cute.jit
+def scan_cross_w(s_hist, s_ws, target, tidx, s_res, blk: cutlass.Constexpr, nb: cutlass.Constexpr):
+    BPT = nb // blk
+    NW = blk // 32
+    lane = tidx & cutlass.Int32(31)
+    wid = tidx >> cutlass.Int32(5)
+    loc = cute.make_rmem_tensor((BPT,), cutlass.Int32)
+    base = tidx * cutlass.Int32(BPT)
+    sm = cutlass.Int32(0)
+    for i in cutlass.range_constexpr(BPT):
+        loc[i] = s_hist[base + cutlass.Int32(i)]
+        sm = sm + loc[i]
+    w = warp_incl_scan_add(sm, lane)
+    if lane == cutlass.Int32(31):
+        s_ws[wid] = w
+    cute.arch.barrier()  # the ONE internal barrier
+    vv = cutlass.Int32(0)
+    if lane < cutlass.Int32(NW):
+        vv = s_ws[lane]
+    tot = cutlass.Int32(warp_add_i32(vv))
+    sel = cutlass.Int32(0)
+    if lane < wid:
+        sel = vv
+    off = cutlass.Int32(warp_add_i32(sel))
+    after = tot - (off + w)
+    if tidx == cutlass.Int32(0):
+        s_res[RES_TOT] = tot
+    for i in cutlass.range_constexpr(BPT - 1, -1, -1):
+        cq = loc[i]
+        s_hist[base + cutlass.Int32(i)] = after  # per-bin OUTPUT CURSOR
+        gb = base + cutlass.Int32(i)
+        cross = cutlass.Int32(0)
+        if after < target:
+            if (after + cq) >= target:
+                cross = cutlass.Int32(1)
+            if gb == cutlass.Int32(0):
+                cross = cutlass.Int32(1)
+        if cross != cutlass.Int32(0):
+            s_res[RES_B] = gb
+            s_res[RES_ABOVE] = after
+            s_res[RES_M] = cq
+        after = after + cq
+
+
+# ===========================================================================
+# merge_scan0<NB_, CS>
+# Warp-0-fused cluster merge + suffix scan: each lane reads its BPT-bin span
+# from EVERY rank's hist via 16B DSMEM loads, sums the cluster totals (and
+# the r<rank prefix that biases this rank's cursors) in registers, runs the
+# suffix scan and writes the biased output cursors straight into mrg. ONE
+# caller barrier (the post-scan publish) instead of two, and no hoff[]
+# array at all. NO barrier inside.
+# rank: this CTA's rank-in-cluster (dynamic Int32); cs: cluster size.
+# ===========================================================================
+@cute.jit
+def merge_scan0(
+    s_hist, s_mrg, rank, target, tidx, s_res, nb: cutlass.Constexpr, cs: cutlass.Constexpr
+):
+    BPT = nb // 32
+    NV = BPT // 4
+    if tidx < cutlass.Int32(32):
+        lane = tidx
+        atom = smem_atom_i32_128()
+        # one mapa per rank on the hist base, offsets applied after
+        mapped = [_mapa_shared_cluster(s_hist.iterator, cutlass.Int32(r)) for r in range(cs)]
+        # pass 1: remote v4 accumulation of tot/pre per vector
+        tot_r = []  # NV entries of [4 x Int32] cluster totals
+        pre_r = []  # NV entries of [4 x Int32] r<rank prefixes
+        sm = cutlass.Int32(0)
+        for q in cutlass.range_constexpr(NV):
+            boff = (lane * cutlass.Int32(BPT) + cutlass.Int32(4 * q)) * cutlass.Int32(4)
+            t = [cutlass.Int32(0)] * 4
+            p = [cutlass.Int32(0)] * 4
+            for r in cutlass.range_constexpr(cs):
+                v0, v1, v2, v3 = _ld_shared_cluster_v4_u32(mapped[r] + boff)
+                t[0] = t[0] + v0
+                t[1] = t[1] + v1
+                t[2] = t[2] + v2
+                t[3] = t[3] + v3
+                if cutlass.Int32(r) < rank:  # predicated adds
+                    p[0] = p[0] + v0
+                    p[1] = p[1] + v1
+                    p[2] = p[2] + v2
+                    p[3] = p[3] + v3
+            tot_r.append(t)
+            pre_r.append(p)
+            sm = sm + t[0] + t[1] + t[2] + t[3]
+        # inclusive scan + totals
+        w = warp_incl_scan_add(sm, lane)
+        tt = cute.arch.shuffle_sync(w, cutlass.Int32(31))
+        after = tt - w
+        if lane == cutlass.Int32(0):
+            s_res[RES_TOT] = tt
+        base = lane * cutlass.Int32(BPT)
+        # descending walk: crossing pin + prefix-biased cursors into mrg
+        for q in cutlass.range_constexpr(NV - 1, -1, -1):
+            o4 = cute.make_rmem_tensor((4,), cutlass.Int32)
+            for j in cutlass.range_constexpr(3, -1, -1):
+                cq = tot_r[q][j]
+                o4[j] = after + pre_r[q][j]
+                gb = base + cutlass.Int32(4 * q + j)
+                cross = cutlass.Int32(0)
+                if after < target:
+                    if (after + cq) >= target:
+                        cross = cutlass.Int32(1)
+                    if gb == cutlass.Int32(0):
+                        cross = cutlass.Int32(1)
+                if cross != cutlass.Int32(0):
+                    s_res[RES_B] = gb
+                    s_res[RES_ABOVE] = after
+                    s_res[RES_M] = cq
+                after = after + cq
+            boff = (lane * cutlass.Int32(NV) + cutlass.Int32(q)) * cutlass.Int32(16)
+            sts128_i32(atom, o4, s_mrg.iterator.toint(), boff)
+
+
+# ===========================================================================
+# gather_hint == GVR_GATHER_HINT(GM_, GX_, KPTV)
+# LAZY block-wide (min,max) of logits[pre_idx[j]] over all k hint slots, in
+# fkey space, returned as floats. Off the hot path by design: two dependent
+# memory round trips (k coalesced P[j] words, then k scattered __ldg 4B
+# gathers). Contains EXACTLY 2 barriers — call sites must be block-uniform.
+# Outputs are block-uniform (every thread computes them).
+# NaN-safe degeneracy guard: if !(GM < GX) both become sentinels.
+#
+# x_addr / p_addr: Int64 byte base addresses of THIS ROW of logits/pre_idx
+# (pass `t.iterator.toint() + row * stride_bytes`). s_wmn/s_wmx: Uint32 smem
+# tensors of >= blk//32 slots. Returns (gm, gx) Float32.
+# Both round trips are issued as predicated flat batches.
+# ===========================================================================
+@cute.jit
+def gather_hint(
+    x_addr, p_addr, k, n, tidx, s_wmn, s_wmx, blk: cutlass.Constexpr, kpt: cutlass.Constexpr
+):
+    NW = blk // 32
+    lane = tidx & cutlass.Int32(31)
+    # batch A: KPT coalesced pre_idx loads, predicated flat
+    pvs = []
+    for t in cutlass.range_constexpr(kpt):
+        pv = cutlass.Int32(-1)
+        j = tidx + cutlass.Int32(t * blk)
+        if j < k:
+            pv = ld_g_i32(p_addr, j)
+        pvs.append(pv)
+    # batch B: KPT scattered read-only gathers, predicated flat
+    xs = []
+    for t in cutlass.range_constexpr(kpt):
+        xv = cutlass.Float32(0.0)
+        if cutlass.Uint32(pvs[t]) < cutlass.Uint32(n):  # (unsigned)p < (unsigned)n
+            xv = ldg_f32(x_addr, pvs[t])
+        xs.append(xv)
+    # fold
+    glmin = cutlass.Uint32(0xFFFFFFFF)
+    glmax = cutlass.Uint32(0)
+    for t in cutlass.range_constexpr(kpt):
+        if cutlass.Uint32(pvs[t]) < cutlass.Uint32(n):
+            u2 = fkey(xs[t])
+            if u2 < glmin:
+                glmin = u2
+            if u2 > glmax:
+                glmax = u2
+    # warp redux + staging
+    glmin = warp_min_u32(glmin)
+    glmax = warp_max_u32(glmax)
+    if lane == cutlass.Int32(0):
+        s_wmn[tidx >> cutlass.Int32(5)] = glmin
+        s_wmx[tidx >> cutlass.Int32(5)] = glmax
+    cute.arch.barrier()  # barrier 1/2
+    # cross-warp redux by EVERY thread — block-uniform outputs
+    a2 = cutlass.Uint32(0xFFFFFFFF)
+    c2 = cutlass.Uint32(0)
+    if lane < cutlass.Int32(NW):
+        a2 = s_wmn[lane]
+        c2 = s_wmx[lane]
+    gm = invkey(warp_min_u32(a2))
+    gx = invkey(warp_max_u32(c2))
+    # NaN-safe degeneracy guard: !(GM < GX) — NaN compares false
+    ok = cutlass.Int32(0)
+    if gm < gx:
+        ok = cutlass.Int32(1)
+    if ok == cutlass.Int32(0):
+        gm = cutlass.Float32(SENT_LO)
+        gx = cutlass.Float32(SENT_HI)
+    cute.arch.barrier()  # barrier 2/2
+    return gm, gx
+
+
+# ===========================================================================
+# ==== family: main ============================================
+# ===========================================================================
+"""gvr_main — streaming self-sampling GVR top-K.
+
+Ctor knobs (compile-time, mirror of the CUDA template params):
+    BLK ∈ {1024, 512, 256}, U ∈ {1,2,4,8}, MINB ∈ {1,2,4}, NBS = 256,
+    KPT ∈ {1,2,4,8}, SPLIT ∈ {True, False}
+Derived constexprs (bit-identical to the CUDA):
+    HB=NBS; KBIG=(KPT>=2 && KPT*BLK>=2048); SCPB=(BLK>=1024)?(SPLIT?8192:16384)
+    :(KBIG?8192:4096); CMPB=(BLK>=1024)?(KBIG?4096:2048):1024; SHD=!SPLIT;
+    VSTG=SPLIT||BLK>=512; PFD=(MINB<=2)?min(U,4):0; PF=PFD>0; NATT=SPLIT?1:3.
+
+Signature (ABI parity with the CUDA form incl. dead SCAP_/CMP_):
+    run(logits[b,npad] f32, pre_idx[b,k] i32, out[b,k] i32,
+        n, npad, k, SCAP_, CMP_, R, SMP, TGT, Q, SS2, TGT2, ws)
+Grid dim3(R, b) native 2-D; block BLK; min_blocks_per_mp=MINB is the
+64-register wall; smem via one SmemAllocator blob (all extents compile-time),
+dynamic-equivalent region byte-identical to the host dispatch formula:
+(SCPB+4)*(VSTG?8:4) + (CMPB+1)*8.
+
+int2 staging convention: an int2 (x=value bits, y=index) is ONE little-endian
+Uint64 = (idx << 32) | value_bits, so cbuf2 / g_buf traffic is single u64
+ld/st (__ldcg = _ldcg_v2_i32).
+
+Barrier placement mirrors the CUDA source one-for-one (plus exactly 2 inside
+each gather_hint expansion); scan_cross0 contains NO internal barrier. Do not
+add or drop barriers.
+"""
+
+
+MAXC__main = C.MAXC
+GCAP__main = C.GCAP
+IDXB__main = C.IDXB
+IDXM__main = C.IDXM
+QUADC_CLUS__main = C.QUADC_CLUS
+WS_BYTES = C.GVR_WS_BUF_OFF + MAXC__main * GCAP__main * 8  # 20,973,568
+
+_NEG_INF = float("-inf")
+
+
+# ---------------------------------------------------------------------------
+# single-rounding fma.rn.f32, used at every CUDA fmaf() site: T/Tk/T3 rung
+# math, HIC, window terms. (x-T)*SC classify shapes stay plain sub+mul
+# (structurally uncontractible).
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _fmaf(a, b, c, *, loc=None, ip=None):
+    return cutlass.Float32(
+        mlir_math.fma(
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            fastmath=mlir_arith.FastMathFlags.none,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _st_g_u64(addr_i64, val_u64):
+    """plain st.global.u64 (slab publish, g_don restore)."""
+    p = cute.make_ptr(cutlass.Uint64, addr_i64, cute.AddressSpace.gmem, assumed_align=8)
+    t = cute.make_tensor(p, cute.make_layout((1,)))
+    t[0] = val_u64
+
+
+def _st_g_u32(addr_i64, val_i32):
+    """plain st.global.u32 (g_off restore)."""
+    p = cute.make_ptr(cutlass.Int32, addr_i64, cute.AddressSpace.gmem, assumed_align=4)
+    t = cute.make_tensor(p, cute.make_layout((1,)))
+    t[0] = val_i32
+
+
+@dsl_user_op
+def _st_s_v2_u32(saddr_i32, lo_u32, hi_u32, *, loc=None, ip=None):
+    """st.shared.v2.u32 [saddr], {lo, hi} — the CUDA make_int2 STS.64 spelling.
+    Byte-identical to the little-endian u64 pack ((hi << 32) | lo) but keeps
+    the two words as independent 32-bit registers, so ptxas can coalesce the
+    emission bit-walk's loop-carried (xv, idx) pair straight into the store
+    pair."""
+    mlir_llvm.inline_asm(
+        res=None,
+        operands_=[
+            saddr_i32.ir_value(loc=loc, ip=ip),
+            lo_u32.ir_value(loc=loc, ip=ip),
+            hi_u32.ir_value(loc=loc, ip=ip),
+        ],
+        asm_string="st.shared.v2.u32 [$0], {$1, $2};",
+        constraints="r,r,r",
+        has_side_effects=True,
+        asm_dialect=mlir_llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _pin_i64(v, *, loc=None, ip=None):
+    """Opaque identity mov.b64: pins a loop-invariant Int64 so NVVM cannot
+    rematerialize its defining chain (param ld.const + %ctaid reads + mul/add)
+    into every scf region body."""
+    return cutlass.Int64(
+        mlir_llvm.inline_asm(
+            T.i64(),
+            [v.ir_value(loc=loc, ip=ip)],
+            "mov.b64 $0, $1;",
+            "=l,l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=mlir_llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _pin_i32(v, *, loc=None, ip=None):
+    """Opaque identity mov.b32 (Int32 twin of _pin_i64)."""
+    return cutlass.Int32(
+        mlir_llvm.inline_asm(
+            T.i32(),
+            [v.ir_value(loc=loc, ip=ip)],
+            "mov.b32 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=mlir_llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _ldg_f32_rs(base_addr, idx, sc4):
+    """__ldg(X + idx) with the byte stride riding a register.
+
+    Identical to ldg_f32 except `* 4` multiplies a caller-held Int32: the
+    row base is uniformized into URx by ptxas, IMAD.WIDE cannot encode an
+    immediate stride next to a UR addend, and a constant stride register
+    would otherwise be re-materialized inside the survivor walk. The caller
+    loads the 4 from smem (LDS results are opaque to ptxas value-tracking;
+    asm movs and shfl are not), so the register stays live and the remat
+    disappears."""
+    atom = C.g2r_atom_f32(32, invariant=True)
+    p = cute.make_ptr(
+        cutlass.Float32,
+        base_addr + cutlass.Int64(idx) * cutlass.Int64(sc4),
+        cute.AddressSpace.gmem,
+        assumed_align=4,
+    )
+    frag = cute.make_rmem_tensor((1,), cutlass.Float32)
+    cute.copy(atom, cute.make_tensor(p, cute.make_layout((1,))), frag)
+    return frag[0]
+
+
+@dsl_user_op
+def _smem_addr_reg(addr, *, loc=None, ip=None):
+    """Pin a CTA-shared 32-bit byte address in ONE register.
+
+    Identity `mov` behind an asm boundary: without it LLVM re-folds the
+    `mov.b32 %r, __dynamic_shmem__0` symbol materialisation into EVERY use
+    site inside the divergent emission bit-walk (one extra IMAD.MOV per
+    survivor). The asm result is not duplicable, so the shared window is
+    materialised exactly once. Value-identical: a plain register copy."""
+    return cutlass.Int32(
+        mlir_llvm.inline_asm(
+            T.i32(),
+            [addr.ir_value(loc=loc, ip=ip)],
+            "mov.u32 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=mlir_llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _red_shared_add1(addr, *, loc=None, ip=None):
+    """CUDA `atomicAdd(&hist[bin], 1u)` with the result unused.
+
+    `red` (not `atom`) is the result-less spelling — ptxas lowers it to the
+    same ATOMS.POPC.INC.32 RZ the CUDA arm emits. Same ordering contract as
+    atomic_add_cta (.relaxed scope .cta). Takes the final shared byte
+    address as a plain Int32 so ptxas fuses the shl+add into one LEA
+    against the pinned `_smem_addr_reg` base."""
+    mlir_llvm.inline_asm(
+        res=None,
+        operands_=[addr.ir_value(loc=loc, ip=ip)],
+        asm_string="red.relaxed.cta.shared.add.u32 [$0], 1;",
+        constraints="r",
+        has_side_effects=True,
+        asm_dialect=mlir_llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+class GvrMainKernel:
+    """gvr_main<BLK, U, MINB, NBS, KPT, SPLIT> — streaming self-sampling GVR."""
+
+    def __init__(
+        self,
+        blk: int,
+        u: int,
+        minb: int,
+        nbs: int,
+        kpt: int,
+        split: bool,
+        tshg: bool = False,
+        varlen: bool = False,
+        next_n: int = 1,
+        cr_shift: int = 0,
+        r_const: int = 1,
+    ):
+        assert nbs == 256, "SNB must stay 256"
+        assert blk in (256, 512, 1024) and u in (1, 2, 4, 8)
+        assert kpt in (1, 2, 4, 8) and minb in (1, 2, 4)
+        self.blk = blk
+        self.u = u
+        self.minb = minb
+        self.nbs = nbs
+        self.kpt = kpt
+        self.split = bool(split)
+        # ---- per-row varlen mode (production heuristicTopKDecode contract) --
+        # n and the sampling-ladder scalars are re-derived PER ROW inside the
+        # kernel from a device kv_lens tensor (route_dynamic formula mirror);
+        # the scalar n/SMP/TGT/Q/SS2/TGT2 launch args become dead.  next_n /
+        # cr_shift (log2 compressRatio: 0 = DSv3.2, 2 = DSv4) / r_const (the
+        # frozen grid.x) are compile-time so their divisions strength-reduce.
+        self.varlen = bool(varlen)
+        self.next_n = int(next_n)
+        self.cr_shift = int(cr_shift)
+        self.r_const = int(r_const)
+        if self.varlen:
+            assert self.next_n >= 1 and self.cr_shift in (0, 2) and self.r_const >= 1
+        # TSH-floor staging arm.  SPLIT-only compile-time key; the CUDA form
+        # is a grid-uniform runtime gate over the same predicate
+        # (b > 15 && k <= 1024 && n4 <= 32768).  varlen mode compiles the
+        # machinery in whenever SPLIT and gates it per row at runtime
+        # (tsh_en && n4 <= 32768) — mirroring the CUDA runtime gate.
+        if self.varlen:
+            self.tshg = bool(split)
+        else:
+            self.tshg = bool(tshg) and bool(split)
+        # derived constexprs (bit-identical to the CUDA)
+        self.hb = nbs
+        self.kbig = (kpt >= 2) and (kpt * blk >= 2048)
+        self.scpb = (8192 if split else 16384) if blk >= 1024 else (8192 if self.kbig else 4096)
+        self.cmpb = (4096 if self.kbig else 2048) if blk >= 1024 else 1024
+        self.shd = not split
+        self.vstg = split or blk >= 512
+        self.pfd = (u if u < 4 else 4) if minb <= 2 else 0
+        self.pf = self.pfd > 0
+        self.natt = 1 if split else 3
+        # smem blob byte map: cbuf/cbuf2 alias @0,
+        # ck64 @ 4*(VSTG ? 2*(SCPB+4) : SCPB+4), size (CMPB+1)*8
+        self.ck_off = 4 * ((2 * (self.scpb + 4)) if self.vstg else (self.scpb + 4))
+        assert self.ck_off % 16 == 0, "ck64 must stay 16B aligned (ulonglong2)"
+        self.dyn_bytes = self.ck_off + (self.cmpb + 1) * 8
+        self.lb = self.nbs.bit_length() - 1  # log2(NBS)=8
+
+    # ------------------------------------------------------------------
+    # GVR_EMITC: classify+stage one survivor.
+    # Returns pos+1. Branchless trash slot min(pos, SCPB).
+    # ------------------------------------------------------------------
+    @cute.jit
+    def _emitc(self, xv, idx, pos, TF, SC, hb, cb2, s_hist, s_cbuf, s_cbuf2):
+        SCPB = self.scpb
+        NBS = self.nbs
+        if cutlass.const_expr(not self.split):
+            bn_u = C.f2u_rz((xv - TF) * SC)  # saturating cvt.rzi
+            if bn_u > cutlass.Uint32(NBS - 1):
+                bn_u = cutlass.Uint32(NBS - 1)
+            bn = cutlass.Int32(bn_u)
+            if cutlass.const_expr(self.vstg):
+                # result unused -> resultless red off the pinned hist base
+                # (no per-site smem-base refold)
+                _red_shared_add1(hb + (bn << cutlass.Int32(2)))
+            else:
+                # VSTG=False tuples sit at the 64-register wall: keep the
+                # original spelling, no pinned base here
+                C.atomic_add_cta(s_hist.iterator + bn, cutlass.Int32(1))
+            if cutlass.const_expr(not self.vstg):
+                ps = pos
+                if ps > cutlass.Int32(SCPB):
+                    ps = cutlass.Int32(SCPB)  # trash slot (IMNMX)
+                s_cbuf[ps] = cutlass.Int32(
+                    (bn_u << cutlass.Uint32(IDXB__main)) | cutlass.Uint32(idx)
+                )
+        if cutlass.const_expr(self.vstg):
+            ps = pos
+            if ps > cutlass.Int32(SCPB):
+                ps = cutlass.Int32(SCPB)
+            # int2 {value bits, idx} via st.shared.v2.u32 — same bytes as the
+            # (idx << 32) | bits u64 pack (+0=bits, +4=idx), but no i64
+            # materialization inside the bit-walk; address = one LEA off the
+            # pinned cb2 base
+            _st_s_v2_u32(cb2 + ps * cutlass.Int32(8), C.u32_of_f32(xv), cutlass.Uint32(idx))
+        return pos + cutlass.Int32(1)
+
+    # ------------------------------------------------------------------
+    # two-predicate warp-ballot emit step (shared by P6 and both degen
+    # emits): q1 winners to out[base1+p] p<cap1, q2 ties to out[base2+p]
+    # p<cap2. s_scal[1]=s_o1, s_scal[2]=s_o2.
+    # ------------------------------------------------------------------
+    @cute.jit
+    def _ballot_pair_emit(self, p1, p2, idv, base1, cap1, base2, cap2, out_row, s_scal, lane):
+        n1 = C.ballot(p1 != cutlass.Int32(0))
+        n2 = C.ballot(p2 != cutlass.Int32(0))
+        b1 = cutlass.Int32(0)
+        b2 = cutlass.Int32(0)
+        if lane == cutlass.Int32(0):
+            if n1 != cutlass.Int32(0):
+                b1 = C.atomic_add_cta(s_scal.iterator + 1, cutlass.Int32(C.popc(n1)))
+            if n2 != cutlass.Int32(0):
+                b2 = C.atomic_add_cta(s_scal.iterator + 2, cutlass.Int32(C.popc(n2)))
+        b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+        b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+        lm = cutlass.Int32(cute.arch.lanemask_lt())
+        if p1 != cutlass.Int32(0):
+            p = b1 + cutlass.Int32(C.popc(n1 & lm))
+            if p < cap1:
+                out_row[base1 + p] = idv
+        if p2 != cutlass.Int32(0):
+            p = b2 + cutlass.Int32(C.popc(n2 & lm))
+            if p < cap2:
+                out_row[base2 + p] = idv
+
+    # ------------------------------------------------------------------
+    # kernel
+    # ------------------------------------------------------------------
+    @cute.kernel
+    def kern(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        out: cute.Tensor,
+        ws: cute.Tensor,
+        n: cutlass.Int32,
+        npad: cutlass.Int32,
+        k: cutlass.Int32,
+        scap_dead: cutlass.Int32,
+        cmp_dead: cutlass.Int32,
+        R: cutlass.Int32,
+        SMP: cutlass.Int32,
+        TGT: cutlass.Int32,
+        Q: cutlass.Int32,
+        SS2: cutlass.Int32,
+        TGT2: cutlass.Int32,
+        kv_lens: cute.Tensor,
+        aim_base: cutlass.Int32,
+        sfac: cutlass.Int32,
+        amin: cutlass.Int32,
+        sd_en: cutlass.Int32,
+        tsh_en: cutlass.Int32,
+    ):
+        BLK = self.blk
+        U = self.u
+        NBS = self.nbs
+        KPT = self.kpt
+        SCPB = self.scpb
+        CMPB = self.cmpb
+        PFD = self.pfd
+        NATT = self.natt
+        NW = BLK // 32
+
+        tidx, _, _ = cute.arch.thread_idx()
+        bx, by, _ = cute.arch.block_idx()  # 2-D grid (part, row)
+        row = by
+        part = cutlass.Int32(0)
+        if cutlass.const_expr(self.split):
+            part = bx
+        lane = tidx & cutlass.Int32(31)
+
+        # ================= per-row varlen prologue (varlen mode only) =========
+        # Production contract: row r serves request r // next_n with
+        # kv_len = kv_lens[r // next_n], n = (kv_len - next_n + r % next_n + 1)
+        # >> cr_shift.  The sampling-ladder scalars are then re-derived from
+        # this row's n by the EXACT route_dynamic() host formulas (the scalar
+        # launch args are dead in this mode).  n <= k rows have no runtime
+        # `return` in CuTe DSL: they run the body as a zero-work pass
+        # (n = 0, TGT = INT_MAX so no rung ever accepts) and the identity/pad
+        # emission happens in the epilogue at the end of the kernel.  Every
+        # value below is a pure function of `row`, so all R split CTAs of a
+        # row (and all threads) compute identical scalars — grid-uniform per
+        # row by construction.
+        short = cutlass.Int32(0)
+        n_row = cutlass.Int32(0)
+        tsh_run = cutlass.Int32(1)
+        if cutlass.const_expr(self.varlen):
+            req = row // cutlass.Int32(self.next_n)
+            rr = row % cutlass.Int32(self.next_n)
+            kvl = kv_lens[req]
+            nv = (kvl - cutlass.Int32(self.next_n) + rr + cutlass.Int32(1)) >> cutlass.Int32(
+                self.cr_shift
+            )
+            if nv < cutlass.Int32(0):
+                nv = cutlass.Int32(0)
+            if nv > npad:
+                nv = npad
+            n_row = nv
+            if nv <= k:
+                short = cutlass.Int32(1)
+                n = cutlass.Int32(0)
+                SMP = cutlass.Int32(0)
+                SS2 = cutlass.Int32(1)
+                # "never accepts" sentinels; 2^30-1 so the TGT*2 scan target
+                # stays positive (0x7FFFFFFF would overflow to -2 and flip
+                # every tot0 >= TGT*2 gate on the all-zero histogram)
+                TGT = cutlass.Int32(0x3FFFFFFF)
+                TGT2 = cutlass.Int32(0x3FFFFFFF)
+                Q = cutlass.Int32(0)
+            if short == cutlass.Int32(0):
+                n = nv
+                n4v = n >> cutlass.Int32(2)
+                # Ladder-scalar baselines only: the real SMP/SS2/TGT/TGT2 are
+                # derived by warp0 alone in the block below (bit-identical
+                # formulas) and published through s_lad — every thread's local
+                # copies here are overwritten by the post-barrier smem read.
+                SMP = cutlass.Int32(0)
+                SS2 = cutlass.Int32(1)
+                TGT = cutlass.Int32(0)
+                TGT2 = cutlass.Int32(0)
+                if cutlass.const_expr(self.split):
+                    Q = (n4v + cutlass.Int32(self.r_const - 1)) // cutlass.Int32(self.r_const)
+                else:
+                    Q = cutlass.Int32(0)
+            # per-row TSH-floor runtime gate (CUDA parity: b>15 && k<=1024 in
+            # tsh_en, n4 <= 32768 per row)
+            tsh_run = cutlass.Int32(0)
+            if tsh_en != cutlass.Int32(0):
+                if (n >> cutlass.Int32(2)) <= cutlass.Int32(32768):
+                    tsh_run = cutlass.Int32(1)
+
+        # ---- shared memory (one blob, compile-time offsets) ----
+        smem = SmemAllocator()
+        s_hist = smem.allocate_tensor(
+            cutlass.Int32, cute.make_ordered_layout((self.hb,), order=(0,)), byte_alignment=128
+        )
+        s_ws = smem.allocate_tensor(  # unused; byte parity  # noqa: F841
+            cutlass.Uint32, cute.make_ordered_layout((NW,), order=(0,)), byte_alignment=16
+        )
+        s_wmn = smem.allocate_tensor(
+            cutlass.Uint32, cute.make_ordered_layout((NW,), order=(0,)), byte_alignment=16
+        )
+        s_wmx = smem.allocate_tensor(
+            cutlass.Uint32, cute.make_ordered_layout((NW,), order=(0,)), byte_alignment=16
+        )
+        # crossing-scan result slots (RES_B/M/ABOVE/TOT/B2/B3)
+        s_res = smem.allocate_tensor(
+            cutlass.Int32, cute.make_ordered_layout((8,), order=(0,)), byte_alignment=16
+        )
+        # scalar block: [0]=s_bufn [1]=s_o1 [2]=s_o2 [3]=s_base
+        s_scal = smem.allocate_tensor(
+            cutlass.Int32, cute.make_ordered_layout((4,), order=(0,)), byte_alignment=16
+        )
+        s_pk = smem.allocate_tensor(
+            cutlass.Int64, cute.make_ordered_layout((1,), order=(0,)), byte_alignment=8
+        )
+        s_tsh = smem.allocate_tensor(
+            cutlass.Float32, cute.make_ordered_layout((1,), order=(0,)), byte_alignment=4
+        )
+        # STATIC smem word for the walk's byte stride — kept out of the blob
+        # so dyn_bytes stays equal to the CUDA dispatch's smem. blk==512 VSTG
+        # only.
+        if cutlass.const_expr(self.vstg and self.blk == 512):
+            s_x4 = smem.allocate_tensor(
+                cutlass.Int32, cute.make_ordered_layout((1,), order=(0,)), byte_alignment=4
+            )
+        s_kmm = smem.allocate_tensor(  # [0]=kmin [1]=kmax
+            cutlass.Uint32, cute.make_ordered_layout((2,), order=(0,)), byte_alignment=8
+        )
+        if cutlass.const_expr(self.varlen):
+            # ladder broadcast slots: [0]=SMP [1]=SS2 [2]=TGT [3]=TGT2
+            # (static like s_x4, so dyn_bytes keeps CUDA dispatch parity)
+            s_lad = smem.allocate_tensor(
+                cutlass.Int32, cute.make_ordered_layout((4,), order=(0,)), byte_alignment=16
+            )
+        blob = smem.allocate_tensor(  # dynamic-equivalent region
+            cutlass.Int8, cute.make_ordered_layout((self.dyn_bytes,), order=(0,)), byte_alignment=16
+        )
+        sbase = blob.iterator.toint()
+        s_cbuf = cute.make_tensor(
+            cute.make_ptr(cutlass.Int32, sbase, cute.AddressSpace.smem, assumed_align=16),
+            cute.make_layout((SCPB + 4,)),
+        )
+        s_cbuf2 = cute.make_tensor(
+            cute.make_ptr(cutlass.Uint64, sbase, cute.AddressSpace.smem, assumed_align=16),
+            cute.make_layout((SCPB + 4,)),
+        )
+        ck_addr = sbase + cutlass.Int32(self.ck_off)
+        s_ck64 = cute.make_tensor(
+            cute.make_ptr(cutlass.Uint64, ck_addr, cute.AddressSpace.smem, assumed_align=16),
+            cute.make_layout((CMPB + 1,)),
+        )
+
+        # emission smem bases pinned ONCE, outside the attempt/tile loops
+        # (asm identity mov) — LLVM otherwise refolds the shared-window
+        # materialisation into every _emitc site inside the divergent
+        # bit-walk. VSTG-only: the VSTG=False tuples keep their original
+        # spellings untouched (64-register wall).
+        hb_pin = cutlass.Int32(0)
+        cb2_pin = cutlass.Int32(0)
+        if cutlass.const_expr(self.vstg):
+            hb_pin = _smem_addr_reg(s_hist.iterator.toint())
+            cb2_pin = _smem_addr_reg(s_cbuf2.iterator.toint())
+        # park the stride 4 in the dedicated smem word and load it back —
+        # the LDS result is opaque to ptxas, so the walk's stride register
+        # cannot be re-materialized in-loop (asm-mov and shfl forms are
+        # folded by ptxas value-tracking). blk==512 family ONLY: the other
+        # arms sit at the 64-register wall. Threads are converged here
+        # (kernel prologue), so the one extra barrier is safe.
+        x4_pin = cutlass.Int32(4)
+        if cutlass.const_expr(self.vstg and self.blk == 512):
+            if tidx == cutlass.Int32(0):
+                s_x4[0] = cutlass.Int32(4)
+            cute.arch.barrier()
+            x4_pin = s_x4[0]
+
+        # ---- row bases ----
+        row64 = cutlass.Int64(row)
+        # _pin_i64: keep the row base a REGISTER across the attempt/tile scf
+        # regions (NVVM otherwise re-derives ld.param+%ctaid.y+mul per region)
+        x_addr = _pin_i64(logits.iterator.toint() + row64 * cutlass.Int64(npad) * cutlass.Int64(4))
+        # varlen: pre_idx is REQUEST-level [num_rows/next_n, k] — a request's
+        # next_n rows share one hint row (production contract); legacy mode
+        # keeps the per-row mapping (next_n == 1 makes them identical).
+        prow64 = row64
+        if cutlass.const_expr(self.varlen):
+            prow64 = cutlass.Int64(row // cutlass.Int32(self.next_n))
+        p_addr = pre_idx.iterator.toint() + prow64 * cutlass.Int64(k) * cutlass.Int64(4)
+        out_row = out[row, None]
+        ws_addr = ws.iterator.toint()
+        gdon_addr = ws_addr  # slab views
+        goff_addr = ws_addr + cutlass.Int64(C.GVR_WS_OFF_OFF)
+        gbuf_addr = ws_addr + cutlass.Int64(C.GVR_WS_BUF_OFF)
+        # SPLIT only: row-slab base pinned like x_addr above; the
+        # publish/gather/P5/degen consumers spell gbuf_row + i*8 instead of
+        # re-deriving gbuf_addr + (row64*GCAP__main + i)*8 per candidate
+        # (value-identical by i64 distributivity).
+        gbuf_row = cutlass.Int64(0)
+        if cutlass.const_expr(self.split):
+            gbuf_row = _pin_i64(gbuf_addr + row64 * cutlass.Int64(GCAP__main) * cutlass.Int64(8))
+
+        n4 = n >> cutlass.Int32(2)
+        c0 = cutlass.Int32(0)
+        c1 = n4
+        if cutlass.const_expr(self.split):
+            c0 = part * Q
+            c1 = c0 + Q
+            if c1 > n4:
+                c1 = n4
+        tail0 = n4 << cutlass.Int32(2)
+        tailn = cutlass.Int32(0)
+        if part == cutlass.Int32(0):
+            tailn = n - tail0
+
+        if tidx == cutlass.Int32(0):
+            s_scal[0] = cutlass.Int32(0)  # s_bufn
+            s_res[C.RES_B2] = cutlass.Int32(-1)
+            s_res[C.RES_B3] = cutlass.Int32(-1)
+        if tidx < cutlass.Int32(self.hb):  # HB<=BLK always
+            s_hist[tidx] = cutlass.Int32(0)
+
+        # ===== varlen: warp0-only ladder mirror + register-free L2 hints =====
+        # The sampling-ladder scalars are a pure function of the row; issuing
+        # the mirror chain (runtime divides + isqrt fixups) per thread costs
+        # more instructions than the rest of the kernel on 1-row launches.
+        # warp0 alone walks the chain and publishes the four derived scalars
+        # through s_lad; the other warps spend the wait issuing L2 prefetch
+        # hints for this CTA's own P3 slice (register-free, so zero pressure
+        # on the 64-register arms — the PRIME-LATE register loads below are
+        # untouched and simply hit L2).  Values are bit-identical to the
+        # per-thread derivation this replaces.
+        if cutlass.const_expr(self.varlen):
+            if tidx < cutlass.Int32(32):
+                if short == cutlass.Int32(0):
+                    # ---- aim ladder (cheap mirror) ----
+                    # The ladder scalars steer the sampling rung only —
+                    # exactness is schedule-invariant (retry/degen close every
+                    # miss), so +-1 drift vs the host double form is allowed.
+                    # Serial latency dominates (this chain sits in front of a
+                    # barrier): runtime divides become MUFU.RCP multiplies and
+                    # the isqrt fixup loops collapse to single steps (the f32
+                    # sqrt of an exactly-representable int (6n <= 2^23) is
+                    # within 1 of isqrt, so one correction per side suffices).
+                    # Q (chunk ownership) stays exact — compile-time divisor.
+                    x6 = cutlass.Int32(6) * n
+                    ri = cutlass.Int32(cmath.sqrt(cutlass.Float32(x6)))
+                    if ri * ri > x6:
+                        ri = ri - cutlass.Int32(1)
+                    if (ri + cutlass.Int32(1)) * (ri + cutlass.Int32(1)) <= x6:
+                        ri = ri + cutlass.Int32(1)
+                    r6 = ri
+                    if x6 - ri * ri > ri:
+                        r6 = ri + cutlass.Int32(1)
+                    aim = aim_base
+                    if r6 > aim:
+                        aim = r6
+                    if cutlass.const_expr(self.r_const > 1):
+                        if aim < amin:
+                            aim = amin
+                    scap_c = cutlass.Int32(SCPB)  # SCAP == SCPB for gvr_main (proven identity)
+                    if aim > (scap_c >> cutlass.Int32(1)):
+                        aim = scap_c >> cutlass.Int32(1)
+                    if aim < k:
+                        aim = k
+                    n4w = n >> cutlass.Int32(2)
+                    # pair-sample gate: (n > SCAP or small_dense) and n4 >= 4;
+                    # small_dense = k > 1024 and not big and n <= SCAP and n > 2k
+                    # (k/big folded into the launch-constant sd_en flag).
+                    gate = cutlass.Int32(0)
+                    if n > scap_c:
+                        gate = cutlass.Int32(1)
+                    if sd_en != cutlass.Int32(0):
+                        if n <= scap_c:
+                            if n > (k << cutlass.Int32(1)):
+                                gate = cutlass.Int32(1)
+                    if n4w < cutlass.Int32(4):
+                        gate = cutlass.Int32(0)
+                    if gate != cutlass.Int32(0):
+                        # sel = sfac*n // aim via rcp (sfac*n <= 2^24: f32-exact
+                        # to the last unit; quotient error < 1 => +-1 drift)
+                        sel = cutlass.Int32(
+                            cutlass.Float32(sfac * n) * cute.arch.rcp_approx(cutlass.Float32(aim))
+                        )
+                        if sel < cutlass.Int32(256):
+                            sel = cutlass.Int32(256)
+                        nh = n >> cutlass.Int32(1)
+                        if sel > nh:
+                            sel = nh
+                        pairs = sel >> cutlass.Int32(3)
+                        if pairs < cutlass.Int32(1):
+                            pairs = cutlass.Int32(1)
+                        half = n4w >> cutlass.Int32(1)
+                        if half < cutlass.Int32(1):
+                            half = cutlass.Int32(1)
+                        if pairs > half:
+                            pairs = half
+                        SS2 = cutlass.Int32(
+                            cutlass.Float32(half) * cute.arch.rcp_approx(cutlass.Float32(pairs))
+                        )
+                        if SS2 < cutlass.Int32(1):
+                            SS2 = cutlass.Int32(1)
+                        SMP = cutlass.Int32(
+                            cutlass.Float32(half) * cute.arch.rcp_approx(cutlass.Float32(SS2))
+                        )
+                        # sample-window guard: the P1 gather indexes up to
+                        # ~SMP*SS2*2 f32x4 lines; keep SMP*SS2 <= half so the
+                        # window never walks past the row (approx error is
+                        # bounded by +1, one decrement closes it)
+                        if SMP * SS2 > half:
+                            SMP = SMP - cutlass.Int32(1)
+                        if SMP < cutlass.Int32(1):
+                            SMP = cutlass.Int32(1)
+                        # TGT/TGT2: i64 products // n -> f32 mul + one rcp(n).
+                        # aim/SMP/k/n are all f32-exact here (<= 2^20); the
+                        # quotients are <= 8*aim ~ 2^16, so the approx error
+                        # stays far below 1 unit — +-1 at worst on the floor.
+                        rn_ = cute.arch.rcp_approx(cutlass.Float32(n))
+                        smp8f = cutlass.Float32(SMP) * cutlass.Float32(8.0)
+                        TGT = cutlass.Int32(cutlass.Float32(aim) * smp8f * rn_)
+                        if TGT < cutlass.Int32(1):
+                            TGT = cutlass.Int32(1)
+                        TGT2 = cutlass.Int32(cutlass.Float32(k) * smp8f * rn_)
+                        if TGT2 < cutlass.Int32(1):
+                            TGT2 = cutlass.Int32(1)
+                if tidx == cutlass.Int32(0):
+                    s_lad[0] = SMP
+                    s_lad[1] = SS2
+                    s_lad[2] = TGT
+                    s_lad[3] = TGT2
+            # Register-free L2 hints for the first U-batch of this CTA's own
+            # P3 slice (clamped in-row): the data P3 touches first starts
+            # flowing while warp0 walks the chain. Short rows clamp every
+            # hint to the row's last line — harmless.
+            plim4 = (npad >> cutlass.Int32(2)) - cutlass.Int32(1)
+            for uu in cutlass.range_constexpr(U):
+                # NOTE: names must not collide with the PRIME-LATE block's
+                # i_/ic — the DSL kills inner-scope names at region exit and
+                # a later same-name assignment inside a dynamic `if` trips
+                # "is None prior to this if".
+                pic = c0 + tidx + cutlass.Int32(uu * BLK)
+                if pic >= c1:
+                    pic = plim4
+                C._prefetch_l2(x_addr + cutlass.Int64(pic) * cutlass.Int64(16))
+            cute.arch.barrier()  # publish s_lad (also covers the smem inits)
+            SMP = s_lad[0]
+            SS2 = s_lad[1]
+            TGT = s_lad[2]
+            TGT2 = s_lad[3]
+
+        # ============ P1: sample prefetch (hint gather LAZY) =================
+        atom128 = C.g2r_atom_f32(128, invariant=True)
+        fsa = cute.make_rmem_tensor((4,), cutlass.Float32)
+        fsb = cute.make_rmem_tensor((4,), cutlass.Float32)
+        shas = cutlass.Int32(0)
+        if tidx < SMP:
+            shas = cutlass.Int32(1)
+        if shas != cutlass.Int32(0):
+            p4 = tidx * SS2 * cutlass.Int32(2)
+            C.ld_g_f32x4(atom128, x_addr, p4, fsa)
+            C.ld_g_f32x4(atom128, x_addr, p4 + cutlass.Int32(1), fsb)
+
+        # ============ P2: quantile rung from the sample ======================
+        smn = cutlass.Float32(float("inf"))
+        smx = cutlass.Float32(float("-inf"))
+        if shas != cutlass.Int32(0):
+            for t in cutlass.range_constexpr(4):
+                smn = C.fmin_f32(smn, fsa[t])
+                smx = C.fmax_f32(smx, fsa[t])
+            for t in cutlass.range_constexpr(4):
+                smn = C.fmin_f32(smn, fsb[t])
+                smx = C.fmax_f32(smx, fsb[t])
+        fma_ = cute.make_rmem_tensor((4,), cutlass.Float32)  # strided-tail pair bufs
+        fmb_ = cute.make_rmem_tensor((4,), cutlass.Float32)
+        j = tidx + cutlass.Int32(BLK)  # strided tail
+        while j < SMP:
+            p4 = j * SS2 * cutlass.Int32(2)
+            C.ld_g_f32x4(atom128, x_addr, p4, fma_)
+            C.ld_g_f32x4(atom128, x_addr, p4 + cutlass.Int32(1), fmb_)
+            for t in cutlass.range_constexpr(4):
+                smn = C.fmin_f32(smn, fma_[t])
+                smx = C.fmax_f32(smx, fma_[t])
+            for t in cutlass.range_constexpr(4):
+                smn = C.fmin_f32(smn, fmb_[t])
+                smx = C.fmax_f32(smx, fmb_[t])
+            j = j + cutlass.Int32(BLK)
+        a0 = C.warp_min_u32(C.fkey(smn))
+        c0m = C.warp_max_u32(C.fkey(smx))
+        if lane == cutlass.Int32(0):
+            s_wmn[tidx >> cutlass.Int32(5)] = a0
+            s_wmx[tidx >> cutlass.Int32(5)] = c0m
+        cute.arch.barrier()  # ---- barrier (sample redux publish) ----
+
+        # PRIME-LATE prefetch block: strictly after the barrier.
+        lim4 = (npad >> cutlass.Int32(2)) - cutlass.Int32(1)
+        pf = [cute.make_rmem_tensor((4,), cutlass.Float32) for _ in range(max(PFD, 1))]
+        if cutlass.const_expr(self.pf):
+            fullsl = cutlass.Int32(0)
+            if (c1 - c0) >= cutlass.Int32(BLK * U):
+                fullsl = cutlass.Int32(1)
+            if fullsl != cutlass.Int32(0):  # prime, full slice
+                for uu in cutlass.range_constexpr(PFD):
+                    C.ld_g_f32x4(atom128, x_addr, c0 + tidx + cutlass.Int32(uu * BLK), pf[uu])
+            else:  # clamped prime
+                for uu in cutlass.range_constexpr(PFD):
+                    i_ = c0 + tidx + cutlass.Int32(uu * BLK)
+                    ic = i_
+                    if ic >= c1:
+                        ic = lim4
+                    C.ld_g_f32x4(atom128, x_addr, ic, pf[uu])
+            # asm prefetch site #1: gate (c1-c0)>=2*BLK*U && SMP>=160
+            g1 = cutlass.Int32(0)
+            if (c1 - c0) >= cutlass.Int32(2 * BLK * U):
+                if SMP >= cutlass.Int32(160):
+                    g1 = cutlass.Int32(1)
+            if g1 != cutlass.Int32(0):
+                for uu in cutlass.range_constexpr(PFD, U):
+                    C._prefetch_l2(
+                        x_addr
+                        + cutlass.Int64(c0 + tidx + cutlass.Int32(uu * BLK)) * cutlass.Int64(16)
+                    )
+        if cutlass.const_expr((not self.pf) and (not self.split)):
+            fullsl = cutlass.Int32(0)
+            if (c1 - c0) >= cutlass.Int32(BLK * U):
+                fullsl = cutlass.Int32(1)
+            if fullsl != cutlass.Int32(0):  # prefetch site #2
+                for uu in cutlass.range_constexpr(U):
+                    C._prefetch_l2(
+                        x_addr
+                        + cutlass.Int64(c0 + tidx + cutlass.Int32(uu * BLK)) * cutlass.Int64(16)
+                    )
+            else:
+                if SMP > cutlass.Int32(0):  # prefetch site #3
+                    for uu in cutlass.range_constexpr(U):
+                        i_ = c0 + tidx + cutlass.Int32(uu * BLK)
+                        ic = i_
+                        if ic >= c1:
+                            ic = lim4
+                        C._prefetch_l2(x_addr + cutlass.Int64(ic) * cutlass.Int64(16))
+
+        # cross-warp sample reduce
+        av = cutlass.Uint32(0xFFFFFFFF)
+        cv = cutlass.Uint32(0)
+        if lane < cutlass.Int32(NW):
+            av = s_wmn[lane]
+            cv = s_wmx[lane]
+        SMIN = C.invkey(C.warp_min_u32(av))
+        SMAX = C.invkey(C.warp_max_u32(cv))
+
+        GMIN = cutlass.Float32(C.SENT_LO)  # sentinels
+        GMAX = cutlass.Float32(C.SENT_HI)
+        T = cutlass.Float32(_NEG_INF)
+        HIC = cutlass.Float32(_NEG_INF)
+        w = cutlass.Float32(0.0)
+        sok = cutlass.Int32(0)
+        if SMP > cutlass.Int32(0):
+            if SMAX > SMIN:
+                sok = cutlass.Int32(1)
+        if sok != cutlass.Int32(0):  # sample histogram
+            w = (SMAX - SMIN) * cutlass.Float32(1.0 / 256.0)
+            # rcp.approx.ftz.f32 = the CUDA arm's --use_fast_math 1.0f/w
+            # (bare MUFU.RCP, no Newton refinement) — bitwise-aligned scale
+            sc_s = cute.arch.rcp_approx(w)
+            if shas != cutlass.Int32(0):
+                for t in cutlass.range_constexpr(4):
+                    bq = C.f2s_rz((fsa[t] - SMIN) * sc_s)
+                    if bq > cutlass.Int32(NBS - 1):
+                        bq = cutlass.Int32(NBS - 1)
+                    C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                for t in cutlass.range_constexpr(4):
+                    bq = C.f2s_rz((fsb[t] - SMIN) * sc_s)
+                    if bq > cutlass.Int32(NBS - 1):
+                        bq = cutlass.Int32(NBS - 1)
+                    C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+            j = tidx + cutlass.Int32(BLK)  # tail re-loads
+            while j < SMP:
+                p4 = j * SS2 * cutlass.Int32(2)
+                C.ld_g_f32x4(atom128, x_addr, p4, fma_)
+                C.ld_g_f32x4(atom128, x_addr, p4 + cutlass.Int32(1), fmb_)
+                for t in cutlass.range_constexpr(4):
+                    bq = C.f2s_rz((fma_[t] - SMIN) * sc_s)
+                    if bq > cutlass.Int32(NBS - 1):
+                        bq = cutlass.Int32(NBS - 1)
+                    C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                for t in cutlass.range_constexpr(4):
+                    bq = C.f2s_rz((fmb_[t] - SMIN) * sc_s)
+                    if bq > cutlass.Int32(NBS - 1):
+                        bq = cutlass.Int32(NBS - 1)
+                    C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                j = j + cutlass.Int32(BLK)
+        cute.arch.barrier()  # ---- barrier (sample histogram) ----
+        # triple-target ZERO scan: TGT / TGT2 / 2*TGT
+        # (THREE = SHD || gated-SPLIT)
+        C.scan_cross0(
+            s_hist,
+            TGT,
+            tidx,
+            s_res,
+            TGT2,
+            TGT * cutlass.Int32(2),
+            s_hist,
+            nb=NBS,
+            zero=True,
+            two=True,
+            three=(self.shd or self.tshg),
+        )
+        cute.arch.barrier()  # ---- barrier (scan publish) ----
+
+        tot0 = s_res[C.RES_TOT]
+        b1v = s_res[C.RES_B]
+        if sok != cutlass.Int32(0):
+            if tot0 >= TGT:
+                T = _fmaf(cutlass.Float32(b1v), w, SMIN)
+        Trung = T  # snapshot
+        needg = cutlass.Int32(1)  # degenerate sample
+        if T > cutlass.Float32(_NEG_INF):
+            needg = cutlass.Int32(0)
+        if needg != cutlass.Int32(0):
+            GMIN, GMAX = C.gather_hint(
+                x_addr, p_addr, k, n, tidx, s_wmn, s_wmx, blk=BLK, kpt=KPT
+            )  # 2 barriers inside
+            T = GMIN
+        if sok != cutlass.Int32(0):  # HIC tighten
+            if tot0 >= TGT:
+                b2v = s_res[C.RES_B2]
+                if b2v >= cutlass.Int32(0):
+                    Tk = _fmaf(cutlass.Float32(b2v), w, SMIN)
+                    anch = T
+                    if cutlass.const_expr(not self.split):
+                        anch = C.fmin_f32(T, Trung)
+                    d_ = C.fmax_f32(Tk - anch, cutlass.Float32(0.0))
+                    HIC = C.fmax_f32(
+                        _fmaf(cutlass.Float32(4.0), d_, T), _fmaf(cutlass.Float32(8.0), w, T)
+                    )
+        if cutlass.const_expr(self.shd or self.tshg):  # TSH floor (+gated SPLIT)
+            if tidx == cutlass.Int32(0):
+                t5 = cutlass.Float32(_NEG_INF)
+                if sok != cutlass.Int32(0):
+                    if tot0 >= TGT * cutlass.Int32(2):
+                        b3v = s_res[C.RES_B3]
+                        if b3v >= cutlass.Int32(0):
+                            if T > GMIN:
+                                T3 = _fmaf(cutlass.Float32(b3v), w, SMIN)
+                                if T3 < T:
+                                    t5 = T3
+                s_tsh[0] = t5
+
+        if cutlass.const_expr(self.tshg):
+            # TSH-FLOOR STAGING: SPLIT has no retry ladder, so a rung
+            # overshoot (count(>=T) < k) used to hand the LAST CTA a
+            # single-CTA whole-row narrowing.  Stage at the sample's
+            # rank-(2*TGT) floor instead: staged population ~aim -> ~2*aim,
+            # and the merged histogram contains the k-crossing whenever
+            # count(>=TSH) >= k.  TSH miss falls to GMIN/degen unchanged.
+            cute.arch.barrier()
+            t5s = s_tsh[0]
+            # varlen: per-row runtime gate (tsh_run == 1 always in legacy
+            # mode, so legacy codegen semantics are unchanged)
+            if tsh_run != cutlass.Int32(0):
+                if t5s > cutlass.Float32(_NEG_INF):
+                    if t5s < T:
+                        T = t5s
+
+        # ============ attempt loop — MUST NOT unroll ============
+        listN = cutlass.Int32(0)
+        above = cutlass.Int32(0)
+        m = cutlass.Int32(0)
+        need = cutlass.Int32(0)
+        B = cutlass.Int32(0)
+        SC = cutlass.Float32(1.0)
+        TF = T
+        complete = cutlass.Int32(0)
+        valid = cutlass.Int32(0)
+        fromg = cutlass.Int32(0)
+        alive = cutlass.Int32(1)
+
+        fr = [
+            cute.make_rmem_tensor((4,), cutlass.Float32) for _ in range(max(U - PFD, 1))
+        ]  # explicit batch
+        att = cutlass.Int32(0)
+        running = cutlass.Int32(1)
+        while running != cutlass.Int32(0):
+            if cutlass.const_expr(not self.split):  # SPLIT never retries (NATT=1)
+                if att > cutlass.Int32(0):  # retry reset
+                    if cutlass.const_expr(self.pf):
+                        # exactness: re-prime pf[] (holds stale roll data)
+                        fullsl = cutlass.Int32(0)
+                        if (c1 - c0) >= cutlass.Int32(BLK * U):
+                            fullsl = cutlass.Int32(1)
+                        if fullsl != cutlass.Int32(0):
+                            for uu in cutlass.range_constexpr(PFD):
+                                C.ld_g_f32x4(
+                                    atom128, x_addr, c0 + tidx + cutlass.Int32(uu * BLK), pf[uu]
+                                )
+                        else:
+                            for uu in cutlass.range_constexpr(PFD):
+                                i_ = c0 + tidx + cutlass.Int32(uu * BLK)
+                                ic = i_
+                                if ic >= c1:
+                                    ic = lim4
+                                C.ld_g_f32x4(atom128, x_addr, ic, pf[uu])
+                    if tidx < cutlass.Int32(NBS):
+                        s_hist[tidx] = cutlass.Int32(0)
+                    if tidx == cutlass.Int32(0):
+                        s_scal[0] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (retry reset) ----
+
+            TF = T  # window
+            hi = C.fmax_f32(GMAX, T)
+            if HIC > T:
+                if HIC < hi:
+                    hi = HIC
+            WD = (hi - T) * cutlass.Float32(1.0 / 256.0)
+            wdok = cutlass.Int32(0)
+            if WD > cutlass.Float32(0.0):
+                wdok = cutlass.Int32(1)
+            if wdok == cutlass.Int32(0):
+                WD = cutlass.Float32(1e-30)
+            # CUDA compiles its own `1.0f / WD` here to a bare MUFU.RCP
+            # (approximate); div.rn's dependent rcp+Newton+CALL chain
+            # serializes the attempt prologue. blk==512 ONLY: the
+            # (256,8,4,·) family keeps the original div.rn spelling below.
+            if cutlass.const_expr(self.blk == 512):
+                SC = cute.arch.rcp_approx(WD)
+            else:
+                SC = cutlass.Float32(1.0) / WD
+
+            # ---- P3 row pass ----
+            span = c1 - c0
+            step = cutlass.Int32(BLK * U)
+            nFull = cutlass.Int32(0)
+            rem = cutlass.Int32(0)
+            if span > cutlass.Int32(0):  # peel
+                nFull = span // step
+                rem = span - nFull * step
+            # _pin_i32: the isfull peel predicate reads nFull every tile iter;
+            # unpinned, NVVM re-derives the whole ld.param+shr/sel div chain
+            # at the loop head
+            nFull = _pin_i32(nFull)
+            nIt = nFull
+            if rem > cutlass.Int32(0):
+                nIt = nIt + cutlass.Int32(1)
+            # _pin_i32: stop NVVM re-deriving the ceil-div bound (ld.param n +
+            # shr/sel chain) inside the tile-loop condition region per iter
+            nIt = _pin_i32(nIt)
+
+            it = cutlass.Int32(0)
+            while it < nIt:
+                i0 = c0 + it * step + tidx
+                M = cutlass.Int32(0)
+                isfull = cutlass.Int32(0)
+                if it < nFull:
+                    isfull = cutlass.Int32(1)
+                if isfull != cutlass.Int32(0):  # full body
+                    for uu in cutlass.range_constexpr(PFD, U):
+                        C.ld_g_f32x4(atom128, x_addr, i0 + cutlass.Int32(uu * BLK), fr[uu - PFD])
+                    for uu in cutlass.range_constexpr(U):
+                        if cutlass.const_expr(uu < PFD):
+                            vv = pf[uu]
+                        else:
+                            vv = fr[uu - PFD]
+                        for q in cutlass.range_constexpr(4):
+                            M = M | (cutlass.Int32(vv[q] >= TF) << cutlass.Int32(uu * 4 + q))
+                else:  # partial body
+                    for uu in cutlass.range_constexpr(PFD, U):
+                        i_ = i0 + cutlass.Int32(uu * BLK)
+                        ic = i_
+                        if ic >= c1:
+                            ic = lim4  # clamped address
+                        C.ld_g_f32x4(atom128, x_addr, ic, fr[uu - PFD])
+                    for uu in cutlass.range_constexpr(U):
+                        if cutlass.const_expr(uu < PFD):
+                            vv = pf[uu]
+                        else:
+                            vv = fr[uu - PFD]
+                        i_ = i0 + cutlass.Int32(uu * BLK)
+                        okq = cutlass.Int32(0)
+                        if i_ < c1:
+                            okq = cutlass.Int32(1)
+                        if okq != cutlass.Int32(0):  # ok-gated (+inf-pad escape)
+                            for q in cutlass.range_constexpr(4):
+                                M = M | (cutlass.Int32(vv[q] >= TF) << cutlass.Int32(uu * 4 + q))
+                # prefetch roll-forward BEFORE reservation/walk
+                if cutlass.const_expr(self.pf):
+                    hasnext = cutlass.Int32(0)
+                    if it + cutlass.Int32(1) < nIt:
+                        hasnext = cutlass.Int32(1)
+                    if hasnext != cutlass.Int32(0):
+                        j0 = i0 + step
+                        infull = cutlass.Int32(0)  # warp-uniform peel
+                        if it + cutlass.Int32(1) < nFull:
+                            infull = cutlass.Int32(1)
+                        if infull != cutlass.Int32(0):
+                            for uu in cutlass.range_constexpr(PFD):
+                                C.ld_g_f32x4(atom128, x_addr, j0 + cutlass.Int32(uu * BLK), pf[uu])
+                        else:
+                            for uu in cutlass.range_constexpr(PFD):
+                                j_ = j0 + cutlass.Int32(uu * BLK)
+                                jc = j_
+                                if jc >= c1:
+                                    jc = lim4
+                                C.ld_g_f32x4(atom128, x_addr, jc, pf[uu])
+                # warp-aggregated reservation
+                cnt = cutlass.Int32(C.popc(M))
+                inc = C.warp_incl_scan_add(cnt, lane)
+                bpos = cutlass.Int32(0)
+                if lane == cutlass.Int32(31):
+                    if inc != cutlass.Int32(0):
+                        bpos = C.atomic_add_cta(s_scal.iterator + 0, inc)
+                pos = cute.arch.shuffle_sync(bpos, cutlass.Int32(31)) + (inc - cnt)
+                # survivor bit-walk, software-pipelined ONE deep;
+                # reload X[idx] — do NOT hold the U float4s (spills)
+                if M != cutlass.Int32(0):
+                    bp = C.ffs_m1(M)
+                    M = M & (M - cutlass.Int32(1))
+                    idx = (
+                        (i0 + (bp >> cutlass.Int32(2)) * cutlass.Int32(BLK)) << cutlass.Int32(2)
+                    ) + (bp & cutlass.Int32(3))
+                    if cutlass.const_expr(self.vstg and self.blk == 512):
+                        xv = _ldg_f32_rs(x_addr, idx, x4_pin)
+                    else:
+                        xv = C.ldg_f32(x_addr, idx)
+                    while M != cutlass.Int32(0):
+                        bp2 = C.ffs_m1(M)
+                        M = M & (M - cutlass.Int32(1))
+                        idx2 = (
+                            (i0 + (bp2 >> cutlass.Int32(2)) * cutlass.Int32(BLK))
+                            << cutlass.Int32(2)
+                        ) + (bp2 & cutlass.Int32(3))
+                        if cutlass.const_expr(self.vstg and self.blk == 512):
+                            xv2 = _ldg_f32_rs(x_addr, idx2, x4_pin)
+                        else:
+                            xv2 = C.ldg_f32(x_addr, idx2)
+                        pos = self._emitc(
+                            xv, idx, pos, TF, SC, hb_pin, cb2_pin, s_hist, s_cbuf, s_cbuf2
+                        )
+                        idx = idx2
+                        xv = xv2
+                    pos = self._emitc(
+                        xv, idx, pos, TF, SC, hb_pin, cb2_pin, s_hist, s_cbuf, s_cbuf2
+                    )
+                it = it + cutlass.Int32(1)
+            # scalar tail, part 0 only
+            i = tidx
+            while i < tailn:
+                x = C.ldg_f32(x_addr, tail0 + i)
+                if x >= TF:
+                    post = C.atomic_add_cta(s_scal.iterator + 0, cutlass.Int32(1))
+                    post = self._emitc(
+                        x, tail0 + i, post, TF, SC, hb_pin, cb2_pin, s_hist, s_cbuf, s_cbuf2
+                    )
+                i = i + cutlass.Int32(BLK)
+            cute.arch.barrier()  # ---- barrier (row pass) ----
+            myn = s_scal[0]
+
+            if cutlass.const_expr(self.split):
+                # ---- SLAB HAND-OFF; exactly ONE attempt ----
+                if tidx == cutlass.Int32(0):
+                    pgo = cute.make_ptr(
+                        cutlass.Int32,
+                        goff_addr + row64 * cutlass.Int64(4),
+                        cute.AddressSpace.gmem,
+                        assumed_align=4,
+                    )
+                    s_scal[3] = cutlass.Int32(cute.arch.atomic_add(pgo, myn))
+                cute.arch.barrier()  # ---- barrier (slab offset) ----
+                base = s_scal[3]
+                if myn <= cutlass.Int32(SCPB):  # coalesced publish
+                    i = tidx
+                    while i < myn:
+                        p = base + i
+                        if p < cutlass.Int32(GCAP__main):
+                            _st_g_u64(gbuf_row + cutlass.Int64(p) * cutlass.Int64(8), s_cbuf2[i])
+                        i = i + cutlass.Int32(BLK)
+                else:  # overflow re-sweep
+                    if tidx == cutlass.Int32(0):
+                        s_scal[0] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (overflow reset) ----
+                    lo2 = c0 << cutlass.Int32(2)
+                    hi2 = c1 << cutlass.Int32(2)
+                    i = lo2 + tidx
+                    while i < hi2:
+                        x = C.ldg_f32(x_addr, i)
+                        if x >= TF:
+                            pq = C.atomic_add_cta(s_scal.iterator + 0, cutlass.Int32(1))
+                            p = base + pq
+                            if p < cutlass.Int32(GCAP__main):
+                                _st_g_u64(
+                                    gbuf_row + cutlass.Int64(p) * cutlass.Int64(8),
+                                    (cutlass.Uint64(cutlass.Uint32(i)) << cutlass.Uint64(32))
+                                    | cutlass.Uint64(C.u32_of_f32(x)),
+                                )
+                        i = i + cutlass.Int32(BLK)
+                    i = tidx  # true tail
+                    while i < tailn:
+                        x = C.ldg_f32(x_addr, tail0 + i)
+                        if x >= TF:
+                            pq = C.atomic_add_cta(s_scal.iterator + 0, cutlass.Int32(1))
+                            p = base + pq
+                            if p < cutlass.Int32(GCAP__main):
+                                _st_g_u64(
+                                    gbuf_row + cutlass.Int64(p) * cutlass.Int64(8),
+                                    (
+                                        cutlass.Uint64(cutlass.Uint32(tail0 + i))
+                                        << cutlass.Uint64(32)
+                                    )
+                                    | cutlass.Uint64(C.u32_of_f32(x)),
+                                )
+                        i = i + cutlass.Int32(BLK)
+                cute.arch.barrier()  # ---- barrier (slab publish) ----
+                if tidx == cutlass.Int32(0):  # release + RMW
+                    C.threadfence_gpu()
+                    pdon = cute.make_ptr(
+                        cutlass.Int64,
+                        gdon_addr + row64 * cutlass.Int64(8),
+                        cute.AddressSpace.gmem,
+                        assumed_align=8,
+                    )
+                    s_pk[0] = C.atomic_add_u64_gpu(
+                        pdon, cutlass.Int64(1 << 32) + cutlass.Int64(myn)
+                    )
+                cute.arch.barrier()  # ---- barrier (arrival word) ----
+                pk = s_pk[0]
+                alive = cutlass.Int32(0)  # last-CTA test
+                if cutlass.Int32(pk >> cutlass.Int64(32)) == R - cutlass.Int32(1):
+                    alive = cutlass.Int32(1)
+                if alive != cutlass.Int32(0):
+                    C.threadfence_gpu()  # acquire
+                    if tidx == cutlass.Int32(0):  # ZERO-RESTORE
+                        _st_g_u32(goff_addr + row64 * cutlass.Int64(4), cutlass.Int32(0))
+                        _st_g_u64(gdon_addr + row64 * cutlass.Int64(8), cutlass.Uint64(0))
+                    total = cutlass.Int32(pk & cutlass.Int64(0xFFFFFFFF)) + myn
+                    if total <= cutlass.Int32(GCAP__main):  # one-pass consume
+                        listN = total
+                        if total > cutlass.Int32(SCPB):
+                            fromg = cutlass.Int32(1)
+                        i = tidx
+                        while i < listN:
+                            gvx, gvy = C._ldcg_v2_i32(
+                                gbuf_row + cutlass.Int64(i) * cutlass.Int64(8)
+                            )
+                            if fromg == cutlass.Int32(0):
+                                s_cbuf2[i] = (
+                                    cutlass.Uint64(cutlass.Uint32(gvy)) << cutlass.Uint64(32)
+                                ) | cutlass.Uint64(cutlass.Uint32(gvx))
+                            bq = C.f2s_rz((C.f32_of_i32(gvx) - TF) * SC)
+                            if bq > cutlass.Int32(NBS - 1):
+                                bq = cutlass.Int32(NBS - 1)
+                            # resultless red off the pinned hist base
+                            _red_shared_add1(hb_pin + (bq << cutlass.Int32(2)))
+                            i = i + cutlass.Int32(BLK)
+                        cute.arch.barrier()  # ---- barrier (slab histogram) ----
+                        C.scan_cross0(
+                            s_hist,
+                            k,
+                            tidx,
+                            s_res,
+                            cutlass.Int32(0),
+                            cutlass.Int32(0),
+                            s_hist,
+                            nb=NBS,
+                            zero=False,
+                        )
+                        cute.arch.barrier()  # ---- barrier (scan publish) ----
+                        if s_res[C.RES_TOT] >= k:
+                            valid = cutlass.Int32(1)
+                            complete = cutlass.Int32(1)
+                            above = s_res[C.RES_ABOVE]
+                            m = s_res[C.RES_M]
+                            need = k - above
+                            B = s_res[C.RES_B]
+                running = cutlass.Int32(0)  # break (NATT==1)
+            else:
+                # ---- non-split verify + rung ladder ----
+                C.scan_cross0(
+                    s_hist,
+                    k,
+                    tidx,
+                    s_res,
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    s_hist,
+                    nb=NBS,
+                    zero=False,
+                )
+                cute.arch.barrier()  # ---- barrier (verify scan) ----
+                tot = s_res[C.RES_TOT]
+                acc = cutlass.Int32(0)
+                if tot >= k:
+                    acc = cutlass.Int32(1)
+                if acc != cutlass.Int32(0):  # accept
+                    valid = cutlass.Int32(1)
+                    complete = cutlass.Int32(0)
+                    if myn <= cutlass.Int32(SCPB):
+                        complete = cutlass.Int32(1)
+                    listN = myn
+                    above = s_res[C.RES_ABOVE]
+                    m = s_res[C.RES_M]
+                    need = k - above
+                    B = s_res[C.RES_B]
+                    running = cutlass.Int32(0)
+                else:
+                    if att == cutlass.Int32(NATT - 1):  # ladder exhausted
+                        running = cutlass.Int32(0)
+                    else:
+                        tshtaken = cutlass.Int32(0)  # TSH retry
+                        if cutlass.const_expr(self.shd):
+                            if att == cutlass.Int32(0):
+                                T5 = s_tsh[0]
+                                if T5 > cutlass.Float32(_NEG_INF):
+                                    if T5 < TF:
+                                        T = T5
+                                        tshtaken = cutlass.Int32(1)
+                        if tshtaken != cutlass.Int32(0):
+                            cute.arch.barrier()  # ---- barrier (TSH retry) ----
+                        else:
+                            # LAZY GATHER (sentinel equality flag)
+                            if GMIN == cutlass.Float32(C.SENT_LO):
+                                GMIN, GMAX = C.gather_hint(
+                                    x_addr, p_addr, k, n, tidx, s_wmn, s_wmx, blk=BLK, kpt=KPT
+                                )
+                            floorhit = cutlass.Int32(1)
+                            if T > GMIN:
+                                floorhit = cutlass.Int32(0)
+                            if floorhit != cutlass.Int32(0):
+                                running = cutlass.Int32(0)
+                            else:
+                                T = GMIN
+                                cute.arch.barrier()  # ---- barrier (floor retry) ----
+            att = att + cutlass.Int32(1)
+
+        # ============ classification ============
+        if alive != cutlass.Int32(0):
+            whole = cutlass.Int32(0)
+            if valid != cutlass.Int32(0):
+                if need >= m:
+                    whole = cutlass.Int32(1)
+            lim1 = above
+            if whole != cutlass.Int32(0):
+                lim1 = above + m
+            degen = cutlass.Int32(0)
+            if valid == cutlass.Int32(0):
+                degen = cutlass.Int32(1)
+            if m > cutlass.Int32(CMPB):
+                degen = cutlass.Int32(1)
+            mc = cutlass.Int32(0)
+            if degen == cutlass.Int32(0):
+                mc = m
+
+            if degen == cutlass.Int32(0):
+                # ---- P5 cursor emit ----
+                if complete != cutlass.Int32(0):
+                    i = tidx
+                    while i < listN:
+                        idv = cutlass.Int32(0)
+                        bq = cutlass.Int32(0)
+                        xv = cutlass.Float32(0.0)
+                        if cutlass.const_expr(self.vstg):
+                            vx = cutlass.Int32(0)
+                            vy = cutlass.Int32(0)
+                            if cutlass.const_expr(self.split):
+                                if fromg != cutlass.Int32(0):
+                                    vx, vy = C._ldcg_v2_i32(
+                                        gbuf_row + cutlass.Int64(i) * cutlass.Int64(8)
+                                    )
+                                else:
+                                    pk64 = s_cbuf2[i]
+                                    vx = cutlass.Int32(
+                                        cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF))
+                                    )
+                                    vy = cutlass.Int32(pk64 >> cutlass.Uint64(32))
+                            else:
+                                pk64 = s_cbuf2[i]
+                                vx = cutlass.Int32(
+                                    cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF))
+                                )
+                                vy = cutlass.Int32(pk64 >> cutlass.Uint64(32))
+                            xv = C.f32_of_i32(vx)
+                            idv = vy
+                            bq = C.f2s_rz((xv - TF) * SC)
+                            if bq > cutlass.Int32(NBS - 1):
+                                bq = cutlass.Int32(NBS - 1)
+                        else:
+                            wpk = cutlass.Uint32(s_cbuf[i])
+                            idv = cutlass.Int32(wpk & cutlass.Uint32(IDXM__main))
+                            bq = cutlass.Int32(wpk >> cutlass.Uint32(IDXB__main))
+                        if bq >= B:
+                            p = C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                            if p < lim1:
+                                out_row[p] = idv
+                            else:
+                                if whole == cutlass.Int32(0):
+                                    q2 = p - above
+                                    if q2 < cutlass.Int32(CMPB):
+                                        if cutlass.const_expr(self.vstg):
+                                            kk = C.fkey(xv)
+                                        else:
+                                            kk = C.fkey(C.ldg_f32(x_addr, idv))
+                                        s_ck64[q2] = (
+                                            cutlass.Uint64(kk) << cutlass.Uint64(32)
+                                        ) | cutlass.Uint64(cutlass.Uint32(idv))
+                        i = i + cutlass.Int32(BLK)
+                else:
+                    # collect overflow: scalar re-sweep, exact tail remap —
+                    # zero extra live registers by design
+                    lo2 = c0 << cutlass.Int32(2)
+                    hi2 = c1 << cutlass.Int32(2)
+                    i0_ = lo2 + tidx
+                    while i0_ < hi2 + tailn:
+                        i_ = i0_
+                        if i0_ >= hi2:
+                            i_ = tail0 + (i0_ - hi2)
+                        x = C.ldg_f32(x_addr, i_)
+                        if x >= TF:
+                            bq = C.f2s_rz((x - TF) * SC)
+                            if bq > cutlass.Int32(NBS - 1):
+                                bq = cutlass.Int32(NBS - 1)
+                            if bq >= B:
+                                p = C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                                if p < lim1:
+                                    out_row[p] = i_
+                                else:
+                                    if whole == cutlass.Int32(0):
+                                        q2 = p - above
+                                        if q2 < cutlass.Int32(CMPB):
+                                            s_ck64[q2] = (
+                                                cutlass.Uint64(C.fkey(x)) << cutlass.Uint64(32)
+                                            ) | cutlass.Uint64(cutlass.Uint32(i_))
+                        i0_ = i0_ + cutlass.Int32(BLK)
+
+                # ---- P6 refine ----
+                if whole == cutlass.Int32(0):
+                    cute.arch.barrier()  # ---- barrier (emit done) ----
+                    if mc <= cutlass.Int32(QUADC_CLUS__main):  # O(mc^2) rank
+                        mc2 = mc & cutlass.Int32(~1)
+                        i = tidx
+                        while i < mc:
+                            # NOTE: values crossing a dynamic-while region are
+                            # re-wrapped SIGNED by the DSL — every u64 compare
+                            # must re-assert Uint64 at the USE site.
+                            u64v = s_ck64[i]
+                            r_ = cutlass.Int32(0)
+                            jq = cutlass.Int32(0)
+                            while jq < mc2:  # ulonglong2 16B reads
+                                vlo, vhi = C._lds_v2_u64(ck_addr + jq * cutlass.Int32(8))
+                                r_ = (
+                                    r_
+                                    + cutlass.Int32(vlo > cutlass.Uint64(u64v))
+                                    + cutlass.Int32(vhi > cutlass.Uint64(u64v))
+                                )
+                                jq = jq + cutlass.Int32(2)
+                            if mc2 < mc:  # odd tail
+                                r_ = r_ + cutlass.Int32(
+                                    cutlass.Uint64(s_ck64[mc2]) > cutlass.Uint64(u64v)
+                                )
+                            if r_ < need:
+                                out_row[above + r_] = cutlass.Int32(
+                                    cutlass.Uint32(
+                                        cutlass.Uint64(u64v) & cutlass.Uint64(0xFFFFFFFF)
+                                    )
+                                )
+                            i = i + cutlass.Int32(BLK)
+                    else:
+                        # key-space narrowing over ck64
+                        if tidx == cutlass.Int32(0):
+                            s_kmm[0] = cutlass.Uint32(0xFFFFFFFF)
+                            s_kmm[1] = cutlass.Uint32(0)
+                        if tidx < cutlass.Int32(NBS):  # cleared ONCE
+                            s_hist[tidx] = cutlass.Int32(0)
+                        cute.arch.barrier()  # ---- barrier (narrowing init) ----
+                        i = tidx
+                        while i < mc:
+                            kk = cutlass.Uint32(s_ck64[i] >> cutlass.Uint64(32))
+                            C.atomic_min_cta(s_kmm.iterator + 0, kk)
+                            C.atomic_max_cta(s_kmm.iterator + 1, kk)
+                            i = i + cutlass.Int32(BLK)
+                        cute.arch.barrier()  # ---- barrier (key range) ----
+                        rlo = s_kmm[0]
+                        rhi = s_kmm[1]
+                        ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                        aboveC = cutlass.Int32(0)
+                        needC = need
+                        mm = mc
+                        brk = cutlass.Int32(0)
+                        lev = cutlass.Int32(0)
+                        while brk == cutlass.Int32(0):  # <=6 levels
+                            if needC == mm:
+                                ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                                aboveC = aboveC + mm
+                                needC = cutlass.Int32(0)
+                                brk = cutlass.Int32(1)
+                            elif cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                                ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                brk = cutlass.Int32(1)
+                            elif lev >= cutlass.Int32(6):
+                                ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                brk = cutlass.Int32(1)
+                            else:
+                                d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                                b2_ = cutlass.Int32(32) - C.clz_i32(
+                                    cutlass.Int32(d2 | cutlass.Uint32(1))
+                                )
+                                sh2 = b2_ - cutlass.Int32(self.lb)
+                                if sh2 < cutlass.Int32(0):
+                                    sh2 = cutlass.Int32(0)
+                                sh2u = cutlass.Uint32(sh2)
+                                i = tidx
+                                while i < mc:  # re-bin
+                                    uq = cutlass.Uint32(s_ck64[i] >> cutlass.Uint64(32))
+                                    if uq >= cutlass.Uint32(rlo):
+                                        if uq <= cutlass.Uint32(rhi):
+                                            du = (uq - cutlass.Uint32(rlo)) >> sh2u
+                                            if du > cutlass.Uint32(NBS - 1):
+                                                du = cutlass.Uint32(NBS - 1)
+                                            C.atomic_add_cta(
+                                                s_hist.iterator + cutlass.Int32(du),
+                                                cutlass.Int32(1),
+                                            )
+                                    i = i + cutlass.Int32(BLK)
+                                cute.arch.barrier()  # ---- barrier (level hist) ----
+                                C.scan_cross0(
+                                    s_hist,
+                                    needC,
+                                    tidx,
+                                    s_res,
+                                    cutlass.Int32(0),
+                                    cutlass.Int32(0),
+                                    s_hist,
+                                    nb=NBS,
+                                    zero=True,
+                                )
+                                cute.arch.barrier()  # ---- barrier (level scan) ----
+                                aboveC = aboveC + s_res[C.RES_ABOVE]
+                                needC = needC - s_res[C.RES_ABOVE]
+                                mm = s_res[C.RES_M]
+                                sB = s_res[C.RES_B]
+                                nlo = cutlass.Uint32(rlo) + (cutlass.Uint32(sB) << sh2u)
+                                if sB != cutlass.Int32(NBS - 1):
+                                    rhi = nlo + ((cutlass.Uint32(1) << sh2u) - cutlass.Uint32(1))
+                                rlo = nlo
+                                lev = lev + cutlass.Int32(1)
+                        if tidx == cutlass.Int32(0):
+                            s_scal[1] = cutlass.Int32(0)
+                            s_scal[2] = cutlass.Int32(0)
+                        cute.arch.barrier()  # ---- barrier (emit counters) ----
+                        it2 = (mc + cutlass.Int32(BLK - 1)) // cutlass.Int32(BLK)
+                        it = cutlass.Int32(0)
+                        while it < it2:  # ballot emit
+                            i = it * cutlass.Int32(BLK) + tidx
+                            p1 = cutlass.Int32(0)
+                            p2 = cutlass.Int32(0)
+                            idv = cutlass.Int32(0)
+                            if i < mc:
+                                w64 = s_ck64[i]
+                                iu = cutlass.Int64(cutlass.Uint32(w64 >> cutlass.Uint64(32)))
+                                idv = cutlass.Int32(
+                                    cutlass.Uint32(w64 & cutlass.Uint64(0xFFFFFFFF))
+                                )
+                                if iu > ethr:
+                                    p1 = cutlass.Int32(1)
+                                if iu == ethr:
+                                    p2 = cutlass.Int32(1)
+                            self._ballot_pair_emit(
+                                p1,
+                                p2,
+                                idv,
+                                above,
+                                aboveC,
+                                above + aboveC,
+                                needC,
+                                out_row,
+                                s_scal,
+                                lane,
+                            )
+                            it = it + cutlass.Int32(1)
+            else:
+                dga = cutlass.Int32(0)  # gate: valid && complete
+                if valid != cutlass.Int32(0):
+                    if complete != cutlass.Int32(0):
+                        dga = cutlass.Int32(1)
+                if dga != cutlass.Int32(0):
+                    # ---- degen A: narrowing over STAGED candidates ----
+                    rlo = cutlass.Uint32(0)
+                    rhi = cutlass.Uint32(0xFFFFFFFF)
+                    above2 = cutlass.Int32(0)
+                    need2 = k
+                    m2 = listN
+                    ethr = cutlass.Int64(0)
+                    tie_m = cutlass.Int32(1)
+                    if tidx < cutlass.Int32(NBS):
+                        s_hist[tidx] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (degen A init) ----
+                    brk = cutlass.Int32(0)
+                    lev = cutlass.Int32(0)
+                    while brk == cutlass.Int32(0):  # <=8 levels
+                        if need2 == m2:
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                            above2 = above2 + m2
+                            need2 = cutlass.Int32(0)
+                            tie_m = cutlass.Int32(0)
+                            brk = cutlass.Int32(1)
+                        elif cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            brk = cutlass.Int32(1)
+                        elif lev >= cutlass.Int32(8):
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            brk = cutlass.Int32(1)
+                        else:
+                            d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                            b2_ = cutlass.Int32(32) - C.clz_i32(
+                                cutlass.Int32(d2 | cutlass.Uint32(1))
+                            )
+                            sh2 = b2_ - cutlass.Int32(self.lb)
+                            if sh2 < cutlass.Int32(0):
+                                sh2 = cutlass.Int32(0)
+                            sh2u = cutlass.Uint32(sh2)
+                            i = tidx
+                            while i < listN:
+                                uq = cutlass.Uint32(0)
+                                if cutlass.const_expr(self.vstg):
+                                    vx = cutlass.Int32(0)
+                                    vy = cutlass.Int32(0)
+                                    if cutlass.const_expr(self.split):
+                                        if fromg != cutlass.Int32(0):
+                                            vx, vy = C._ldcg_v2_i32(
+                                                gbuf_row + cutlass.Int64(i) * cutlass.Int64(8)
+                                            )
+                                        else:
+                                            pk64 = s_cbuf2[i]
+                                            vx = cutlass.Int32(
+                                                cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF))
+                                            )
+                                    else:
+                                        pk64 = s_cbuf2[i]
+                                        vx = cutlass.Int32(
+                                            cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF))
+                                        )
+                                    uq = C.fkey_bits(cutlass.Uint32(vx))
+                                else:
+                                    id0 = cutlass.Int32(
+                                        cutlass.Uint32(s_cbuf[i]) & cutlass.Uint32(IDXM__main)
+                                    )
+                                    uq = C.fkey(C.ldg_f32(x_addr, id0))
+                                if uq >= cutlass.Uint32(rlo):
+                                    if uq <= cutlass.Uint32(rhi):
+                                        du = (uq - cutlass.Uint32(rlo)) >> sh2u
+                                        if du > cutlass.Uint32(NBS - 1):
+                                            du = cutlass.Uint32(NBS - 1)
+                                        C.atomic_add_cta(
+                                            s_hist.iterator + cutlass.Int32(du), cutlass.Int32(1)
+                                        )
+                                i = i + cutlass.Int32(BLK)
+                            cute.arch.barrier()  # ---- barrier (level hist) ----
+                            C.scan_cross0(
+                                s_hist,
+                                need2,
+                                tidx,
+                                s_res,
+                                cutlass.Int32(0),
+                                cutlass.Int32(0),
+                                s_hist,
+                                nb=NBS,
+                                zero=True,
+                            )
+                            cute.arch.barrier()  # ---- barrier (level scan) ----
+                            above2 = above2 + s_res[C.RES_ABOVE]
+                            need2 = need2 - s_res[C.RES_ABOVE]
+                            m2 = s_res[C.RES_M]
+                            sB = s_res[C.RES_B]
+                            nlo = cutlass.Uint32(rlo) + (cutlass.Uint32(sB) << sh2u)
+                            if sB != cutlass.Int32(NBS - 1):
+                                rhi = nlo + ((cutlass.Uint32(1) << sh2u) - cutlass.Uint32(1))
+                            rlo = nlo
+                            lev = lev + cutlass.Int32(1)
+                    if tidx == cutlass.Int32(0):
+                        s_scal[1] = cutlass.Int32(0)
+                        s_scal[2] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (emit counters) ----
+                    nA = k
+                    nT = cutlass.Int32(0)
+                    if tie_m != cutlass.Int32(0):
+                        nA = above2
+                        nT = need2
+                    it2 = (listN + cutlass.Int32(BLK - 1)) // cutlass.Int32(BLK)
+                    it = cutlass.Int32(0)
+                    while it < it2:
+                        i = it * cutlass.Int32(BLK) + tidx
+                        p1 = cutlass.Int32(0)
+                        p2 = cutlass.Int32(0)
+                        idv = cutlass.Int32(0)
+                        if i < listN:
+                            uq = cutlass.Uint32(0)
+                            if cutlass.const_expr(self.vstg):
+                                vx = cutlass.Int32(0)
+                                vy = cutlass.Int32(0)
+                                if cutlass.const_expr(self.split):
+                                    if fromg != cutlass.Int32(0):
+                                        vx, vy = C._ldcg_v2_i32(
+                                            gbuf_row + cutlass.Int64(i) * cutlass.Int64(8)
+                                        )
+                                    else:
+                                        pk64 = s_cbuf2[i]
+                                        vx = cutlass.Int32(
+                                            cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF))
+                                        )
+                                        vy = cutlass.Int32(pk64 >> cutlass.Uint64(32))
+                                else:
+                                    pk64 = s_cbuf2[i]
+                                    vx = cutlass.Int32(
+                                        cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF))
+                                    )
+                                    vy = cutlass.Int32(pk64 >> cutlass.Uint64(32))
+                                uq = C.fkey_bits(cutlass.Uint32(vx))
+                                idv = vy
+                            else:
+                                idv = cutlass.Int32(
+                                    cutlass.Uint32(s_cbuf[i]) & cutlass.Uint32(IDXM__main)
+                                )
+                                uq = C.fkey(C.ldg_f32(x_addr, idv))
+                            iu = cutlass.Int64(uq)
+                            if iu > ethr:
+                                p1 = cutlass.Int32(1)
+                            if tie_m != cutlass.Int32(0):
+                                if iu == ethr:
+                                    p2 = cutlass.Int32(1)
+                        self._ballot_pair_emit(
+                            p1, p2, idv, cutlass.Int32(0), nA, nA, nT, out_row, s_scal, lane
+                        )
+                        it = it + cutlass.Int32(1)
+                else:
+                    # ---- degen B: whole-row narrowing ----
+                    rlo = cutlass.Uint32(0)
+                    rhi = cutlass.Uint32(0xFFFFFFFF)
+                    above2 = cutlass.Int32(0)
+                    need2 = k
+                    m2 = n
+                    ethr = cutlass.Int64(0)
+                    tie_m = cutlass.Int32(1)
+                    if tidx < cutlass.Int32(NBS):
+                        s_hist[tidx] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (degen B init) ----
+                    brk = cutlass.Int32(0)
+                    lev = cutlass.Int32(0)
+                    while brk == cutlass.Int32(0):  # <=8 levels
+                        if need2 == m2:
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                            above2 = above2 + m2
+                            need2 = cutlass.Int32(0)
+                            tie_m = cutlass.Int32(0)
+                            brk = cutlass.Int32(1)
+                        elif cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            brk = cutlass.Int32(1)
+                        elif lev >= cutlass.Int32(8):
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            brk = cutlass.Int32(1)
+                        else:
+                            d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                            b2_ = cutlass.Int32(32) - C.clz_i32(
+                                cutlass.Int32(d2 | cutlass.Uint32(1))
+                            )
+                            sh2 = b2_ - cutlass.Int32(self.lb)
+                            if sh2 < cutlass.Int32(0):
+                                sh2 = cutlass.Int32(0)
+                            sh2u = cutlass.Uint32(sh2)
+                            i = tidx
+                            while i < n:  # whole row
+                                uq = C.fkey(C.ldg_f32(x_addr, i))
+                                if uq >= cutlass.Uint32(rlo):
+                                    if uq <= cutlass.Uint32(rhi):
+                                        du = (uq - cutlass.Uint32(rlo)) >> sh2u
+                                        if du > cutlass.Uint32(NBS - 1):
+                                            du = cutlass.Uint32(NBS - 1)
+                                        C.atomic_add_cta(
+                                            s_hist.iterator + cutlass.Int32(du), cutlass.Int32(1)
+                                        )
+                                i = i + cutlass.Int32(BLK)
+                            cute.arch.barrier()  # ---- barrier (level hist) ----
+                            C.scan_cross0(
+                                s_hist,
+                                need2,
+                                tidx,
+                                s_res,
+                                cutlass.Int32(0),
+                                cutlass.Int32(0),
+                                s_hist,
+                                nb=NBS,
+                                zero=True,
+                            )
+                            cute.arch.barrier()  # ---- barrier (level scan) ----
+                            above2 = above2 + s_res[C.RES_ABOVE]
+                            need2 = need2 - s_res[C.RES_ABOVE]
+                            m2 = s_res[C.RES_M]
+                            sB = s_res[C.RES_B]
+                            nlo = cutlass.Uint32(rlo) + (cutlass.Uint32(sB) << sh2u)
+                            if sB != cutlass.Int32(NBS - 1):
+                                rhi = nlo + ((cutlass.Uint32(1) << sh2u) - cutlass.Uint32(1))
+                            rlo = nlo
+                            lev = lev + cutlass.Int32(1)
+                    if tidx == cutlass.Int32(0):
+                        s_scal[1] = cutlass.Int32(0)
+                        s_scal[2] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (emit counters) ----
+                    nA = k
+                    nT = cutlass.Int32(0)
+                    if tie_m != cutlass.Int32(0):
+                        nA = above2
+                        nT = need2
+                    it2 = (n + cutlass.Int32(BLK - 1)) // cutlass.Int32(BLK)
+                    it = cutlass.Int32(0)
+                    while it < it2:
+                        i = it * cutlass.Int32(BLK) + tidx
+                        p1 = cutlass.Int32(0)
+                        p2 = cutlass.Int32(0)
+                        if i < n:
+                            uq = C.fkey(C.ldg_f32(x_addr, i))
+                            iu = cutlass.Int64(uq)
+                            if iu > ethr:
+                                p1 = cutlass.Int32(1)
+                            if tie_m != cutlass.Int32(0):
+                                if iu == ethr:
+                                    p2 = cutlass.Int32(1)
+                        self._ballot_pair_emit(
+                            p1, p2, i, cutlass.Int32(0), nA, nA, nT, out_row, s_scal, lane
+                        )
+                        it = it + cutlass.Int32(1)
+
+        # ---- varlen short-row epilogue (production heuristicTopKDecode
+        # convention): every valid position is in the top-K — emit identity
+        # indices and pad the tail with -1.  The body above ran as a
+        # zero-work pass for these rows (n = 0, TGT = INT_MAX) so nothing
+        # was written; only part 0 of a SPLIT row emits.
+        if cutlass.const_expr(self.varlen):
+            if short != cutlass.Int32(0):
+                if part == cutlass.Int32(0):
+                    i = tidx
+                    while i < n_row:
+                        out_row[i] = i
+                        i = i + cutlass.Int32(BLK)
+                    j = n_row + tidx
+                    while j < k:
+                        out_row[j] = cutlass.Int32(-1)
+                        j = j + cutlass.Int32(BLK)
+
+    # ------------------------------------------------------------------
+    # host launcher (grid dim3(R, b); MINB wall via min_blocks_per_mp)
+    # ------------------------------------------------------------------
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        out: cute.Tensor,
+        ws: cute.Tensor,
+        n: cutlass.Int32,
+        npad: cutlass.Int32,
+        k: cutlass.Int32,
+        scap_dead: cutlass.Int32,
+        cmp_dead: cutlass.Int32,
+        R: cutlass.Int32,
+        SMP: cutlass.Int32,
+        TGT: cutlass.Int32,
+        Q: cutlass.Int32,
+        SS2: cutlass.Int32,
+        TGT2: cutlass.Int32,
+        kv_lens: cute.Tensor,
+        aim_base: cutlass.Int32,
+        sfac: cutlass.Int32,
+        amin: cutlass.Int32,
+        sd_en: cutlass.Int32,
+        tsh_en: cutlass.Int32,
+        stream,
+    ):
+        b = logits.shape[0]
+        self.kern(
+            logits,
+            pre_idx,
+            out,
+            ws,
+            n,
+            npad,
+            k,
+            scap_dead,
+            cmp_dead,
+            R,
+            SMP,
+            TGT,
+            Q,
+            SS2,
+            TGT2,
+            kv_lens,
+            aim_base,
+            sfac,
+            amin,
+            sd_en,
+            tsh_en,
+        ).launch(grid=(R, b, 1), block=(self.blk, 1, 1), stream=stream, min_blocks_per_mp=self.minb)
+
+
+# ---------------------------------------------------------------------------
+# compile cache + torch-facing entry
+# ---------------------------------------------------------------------------
+_COMPILE_CACHE = {}
+
+
+def get_compiled(tpl, options_extra: str = ""):
+    """Compile (or fetch) the gvr_main variant for constexpr tuple
+    tpl = (BLK, U, MINB, NBS, KPT, SPLIT, TSHG)                — legacy, or
+    tpl = (BLK, U, MINB, NBS, KPT, SPLIT, TSHG, NEXT_N, CR_SHIFT, R_CONST)
+    — per-row varlen mode (TSHG slot is ignored: varlen compiles the TSH
+    machinery in whenever SPLIT and gates it per row at runtime)."""
+    key = (tuple(tpl), options_extra)
+    hit = _COMPILE_CACHE.get(key)
+    if hit is not None:
+        return hit
+    if len(tpl) == 7:
+        blk, u, minb, nbs, kpt, split, tshg = tpl
+        kern = GvrMainKernel(blk, u, minb, nbs, kpt, bool(split), bool(tshg))
+    else:
+        blk, u, minb, nbs, kpt, split, tshg, next_n, cr_shift, r_const = tpl
+        kern = GvrMainKernel(
+            blk,
+            u,
+            minb,
+            nbs,
+            kpt,
+            bool(split),
+            bool(tshg),
+            varlen=True,
+            next_n=next_n,
+            cr_shift=cr_shift,
+            r_const=r_const,
+        )
+    r0, c0 = cute.sym_int(), cute.sym_int()
+    r1, c1 = cute.sym_int(), cute.sym_int()
+    r2, c2 = cute.sym_int(), cute.sym_int()
+    w0 = cute.sym_int()
+    v0 = cute.sym_int()
+    logits_fake = _crt.make_fake_compact_tensor(
+        cutlass.Float32, (r0, c0), stride_order=(1, 0), assumed_align=16
+    )
+    pre_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (r1, c1), stride_order=(1, 0), assumed_align=16
+    )
+    out_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (r2, c2), stride_order=(1, 0), assumed_align=16
+    )
+    ws_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (w0,), stride_order=(0,), assumed_align=16
+    )
+    kv_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (v0,), stride_order=(0,), assumed_align=4
+    )
+    fake_stream = _crt.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    def _compile_fn():
+        return cute.compile(
+            kern,
+            logits_fake,
+            pre_fake,
+            out_fake,
+            ws_fake,
+            *([cutlass.Int32(0)] * 11),
+            kv_fake,
+            *([cutlass.Int32(0)] * 5),
+            stream=fake_stream,
+            options=("--enable-tvm-ffi " + options_extra).strip(),
+        )
+
+    name = "main_" + "_".join(str(x) for x in tuple(tpl))
+    if options_extra:
+        name += "_opt_" + options_extra
+    compiled = C._persist(name, _compile_fn)
+    _COMPILE_CACHE[key] = compiled
+    return compiled
+
+
+def workspace_bytes() -> int:
+    return WS_BYTES
+
+
+def run(logits, pre_idx, n: int, out, ws):
+    """torch-facing single-call entry: routes (b, n, k) through ct_dispatch,
+    asserts the shape lands on gvr_main, launches the matching variant.
+    ws: zero-initialised >=20,973,568-B CUDA buffer (reused across launches;
+    the kernel restores the zeros it consumes)."""
+    try:
+        from . import gvr2_topk_host as ct_dispatch
+    except ImportError:
+        import gvr2_topk_host as ct_dispatch
+    b, npad = logits.shape
+    k = pre_idx.shape[1]
+    r = ct_dispatch.route(b, int(n), npad, k)
+    assert r["kernel"] == "main", f"shape routes to {r['kernel']}, not gvr_main"
+    assert ws.numel() * ws.element_size() >= WS_BYTES
+    rt = r["rt"]
+    fn = get_compiled(tuple(r["tpl"]))
+    fn(
+        logits,
+        pre_idx,
+        out,
+        ws,
+        rt["n"],
+        rt["npad"],
+        rt["k"],
+        rt["SCAP_"],
+        rt["CMP_"],
+        rt["R"],
+        rt["SMP"],
+        rt["TGT"],
+        rt["Q"],
+        rt["SS2"],
+        rt["TGT2"],
+        _legacy_dummy_kv(pre_idx),  # dummy kv_lens (dead in legacy mode)
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    return r
+
+
+_LEGACY_DUMMY_KV = {}
+
+
+def _legacy_dummy_kv(ref):
+    """Cached 1-element int32 tensor per device for the dead kv_lens ABI slot
+    (avoids a per-call allocator round-trip on the legacy hot path)."""
+    d = ref.get_device()
+    t = _LEGACY_DUMMY_KV.get(d)
+    if t is None:
+        t = ref.new_zeros(1)
+        _LEGACY_DUMMY_KV[d] = t
+    return t
+
+
+# ===========================================================================
+# ==== family: reg =============================================
+# ===========================================================================
+"""gvr_topk_reg — register-resident exact top-K, one CTA per row, histogram
+bins in FLOAT space.
+
+Template knobs (CUDA `gvr_topk_reg<BLK,VPT,MINB,KPT,CUR,DEG,IMGF,NBH>`):
+ctor args of :class:`GvrTopkRegKernel`, read as `cutlass.const_expr(self.x)`
+inside the kernel. Runtime args mirror the CUDA `(n, npad, k, CMP, IMGOFF,
+QC)` — npad/k come from tensor shapes, IMGOFF is dropped (dispatch pins
+IMGOFF == NBSEL == NBH at every site, asserted in the host wrapper).
+
+Shared-memory map (single dynamic window, word offsets; the CUDA static
+__shared__ block is folded into the first 512 B so occupancy accounting
+matches nvcc's static+dynamic sum):
+
+    [0..5]        s_res    (shared slot map RES_B/M/ABOVE/TOT/B2/B3)
+    [6..7]        s_cnt    (s_o1, s_oc)
+    [8..9]        s_kmm    (s_kmin, s_kmax — Uint32)
+    [10..11]      s_e12    (s_e1, s_e2)
+    [16..16+NW)   ws       (scan_cross_w workspace)
+    [48..48+NW)   wmn      (Uint32 warp min partials)
+    [80..80+NW)   wmx      (Uint32 warp max partials)
+    [128..128+NBH)          hist
+    [128+NBH..128+NBH+CMP)  ck     (Uint32 crossing keys; CMP dynamic)
+    [128+NBH+CMP..+2CMP)    ci     (Int32 crossing indices)
+    img/bm alias ck at word 128+NBH (IMGOFF==NBH)
+
+Launch smem = 512 + dispatch_smem_bytes (dynamic Int32).
+
+TOOLCHAIN GOTCHA: dynamic launch smem with min_blocks_per_mp>1 crashes
+cutlass_dsl._build_kernel_attrs (host ceil() on a dynamic value while
+computing the PREFERRED_SHARED_MEMORY_CARVEOUT hint). `_no_carveout()`
+scopes a monkeypatch around cute.compile dropping ONLY that hint (CUDA
+__launch_bounds__ sets no carveout either); `.reqntid`/`.minnctapersm`
+(the register wall) are unaffected.
+"""
+
+
+NB__reg = 1024  # NBH default
+STATIC_WORDS = 128  # DSL smem prelude (static-__shared__ mirror)
+STATIC_BYTES = STATIC_WORDS * 4
+_NEG_INF__reg = float("-inf")
+_POS_INF = float("inf")
+
+
+# ---------------------------------------------------------------------------
+# module-local FP spellings
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _fmaf__reg(a, b, c, *, loc=None, ip=None):
+    """CUDA fmaf: single fma.rn.f32."""
+    return cutlass.Float32(
+        mlir_math.fma(
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            fastmath=mlir_arith.FastMathFlags.none,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _submul_asm(v, t, sc, *, loc=None, ip=None):
+    """(v - t) * sc with two roundings, opaque to CSE/contraction.
+
+    Used at the !BRL classify site so no sub-expression is shared with the
+    emit's `fmaf(v - T, SC, OFF)` — the CUDA deliberately spells the two
+    sites differently to stop the compiler holding all S q's live across
+    the barrier.
+    """
+    return cutlass.Float32(
+        llvm.inline_asm(
+            T.f32(),
+            [v.ir_value(loc=loc, ip=ip), t.ir_value(loc=loc, ip=ip), sc.ir_value(loc=loc, ip=ip)],
+            "{\n\t.reg .f32 rtmp;\n\tsub.rn.f32 rtmp, $1, $2;\n\tmul.rn.f32 $0, rtmp, $3;\n\t}",
+            "=f,f,f,f",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _smem_addr_reg__reg(addr, *, loc=None, ip=None):
+    """Pin a CTA-shared 32-bit byte address in ONE register.
+
+    Identity `mov` behind an asm boundary: without it LLVM re-folds the
+    `mov.b32 %r, __dynamic_shmem__0` symbol materialisation into EVERY use
+    site, and ptxas then re-derives the CGA shared window (S2UR SR_CgaCtaId
+    + UMOV + ULEA, 3 instructions) inside each divergent classify block.
+    The asm result is not duplicable, so the window is materialised exactly
+    once. Value-identical: a plain register copy.
+    """
+    return cutlass.Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [addr.ir_value(loc=loc, ip=ip)],
+            "mov.u32 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _red_shared_add1__reg(addr, *, loc=None, ip=None):
+    """CUDA classify `atomicAdd(&hist[bin], 1u)` with the result unused.
+
+    `red` (not `atom`) is the result-less spelling — ptxas lowers it to the
+    same ATOMS.POPC.INC.32 RZ the CUDA arm emits. Same ordering contract as
+    atomic_add_cta: .relaxed scope .cta. Takes the final shared byte address
+    as a plain Int32 so the address datapath stays ordinary IR (ptxas fuses
+    the shl+add into one LEA against the pinned `_smem_addr_reg__reg` base).
+    """
+    llvm.inline_asm(
+        res=None,
+        operands_=[addr.ir_value(loc=loc, ip=ip)],
+        asm_string="red.relaxed.cta.shared.add.u32 [$0], 1;",
+        constraints="r",
+        has_side_effects=True,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _umin_u32(a, b):
+    """unsigned min(a, b) — CUDA min() on the bin clamp (IMNMX)."""
+    r = a
+    if b < a:
+        r = b
+    return r
+
+
+@cute.jit
+def _fabsf(x):
+    """|x| via sign-bit clear (exact, matches fabsf)."""
+    return f32_of_u32(u32_of_f32(x) & cutlass.Uint32(0x7FFFFFFF))
+
+
+def _f32_smem_atom():
+    return cute.make_copy_atom(cute.nvgpu.CopyUniversalOp(), cutlass.Float32, num_bits_per_copy=128)
+
+
+def _sts128_f32(atom, frag, base_addr, byte_off):
+    p = cute.make_ptr(
+        cutlass.Float32, base_addr + byte_off, cute.AddressSpace.smem, assumed_align=16
+    )
+    cute.copy(atom, frag, cute.make_tensor(p, cute.make_layout((4,))))
+
+
+def _smem_view(dtype, sbase, word_off: int, length: int, align: int = 16):
+    """Typed tensor view at a constexpr word offset into the smem window."""
+    p = cute.make_ptr(
+        dtype, sbase + cutlass.Int32(word_off * 4), cute.AddressSpace.smem, assumed_align=align
+    )
+    return cute.make_tensor(p, cute.make_layout((length,)))
+
+
+def _val(frags, s: int):
+    """val[s] accessor over the float4[VPT] register batch (constexpr s)."""
+    return frags[s // 4][s % 4]
+
+
+@contextlib.contextmanager
+def _no_carveout():
+    """Scoped: drop the DSL's carveout hint (see module docstring)."""
+    import cutlass.cutlass_dsl.cutlass as _cdsl
+
+    orig = _cdsl._build_kernel_attrs
+    _cdsl._build_kernel_attrs = lambda config: {}
+    # DSL >= 4.6.1 also derives a carveout inside the compiled artifact from
+    # the smem.max_smem_per_mp MLIR attribute (emitted when
+    # min_blocks_per_mp > 1).  That calculation only sees the static smem, so
+    # with dynamic launch smem it selects a 16 KiB shared-memory config and
+    # pins the SM to one resident CTA.  Drop the attribute as well so the
+    # driver default carveout stays in effect.
+    base = getattr(_cdsl, "CutlassBaseDSL", None)
+    orig_gen = getattr(base, "_generate_kernel_attrs", None)
+
+    if orig_gen is not None:
+
+        def _gen(self, config, _orig=orig_gen):
+            ret = _orig(self, config)
+            ret.pop("smem.max_smem_per_mp", None)
+            return ret
+
+        base._generate_kernel_attrs = _gen
+    try:
+        yield
+    finally:
+        _cdsl._build_kernel_attrs = orig
+        if orig_gen is not None:
+            base._generate_kernel_attrs = orig_gen
+
+
+class GvrTopkRegKernel:
+    """gvr_topk_reg<BLK, VPT, MINB, KPT, CUR, DEG, IMGF, NBH>."""
+
+    def __init__(
+        self,
+        blk: int,
+        vpt: int,
+        minb: int,
+        kpt: int,
+        cur: bool,
+        deg: bool,
+        img: bool,
+        nbh: int = NB__reg,
+        pdl: bool = False,
+        varlen: bool = False,
+        next_n: int = 1,
+        cr_shift: int = 0,
+    ):
+        assert blk in (256, 512, 1024) and vpt in (1, 2, 4)
+        assert nbh in (256, 512, 1024, 2048)
+        assert nbh % blk == 0 or blk % nbh == 0
+        self.blk = blk
+        self.vpt = vpt
+        self.minb = minb
+        self.kpt = kpt
+        self.cur = bool(cur)
+        self.deg = bool(deg)
+        self.img = bool(img)
+        self.nbh = nbh
+        self.pdl = bool(pdl)
+        # per-row varlen mode (production heuristicTopKDecode contract, same
+        # semantics as GvrMainKernel/GvrRegClusKernel): n is re-derived PER
+        # ROW in-kernel from a device kv_lens tensor; the scalar n launch arg
+        # becomes the envelope clamp bound. next_n / cr_shift compile-time.
+        self.varlen = bool(varlen)
+        self.next_n = int(next_n)
+        self.cr_shift = int(cr_shift)
+        if self.varlen:
+            assert self.next_n >= 1 and self.cr_shift in (0, 2)
+        # derived compile-time constants
+        self.S = vpt * 4
+        self.lnbh = {256: 8, 512: 9, 2048: 11}.get(nbh, 10)
+        self.use_bm = (not deg) and (not img) and kpt >= 2 and vpt == 1
+        self.use_img = img and vpt == 1
+        self.brl = (minb * blk <= 1024) or (vpt == 1)
+
+    # ------------------------------------------------------------------
+    @cute.kernel
+    def kern(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        kv_lens: cute.Tensor,
+        out: cute.Tensor,
+        n: cutlass.Int32,
+        cmp_: cutlass.Int32,
+        qc: cutlass.Int32,
+        smem_bytes: cutlass.Int32,
+    ):
+        BLK = cutlass.const_expr(self.blk)
+        VPT = cutlass.const_expr(self.vpt)
+        KPT = cutlass.const_expr(self.kpt)
+        NBH = cutlass.const_expr(self.nbh)  # noqa: F841
+        S = cutlass.const_expr(self.S)
+        LNBH = cutlass.const_expr(self.lnbh)
+        NW = cutlass.const_expr(self.blk // 32)
+
+        if cutlass.const_expr(self.pdl):
+            cute.arch.griddepcontrol_wait()  # knob default off
+
+        tid, _, _ = cute.arch.thread_idx()
+        row, _, _ = cute.arch.block_idx()
+        lane = tid & cutlass.Int32(31)
+
+        # ================= per-row varlen prologue (varlen mode only) =========
+        # Production heuristicTopKDecode contract (GvrMainKernel /
+        # GvrRegClusKernel discipline): row r serves request r // next_n with
+        # n = (kv_lens[req] - next_n + r % next_n + 1) >> cr_shift, clamped to
+        # the envelope launch arg n (the launcher admits this family only when
+        # the envelope fits its capacity window, so per-row n never exceeds
+        # capacity). One CTA per row, so the whole-body guard below is
+        # trivially block-uniform. Short rows (n <= k) emit identity + (-1)
+        # tail here (k can exceed BLK on this family -> strided loop, unlike
+        # the reg_clus k <= BLK single predicate) and SKIP the body entirely:
+        # a zero-work pass would reach the degenerate emitter and poison out.
+        short = cutlass.Int32(0)
+        prow = row
+        if cutlass.const_expr(self.varlen):
+            kq = cutlass.Int32(pre_idx.shape[1])
+            req = row // cutlass.Int32(self.next_n)
+            rr = row % cutlass.Int32(self.next_n)
+            prow = req
+            kvl = kv_lens[req]
+            nv = (kvl - cutlass.Int32(self.next_n) + rr + cutlass.Int32(1)) >> cutlass.Int32(
+                self.cr_shift
+            )
+            if nv < cutlass.Int32(0):
+                nv = cutlass.Int32(0)
+            if nv > n:
+                nv = n
+            if nv <= kq:
+                short = cutlass.Int32(1)
+            if short == cutlass.Int32(0):
+                n = nv
+            if short != cutlass.Int32(0):
+                i = tid
+                while i < kq:
+                    ov = cutlass.Int32(-1)
+                    if i < nv:
+                        ov = i
+                    out[row, i] = ov
+                    i = i + cutlass.Int32(BLK)
+
+        # ------------------------------------------------------------------
+        # Predeclarations: the DSL AST transformer requires every scalar that
+        # is (re)assigned under a dynamic if/while region to pre-exist with a
+        # stable type at every enclosing region level. Constant inits are
+        # sunk/dead-coded by LLVM, so this costs no registers.
+        # ------------------------------------------------------------------
+        i = cutlass.Int32(0)
+        j = cutlass.Int32(0)
+        r = cutlass.Int32(0)
+        tinc = cutlass.Int32(0)
+        cnt = cutlass.Int32(0)
+        bit = cutlass.Int32(0)
+        abv = cutlass.Int32(0)
+        nA = cutlass.Int32(0)
+        nT = cutlass.Int32(0)
+        n1 = cutlass.Int32(0)
+        n2 = cutlass.Int32(0)
+        b1 = cutlass.Int32(0)
+        b2 = cutlass.Int32(0)
+        p1e = cutlass.Int32(0)
+        p2e = cutlass.Int32(0)
+        lml = cutlass.Int32(0)
+        aboveC = cutlass.Int32(0)
+        needC = cutlass.Int32(0)
+        mm = cutlass.Int32(0)
+        lev = cutlass.Int32(0)
+        done = cutlass.Int32(0)
+        b2w = cutlass.Int32(0)
+        sh2 = cutlass.Int32(0)
+        it = cutlass.Int32(0)
+        it2 = cutlass.Int32(0)
+        idv = cutlass.Int32(0)
+        q1e = cutlass.Int32(0)
+        q2e = cutlass.Int32(0)
+        q1f = cutlass.Int32(0)
+        q2f = cutlass.Int32(0)
+        b_lv = cutlass.Int32(0)
+        mc = cutlass.Int32(0)
+        quad = cutlass.Int32(0)
+        lim1 = cutlass.Int32(0)
+        p = cutlass.Int32(0)
+        q2i = cutlass.Int32(0)
+        idx = cutlass.Int32(0)
+        m1 = cutlass.Int32(0)
+        m2 = cutlass.Int32(0)
+        t1 = cutlass.Int32(0)
+        t2 = cutlass.Int32(0)
+        c1 = cutlass.Int32(0)
+        c2 = cutlass.Int32(0)
+        s1 = cutlass.Int32(0)
+        s2 = cutlass.Int32(0)
+        p1 = cutlass.Int32(0)
+        p2 = cutlass.Int32(0)
+        wm = cutlass.Int32(0)
+        sdyn = cutlass.Int32(0)
+        nbw = cutlass.Int32(0)
+        uq = cutlass.Uint32(0)
+        vq = cutlass.Uint32(0)
+        kt = cutlass.Uint32(0)
+        klo = cutlass.Uint32(0)
+        kv = cutlass.Uint32(0)
+        rlo = cutlass.Uint32(0)
+        rhi = cutlass.Uint32(0)
+        d2 = cutlass.Uint32(0)
+        unar = cutlass.Uint32(0)
+        bnn = cutlass.Uint32(0)
+        nlo = cutlass.Uint32(0)
+        uke = cutlass.Uint32(0)
+        uk = cutlass.Uint32(0)
+        bn = cutlass.Uint32(0)
+        w = cutlass.Uint32(0)
+        wt = cutlass.Uint32(0)
+        ethr = cutlass.Int64(0)
+        u64 = cutlass.Int64(0)
+        LOQ = cutlass.Float32(0.0)
+        HIf = cutlass.Float32(0.0)
+        LOf = cutlass.Float32(0.0)
+        qt2 = cutlass.Float32(0.0)
+        qt3 = cutlass.Float32(0.0)
+
+        # wrap-scoping additions (varlen whole-body guard): names whose
+        # first assignment moves under the dynamic `if short == 0` region
+        # below and are reassigned deeper — same rule as the block above.
+        a = cutlass.Uint32(0)
+        c = cutlass.Uint32(0)
+        lmin = cutlass.Uint32(0)
+        lmax = cutlass.Uint32(0)
+        esc = cutlass.Int32(0)
+        okc = cutlass.Int32(0)
+        whole = cutlass.Int32(0)
+        tval = cutlass.Float32(0.0)
+        wsel = cutlass.Float32(0.0)
+        GMAX = cutlass.Float32(0.0)
+        Tv = cutlass.Float32(0.0)
+        lmn = cutlass.Float32(0.0)
+        lmx = cutlass.Float32(0.0)
+
+        if short == cutlass.Int32(0):
+            npad = cutlass.Int32(logits.shape[1])  # noqa: F841
+            k = cutlass.Int32(pre_idx.shape[1])
+            out_row = out[row, None]
+            x_addr = logits[row, None].iterator.toint()  # Int64 gmem byte base
+            p_addr = pre_idx[prow, None].iterator.toint()  # request-level under varlen
+
+            # ---- shared-memory window (map in module docstring) ----
+            sptr = cute.arch.get_dyn_smem(cutlass.Int32, alignment=16)
+            sbase = sptr.toint()  # Int32 shared addr
+
+            s_res = _smem_view(cutlass.Int32, sbase, 0, 6)
+            s_cnt = _smem_view(cutlass.Int32, sbase, 6, 2)  # [0]=s_o1 [1]=s_oc
+            s_kmm = _smem_view(cutlass.Uint32, sbase, 8, 2)  # [0]=s_kmin [1]=s_kmax
+            s_e12 = _smem_view(cutlass.Int32, sbase, 10, 2)  # [0]=s_e1 [1]=s_e2
+            s_ws = _smem_view(cutlass.Int32, sbase, 16, 32)
+            s_wmn = _smem_view(cutlass.Uint32, sbase, 48, 32)
+            s_wmx = _smem_view(cutlass.Uint32, sbase, 80, 32)
+            s_hist = _smem_view(cutlass.Int32, sbase, STATIC_WORDS, self.nbh)
+            ck_base = sbase + cutlass.Int32((STATIC_WORDS + self.nbh) * 4)
+            ck = cute.make_tensor(
+                cute.make_ptr(cutlass.Uint32, ck_base, cute.AddressSpace.smem, assumed_align=16),
+                cute.make_layout((65536,)),
+            )  # typed view, no bound
+            ci = cute.make_tensor(
+                cute.make_ptr(
+                    cutlass.Int32,
+                    ck_base + cmp_ * cutlass.Int32(4),
+                    cute.AddressSpace.smem,
+                    assumed_align=4,
+                ),
+                cute.make_layout((65536,)),
+            )
+            img_f = cute.make_tensor(  # aliases ck/ci
+                cute.make_ptr(cutlass.Float32, ck_base, cute.AddressSpace.smem, assumed_align=16),
+                cute.make_layout((65536,)),
+            )
+            bm = cute.make_tensor(  # aliases ck
+                cute.make_ptr(cutlass.Int32, ck_base, cute.AddressSpace.smem, assumed_align=16),
+                cute.make_layout((65536,)),
+            )
+
+            n4 = n >> cutlass.Int32(2)
+            ntail = n - (n4 << cutlass.Int32(2))
+            tix = (n4 << cutlass.Int32(2)) + tid  # CUDA `tidx`
+
+            # ---- hint prefetch: KPT coalesced pre_idx words BEFORE any
+            # dependent gather; compiled out under DEG.
+            pvs = []
+            if cutlass.const_expr(not self.deg):
+                for t in cutlass.range_constexpr(KPT):
+                    pv = cutlass.Int32(-1)
+                    j = tid + cutlass.Int32(t * self.blk)
+                    if j < k:
+                        pv = ld_g_i32(p_addr, j)
+                    pvs.append(pv)
+
+            # ---- row load: exact-fit peel + float4[VPT] register batch
+            atom128 = g2r_atom_f32(128, invariant=True)
+            frags = [cute.make_rmem_tensor((4,), cutlass.Float32) for _ in range(VPT)]
+            if n4 >= cutlass.Int32(self.blk * self.vpt):  # block-uniform peel
+                for u in cutlass.range_constexpr(VPT):
+                    ld_g_f32x4(atom128, x_addr, tid + cutlass.Int32(u * self.blk), frags[u])
+            else:  # predicated flat batch
+                for u in cutlass.range_constexpr(VPT):
+                    i = tid + cutlass.Int32(u * self.blk)
+                    if i < n4:
+                        ld_g_f32x4(atom128, x_addr, i, frags[u])
+                for u in cutlass.range_constexpr(VPT):
+                    i = tid + cutlass.Int32(u * self.blk)
+                    if i >= n4:  # -INFINITY fill
+                        for q in cutlass.range_constexpr(4):
+                            frags[u][q] = cutlass.Float32(_NEG_INF__reg)
+
+            tval = cutlass.Float32(_NEG_INF__reg)
+            if tid < ntail:
+                tval = ldg_f32(x_addr, tix)
+
+            # ---- init
+            if tid == cutlass.Int32(0):
+                s_cnt[0] = cutlass.Int32(0)
+                s_cnt[1] = cutlass.Int32(0)
+            for z in cutlass.range_constexpr(self.nbh // self.blk):
+                s_hist[tid + cutlass.Int32(z * self.blk)] = cutlass.Int32(0)
+
+            # ---- bracket: 4 mutually exclusive compile-time arms
+            lmin = cutlass.Uint32(0xFFFFFFFF)
+            lmax = cutlass.Uint32(0)
+            if cutlass.const_expr(self.use_img):
+                fatom = _f32_smem_atom()
+                for u in cutlass.range_constexpr(VPT):  # VPT == 1 here
+                    i = tid + cutlass.Int32(u * self.blk)
+                    if i < n4:
+                        _sts128_f32(fatom, frags[u], ck_base, i * cutlass.Int32(16))
+                if tid < ntail:
+                    img_f[tix] = tval
+                cute.arch.barrier()  # image staged
+                for t in cutlass.range_constexpr(KPT):
+                    p = pvs[t]
+                    if cutlass.Uint32(p) < cutlass.Uint32(n):
+                        uk = fkey(img_f[p])
+                        if uk < lmin:
+                            lmin = uk
+                        if uk > lmax:
+                            lmax = uk
+                cute.arch.barrier()  # img dies
+            elif cutlass.const_expr(self.use_bm):
+                nbw = (n + cutlass.Int32(31)) >> cutlass.Int32(5)
+                i = tid
+                while i < nbw:  # bitmap clear
+                    bm[i] = cutlass.Int32(0)
+                    i = i + cutlass.Int32(BLK)
+                cute.arch.barrier()  # bitmap cleared
+                for t in cutlass.range_constexpr(KPT):
+                    p = pvs[t]
+                    if cutlass.Uint32(p) < cutlass.Uint32(n):
+                        atomic_or_cta(
+                            bm.iterator + (p >> cutlass.Int32(5)),
+                            cutlass.Int32(1) << (p & cutlass.Int32(31)),
+                        )
+                cute.arch.barrier()  # bitmap set
+                lmn = cutlass.Float32(_POS_INF)
+                lmx = cutlass.Float32(_NEG_INF__reg)
+                for u in cutlass.range_constexpr(VPT):
+                    base = (tid + cutlass.Int32(u * self.blk)) << cutlass.Int32(2)
+                    w = cutlass.Uint32(0)
+                    if cutlass.Uint32(base) < cutlass.Uint32(n):
+                        w = cutlass.Uint32(bm[base >> cutlass.Int32(5)]) >> cutlass.Uint32(
+                            base & cutlass.Int32(31)
+                        )
+                    for cbit in cutlass.range_constexpr(4):
+                        if (w & cutlass.Uint32(1 << cbit)) != cutlass.Uint32(0):
+                            lmn = fmin_f32(lmn, _val(frags, 4 * u + cbit))
+                            lmx = fmax_f32(lmx, _val(frags, 4 * u + cbit))
+                if tid < ntail:
+                    wt = cutlass.Uint32(bm[tix >> cutlass.Int32(5)]) >> cutlass.Uint32(
+                        tix & cutlass.Int32(31)
+                    )
+                    if (wt & cutlass.Uint32(1)) != cutlass.Uint32(0):
+                        lmn = fmin_f32(lmn, tval)
+                        lmx = fmax_f32(lmx, tval)
+                lmin = fkey(lmn)
+                lmax = fkey(lmx)  # monotone
+                cute.arch.barrier()  # bm dies
+            elif cutlass.const_expr(self.deg):
+                lmn = cutlass.Float32(_POS_INF)
+                lmx = cutlass.Float32(_NEG_INF__reg)
+                for s in cutlass.range_constexpr(S):
+                    v = _val(frags, s)
+                    if v > cutlass.Float32(_NEG_INF__reg):
+                        lmn = fmin_f32(lmn, v)
+                        lmx = fmax_f32(lmx, v)
+                if tid < ntail:
+                    lmn = fmin_f32(lmn, tval)
+                    lmx = fmax_f32(lmx, tval)
+                lmin = fkey(lmn)
+                lmax = fkey(lmx)
+            else:
+                # default: KPT scattered fkey ldg gathers, batch-then-fold
+                xs = []
+                for t in cutlass.range_constexpr(KPT):
+                    xv = cutlass.Float32(0.0)
+                    if cutlass.Uint32(pvs[t]) < cutlass.Uint32(n):
+                        xv = ldg_f32(x_addr, pvs[t])
+                    xs.append(xv)
+                for t in cutlass.range_constexpr(KPT):
+                    if cutlass.Uint32(pvs[t]) < cutlass.Uint32(n):
+                        uk = fkey(xs[t])
+                        if uk < lmin:
+                            lmin = uk
+                        if uk > lmax:
+                            lmax = uk
+
+            # ---- block min/max in ONE barrier; publishes hist clear
+            lmin = warp_min_u32(lmin)
+            lmax = warp_max_u32(lmax)
+            if lane == cutlass.Int32(0):
+                s_wmn[tid >> cutlass.Int32(5)] = lmin
+                s_wmx[tid >> cutlass.Int32(5)] = lmax
+            cute.arch.barrier()  # warp partials published
+            a = cutlass.Uint32(0xFFFFFFFF)
+            c = cutlass.Uint32(0)
+            if lane < cutlass.Int32(NW):
+                a = cutlass.Uint32(s_wmn[lane])
+                c = cutlass.Uint32(s_wmx[lane])
+            lmin = warp_min_u32(a)
+            lmax = warp_max_u32(c)
+            Tv = invkey(lmin)
+            GMAX = invkey(lmax)
+
+            # ---- collapse guard, NaN-safe
+            okc = cutlass.Int32(0)
+            if Tv < GMAX:
+                if (GMAX - Tv) > cutlass.Float32(1e-30):
+                    okc = cutlass.Int32(1)
+            if okc == cutlass.Int32(0):
+                Tv = cutlass.Float32(SENT_LO)
+                GMAX = cutlass.Float32(SENT_HI)
+
+            # ---- bin transform constants
+            BRL = cutlass.const_expr(self.brl)  # noqa: F841
+            OFFf = cutlass.Float32(1.0 if self.brl else 0.0)
+            recip = 1.0 / float(self.nbh - (2 if self.brl else 0))
+            WD = (GMAX - Tv) * cutlass.Float32(recip)
+            wsel = cutlass.Float32(1e-30)
+            if WD > cutlass.Float32(0.0):
+                wsel = WD
+            # rcp.approx (single MUFU.RCP) — the CUDA arm's exact lowering of
+            # `1.0f / wsel`; a plain `1.0 / wsel` would emit the IEEE div.rn
+            # Newton triple + slowpath CALL on the barrier-bounded chain
+            # feeding all S classify FMULs. Output exactness is SC-invariant
+            # (any SC > 0 preserves the sign/monotonicity invariants) and the
+            # WD > 0 arm is bit-identical to CUDA's MUFU.RCP.
+            SC = cute.arch.rcp_approx(wsel)
+            QCAPf = cutlass.Float32(float(self.nbh - 1))
+            CQ0 = OFFf - Tv * SC
+            CQ = CQ0 + cutlass.Float32(1e-6) * (_fabsf(CQ0) + cutlass.Float32(1.0))
+
+            # ---- histogram
+            if cutlass.const_expr(self.brl):
+                # BRL classify arm: hist base pinned ONCE via the same
+                # _smem_addr_reg__reg identity-mov used in the !BRL arm below,
+                # and the result-discarded classify atomics spelled as
+                # resultless red.shared (_red_shared_add1__reg).
+                # Value-identical: same +1 to the same byte address
+                # (hb + 4*bn == &s_hist[bn]), same .relaxed.cta ordering; the
+                # q/bn computations are untouched so classify/emit
+                # bit-identity (BRL requirement) is preserved. Emit-path hist
+                # atomics (results used) are NOT touched.
+                hb = _smem_addr_reg__reg(sbase + cutlass.Int32(STATIC_WORDS * 4))
+                for s in cutlass.range_constexpr(S):
+                    q = _fmaf__reg(_val(frags, s), SC, CQ)
+                    bn = _umin_u32(f2u_rz(q), cutlass.Uint32(self.nbh - 1))
+                    _red_shared_add1__reg(hb + (cutlass.Int32(bn) << cutlass.Int32(2)))
+                qt = _fmaf__reg(tval, SC, CQ)  # unconditional
+                bnt = _umin_u32(f2u_rz(qt), cutlass.Uint32(self.nbh - 1))
+                _red_shared_add1__reg(hb + (cutlass.Int32(bnt) << cutlass.Int32(2)))
+            else:
+                # hist base pinned ONCE (byte addr, +STATIC_BYTES = word 128 map);
+                # each site below is then LEA + ATOMS exactly like the CUDA arm
+                # instead of re-deriving the shared window per divergent block.
+                hb = _smem_addr_reg__reg(sbase + cutlass.Int32(STATIC_WORDS * 4))
+                for s in cutlass.range_constexpr(S):
+                    q = _submul_asm(_val(frags, s), Tv, SC)  # anti-CSE classify
+                    if q >= cutlass.Float32(0.0):
+                        _red_shared_add1__reg(hb + (f2s_rz(fmin_f32(q, QCAPf)) << cutlass.Int32(2)))
+                qt = _submul_asm(tval, Tv, SC)
+                if qt >= cutlass.Float32(0.0):
+                    _red_shared_add1__reg(hb + (f2s_rz(fmin_f32(qt, QCAPf)) << cutlass.Int32(2)))
+            cute.arch.barrier()  # histogram done
+
+            # ---- crossing-bin find
+            if cutlass.const_expr(self.cur or self.nbh > 1024):
+                scan_cross_w(s_hist, s_ws, k, tid, s_res, blk=self.blk, nb=self.nbh)
+            else:
+                find_cross(s_hist, k, tid, s_res, nb=self.nbh)
+            cute.arch.barrier()  # crossing published
+            above = s_res[RES_ABOVE]
+            m = s_res[RES_M]
+            Bv = s_res[RES_B]
+            need = k - above
+            whole = cutlass.Int32(0)
+            if need >= m:
+                whole = cutlass.Int32(1)
+
+            # ---- ESCAPE: 32-step key-space bisection
+            esc = cutlass.Int32(0)
+            if whole == cutlass.Int32(0):
+                if m > cmp_:
+                    esc = cutlass.Int32(1)
+            if esc == cutlass.Int32(1):
+                if tid == cutlass.Int32(0):
+                    s_cnt[0] = cutlass.Int32(0)
+                    s_cnt[1] = cutlass.Int32(0)
+                    # DEVIATION (race fix): the CUDA zeroes s_o1/s_oc again
+                    # between the nA read and the emit with only ONE barrier
+                    # pair around both — a read/write race. Emit instead
+                    # through the path-exclusive s_e1/s_e2 slots, zeroed HERE
+                    # under the existing barrier; the racy mid-emit rezero is
+                    # dropped. Barrier count unchanged.
+                    s_e12[0] = cutlass.Int32(0)
+                    s_e12[1] = cutlass.Int32(0)
+                cute.arch.barrier()  # escape init
+                klo = cutlass.Uint32(0)
+                bit = cutlass.Int32(31)
+                while bit >= cutlass.Int32(0):
+                    kt = klo | (cutlass.Uint32(1) << cutlass.Uint32(bit))
+                    cnt = cutlass.Int32(0)
+                    for s in cutlass.range_constexpr(S):
+                        ix = (
+                            (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                        ) + cutlass.Int32(s % 4)
+                        if ix < n:
+                            if fkey(_val(frags, s)) >= kt:
+                                cnt = cnt + cutlass.Int32(1)
+                    if tid < ntail:
+                        if fkey(tval) >= kt:
+                            cnt = cnt + cutlass.Int32(1)
+                    cnt = cutlass.Int32(warp_add_i32(cnt))
+                    if lane == cutlass.Int32(0):
+                        if cnt != cutlass.Int32(0):
+                            atomic_add_cta(s_cnt.iterator, cnt)
+                    cute.arch.barrier()  # count published
+                    if s_cnt[0] >= k:
+                        klo = kt
+                    cute.arch.barrier()  # count consumed
+                    if tid == cutlass.Int32(0):
+                        s_cnt[0] = cutlass.Int32(0)
+                    cute.arch.barrier()  # count reset
+                    bit = bit - cutlass.Int32(1)
+                ethr = cutlass.Int64(klo)  # k-th largest key
+                abv = cutlass.Int32(0)
+                for s in cutlass.range_constexpr(S):
+                    ix = (
+                        (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                    ) + cutlass.Int32(s % 4)
+                    if ix < n:
+                        if cutlass.Int64(fkey(_val(frags, s))) > ethr:
+                            abv = abv + cutlass.Int32(1)
+                if tid < ntail:
+                    if cutlass.Int64(fkey(tval)) > ethr:
+                        abv = abv + cutlass.Int32(1)
+                abv = cutlass.Int32(warp_add_i32(abv))
+                if lane == cutlass.Int32(0):
+                    if abv != cutlass.Int32(0):
+                        atomic_add_cta(s_cnt.iterator + 1, abv)
+                cute.arch.barrier()  # above-count published
+                nA = s_cnt[1]
+                nT = k - nA
+                # (rezero dropped — emit counters live in s_e12, see race-fix note)
+                cute.arch.barrier()  # nA consumed
+                lml = cutlass.Int32(cute.arch.lanemask_lt())
+                for s in cutlass.range_constexpr(S):
+                    ixv = (
+                        (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                    ) + cutlass.Int32(s % 4)
+                    u64 = cutlass.Int64(-1)
+                    if ixv < n:
+                        u64 = cutlass.Int64(fkey(_val(frags, s)))
+                    q1e = cutlass.Int32(0)
+                    q2e = cutlass.Int32(0)
+                    if u64 > ethr:
+                        q1e = cutlass.Int32(1)
+                    if u64 == ethr:
+                        q2e = cutlass.Int32(1)
+                    n1 = ballot(q1e == cutlass.Int32(1))
+                    n2 = ballot(q2e == cutlass.Int32(1))
+                    b1 = cutlass.Int32(0)
+                    b2 = cutlass.Int32(0)
+                    if lane == cutlass.Int32(0):
+                        if n1 != cutlass.Int32(0):
+                            b1 = atomic_add_cta(s_e12.iterator, popc(n1))
+                        if n2 != cutlass.Int32(0):
+                            b2 = atomic_add_cta(s_e12.iterator + 1, popc(n2))
+                    b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+                    b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+                    p1e = b1 + popc(n1 & lml)
+                    p2e = b2 + popc(n2 & lml)
+                    if q1e == cutlass.Int32(1):
+                        if p1e < nA:
+                            out_row[p1e] = ixv
+                    if q2e == cutlass.Int32(1):
+                        if p2e < nT:
+                            out_row[nA + p2e] = ixv
+                # tail element
+                u64 = cutlass.Int64(-1)
+                if tid < ntail:
+                    u64 = cutlass.Int64(fkey(tval))
+                q1e = cutlass.Int32(0)
+                q2e = cutlass.Int32(0)
+                if u64 > ethr:
+                    q1e = cutlass.Int32(1)
+                if u64 == ethr:
+                    q2e = cutlass.Int32(1)
+                n1 = ballot(q1e == cutlass.Int32(1))
+                n2 = ballot(q2e == cutlass.Int32(1))
+                b1 = cutlass.Int32(0)
+                b2 = cutlass.Int32(0)
+                if lane == cutlass.Int32(0):
+                    if n1 != cutlass.Int32(0):
+                        b1 = atomic_add_cta(s_e12.iterator, popc(n1))
+                    if n2 != cutlass.Int32(0):
+                        b2 = atomic_add_cta(s_e12.iterator + 1, popc(n2))
+                b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+                b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+                p1e = b1 + popc(n1 & lml)
+                p2e = b2 + popc(n2 & lml)
+                if q1e == cutlass.Int32(1):
+                    if p1e < nA:
+                        out_row[p1e] = tix
+                if q2e == cutlass.Int32(1):
+                    if p2e < nT:
+                        out_row[nA + p2e] = tix
+                # (CUDA returns here — everything below is the else-arm)
+            else:
+                # ---- emit
+                if cutlass.const_expr(self.cur):
+                    LOQ = cutlass.Float32(Bv)  # int->float cvt
+                    lim1 = above
+                    if whole == cutlass.Int32(1):
+                        lim1 = above + m
+                    for s in cutlass.range_constexpr(S):
+                        if cutlass.const_expr(self.brl):
+                            q = _fmaf__reg(_val(frags, s), SC, CQ)  # bit-identical to classify
+                        else:
+                            q = _fmaf__reg(_val(frags, s) - Tv, SC, OFFf)  # emit spelling
+                        idx = (
+                            (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                        ) + cutlass.Int32(s % 4)
+                        p = cutlass.Int32(0)
+                        if q >= LOQ:
+                            bn = _umin_u32(f2u_rz(q), cutlass.Uint32(self.nbh - 1))
+                            p = atomic_add_cta(
+                                s_hist.iterator + cutlass.Int32(bn), cutlass.Int32(1)
+                            )
+                            if p < lim1:
+                                out_row[p] = idx
+                            else:
+                                if whole == cutlass.Int32(0):
+                                    q2i = p - above
+                                    if q2i < cmp_:  # escape-made-safe guard
+                                        ck[q2i] = fkey(_val(frags, s))
+                                        ci[q2i] = idx
+                    # tail
+                    if cutlass.const_expr(self.brl):
+                        qt2 = _fmaf__reg(tval, SC, CQ)
+                    else:
+                        qt2 = _fmaf__reg(tval - Tv, SC, OFFf)
+                    p = cutlass.Int32(0)
+                    if qt2 >= LOQ:
+                        bn = _umin_u32(f2u_rz(qt2), cutlass.Uint32(self.nbh - 1))
+                        p = atomic_add_cta(s_hist.iterator + cutlass.Int32(bn), cutlass.Int32(1))
+                        if p < lim1:
+                            out_row[p] = tix
+                        else:
+                            if whole == cutlass.Int32(0):
+                                q2i = p - above
+                                if q2i < cmp_:
+                                    ck[q2i] = fkey(tval)
+                                    ci[q2i] = tix
+                else:
+                    # two-mask ballot emit
+                    HIf = cutlass.Float32(_POS_INF)
+                    LOf = cutlass.Float32(_POS_INF)
+                    if whole == cutlass.Int32(1):
+                        HIf = cutlass.Float32(Bv)
+                    else:
+                        if Bv < cutlass.Int32(self.nbh - 1):
+                            HIf = cutlass.Float32(Bv + cutlass.Int32(1))
+                        LOf = cutlass.Float32(Bv)
+                    m1 = cutlass.Int32(0)
+                    m2 = cutlass.Int32(0)
+                    for s in cutlass.range_constexpr(S):
+                        if cutlass.const_expr(self.brl):
+                            q = _fmaf__reg(_val(frags, s), SC, CQ)
+                        else:
+                            q = _fmaf__reg(_val(frags, s) - Tv, SC, OFFf)
+                        if q >= HIf:
+                            m1 = m1 | cutlass.Int32(1 << s)
+                        else:
+                            if q >= LOf:
+                                m2 = m2 | cutlass.Int32(1 << s)
+                    if cutlass.const_expr(self.brl):
+                        qt3 = _fmaf__reg(tval, SC, CQ)
+                    else:
+                        qt3 = _fmaf__reg(tval - Tv, SC, OFFf)
+                    t1 = cutlass.Int32(0)
+                    t2 = cutlass.Int32(0)
+                    if qt3 >= HIf:
+                        t1 = cutlass.Int32(1)
+                    else:
+                        if qt3 >= LOf:
+                            t2 = cutlass.Int32(1)
+                    c1 = popc(m1) + t1
+                    c2 = popc(m2) + t2
+                    s1, s2 = warp_incl_scan_add2(c1, c2, lane)
+                    b1 = cutlass.Int32(0)
+                    b2 = cutlass.Int32(0)
+                    if lane == cutlass.Int32(31):
+                        b1 = atomic_add_cta(s_cnt.iterator, s1)
+                        b2 = atomic_add_cta(s_cnt.iterator + 1, s2)
+                    b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(31))
+                    b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(31))
+                    p1 = b1 + (s1 - c1)
+                    p2 = b2 + (s2 - c2)
+                    lim1 = above
+                    if whole == cutlass.Int32(1):
+                        lim1 = k
+                    wm = m1  # sparse set-bit walk
+                    while wm != cutlass.Int32(0):
+                        sdyn = ffs_m1(wm)
+                        idx = (
+                            (tid + (sdyn >> cutlass.Int32(2)) * cutlass.Int32(self.blk))
+                            << cutlass.Int32(2)
+                        ) + (sdyn & cutlass.Int32(3))
+                        if p1 < lim1:
+                            out_row[p1] = idx
+                        p1 = p1 + cutlass.Int32(1)
+                        wm = wm & (wm - cutlass.Int32(1))
+                    if t1 == cutlass.Int32(1):
+                        if p1 < lim1:
+                            out_row[p1] = tix
+                        p1 = p1 + cutlass.Int32(1)
+                    if m2 != cutlass.Int32(0):  # static-unrolled
+                        for s in cutlass.range_constexpr(S):
+                            if (m2 & cutlass.Int32(1 << s)) != cutlass.Int32(0):
+                                idx = (
+                                    (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                                ) + cutlass.Int32(s % 4)
+                                if p2 < cmp_:
+                                    ck[p2] = fkey(_val(frags, s))
+                                    ci[p2] = idx
+                                p2 = p2 + cutlass.Int32(1)
+                    if t2 == cutlass.Int32(1):
+                        if p2 < cmp_:
+                            ck[p2] = fkey(tval)
+                            ci[p2] = tix
+                        p2 = p2 + cutlass.Int32(1)
+
+                # ---- refine (skipped when whole — CUDA returned inside emit)
+                if whole == cutlass.Int32(0):
+                    cute.arch.barrier()  # emit done
+                    if cutlass.const_expr(self.cur):
+                        mc = m
+                        if mc > cmp_:
+                            mc = cmp_
+                    else:
+                        mc = s_cnt[1]
+                        if mc > cmp_:
+                            mc = cmp_
+                    quad = cutlass.Int32(0)
+                    if mc >= m:
+                        if mc <= qc:
+                            quad = cutlass.Int32(1)
+                    if quad == cutlass.Int32(1):
+                        # O(mc^2) index-tie-broken rank
+                        i = tid
+                        while i < mc:
+                            uq = cutlass.Uint32(ck[i])
+                            r = cutlass.Int32(0)
+                            j = cutlass.Int32(0)
+                            while j < mc:
+                                vq = cutlass.Uint32(ck[j])
+                                tinc = cutlass.Int32(0)
+                                if vq > uq:
+                                    tinc = cutlass.Int32(1)
+                                if vq == uq:
+                                    if j < i:
+                                        tinc = cutlass.Int32(1)
+                                r = r + tinc
+                                j = j + cutlass.Int32(1)
+                            if r < need:
+                                out_row[above + r] = ci[i]
+                            i = i + cutlass.Int32(BLK)
+                    else:
+                        # ---- fallback: exact key-space narrowing
+                        if tid == cutlass.Int32(0):
+                            s_kmm[0] = cutlass.Uint32(0xFFFFFFFF)
+                            s_kmm[1] = cutlass.Uint32(0)
+                        cute.arch.barrier()  # kmm init
+                        i = tid
+                        while i < mc:
+                            kv = cutlass.Uint32(ck[i])
+                            atomic_min_cta(s_kmm.iterator, kv)
+                            atomic_max_cta(s_kmm.iterator + 1, kv)
+                            i = i + cutlass.Int32(BLK)
+                        cute.arch.barrier()  # key range published
+                        rlo = cutlass.Uint32(s_kmm[0])
+                        rhi = cutlass.Uint32(s_kmm[1])
+                        ethr = cutlass.Int64(rlo)
+                        aboveC = cutlass.Int32(0)
+                        needC = need
+                        mm = mc
+                        lev = cutlass.Int32(0)
+                        done = cutlass.Int32(0)
+                        while done == cutlass.Int32(0):
+                            if needC == mm:
+                                ethr = cutlass.Int64(rlo) - cutlass.Int64(1)
+                                aboveC = aboveC + mm
+                                needC = cutlass.Int32(0)
+                                done = cutlass.Int32(1)
+                            if done == cutlass.Int32(0):
+                                if rlo >= rhi:
+                                    ethr = cutlass.Int64(rlo)
+                                    done = cutlass.Int32(1)
+                                if lev >= cutlass.Int32(6):
+                                    ethr = cutlass.Int64(rlo)
+                                    done = cutlass.Int32(1)
+                            if done == cutlass.Int32(0):
+                                d2 = rhi - rlo
+                                b2w = cutlass.Int32(32) - clz_i32(
+                                    cutlass.Int32(d2 | cutlass.Uint32(1))
+                                )
+                                sh2 = cutlass.Int32(0)
+                                if b2w > cutlass.Int32(LNBH):
+                                    sh2 = b2w - cutlass.Int32(LNBH)
+                                for z in cutlass.range_constexpr(self.nbh // self.blk):
+                                    s_hist[tid + cutlass.Int32(z * self.blk)] = cutlass.Int32(0)
+                                cute.arch.barrier()  # level clear
+                                i = tid
+                                while i < mc:
+                                    unar = cutlass.Uint32(ck[i])
+                                    if unar >= rlo:
+                                        if unar <= rhi:
+                                            bnn = (unar - rlo) >> cutlass.Uint32(sh2)
+                                            bnn = _umin_u32(bnn, cutlass.Uint32(self.nbh - 1))
+                                            atomic_add_cta(
+                                                s_hist.iterator + cutlass.Int32(bnn),
+                                                cutlass.Int32(1),
+                                            )
+                                    i = i + cutlass.Int32(BLK)
+                                cute.arch.barrier()  # level hist
+                                if cutlass.const_expr(self.nbh > 1024):
+                                    scan_cross_w(
+                                        s_hist, s_ws, needC, tid, s_res, blk=self.blk, nb=self.nbh
+                                    )
+                                else:
+                                    find_cross(s_hist, needC, tid, s_res, nb=self.nbh)
+                                cute.arch.barrier()  # level scan
+                                aboveC = aboveC + s_res[RES_ABOVE]
+                                needC = needC - s_res[RES_ABOVE]
+                                mm = s_res[RES_M]
+                                b_lv = s_res[RES_B]
+                                nlo = rlo + (cutlass.Uint32(b_lv) << cutlass.Uint32(sh2))
+                                if b_lv != cutlass.Int32(self.nbh - 1):
+                                    rhi = nlo + (
+                                        (cutlass.Uint32(1) << cutlass.Uint32(sh2))
+                                        - cutlass.Uint32(1)
+                                    )
+                                rlo = nlo
+                                lev = lev + cutlass.Int32(1)
+                        # final two-predicate ballot emit
+                        if tid == cutlass.Int32(0):
+                            s_e12[0] = cutlass.Int32(0)
+                            s_e12[1] = cutlass.Int32(0)
+                        cute.arch.barrier()  # emit counters
+                        lml = cutlass.Int32(cute.arch.lanemask_lt())
+                        it2 = (mc + cutlass.Int32(self.blk - 1)) // cutlass.Int32(self.blk)
+                        it = cutlass.Int32(0)
+                        while it < it2:
+                            i = it * cutlass.Int32(BLK) + tid
+                            uke = cutlass.Uint32(0)
+                            idv = cutlass.Int32(0)
+                            if i < mc:
+                                uke = cutlass.Uint32(ck[i])
+                                idv = ci[i]
+                            q1f = cutlass.Int32(0)
+                            q2f = cutlass.Int32(0)
+                            if i < mc:
+                                if cutlass.Int64(uke) > ethr:
+                                    q1f = cutlass.Int32(1)
+                                if cutlass.Int64(uke) == ethr:
+                                    q2f = cutlass.Int32(1)
+                            n1 = ballot(q1f == cutlass.Int32(1))
+                            n2 = ballot(q2f == cutlass.Int32(1))
+                            b1 = cutlass.Int32(0)
+                            b2 = cutlass.Int32(0)
+                            if lane == cutlass.Int32(0):
+                                if n1 != cutlass.Int32(0):
+                                    b1 = atomic_add_cta(s_e12.iterator, popc(n1))
+                                if n2 != cutlass.Int32(0):
+                                    b2 = atomic_add_cta(s_e12.iterator + 1, popc(n2))
+                            b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+                            b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+                            p1e = b1 + popc(n1 & lml)
+                            p2e = b2 + popc(n2 & lml)
+                            if q1f == cutlass.Int32(1):
+                                if p1e < aboveC:
+                                    out_row[above + p1e] = idv
+                            if q2f == cutlass.Int32(1):
+                                if p2e < needC:
+                                    out_row[above + aboveC + p2e] = idv
+                            it = it + cutlass.Int32(1)
+
+    # ------------------------------------------------------------------
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        kv_lens: cute.Tensor,
+        out: cute.Tensor,
+        n: cutlass.Int32,
+        cmp_: cutlass.Int32,
+        qc: cutlass.Int32,
+        smem_bytes: cutlass.Int32,
+        stream,
+    ):
+        b = logits.shape[0]
+        self.kern(logits, pre_idx, kv_lens, out, n, cmp_, qc, smem_bytes).launch(
+            grid=(b, 1, 1),
+            block=(self.blk, 1, 1),
+            stream=stream,
+            smem=smem_bytes,
+            min_blocks_per_mp=self.minb,
+            use_pdl=self.pdl,
+        )
+
+
+# ---------------------------------------------------------------------------
+# host wrapper: compile cache + route()-driven entry
+# ---------------------------------------------------------------------------
+_COMPILE_CACHE__reg: dict = {}
+
+
+def get_compiled__reg(tpl, dump_dir=None, pdl=False, varlen=False, next_n=1, cr_shift=0):
+    """Compile (or fetch) the variant for constexpr tuple
+    (BLK, VPT, MINB, KPT, CUR, DEG, IMG, NBH)."""
+    key = (tuple(tpl), bool(pdl), bool(varlen), int(next_n), int(cr_shift))
+    compiled = _COMPILE_CACHE__reg.get(key)
+    if compiled is None:
+        from cutlass.cute import runtime as _crt
+
+        blk, vpt, minb, kpt, cur, deg, img, nbh = tpl
+        kernel = GvrTopkRegKernel(
+            blk,
+            vpt,
+            minb,
+            kpt,
+            cur,
+            deg,
+            img,
+            nbh,
+            pdl=pdl,
+            varlen=varlen,
+            next_n=next_n,
+            cr_shift=cr_shift,
+        )
+        nb_, nc_ = cute.sym_int(), cute.sym_int()
+        nb2_, nc2_ = cute.sym_int(), cute.sym_int()
+        nb3_, nc3_ = cute.sym_int(), cute.sym_int()
+        lg_fake = _crt.make_fake_compact_tensor(
+            cutlass.Float32, (nb_, nc_), stride_order=(1, 0), assumed_align=16
+        )
+        pi_fake = _crt.make_fake_compact_tensor(
+            cutlass.Int32, (nb2_, nc2_), stride_order=(1, 0), assumed_align=16
+        )
+        out_fake = _crt.make_fake_compact_tensor(
+            cutlass.Int32, (nb3_, nc3_), stride_order=(1, 0), assumed_align=16
+        )
+        v0_ = cute.sym_int()
+        kv_fake = _crt.make_fake_compact_tensor(
+            cutlass.Int32, (v0_,), stride_order=(0,), assumed_align=4
+        )
+        fake_stream = _crt.make_fake_stream(use_tvm_ffi_env_stream=True)
+        opts = "--enable-tvm-ffi"
+        if dump_dir:
+            opts += f" --keep-ptx --keep-cubin --dump-dir {dump_dir}"
+
+        def _compile_fn():
+            with _no_carveout():
+                return cute.compile(
+                    kernel,
+                    lg_fake,
+                    pi_fake,
+                    kv_fake,
+                    out_fake,
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    cutlass.Int32(0),
+                    stream=fake_stream,
+                    options=opts,
+                )
+
+        if dump_dir:
+            # debug dumps: compile in-process, do not persist
+            compiled = _compile_fn()
+        else:
+            name = (
+                "reg_" + "_".join(str(x) for x in tuple(tpl))
+                + f"_pdl{int(bool(pdl))}_vl{int(bool(varlen))}_nn{int(next_n)}_cs{int(cr_shift)}"
+            )
+            compiled = C._persist(name, _compile_fn)
+        _COMPILE_CACHE__reg[key] = compiled
+    return compiled
+
+
+def reg_topk(logits, pre_idx, n, out, rd=None):
+    """torch-facing entry for the register family.
+
+    logits [b, npad] f32, pre_idx [b, k] i32, out [b, >=k] i32, n = valid len.
+    rd: optional pre-computed ct_dispatch.route() dict (must be reg/regimg).
+    """
+    if rd is None:
+        try:
+            from .gvr2_topk_host import route
+        except ImportError:
+            from gvr2_topk_host import route
+        rd = route(logits.shape[0], int(n), logits.shape[1], pre_idx.shape[1])
+    assert rd["kernel"] in ("reg", "regimg"), rd["kernel"]
+    tpl = rd["tpl"]
+    rt = rd["rt"]
+    assert rt["IMGOFF"] == tpl[7], (rt["IMGOFF"], tpl[7])  # IMGOFF == NBH
+    compiled = get_compiled__reg(tpl)
+    smem = STATIC_BYTES + rd["smem"]
+    try:
+        from .gvr2_topk_host import _dummy_kv
+    except ImportError:
+        from gvr2_topk_host import _dummy_kv
+    kv = _dummy_kv(logits.get_device(), logits.device)  # dead varlen ABI slot
+    compiled(logits, pre_idx, kv, out, int(n), rt["CMP"], rt["QC"], smem)
+    return out
+
+
+# ===========================================================================
+# ==== family: clus ============================================
+# ===========================================================================
+"""gvr_clus — clustered streaming self-sampling GVR; per-CTA stream mirrors
+gvr_main.
+
+Ctor knobs (compile-time, mirror of the CUDA template params):
+    BLK = 1024, U ∈ {1,2,4,8}, MINB = 1, NBS = 256, CS ∈ {2,4,8}
+    (+ scap/cmp smem-extent knobs: every reachable route has 8192/2048 —
+     SCAP/CMP stay LIVE runtime args for all value logic, ABI parity).
+Derived: HB=NBS, STEPC=BLK*U, PFD=min(U,4).
+
+Signature (ABI parity with the CUDA form; Q is dead in-kernel):
+    run__clus(logits[b,npad] f32, pre_idx[b,k] i32, out[b,k] i32) via
+    kern(..., n, npad, k, SCAP, CMP, SMP, TGT, Q, SS2, TGT2)
+Grid dim3(CS, b) native 2-D + cluster (CS,1,1); block 1024;
+min_blocks_per_mp=1 (64-register wall); smem one SmemAllocator blob
+mirroring the CUDA dynamic map hist|cbuf|ck64c|mrg, dyn-equivalent bytes ==
+the host dispatch formula (asserted in run__clus()).
+
+int2 staging convention (same as gvr_main): int2(value bits, index) is ONE
+little-endian Uint64 = (idx << 32) | value_bits — single u64 smem ld/st.
+
+Barrier / cluster-op placement mirrors the CUDA source one-for-one:
+    sample redux publish, sample hist, scan publish,
+    [degenerate sample: 2 inside gather_hint],
+    retry preamble: clus.sync + __syncthreads,
+    clus.sync (merge), __syncthreads (merge publish),
+    [ladder gather: 2 inside gather_hint],
+    clus.sync (EXIT RENDEZVOUS — the only one; rank!=0 falls through),
+    narrowing / degen per-level barriers (+1 INSIDE scan_cross).
+    NO loop-tail ladder barriers (gvr_clus has none — unlike gvr_main).
+    All clus.sync = releasing aligned arrive+wait, never relaxed.
+Cluster ops: merge = _merge_scan0_local, a LOCAL patched copy of
+    merge_scan0 that rematerializes mapa per (q, r) like the CUDA
+    (register-pressure fix); ONE packed u64 st.shared::cluster candidate
+    push to rank-0 ck64c (never split into 4B stores); mapa of ck64c to
+    rank 0.
+Every rung/ladder decision is cluster-uniform by construction (identical
+sample locations on every rank; merged tot; block-uniform gather) — the
+conditional retry clus.sync cannot deadlock.
+"""
+
+
+QUADC_CLUS__clus = C.QUADC_CLUS
+
+_NEG_INF__clus = float("-inf")
+
+
+# ---------------------------------------------------------------------------
+# single-rounding fma.rn.f32, used at the T / Tk / T3 / HIC sites.
+# (x-TF)*SC classify shapes stay plain sub+mul (uncontractible).
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _fmaf__clus(a, b, c, *, loc=None, ip=None):
+    return cutlass.Float32(
+        mlir_math.fma(
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            fastmath=mlir_arith.FastMathFlags.none,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+class GvrClusKernel:
+    """gvr_clus<BLK, U, MINB, NBS, CS> — clustered streaming GVR."""
+
+    def __init__(
+        self,
+        blk: int,
+        u: int,
+        minb: int,
+        nbs: int,
+        cs: int,
+        scap: int = 8192,
+        cmp_: int = 2048,
+        varlen: bool = False,
+        next_n: int = 1,
+        cr_shift: int = 0,
+    ):
+        assert blk == 1024, "gvr_clus is always BLK=1024"
+        assert minb == 1, "gvr_clus is __launch_bounds__(BLK, 1)"
+        assert nbs == 256, "SNB must stay 256"
+        assert u in (1, 2, 4, 8) and cs in (2, 4, 8)
+        # per-row varlen mode (production heuristicTopKDecode contract, same
+        # semantics as GvrMainKernel / GvrRegClusKernel): n and the sampling-
+        # ladder scalars are re-derived PER ROW in-kernel from a device
+        # kv_lens tensor; the scalar launch args become the envelope clamp
+        # bound (n) and dead slots (SMP/TGT/Q/SS2/TGT2).
+        self.varlen = bool(varlen)
+        self.next_n = int(next_n)
+        self.cr_shift = int(cr_shift)
+        if self.varlen:
+            assert self.next_n >= 1 and self.cr_shift in (0, 2)
+        self.lcs = cs.bit_length() - 1  # log2(CS) for the per-row Q shift
+        self.blk = blk
+        self.u = u
+        self.minb = minb
+        self.nbs = nbs
+        self.cs = cs
+        self.scap = scap  # smem extents only —
+        self.cmp = cmp_  # value logic uses rt args
+        self.hb = nbs
+        self.stepc = blk * u
+        self.pfd = u if u < 4 else 4  # PFD=min(U,4)
+        self.lb = nbs.bit_length() - 1  # log2(NBS)=8
+        # dynamic-region byte map: hist | cbuf(int2) | ck64c | mrg
+        self.cbuf_bytes = (scap + 4) * 8
+        assert self.cbuf_bytes % 16 == 0
+        self.ck_off = self.cbuf_bytes  # inside the blob
+        self.dyn_bytes = nbs * 4 + self.cbuf_bytes + cmp_ * 8 + nbs * 4
+        # == host smc = SNB*8 + (SCAP+4)*8 + CMP*8
+
+    # ------------------------------------------------------------------
+    # GVR_EMITK: classify+stage one survivor.
+    # bn via UNSIGNED saturating convert (f2u_rz); staging store is ONE
+    # u64; branchless trash slot min(pos, SCAP) (runtime SCAP). Returns pos+1.
+    # ------------------------------------------------------------------
+    @cute.jit
+    def _emitk(self, xv, idx, pos, TF, SC, SCAP, s_hist, s_cbuf2):
+        NBS = self.nbs
+        bn_u = C.f2u_rz((xv - TF) * SC)
+        if bn_u > cutlass.Uint32(NBS - 1):
+            bn_u = cutlass.Uint32(NBS - 1)
+        bn = cutlass.Int32(bn_u)
+        C.atomic_add_cta(s_hist.iterator + bn, cutlass.Int32(1))
+        ps = pos
+        if ps > SCAP:
+            ps = SCAP  # trash slot (IMNMX)
+        s_cbuf2[ps] = (cutlass.Uint64(cutlass.Uint32(idx)) << cutlass.Uint64(32)) | cutlass.Uint64(
+            C.u32_of_f32(xv)
+        )
+        return pos + cutlass.Int32(1)
+
+    # ------------------------------------------------------------------
+    # P5 emit step: bn via SIGNED rz convert (__float2int_rz); bn>=B gate;
+    # LOCAL mrg atomicAdd whose result is a CLUSTER-GLOBAL position
+    # (prefix-biased cursors from merge_scan0); overflow -> ONE packed u64
+    # DSMEM store to rank-0 ck64c (never split into 4B stores).
+    # ------------------------------------------------------------------
+    @cute.jit
+    def _p5_emit(self, xv, idv, TF, SC, B, above, lim1, whole, CMP, s_mrg, out_row, rk64):
+        NBS = self.nbs
+        bn = C.f2s_rz((xv - TF) * SC)
+        if bn > cutlass.Int32(NBS - 1):
+            bn = cutlass.Int32(NBS - 1)
+        if bn >= B:
+            p = C.atomic_add_cta(s_mrg.iterator + bn, cutlass.Int32(1))
+            if p < lim1:
+                out_row[p] = idv
+            else:
+                if whole == cutlass.Int32(0):
+                    q2 = p - above
+                    if q2 < CMP:
+                        C._st_shared_cluster_u64(
+                            rk64 + q2 * cutlass.Int32(8),
+                            (cutlass.Uint64(C.fkey(xv)) << cutlass.Uint64(32))
+                            | cutlass.Uint64(cutlass.Uint32(idv)),
+                        )
+
+    # ------------------------------------------------------------------
+    # LOCAL patched copy of merge_scan0: rematerializes mapa per (q, r)
+    # exactly like the CUDA instead of holding CS mapped base addresses
+    # across the whole merge. The hoisted-array form costs CS extra
+    # long-lived registers; with the U>=4 sixteen-register pf prime batch
+    # it tips ptxas into spilling the batch across the rung phase.
+    # Semantics, the DSMEM v4 load spelling, the register accumulation and
+    # the prefix-biased STS.128 cursor write are IDENTICAL to merge_scan0.
+    # NO barrier inside (caller pays the merge-publish barrier).
+    # ------------------------------------------------------------------
+    @cute.jit
+    def _merge_scan0_local(self, s_hist, s_mrg, rank, target, tidx, s_res):
+        NBS = self.nbs
+        CS = self.cs
+        BPT = NBS // 32
+        NV = BPT // 4
+        if tidx < cutlass.Int32(32):
+            lane = tidx
+            atom = C.smem_atom_i32_128()
+            hbase = s_hist.iterator.toint()
+            # pass 1: remote v4 accumulation of tot/pre per vector
+            tot_r = []
+            pre_r = []
+            sm = cutlass.Int32(0)
+            for q in cutlass.range_constexpr(NV):
+                boff = (lane * cutlass.Int32(BPT) + cutlass.Int32(4 * q)) * cutlass.Int32(4)
+                t = [cutlass.Int32(0)] * 4
+                p = [cutlass.Int32(0)] * 4
+                for r in cutlass.range_constexpr(CS):
+                    mapped = C._mapa_shared_cluster_addr(
+                        hbase + boff, cutlass.Int32(r)
+                    )  # per-use mapa
+                    v0, v1, v2, v3 = C._ld_shared_cluster_v4_u32(mapped)
+                    t[0] = t[0] + v0
+                    t[1] = t[1] + v1
+                    t[2] = t[2] + v2
+                    t[3] = t[3] + v3
+                    if cutlass.Int32(r) < rank:  # predicated adds
+                        p[0] = p[0] + v0
+                        p[1] = p[1] + v1
+                        p[2] = p[2] + v2
+                        p[3] = p[3] + v3
+                tot_r.append(t)
+                pre_r.append(p)
+                sm = sm + t[0] + t[1] + t[2] + t[3]
+            # inclusive scan + totals
+            w = C.warp_incl_scan_add(sm, lane)
+            tt = cute.arch.shuffle_sync(w, cutlass.Int32(31))
+            after = tt - w
+            if lane == cutlass.Int32(0):
+                s_res[C.RES_TOT] = tt
+            base = lane * cutlass.Int32(BPT)
+            # descending walk: crossing pin + prefix-biased cursors into mrg
+            for q in cutlass.range_constexpr(NV - 1, -1, -1):
+                o4 = cute.make_rmem_tensor((4,), cutlass.Int32)
+                for j in cutlass.range_constexpr(3, -1, -1):
+                    cq = tot_r[q][j]
+                    o4[j] = after + pre_r[q][j]
+                    gb = base + cutlass.Int32(4 * q + j)
+                    cross = cutlass.Int32(0)
+                    if after < target:
+                        if (after + cq) >= target:
+                            cross = cutlass.Int32(1)
+                        if gb == cutlass.Int32(0):
+                            cross = cutlass.Int32(1)
+                    if cross != cutlass.Int32(0):
+                        s_res[C.RES_B] = gb
+                        s_res[C.RES_ABOVE] = after
+                        s_res[C.RES_M] = cq
+                    after = after + cq
+                boff = (lane * cutlass.Int32(NV) + cutlass.Int32(q)) * cutlass.Int32(16)
+                C.sts128_i32(atom, o4, s_mrg.iterator.toint(), boff)
+
+    # ------------------------------------------------------------------
+    # two-predicate warp-ballot emit step (narrowing and degen emits) —
+    # same helper as the main family. s_scal[1]=s_o1, s_scal[2]=s_o2.
+    # ------------------------------------------------------------------
+    @cute.jit
+    def _ballot_pair_emit(self, p1, p2, idv, base1, cap1, base2, cap2, out_row, s_scal, lane):
+        n1 = C.ballot(p1 != cutlass.Int32(0))
+        n2 = C.ballot(p2 != cutlass.Int32(0))
+        b1 = cutlass.Int32(0)
+        b2 = cutlass.Int32(0)
+        if lane == cutlass.Int32(0):
+            if n1 != cutlass.Int32(0):
+                b1 = C.atomic_add_cta(s_scal.iterator + 1, cutlass.Int32(C.popc(n1)))
+            if n2 != cutlass.Int32(0):
+                b2 = C.atomic_add_cta(s_scal.iterator + 2, cutlass.Int32(C.popc(n2)))
+        b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+        b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+        lm = cutlass.Int32(cute.arch.lanemask_lt())
+        if p1 != cutlass.Int32(0):
+            p = b1 + cutlass.Int32(C.popc(n1 & lm))
+            if p < cap1:
+                out_row[base1 + p] = idv
+        if p2 != cutlass.Int32(0):
+            p = b2 + cutlass.Int32(C.popc(n2 & lm))
+            if p < cap2:
+                out_row[base2 + p] = idv
+
+    # ------------------------------------------------------------------
+    # kernel
+    # ------------------------------------------------------------------
+    @cute.kernel
+    def kern(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        kv_lens: cute.Tensor,
+        out: cute.Tensor,
+        n: cutlass.Int32,
+        npad: cutlass.Int32,
+        k: cutlass.Int32,
+        SCAP: cutlass.Int32,
+        CMP: cutlass.Int32,
+        SMP: cutlass.Int32,
+        TGT: cutlass.Int32,
+        Q: cutlass.Int32,
+        SS2: cutlass.Int32,
+        TGT2: cutlass.Int32,
+        bigf: cutlass.Int32,
+    ):
+        BLK = self.blk
+        U = self.u
+        NBS = self.nbs
+        CS = self.cs
+        PFD = self.pfd
+        STEPC = self.stepc
+        NW = BLK // 32
+
+        tidx, _, _ = cute.arch.thread_idx()
+        bx, by, _ = cute.arch.block_idx()  # (rank, row)
+        rank = bx
+        row = by
+        lane = tidx & cutlass.Int32(31)
+
+        # ============ per-row varlen prologue — shared contract lives in ======
+        # GvrMainKernel's prologue (per-row n from kv_lens; ladder scalars are
+        # dead launch args, re-derived here by the route_dynamic() clus
+        # formulas). Clus deviation: QUAD sample geometry runs for every
+        # non-short row (host never launches clus at n <= SCAP, so SMP == 0 is
+        # untested; sampling only steers the rung — exactness is
+        # schedule-invariant). All values are pure functions of `row`, so the
+        # whole-body guard and the cluster barriers stay cluster-uniform.
+        # Short rows (n <= k): rank 0 emits identity + (-1); body is SKIPped.
+        short = cutlass.Int32(0)
+        prow = row
+        if cutlass.const_expr(self.varlen):
+            kq = cutlass.Int32(pre_idx.shape[1])
+            req = row // cutlass.Int32(self.next_n)
+            rr = row % cutlass.Int32(self.next_n)
+            prow = req
+            kvl = kv_lens[req]
+            nv = (kvl - cutlass.Int32(self.next_n) + rr + cutlass.Int32(1)) >> cutlass.Int32(
+                self.cr_shift
+            )
+            if nv < cutlass.Int32(0):
+                nv = cutlass.Int32(0)
+            if nv > n:
+                nv = n
+            if nv <= kq:
+                short = cutlass.Int32(1)
+            if short == cutlass.Int32(0):
+                n = nv
+                # ---- aim ladder (cheap mirror, all-thread) ----
+                # Schedule quantities only (exactness is schedule-invariant,
+                # same argument as the always-sample deviation above): divides
+                # become MUFU.RCP multiplies and the isqrt fixup loops collapse
+                # to single steps (f32 sqrt of an exactly-representable int
+                # (6n <= 2^23) is within 1 of isqrt).  All-thread on purpose:
+                # this family's mirror redundancy is small, and a
+                # warp0+barrier hoist EXPOSES the chain's serial latency at
+                # ~1 CTA/SM, while the redundant form hides it across warps.
+                # Q (chunk ownership) keeps its exact shift form.
+                x6 = cutlass.Int32(6) * nv
+                ri = cutlass.Int32(cmath.sqrt(cutlass.Float32(x6)))
+                if ri * ri > x6:
+                    ri = ri - cutlass.Int32(1)
+                if (ri + cutlass.Int32(1)) * (ri + cutlass.Int32(1)) <= x6:
+                    ri = ri + cutlass.Int32(1)
+                r6 = ri
+                if x6 - ri * ri > ri:
+                    r6 = ri + cutlass.Int32(1)
+                # aim_base: R = CS > 1 always for this family; bigf is the
+                # launch-computed occupancy flag (num_rows * CS <= 148).
+                aim = k << cutlass.Int32(1)
+                if bigf == cutlass.Int32(0):
+                    if k >= cutlass.Int32(1024):
+                        aim = (cutlass.Int32(11) * k) >> cutlass.Int32(3)
+                    else:
+                        aim = (cutlass.Int32(3) * k) >> cutlass.Int32(1)
+                if r6 > aim:
+                    aim = r6
+                amin = cutlass.Int32(3) * k
+                if cutlass.const_expr(self.cs != 2):
+                    amin = (cutlass.Int32(7) * k) >> cutlass.Int32(1)
+                if aim < amin:
+                    aim = amin
+                if aim > (SCAP >> cutlass.Int32(1)):
+                    aim = SCAP >> cutlass.Int32(1)
+                if aim < k:
+                    aim = k
+                # ---- QUAD sample geometry (route_dynamic clus override,
+                # always-on per the deviation note above; k <= 1024 for this
+                # family so sfac has no k > 1024 arm).
+                n4v = nv >> cutlass.Int32(2)
+                sel = cutlass.Int32(
+                    cutlass.Float32(nv)
+                    * cutlass.Float32(32.0 if self.cs == 2 else 16.0)
+                    * cute.arch.rcp_approx(cutlass.Float32(aim))
+                )
+                if sel < cutlass.Int32(256):
+                    sel = cutlass.Int32(256)
+                nh = nv >> cutlass.Int32(1)
+                if sel > nh:
+                    sel = nh
+                quads = sel >> cutlass.Int32(4)
+                if quads < cutlass.Int32(1):
+                    quads = cutlass.Int32(1)
+                quarter = n4v >> cutlass.Int32(2)
+                if quarter < cutlass.Int32(1):
+                    quarter = cutlass.Int32(1)
+                if quads > quarter:
+                    quads = quarter
+                SS2 = cutlass.Int32(
+                    cutlass.Float32(quarter) * cute.arch.rcp_approx(cutlass.Float32(quads))
+                )
+                if SS2 < cutlass.Int32(1):
+                    SS2 = cutlass.Int32(1)
+                SMP = cutlass.Int32(
+                    cutlass.Float32(quarter) * cute.arch.rcp_approx(cutlass.Float32(SS2))
+                )
+                # sample-window guard: P1 indexes up to ~SMP*SS2*4 lines; keep
+                # SMP*SS2 <= quarter (approx error <= +1, one step closes it)
+                if SMP * SS2 > quarter:
+                    SMP = SMP - cutlass.Int32(1)
+                if SMP < cutlass.Int32(1):
+                    SMP = cutlass.Int32(1)
+                rn_ = cute.arch.rcp_approx(cutlass.Float32(nv))
+                smp16f = cutlass.Float32(SMP) * cutlass.Float32(16.0)
+                TGT = cutlass.Int32(cutlass.Float32(aim) * smp16f * rn_)
+                if TGT < cutlass.Int32(1):
+                    TGT = cutlass.Int32(1)
+                TGT2 = cutlass.Int32(cutlass.Float32(k) * smp16f * rn_)
+                if TGT2 < cutlass.Int32(1):
+                    TGT2 = cutlass.Int32(1)
+                # NB: the Q launch slot is dead in this family (no in-kernel
+                # consumer); chunk ownership derives from n4/STEPC below.
+            if short != cutlass.Int32(0):
+                if rank == cutlass.Int32(0):
+                    if tidx < kq:
+                        ov = cutlass.Int32(-1)
+                        if tidx < nv:
+                            ov = tidx
+                        out[row, tidx] = ov
+
+        # ---- shared memory (CUDA dynamic map order, then static allocs) ----
+        smem = SmemAllocator()
+        s_hist = smem.allocate_tensor(  # hist[NBS] @ blob start
+            cutlass.Int32, cute.make_ordered_layout((self.hb,), order=(0,)), byte_alignment=128
+        )
+        blob = smem.allocate_tensor(  # cbuf(int2) | ck64c
+            cutlass.Int8,
+            cute.make_ordered_layout((self.cbuf_bytes + self.cmp * 8,), order=(0,)),
+            byte_alignment=16,
+        )
+        s_mrg = smem.allocate_tensor(  # mrg[NBS]
+            cutlass.Int32, cute.make_ordered_layout((self.nbs,), order=(0,)), byte_alignment=16
+        )
+        s_ws = smem.allocate_tensor(  # degen scan only
+            cutlass.Int32, cute.make_ordered_layout((NW,), order=(0,)), byte_alignment=16
+        )
+        # scan_cross predeclares its second-stage partial as Int32 and reads
+        # s_ws inside a dynamic if — a Uint32 ws tensor trips the DSL type-
+        # stability check (counts < 2^31 so Int32 is exact).
+        s_wmn = smem.allocate_tensor(
+            cutlass.Uint32, cute.make_ordered_layout((NW,), order=(0,)), byte_alignment=16
+        )
+        s_wmx = smem.allocate_tensor(
+            cutlass.Uint32, cute.make_ordered_layout((NW,), order=(0,)), byte_alignment=16
+        )
+        s_res = smem.allocate_tensor(  # shared slot map
+            cutlass.Int32, cute.make_ordered_layout((8,), order=(0,)), byte_alignment=16
+        )
+        # scalar block: [0]=s_bufn [1]=s_o1 [2]=s_o2
+        s_scal = smem.allocate_tensor(
+            cutlass.Int32, cute.make_ordered_layout((4,), order=(0,)), byte_alignment=16
+        )
+        s_tsh = smem.allocate_tensor(
+            cutlass.Float32, cute.make_ordered_layout((1,), order=(0,)), byte_alignment=4
+        )
+        s_kmm = smem.allocate_tensor(  # [0]=kmin [1]=kmax
+            cutlass.Uint32, cute.make_ordered_layout((2,), order=(0,)), byte_alignment=8
+        )
+        sbase = blob.iterator.toint()
+        s_cbuf2 = cute.make_tensor(  # int2 staged as u64
+            cute.make_ptr(cutlass.Uint64, sbase, cute.AddressSpace.smem, assumed_align=16),
+            cute.make_layout((self.scap + 4,)),
+        )
+        ck_addr = sbase + cutlass.Int32(self.ck_off)
+        s_ck64 = cute.make_tensor(
+            cute.make_ptr(cutlass.Uint64, ck_addr, cute.AddressSpace.smem, assumed_align=16),
+            cute.make_layout((self.cmp,)),
+        )
+
+        # ---- whole-body short-row guard (cluster-uniform: `short` is a pure
+        # function of `row`, identical across all CS ranks and threads, so
+        # every cluster barrier below stays aligned; short rows already
+        # emitted identity + -1 tail in the prologue) ----
+        if short == cutlass.Int32(0):
+            # ---- row bases (pre_idx is request-level under varlen) ----
+            row64 = cutlass.Int64(row)
+            x_addr = logits.iterator.toint() + row64 * cutlass.Int64(npad) * cutlass.Int64(4)
+            p_addr = pre_idx.iterator.toint() + cutlass.Int64(prow) * cutlass.Int64(
+                k
+            ) * cutlass.Int64(4)
+            out_row = out[row, None]
+
+            # ---- interleaved chunk ownership ----
+            n4 = n >> cutlass.Int32(2)
+            nCh = (n4 + cutlass.Int32(STEPC - 1)) // cutlass.Int32(STEPC)
+            nFullG = n4 // cutlass.Int32(STEPC)
+            tail0 = n4 << cutlass.Int32(2)
+            tailn = cutlass.Int32(0)
+            if rank == cutlass.Int32(0):
+                tailn = n - tail0
+
+            if tidx == cutlass.Int32(0):
+                s_res[C.RES_B2] = cutlass.Int32(-1)
+                s_res[C.RES_B3] = cutlass.Int32(-1)
+                s_scal[0] = cutlass.Int32(0)  # s_bufn
+            if tidx < cutlass.Int32(self.hb):  # HB<=BLK
+                s_hist[tidx] = cutlass.Int32(0)
+
+            # ============ P1: QUAD sample (hint gather LAZY) =====================
+            # one 64B line = 4 float4 per location, TWO threads: tid takes the
+            # lower pair at p4, tid+SMP the upper pair at p4+2.
+            atom128 = C.g2r_atom_f32(128, invariant=True)
+            fsa = cute.make_rmem_tensor((4,), cutlass.Float32)
+            fsb = cute.make_rmem_tensor((4,), cutlass.Float32)
+            smp2 = SMP * cutlass.Int32(2)
+            shas = cutlass.Int32(0)
+            if tidx < smp2:
+                shas = cutlass.Int32(1)
+            if shas != cutlass.Int32(0):
+                p4 = tidx * SS2 * cutlass.Int32(4)
+                if tidx >= SMP:
+                    p4 = (tidx - SMP) * SS2 * cutlass.Int32(4) + cutlass.Int32(2)
+                C.ld_g_f32x4(atom128, x_addr, p4, fsa)
+                C.ld_g_f32x4(atom128, x_addr, p4 + cutlass.Int32(1), fsb)
+
+            # ============ P2: quantile rung, redundant per CTA ===================
+            smn = cutlass.Float32(float("inf"))
+            smx = cutlass.Float32(float("-inf"))
+            if shas != cutlass.Int32(0):
+                for t in cutlass.range_constexpr(4):
+                    smn = C.fmin_f32(smn, fsa[t])
+                    smx = C.fmax_f32(smx, fsa[t])
+                for t in cutlass.range_constexpr(4):
+                    smn = C.fmin_f32(smn, fsb[t])
+                    smx = C.fmax_f32(smx, fsb[t])
+            fma_ = cute.make_rmem_tensor((4,), cutlass.Float32)  # mop-up pair bufs
+            fmb_ = cute.make_rmem_tensor((4,), cutlass.Float32)
+            j = tidx + cutlass.Int32(BLK)  # mop-up
+            while j < smp2:
+                p4 = j * SS2 * cutlass.Int32(4)
+                if j >= SMP:
+                    p4 = (j - SMP) * SS2 * cutlass.Int32(4) + cutlass.Int32(2)
+                C.ld_g_f32x4(atom128, x_addr, p4, fma_)
+                C.ld_g_f32x4(atom128, x_addr, p4 + cutlass.Int32(1), fmb_)
+                for t in cutlass.range_constexpr(4):
+                    smn = C.fmin_f32(smn, fma_[t])
+                    smx = C.fmax_f32(smx, fma_[t])
+                for t in cutlass.range_constexpr(4):
+                    smn = C.fmin_f32(smn, fmb_[t])
+                    smx = C.fmax_f32(smx, fmb_[t])
+                j = j + cutlass.Int32(BLK)
+            a0 = C.warp_min_u32(C.fkey(smn))
+            c0m = C.warp_max_u32(C.fkey(smx))
+            if lane == cutlass.Int32(0):
+                s_wmn[tidx >> cutlass.Int32(5)] = a0
+                s_wmx[tidx >> cutlass.Int32(5)] = c0m
+            cute.arch.barrier()  # ---- barrier (sample redux publish) ----
+
+            # PRIME-LATE: every rank's sample has landed; prime NOW.
+            lim4 = (npad >> cutlass.Int32(2)) - cutlass.Int32(1)
+            pf = [cute.make_rmem_tensor((4,), cutlass.Float32) for _ in range(PFD)]
+            for uu in cutlass.range_constexpr(PFD):  # clamped prime
+                i_ = rank * cutlass.Int32(STEPC) + tidx + cutlass.Int32(uu * BLK)
+                ic = i_
+                if ic >= n4:
+                    ic = lim4
+                C.ld_g_f32x4(atom128, x_addr, ic, pf[uu])
+            # asm prefetch gate: DEEP rows only; empty for U<=PFD
+            if cutlass.const_expr(U > PFD):
+                gpp = cutlass.Int32(0)
+                if n4 >= cutlass.Int32(32768):
+                    if (rank + cutlass.Int32(1)) * cutlass.Int32(STEPC) <= n4:
+                        gpp = cutlass.Int32(1)
+                if gpp != cutlass.Int32(0):
+                    for uu in cutlass.range_constexpr(PFD, U):
+                        C._prefetch_l2(
+                            x_addr
+                            + cutlass.Int64(
+                                rank * cutlass.Int32(STEPC) + tidx + cutlass.Int32(uu * BLK)
+                            )
+                            * cutlass.Int64(16)
+                        )
+
+            # cross-warp sample reduce
+            av = cutlass.Uint32(0xFFFFFFFF)
+            cv = cutlass.Uint32(0)
+            if lane < cutlass.Int32(NW):
+                av = s_wmn[lane]
+                cv = s_wmx[lane]
+            SMIN = C.invkey(C.warp_min_u32(av))
+            SMAX = C.invkey(C.warp_max_u32(cv))
+
+            GMIN = cutlass.Float32(C.SENT_LO)  # sentinels
+            GMAX = cutlass.Float32(C.SENT_HI)
+            T = cutlass.Float32(_NEG_INF__clus)
+            HIC = cutlass.Float32(_NEG_INF__clus)
+            w = cutlass.Float32(0.0)
+            sok = cutlass.Int32(0)
+            if SMP > cutlass.Int32(0):
+                if SMAX > SMIN:
+                    sok = cutlass.Int32(1)
+            if sok != cutlass.Int32(0):  # sample hist
+                w = (SMAX - SMIN) * cutlass.Float32(1.0 / 256.0)
+                # CUDA --use_fast_math lowers `1.0f / w` to a bare MUFU.RCP;
+                # a plain `/` would emit the IEEE div.rn rcp+Newton+CALL
+                # chain. w > 0 by the sok guard; bucketing is SC-invariant.
+                sc_s = cute.arch.rcp_approx(w)
+                if shas != cutlass.Int32(0):
+                    for t in cutlass.range_constexpr(4):
+                        bq = C.f2s_rz((fsa[t] - SMIN) * sc_s)
+                        if bq > cutlass.Int32(NBS - 1):
+                            bq = cutlass.Int32(NBS - 1)
+                        C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                    for t in cutlass.range_constexpr(4):
+                        bq = C.f2s_rz((fsb[t] - SMIN) * sc_s)
+                        if bq > cutlass.Int32(NBS - 1):
+                            bq = cutlass.Int32(NBS - 1)
+                        C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                j = tidx + cutlass.Int32(BLK)  # mop-up reloads
+                while j < smp2:
+                    p4 = j * SS2 * cutlass.Int32(4)
+                    if j >= SMP:
+                        p4 = (j - SMP) * SS2 * cutlass.Int32(4) + cutlass.Int32(2)
+                    C.ld_g_f32x4(atom128, x_addr, p4, fma_)
+                    C.ld_g_f32x4(atom128, x_addr, p4 + cutlass.Int32(1), fmb_)
+                    for t in cutlass.range_constexpr(4):
+                        bq = C.f2s_rz((fma_[t] - SMIN) * sc_s)
+                        if bq > cutlass.Int32(NBS - 1):
+                            bq = cutlass.Int32(NBS - 1)
+                        C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                    for t in cutlass.range_constexpr(4):
+                        bq = C.f2s_rz((fmb_[t] - SMIN) * sc_s)
+                        if bq > cutlass.Int32(NBS - 1):
+                            bq = cutlass.Int32(NBS - 1)
+                        C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                    j = j + cutlass.Int32(BLK)
+            cute.arch.barrier()  # ---- barrier (sample histogram) ----
+            # triple-target ZERO scan: TGT / TGT2 / 2*TGT
+            C.scan_cross0(
+                s_hist,
+                TGT,
+                tidx,
+                s_res,
+                TGT2,
+                TGT * cutlass.Int32(2),
+                s_hist,
+                nb=NBS,
+                zero=True,
+                two=True,
+                three=True,
+            )
+            cute.arch.barrier()  # ---- barrier (scan publish) ----
+
+            tot0 = s_res[C.RES_TOT]
+            b1v = s_res[C.RES_B]
+            if sok != cutlass.Int32(0):
+                if tot0 >= TGT:
+                    T = _fmaf__clus(cutlass.Float32(b1v), w, SMIN)
+            needg = cutlass.Int32(1)
+            if T > cutlass.Float32(_NEG_INF__clus):
+                needg = cutlass.Int32(0)
+            if needg != cutlass.Int32(0):
+                # degenerate sample: identical on every rank of the cluster
+                GMIN, GMAX = C.gather_hint(
+                    x_addr, p_addr, k, n, tidx, s_wmn, s_wmx, blk=BLK, kpt=1
+                )  # 2 barriers
+                T = GMIN
+            if sok != cutlass.Int32(0):  # HIC tighten
+                if tot0 >= TGT:
+                    b2v = s_res[C.RES_B2]
+                    if b2v >= cutlass.Int32(0):
+                        Tk = _fmaf__clus(cutlass.Float32(b2v), w, SMIN)
+                        up = C.fmax_f32(Tk - T, cutlass.Float32(0.0))
+                        # heavy-tail cap by T - T3 (rank-TGT..rank-2TGT distance)
+                        if tot0 >= TGT * cutlass.Int32(2):
+                            b3v = s_res[C.RES_B3]
+                            if b3v >= cutlass.Int32(0):
+                                T3 = _fmaf__clus(cutlass.Float32(b3v), w, SMIN)
+                                if T > T3:
+                                    up = C.fmin_f32(up, cutlass.Float32(2.0) * (T - T3))
+                        HIC = C.fmax_f32(
+                            _fmaf__clus(cutlass.Float32(4.0), up, T),
+                            _fmaf__clus(cutlass.Float32(8.0), w, T),
+                        )
+            # ladder floor kept in SHARED (64-register wall)
+            if tidx == cutlass.Int32(0):
+                t5 = cutlass.Float32(_NEG_INF__clus)
+                if sok != cutlass.Int32(0):
+                    if tot0 >= TGT * cutlass.Int32(2):
+                        b3v = s_res[C.RES_B3]
+                        if b3v >= cutlass.Int32(0):
+                            if T > GMIN:
+                                T3 = _fmaf__clus(cutlass.Float32(b3v), w, SMIN)
+                                if T3 < T:
+                                    t5 = T3
+                s_tsh[0] = t5
+
+            # ============ attempt loop — MUST NOT unroll ===========
+            listN = cutlass.Int32(0)
+            above = cutlass.Int32(0)
+            m = cutlass.Int32(0)
+            need = cutlass.Int32(0)
+            B = cutlass.Int32(0)
+            SC = cutlass.Float32(1.0)
+            TF = T
+            complete = cutlass.Int32(0)
+            valid = cutlass.Int32(0)
+
+            fr = [
+                cute.make_rmem_tensor((4,), cutlass.Float32) for _ in range(U - PFD)
+            ]  # explicit batch
+            # (empty for U<=PFD — every row-pass float4 then comes from pf[])
+            att = cutlass.Int32(0)
+            running = cutlass.Int32(1)
+            while running != cutlass.Int32(0):
+                if att > cutlass.Int32(0):  # retry preamble
+                    # exactness: re-prime pf[] (holds stale roll data)
+                    if rank < nFullG:
+                        for uu in cutlass.range_constexpr(PFD):
+                            C.ld_g_f32x4(
+                                atom128,
+                                x_addr,
+                                rank * cutlass.Int32(STEPC) + tidx + cutlass.Int32(uu * BLK),
+                                pf[uu],
+                            )
+                    else:
+                        for uu in cutlass.range_constexpr(PFD):
+                            i_ = rank * cutlass.Int32(STEPC) + tidx + cutlass.Int32(uu * BLK)
+                            ic = i_
+                            if ic >= n4:
+                                ic = lim4
+                            C.ld_g_f32x4(atom128, x_addr, ic, pf[uu])
+                    C._cluster_sync_aligned()  # ==== clus.sync (retry) ====
+                    if tidx < cutlass.Int32(NBS):
+                        s_hist[tidx] = cutlass.Int32(0)
+                    if tidx == cutlass.Int32(0):
+                        s_scal[0] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (retry reset) ----
+
+                TF = T  # window
+                hi = C.fmax_f32(GMAX, T)
+                if HIC > T:
+                    if HIC < hi:
+                        hi = HIC
+                WD = (hi - T) * cutlass.Float32(1.0 / 256.0)
+                wdok = cutlass.Int32(0)
+                if WD > cutlass.Float32(0.0):
+                    wdok = cutlass.Int32(1)
+                if wdok == cutlass.Int32(0):
+                    WD = cutlass.Float32(1e-30)
+                # MUFU.RCP spelling: WD >= 1e-30 finite by the wdok clamp;
+                # classify bucketing is SC-invariant for any SC > 0.
+                SC = cute.arch.rcp_approx(WD)
+
+                # ---- P3 row pass over OWNED CHUNKS ----
+                g = rank + cutlass.Int32(0)
+                while g < nCh:
+                    i0 = g * cutlass.Int32(STEPC) + tidx
+                    M = cutlass.Int32(0)
+                    isfull = cutlass.Int32(0)
+                    if g < nFullG:
+                        isfull = cutlass.Int32(1)
+                    if isfull != cutlass.Int32(0):  # full body
+                        for uu in cutlass.range_constexpr(PFD, U):
+                            C.ld_g_f32x4(
+                                atom128, x_addr, i0 + cutlass.Int32(uu * BLK), fr[uu - PFD]
+                            )
+                        for uu in cutlass.range_constexpr(U):
+                            if cutlass.const_expr(uu < PFD):
+                                vv = pf[uu]
+                            else:
+                                vv = fr[uu - PFD]
+                            for q in cutlass.range_constexpr(4):
+                                M = M | (cutlass.Int32(vv[q] >= TF) << cutlass.Int32(uu * 4 + q))
+                    else:  # partial body
+                        for uu in cutlass.range_constexpr(PFD, U):
+                            i_ = i0 + cutlass.Int32(uu * BLK)
+                            ic = i_
+                            if ic >= n4:
+                                ic = lim4  # clamp in [n, npad)
+                            C.ld_g_f32x4(atom128, x_addr, ic, fr[uu - PFD])
+                        for uu in cutlass.range_constexpr(U):
+                            if cutlass.const_expr(uu < PFD):
+                                vv = pf[uu]
+                            else:
+                                vv = fr[uu - PFD]
+                            i_ = i0 + cutlass.Int32(uu * BLK)
+                            okq = cutlass.Int32(0)
+                            if i_ < n4:
+                                okq = cutlass.Int32(1)
+                            if okq != cutlass.Int32(0):  # +inf-pad escape, ok-gated
+                                for q in cutlass.range_constexpr(4):
+                                    M = M | (
+                                        cutlass.Int32(vv[q] >= TF) << cutlass.Int32(uu * 4 + q)
+                                    )
+                    # ROLL THE PREFETCH FORWARD: next OWNED chunk, issued
+                    # before the reservation and the survivor walk.
+                    g2 = g + cutlass.Int32(CS)
+                    if g2 < nCh:
+                        j0 = g2 * cutlass.Int32(STEPC) + tidx
+                        infull = cutlass.Int32(0)
+                        if g2 < nFullG:
+                            infull = cutlass.Int32(1)
+                        if infull != cutlass.Int32(0):
+                            for uu in cutlass.range_constexpr(PFD):
+                                C.ld_g_f32x4(atom128, x_addr, j0 + cutlass.Int32(uu * BLK), pf[uu])
+                        else:
+                            for uu in cutlass.range_constexpr(PFD):
+                                j_ = j0 + cutlass.Int32(uu * BLK)
+                                jc = j_
+                                if jc >= n4:
+                                    jc = lim4
+                                C.ld_g_f32x4(atom128, x_addr, jc, pf[uu])
+                    # warp-aggregated slot reservation
+                    cnt = cutlass.Int32(C.popc(M))
+                    inc = C.warp_incl_scan_add(cnt, lane)
+                    bpos = cutlass.Int32(0)
+                    if lane == cutlass.Int32(31):
+                        if inc != cutlass.Int32(0):
+                            bpos = C.atomic_add_cta(s_scal.iterator + 0, inc)
+                    pos = cute.arch.shuffle_sync(bpos, cutlass.Int32(31)) + (inc - cnt)
+                    # survivor bit-walk, software-pipelined ONE deep;
+                    # reload X[idx] — never hold the U float4s across the walk
+                    if M != cutlass.Int32(0):
+                        bp = C.ffs_m1(M)
+                        M = M & (M - cutlass.Int32(1))
+                        idx = (
+                            (i0 + (bp >> cutlass.Int32(2)) * cutlass.Int32(BLK)) << cutlass.Int32(2)
+                        ) + (bp & cutlass.Int32(3))
+                        xv = C.ldg_f32(x_addr, idx)
+                        while M != cutlass.Int32(0):
+                            bp2 = C.ffs_m1(M)
+                            M = M & (M - cutlass.Int32(1))
+                            idx2 = (
+                                (i0 + (bp2 >> cutlass.Int32(2)) * cutlass.Int32(BLK))
+                                << cutlass.Int32(2)
+                            ) + (bp2 & cutlass.Int32(3))
+                            xv2 = C.ldg_f32(x_addr, idx2)
+                            pos = self._emitk(xv, idx, pos, TF, SC, SCAP, s_hist, s_cbuf2)
+                            idx = idx2
+                            xv = xv2
+                        pos = self._emitk(xv, idx, pos, TF, SC, SCAP, s_hist, s_cbuf2)
+                    g = g + cutlass.Int32(CS)
+                # rank-0 scalar tail: per-thread atomics, bound-check
+                i = tidx
+                while i < tailn:
+                    x = C.ldg_f32(x_addr, tail0 + i)
+                    if x >= TF:
+                        bq = C.f2s_rz((x - TF) * SC)  # signed form
+                        if bq > cutlass.Int32(NBS - 1):
+                            bq = cutlass.Int32(NBS - 1)
+                        C.atomic_add_cta(s_hist.iterator + bq, cutlass.Int32(1))
+                        post = C.atomic_add_cta(s_scal.iterator + 0, cutlass.Int32(1))
+                        if post < SCAP:
+                            s_cbuf2[post] = (
+                                cutlass.Uint64(cutlass.Uint32(tail0 + i)) << cutlass.Uint64(32)
+                            ) | cutlass.Uint64(C.u32_of_f32(x))
+                    i = i + cutlass.Int32(BLK)
+
+                # ---- cluster merge ----
+                C._cluster_sync_aligned()  # ==== clus.sync (merge) ====
+                myn = s_scal[0]
+                self._merge_scan0_local(s_hist, s_mrg, rank, k, tidx, s_res)
+                cute.arch.barrier()  # ---- barrier (merge publish) ----
+                tot = s_res[C.RES_TOT]
+                acc = cutlass.Int32(0)
+                if tot >= k:
+                    acc = cutlass.Int32(1)
+                if acc != cutlass.Int32(0):  # accept
+                    valid = cutlass.Int32(1)
+                    complete = cutlass.Int32(0)
+                    if myn <= SCAP:
+                        complete = cutlass.Int32(1)
+                    listN = myn
+                    above = s_res[C.RES_ABOVE]
+                    m = s_res[C.RES_M]
+                    need = k - s_res[C.RES_ABOVE]
+                    B = s_res[C.RES_B]
+                    running = cutlass.Int32(0)
+                else:
+                    if att == cutlass.Int32(2):  # ladder exhausted
+                        running = cutlass.Int32(0)
+                    else:
+                        # rung ladder — cluster-uniform on every arm
+                        tshtaken = cutlass.Int32(0)
+                        if att == cutlass.Int32(0):
+                            T5 = s_tsh[0]
+                            if T5 > cutlass.Float32(_NEG_INF__clus):
+                                if T5 < TF:
+                                    T = T5
+                                    tshtaken = cutlass.Int32(1)
+                        if tshtaken == cutlass.Int32(0):
+                            # LAZY GATHER — every rank computes identical GMIN
+                            if GMIN == cutlass.Float32(C.SENT_LO):
+                                GMIN, GMAX = C.gather_hint(
+                                    x_addr, p_addr, k, n, tidx, s_wmn, s_wmx, blk=BLK, kpt=1
+                                )  # 2 barriers inside
+                            floorhit = cutlass.Int32(1)
+                            if T > GMIN:
+                                floorhit = cutlass.Int32(0)
+                            if floorhit != cutlass.Int32(0):
+                                running = cutlass.Int32(0)
+                            else:
+                                T = GMIN
+                att = att + cutlass.Int32(1)
+
+            # ============ classification ============
+            whole = cutlass.Int32(0)
+            if valid != cutlass.Int32(0):
+                if need >= m:
+                    whole = cutlass.Int32(1)
+            lim1 = above
+            if whole != cutlass.Int32(0):
+                lim1 = above + m
+            degen = cutlass.Int32(0)
+            if valid == cutlass.Int32(0):
+                degen = cutlass.Int32(1)
+            if m > CMP:
+                degen = cutlass.Int32(1)
+            mc = cutlass.Int32(0)
+            if degen == cutlass.Int32(0):
+                mc = m
+            # crossing candidates land in RANK 0's ck64c via DSMEM
+            rk64 = C._mapa_shared_cluster_addr(ck_addr, cutlass.Int32(0))
+
+            if degen == cutlass.Int32(0):
+                if complete != cutlass.Int32(0):
+                    # ---- P5 emit from staged cbuf ----
+                    i = tidx
+                    while i < listN:
+                        pk64 = s_cbuf2[i]
+                        vx = cutlass.Int32(cutlass.Uint32(pk64 & cutlass.Uint64(0xFFFFFFFF)))
+                        idv = cutlass.Int32(pk64 >> cutlass.Uint64(32))
+                        xv = C.f32_of_i32(vx)
+                        self._p5_emit(
+                            xv, idv, TF, SC, B, above, lim1, whole, CMP, s_mrg, out_row, rk64
+                        )
+                        i = i + cutlass.Int32(BLK)
+                else:
+                    # ---- exactness re-sweep: OWNED CHUNKS + rank-0 true tail ----
+                    g = rank + cutlass.Int32(0)
+                    while g < nCh:
+                        lo2 = (g * cutlass.Int32(STEPC)) << cutlass.Int32(2)
+                        e4 = (g + cutlass.Int32(1)) * cutlass.Int32(STEPC)
+                        if e4 > n4:
+                            e4 = n4
+                        hi2 = e4 << cutlass.Int32(2)
+                        i = lo2 + tidx
+                        while i < hi2:
+                            x = C.ldg_f32(x_addr, i)
+                            if x >= TF:
+                                self._p5_emit(
+                                    x, i, TF, SC, B, above, lim1, whole, CMP, s_mrg, out_row, rk64
+                                )
+                            i = i + cutlass.Int32(BLK)
+                        g = g + cutlass.Int32(CS)
+                    t2 = tidx
+                    while t2 < tailn:
+                        ii = tail0 + t2
+                        x = C.ldg_f32(x_addr, ii)
+                        if x >= TF:
+                            self._p5_emit(
+                                x, ii, TF, SC, B, above, lim1, whole, CMP, s_mrg, out_row, rk64
+                            )
+                        t2 = t2 + cutlass.Int32(BLK)
+
+            # ============ EXIT RENDEZVOUS ============
+            # all DSMEM traffic retired; the ONLY exit rendezvous. rank!=0
+            # falls through to the kernel end (post-barrier asymmetric exit);
+            # NO later cluster barrier.
+            C._cluster_sync_aligned()  # ==== clus.sync (exit) ====
+
+            if rank == cutlass.Int32(0):
+                if degen == cutlass.Int32(0):
+                    if whole == cutlass.Int32(0):
+                        # ---- P6 rank-0 refine ----
+                        if mc <= cutlass.Int32(QUADC_CLUS__clus):  # O(mc^2)
+                            mc2 = mc & cutlass.Int32(~1)
+                            i = tidx
+                            while i < mc:
+                                # re-assert Uint64 at every unsigned compare
+                                # in/after dynamic loops.
+                                u64v = s_ck64[i]
+                                r_ = cutlass.Int32(0)
+                                jq = cutlass.Int32(0)
+                                while jq < mc2:  # ulonglong2 16B reads
+                                    vlo, vhi = C._lds_v2_u64(ck_addr + jq * cutlass.Int32(8))
+                                    r_ = (
+                                        r_
+                                        + cutlass.Int32(vlo > cutlass.Uint64(u64v))
+                                        + cutlass.Int32(vhi > cutlass.Uint64(u64v))
+                                    )
+                                    jq = jq + cutlass.Int32(2)
+                                if mc2 < mc:  # odd tail
+                                    r_ = r_ + cutlass.Int32(
+                                        cutlass.Uint64(s_ck64[mc2]) > cutlass.Uint64(u64v)
+                                    )
+                                if r_ < need:
+                                    out_row[above + r_] = cutlass.Int32(
+                                        cutlass.Uint32(
+                                            cutlass.Uint64(u64v) & cutlass.Uint64(0xFFFFFFFF)
+                                        )
+                                    )
+                                i = i + cutlass.Int32(BLK)
+                        else:
+                            # key-space narrowing over ck64c
+                            if tidx == cutlass.Int32(0):
+                                s_kmm[0] = cutlass.Uint32(0xFFFFFFFF)
+                                s_kmm[1] = cutlass.Uint32(0)
+                            if tidx < cutlass.Int32(NBS):  # cleared ONCE
+                                s_hist[tidx] = cutlass.Int32(0)
+                            cute.arch.barrier()  # ---- barrier (narrowing init) ----
+                            i = tidx
+                            while i < mc:
+                                kk = cutlass.Uint32(s_ck64[i] >> cutlass.Uint64(32))
+                                C.atomic_min_cta(s_kmm.iterator + 0, kk)
+                                C.atomic_max_cta(s_kmm.iterator + 1, kk)
+                                i = i + cutlass.Int32(BLK)
+                            cute.arch.barrier()  # ---- barrier (key range) ----
+                            rlo = s_kmm[0]
+                            rhi = s_kmm[1]
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            aboveC = cutlass.Int32(0)
+                            needC = need
+                            mm = mc
+                            brk = cutlass.Int32(0)
+                            lev = cutlass.Int32(0)
+                            while brk == cutlass.Int32(0):  # <=6 levels
+                                if needC == mm:
+                                    ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                                    aboveC = aboveC + mm
+                                    needC = cutlass.Int32(0)
+                                    brk = cutlass.Int32(1)
+                                elif cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                                    ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                    brk = cutlass.Int32(1)
+                                elif lev >= cutlass.Int32(6):
+                                    ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                    brk = cutlass.Int32(1)
+                                else:
+                                    d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                                    b2_ = cutlass.Int32(32) - C.clz_i32(
+                                        cutlass.Int32(d2 | cutlass.Uint32(1))
+                                    )
+                                    sh2 = b2_ - cutlass.Int32(self.lb)
+                                    if sh2 < cutlass.Int32(0):
+                                        sh2 = cutlass.Int32(0)
+                                    sh2u = cutlass.Uint32(sh2)
+                                    i = tidx
+                                    while i < mc:  # re-bin
+                                        uq = cutlass.Uint32(s_ck64[i] >> cutlass.Uint64(32))
+                                        if uq >= cutlass.Uint32(rlo):
+                                            if uq <= cutlass.Uint32(rhi):
+                                                du = (uq - cutlass.Uint32(rlo)) >> sh2u
+                                                if du > cutlass.Uint32(NBS - 1):
+                                                    du = cutlass.Uint32(NBS - 1)
+                                                C.atomic_add_cta(
+                                                    s_hist.iterator + cutlass.Int32(du),
+                                                    cutlass.Int32(1),
+                                                )
+                                        i = i + cutlass.Int32(BLK)
+                                    cute.arch.barrier()  # ---- barrier (level hist) ----
+                                    C.scan_cross0(
+                                        s_hist,
+                                        needC,
+                                        tidx,
+                                        s_res,
+                                        cutlass.Int32(0),
+                                        cutlass.Int32(0),
+                                        s_hist,
+                                        nb=NBS,
+                                        zero=True,
+                                    )
+                                    cute.arch.barrier()  # ---- barrier (level scan) ----
+                                    aboveC = aboveC + s_res[C.RES_ABOVE]
+                                    needC = needC - s_res[C.RES_ABOVE]
+                                    mm = s_res[C.RES_M]
+                                    sB = s_res[C.RES_B]
+                                    nlo = cutlass.Uint32(rlo) + (cutlass.Uint32(sB) << sh2u)
+                                    if sB != cutlass.Int32(NBS - 1):
+                                        rhi = nlo + (
+                                            (cutlass.Uint32(1) << sh2u) - cutlass.Uint32(1)
+                                        )
+                                    rlo = nlo
+                                    lev = lev + cutlass.Int32(1)
+                            if tidx == cutlass.Int32(0):
+                                s_scal[1] = cutlass.Int32(0)
+                                s_scal[2] = cutlass.Int32(0)
+                            cute.arch.barrier()  # ---- barrier (emit counters) ----
+                            it2 = (mc + cutlass.Int32(BLK - 1)) // cutlass.Int32(BLK)
+                            it = cutlass.Int32(0)
+                            while it < it2:  # ballot emit
+                                i = it * cutlass.Int32(BLK) + tidx
+                                p1 = cutlass.Int32(0)
+                                p2 = cutlass.Int32(0)
+                                idv = cutlass.Int32(0)
+                                if i < mc:
+                                    w64 = s_ck64[i]
+                                    iu = cutlass.Int64(cutlass.Uint32(w64 >> cutlass.Uint64(32)))
+                                    idv = cutlass.Int32(
+                                        cutlass.Uint32(w64 & cutlass.Uint64(0xFFFFFFFF))
+                                    )
+                                    if iu > ethr:
+                                        p1 = cutlass.Int32(1)
+                                    if iu == ethr:
+                                        p2 = cutlass.Int32(1)
+                                self._ballot_pair_emit(
+                                    p1,
+                                    p2,
+                                    idv,
+                                    above,
+                                    aboveC,
+                                    above + aboveC,
+                                    needC,
+                                    out_row,
+                                    s_scal,
+                                    lane,
+                                )
+                                it = it + cutlass.Int32(1)
+                else:
+                    # ---- degen fallback: whole-row key-space narrowing
+                    # (per-level clear + scan_cross w/ ws) ----
+                    rlo = cutlass.Uint32(0)
+                    rhi = cutlass.Uint32(0xFFFFFFFF)
+                    above2 = cutlass.Int32(0)
+                    need2 = k
+                    m2 = n
+                    ethr = cutlass.Int64(0)
+                    tie_m = cutlass.Int32(1)
+                    brk = cutlass.Int32(0)
+                    lev = cutlass.Int32(0)
+                    while brk == cutlass.Int32(0):  # <=8 levels
+                        if need2 == m2:
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                            above2 = above2 + m2
+                            need2 = cutlass.Int32(0)
+                            tie_m = cutlass.Int32(0)
+                            brk = cutlass.Int32(1)
+                        elif cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            brk = cutlass.Int32(1)
+                        elif lev >= cutlass.Int32(8):
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            brk = cutlass.Int32(1)
+                        else:
+                            d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                            b2_ = cutlass.Int32(32) - C.clz_i32(
+                                cutlass.Int32(d2 | cutlass.Uint32(1))
+                            )
+                            sh2 = b2_ - cutlass.Int32(self.lb)
+                            if sh2 < cutlass.Int32(0):
+                                sh2 = cutlass.Int32(0)
+                            sh2u = cutlass.Uint32(sh2)
+                            if tidx < cutlass.Int32(NBS):  # per-level clear
+                                s_hist[tidx] = cutlass.Int32(0)
+                            cute.arch.barrier()  # ---- barrier (level clear) ----
+                            i = tidx
+                            while i < n:  # whole row
+                                uq = C.fkey(C.ldg_f32(x_addr, i))
+                                if uq >= cutlass.Uint32(rlo):
+                                    if uq <= cutlass.Uint32(rhi):
+                                        du = (uq - cutlass.Uint32(rlo)) >> sh2u
+                                        if du > cutlass.Uint32(NBS - 1):
+                                            du = cutlass.Uint32(NBS - 1)
+                                        C.atomic_add_cta(
+                                            s_hist.iterator + cutlass.Int32(du), cutlass.Int32(1)
+                                        )
+                                i = i + cutlass.Int32(BLK)
+                            cute.arch.barrier()  # ---- barrier (level hist) ----
+                            # block-parallel scan (ONE internal barrier; only
+                            # use of ws in this kernel)
+                            C.scan_cross(
+                                s_hist,
+                                s_ws,
+                                need2,
+                                tidx,
+                                s_res,
+                                cutlass.Int32(0),
+                                blk=BLK,
+                                nb=NBS,
+                                two=False,
+                            )
+                            cute.arch.barrier()  # ---- barrier (level scan) ----
+                            above2 = above2 + s_res[C.RES_ABOVE]
+                            need2 = need2 - s_res[C.RES_ABOVE]
+                            m2 = s_res[C.RES_M]
+                            sB = s_res[C.RES_B]
+                            nlo = cutlass.Uint32(rlo) + (cutlass.Uint32(sB) << sh2u)
+                            if sB != cutlass.Int32(NBS - 1):
+                                rhi = nlo + ((cutlass.Uint32(1) << sh2u) - cutlass.Uint32(1))
+                            rlo = nlo
+                            lev = lev + cutlass.Int32(1)
+                    if tidx == cutlass.Int32(0):
+                        s_scal[1] = cutlass.Int32(0)
+                        s_scal[2] = cutlass.Int32(0)
+                    cute.arch.barrier()  # ---- barrier (emit counters) ----
+                    nA = k
+                    nT = cutlass.Int32(0)
+                    if tie_m != cutlass.Int32(0):
+                        nA = above2
+                        nT = need2
+                    it2 = (n + cutlass.Int32(BLK - 1)) // cutlass.Int32(BLK)
+                    it = cutlass.Int32(0)
+                    while it < it2:
+                        i = it * cutlass.Int32(BLK) + tidx
+                        p1 = cutlass.Int32(0)
+                        p2 = cutlass.Int32(0)
+                        if i < n:
+                            uq = C.fkey(C.ldg_f32(x_addr, i))
+                            iu = cutlass.Int64(uq)
+                            if iu > ethr:
+                                p1 = cutlass.Int32(1)
+                            if tie_m != cutlass.Int32(0):
+                                if iu == ethr:
+                                    p2 = cutlass.Int32(1)
+                        self._ballot_pair_emit(
+                            p1, p2, i, cutlass.Int32(0), nA, nA, nT, out_row, s_scal, lane
+                        )
+                        it = it + cutlass.Int32(1)
+
+    # ------------------------------------------------------------------
+    # host launcher: grid dim3(CS, b) + cluster (CS,1,1);
+    # min_blocks_per_mp=1 == __launch_bounds__(1024, 1) 64-register wall.
+    # ------------------------------------------------------------------
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        kv_lens: cute.Tensor,
+        out: cute.Tensor,
+        n: cutlass.Int32,
+        npad: cutlass.Int32,
+        k: cutlass.Int32,
+        SCAP: cutlass.Int32,
+        CMP: cutlass.Int32,
+        SMP: cutlass.Int32,
+        TGT: cutlass.Int32,
+        Q: cutlass.Int32,
+        SS2: cutlass.Int32,
+        TGT2: cutlass.Int32,
+        stream,
+    ):
+        # varlen grid rows = out.shape[0] (logits row count == out row count in
+        # both modes); bigf = the route() `big` occupancy flag, a pure function
+        # of (rows, CS) so it is launch-computed, not an ABI scalar.
+        b = out.shape[0]
+        bigf = cutlass.Int32(0)
+        if b * cutlass.Int32(self.cs) <= cutlass.Int32(148):
+            bigf = cutlass.Int32(1)
+        self.kern(
+            logits, pre_idx, kv_lens, out, n, npad, k, SCAP, CMP, SMP, TGT, Q, SS2, TGT2, bigf
+        ).launch(
+            grid=(self.cs, b, 1),
+            block=(self.blk, 1, 1),
+            cluster=(self.cs, 1, 1),
+            stream=stream,
+            min_blocks_per_mp=self.minb,
+        )
+
+
+# ---------------------------------------------------------------------------
+# compile cache + torch-facing entry
+# ---------------------------------------------------------------------------
+_COMPILE_CACHE__clus = {}
+
+
+def get_compiled__clus(
+    tpl,
+    scap: int = 8192,
+    cmp_: int = 2048,
+    options_extra: str = "",
+    varlen: bool = False,
+    next_n: int = 1,
+    cr_shift: int = 0,
+):
+    """Compile (or fetch) the gvr_clus variant for constexpr tuple
+    tpl = (BLK, U, MINB, NBS, CS); scap/cmp are smem-extent keys (every
+    reachable route has 8192/2048 — asserted by run__clus())."""
+    key = (tuple(tpl), scap, cmp_, options_extra, bool(varlen), int(next_n), int(cr_shift))
+    hit = _COMPILE_CACHE__clus.get(key)
+    if hit is not None:
+        return hit
+    blk, u, minb, nbs, cs = tpl
+    kern = GvrClusKernel(
+        blk, u, minb, nbs, cs, scap=scap, cmp_=cmp_, varlen=varlen, next_n=next_n, cr_shift=cr_shift
+    )
+    r0, c0 = cute.sym_int(), cute.sym_int()
+    r1, c1 = cute.sym_int(), cute.sym_int()
+    r2, c2 = cute.sym_int(), cute.sym_int()
+    logits_fake = _crt.make_fake_compact_tensor(
+        cutlass.Float32, (r0, c0), stride_order=(1, 0), assumed_align=16
+    )
+    pre_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (r1, c1), stride_order=(1, 0), assumed_align=16
+    )
+    out_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (r2, c2), stride_order=(1, 0), assumed_align=16
+    )
+    v0 = cute.sym_int()
+    kv_fake = _crt.make_fake_compact_tensor(
+        cutlass.Int32, (v0,), stride_order=(0,), assumed_align=4
+    )
+    fake_stream = _crt.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    def _compile_fn():
+        return cute.compile(
+            kern,
+            logits_fake,
+            pre_fake,
+            kv_fake,
+            out_fake,
+            *([cutlass.Int32(0)] * 10),
+            stream=fake_stream,
+            options=("--enable-tvm-ffi " + options_extra).strip(),
+        )
+
+    name = (
+        "clus_" + "_".join(str(x) for x in tuple(tpl))
+        + f"_scap{int(scap)}_cmp{int(cmp_)}_vl{int(bool(varlen))}_nn{int(next_n)}_cs{int(cr_shift)}"
+    )
+    if options_extra:
+        name += "_opt_" + options_extra
+    compiled = C._persist(name, _compile_fn)
+    _COMPILE_CACHE__clus[key] = compiled
+    return compiled
+
+
+def run__clus(logits, pre_idx, n: int, out):
+    """torch-facing single-call entry: routes (b, n, k) through ct_dispatch,
+    asserts the shape lands on gvr_clus, launches the matching variant.
+    gvr_clus takes NO workspace."""
+    import torch  # debug-entry only: module stays torch-free at import
+
+    try:
+        from . import gvr2_topk_host as ct_dispatch
+    except ImportError:
+        import gvr2_topk_host as ct_dispatch
+    b, npad = logits.shape
+    k = pre_idx.shape[1]
+    r = ct_dispatch.route(b, int(n), npad, k)
+    assert r["kernel"] == "clus", f"shape routes to {r['kernel']}, not gvr_clus"
+    rt = r["rt"]
+    kobj = GvrClusKernel(*r["tpl"], scap=rt["SCAP"], cmp_=rt["CMP"])
+    assert r["smem"] == kobj.dyn_bytes, (r["smem"], kobj.dyn_bytes)
+    fn = get_compiled__clus(tuple(r["tpl"]), scap=rt["SCAP"], cmp_=rt["CMP"])
+    dkv = torch.zeros(1, dtype=torch.int32, device=logits.device)  # dead varlen slot
+    fn(
+        logits,
+        pre_idx,
+        dkv,
+        out,
+        rt["n"],
+        rt["npad"],
+        rt["k"],
+        rt["SCAP"],
+        rt["CMP"],
+        rt["SMP"],
+        rt["TGT"],
+        rt["Q"],
+        rt["SS2"],
+        rt["TGT2"],
+    )
+    return r
+
+
+def run_manual(logits, pre_idx, n: int, out, tpl, rt):
+    """Manual-lattice entry for route()-unreachable (U, CS) members: launches
+    tpl with caller-supplied runtime scalars (must be route()-consistent for
+    the same CS; U only changes the chunk geometry)."""
+    import torch  # debug-entry only: module stays torch-free at import
+
+    fn = get_compiled__clus(tuple(tpl), scap=rt["SCAP"], cmp_=rt["CMP"])
+    dkv = torch.zeros(1, dtype=torch.int32, device=logits.device)  # dead varlen slot
+    fn(
+        logits,
+        pre_idx,
+        dkv,
+        out,
+        rt["n"],
+        rt["npad"],
+        rt["k"],
+        rt["SCAP"],
+        rt["CMP"],
+        rt["SMP"],
+        rt["TGT"],
+        rt["Q"],
+        rt["SS2"],
+        rt["TGT2"],
+    )
+
+
+# ===========================================================================
+# ==== family: regclus =========================================
+# ===========================================================================
+"""gvr_reg_clus — CLUSTERED register-resident GVR: the register algorithm
+(T = GMIN directly, one float-space histogram, one register sweep) run
+across a cluster of CS CTAs; per-CTA instruction stream intentionally
+identical to the single-CTA reg path plus two hardware cluster barriers and
+CS DSMEM reads per bin. Signedness rule applied at every unsigned
+compare/shift in/after dynamic loops.
+
+Template knobs (CUDA `gvr_reg_clus<BLK,VPT,CS>`, all instantiations
+BLK=BLKC=1024): ctor args of :class:`GvrRegClusKernel`. Runtime args mirror
+the CUDA `(n, npad, k)` — npad/k come from tensor shapes, so only `n` crosses
+the ABI. Launch: grid=(CS, b), cluster=(CS,1,1), block=1024, dynamic smem
+45,056 B (+512 B static-mirror prelude), `__launch_bounds__(1024,1)` ==
+min_blocks_per_mp=1 -> 64-register wall.
+
+Shared-memory map (single dynamic window, word offsets; the CUDA static
+__shared__ block folded into the first 512 B — byte-identical layout in every
+CTA, a mapa/DSMEM requirement):
+
+    [0..5]        s_res   (shared slot map RES_B/M/ABOVE/TOT/B2/B3)
+    [6..7]        s_cnt   (s_o1, s_o2)
+    [8..9]        s_kmm   (s_kmin, s_kmax — Uint32)
+    [16..16+32)   ws      (scan_cross_w workspace)
+    [48..48+32)   wmn     (Uint32 warp min partials)
+    [80..80+32)   wmx     (Uint32 warp max partials)
+    [128..1152)   hist    (this CTA's raw counts)
+    [1152..2176)  mrg     (cluster totals -> per-CTA global write cursors)
+    [2176..3200)  hoff    (this CTA's rank-exclusive bin offset)
+    [3200..7296)  ck      (crossing keys, Uint32, CMPC=4096 slots)
+    [7296..11392) ci      (crossing indices, Int32, CMPC slots)
+
+Launch smem = 45,568 B (compile-time constant -> plain int at .launch();
+MINB==1 so the _build_kernel_attrs carveout path is not taken and the reg
+family's _no_carveout workaround is unnecessary here).
+"""
+
+
+# ---- constants --------------------------------------------------------------
+NB__regclus = 1024  # histogram bins; == BLKC here
+LNB = 10  # log2(NB__regclus) — reg_clus narrowing shift
+QUADC__regclus = 96  # O(mc^2) rank gate
+CMPC = 4096  # crossing slots PER CTA (pow2)
+LCMPC = 12  # log2(CMPC)
+BLKC = 1024  # CTA size
+
+STATIC_WORDS__regclus = 128  # DSL smem prelude (static-__shared__ mirror)
+STATIC_BYTES__regclus = STATIC_WORDS__regclus * 4
+DYN_SMEM_BYTES = (3 * NB__regclus + 2 * CMPC) * 4  # 45,056
+SMEM_BYTES = STATIC_BYTES__regclus + DYN_SMEM_BYTES  # 45,568
+
+# word offsets into the shared window (module docstring)
+W_HIST = STATIC_WORDS__regclus
+W_MRG = STATIC_WORDS__regclus + NB__regclus
+W_HOFF = STATIC_WORDS__regclus + 2 * NB__regclus
+W_CK = STATIC_WORDS__regclus + 3 * NB__regclus
+W_CI = STATIC_WORDS__regclus + 3 * NB__regclus + CMPC
+
+_NEG_INF__regclus = float("-inf")
+_POS_INF__regclus = float("inf")
+
+
+# ---------------------------------------------------------------------------
+# module-local FP/util spellings (same forms as the reg family)
+# ---------------------------------------------------------------------------
+@dsl_user_op
+def _fmaf__regclus(a, b, c, *, loc=None, ip=None):
+    """CUDA fmaf: single fma.rn.f32 (classify == emit bit-exact)."""
+    return cutlass.Float32(
+        mlir_math.fma(
+            a.ir_value(loc=loc, ip=ip),
+            b.ir_value(loc=loc, ip=ip),
+            c.ir_value(loc=loc, ip=ip),
+            fastmath=mlir_arith.FastMathFlags.none,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@cute.jit
+def _umin_u32__regclus(a, b):
+    """unsigned min(a, b) — CUDA min() on the bin clamp (IMNMX)."""
+    r = a
+    if b < a:
+        r = b
+    return r
+
+
+@cute.jit
+def _fabsf__regclus(x):
+    """|x| via sign-bit clear (exact, matches fabsf)."""
+    return f32_of_u32(u32_of_f32(x) & cutlass.Uint32(0x7FFFFFFF))
+
+
+def _smem_view__regclus(dtype, sbase, word_off: int, length: int, align: int = 16):
+    """Typed tensor view at a constexpr word offset into the smem window."""
+    p = cute.make_ptr(
+        dtype, sbase + cutlass.Int32(word_off * 4), cute.AddressSpace.smem, assumed_align=align
+    )
+    return cute.make_tensor(p, cute.make_layout((length,)))
+
+
+def _val__regclus(frags, s: int):
+    """val[s] accessor over the float4[VPT] register batch (constexpr s)."""
+    return frags[s // 4][s % 4]
+
+
+class GvrRegClusKernel:
+    """gvr_reg_clus<BLK, VPT, CS>."""
+
+    def __init__(
+        self,
+        blk: int,
+        vpt: int,
+        cs: int,
+        pdl: bool = False,
+        varlen: bool = False,
+        next_n: int = 1,
+        cr_shift: int = 0,
+    ):
+        assert blk == BLKC, "all instantiations BLK=BLKC=1024"
+        assert vpt in (1, 2, 4) and cs in (2, 4, 8)
+        self.blk = blk
+        self.vpt = vpt
+        self.cs = cs
+        self.pdl = bool(pdl)
+        # per-row varlen mode (production heuristicTopKDecode contract, same
+        # semantics as GvrMainKernel): n is re-derived PER ROW in-kernel from
+        # a device kv_lens tensor; the scalar n launch arg becomes the
+        # envelope clamp bound. next_n / cr_shift are compile-time.
+        self.varlen = bool(varlen)
+        self.next_n = int(next_n)
+        self.cr_shift = int(cr_shift)
+        if self.varlen:
+            assert self.next_n >= 1 and self.cr_shift in (0, 2)
+        self.S = vpt * 4
+        self.span = blk * vpt  # float4 per CTA
+
+    # ------------------------------------------------------------------
+    @cute.kernel
+    def kern(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        kv_lens: cute.Tensor,
+        out: cute.Tensor,
+        n: cutlass.Int32,
+    ):
+        BLK = cutlass.const_expr(self.blk)
+        VPT = cutlass.const_expr(self.vpt)
+        CS = cutlass.const_expr(self.cs)
+        S = cutlass.const_expr(self.S)
+        NW = cutlass.const_expr(self.blk // 32)
+
+        if cutlass.const_expr(self.pdl):
+            cute.arch.griddepcontrol_wait()  # knob default off
+
+        tid, _, _ = cute.arch.thread_idx()
+        rank, row, _ = cute.arch.block_idx()  # bx=rank
+        lane = tid & cutlass.Int32(31)
+
+        # ============ per-row varlen prologue — shared contract lives in ======
+        # GvrMainKernel's prologue (per-row n from kv_lens, clamped to the
+        # envelope arg; the launcher admits this family only when the envelope
+        # fits its capacity window). Pure functions of `row` keep the body
+        # guard and cluster barriers cluster-uniform. Short rows (n <= k):
+        # rank 0 emits identity + (-1) and the body is SKIPped — a zero-work
+        # pass would reach the crossing-overflow emitter and poison the output.
+        short = cutlass.Int32(0)
+        prow = row
+        if cutlass.const_expr(self.varlen):
+            kq = cutlass.Int32(pre_idx.shape[1])
+            req = row // cutlass.Int32(self.next_n)
+            rr = row % cutlass.Int32(self.next_n)
+            prow = req
+            kvl = kv_lens[req]
+            nv = (kvl - cutlass.Int32(self.next_n) + rr + cutlass.Int32(1)) >> cutlass.Int32(
+                self.cr_shift
+            )
+            if nv < cutlass.Int32(0):
+                nv = cutlass.Int32(0)
+            if nv > n:
+                nv = n
+            if nv <= kq:
+                short = cutlass.Int32(1)
+            if short == cutlass.Int32(0):
+                n = nv
+            if short != cutlass.Int32(0):
+                if rank == cutlass.Int32(0):
+                    if tid < kq:
+                        ov = cutlass.Int32(-1)
+                        if tid < nv:
+                            ov = tid
+                        out[row, tid] = ov
+
+        # ------------------------------------------------------------------
+        # Predeclarations (DSL AST rule: every scalar (re)assigned under a
+        # dynamic if/while must pre-exist with a stable type; constant inits
+        # are dead-coded).
+        # ------------------------------------------------------------------
+        i = cutlass.Int32(0)
+        j = cutlass.Int32(0)
+        rnk = cutlass.Int32(0)
+        tinc = cutlass.Int32(0)
+        mc = cutlass.Int32(0)
+        p = cutlass.Int32(0)
+        q2i = cutlass.Int32(0)
+        idx = cutlass.Int32(0)
+        lim1 = cutlass.Int32(0)
+        aboveC = cutlass.Int32(0)
+        needC = cutlass.Int32(0)
+        mm = cutlass.Int32(0)
+        lev = cutlass.Int32(0)
+        done = cutlass.Int32(0)
+        b2w = cutlass.Int32(0)
+        sh2 = cutlass.Int32(0)
+        b_lv = cutlass.Int32(0)
+        it = cutlass.Int32(0)
+        it2 = cutlass.Int32(0)
+        idv = cutlass.Int32(0)
+        q1f = cutlass.Int32(0)
+        q2f = cutlass.Int32(0)
+        n1 = cutlass.Int32(0)
+        n2 = cutlass.Int32(0)
+        b1 = cutlass.Int32(0)
+        b2 = cutlass.Int32(0)
+        p1e = cutlass.Int32(0)
+        p2e = cutlass.Int32(0)
+        lml = cutlass.Int32(0)
+        nA = cutlass.Int32(0)
+        nT = cutlass.Int32(0)
+        tie_m = cutlass.Int32(0)
+        pv0 = cutlass.Int32(-1)
+        okc = cutlass.Int32(0)
+        whole = cutlass.Int32(0)
+        degen = cutlass.Int32(0)
+        pre_a = cutlass.Int32(0)
+        tot_a = cutlass.Int32(0)
+        uk = cutlass.Uint32(0)
+        uq = cutlass.Uint32(0)
+        vq = cutlass.Uint32(0)
+        kv = cutlass.Uint32(0)
+        rlo = cutlass.Uint32(0)
+        rhi = cutlass.Uint32(0)
+        d2 = cutlass.Uint32(0)
+        unar = cutlass.Uint32(0)
+        bnn = cutlass.Uint32(0)
+        nlo = cutlass.Uint32(0)
+        uke = cutlass.Uint32(0)
+        bn = cutlass.Uint32(0)
+        ethr = cutlass.Int64(0)
+        tval = cutlass.Float32(_NEG_INF__regclus)
+        LOQ = cutlass.Float32(0.0)
+        qv = cutlass.Float32(0.0)
+
+        if short == cutlass.Int32(0):
+            npad = cutlass.Int32(logits.shape[1])  # noqa: F841
+            k = cutlass.Int32(pre_idx.shape[1])
+            out_row = out[row, None]
+            x_addr = logits[row, None].iterator.toint()  # Int64 gmem byte base
+            p_addr = pre_idx[prow, None].iterator.toint()  # request-level under varlen
+
+            # ---- shared-memory window (map in module docstring) ----
+            sptr = cute.arch.get_dyn_smem(cutlass.Int32, alignment=16)
+            sbase = sptr.toint()  # Int32 shared addr
+
+            s_res = _smem_view__regclus(cutlass.Int32, sbase, 0, 6)
+            s_cnt = _smem_view__regclus(cutlass.Int32, sbase, 6, 2)  # [0]=s_o1 [1]=s_o2
+            s_kmm = _smem_view__regclus(cutlass.Uint32, sbase, 8, 2)  # [0]=s_kmin [1]=s_kmax
+            s_ws = _smem_view__regclus(cutlass.Int32, sbase, 16, 32)
+            s_wmn = _smem_view__regclus(cutlass.Uint32, sbase, 48, 32)
+            s_wmx = _smem_view__regclus(cutlass.Uint32, sbase, 80, 32)
+            s_hist = _smem_view__regclus(cutlass.Int32, sbase, W_HIST, NB__regclus)
+            s_mrg = _smem_view__regclus(cutlass.Int32, sbase, W_MRG, NB__regclus)
+            s_hoff = _smem_view__regclus(cutlass.Int32, sbase, W_HOFF, NB__regclus)
+            s_ck = _smem_view__regclus(cutlass.Uint32, sbase, W_CK, CMPC)
+            s_ci = _smem_view__regclus(cutlass.Int32, sbase, W_CI, CMPC, align=4)
+            # raw byte bases for DSMEM (mapa) addressing
+            hist_addr = sbase + cutlass.Int32(W_HIST * 4)
+            ck_addr = sbase + cutlass.Int32(W_CK * 4)
+            ci_addr = sbase + cutlass.Int32(W_CI * 4)
+
+            n4 = n >> cutlass.Int32(2)
+            ntail = n - (n4 << cutlass.Int32(2))
+            base4 = rank * cutlass.Int32(self.span)
+            tix = (n4 << cutlass.Int32(2)) + tid  # CUDA `tidx`
+
+            # ---- P0: redundant hint gather, EVERY CTA (k<=BLK by dispatch
+            # gate). One coalesced word per thread, NO cluster barrier —
+            # GMIN/GMAX identical everywhere by construction.
+            if tid < k:
+                pv0 = ld_g_i32(p_addr, tid)
+
+            # ---- P1: row load — predicated flat float4[VPT] batch (the CUDA
+            # has NO exact-fit peel here, guard is per-load). Issue all loads
+            # first, then -INFINITY-fill missed slots.
+            atom128 = g2r_atom_f32(128, invariant=True)
+            frags = [cute.make_rmem_tensor((4,), cutlass.Float32) for _ in range(VPT)]
+            for u in cutlass.range_constexpr(VPT):
+                i = base4 + tid + cutlass.Int32(u * self.blk)
+                if i < n4:
+                    ld_g_f32x4(atom128, x_addr, i, frags[u])
+            for u in cutlass.range_constexpr(VPT):
+                i = base4 + tid + cutlass.Int32(u * self.blk)
+                if i >= n4:  # -INFINITY fill
+                    for z in cutlass.range_constexpr(4):
+                        frags[u][z] = cutlass.Float32(_NEG_INF__regclus)
+            # tail element: rank 0 only
+            if rank == cutlass.Int32(0):
+                if tid < ntail:
+                    tval = ldg_f32(x_addr, tix)
+
+            # ---- P2: init. NB__regclus == BLK -> single-pass hist clear.
+            if tid == cutlass.Int32(0):
+                s_cnt[0] = cutlass.Int32(0)
+                s_cnt[1] = cutlass.Int32(0)
+            for z in cutlass.range_constexpr(NB__regclus // self.blk):
+                s_hist[tid + cutlass.Int32(z * self.blk)] = cutlass.Int32(0)
+
+            # ---- P3: GMIN/GMAX from the hint, ONE barrier fold.
+            lmin = cutlass.Uint32(0xFFFFFFFF)
+            lmax = cutlass.Uint32(0)
+            if cutlass.Uint32(pv0) < cutlass.Uint32(n):
+                uk = fkey(ldg_f32(x_addr, pv0))  # __ldg(X+pv0)
+                lmin = uk
+                lmax = uk
+            lmin = warp_min_u32(lmin)
+            lmax = warp_max_u32(lmax)
+            if lane == cutlass.Int32(0):
+                s_wmn[tid >> cutlass.Int32(5)] = lmin
+                s_wmx[tid >> cutlass.Int32(5)] = lmax
+            cute.arch.barrier()  # warp partials published
+            a = cutlass.Uint32(0xFFFFFFFF)
+            c = cutlass.Uint32(0)
+            if lane < cutlass.Int32(NW):
+                a = cutlass.Uint32(s_wmn[lane])
+                c = cutlass.Uint32(s_wmx[lane])
+            lmin = warp_min_u32(a)
+            lmax = warp_max_u32(c)
+            Tv = invkey(lmin)
+            GMAX = invkey(lmax)
+
+            # ---- collapse guard, NaN-safe
+            okc = cutlass.Int32(0)
+            if Tv < GMAX:
+                if (GMAX - Tv) > cutlass.Float32(1e-30):
+                    okc = cutlass.Int32(1)
+            if okc == cutlass.Int32(0):
+                Tv = cutlass.Float32(SENT_LO)
+                GMAX = cutlass.Float32(SENT_HI)
+
+            # ---- bin transform constants: branchless trash bin.
+            WD = (GMAX - Tv) * cutlass.Float32(1.0 / float(NB__regclus - 2))
+            wsel = cutlass.Float32(1e-30)
+            if WD > cutlass.Float32(0.0):
+                wsel = WD
+            # MUFU.RCP spelling (mirrors the reg family's site):
+            # wsel >= 1e-30 finite; bucketing is SC-invariant for any SC > 0.
+            SC = cute.arch.rcp_approx(wsel)
+            CQ0 = cutlass.Float32(1.0) - Tv * SC
+            CQ = CQ0 + cutlass.Float32(1e-6) * (_fabsf__regclus(CQ0) + cutlass.Float32(1.0))
+
+            # ---- P4: histogram; tval add UNCONDITIONAL (trash bin swallows
+            # -INFINITY via the saturating cvt).
+            for s in cutlass.range_constexpr(S):
+                qv = _fmaf__regclus(_val__regclus(frags, s), SC, CQ)
+                bn = _umin_u32__regclus(f2u_rz(qv), cutlass.Uint32(NB__regclus - 1))
+                atomic_add_cta(s_hist.iterator + cutlass.Int32(bn), cutlass.Int32(1))
+            qv = _fmaf__regclus(tval, SC, CQ)
+            bn = _umin_u32__regclus(f2u_rz(qv), cutlass.Uint32(NB__regclus - 1))
+            atomic_add_cta(s_hist.iterator + cutlass.Int32(bn), cutlass.Int32(1))
+
+            # ---- P5: cluster merge
+            _cluster_sync_aligned()  # histograms complete on every rank
+            for z in cutlass.range_constexpr(NB__regclus // self.blk):
+                i = tid + cutlass.Int32(z * self.blk)
+                # CS-unrolled remote u32 loads: batch-issue, then fold
+                # (one mapa per (i, r) exactly like the CUDA)
+                hvals = []
+                for r in cutlass.range_constexpr(CS):
+                    ma = _mapa_shared_cluster_addr(
+                        hist_addr + (i << cutlass.Int32(2)), cutlass.Int32(r)
+                    )
+                    hvals.append(_ld_shared_cluster_i32(ma))
+                tot_a = cutlass.Int32(0)
+                pre_a = cutlass.Int32(0)
+                for r in cutlass.range_constexpr(CS):
+                    if cutlass.Int32(r) < rank:
+                        pre_a = pre_a + hvals[r]  # rank-exclusive
+                    tot_a = tot_a + hvals[r]
+                s_mrg[i] = tot_a
+                s_hoff[i] = pre_a
+
+            # ---- P6: scan
+            cute.arch.barrier()  # merge published
+            scan_cross_w(s_mrg, s_ws, k, tid, s_res, blk=self.blk, nb=NB__regclus)
+            cute.arch.barrier()  # scan published
+            above = s_res[RES_ABOVE]
+            m = s_res[RES_M]
+            Bv = s_res[RES_B]
+            need = k - above
+            whole = cutlass.Int32(0)
+            if need >= m:
+                whole = cutlass.Int32(1)
+            degen = cutlass.Int32(0)
+            if m > cutlass.Int32(CS * CMPC):
+                degen = cutlass.Int32(1)
+            for z in cutlass.range_constexpr(NB__regclus // self.blk):
+                i = tid + cutlass.Int32(z * self.blk)
+                s_mrg[i] = s_mrg[i] + s_hoff[i]  # global cursor
+            cute.arch.barrier()  # cursors published
+
+            # ---- P7: register sweep emit (!degen)
+            if degen == cutlass.Int32(0):
+                LOQ = cutlass.Float32(Bv)
+                lim1 = above
+                if whole == cutlass.Int32(1):
+                    lim1 = above + m
+                for s in cutlass.range_constexpr(S):
+                    qv = _fmaf__regclus(_val__regclus(frags, s), SC, CQ)  # bit-identical
+                    if qv >= LOQ:
+                        bn = _umin_u32__regclus(f2u_rz(qv), cutlass.Uint32(NB__regclus - 1))
+                        p = atomic_add_cta(s_mrg.iterator + cutlass.Int32(bn), cutlass.Int32(1))
+                        idx = (
+                            (base4 + tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                        ) + cutlass.Int32(s % 4)
+                        if p < lim1:
+                            out_row[p] = idx
+                        else:
+                            if whole == cutlass.Int32(0):
+                                # crossing overflow -> striped DSMEM slabs; TWO
+                                # separate u32 remote stores (NOT packed)
+                                q2i = p - above
+                                rnk = q2i >> cutlass.Int32(LCMPC)
+                                j = (q2i & cutlass.Int32(CMPC - 1)) << cutlass.Int32(2)
+                                _st_shared_cluster_i32(
+                                    _mapa_shared_cluster_addr(ck_addr + j, rnk),
+                                    fkey(_val__regclus(frags, s)),
+                                )
+                                _st_shared_cluster_i32(
+                                    _mapa_shared_cluster_addr(ci_addr + j, rnk), idx
+                                )
+                # tail element: tval == -INF fails q>=LOQ elsewhere
+                qv = _fmaf__regclus(tval, SC, CQ)
+                if qv >= LOQ:
+                    bn = _umin_u32__regclus(f2u_rz(qv), cutlass.Uint32(NB__regclus - 1))
+                    p = atomic_add_cta(s_mrg.iterator + cutlass.Int32(bn), cutlass.Int32(1))
+                    if p < lim1:
+                        out_row[p] = tix
+                    else:
+                        if whole == cutlass.Int32(0):
+                            q2i = p - above
+                            rnk = q2i >> cutlass.Int32(LCMPC)
+                            j = (q2i & cutlass.Int32(CMPC - 1)) << cutlass.Int32(2)
+                            _st_shared_cluster_i32(
+                                _mapa_shared_cluster_addr(ck_addr + j, rnk), fkey(tval)
+                            )
+                            _st_shared_cluster_i32(_mapa_shared_cluster_addr(ci_addr + j, rnk), tix)
+
+            # ---- P8: release staging to rank 0
+            cute.arch.barrier()
+            _cluster_sync_aligned()
+
+            # ---- P9: rank-0 selection
+            if rank == cutlass.Int32(0):
+                if whole == cutlass.Int32(0):
+                    mc = m
+                    if degen == cutlass.Int32(1):
+                        mc = cutlass.Int32(0)
+                    if degen == cutlass.Int32(0):
+                        if mc <= cutlass.Int32(QUADC__regclus):
+                            # (1) quad-96: all candidates LOCAL (96 < CMPC),
+                            # O(mc^2) slot-order tie-broken rank
+                            i = tid
+                            while i < mc:
+                                uq = cutlass.Uint32(s_ck[i])
+                                rnk = cutlass.Int32(0)
+                                j = cutlass.Int32(0)
+                                while j < mc:
+                                    vq = cutlass.Uint32(s_ck[j])
+                                    tinc = cutlass.Int32(0)
+                                    if vq > uq:
+                                        tinc = cutlass.Int32(1)
+                                    if vq == uq:
+                                        if j < i:
+                                            tinc = cutlass.Int32(1)
+                                    rnk = rnk + tinc
+                                    j = j + cutlass.Int32(1)
+                                if rnk < need:
+                                    out_row[above + rnk] = s_ci[i]
+                                i = i + cutlass.Int32(BLK)
+                        else:
+                            # (2) key-space narrowing over striped DSMEM slabs:
+                            # slot = i & (CMPC-1), rank = i >> LCMPC
+                            if tid == cutlass.Int32(0):
+                                s_kmm[0] = cutlass.Uint32(0xFFFFFFFF)
+                                s_kmm[1] = cutlass.Uint32(0)
+                            cute.arch.barrier()  # kmm init
+                            i = tid
+                            while i < mc:
+                                kv = cutlass.Uint32(
+                                    _ld_shared_cluster_i32(
+                                        _mapa_shared_cluster_addr(
+                                            ck_addr
+                                            + ((i & cutlass.Int32(CMPC - 1)) << cutlass.Int32(2)),
+                                            i >> cutlass.Int32(LCMPC),
+                                        )
+                                    )
+                                )
+                                atomic_min_cta(s_kmm.iterator, kv)
+                                atomic_max_cta(s_kmm.iterator + 1, kv)
+                                i = i + cutlass.Int32(BLK)
+                            cute.arch.barrier()  # key range published
+                            rlo = cutlass.Uint32(s_kmm[0])
+                            rhi = cutlass.Uint32(s_kmm[1])
+                            ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                            aboveC = cutlass.Int32(0)
+                            needC = need
+                            mm = mc
+                            lev = cutlass.Int32(0)
+                            done = cutlass.Int32(0)
+                            while done == cutlass.Int32(0):  # <=6 levels
+                                if needC == mm:
+                                    ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                                    aboveC = aboveC + mm
+                                    needC = cutlass.Int32(0)
+                                    done = cutlass.Int32(1)
+                                if done == cutlass.Int32(0):
+                                    if cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                                        ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                        done = cutlass.Int32(1)
+                                    if lev >= cutlass.Int32(6):
+                                        ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                        done = cutlass.Int32(1)
+                                if done == cutlass.Int32(0):
+                                    d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                                    b2w = cutlass.Int32(32) - clz_i32(
+                                        cutlass.Int32(d2 | cutlass.Uint32(1))
+                                    )
+                                    sh2 = cutlass.Int32(0)
+                                    if b2w > cutlass.Int32(LNB):
+                                        sh2 = b2w - cutlass.Int32(LNB)
+                                    for z in cutlass.range_constexpr(NB__regclus // self.blk):
+                                        s_hist[tid + cutlass.Int32(z * self.blk)] = cutlass.Int32(0)
+                                    cute.arch.barrier()  # level clear
+                                    i = tid
+                                    while i < mc:
+                                        unar = cutlass.Uint32(
+                                            _ld_shared_cluster_i32(
+                                                _mapa_shared_cluster_addr(
+                                                    ck_addr
+                                                    + (
+                                                        (i & cutlass.Int32(CMPC - 1))
+                                                        << cutlass.Int32(2)
+                                                    ),
+                                                    i >> cutlass.Int32(LCMPC),
+                                                )
+                                            )
+                                        )
+                                        if cutlass.Uint32(unar) >= cutlass.Uint32(rlo):
+                                            if cutlass.Uint32(unar) <= cutlass.Uint32(rhi):
+                                                bnn = (
+                                                    cutlass.Uint32(unar) - cutlass.Uint32(rlo)
+                                                ) >> cutlass.Uint32(sh2)
+                                                bnn = _umin_u32__regclus(
+                                                    bnn, cutlass.Uint32(NB__regclus - 1)
+                                                )
+                                                atomic_add_cta(
+                                                    s_hist.iterator + cutlass.Int32(bnn),
+                                                    cutlass.Int32(1),
+                                                )
+                                        i = i + cutlass.Int32(BLK)
+                                    cute.arch.barrier()  # level hist
+                                    find_cross(s_hist, needC, tid, s_res, nb=NB__regclus)
+                                    cute.arch.barrier()  # level scan
+                                    aboveC = aboveC + s_res[RES_ABOVE]
+                                    needC = needC - s_res[RES_ABOVE]
+                                    mm = s_res[RES_M]
+                                    b_lv = s_res[RES_B]
+                                    nlo = cutlass.Uint32(rlo) + (
+                                        cutlass.Uint32(b_lv) << cutlass.Uint32(sh2)
+                                    )
+                                    if b_lv != cutlass.Int32(NB__regclus - 1):
+                                        rhi = nlo + (
+                                            (cutlass.Uint32(1) << cutlass.Uint32(sh2))
+                                            - cutlass.Uint32(1)
+                                        )
+                                    rlo = nlo
+                                    lev = lev + cutlass.Int32(1)
+                            cute.arch.barrier()  # narrowing done
+                            # two-predicate ballot emit over the striped slabs
+                            lml = cutlass.Int32(cute.arch.lanemask_lt())
+                            it2 = (mc + cutlass.Int32(self.blk - 1)) // cutlass.Int32(self.blk)
+                            it = cutlass.Int32(0)
+                            while it < it2:
+                                i = it * cutlass.Int32(BLK) + tid
+                                uke = cutlass.Uint32(0)
+                                idv = cutlass.Int32(0)
+                                if i < mc:  # predicated remote
+                                    uke = cutlass.Uint32(
+                                        _ld_shared_cluster_i32(
+                                            _mapa_shared_cluster_addr(
+                                                ck_addr
+                                                + (
+                                                    (i & cutlass.Int32(CMPC - 1))
+                                                    << cutlass.Int32(2)
+                                                ),
+                                                i >> cutlass.Int32(LCMPC),
+                                            )
+                                        )
+                                    )
+                                    idv = _ld_shared_cluster_i32(
+                                        _mapa_shared_cluster_addr(
+                                            ci_addr
+                                            + ((i & cutlass.Int32(CMPC - 1)) << cutlass.Int32(2)),
+                                            i >> cutlass.Int32(LCMPC),
+                                        )
+                                    )
+                                q1f = cutlass.Int32(0)
+                                q2f = cutlass.Int32(0)
+                                if i < mc:
+                                    if cutlass.Int64(cutlass.Uint32(uke)) > ethr:
+                                        q1f = cutlass.Int32(1)
+                                    if cutlass.Int64(cutlass.Uint32(uke)) == ethr:
+                                        q2f = cutlass.Int32(1)
+                                n1 = ballot(q1f == cutlass.Int32(1))
+                                n2 = ballot(q2f == cutlass.Int32(1))
+                                b1 = cutlass.Int32(0)
+                                b2 = cutlass.Int32(0)
+                                if lane == cutlass.Int32(0):
+                                    if n1 != cutlass.Int32(0):
+                                        b1 = atomic_add_cta(s_cnt.iterator, popc(n1))
+                                    if n2 != cutlass.Int32(0):
+                                        b2 = atomic_add_cta(s_cnt.iterator + 1, popc(n2))
+                                b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+                                b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+                                p1e = b1 + popc(n1 & lml)
+                                p2e = b2 + popc(n2 & lml)
+                                if q1f == cutlass.Int32(1):
+                                    if p1e < aboveC:
+                                        out_row[above + p1e] = idv
+                                if q2f == cutlass.Int32(1):
+                                    if p2e < needC:
+                                        out_row[above + aboveC + p2e] = idv
+                                it = it + cutlass.Int32(1)
+                    else:
+                        # (3) degen safety net: crossing bin larger than the
+                        # whole cluster buffer -> exact whole-row key-space
+                        # narrowing by rank 0 alone, <=8 levels.
+                        rlo = cutlass.Uint32(0)
+                        rhi = cutlass.Uint32(0xFFFFFFFF)
+                        aboveC = cutlass.Int32(0)  # above2
+                        needC = k  # need2
+                        mm = n  # m2
+                        ethr = cutlass.Int64(0)
+                        tie_m = cutlass.Int32(1)
+                        lev = cutlass.Int32(0)
+                        done = cutlass.Int32(0)
+                        while done == cutlass.Int32(0):
+                            if needC == mm:
+                                ethr = cutlass.Int64(cutlass.Uint32(rlo)) - cutlass.Int64(1)
+                                aboveC = aboveC + mm
+                                needC = cutlass.Int32(0)
+                                tie_m = cutlass.Int32(0)
+                                done = cutlass.Int32(1)
+                            if done == cutlass.Int32(0):
+                                if cutlass.Uint32(rlo) >= cutlass.Uint32(rhi):
+                                    ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                    done = cutlass.Int32(1)
+                                if lev >= cutlass.Int32(8):
+                                    ethr = cutlass.Int64(cutlass.Uint32(rlo))
+                                    done = cutlass.Int32(1)
+                            if done == cutlass.Int32(0):
+                                d2 = cutlass.Uint32(rhi) - cutlass.Uint32(rlo)
+                                b2w = cutlass.Int32(32) - clz_i32(
+                                    cutlass.Int32(d2 | cutlass.Uint32(1))
+                                )
+                                sh2 = cutlass.Int32(0)
+                                if b2w > cutlass.Int32(LNB):
+                                    sh2 = b2w - cutlass.Int32(LNB)
+                                for z in cutlass.range_constexpr(NB__regclus // self.blk):
+                                    s_hist[tid + cutlass.Int32(z * self.blk)] = cutlass.Int32(0)
+                                cute.arch.barrier()  # level clear
+                                i = tid
+                                while i < n:  # whole-row bin
+                                    unar = fkey(ldg_f32(x_addr, i))
+                                    if cutlass.Uint32(unar) >= cutlass.Uint32(rlo):
+                                        if cutlass.Uint32(unar) <= cutlass.Uint32(rhi):
+                                            bnn = (
+                                                cutlass.Uint32(unar) - cutlass.Uint32(rlo)
+                                            ) >> cutlass.Uint32(sh2)
+                                            bnn = _umin_u32__regclus(
+                                                bnn, cutlass.Uint32(NB__regclus - 1)
+                                            )
+                                            atomic_add_cta(
+                                                s_hist.iterator + cutlass.Int32(bnn),
+                                                cutlass.Int32(1),
+                                            )
+                                    i = i + cutlass.Int32(BLK)
+                                cute.arch.barrier()  # level hist
+                                find_cross(s_hist, needC, tid, s_res, nb=NB__regclus)
+                                cute.arch.barrier()  # level scan
+                                aboveC = aboveC + s_res[RES_ABOVE]
+                                needC = needC - s_res[RES_ABOVE]
+                                mm = s_res[RES_M]
+                                b_lv = s_res[RES_B]
+                                nlo = cutlass.Uint32(rlo) + (
+                                    cutlass.Uint32(b_lv) << cutlass.Uint32(sh2)
+                                )
+                                if b_lv != cutlass.Int32(NB__regclus - 1):
+                                    rhi = nlo + (
+                                        (cutlass.Uint32(1) << cutlass.Uint32(sh2))
+                                        - cutlass.Uint32(1)
+                                    )
+                                rlo = nlo
+                                lev = lev + cutlass.Int32(1)
+                        cute.arch.barrier()  # narrowing done
+                        nA = k  # tie_m ? above2 : k
+                        if tie_m == cutlass.Int32(1):
+                            nA = aboveC
+                        nT = cutlass.Int32(0)
+                        if tie_m == cutlass.Int32(1):
+                            nT = needC
+                        lml = cutlass.Int32(cute.arch.lanemask_lt())
+                        it2 = (n + cutlass.Int32(self.blk - 1)) // cutlass.Int32(self.blk)
+                        it = cutlass.Int32(0)
+                        while it < it2:
+                            i = it * cutlass.Int32(BLK) + tid
+                            uke = cutlass.Uint32(0)
+                            if i < n:
+                                uke = fkey(ldg_f32(x_addr, i))
+                            q1f = cutlass.Int32(0)
+                            q2f = cutlass.Int32(0)
+                            if i < n:
+                                if cutlass.Int64(cutlass.Uint32(uke)) > ethr:
+                                    q1f = cutlass.Int32(1)
+                                if tie_m == cutlass.Int32(1):
+                                    if cutlass.Int64(cutlass.Uint32(uke)) == ethr:
+                                        q2f = cutlass.Int32(1)
+                            n1 = ballot(q1f == cutlass.Int32(1))
+                            n2 = ballot(q2f == cutlass.Int32(1))
+                            b1 = cutlass.Int32(0)
+                            b2 = cutlass.Int32(0)
+                            if lane == cutlass.Int32(0):
+                                if n1 != cutlass.Int32(0):
+                                    b1 = atomic_add_cta(s_cnt.iterator, popc(n1))
+                                if n2 != cutlass.Int32(0):
+                                    b2 = atomic_add_cta(s_cnt.iterator + 1, popc(n2))
+                            b1 = cute.arch.shuffle_sync(b1, cutlass.Int32(0))
+                            b2 = cute.arch.shuffle_sync(b2, cutlass.Int32(0))
+                            p1e = b1 + popc(n1 & lml)
+                            p2e = b2 + popc(n2 & lml)
+                            if q1f == cutlass.Int32(1):
+                                if p1e < nA:
+                                    out_row[p1e] = i
+                            if q2f == cutlass.Int32(1):
+                                if p2e < nT:
+                                    out_row[nA + p2e] = i
+                            it = it + cutlass.Int32(1)
+
+            # ---- P10: FINAL cluster rendezvous — ALL ranks reach it;
+            # keeps peers resident until rank 0 has read their ck/ci.
+            _cluster_sync_aligned()
+
+    # ------------------------------------------------------------------
+    @cute.jit
+    def __call__(
+        self,
+        logits: cute.Tensor,
+        pre_idx: cute.Tensor,
+        kv_lens: cute.Tensor,
+        out: cute.Tensor,
+        n: cutlass.Int32,
+        stream,
+    ):
+        b = out.shape[0]
+        self.kern(logits, pre_idx, kv_lens, out, n).launch(
+            grid=(self.cs, b, 1),
+            block=(self.blk, 1, 1),
+            cluster=(self.cs, 1, 1),
+            stream=stream,
+            smem=SMEM_BYTES,
+            min_blocks_per_mp=1,
+            use_pdl=self.pdl,
+        )
+
+
+# ---------------------------------------------------------------------------
+# host wrapper: compile cache + route()-driven entry
+# ---------------------------------------------------------------------------
+_COMPILE_CACHE__regclus: dict = {}
+
+
+def get_compiled__regclus(tpl, dump_dir=None, pdl=False, varlen=False, next_n=1, cr_shift=0):
+    """Compile (or fetch) the variant for constexpr tuple (BLK, VPT, CS)."""
+    key = (tuple(tpl), bool(pdl), bool(varlen), int(next_n), int(cr_shift))
+    compiled = _COMPILE_CACHE__regclus.get(key)
+    if compiled is None:
+        from cutlass.cute import runtime as _crt
+
+        blk, vpt, cs = tpl
+        kernel = GvrRegClusKernel(
+            blk, vpt, cs, pdl=pdl, varlen=varlen, next_n=next_n, cr_shift=cr_shift
+        )
+        nb_, nc_ = cute.sym_int(), cute.sym_int()
+        nb2_, nc2_ = cute.sym_int(), cute.sym_int()
+        nb3_, nc3_ = cute.sym_int(), cute.sym_int()
+        lg_fake = _crt.make_fake_compact_tensor(
+            cutlass.Float32, (nb_, nc_), stride_order=(1, 0), assumed_align=16
+        )
+        pi_fake = _crt.make_fake_compact_tensor(
+            cutlass.Int32, (nb2_, nc2_), stride_order=(1, 0), assumed_align=16
+        )
+        out_fake = _crt.make_fake_compact_tensor(
+            cutlass.Int32, (nb3_, nc3_), stride_order=(1, 0), assumed_align=16
+        )
+        v0_ = cute.sym_int()
+        kv_fake = _crt.make_fake_compact_tensor(
+            cutlass.Int32, (v0_,), stride_order=(0,), assumed_align=4
+        )
+        fake_stream = _crt.make_fake_stream(use_tvm_ffi_env_stream=True)
+        opts = "--enable-tvm-ffi"
+        if dump_dir:
+            opts += f" --keep-ptx --keep-cubin --dump-dir {dump_dir}"
+
+        def _compile_fn():
+            return cute.compile(
+                kernel,
+                lg_fake,
+                pi_fake,
+                kv_fake,
+                out_fake,
+                cutlass.Int32(0),
+                stream=fake_stream,
+                options=opts,
+            )
+
+        if dump_dir:
+            # debug dumps: compile in-process, do not persist
+            compiled = _compile_fn()
+        else:
+            name = (
+                "regclus_" + "_".join(str(x) for x in tuple(tpl))
+                + f"_pdl{int(bool(pdl))}_vl{int(bool(varlen))}_nn{int(next_n)}_cs{int(cr_shift)}"
+            )
+            compiled = C._persist(name, _compile_fn)
+        _COMPILE_CACHE__regclus[key] = compiled
+    return compiled
+
+
+def regclus_topk(logits, pre_idx, n, out, rd=None):
+    """torch-facing entry for the clustered register family.
+
+    logits [b, npad] f32, pre_idx [b, k] i32, out [b, >=k] i32, n = valid len.
+    rd: optional pre-computed ct_dispatch.route() dict (must be reg_clus).
+    """
+    if rd is None:
+        try:
+            from .gvr2_topk_host import route
+        except ImportError:
+            from gvr2_topk_host import route
+        rd = route(logits.shape[0], int(n), logits.shape[1], pre_idx.shape[1])
+    assert rd["kernel"] == "reg_clus", rd["kernel"]
+    tpl = tuple(rd["tpl"])
+    assert pre_idx.shape[1] <= tpl[0], "k <= BLK enforced by dispatch"
+    assert rd["smem"] == DYN_SMEM_BYTES
+    compiled = get_compiled__regclus(tpl)
+    try:
+        from .gvr2_topk_host import _dummy_kv
+    except ImportError:
+        from gvr2_topk_host import _dummy_kv
+    # dead varlen ABI slot (upstream passed 4 args to the 5-arg ABI — fixed here)
+    kv = _dummy_kv(logits.get_device(), logits.device)
+    compiled(logits, pre_idx, kv, out, int(n))
+    return out
+
+
+__all__ = [
+    "get_compiled",
+    "get_compiled__clus",
+    "get_compiled__reg",
+    "get_compiled__regclus",
+    "run",
+    "run__clus",
+]

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -52,6 +52,28 @@ from cutlass.utils.smem_allocator import SmemAllocator
 C = sys.modules[__name__]
 
 
+def _compile_arch_token() -> str:
+    """Current compile target, mirroring the persistent cache's arch axis
+    (CUTE_DSL_ARCH env override, else the current device's capability).
+
+    Included in the in-process ``_COMPILE_CACHE*`` keys so a heterogeneous
+    multi-GPU process (e.g. SM100 + SM103) never serves a callable compiled
+    for another architecture — the on-disk cache is arch-namespaced, but
+    these dicts sit above it."""
+    import os
+
+    env = os.environ.get("CUTE_DSL_ARCH")
+    if env:
+        return env
+    try:
+        import torch  # lazy: module stays torch-free at import
+
+        major, minor = torch.cuda.get_device_capability()
+        return f"sm{major}{minor}"
+    except Exception:  # noqa: BLE001 — no GPU context: single-arch fallback
+        return "unknown"
+
+
 def _persist(kernel_name: str, compile_fn):
     """Route a ``cute.compile`` closure through FlashInfer's persistent
     CuTe-DSL kernel cache (one ``gvr2_topk`` module directory shared by all
@@ -2988,7 +3010,7 @@ def get_compiled(tpl, options_extra: str = ""):
     tpl = (BLK, U, MINB, NBS, KPT, SPLIT, TSHG, NEXT_N, CR_SHIFT, R_CONST)
     — per-row varlen mode (TSHG slot is ignored: varlen compiles the TSH
     machinery in whenever SPLIT and gates it per row at runtime)."""
-    key = (tuple(tpl), options_extra)
+    key = (tuple(tpl), options_extra, C._compile_arch_token())
     hit = _COMPILE_CACHE.get(key)
     if hit is not None:
         return hit
@@ -4239,7 +4261,7 @@ _COMPILE_CACHE__reg: dict = {}
 def get_compiled__reg(tpl, dump_dir=None, pdl=False, varlen=False, next_n=1, cr_shift=0):
     """Compile (or fetch) the variant for constexpr tuple
     (BLK, VPT, MINB, KPT, CUR, DEG, IMG, NBH)."""
-    key = (tuple(tpl), bool(pdl), bool(varlen), int(next_n), int(cr_shift))
+    key = (tuple(tpl), bool(pdl), bool(varlen), int(next_n), int(cr_shift), C._compile_arch_token())
     compiled = _COMPILE_CACHE__reg.get(key)
     if compiled is None:
         from cutlass.cute import runtime as _crt
@@ -5604,7 +5626,16 @@ def get_compiled__clus(
     """Compile (or fetch) the gvr_clus variant for constexpr tuple
     tpl = (BLK, U, MINB, NBS, CS); scap/cmp are smem-extent keys (every
     reachable route has 8192/2048 — asserted by run__clus())."""
-    key = (tuple(tpl), scap, cmp_, options_extra, bool(varlen), int(next_n), int(cr_shift))
+    key = (
+        tuple(tpl),
+        scap,
+        cmp_,
+        options_extra,
+        bool(varlen),
+        int(next_n),
+        int(cr_shift),
+        C._compile_arch_token(),
+    )
     hit = _COMPILE_CACHE__clus.get(key)
     if hit is not None:
         return hit
@@ -6514,7 +6545,7 @@ _COMPILE_CACHE__regclus: dict = {}
 
 def get_compiled__regclus(tpl, dump_dir=None, pdl=False, varlen=False, next_n=1, cr_shift=0):
     """Compile (or fetch) the variant for constexpr tuple (BLK, VPT, CS)."""
-    key = (tuple(tpl), bool(pdl), bool(varlen), int(next_n), int(cr_shift))
+    key = (tuple(tpl), bool(pdl), bool(varlen), int(next_n), int(cr_shift), C._compile_arch_token())
     compiled = _COMPILE_CACHE__regclus.get(key)
     if compiled is None:
         from cutlass.cute import runtime as _crt

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Self-sampling GVR top-K decode kernels (CuTe DSL, Blackwell sm_100a).
+"""Self-sampling GVR top-K decode kernels (CuTe DSL, Blackwell sm_100a; the same
+source compiles for sm_103a and Rubin sm_107a — it uses only family-portable
+ops, no tcgen05 / block-scaled MMA — and the compile target follows the current
+device).
 
 Sample-calibrated threshold ladders for exact single-pass top-K: the kernel
 derives its selection threshold from an in-kernel sample of the row itself

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -77,6 +77,28 @@ def _compile_arch_token() -> str:
         return "unknown"
 
 
+def _base_compile_opts() -> str:
+    """Base ``cute.compile`` options for every gvr2 family: the TVM-FFI ABI
+    (the persistent cache reloads artifacts through it) plus an explicit
+    ``--gpu-arch`` for the CURRENT device. Without the latter the DSL resolves
+    its target once per process from device 0 (``detect_gpu_arch``), so in a
+    heterogeneous process a kernel compiled while device 1 is current is built
+    for device 0's architecture and fails to load
+    (cudaErrorNoKernelImageForDevice). ``CUTE_DSL_ARCH`` still wins when set."""
+    import os
+
+    opts = "--enable-tvm-ffi"
+    if os.environ.get("CUTE_DSL_ARCH"):
+        return opts
+    try:
+        import torch  # lazy: module stays torch-free at import
+
+        major, minor = torch.cuda.get_device_capability()
+    except Exception:  # noqa: BLE001 — no GPU context: let the DSL detect
+        return opts
+    return f"{opts} --gpu-arch sm_{major}{minor}{'a' if major >= 9 else ''}"
+
+
 def _persist(kernel_name: str, compile_fn):
     """Route a ``cute.compile`` closure through FlashInfer's persistent
     CuTe-DSL kernel cache (one ``gvr2_topk`` module directory shared by all
@@ -1539,7 +1561,8 @@ class GvrMainKernel:
         # kv_len = kv_lens[r // next_n], n = (kv_len - next_n + r % next_n + 1)
         # >> cr_shift.  The sampling-ladder scalars are then re-derived from
         # this row's n by the EXACT route_dynamic() host formulas (the scalar
-        # launch args are dead in this mode).  n <= k rows have no runtime
+        # launch args are dead in this mode, except `n`, which carries the
+        # envelope the per-row length is clamped to).  n <= k rows have no runtime
         # `return` in CuTe DSL: they run the body as a zero-work pass
         # (n = 0, TGT = INT_MAX so no rung ever accepts) and the identity/pad
         # emission happens in the epilogue at the end of the kernel.  Every
@@ -1558,8 +1581,13 @@ class GvrMainKernel:
             )
             if nv < cutlass.Int32(0):
                 nv = cutlass.Int32(0)
-            if nv > npad:
-                nv = npad
+            # Clamp to the logical envelope carried in the (otherwise dead)
+            # `n` launch slot, NOT to the row stride `npad`: on a wider-stride
+            # arena view the columns in [n, npad) belong to the arena, never
+            # to this row, so an oversized kv_len must not classify them
+            # (same clamp the reg / reg_clus / clus varlen prologues apply).
+            if nv > n:
+                nv = n
             n_row = nv
             if nv <= k:
                 short = cutlass.Int32(1)
@@ -3068,7 +3096,7 @@ def get_compiled(tpl, options_extra: str = ""):
             kv_fake,
             *([cutlass.Int32(0)] * 5),
             stream=fake_stream,
-            options=("--enable-tvm-ffi " + options_extra).strip(),
+            options=(_base_compile_opts() + " " + options_extra).strip(),
         )
 
     name = "main_" + "_".join(str(x) for x in tuple(tpl))
@@ -4301,7 +4329,7 @@ def get_compiled__reg(tpl, dump_dir=None, pdl=False, varlen=False, next_n=1, cr_
             cutlass.Int32, (v0_,), stride_order=(0,), assumed_align=4
         )
         fake_stream = _crt.make_fake_stream(use_tvm_ffi_env_stream=True)
-        opts = "--enable-tvm-ffi"
+        opts = _base_compile_opts()
         if dump_dir:
             opts += f" --keep-ptx --keep-cubin --dump-dir {dump_dir}"
 
@@ -5673,7 +5701,7 @@ def get_compiled__clus(
             out_fake,
             *([cutlass.Int32(0)] * 10),
             stream=fake_stream,
-            options=("--enable-tvm-ffi " + options_extra).strip(),
+            options=(_base_compile_opts() + " " + options_extra).strip(),
         )
 
     name = (
@@ -6574,7 +6602,7 @@ def get_compiled__regclus(tpl, dump_dir=None, pdl=False, varlen=False, next_n=1,
             cutlass.Int32, (v0_,), stride_order=(0,), assumed_align=4
         )
         fake_stream = _crt.make_fake_stream(use_tvm_ffi_env_stream=True)
-        opts = "--enable-tvm-ffi"
+        opts = _base_compile_opts()
         if dump_dir:
             opts += f" --keep-ptx --keep-cubin --dump-dir {dump_dir}"
 

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_decode.py
@@ -31,10 +31,13 @@ collision symbols carry a ``__<family>`` suffix.
 
 Provenance: ported near-verbatim from TensorRT-LLM
 ``tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_self_sampling.py``
-(PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf). FlashInfer-local changes:
-module rename, this note, and the ``_persist`` hook that routes the four
-``get_compiled*`` builders through FlashInfer's on-disk CuTe-DSL kernel cache.
-Keep future diffs against upstream mechanical.
+(PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf), plus the register-family
+escape fix from PR NVIDIA/TensorRT-LLM#18501 (count-crossing enforcement when
+the histogram total never reaches k, radix-descent escape, -inf fill-lane
+bound) ported verbatim into ``GvrTopkRegKernel.kern``.  FlashInfer-local
+changes: module rename, this note, and the ``_persist`` hook that routes the
+four ``get_compiled*`` builders through FlashInfer's on-disk CuTe-DSL kernel
+cache.  Keep future diffs against upstream mechanical.
 """
 
 import contextlib
@@ -3497,9 +3500,6 @@ class GvrTopkRegKernel:
         j = cutlass.Int32(0)
         r = cutlass.Int32(0)
         tinc = cutlass.Int32(0)
-        cnt = cutlass.Int32(0)
-        bit = cutlass.Int32(0)
-        abv = cutlass.Int32(0)
         nA = cutlass.Int32(0)
         nT = cutlass.Int32(0)
         n1 = cutlass.Int32(0)
@@ -3545,8 +3545,6 @@ class GvrTopkRegKernel:
         nbw = cutlass.Int32(0)
         uq = cutlass.Uint32(0)
         vq = cutlass.Uint32(0)
-        kt = cutlass.Uint32(0)
-        klo = cutlass.Uint32(0)
         kv = cutlass.Uint32(0)
         rlo = cutlass.Uint32(0)
         rhi = cutlass.Uint32(0)
@@ -3844,16 +3842,29 @@ class GvrTopkRegKernel:
             above = s_res[RES_ABOVE]
             m = s_res[RES_M]
             Bv = s_res[RES_B]
+            tot = s_res[RES_TOT]
             need = k - above
             whole = cutlass.Int32(0)
             if need >= m:
                 whole = cutlass.Int32(1)
 
-            # ---- ESCAPE: 32-step key-space bisection
+            # ---- ESCAPE: radix descent over the key space
+            # (upstream TensorRT-LLM PR #18501, ported verbatim.)
+            # Count-crossing enforcement: when the hint-derived bracket's low
+            # edge sits above the true k-th value, the classify arms count
+            # fewer than k entries (q < 0 is never histogrammed) and the
+            # crossing scan pins its bin-0 fallback as a fake crossing — the
+            # whole-bin emit would then stop at the histogram total and leave
+            # out_row[tot:k) unwritten. Exactness must come from the
+            # count-crossing invariant, never from the bracket estimate: when
+            # the histogram never reaches k (tot < k), take the escape — it
+            # ranks the FULL row in key space, independent of the bracket.
             esc = cutlass.Int32(0)
             if whole == cutlass.Int32(0):
                 if m > cmp_:
                     esc = cutlass.Int32(1)
+            if tot < k:
+                esc = cutlass.Int32(1)
             if esc == cutlass.Int32(1):
                 if tid == cutlass.Int32(0):
                     s_cnt[0] = cutlass.Int32(0)
@@ -3867,61 +3878,106 @@ class GvrTopkRegKernel:
                     s_e12[0] = cutlass.Int32(0)
                     s_e12[1] = cutlass.Int32(0)
                 cute.arch.barrier()  # escape init
-                klo = cutlass.Uint32(0)
-                bit = cutlass.Int32(31)
-                while bit >= cutlass.Int32(0):
-                    kt = klo | (cutlass.Uint32(1) << cutlass.Uint32(bit))
-                    cnt = cutlass.Int32(0)
-                    for s in cutlass.range_constexpr(S):
-                        ix = (
-                            (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
-                        ) + cutlass.Int32(s % 4)
-                        if ix < n:
-                            if fkey(_val(frags, s)) >= kt:
-                                cnt = cnt + cutlass.Int32(1)
-                    if tid < ntail:
-                        if fkey(tval) >= kt:
-                            cnt = cnt + cutlass.Int32(1)
-                    cnt = cutlass.Int32(warp_add_i32(cnt))
-                    if lane == cutlass.Int32(0):
-                        if cnt != cutlass.Int32(0):
-                            atomic_add_cta(s_cnt.iterator, cnt)
-                    cute.arch.barrier()  # count published
-                    if s_cnt[0] >= k:
-                        klo = kt
-                    cute.arch.barrier()  # count consumed
-                    if tid == cutlass.Int32(0):
-                        s_cnt[0] = cutlass.Int32(0)
-                    cute.arch.barrier()  # count reset
-                    bit = bit - cutlass.Int32(1)
-                ethr = cutlass.Int64(klo)  # k-th largest key
-                abv = cutlass.Int32(0)
-                for s in cutlass.range_constexpr(S):
-                    ix = (
-                        (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
-                    ) + cutlass.Int32(s % 4)
-                    if ix < n:
-                        if cutlass.Int64(fkey(_val(frags, s))) > ethr:
-                            abv = abv + cutlass.Int32(1)
-                if tid < ntail:
-                    if cutlass.Int64(fkey(tval)) > ethr:
-                        abv = abv + cutlass.Int32(1)
-                abv = cutlass.Int32(warp_add_i32(abv))
-                if lane == cutlass.Int32(0):
-                    if abv != cutlass.Int32(0):
-                        atomic_add_cta(s_cnt.iterator + 1, abv)
-                cute.arch.barrier()  # above-count published
-                nA = s_cnt[1]
-                nT = k - nA
-                # (rezero dropped — emit counters live in s_e12, see race-fix note)
-                cute.arch.barrier()  # nA consumed
+                # Vector-lane bound: the register batch holds real data only
+                # below 4*n4 — lanes in [4*n4, n) are the -inf FILL of the
+                # last partial float4 (the real values there live in tval).
+                # Bounding by n would count/emit each tail element twice
+                # (once as a fill key, once via tval): benign while the tie
+                # threshold is finite (a fill key loses every compare), but
+                # it emits duplicate indices when the tie class is the -inf
+                # key itself (in-window -inf entries are admissible).
+                nvec = n4 << cutlass.Int32(2)
+                # Narrow LNBH bits per level over the register batch — the
+                # same descent the Phase-3 ck fallback below runs — instead of
+                # one rescan per key bit: ceil(32/LNBH) levels at worst and
+                # two in practice, since the first level's LNBH bits already
+                # cut inside the exponent field, where the bisection took 32.
+                # The exit arms carry the count crossing, so the old separate
+                # above-count pass folds in.
+                # Neither ethr nor aboveC is carried across the descent: ethr
+                # is an Int64 derivable from rlo and the exit arm, and
+                # aboveC + needC == k holds at every exit.
+                rlo = cutlass.Uint32(0)
+                rhi = cutlass.Uint32(0xFFFFFFFF)
+                needC = k
+                mm = n  # in-range count, carried from the previous level
+                lev = cutlass.Int32(0)
+                state = cutlass.Int32(0)  # 1 -> ethr = rlo, 2 -> ethr = rlo - 1
+                while state == cutlass.Int32(0):
+                    if needC == mm:
+                        # whole in-range block is needed: threshold below it
+                        needC = cutlass.Int32(0)
+                        state = cutlass.Int32(2)
+                    if state == cutlass.Int32(0):
+                        if rlo >= rhi:  # single key left == the k-th key
+                            state = cutlass.Int32(1)
+                        if lev >= cutlass.Int32(34):  # non-binding: sh2 strictly shrinks
+                            state = cutlass.Int32(1)
+                    if state == cutlass.Int32(0):
+                        d2 = rhi - rlo
+                        b2w = cutlass.Int32(32) - clz_i32(cutlass.Int32(d2 | cutlass.Uint32(1)))
+                        sh2 = cutlass.Int32(0)
+                        if b2w > cutlass.Int32(LNBH):
+                            sh2 = b2w - cutlass.Int32(LNBH)
+                        for z in cutlass.range_constexpr(self.nbh // self.blk):
+                            s_hist[tid + cutlass.Int32(z * self.blk)] = cutlass.Int32(0)
+                        cute.arch.barrier()  # esc level clear
+                        for s in cutlass.range_constexpr(S):
+                            ix = (
+                                (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
+                            ) + cutlass.Int32(s % 4)
+                            if ix < nvec:
+                                uev = fkey(_val(frags, s))
+                                if uev >= rlo:
+                                    if uev <= rhi:
+                                        bne = _umin_u32(
+                                            (uev - rlo) >> cutlass.Uint32(sh2),
+                                            cutlass.Uint32(self.nbh - 1),
+                                        )
+                                        atomic_add_cta(
+                                            s_hist.iterator + cutlass.Int32(bne),
+                                            cutlass.Int32(1),
+                                        )
+                        if tid < ntail:
+                            uev = fkey(tval)
+                            if uev >= rlo:
+                                if uev <= rhi:
+                                    bne = _umin_u32(
+                                        (uev - rlo) >> cutlass.Uint32(sh2),
+                                        cutlass.Uint32(self.nbh - 1),
+                                    )
+                                    atomic_add_cta(
+                                        s_hist.iterator + cutlass.Int32(bne), cutlass.Int32(1)
+                                    )
+                        cute.arch.barrier()  # esc level hist
+                        if cutlass.const_expr(self.nbh > 1024):
+                            scan_cross_w(s_hist, s_ws, needC, tid, s_res, blk=self.blk, nb=self.nbh)
+                        else:
+                            find_cross(s_hist, needC, tid, s_res, nb=self.nbh)
+                        cute.arch.barrier()  # esc level scan
+                        needC = needC - s_res[RES_ABOVE]
+                        mm = s_res[RES_M]
+                        b_lv = s_res[RES_B]
+                        nlo = rlo + (cutlass.Uint32(b_lv) << cutlass.Uint32(sh2))
+                        if b_lv != cutlass.Int32(self.nbh - 1):
+                            rhi = nlo + (
+                                (cutlass.Uint32(1) << cutlass.Uint32(sh2)) - cutlass.Uint32(1)
+                            )
+                        rlo = nlo
+                        lev = lev + cutlass.Int32(1)
+                nA = k - needC
+                nT = needC
+                ethr = cutlass.Int64(rlo)
+                if state == cutlass.Int32(2):
+                    ethr = ethr - cutlass.Int64(1)
+                cute.arch.barrier()  # descent done
                 lml = cutlass.Int32(cute.arch.lanemask_lt())
                 for s in cutlass.range_constexpr(S):
                     ixv = (
                         (tid + cutlass.Int32((s // 4) * self.blk)) << cutlass.Int32(2)
                     ) + cutlass.Int32(s % 4)
                     u64 = cutlass.Int64(-1)
-                    if ixv < n:
+                    if ixv < nvec:
                         u64 = cutlass.Int64(fkey(_val(frags, s)))
                     q1e = cutlass.Int32(0)
                     q2e = cutlass.Int32(0)

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -136,6 +136,11 @@ def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
     """Mirror of the CUDA gvr_topk_launch dispatch. Pure. See module doc."""
     if b < 1:
         raise RuntimeError(f"route requires b >= 1, got {b}")
+    # 148 is the B200 SM count, baked in by the upstream CUDA dispatch (route()
+    # is a pure mirror of it). It only steers occupancy heuristics (one-wave
+    # tests, split factors, cluster sizing), never correctness: on Rubin
+    # (SM107, 208 SMs) the same constants are merely conservative. Retuning
+    # per-arch is a perf follow-up, not a functional requirement.
     wide = b <= 148
 
     # ======================= register-resident block ========================

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -17,7 +17,13 @@
 Provenance: ported near-verbatim from TensorRT-LLM
 ``tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_self_sampling_host.py``
 (PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf). FlashInfer-local changes:
-module rename and this note. FlashInfer's ``top_k_varlen(backend="gvr_2")``
+module rename and this note; ``_varlen_launcher`` keeps the kernels' row-read
+bound at the physical width and inflates only the routing value (DKG #60);
+``warmup_varlen`` populates the exact-row launchers on every call (DKG #60);
+``validate_run_ws`` enforces the 16-byte alignment the compiled workspace
+declares; ``run_varlen`` rejects overlapping row layouts; ``run``/``run_ws``/
+``run_varlen`` re-enter under the logits device and every compile passes an
+explicit ``--gpu-arch``. FlashInfer's ``top_k_varlen(backend="gvr_2")``
 calls ``run_varlen`` below; the batch-uniform ``run``/``run_ws`` entries are
 kept for parity tests and benchmarking. Keep future diffs against upstream
 mechanical.
@@ -732,7 +738,16 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     hit = _VARLEN_CACHE.get(key)
     if hit is not None:
         return hit
-    n_eff = max(min(n_env, npad), k + 1)
+    # Two envelopes (FlashInfer-local split, reported upstream as DKG #60):
+    # `n_kernel` is what the kernels get as their per-row clamp bound and must
+    # never exceed the physical row width, else a request whose kv length
+    # exceeds k makes the register families read k + 1 elements at the row
+    # stride (into the next row, then past the tensor) when N <= k; `n_route`
+    # is the routing-only value, inflated to k + 1 so route() sees a
+    # non-degenerate problem. With n_kernel <= k every row takes the
+    # in-kernel short path (identity + -1 tail).
+    n_kernel = min(n_env, npad)
+    n_route = max(n_kernel, k + 1)
     cr_shift = 0 if cr == 1 else 2
     dev = _device()
     # ---- route() parity, family tier 1: clustered register-resident --------
@@ -740,12 +755,12 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # admission window (n4 <= 32768) fits capture-frozen envelopes. The
     # choice is a pure function of this cache key, so CUDA-graph replay
     # safety is unchanged; per-row n / short-row handling lives in-kernel.
-    plan_free = route(num_rows, n_eff, npad, k)
+    plan_free = route(num_rows, n_route, npad, k)
     if plan_free["kernel"] == "reg_clus":
         fn = dev.get_compiled__regclus(
             tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
         )
-        lc = ("reg_clus", fn, n_eff)
+        lc = ("reg_clus", fn, n_kernel)
         _VARLEN_CACHE[key] = lc
         return lc
     # ---- route() parity, family tier 2: register-resident (+img flavor) ----
@@ -763,7 +778,7 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
         lc = (
             "reg",
             fn,
-            (rt_f["n"], rt_f["CMP"], rt_f["QC"], dev.STATIC_BYTES + plan_free["smem"]),
+            (n_kernel, rt_f["CMP"], rt_f["QC"], dev.STATIC_BYTES + plan_free["smem"]),
         )
         _VARLEN_CACHE[key] = lc
         return lc
@@ -787,11 +802,11 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
         lc = (
             "clus",
             fn,
-            (n_eff, npad, k, rt_f["SCAP"], rt_f["CMP"], 0, 0, 0, 0, 0),
+            (n_kernel, npad, k, rt_f["SCAP"], rt_f["CMP"], 0, 0, 0, 0, 0),
         )
         _VARLEN_CACHE[key] = lc
         return lc
-    plan = route_streaming(num_rows, n_eff, npad, k, force_main=True)
+    plan = route_streaming(num_rows, n_route, npad, k, force_main=True)
     tpl = tuple(plan["tpl"])  # (BLK, U, MINB, SNB, KPT, SPLIT, TSHG)
     rt = plan["rt"]
     r_const = rt["R"]
@@ -819,7 +834,7 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     tsh_en = 1 if (tpl[5] and k <= 1024) else 0
     # slot 0 (`n`) carries the envelope: the varlen prologue clamps each row's
     # kv-derived length to it, never to the row stride npad (arena tails)
-    pre = (n_env, npad, k, rt["SCAP_"], rt["CMP_"], r_const, 0, 0, 0, 0, 0)
+    pre = (n_kernel, npad, k, rt["SCAP_"], rt["CMP_"], r_const, 0, 0, 0, 0, 0)
     tail = (aim_base, sfac, amin, sd_en, tsh_en)
     lc = ("main", fn, pre, tail)
     _VARLEN_CACHE[key] = lc
@@ -924,13 +939,15 @@ def default_workspace(ref: torch.Tensor) -> torch.Tensor:
 def validate_run_ws(workspace: torch.Tensor, logits: torch.Tensor) -> None:
     """run_ws() workspace hardening, in a fixed predicate order:
     CUDA + same device as logits; numel*element_size >= workspace_bytes();
-    base 8-byte aligned."""
+    base 16-byte aligned (the compiled ABI's assumed_align)."""
     if not (workspace.is_cuda and workspace.get_device() == logits.get_device()):
         raise RuntimeError("workspace must be a CUDA tensor on the same device")
     if workspace.numel() * workspace.element_size() < WS_BYTES:
         raise RuntimeError(f"workspace too small: need {WS_BYTES} bytes")
-    if workspace.data_ptr() & 7:
-        raise RuntimeError("workspace must be 8-byte aligned")
+    if workspace.data_ptr() & 15:
+        # the compiled ws_fake declares assumed_align=16 (FlashInfer-local
+        # tightening from 8; an 8-but-not-16 pointer used to fail at launch)
+        raise RuntimeError("workspace must be 16-byte aligned")
 
 
 def kernel_view(workspace: torch.Tensor) -> torch.Tensor:
@@ -938,10 +955,9 @@ def kernel_view(workspace: torch.Tensor) -> torch.Tensor:
     bytes at the tensor's data_ptr() as int32[WS_BYTES/4], ignoring
     dtype/shape.
 
-    NOTE: the DSL-side fake tensor declares assumed_align=16; a workspace at
-    8-but-not-16-byte alignment passes the validate_run_ws check but is
-    rejected by the DSL at conversion -- surfaced as a launch failure with
-    shape context."""
+    NOTE: the DSL-side fake tensor declares assumed_align=16, which
+    validate_run_ws enforces up front (an 8-but-not-16-byte pointer used to
+    pass the host check and be rejected by the DSL at conversion)."""
     if (
         workspace.dtype is torch.int32
         and workspace.dim() == 1
@@ -1409,6 +1425,13 @@ def run_varlen(
             raise RuntimeError(f"indices width {indices.shape[1]} < k={k}")
         if not (pre_idx.is_contiguous() and indices.is_contiguous() and kv_lens.is_contiguous()):
             raise RuntimeError("pre_idx/indices/kv_lens must be contiguous")
+        if (pre_idx.data_ptr() | indices.data_ptr()) & 15:
+            # the compiled fakes declare assumed_align=16 for pre_idx/indices
+            # (FlashInfer-local check; the DSL used to refuse at conversion)
+            raise RuntimeError(
+                "pre_idx/indices base must be 16-byte aligned (shifted views are "
+                "not supported)"
+            )
         # logits: accept row-major views with a wider row stride (the DSL
         # paged-MQA logits arena is 256-aligned and column-sliced — a legal
         # NON-contiguous view). The kernel only needs (base, row stride):
@@ -1416,6 +1439,14 @@ def run_varlen(
         # the tail columns are never classified (per-row n gates all reads).
         if logits.stride(1) != 1:
             raise RuntimeError("logits inner stride must be 1")
+        if num_rows > 1 and logits.stride(0) < logits.shape[1]:
+            # the row pitch is derived from stride(0); overlapping rows (an
+            # expand view, stride 0) would shrink the search domain and drive
+            # reads past the storage (FlashInfer-local check)
+            raise RuntimeError(
+                "logits rows overlap (stride(0) < shape[1]); pass a row-major "
+                "view with stride(0) >= shape[1]"
+            )
         npad = logits.stride(0) if num_rows > 1 else logits.shape[1]
         lg = logits
         if not logits.is_contiguous():
@@ -1627,9 +1658,19 @@ def warmup_varlen(
                 f"row_stride must be a float4-multiple >= n_env={n_env}, got {row_stride}"
             )
     key = (dev, int(top_k), int(max_seq_len), int(compress_ratio), nn, tuple(rows_list), npad)
+    n_env_l = min(max(int(max_seq_len) >> (0 if int(compress_ratio) == 1 else 2), 1), npad)
     with _VARLEN_WARMUP_LOCK:
-        if key in _VARLEN_WARMUP_DONE:
-            return
+        bands_done = key in _VARLEN_WARMUP_DONE
+    if bands_done:
+        # FlashInfer-local (DKG #60): the done key covers the ENGINE band
+        # launches only (they depend on the representative rows, not on the
+        # exact request), so the pure-host exact-row launcher population must
+        # still run for a later warmup that adds a row count mapping to an
+        # already-warmed engine — otherwise a CUDA-graph capture at that row
+        # count misses the launcher cache.
+        for r in req_rows:
+            _varlen_launcher(r, npad, int(top_k), n_env_l, nn, int(compress_ratio))
+        return
     rows_max = rows_list[-1]
     # one allocation at the largest geometry; smaller row counts run on
     # contiguous prefix views (compile keys depend on shapes only)
@@ -1654,7 +1695,6 @@ def warmup_varlen(
     # LAUNCHER cache entries for the exact requested row counts (pure host
     # work, zero allocation/launch — engines hit the compile cache), so a
     # CUDA-graph capture at any requested geometry finds its key immediately.
-    n_env_l = min(max(int(max_seq_len) >> (0 if int(compress_ratio) == 1 else 2), 1), npad)
     for r in req_rows:
         _varlen_launcher(r, npad, int(top_k), n_env_l, nn, int(compress_ratio))
     with _VARLEN_WARMUP_LOCK:

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -1,0 +1,1603 @@
+# Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Self-sampling GVR top-K decode — host side (dispatch, workspace, entry).
+
+Provenance: ported near-verbatim from TensorRT-LLM
+``tensorrt_llm/_torch/cute_dsl_kernels/blackwell/top_k/gvr_topk_decode_self_sampling_host.py``
+(PR NVIDIA/TensorRT-LLM#17821, commit ed94d4cfbf). FlashInfer-local changes:
+module rename and this note. FlashInfer's ``top_k_varlen(backend="gvr_2")``
+calls ``run_varlen`` below; the batch-uniform ``run``/``run_ws`` entries are
+kept for parity tests and benchmarking. Keep future diffs against upstream
+mechanical.
+
+Companion to ``gvr2_topk_decode.py`` (the device module).
+Three sections:
+
+1. dispatch — the CUDA host dispatch as a pure function
+   ``route(b, n, npad, k)``;
+2. workspace — one zero-initialised per-device slab (20,973,568 B) via the
+   torch caching allocator, with keep-alive + double-checked locking;
+3. operator entry — ``run(logits, pre_idx, n_valid, indices)`` /
+   ``run_ws(..., workspace)`` DPS forms with input hardening and a
+   bind-once launch cache keyed on ``(b, n, npad, k)``.
+
+OPERATOR CONTRACT (batch-uniform entries): ``n_valid`` is one host python
+int for the whole batch — every row shares the same valid prefix, in
+COMPRESSED index space (the caller applies any ``compressRatio`` division).
+``pre_idx`` is consumed as-is — raw prev-step top-K indices, uniformly for
+DSv3.2 / DSv4 Flash / Pro. The +1 temporal shift ``heuristicTopKDecode.cu``
+applies for cr==1 is deliberately dropped: hints only steer the sampling
+ladder (exactness never depends on them), and raw prev-step hints overlap
+the current top-K at least as well as +1-shifted ones on real decode data,
+so one offset-free hint convention serves all three models. The production
+per-row contract (per-request ``kv_lens`` read on-device, per-row MTP
+offsets — sync-free and CUDA-graph-replay safe with growing KV) is
+implemented by ``run_varlen``, which is the entry the opt-in DSA dispatch
+seam calls. The batch-uniform ``run``/``run_ws`` entries keep the simpler
+contract (one host-side ``n_valid`` for the whole batch), are exercised for
+unit tests and benchmarking only, and must not be substituted for
+``run_varlen`` under continuous batching, MTP (``next_n > 1``), or
+CUDA-graph capture.
+"""
+
+import math
+import operator
+import threading
+from collections.abc import Sequence
+
+import torch
+
+_dev_mod = None
+
+
+def _device():
+    """Lazy import of the merged device module (first routed shape compiles;
+    a broken/absent device module only fails when actually reached)."""
+    global _dev_mod
+    if _dev_mod is None:
+        try:
+            from . import gvr2_topk_decode as _m  # in-tree
+        except ImportError:  # standalone dir
+            import gvr2_topk_decode as _m
+        _dev_mod = _m
+    return _dev_mod
+
+
+# ===========================================================================
+# ==== dispatch =============================================================
+# ===========================================================================
+"""Pure-Python mirror of the GVR CUDA host dispatch (gvr_topk_launch).
+
+route(b, n, npad, k) is a PURE function of its four ints -- no env knobs, no
+GPU, stdlib only.  It returns the kernel family, its compile-time template
+tuple, the runtime scalar pack `rt`, grid/cluster/block geometry, smem size,
+and whether the family needs the workspace.
+
+rt carries the FULL runtime scalar list each kernel receives, in signature
+order, always starting with (n, npad, k).
+
+Dead ABI-parity args: gvr_main's `int SCAP_, int CMP_` params are NEVER read
+by the kernel body -- it recomputes them as constexprs that mirror the host
+formulas bit-identically.  They are kept in rt purely for ABI parity.
+gvr_clus's SCAP/CMP are LIVE runtime args.  `aim` and `SFAC` are host-side
+intermediates only (never cross the ABI), so they do not appear in rt.
+
+C-semantics notes encoded here:
+  * every `/` on ints is C truncating division -> Python `//` (all operands
+    are non-negative on every reachable path);
+  * `sel = (long long)SFAC * n / aim` and the TGT/TGT2 products are 64-bit in C;
+    Python ints are exact, so `//` reproduces them;
+  * `int r = (int)(0.5 + sqrt((double)(6LL*n)))` truncates toward zero after
+    the +0.5 -> `int(0.5 + math.sqrt(float(6*n)))`;
+  * `IMGW = (n + 3) & ~3` four-element float4 round-up;
+  * the reg-block CMP (possibly widened to n by DEGE) is scoped to the
+    register-resident block; the streaming path re-derives its own CMP.
+"""
+
+
+# ---- dispatch constants (must match the device kernels) ---------------------
+NB = 1024  # register-path histogram bins
+QUADC = 96  # crossing-bin O(mc^2) rank gate (streaming/reg paths)
+SNB = 256  # streaming-path bin count
+CMPC = 4096  # crossing-bin slots per CTA, clustered register path
+BLKC = 1024  # CTA size of the clustered register path
+
+
+def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
+    """Mirror of the CUDA gvr_topk_launch dispatch. Pure. See module doc."""
+    if b < 1:
+        raise RuntimeError(f"route requires b >= 1, got {b}")
+    wide = b <= 148
+
+    # ======================= register-resident block ========================
+    n4 = n >> 2
+    CMP = n if n < 2560 else 2560
+    QC = 1024 if b > 148 else QUADC
+    CURE = not (n < 2 * k and b > 148)
+    DEGE = (n <= 3 * k) or (n <= 4 * k + 64)
+    if DEGE and CMP < n:
+        CMP = n
+    NBSEL = (2 * NB) if (n4 > 512 and not (n4 <= 1024 and not wide)) else NB
+    IMGOFF = NBSEL
+    smem_reg = (NBSEL + 2 * CMP) * 4
+
+    def _reg(BLK, VPT, MINB, NBH):
+        # DEG wins over the CUR flag; DEG forces KPT=1, else KPT ladder 1/2/4.
+        if DEGE:
+            tpl = (BLK, VPT, MINB, 1, CURE, True, False, NBH)
+        else:
+            kpt = 1 if k <= BLK else (2 if k <= 2 * BLK else 4)
+            tpl = (BLK, VPT, MINB, kpt, CURE, False, False, NBH)
+        return {
+            "kernel": "reg",
+            "tpl": tpl,
+            "rt": {
+                "n": n,
+                "npad": npad,
+                "k": k,  # full ABI
+                "CMP": CMP,
+                "IMGOFF": IMGOFF,
+                "QC": QC,
+            },
+            "grid": (b, 1),
+            "cluster": 1,
+            "block": BLK,
+            "smem": smem_reg,
+            "ws": False,
+        }
+
+    IMGW = (n + 3) & ~3
+    smi = (NBSEL + (2 * CMP if 2 * CMP > IMGW else IMGW)) * 4
+    IMGE = wide and (not DEGE) and k <= 1024
+
+    if n4 <= 256:
+        return _reg(256, 1, 8, NB)
+    if n4 <= 512:
+        return _reg(512, 1, 4, NB)
+    if n4 <= 1024:
+        if wide:
+            if IMGE:
+                # regimg launch: gvr_topk_reg<1024,1,2,1,true,false,true,2048>
+                return {
+                    "kernel": "regimg",
+                    "tpl": (1024, 1, 2, 1, True, False, True, 2 * NB),
+                    "rt": {
+                        "n": n,
+                        "npad": npad,
+                        "k": k,  # full ABI
+                        "CMP": CMP,
+                        "IMGOFF": IMGOFF,
+                        "QC": QC,
+                    },
+                    "grid": (b, 1),
+                    "cluster": 1,
+                    "block": 1024,
+                    "smem": smi,
+                    "ws": False,
+                }
+            return _reg(1024, 1, 2, 2 * NB)
+        return _reg(512, 2, 4, NB)
+
+    # ---- clustered register-resident path ----
+    if n4 > 4096 and n4 <= 8 * BLKC * 4 and k <= BLKC:
+        av = 148 // (b if b > 0 else 1)  # truncating
+        amax = 1
+        while (amax << 1) <= av and amax < 8:
+            amax <<= 1
+        vsel = 0
+        cs = 0
+        if amax >= 2:
+            # cs=8 co-residency veto: an 8-CTA cluster with b > 15 exceeds
+            # GPC packing; such shapes fall through to the streaming path.
+            for v in (1, 2, 4):
+                c = 1  # 64-bit product in C
+                while c * BLKC * v < n4:
+                    c <<= 1
+                if c == 8 and b > 15:  # the veto
+                    continue
+                if c <= amax:
+                    vsel = v
+                    cs = c
+                    break
+        if vsel and cs >= 2:
+            smc = (3 * NB + 2 * CMPC) * 4
+            return {
+                "kernel": "reg_clus",
+                "tpl": (BLKC, vsel, cs),
+                "rt": {"n": n, "npad": npad, "k": k},  # dims only
+                "grid": (cs, b),
+                "cluster": cs,
+                "block": BLKC,
+                "smem": smc,
+                "ws": False,
+            }
+
+    if n4 <= 4096 and wide:
+        return _reg(1024, 4, 1, 2 * NB)
+
+    # ====================== streaming / collect path ========================
+    R = 1
+    if b <= 32:
+        r1 = 148 // b
+        if r1 < 1:
+            r1 = 1
+        r2 = ((n >> 2) + 1023) // 1024
+        if r2 < 1:
+            r2 = 1
+        R = r1 if r1 < r2 else r2
+        if R < 1:
+            R = 1
+    elif b <= 74 and (n >> 2) >= 16384 and k <= 1024:  # shallow R=2 split
+        R = 2
+
+    useclus = False
+    if 2 <= R <= 8 and k <= 1024:
+        p2 = 1
+        while (p2 << 1) <= R:
+            p2 <<= 1
+        # gvr_clus cs=8 hits the same GPC packing wall as the clustered
+        # register path; same veto, same b > 15 threshold.
+        if p2 == 8 and b > 15:
+            p2 = 4
+        R = p2
+        useclus = True
+
+    big = b * R <= 148
+    SCAP = (16384 if R == 1 else 8192) if big else (8192 if k > 1024 else 4096)
+    CMP = (4096 if k > 1024 else 2048) if big else 1024
+
+    aim = (
+        ((4 * k if k >= 1024 else 2 * k) if R == 1 else 2 * k)
+        if big
+        else ((11 * k) // 8 if k >= 1024 else (3 * k) // 2)
+    )
+    q = 6 * n  # 6LL * n
+    r = int(0.5 + math.sqrt(float(q)))  # C cast trunc
+    if r > aim:
+        aim = r
+    SFAC = (32 if R == 2 else (48 if k > 1024 else 16)) if R > 1 else (64 if k >= 1024 else 32)
+    amin = 3 * k if R == 2 else (7 * k) // 2
+    if R > 1 and aim < amin:
+        aim = amin
+    if aim > (SCAP >> 1):
+        aim = SCAP >> 1
+    if aim < k:
+        aim = k
+
+    n4s = n >> 2
+    SMP, SS2, TGT, TGT2 = 0, 1, 0, 0
+    small_dense = (k > 1024) and (not big) and n <= SCAP and n > 2 * k
+    if (n > SCAP or small_dense) and n4s >= 4:  # PAIR sample
+        sel = SFAC * n // aim  # 64-bit
+        if sel < 256:
+            sel = 256
+        if sel > n // 2:
+            sel = n // 2
+        pairs = sel >> 3
+        if pairs < 1:
+            pairs = 1
+        half = n4s >> 1
+        if half < 1:
+            half = 1
+        if pairs > half:
+            pairs = half
+        SS2 = half // pairs
+        if SS2 < 1:
+            SS2 = 1
+        SMP = half // SS2
+        if SMP < 1:
+            SMP = 1
+        TGT = (aim * (SMP * 8)) // n  # 64-bit
+        if TGT < 1:
+            TGT = 1
+        TGT2 = (k * (SMP * 8)) // n  # 64-bit
+        if TGT2 < 1:
+            TGT2 = 1
+    Q = (n4s + R - 1) // R
+
+    if useclus:
+        if n > SCAP and n4s >= 4:  # QUAD override
+            sel = SFAC * n // aim
+            if sel < 256:
+                sel = 256
+            if sel > n // 2:
+                sel = n // 2
+            quads = sel >> 4
+            if quads < 1:
+                quads = 1
+            quarter = n4s >> 2
+            if quarter < 1:
+                quarter = 1
+            if quads > quarter:
+                quads = quarter
+            SS2 = quarter // quads
+            if SS2 < 1:
+                SS2 = 1
+            SMP = quarter // SS2
+            if SMP < 1:
+                SMP = 1
+            TGT = (aim * (SMP * 16)) // n
+            if TGT < 1:
+                TGT = 1
+            TGT2 = (k * (SMP * 16)) // n
+            if TGT2 < 1:
+                TGT2 = 1
+        smc = SNB * 8 + (SCAP + 4) * 8 + CMP * 8
+        per = Q >> 10
+        U = 8 if per >= 8 else (4 if per >= 4 else (2 if per >= 2 else 1))
+        CS = 2 if R == 2 else (4 if R == 4 else 8)
+        return {
+            "kernel": "clus",
+            "tpl": (1024, U, 1, SNB, CS),
+            "rt": {
+                "n": n,
+                "npad": npad,
+                "k": k,  # ABI (live)
+                "SCAP": SCAP,
+                "CMP": CMP,
+                "SMP": SMP,
+                "TGT": TGT,
+                "Q": Q,
+                "SS2": SS2,
+                "TGT2": TGT2,
+            },
+            "grid": (CS, b),
+            "cluster": CS,
+            "block": 1024,
+            "smem": smc,
+            "ws": False,
+        }
+
+    smem_main = (SCAP + 4) * (8 if (R > 1 or b <= 296) else 4) + (CMP + 1) * 8
+
+    def _main(BLK, MINB, U, SPLIT):
+        # KPT ladder 1/2/4/8; grid = (R, b).
+        kpt = 1 if k <= BLK else (2 if k <= 2 * BLK else (4 if k <= 4 * BLK else 8))
+        # TSH-floor staging gate.  The CUDA form is a grid-uniform RUNTIME
+        # gate (gridDim.y > 15 && k <= 1024 && (n >> 2) <= 32768); here it
+        # is a compile-time key -- per-launch semantics are identical
+        # because the gate is uniform over the grid.
+        tshg = bool(SPLIT) and b > 15 and k <= 1024 and (n >> 2) <= 32768
+        return {
+            "kernel": "main",
+            "tpl": (BLK, U, MINB, SNB, kpt, SPLIT, tshg),
+            # SCAP_/CMP_ are dead ABI-parity args: gvr_main never reads them
+            # (it recomputes them as constexprs).
+            "rt": {
+                "n": n,
+                "npad": npad,
+                "k": k,  # full ABI
+                "SCAP_": SCAP,
+                "CMP_": CMP,
+                "R": R,
+                "SMP": SMP,
+                "TGT": TGT,
+                "Q": Q,
+                "SS2": SS2,
+                "TGT2": TGT2,
+            },
+            "grid": (R, b),
+            "cluster": 1,
+            "block": BLK,
+            "smem": smem_main,
+            "ws": True,
+        }
+
+    if big:
+        per = Q >> 10
+        U = 8 if per >= 8 else (4 if per >= 4 else (2 if per >= 2 else 1))
+        return _main(1024, 1, U, R > 1)  # SPLIT iff R>1
+    if b <= 296:
+        return _main(512, 2, 8, False)
+    return _main(256, 4, 8, False)
+
+
+if __name__ == "__main__":
+    smoke = [
+        # (b, n, npad, k)                          expected family
+        (64, 1024, 1024, 512),  # reg   n4<=256 rung (DEG: n<=3k)
+        (64, 2048, 2048, 512),  # reg   n4<=512 rung
+        (1024, 4096, 4096, 1024),  # reg   n4<=1024, b>148 -> (512,2,4)
+        (64, 4096, 4096, 512),  # regimg wide !DEGE k<=1024
+        (64, 4096, 4096, 1024),  # reg   wide but DEGE (n<=4k+64)
+        (8, 65536, 65536, 1024),  # reg_clus (vsel=2, cs=8; b<=15 no veto)
+        (16, 131072, 131072, 512),  # main  cs=8 veto fall-through -> SPLIT slab, tshg=True
+        (64, 16384, 16384, 1024),  # reg   wide 4k fallback (1024,4,1)
+        (64, 262144, 262144, 1024),  # clus  R=2 shallow cluster split
+        (1, 1048576, 1048576, 1024),  # main  deep slab SPLIT R=148
+        (20, 262144, 262144, 2048),  # main  k>1024 split (no useclus)
+        (512, 131072, 131072, 1024),  # main  b>296 BLK=256
+        (256, 6144, 6144, 2048),  # main  small_dense sample gate
+        (256, 262144, 262144, 2048),  # main  KBIG-domain (k>1024), BLK=512 KPT=4
+    ]
+    for shp in smoke:
+        print(shp, "->", route(*shp))
+
+
+# ---------------------------------------------------------------------------
+# two-time-scale dispatch split (per-row varlen / CUDA-graph groundwork)
+# ---------------------------------------------------------------------------
+# route(b, n, npad, k) factored into
+#   route_static(b, n, npad, k)  — everything that must be frozen per launch:
+#       family, compile tuple, grid, cluster, block, and the rt scalars that
+#       change only at discrete n-thresholds;
+#   route_dynamic(static, n)     — the n-continuous scalars a per-row kernel
+#       recomputes from its own row length (the device code will mirror these
+#       formulas): n, CMP (reg families), the sampling ladder
+#       SMP/TGT/SS2/TGT2/Q (streaming families), and the reg-family smem
+#       footprint.
+# INVARIANT: merging route_dynamic back into route_static reproduces
+# route() EXACTLY for every n. The policy of which n to freeze the static
+# half at (e.g. max_seq_len) is a perf-only choice — the factorization
+# itself is lossless.
+
+_DYN_RT = {
+    "reg": ("n", "CMP"),
+    "regimg": ("n", "CMP"),
+    "reg_clus": ("n",),
+    "clus": ("n", "SMP", "TGT", "Q", "SS2", "TGT2"),
+    "main": ("n", "SMP", "TGT", "Q", "SS2", "TGT2"),
+}
+_DYN_SMEM = ("reg", "regimg")  # smem depends on CMP/IMGW -> recomputed per n
+
+
+def route_static(b: int, n: int, npad: int, k: int) -> dict[str, object]:
+    """route() with the n-continuous fields redacted (see _DYN_RT/_DYN_SMEM).
+    Constant on maximal n-intervals ("bands"); every redacted field is
+    reconstructible from (static, n) by route_dynamic."""
+    plan = route(b, n, npad, k)
+    st = {key: (dict(val) if isinstance(val, dict) else val) for key, val in plan.items()}
+    for f in _DYN_RT[st["kernel"]]:
+        st["rt"].pop(f)
+    if st["kernel"] in _DYN_SMEM:
+        st.pop("smem")
+    return st
+
+
+def route_dynamic(static: dict[str, object], n: int) -> tuple[dict[str, object], int]:
+    """Recompute the redacted n-continuous scalars from (static, n).
+    Returns (rt_updates, smem). Must stay equivalent to route(); the
+    device-side per-row engine mirrors exactly these formulas."""
+    fam = static["kernel"]
+    k = static["rt"]["k"]
+    if fam in ("reg", "regimg"):
+        dege = static["tpl"][5]
+        cmp_ = n if dege else (n if n < 2560 else 2560)
+        nbsel = static["rt"]["IMGOFF"]
+        if fam == "regimg":
+            imgw = (n + 3) & ~3
+            smem = (nbsel + (2 * cmp_ if 2 * cmp_ > imgw else imgw)) * 4
+        else:
+            smem = (nbsel + 2 * cmp_) * 4
+        return {"n": n, "CMP": cmp_}, smem
+    if fam == "reg_clus":
+        return {"n": n}, static["smem"]
+
+    # streaming families (main / clus): the sampling-ladder scalars
+    b = static["grid"][1]
+    if fam == "clus":
+        R = static["cluster"]
+        scap = static["rt"]["SCAP"]
+    else:
+        R = static["rt"]["R"]
+        scap = static["rt"]["SCAP_"]
+    big = b * R <= 148
+    aim = (
+        ((4 * k if k >= 1024 else 2 * k) if R == 1 else 2 * k)
+        if big
+        else ((11 * k) // 8 if k >= 1024 else (3 * k) // 2)
+    )
+    r_ = int(0.5 + math.sqrt(float(6 * n)))
+    if r_ > aim:
+        aim = r_
+    sfac = (32 if R == 2 else (48 if k > 1024 else 16)) if R > 1 else (64 if k >= 1024 else 32)
+    amin = 3 * k if R == 2 else (7 * k) // 2
+    if R > 1 and aim < amin:
+        aim = amin
+    if aim > (scap >> 1):
+        aim = scap >> 1
+    if aim < k:
+        aim = k
+
+    n4s = n >> 2
+    smp, ss2, tgt, tgt2 = 0, 1, 0, 0
+    small_dense = (k > 1024) and (not big) and n <= scap and n > 2 * k
+    if (n > scap or small_dense) and n4s >= 4:
+        sel = sfac * n // aim
+        sel = 256 if sel < 256 else sel
+        sel = n // 2 if sel > n // 2 else sel
+        pairs = max(sel >> 3, 1)
+        half = max(n4s >> 1, 1)
+        pairs = half if pairs > half else pairs
+        ss2 = max(half // pairs, 1)
+        smp = max(half // ss2, 1)
+        tgt = max((aim * (smp * 8)) // n, 1)
+        tgt2 = max((k * (smp * 8)) // n, 1)
+    q_ = (n4s + R - 1) // R
+    if fam == "clus" and n > scap and n4s >= 4:
+        sel = sfac * n // aim
+        sel = 256 if sel < 256 else sel
+        sel = n // 2 if sel > n // 2 else sel
+        quads = max(sel >> 4, 1)
+        quarter = max(n4s >> 2, 1)
+        quads = quarter if quads > quarter else quads
+        ss2 = max(quarter // quads, 1)
+        smp = max(quarter // ss2, 1)
+        tgt = max((aim * (smp * 16)) // n, 1)
+        tgt2 = max((k * (smp * 16)) // n, 1)
+    return (
+        {"n": n, "SMP": smp, "TGT": tgt, "Q": q_, "SS2": ss2, "TGT2": tgt2},
+        static["smem"],
+    )
+
+
+def route_split(b: int, n: int, npad: int, k: int) -> dict[str, object]:
+    """route_static + route_dynamic recombined — must equal route() exactly
+    (the factorization fuzz in the unit tests asserts this)."""
+    st = route_static(b, n, npad, k)
+    dyn, smem = route_dynamic(st, n)
+    plan = {key: (dict(val) if isinstance(val, dict) else val) for key, val in st.items()}
+    plan["rt"].update(dyn)
+    plan["smem"] = smem
+    return plan
+
+
+def route_streaming(
+    b: int, n: int, npad: int, k: int, force_main: bool = False
+) -> dict[str, object]:
+    """route() restricted to its STREAMING half (main / clus) — the varlen
+    capture policy: per-row kernels must be picked from the families that are
+    correct for ANY row length, so the register-resident specialists are
+    skipped even when the envelope n would normally land on them.  Where
+    route() itself lands on main/clus this is IDENTICAL to route().
+    force_main additionally skips the clus rounding, so the raw
+    min(r1, r2) R matches the CUDA else-branch exactly."""
+    if b < 1:
+        raise RuntimeError(f"route_streaming requires b >= 1, got {b}")
+    R = 1
+    if b <= 32:
+        r1 = max(148 // b, 1)
+        r2 = max(((n >> 2) + 1023) // 1024, 1)
+        R = max(min(r1, r2), 1)
+    elif b <= 74 and (n >> 2) >= 16384 and k <= 1024:
+        R = 2
+    useclus = False
+    if not force_main and 2 <= R <= 8 and k <= 1024:
+        p2 = 1
+        while (p2 << 1) <= R:
+            p2 <<= 1
+        if p2 == 8 and b > 15:
+            p2 = 4
+        R = p2
+        useclus = True
+    big = b * R <= 148
+    scap = (16384 if R == 1 else 8192) if big else (8192 if k > 1024 else 4096)
+    cmp_ = (4096 if k > 1024 else 2048) if big else 1024
+    aim = (
+        ((4 * k if k >= 1024 else 2 * k) if R == 1 else 2 * k)
+        if big
+        else ((11 * k) // 8 if k >= 1024 else (3 * k) // 2)
+    )
+    r_ = int(0.5 + math.sqrt(float(6 * n)))
+    if r_ > aim:
+        aim = r_
+    sfac = (32 if R == 2 else (48 if k > 1024 else 16)) if R > 1 else (64 if k >= 1024 else 32)
+    amin = 3 * k if R == 2 else (7 * k) // 2
+    if R > 1 and aim < amin:
+        aim = amin
+    if aim > (scap >> 1):
+        aim = scap >> 1
+    if aim < k:
+        aim = k
+    n4s = n >> 2
+    smp, ss2, tgt, tgt2 = 0, 1, 0, 0
+    small_dense = (k > 1024) and (not big) and n <= scap and n > 2 * k
+    if (n > scap or small_dense) and n4s >= 4:
+        sel = min(max(sfac * n // aim, 256), n // 2)
+        pairs = min(max(sel >> 3, 1), max(n4s >> 1, 1))
+        half = max(n4s >> 1, 1)
+        ss2 = max(half // pairs, 1)
+        smp = max(half // ss2, 1)
+        tgt = max((aim * (smp * 8)) // n, 1)
+        tgt2 = max((k * (smp * 8)) // n, 1)
+    q_ = (n4s + R - 1) // R
+    if useclus:
+        if n > scap and n4s >= 4:
+            sel = min(max(sfac * n // aim, 256), n // 2)
+            quads = min(max(sel >> 4, 1), max(n4s >> 2, 1))
+            quarter = max(n4s >> 2, 1)
+            ss2 = max(quarter // quads, 1)
+            smp = max(quarter // ss2, 1)
+            tgt = max((aim * (smp * 16)) // n, 1)
+            tgt2 = max((k * (smp * 16)) // n, 1)
+        smc = SNB * 8 + (scap + 4) * 8 + cmp_ * 8
+        per = q_ >> 10
+        u_ = 8 if per >= 8 else (4 if per >= 4 else (2 if per >= 2 else 1))
+        cs = 2 if R == 2 else (4 if R == 4 else 8)
+        return {
+            "kernel": "clus",
+            "tpl": (1024, u_, 1, SNB, cs),
+            "rt": {
+                "n": n,
+                "npad": npad,
+                "k": k,
+                "SCAP": scap,
+                "CMP": cmp_,
+                "SMP": smp,
+                "TGT": tgt,
+                "Q": q_,
+                "SS2": ss2,
+                "TGT2": tgt2,
+            },
+            "grid": (cs, b),
+            "cluster": cs,
+            "block": 1024,
+            "smem": smc,
+            "ws": False,
+        }
+    smem_main = (scap + 4) * (8 if (R > 1 or b <= 296) else 4) + (cmp_ + 1) * 8
+
+    def _main(blk_, minb_, u_, split_):
+        kpt = 1 if k <= blk_ else (2 if k <= 2 * blk_ else (4 if k <= 4 * blk_ else 8))
+        tshg = bool(split_) and b > 15 and k <= 1024 and (n >> 2) <= 32768
+        return {
+            "kernel": "main",
+            "tpl": (blk_, u_, minb_, SNB, kpt, split_, tshg),
+            "rt": {
+                "n": n,
+                "npad": npad,
+                "k": k,
+                "SCAP_": scap,
+                "CMP_": cmp_,
+                "R": R,
+                "SMP": smp,
+                "TGT": tgt,
+                "Q": q_,
+                "SS2": ss2,
+                "TGT2": tgt2,
+            },
+            "grid": (R, b),
+            "cluster": 1,
+            "block": blk_,
+            "smem": smem_main,
+            "ws": True,
+        }
+
+    if big:
+        per = q_ >> 10
+        u_ = 8 if per >= 8 else (4 if per >= 4 else (2 if per >= 2 else 1))
+        return _main(1024, 1, u_, R > 1)
+    if b <= 296:
+        return _main(512, 2, 8, False)
+    return _main(256, 4, 8, False)
+
+
+_VARLEN_CACHE = {}
+
+
+def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
+    """Capture-time varlen plan + compiled launcher.  The gvr_main port is
+    the universally correct fallback; specialist family tiers below.  Every
+    choice here is a function of capture-stable quantities only — mirroring
+    the in-tree runner's pick_tuning(graph_capture=...) discipline."""
+    key = (num_rows, npad, k, n_env, next_n, cr)
+    hit = _VARLEN_CACHE.get(key)
+    if hit is not None:
+        return hit
+    n_eff = max(min(n_env, npad), k + 1)
+    cr_shift = 0 if cr == 1 else 2
+    dev = _device()
+    # ---- route() parity, family tier 1: clustered register-resident --------
+    # Admit reg_clus exactly where the free route picks it; its whole
+    # admission window (n4 <= 32768) fits capture-frozen envelopes. The
+    # choice is a pure function of this cache key, so CUDA-graph replay
+    # safety is unchanged; per-row n / short-row handling lives in-kernel.
+    plan_free = route(num_rows, n_eff, npad, k)
+    if plan_free["kernel"] == "reg_clus":
+        fn = dev.get_compiled__regclus(
+            tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
+        )
+        lc = ("reg_clus", fn, n_eff)
+        _VARLEN_CACHE[key] = lc
+        return lc
+    # ---- route() parity, family tier 2: register-resident (+img flavor) ----
+    # Same admission rule as tier 1: exactly where the free route picks
+    # reg/regimg (the whole small/mid-N band across all row counts). CMP/QC/
+    # smem are envelope-derived launch constants -- in-kernel they are pure
+    # capacity clamps (CMP), a fast-path threshold (QC) and the launch smem
+    # size, all safe upper bounds for every per-row n <= envelope; per-row n
+    # / short-row handling lives in-kernel.
+    if plan_free["kernel"] in ("reg", "regimg"):
+        fn = dev.get_compiled__reg(
+            tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
+        )
+        rt_f = plan_free["rt"]
+        lc = (
+            "reg",
+            fn,
+            (rt_f["n"], rt_f["CMP"], rt_f["QC"], dev.STATIC_BYTES + plan_free["smem"]),
+        )
+        _VARLEN_CACHE[key] = lc
+        return lc
+    # ---- route() parity, family tier 3: cluster split (clus) ---------------
+    # Same admission rule: exactly where the free route picks clus (the
+    # large-N mid-rows band). SCAP/CMP are launch-stable (pure functions of
+    # rows/CS/k — never of n) so the envelope values are the per-row values;
+    # the sampling-ladder scalars (SMP/TGT/Q/SS2/TGT2) are dead launch slots,
+    # re-derived per row in-kernel by the route_dynamic clus mirror.
+    # Per-row n / short-row handling in-kernel.
+    if plan_free["kernel"] == "clus":
+        rt_f = plan_free["rt"]
+        fn = dev.get_compiled__clus(
+            tuple(plan_free["tpl"]),
+            scap=rt_f["SCAP"],
+            cmp_=rt_f["CMP"],
+            varlen=True,
+            next_n=next_n,
+            cr_shift=cr_shift,
+        )
+        lc = (
+            "clus",
+            fn,
+            (n_eff, npad, k, rt_f["SCAP"], rt_f["CMP"], 0, 0, 0, 0, 0),
+        )
+        _VARLEN_CACHE[key] = lc
+        return lc
+    plan = route_streaming(num_rows, n_eff, npad, k, force_main=True)
+    tpl = tuple(plan["tpl"])  # (BLK, U, MINB, SNB, KPT, SPLIT, TSHG)
+    rt = plan["rt"]
+    r_const = rt["R"]
+    # TSHG (tpl[6]) is dead under varlen (the ctor compiles the TSH
+    # machinery in whenever SPLIT); normalize it out of the compile key so
+    # row counts differing only in that slot share one engine
+    fn = dev.get_compiled(tpl[:6] + (False,) + (next_n, cr_shift, r_const))
+    big = num_rows * r_const <= 148
+    aim_base = (
+        ((4 * k if k >= 1024 else 2 * k) if r_const == 1 else 2 * k)
+        if big
+        else ((11 * k) // 8 if k >= 1024 else (3 * k) // 2)
+    )
+    sfac = (
+        (32 if r_const == 2 else (48 if k > 1024 else 16))
+        if r_const > 1
+        else (64 if k >= 1024 else 32)
+    )
+    amin = 3 * k if r_const == 2 else (7 * k) // 2
+    sd_en = 1 if (k > 1024 and not big) else 0
+    # TSH-floor staging: gate on SPLIT and K only. Gating additionally on
+    # num_rows > 15 would strand small batches in SPLIT-main without the
+    # staged floor (a distribution-dependent tail regression); the kernel
+    # gates TSH per row at runtime anyway.
+    tsh_en = 1 if (tpl[5] and k <= 1024) else 0
+    pre = (0, npad, k, rt["SCAP_"], rt["CMP_"], r_const, 0, 0, 0, 0, 0)
+    tail = (aim_base, sfac, amin, sd_en, tsh_en)
+    lc = ("main", fn, pre, tail)
+    _VARLEN_CACHE[key] = lc
+    return lc
+
+
+def route_bands(
+    b: int, npad: int, k: int, n_lo: int | None = None, n_hi: int | None = None
+) -> list[tuple[int, int, dict[str, object]]]:
+    """Enumerate maximal n-intervals on which route_static is constant.
+    Dense O(n_hi - n_lo) scan of the pure host dispatch — an offline /
+    engine-init tool (seconds for the 262144-token envelope), NOT a hot
+    path. Returns [(n_lo, n_hi, static_plan), ...]."""
+    lo = k + 1 if n_lo is None else max(n_lo, k + 1)
+    hi = npad if n_hi is None else min(n_hi, npad)
+    bands = []
+    cur_key, cur_lo, cur_plan = None, lo, None
+    for n in range(lo, hi + 1):
+        st = route_static(b, n, npad, k)
+        key = repr(st)
+        if key != cur_key:
+            if cur_key is not None:
+                bands.append((cur_lo, n - 1, cur_plan))
+            cur_key, cur_lo, cur_plan = key, n, st
+    if cur_key is not None:
+        bands.append((cur_lo, hi, cur_plan))
+    return bands
+
+
+# ===========================================================================
+# ==== workspace ============================================================
+# ===========================================================================
+"""Per-device workspace slab for the multi-CTA SPLIT path.
+
+Semantics:
+  * ONE zero-initialised slab workspace per device, lazily allocated through
+    the torch caching allocator;
+  * keep-alive store: module dict `_ws_keep` (tensor refcount = keep-alive);
+  * double-checked locking: lock-free hot-path load (a GIL-atomic dict get
+    plays an acquire load), slow path re-checks under a mutex;
+  * device index bounds `0 <= d < GVR_MAX_DEV` -- checked BEFORE the
+    CUDA-ness of the tensor (run() resolves the default workspace before the
+    input checks, so a CPU logits tensor dies here with "device index out of
+    range: -1").
+
+Concurrent STREAMS on one device that may both take the multi-CTA SPLIT path
+must pass their own workspace via run_ws().
+
+Size: workspace_bytes() = GVR_WS_BUF_OFF + MAXC*GCAP*sizeof(int2)
+    = 2048 + 160*16384*8 = 20,973,568 B.
+
+Kernel-facing view: the compiled main-family signature takes the workspace
+as a 1-D contiguous int32 tensor (fake tensor dtype Int32, assumed_align=16
+-- torch caching-allocator bases are 256B-aligned so the default slab always
+satisfies it).  `kernel_view()` reproduces raw `workspace.data_ptr()`
+semantics for arbitrary user tensors by aliasing the underlying storage at
+the tensor's byte offset.
+"""
+
+
+# workspace geometry constants -- must match the device kernels
+GVR_MAX_DEV = 64
+_MAXC = 160
+_GCAP = 16384
+_GVR_WS_BUF_OFF = 2048
+WS_BYTES = _GVR_WS_BUF_OFF + _MAXC * _GCAP * 8  # 20,973,568
+assert WS_BYTES == 20_973_568
+
+_mu = threading.Lock()  # slow-path mutex
+_ws_keep = {}  # device index -> keep-alive int32 view
+
+
+def workspace_bytes() -> int:
+    """Workspace bytes required by the multi-CTA SPLIT path."""
+    return WS_BYTES
+
+
+def default_workspace(ref: torch.Tensor) -> torch.Tensor:
+    """Per-device cached workspace slab.
+
+    Returns the kernel-facing 1-D int32 view (zero-initialised on first use;
+    the kernel restores the zeros it consumes, so one zeroing suffices for
+    the lifetime of the cache entry)."""
+    d = ref.get_device()
+    if not (0 <= d < GVR_MAX_DEV):
+        raise RuntimeError(f"device index out of range: {d}")
+    ws = _ws_keep.get(d)  # hot path: one (GIL-atomic) load
+    if ws is not None:
+        return ws
+    with _mu:  # slow path: double-checked
+        ws = _ws_keep.get(d)
+        if ws is not None:
+            return ws
+        # lazy zeros via the torch caching allocator, viewed int32 for the
+        # DSL launch signature.
+        buf = torch.zeros(WS_BYTES, dtype=torch.uint8, device=ref.device)
+        ws = buf.view(torch.int32)
+        _ws_keep[d] = ws  # keep-alive (ws_keep[d] = tensor)
+        return ws
+
+
+def validate_run_ws(workspace: torch.Tensor, logits: torch.Tensor) -> None:
+    """run_ws() workspace hardening, in a fixed predicate order:
+    CUDA + same device as logits; numel*element_size >= workspace_bytes();
+    base 8-byte aligned."""
+    if not (workspace.is_cuda and workspace.get_device() == logits.get_device()):
+        raise RuntimeError("workspace must be a CUDA tensor on the same device")
+    if workspace.numel() * workspace.element_size() < WS_BYTES:
+        raise RuntimeError(f"workspace too small: need {WS_BYTES} bytes")
+    if workspace.data_ptr() & 7:
+        raise RuntimeError("workspace must be 8-byte aligned")
+
+
+def kernel_view(workspace: torch.Tensor) -> torch.Tensor:
+    """Raw-pointer view of a user workspace tensor: alias the first WS_BYTES
+    bytes at the tensor's data_ptr() as int32[WS_BYTES/4], ignoring
+    dtype/shape.
+
+    NOTE: the DSL-side fake tensor declares assumed_align=16; a workspace at
+    8-but-not-16-byte alignment passes the validate_run_ws check but is
+    rejected by the DSL at conversion -- surfaced as a launch failure with
+    shape context."""
+    if (
+        workspace.dtype is torch.int32
+        and workspace.dim() == 1
+        and workspace.is_contiguous()
+        and workspace.storage_offset() == 0
+        and workspace.numel() == WS_BYTES // 4
+    ):
+        return workspace  # already the canonical view
+    off_bytes = workspace.storage_offset() * workspace.element_size()
+    if off_bytes & 3:
+        # unreachable past the 8B-alignment check for allocator-backed
+        # storages; kept as a hard error rather than silent misalias.
+        raise RuntimeError("workspace storage offset must be 4-byte aligned")
+    t = torch.empty(0, dtype=torch.int32, device=workspace.device)
+    t.set_(workspace.untyped_storage(), off_bytes // 4, (WS_BYTES // 4,))
+    return t
+
+
+def _reset_for_tests() -> None:
+    """Drop cached slabs (tests only; NOT part of the C contract)."""
+    with _mu:
+        _ws_keep.clear()
+
+
+# ===========================================================================
+# ==== operator entry =======================================================
+# ===========================================================================
+"""Operator entry: input hardening, dispatch, and bind-once launch cache.
+
+Hardening checks run in a fixed order with fixed predicates:
+  1. all three tensors CUDA
+  2. dtypes: logits f32, pre_idx i32, indices i32
+  3. all 2-D
+  4. all contiguous
+  5. n_valid unwrap: python-int fast path (strict integral cast); Tensor
+     path checks torch.cuda.is_current_stream_capturing() FIRST and fails
+     loudly, else .item() (the D2H sync)
+  6. b/npad from logits, k = pre_idx.size(1)
+  7. b == 0 -> early no-op
+  8. npad % 4 == 0 (float4 row loads)
+  9. logits base 16-byte aligned
+ 10. pre_idx/indices batch dims match
+ 11. indices width >= k
+ 12. n_valid >= 0
+ 13. n = min(nv, npad) clamped in unbounded ints BEFORE any narrowing
+
+Dispatch: route(b, n, npad, k) -> compile cache keyed on (kernel family,
+constexpr tuple) in the device module -> bind-once launch cache keyed on the
+shape key (b, n, npad, k): caches the compiled callable + the prebuilt
+runtime-scalar arg pack as plain Python ints (never pre-wrapped
+cutlass.Int32 -- the FFI per-argument cost is paid every call regardless;
+pre-binding removes only route()/marshal-prep work).
+
+Error contract: launch failures surface as exceptions WITH
+(b, n, npad, k) context.
+
+The device module is imported LAZILY (first shape that routes to it), so a
+missing/broken module only fails when actually reached, with (b, n, npad, k)
+context.  The per-family compiled ABIs are documented at each launcher
+builder in _build_launcher; only the main family takes the workspace.
+"""
+
+
+# shape key (b, n, npad, k) -> (fn, args tuple of python ints, needs_ws)
+_LAUNCH_CACHE = {}
+_DUMMY_KV = {}
+
+
+def _dummy_kv(dev_index, device):
+    """Cached 1-element int32 tensor per device — the dead kv_lens slot of
+    the extended gvr_main ABI in legacy (batch-uniform) mode."""
+    t = _DUMMY_KV.get(dev_index)
+    if t is None:
+        t = torch.zeros(1, dtype=_I32, device=device)
+        _DUMMY_KV[dev_index] = t
+    return t
+
+
+# hot-path local bindings: each torch.<attr> lookup costs ~0.1 us and the
+# validation battery runs on EVERY call
+_F32 = torch.float32
+_I32 = torch.int32
+_TENSOR = torch.Tensor
+_is_capturing = torch.cuda.is_current_stream_capturing
+_index = operator.index
+_ws_hot = _ws_keep  # shared dict object (hot-path load)
+_GVR_MAX_DEV = GVR_MAX_DEV
+
+
+# ---------------------------------------------------------------------------
+# per-family launcher builders (cold path: once per distinct shape key)
+# ---------------------------------------------------------------------------
+def _build_launcher(b, n, npad, k):
+    rd = route(b, n, npad, k)
+    fam = rd["kernel"]
+    tpl = tuple(rd["tpl"])
+    rt = rd["rt"]
+    if fam in ("reg", "regimg"):
+        dev = _device()
+        raw = dev.get_compiled__reg(tpl)
+
+        # compiled ABI: (logits, pre_idx, kv_lens, out, n, CMP, QC,
+        # smem_total) -- kv_lens is the dead varlen slot in batch-uniform
+        # mode (cached dummy tensor)
+        def fn(lg, pi, o, *a, _raw=raw):
+            _raw(lg, pi, _dummy_kv(lg.get_device(), lg.device), o, *a)
+
+        args = (rt["n"], rt["CMP"], rt["QC"], dev.STATIC_BYTES + rd["smem"])
+        return (fn, args, False)
+    if fam == "main":
+        dev = _device()
+        raw = dev.get_compiled(tpl)
+
+        # compiled ABI: (logits, pre_idx, out, ws, n, npad, k, SCAP_, CMP_,
+        #                R, SMP, TGT, Q, SS2, TGT2,
+        #                kv_lens, aim_base, sfac, amin, sd_en, tsh_en)
+        # [SCAP_/CMP_ dead, ABI parity; the trailing varlen block is dead in
+        #  legacy mode — a cached dummy kv_lens tensor + five zeros]
+        def fn(lg, pi, o, w, *a, _raw=raw):
+            _raw(lg, pi, o, w, *a, _dummy_kv(lg.get_device(), lg.device), 0, 0, 0, 0, 0)
+
+        args = (
+            rt["n"],
+            rt["npad"],
+            rt["k"],
+            rt["SCAP_"],
+            rt["CMP_"],
+            rt["R"],
+            rt["SMP"],
+            rt["TGT"],
+            rt["Q"],
+            rt["SS2"],
+            rt["TGT2"],
+        )
+        return (fn, args, True)
+    if fam == "clus":
+        dev = _device()
+        # compile key carries the smem-extent scalars (scap/cmp_); compiled
+        # ABI: (logits, pre_idx, kv_lens, out, n, npad, k, SCAP, CMP, SMP,
+        #       TGT, Q, SS2, TGT2) -- NO workspace; kv_lens is the dead
+        # varlen slot in batch-uniform mode (cached dummy tensor)
+        fn = dev.get_compiled__clus(tpl, scap=rt["SCAP"], cmp_=rt["CMP"])
+        args = (
+            rt["n"],
+            rt["npad"],
+            rt["k"],
+            rt["SCAP"],
+            rt["CMP"],
+            rt["SMP"],
+            rt["TGT"],
+            rt["Q"],
+            rt["SS2"],
+            rt["TGT2"],
+        )
+
+        def _call(lg, pi, idx, _fn=fn, _args=args):
+            _fn(lg, pi, _dummy_kv(lg.get_device(), lg.device), idx, *_args)
+
+        return (_call, (), False)
+    if fam == "reg_clus":
+        dev = _device()
+        # compiled ABI: (logits, pre_idx, kv_lens, out, n) -- kv_lens is the
+        # dead varlen slot in batch-uniform mode (cached dummy tensor);
+        # smem/k derived in-module
+        fn = dev.get_compiled__regclus(tpl)
+        n_arg = rt["n"]
+
+        def _call(lg, pi, idx, _fn=fn, _n=n_arg):
+            _fn(lg, pi, _dummy_kv(lg.get_device(), lg.device), idx, _n)
+
+        return (_call, (), False)
+    # unreachable: route() only emits the five families above
+    raise RuntimeError(f"unknown dispatch family {fam!r}")
+
+
+# ---------------------------------------------------------------------------
+# shared implementation of the batch-uniform entries
+# ---------------------------------------------------------------------------
+def _run_impl(logits, pre_idx, n_valid, indices, ws, values=None):
+    if not (logits.is_cuda and pre_idx.is_cuda and indices.is_cuda):
+        raise RuntimeError("all tensors must be CUDA")
+    if logits.dtype is not _F32:
+        raise RuntimeError("logits must be float32")
+    if pre_idx.dtype is not _I32:
+        raise RuntimeError("pre_idx must be int32")
+    if indices.dtype is not _I32:
+        raise RuntimeError("indices must be int32")
+    lsh, psh, ish = logits.shape, pre_idx.shape, indices.shape
+    if not (len(lsh) == 2 and len(psh) == 2 and len(ish) == 2):
+        raise RuntimeError("logits/pre_idx/indices must be 2-D")
+    if not (logits.is_contiguous() and pre_idx.is_contiguous() and indices.is_contiguous()):
+        raise RuntimeError("tensors must be contiguous")
+
+    # n_valid unwrap: tensor path = D2H sync, illegal under CUDA graph
+    # capture -- fail loudly instead of crashing the capture.
+    if isinstance(n_valid, _TENSOR):
+        if _is_capturing():
+            raise RuntimeError(
+                "tensor n_valid requires a D2H sync, illegal under CUDA "
+                "graph capture — pass n_valid as a python int"
+            )
+        nv = int(n_valid.item())
+    else:
+        # strict integral cast (rejects floats/strings)
+        nv = _index(n_valid)
+
+    b, npad = lsh
+    k = psh[1]
+    if b == 0:  # empty batch: no-op
+        return
+    if npad & 3:
+        raise RuntimeError(f"npad (logits stride) must be a multiple of 4, got {npad}")
+    if logits.data_ptr() & 15:
+        raise RuntimeError(
+            "logits base must be 16-byte aligned (storage-offset views break the float4 row loads)"
+        )
+    if psh[0] != b or ish[0] != b:
+        raise RuntimeError(f"batch dims must match: logits {b} pre_idx {psh[0]} indices {ish[0]}")
+    if ish[1] < k:
+        raise RuntimeError(f"indices width {ish[1]} < k={k} (k is pre_idx.size(1))")
+    if nv < 0:
+        raise RuntimeError(f"n_valid must be non-negative, got {nv}")
+    # clamp BEFORE any narrowing (python ints are unbounded, so min() is the
+    # exact 64-bit clamp)
+    n = nv if nv < npad else npad
+
+    # CUDA out-indexing mirror: every kernel derives O = out + row*k --
+    # flat PACKED rows, ignoring the actual indices width.  The DSL kernels
+    # index out[row, :] with the tensor's own row stride, so a wider
+    # `indices` must be re-viewed packed (pure view, no copy; contiguity
+    # already checked).
+    if ish[1] != k:
+        indices = indices.reshape(-1)[: b * k].view(b, k)
+
+    # ---- optional values output (production parity, default OFF) ------------
+    # dsa.py allocates the values scratch only for the non-CuTeDSL path, so
+    # values stay opt-in. The indices are exact, so a gather epilogue
+    # reproduces the in-kernel writeback bit-for-bit; the constexpr in-kernel
+    # form rides the CUDA-graph per-row rewrite.
+    if values is not None:
+        if not values.is_cuda:
+            raise RuntimeError("values must be CUDA")
+        if values.dtype is not _F32:
+            raise RuntimeError("values must be float32")
+        vsh = values.shape
+        if len(vsh) != 2 or not values.is_contiguous():
+            raise RuntimeError("values must be 2-D contiguous")
+        if vsh[0] != b:
+            raise RuntimeError(f"batch dims must match: logits {b} values {vsh[0]}")
+        if vsh[1] < k:
+            raise RuntimeError(f"values width {vsh[1]} < k={k}")
+        if vsh[1] != k:
+            values = values.reshape(-1)[: b * k].view(b, k)
+
+    # ---- n <= k short path (heuristicTopKDecode.cu parity) ------------------
+    # Every valid position is in the top-K: emit identity indices and pad the
+    # tail with -1 (the production pad convention; downstream treats -1 as
+    # invalid). Order is contract-irrelevant — exactness is tie-interchangeable
+    # SET semantics. Torch-op path for now; the CUDA-graph-safe per-row rewrite
+    # moves this branch in-kernel (it cannot fall back per row inside a graph).
+    if n <= k:
+        if n > 0:
+            indices[:, :n] = torch.arange(n, dtype=_I32, device=indices.device)
+            if values is not None:
+                values[:, :n] = logits[:, :n]
+        if n < k:
+            indices[:, n:] = -1
+            if values is not None:
+                values[:, n:] = torch.finfo(_F32).min  # -FLT_MAX pad
+        return
+
+    key = (b, n, npad, k)
+    lc = _LAUNCH_CACHE.get(key)
+    if lc is None:
+        lc = _build_launcher(b, n, npad, k)
+        _LAUNCH_CACHE[key] = lc
+    fn, args, needs_ws = lc
+    try:
+        if needs_ws:
+            fn(logits, pre_idx, indices, ws, *args)
+        else:
+            fn(logits, pre_idx, indices, *args)
+    except Exception as e:
+        raise RuntimeError(f"gvr_topk launch failed (b={b} n={n} npad={npad} k={k}): {e}") from e
+    if values is not None:
+        # same epilogue as run_varlen: a (never-expected) negative index
+        # degrades to -FLT_MAX instead of a context-poisoning device assert
+        idx64 = indices.to(torch.int64)
+        values.copy_(logits.gather(1, idx64.clamp_min(0)))
+        values.masked_fill_(indices < 0, torch.finfo(_F32).min)
+
+
+# ---------------------------------------------------------------------------
+# exports
+# ---------------------------------------------------------------------------
+def run(
+    logits: torch.Tensor,
+    pre_idx: torch.Tensor,
+    n_valid: int,
+    indices: torch.Tensor,
+    values: torch.Tensor | None = None,
+) -> None:
+    """TESTING/BENCH ONLY — production callers must use ``run_varlen`` (per-request
+    device kv_lens; this entry assumes one batch-uniform host ``n_valid``,
+    which real serving batches do not satisfy).
+
+    Fast 4-arg form.  ``values`` (optional DPS output, default None = OFF)
+    mirrors the production values writeback; see _run_impl.
+    The default per-device slab workspace is resolved FIRST (a CPU logits
+    tensor therefore dies with 'device index out of range').
+    Hot path inlines the device check + atomic load + cache hit; the slow
+    path allocates under the workspace lock."""
+    d = logits.get_device()
+    if not 0 <= d < _GVR_MAX_DEV:  # checked on EVERY call
+        raise RuntimeError(f"device index out of range: {d}")
+    ws = _ws_hot.get(d)
+    if ws is None:
+        ws = default_workspace(logits)
+    _run_impl(logits, pre_idx, n_valid, indices, ws, values)
+
+
+def run_ws(
+    logits: torch.Tensor,
+    pre_idx: torch.Tensor,
+    n_valid: int,
+    indices: torch.Tensor,
+    workspace: torch.Tensor,
+    values: torch.Tensor | None = None,
+) -> None:
+    """TESTING/BENCH ONLY — production callers must use ``run_varlen(workspace=...)``.
+
+    Explicit-workspace form for multi-stream callers."""
+    validate_run_ws(workspace, logits)
+    _run_impl(logits, pre_idx, n_valid, indices, kernel_view(workspace), values)
+
+
+def run_varlen(
+    logits: torch.Tensor,
+    pre_idx: torch.Tensor,
+    kv_lens: torch.Tensor,
+    indices: torch.Tensor,
+    next_n: int = 1,
+    compress_ratio: int = 1,
+    values: torch.Tensor | None = None,
+    max_seq_len: int | None = None,
+    engine: str = "auto",
+    workspace: torch.Tensor | None = None,
+) -> None:
+    """Production-contract varlen entry (per-row device kv_lens).
+
+    Row semantics (mirror of ``heuristicTopKDecode.cu`` and the in-tree
+    ``cute_dsl_gvr_topk_decode`` runner):
+
+      ``num_rows = logits.shape[0]``, ``batch = num_rows // next_n``;
+      ``kv_lens`` int32 ``[batch]`` — per-request TOTAL cache length in
+      UNCOMPRESSED token space (dsa.py ``metadata.kv_lens_cuda_runtime``,
+      not new-token seq_lens); row ``r`` uses
+      ``n_r = (kv_lens[r // next_n] - next_n + (r % next_n) + 1) //
+      compress_ratio`` valid entries (cr 1 = DSv3.2, 4 = DSv4 Flash/Pro);
+      ``pre_idx`` ``[batch, k]`` is REQUEST-level raw prev-step top-K,
+      shared by a request's ``next_n`` rows (offset-free hint contract);
+      per-row ``n_r <= k`` takes the short path (identity + ``-1`` tail).
+
+    ENGINES: ``engine="auto"`` (default) launches the per-row IN-KERNEL
+    gvr_main varlen port — ONE launch for the whole batch; each CTA reads its
+    row's kv_len on device and re-derives the sampling ladder (route_dynamic
+    formula mirror), so with ``max_seq_len`` given (a capture-stable engine
+    constant, e.g. dsa.py's ``indexer_max_seq_len``) the call performs NO
+    host reads.  Without ``max_seq_len`` the envelope comes from ONE
+    ``kv_lens.max()`` host read (documented sync, refused under capture).
+    ``engine="reference"`` keeps the b=1 host-loop reference implementation —
+    the differential oracle the in-kernel engine is validated against.
+
+    KNOWN LIMITATION: on rows containing NaN logits the selected index SET
+    can differ from ``heuristicTopKDecode.cu`` (both kernels order NaNs
+    implementation-specifically). Finite inputs — including +/-inf and
+    denormals — are tie-aware exact.
+
+    CONTRACT: correct and dispatched for any ``num_rows``
+    (BS 1..1024+ x next_n) and any envelope up to 1M kv tokens.  Family
+    selection (streaming main / clustered register-resident) is a pure
+    function of the capture-stable launcher key.
+    """
+    if logits.dtype is not torch.float32:
+        raise RuntimeError(
+            f"logits must be float32 (got {logits.dtype}); bf16/fp16 paths "
+            "are a follow-up — see the PR roadmap"
+        )
+    if not (isinstance(kv_lens, _TENSOR) and kv_lens.is_cuda):
+        raise RuntimeError("kv_lens must be a CUDA tensor")
+    if kv_lens.dtype is not _I32:
+        raise RuntimeError("kv_lens must be int32")
+    if kv_lens.dim() != 1:
+        raise RuntimeError("kv_lens must be 1-D")
+    nn = _index(next_n)
+    cr = _index(compress_ratio)
+    if nn < 1:
+        raise RuntimeError(f"next_n must be >= 1, got {nn}")
+    if cr not in (1, 4):
+        raise RuntimeError(f"compress_ratio must be 1 (DSv3.2) or 4 (DSv4), got {cr}")
+    if len(logits.shape) != 2:
+        raise RuntimeError("logits must be 2-D")
+    num_rows = logits.shape[0]
+    if num_rows == 0:
+        return
+    if num_rows % nn:
+        raise RuntimeError(f"num_rows {num_rows} not divisible by next_n {nn}")
+    batch = num_rows // nn
+    if kv_lens.shape[0] != batch:
+        raise RuntimeError(f"kv_lens length {kv_lens.shape[0]} != num_rows/next_n = {batch}")
+    if len(pre_idx.shape) != 2 or pre_idx.shape[0] != batch:
+        raise RuntimeError(
+            f"pre_idx must be [batch={batch}, k] REQUEST-level, got {tuple(pre_idx.shape)}"
+        )
+    d = logits.get_device()
+    if not 0 <= d < _GVR_MAX_DEV:
+        raise RuntimeError(f"device index out of range: {d}")
+    if workspace is not None:
+        # multi-stream escape hatch (run_ws parity): concurrent varlen
+        # launches on one device must not share the SPLIT publish slab
+        validate_run_ws(workspace, logits)
+        ws = kernel_view(workspace)
+    else:
+        ws = _ws_hot.get(d)
+        if ws is None:
+            ws = default_workspace(logits)
+
+    if engine == "auto":
+        # ---- per-row in-kernel engine (gvr_main varlen port) ----------------
+        # Full validation battery (the engine bypasses _run_impl — every
+        # check the batch-uniform path enforces is replayed here; the
+        # batch-dim check is CRITICAL: the kernel grid comes from
+        # logits.shape[0], so a short indices/values tensor would be written
+        # out of bounds).
+        if not (logits.is_cuda and pre_idx.is_cuda and indices.is_cuda):
+            raise RuntimeError("all tensors must be CUDA")
+        if logits.dtype is not _F32 or pre_idx.dtype is not _I32 or indices.dtype is not _I32:
+            raise RuntimeError("logits must be float32; pre_idx/indices int32")
+        if len(indices.shape) != 2 or indices.shape[0] != num_rows:
+            raise RuntimeError(
+                f"indices must be [num_rows={num_rows}, >=k], got {tuple(indices.shape)}"
+            )
+        k = pre_idx.shape[1]
+        if indices.shape[1] < k:
+            raise RuntimeError(f"indices width {indices.shape[1]} < k={k}")
+        if not (pre_idx.is_contiguous() and indices.is_contiguous() and kv_lens.is_contiguous()):
+            raise RuntimeError("pre_idx/indices/kv_lens must be contiguous")
+        # logits: accept row-major views with a wider row stride (the DSL
+        # paged-MQA logits arena is 256-aligned and column-sliced — a legal
+        # NON-contiguous view). The kernel only needs (base, row stride):
+        # widen back to a compact [rows, stride] view over the same storage;
+        # the tail columns are never classified (per-row n gates all reads).
+        if logits.stride(1) != 1:
+            raise RuntimeError("logits inner stride must be 1")
+        npad = logits.stride(0) if num_rows > 1 else logits.shape[1]
+        lg = logits
+        if not logits.is_contiguous():
+            need = logits.storage_offset() + num_rows * npad
+            if logits.untyped_storage().size() // 4 < need:
+                raise RuntimeError("logits view storage too small to widen to its row stride")
+            lg = logits.as_strided((num_rows, npad), (npad, 1), logits.storage_offset())
+        if npad & 3:
+            raise RuntimeError(f"npad (logits row stride) must be a multiple of 4, got {npad}")
+        if lg.data_ptr() & 15:
+            raise RuntimeError("logits base must be 16-byte aligned")
+        if values is not None:
+            if not values.is_cuda or values.dtype is not _F32:
+                raise RuntimeError("values must be CUDA float32")
+            if (
+                len(values.shape) != 2
+                or values.shape[0] != num_rows
+                or values.shape[1] < k
+                or not values.is_contiguous()
+            ):
+                raise RuntimeError(
+                    f"values must be contiguous [num_rows={num_rows}, >=k], "
+                    f"got {tuple(values.shape)}"
+                )
+        cshift = 0 if cr == 1 else 2
+        if max_seq_len is not None:
+            n_env = int(max_seq_len) >> cshift
+        else:
+            if _is_capturing():
+                raise RuntimeError(
+                    "run_varlen without max_seq_len reads kv_lens.max() on "
+                    "host — pass max_seq_len (a capture-stable engine "
+                    "constant) under CUDA graph capture"
+                )
+            n_env = int(kv_lens.max().item()) >> cshift
+            # eager mode: quantize the data-dependent envelope up to the next
+            # power of two so a growing decode does not recompile at every
+            # R increment (bounded plans, bounded _VARLEN_CACHE)
+            n_env = 1 << max(n_env - 1, 1).bit_length()
+        n_env = min(max(n_env, 1), npad)
+        key = (num_rows, npad, k, n_env, nn, cr)
+        lc = _VARLEN_CACHE.get(key)
+        if lc is None:
+            if _is_capturing():
+                raise RuntimeError(
+                    "varlen launcher not compiled for this shape — warm up "
+                    "before CUDA graph capture"
+                )
+            lc = _varlen_launcher(num_rows, npad, k, n_env, nn, cr)
+        idx = indices
+        if idx.shape[1] != k:
+            idx = idx.reshape(-1)[: num_rows * k].view(num_rows, k)
+        vals = values
+        if vals is not None and vals.shape[1] != k:
+            vals = vals.reshape(-1)[: num_rows * k].view(num_rows, k)
+        if lc[0] == "reg_clus":
+            # compiled ABI: (logits, pre_idx, kv_lens, out, n_envelope)
+            lc[1](lg, pre_idx, kv_lens, idx, lc[2])
+        elif lc[0] == "reg":
+            # compiled ABI: (logits, pre_idx, kv_lens, out, n_env, CMP, QC, smem)
+            lc[1](lg, pre_idx, kv_lens, idx, *lc[2])
+        elif lc[0] == "clus":
+            # compiled ABI: (logits, pre_idx, kv_lens, out, n_env, npad, k,
+            #                SCAP, CMP, dead DYN x5)
+            lc[1](lg, pre_idx, kv_lens, idx, *lc[2])
+        else:
+            _, fn, pre, tail = lc
+            fn(lg, pre_idx, idx, ws, *pre, kv_lens, *tail)
+        if vals is not None:
+            idx64 = idx.to(torch.int64)
+            vals.copy_(lg.gather(1, idx64.clamp_min(0)))
+            vals.masked_fill_(idx < 0, torch.finfo(_F32).min)
+        return
+    if engine != "reference":
+        raise RuntimeError(f"engine must be 'auto' or 'reference', got {engine!r}")
+
+    # ---- reference engine (differential oracle): b=1 host loop --------------
+    if _is_capturing():
+        raise RuntimeError(
+            "run_varlen reference engine reads kv_lens on host, illegal under CUDA graph capture"
+        )
+    # match the engine's flat-packed output convention for wider-than-k
+    # buffers (pack ONCE from the tensor base, then slice per row)
+    k = pre_idx.shape[1]
+    idx = indices
+    if len(idx.shape) != 2 or idx.shape[0] != num_rows:
+        raise RuntimeError(
+            f"indices must be [num_rows={num_rows}, >=k], got {tuple(indices.shape)}"
+        )
+    if idx.shape[1] != k:
+        idx = idx.reshape(-1)[: num_rows * k].view(num_rows, k)
+    vals = values
+    if vals is not None and vals.shape[1] != k:
+        vals = vals.reshape(-1)[: num_rows * k].view(num_rows, k)
+    kl = kv_lens.tolist()  # the ONE documented D2H sync of this engine
+    for r in range(num_rows):
+        # production graph slots can carry kv_len < next_n (padded / evicted
+        # requests): clamp to the empty row, emitting all -1 — the same
+        # contract the in-kernel engine implements
+        actual = max(kl[r // nn] - nn + (r % nn) + 1, 0)
+        req = r // nn
+        _run_impl(
+            logits[r : r + 1],
+            pre_idx[req : req + 1],
+            actual // cr,
+            idx[r : r + 1],
+            ws,
+            None if vals is None else vals[r : r + 1],
+        )
+
+
+__all__ = [
+    "route",
+    "route_static",
+    "route_dynamic",
+    "route_split",
+    "route_bands",
+    "run",
+    "run_ws",
+    "run_varlen",
+    "warmup_varlen",
+    "workspace_bytes",
+    "WS_BYTES",
+    "default_workspace",
+    "validate_run_ws",
+    "kernel_view",
+]
+
+
+# --------------------------------------------------------------------------
+# warmup: pre-compile the varlen engine for an engine envelope so no live
+# request pays the first-touch DSL JIT (mirrors warmup_heuristic_topk_decode
+# and warmup_cute_dsl_radix_topk). Idempotent per (device, geometry) key.
+# CUDA-graph capture warmup naturally compiles the captured batch sizes;
+# this covers the eager/first-touch path (num_rows defaults to (1,)).
+_VARLEN_WARMUP_DONE: set = set()
+_VARLEN_WARMUP_LOCK = threading.Lock()
+
+
+def warmup_varlen(
+    top_k: int,
+    max_seq_len: int,
+    compress_ratio: int = 1,
+    next_n: int = 1,
+    num_rows_list: Sequence[int] = (1,),
+    row_stride: int | None = None,
+) -> None:
+    """TESTING/INIT ONLY — compile the varlen engine's envelope tuples.
+
+    One tiny real launch per requested ``num_rows`` (compile keys do not
+    depend on tensor contents). Uses the current CUDA device. The done-key
+    is recorded only after every launch succeeds, so a failed or interrupted
+    warmup is retried on the next call instead of short-circuiting to an
+    uncompiled engine.
+
+    ``row_stride`` must be the logits row stride the serving producer will
+    emit: the launcher key includes it, so a warmup at a different stride
+    compiles a variant dispatch never looks up. Callers that know the
+    producer layout (e.g. the DSL paged-MQA arena's 256-element rounding)
+    must pass it; the 64-element default only matches producers that round
+    the same way.
+    """
+    dev = torch.cuda.current_device()
+    nn = max(1, int(next_n))
+    # round each request down to a next_n multiple (min next_n) and dedup
+    req_rows = sorted({max(int(r) - int(r) % nn, nn) for r in num_rows_list})
+    if not req_rows:
+        return
+    # BAND-AWARE enumeration: the engine compile key depends on the plan's
+    # constexpr tuple (+ r_const family axis), NOT on the exact row count, so
+    # warming ONE representative row per distinct engine key covers every row
+    # count up to the largest request. Representatives are the first row of
+    # each band, which keeps the warmup allocation bounded (~a few hundred
+    # rows) even when CUDA-graph batch lists reach thousands of rows.
+    n_env_c = max(1, int(max_seq_len) // int(compress_ratio))
+    npad_c = (n_env_c + 63) // 64 * 64 if row_stride is None else int(row_stride)
+    seen_keys = set()
+    rows_list = []
+    r = nn
+    r_max = req_rows[-1]
+    while r <= r_max:
+        plan_free = route(r, max(min(n_env_c, npad_c), int(top_k) + 1), npad_c, int(top_k))
+        if plan_free["kernel"] == "reg_clus":
+            ekey = ("reg_clus", tuple(plan_free["tpl"]))
+        elif plan_free["kernel"] in ("reg", "regimg"):
+            ekey = ("reg", tuple(plan_free["tpl"]))
+        else:
+            p = route_streaming(
+                r,
+                max(min(n_env_c, npad_c), int(top_k) + 1),
+                npad_c,
+                int(top_k),
+                force_main=True,
+            )
+            ekey = ("main", tuple(p["tpl"][:6]), p["rt"]["R"])
+        if ekey not in seen_keys:
+            seen_keys.add(ekey)
+            rows_list.append(r)
+        r += nn
+    if not rows_list:
+        return
+    n_env = max(1, int(max_seq_len) // int(compress_ratio))
+    if row_stride is None:
+        npad = (n_env + 63) // 64 * 64
+    else:
+        npad = int(row_stride)
+        if npad < n_env or npad % 4:
+            raise RuntimeError(
+                f"row_stride must be a float4-multiple >= n_env={n_env}, got {row_stride}"
+            )
+    key = (dev, int(top_k), int(max_seq_len), int(compress_ratio), nn, tuple(rows_list), npad)
+    with _VARLEN_WARMUP_LOCK:
+        if key in _VARLEN_WARMUP_DONE:
+            return
+    rows_max = rows_list[-1]
+    # one allocation at the largest geometry; smaller row counts run on
+    # contiguous prefix views (compile keys depend on shapes only)
+    logits = torch.zeros((rows_max, npad), dtype=torch.float32, device=dev)
+    kv_lens = torch.full((rows_max // nn,), int(max_seq_len), dtype=torch.int32, device=dev)
+    pre_idx = torch.zeros((rows_max // nn, int(top_k)), dtype=torch.int32, device=dev)
+    out = torch.empty((rows_max, int(top_k)), dtype=torch.int32, device=dev)
+    for rows in rows_list:
+        batch = rows // nn
+        run_varlen(
+            logits[:rows],
+            pre_idx[:batch],
+            kv_lens[:batch],
+            out[:rows],
+            next_n=nn,
+            compress_ratio=int(compress_ratio),
+            max_seq_len=int(max_seq_len),
+        )
+    del logits, kv_lens, pre_idx, out
+    torch.cuda.synchronize()
+    # band launches compiled every ENGINE; now populate the per-row-count
+    # LAUNCHER cache entries for the exact requested row counts (pure host
+    # work, zero allocation/launch — engines hit the compile cache), so a
+    # CUDA-graph capture at any requested geometry finds its key immediately.
+    n_env_l = min(max(int(max_seq_len) >> (0 if int(compress_ratio) == 1 else 2), 1), npad)
+    for r in req_rows:
+        _varlen_launcher(r, npad, int(top_k), n_env_l, nn, int(compress_ratio))
+    with _VARLEN_WARMUP_LOCK:
+        _VARLEN_WARMUP_DONE.add(key)

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -75,6 +75,23 @@ def _device():
     return _dev_mod
 
 
+def _arch_token() -> str:
+    """Compile-target token for the launcher caches (mirrors the device
+    module's _compile_arch_token without forcing its cutlass import): a
+    heterogeneous multi-GPU process must not reuse a launcher whose compiled
+    engine targets another architecture."""
+    import os
+
+    env = os.environ.get("CUTE_DSL_ARCH")
+    if env:
+        return env
+    try:
+        major, minor = torch.cuda.get_device_capability()
+        return f"sm{major}{minor}"
+    except Exception:  # noqa: BLE001 — no GPU context: single-arch fallback
+        return "unknown"
+
+
 # ===========================================================================
 # ==== dispatch =============================================================
 # ===========================================================================
@@ -692,7 +709,7 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     the universally correct fallback; specialist family tiers below.  Every
     choice here is a function of capture-stable quantities only — mirroring
     the in-tree runner's pick_tuning(graph_capture=...) discipline."""
-    key = (num_rows, npad, k, n_env, next_n, cr)
+    key = (num_rows, npad, k, n_env, next_n, cr, _arch_token())
     hit = _VARLEN_CACHE.get(key)
     if hit is not None:
         return hit
@@ -1175,7 +1192,7 @@ def _run_impl(logits, pre_idx, n_valid, indices, ws, values=None):
                 values[:, n:] = torch.finfo(_F32).min  # -FLT_MAX pad
         return
 
-    key = (b, n, npad, k)
+    key = (b, n, npad, k, _arch_token())
     lc = _LAUNCH_CACHE.get(key)
     if lc is None:
         lc = _build_launcher(b, n, npad, k)
@@ -1398,7 +1415,7 @@ def run_varlen(
             # R increment (bounded plans, bounded _VARLEN_CACHE)
             n_env = 1 << max(n_env - 1, 1).bit_length()
         n_env = min(max(n_env, 1), npad)
-        key = (num_rows, npad, k, n_env, nn, cr)
+        key = (num_rows, npad, k, n_env, nn, cr, _arch_token())
         lc = _VARLEN_CACHE.get(key)
         if lc is None:
             if _is_capturing():

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -79,7 +79,9 @@ def _arch_token() -> str:
     """Compile-target token for the launcher caches (mirrors the device
     module's _compile_arch_token without forcing its cutlass import): a
     heterogeneous multi-GPU process must not reuse a launcher whose compiled
-    engine targets another architecture."""
+    engine targets another architecture. Reads the CURRENT device, exactly
+    like the DSL compile target and the launch stream do — the public entries
+    pin the current device to ``logits.device`` first (_on_other_device)."""
     import os
 
     env = os.environ.get("CUTE_DSL_ARCH")
@@ -90,6 +92,18 @@ def _arch_token() -> str:
         return f"sm{major}{minor}"
     except Exception:  # noqa: BLE001 — no GPU context: single-arch fallback
         return "unknown"
+
+
+def _on_other_device(logits: torch.Tensor) -> bool:
+    """True when ``logits`` lives on a CUDA device other than the current one.
+
+    The launcher cache keys (_arch_token), the DSL compile target
+    (_compile_arch_token) and the launch stream all follow the CURRENT
+    device, so ``run`` / ``run_ws`` / ``run_varlen`` re-enter themselves under
+    ``torch.cuda.device(logits.device)`` in that case: a heterogeneous
+    multi-GPU process must never cache, compile for, or launch on the wrong
+    architecture. One device-index compare on the common (same-device) path."""
+    return logits.is_cuda and logits.get_device() != torch.cuda.current_device()
 
 
 # ===========================================================================
@@ -803,7 +817,9 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # staged floor (a distribution-dependent tail regression); the kernel
     # gates TSH per row at runtime anyway.
     tsh_en = 1 if (tpl[5] and k <= 1024) else 0
-    pre = (0, npad, k, rt["SCAP_"], rt["CMP_"], r_const, 0, 0, 0, 0, 0)
+    # slot 0 (`n`) carries the envelope: the varlen prologue clamps each row's
+    # kv-derived length to it, never to the row stride npad (arena tails)
+    pre = (n_env, npad, k, rt["SCAP_"], rt["CMP_"], r_const, 0, 0, 0, 0, 0)
     tail = (aim_base, sfac, amin, sd_en, tsh_en)
     lc = ("main", fn, pre, tail)
     _VARLEN_CACHE[key] = lc
@@ -1238,6 +1254,9 @@ def run(
     tensor therefore dies with 'device index out of range').
     Hot path inlines the device check + atomic load + cache hit; the slow
     path allocates under the workspace lock."""
+    if _on_other_device(logits):
+        with torch.cuda.device(logits.get_device()):
+            return run(logits, pre_idx, n_valid, indices, values)
     d = logits.get_device()
     if not 0 <= d < _GVR_MAX_DEV:  # checked on EVERY call
         raise RuntimeError(f"device index out of range: {d}")
@@ -1258,6 +1277,9 @@ def run_ws(
     """TESTING/BENCH ONLY — production callers must use ``run_varlen(workspace=...)``.
 
     Explicit-workspace form for multi-stream callers."""
+    if _on_other_device(logits):
+        with torch.cuda.device(logits.get_device()):
+            return run_ws(logits, pre_idx, n_valid, indices, workspace, values)
     validate_run_ws(workspace, logits)
     _run_impl(logits, pre_idx, n_valid, indices, kernel_view(workspace), values)
 
@@ -1309,6 +1331,20 @@ def run_varlen(
     selection (streaming main / clustered register-resident) is a pure
     function of the capture-stable launcher key.
     """
+    if _on_other_device(logits):
+        with torch.cuda.device(logits.get_device()):
+            return run_varlen(
+                logits,
+                pre_idx,
+                kv_lens,
+                indices,
+                next_n=next_n,
+                compress_ratio=compress_ratio,
+                values=values,
+                max_seq_len=max_seq_len,
+                engine=engine,
+                workspace=workspace,
+            )
     if logits.dtype is not torch.float32:
         raise RuntimeError(
             f"logits must be float32 (got {logits.dtype}); bf16/fp16 paths "

--- a/flashinfer/topk_varlen/kernels/gvr_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr_topk_decode.py
@@ -127,6 +127,49 @@ def float_as_uint32(float_val):
     return llvm.bitcast(cutlass.Uint32.mlir_type, float_val.ir_value())
 
 
+def float_as_int32(float_val):
+    """Interpret FP32 value as int32 bit pattern (cuTe DSL bit-cast)."""
+    return cutlass.Int32(llvm.bitcast(cutlass.Int32.mlir_type, float_val.ir_value()))
+
+
+def f32_order_key(float_val):
+    """Order-preserving fp32 -> int32 key (unsigned-monotonic bit pattern).
+
+    ``s ^ ((s >> 31) | 0x80000000)``: positive floats map to
+    ``bits | 0x80000000``, negative floats to ``~bits`` — the standard radix
+    transform whose UNSIGNED order equals fp32 order (NaN-free inputs). The
+    returned Int32 must only be consumed digit-wise (``(k >> s) & 0xFF``) or
+    via equality / prefix-equality; for a full ordered compare, flip the top
+    bit first (``k ^ 0x80000000`` is signed-monotonic).
+    """
+    s = float_as_int32(float_val)
+    return s ^ ((s >> cutlass.Int32(31)) | cutlass.Int32(-2147483648))
+
+
+def f32_order_key_signed(float_val):
+    """Signed-monotonic Int32 key (fp32 order == signed Int32 order), so the
+    Phase-3 repair can bisect with provable collapse in <= 32 steps."""
+    return f32_order_key(float_val) ^ cutlass.Int32(-2147483648)
+
+
+def order_key_signed_to_f32(m):
+    """Branchless inverse of :func:`f32_order_key_signed` (non-NaN keys)."""
+    k = m ^ cutlass.Int32(-2147483648)
+    top = k >> cutlass.Int32(31)  # -1 if top bit set, else 0
+    mask = cutlass.Int32(-2147483648) | (~top & cutlass.Int32(2147483647))
+    s = k ^ mask
+    return cutlass.Float32(llvm.bitcast(cutlass.Float32.mlir_type, s.ir_value()))
+
+
+def order_key_mid_f32(v_lo, v_hi):
+    """Ordered-key midpoint; returns (mid_float, is_adjacent) where adjacency
+    means no float strictly between v_lo and v_hi exists."""
+    m_lo = f32_order_key_signed(v_lo)
+    m_hi = f32_order_key_signed(v_hi)
+    m_mid = (m_lo & m_hi) + ((m_lo ^ m_hi) >> cutlass.Int32(1))
+    return order_key_signed_to_f32(m_mid), m_mid == m_lo
+
+
 def _fmin_f32_inline(a, b):
     """Single PTX ``min.f32`` → one SASS FMNMX.
 
@@ -551,7 +594,7 @@ class GvrTopKKernel:
         smem_wsum_f32,  # cute.Tensor [NUM_WARPS] float32
         smem_wcnt_i32,  # cute.Tensor [NUM_WARPS] int32
         s_thr,  # cute.Tensor [3] float32: [threshold, val_lo, val_hi]
-        s_iscalars,  # cute.Tensor [6] int32: [cand_count, done, cnt_lo, cnt_hi, out_count, local_cand_count]
+        s_iscalars,  # cute.Tensor [8] int32: [cand_count, done, cnt_lo, cnt_hi, out_count, local_cand_count, plateau_flag, fill_ticket]
         tidx,
         warp_id,
         lane,
@@ -719,7 +762,7 @@ class GvrTopKKernel:
         threshold,  # cutlass.Float32 scalar
         smem_ptcnt,  # cute.Tensor [BLOCK_SIZE] int32 (P3 cache)
         smem_wcnt,  # cute.Tensor [NUM_WARPS] int32 (block reduce scratch)
-        s_iscalars,  # cute.Tensor [6] int32 (writes [0] = cand_count)
+        s_iscalars,  # cute.Tensor [8] int32 (writes [0] = cand_count)
         s_cluster_partial,  # cute.Tensor [1] int32 (per-CTA partial scratch for DSMEM)
         tidx,
         warp_id,
@@ -976,7 +1019,7 @@ class GvrTopKKernel:
         smem_ptcnt,
         smem_wcnt,
         s_thr,  # [threshold, val_lo, val_hi]
-        s_iscalars,  # [cand_count, done, cnt_lo, cnt_hi, out_count]
+        s_iscalars,  # [cand_count, done, cnt_lo, cnt_hi, out_count, ...]
         s_cluster_partial,  # [3] int32 cluster scratch (parity slots + counter)
         tidx,
         warp_id,
@@ -988,7 +1031,10 @@ class GvrTopKKernel:
 
         Each iter calls block_count_ge at the candidate threshold and
         updates the bracket (val_lo, val_hi, cnt_lo, cnt_hi). Sets
-        s_iscalars[1] (done) = 1 on convergence, 2 on bracket exhaustion.
+        s_iscalars[1] (done) = 1 on convergence, 2 on bracket exhaustion
+        (Phase 3's two-sided repair then re-derives the threshold), or 3 on
+        an adjacent-float tie plateau wider than kC (threshold = the
+        sure-winner side; Phase 4's plateau fill completes the row).
         """
         kK = cutlass.const_expr(self.top_k)
         kCC = cutlass.const_expr(self.kC)
@@ -1058,8 +1104,18 @@ class GvrTopKKernel:
                 if nv == vlo_r or nv == vhi_r:
                     nv = (vlo_r + vhi_r) * cutlass.Float32(0.5)
                     if nv == vlo_r or nv == vhi_r:
-                        thr_r = vlo_r
-                        done_r = cutlass.Int32(2)
+                        # ADJACENT-FLOAT bracket, same terminal as the
+                        # leader path: a low side over the candidate
+                        # buffer plus a high side under K means the
+                        # boundary sits inside a bitwise-equal plateau
+                        # wider than kC. Keep the sure-winner threshold
+                        # and let Phase 4's plateau fill finish the row.
+                        if clo_r > cutlass.Int32(kCC) and chi_r < cutlass.Int32(kK):
+                            thr_r = vhi_r
+                            done_r = cutlass.Int32(3)
+                        else:
+                            thr_r = vlo_r
+                            done_r = cutlass.Int32(2)
                 if done_r == cutlass.Int32(0):
                     thr_r = nv
                     par_r = par_r ^ cutlass.Int32(1)
@@ -1089,6 +1145,75 @@ class GvrTopKKernel:
                         vhi_r = thr_r
                         chi_r = cnt_r
                 it = it + cutlass.Int32(1)
+            # ---- Budget-exhausted plateau collapse (mirrors the leader
+            # path): the refine budget can run out while the bracket is
+            # still wide because a tie plateau wider than kC admits no
+            # threshold. On exactly that signature, bisect to adjacent
+            # floats so the plateau terminal is exact. Every thread
+            # replays this from identical registers, so the branch stays
+            # warp-uniform and block_count_ge keeps its barrier cadence.
+            if (
+                done_r == cutlass.Int32(0)
+                and clo_r > cutlass.Int32(kCC)
+                and chi_r >= cutlass.Int32(0)
+                and chi_r < cutlass.Int32(kK)
+            ):
+                itc = cutlass.Int32(0)
+                while itc < cutlass.Int32(64) and done_r == cutlass.Int32(0):
+                    mid_c = (vlo_r + vhi_r) * cutlass.Float32(0.5)
+                    if mid_c == vlo_r or mid_c == vhi_r:
+                        thr_r = vhi_r
+                        done_r = cutlass.Int32(3)
+                    else:
+                        thr_r = mid_c
+                        par_r = par_r ^ cutlass.Int32(1)
+                        cnt_r = self.block_count_ge(
+                            input_row,
+                            slice_start,
+                            slice_end,
+                            thr_r,
+                            smem_ptcnt,
+                            smem_wcnt,
+                            s_iscalars,
+                            s_cluster_partial,
+                            tidx,
+                            warp_id,
+                            lane,
+                            cutlass.Boolean(False),  # do_cluster_sync (cs==1)
+                            smem_input=smem_input,
+                            redundant=True,
+                            wcnt_off=par_r * cutlass.Int32(nwp2),
+                        )
+                        if cnt_r >= cutlass.Int32(kK) and cnt_r <= cutlass.Int32(kCC):
+                            done_r = cutlass.Int32(1)
+                        elif cnt_r > cutlass.Int32(kCC):
+                            vlo_r = thr_r
+                            clo_r = cnt_r
+                        else:
+                            vhi_r = thr_r
+                            chi_r = cnt_r
+                    itc = itc + cutlass.Int32(1)
+                if done_r == cutlass.Int32(3):
+                    # recount at the terminal threshold so Phase 3 sees
+                    # per-thread counts for the sure-winner set.
+                    par_r = par_r ^ cutlass.Int32(1)
+                    cnt_r = self.block_count_ge(
+                        input_row,
+                        slice_start,
+                        slice_end,
+                        thr_r,
+                        smem_ptcnt,
+                        smem_wcnt,
+                        s_iscalars,
+                        s_cluster_partial,
+                        tidx,
+                        warp_id,
+                        lane,
+                        cutlass.Boolean(False),  # do_cluster_sync (cs==1)
+                        smem_input=smem_input,
+                        redundant=True,
+                        wcnt_off=par_r * cutlass.Int32(nwp2),
+                    )
             if done_r == cutlass.Int32(0):
                 if clo_r <= cutlass.Int32(kCC * 2):
                     thr_r = vlo_r
@@ -1174,11 +1299,22 @@ class GvrTopKKernel:
                     nv = vhi - rng * cutlass.Float32(0.05)
 
                 if nv == vlo or nv == vhi:
-                    # Bracket exhausted — try midpoint, else give up.
+                    # Bracket exhausted — try midpoint, else terminal.
                     nv = (vlo + vhi) * cutlass.Float32(0.5)
                     if nv == vlo or nv == vhi:
-                        s_thr[0] = vlo
-                        s_iscalars[1] = cutlass.Int32(2)  # done = 2 (give up)
+                        # ADJACENT-FLOAT bracket: every value in
+                        # [vlo, vhi) is bitwise-equal to vlo. Low side
+                        # overflowing the candidate buffer AND high side
+                        # undershooting K means the boundary sits inside
+                        # a bitwise-equal plateau wider than kC — record
+                        # the plateau terminal (done = 3) and keep the
+                        # sure-winner threshold vhi.
+                        if clo > cutlass.Int32(kCC) and chi < cutlass.Int32(kK):
+                            s_thr[0] = vhi
+                            s_iscalars[1] = cutlass.Int32(3)  # done = 3 (plateau)
+                        else:
+                            s_thr[0] = vlo
+                            s_iscalars[1] = cutlass.Int32(2)  # done = 2 (give up)
                     else:
                         s_thr[0] = nv
                 else:
@@ -1217,6 +1353,84 @@ class GvrTopKKernel:
                         s_iscalars[3] = c_new
                 cute.arch.barrier()
             it = it + cutlass.Int32(1)
+
+        # ---- Budget-exhausted plateau collapse ----
+        # The refine budget can run out while the bracket is still wide: the
+        # secant step keeps making progress (the bracket shrinks every
+        # iteration) but a tie plateau wider than kC admits no threshold, so
+        # the count never lands in [kK, kCC]. In exactly that signature -
+        # count(>= v_lo) > kCC AND count(>= v_hi) < kK, both counts current -
+        # collapse the bracket by pure bisection until the ends are ADJACENT
+        # floats; every value in [v_lo, v_hi) is then bitwise-equal, so the
+        # plateau terminal (done = 3) is exact and Phase 4 completes the row
+        # from that tie class. A count landing in [kK, kCC] mid-collapse
+        # converges normally. Anything else keeps the legacy give-up below.
+        if (
+            s_iscalars[1] == cutlass.Int32(0)
+            and s_iscalars[2] > cutlass.Int32(kCC)
+            and s_iscalars[3] >= cutlass.Int32(0)
+            and s_iscalars[3] < cutlass.Int32(kK)
+        ):
+            itc = cutlass.Int32(0)
+            while itc < cutlass.Int32(64) and s_iscalars[1] == cutlass.Int32(0):
+                if tidx == 0:
+                    vlo_c = s_thr[1]
+                    vhi_c = s_thr[2]
+                    mid_c = (vlo_c + vhi_c) * cutlass.Float32(0.5)
+                    if mid_c == vlo_c or mid_c == vhi_c:
+                        s_thr[0] = vhi_c
+                        s_iscalars[1] = cutlass.Int32(3)  # plateau terminal
+                    else:
+                        s_thr[0] = mid_c
+                cute.arch.barrier()
+                if s_iscalars[1] == cutlass.Int32(0):
+                    self.block_count_ge(
+                        input_row,
+                        slice_start,
+                        slice_end,
+                        s_thr[0],
+                        smem_ptcnt,
+                        smem_wcnt,
+                        s_iscalars,
+                        s_cluster_partial,
+                        tidx,
+                        warp_id,
+                        lane,
+                        smem_input=smem_input,
+                        do_cluster_sync=do_cluster_sync,
+                    )
+                    if tidx == 0:
+                        c_c = s_iscalars[0]
+                        t_c = s_thr[0]
+                        if c_c >= cutlass.Int32(kK) and c_c <= cutlass.Int32(kCC):
+                            s_iscalars[1] = cutlass.Int32(1)
+                        elif c_c > cutlass.Int32(kCC):
+                            s_thr[1] = t_c
+                            s_iscalars[2] = c_c
+                        else:
+                            s_thr[2] = t_c
+                            s_iscalars[3] = c_c
+                    cute.arch.barrier()
+                itc = itc + cutlass.Int32(1)
+            if s_iscalars[1] == cutlass.Int32(3):
+                # recount at the terminal threshold so Phase 3's cached
+                # per-thread counts describe the sure-winner set.
+                self.block_count_ge(
+                    input_row,
+                    slice_start,
+                    slice_end,
+                    s_thr[0],
+                    smem_ptcnt,
+                    smem_wcnt,
+                    s_iscalars,
+                    s_cluster_partial,
+                    tidx,
+                    warp_id,
+                    lane,
+                    smem_input=smem_input,
+                    do_cluster_sync=do_cluster_sync,
+                )
+                cute.arch.barrier()
 
         # ---- Post-loop fallback: if still not done, force threshold ----
         if tidx == 0:
@@ -1289,29 +1503,68 @@ class GvrTopKKernel:
                 smem_input=smem_input,
                 do_cluster_sync=do_cluster_sync,
             )
+            # Two-sided repair: the old retry only guarded overflow, so an
+            # undershooting threshold shipped a -1-padded, silently wrong
+            # top-K. Anchor the untested bracket end at a float extreme, then
+            # bisect on the signed order-key image (provable collapse).
             if tidx == 0:
-                if s_iscalars[0] > cutlass.Int32(kCC):
-                    s_thr[1] = s_thr[0]  # val_lo = threshold
+                c0 = s_iscalars[0]
+                if c0 > cutlass.Int32(kCC):
+                    s_thr[1] = s_thr[0]
+                    s_thr[2] = cutlass.Float32(self.FLT_MAX)
+                elif c0 < cutlass.Int32(kK):
+                    s_thr[2] = s_thr[0]
+                    s_thr[1] = cutlass.Float32(self.NEG_FLT_MAX)
             cute.arch.barrier()
 
-            # 10-iter retry-shrink. Runtime while with `cand_count > kCC` in the
-            # loop condition.
             rs = cutlass.Int32(0)
-            while rs < cutlass.Int32(10) and s_iscalars[0] > cutlass.Int32(kCC):
+            collapsed = cutlass.Int32(0)
+            while (
+                rs < cutlass.Int32(48)
+                and (s_iscalars[0] > cutlass.Int32(kCC) or s_iscalars[0] < cutlass.Int32(kK))
+                and collapsed == cutlass.Int32(0)
+            ):
+                mid_f, adj = order_key_mid_f32(s_thr[1], s_thr[2])
+                if adj:
+                    collapsed = cutlass.Int32(1)
+                if collapsed == cutlass.Int32(0):
+                    if tidx == 0:
+                        s_thr[0] = mid_f
+                    cute.arch.barrier()
+                    self.block_count_ge(
+                        input_row,
+                        slice_start,
+                        slice_end,
+                        s_thr[0],
+                        smem_ptcnt,
+                        smem_wcnt,
+                        s_iscalars,
+                        s_cluster_partial,
+                        tidx,
+                        warp_id,
+                        lane,
+                        smem_input=smem_input,
+                        do_cluster_sync=do_cluster_sync,
+                    )
+                    if tidx == 0:
+                        c_rs = s_iscalars[0]
+                        if c_rs > cutlass.Int32(kCC):
+                            s_thr[1] = s_thr[0]
+                        elif c_rs < cutlass.Int32(kK):
+                            s_thr[2] = s_thr[0]
+                    cute.arch.barrier()
+                rs = rs + cutlass.Int32(1)
+
+            # Undershoot at collapse: val_lo admits >= kK by construction.
+            if s_iscalars[0] < cutlass.Int32(kK):
                 if tidx == 0:
-                    lo = s_thr[1]
-                    hi = s_thr[2]
-                    mid = (lo + hi) * cutlass.Float32(0.5)
-                    if mid == lo:
-                        mid = hi
-                    s_thr[0] = mid
+                    s_thr[0] = s_thr[1]
                 cute.arch.barrier()
-                new_thr = s_thr[0]
                 self.block_count_ge(
                     input_row,
                     slice_start,
                     slice_end,
-                    new_thr,
+                    s_thr[0],
                     smem_ptcnt,
                     smem_wcnt,
                     s_iscalars,
@@ -1322,14 +1575,33 @@ class GvrTopKKernel:
                     smem_input=smem_input,
                     do_cluster_sync=do_cluster_sync,
                 )
+            cute.arch.barrier()
+
+            # Collapsed tie plateau (> kCC at an adjacent bracket): hand the
+            # row to the existing done=3 machinery; Phase 4 fills from the
+            # tie class in [val_lo, val_hi).
+            mid_chk, adj_chk = order_key_mid_f32(s_thr[1], s_thr[2])
+            if s_iscalars[0] > cutlass.Int32(kCC) and adj_chk:
                 if tidx == 0:
-                    c_rs = s_iscalars[0]
-                    if c_rs > cutlass.Int32(kCC):
-                        s_thr[1] = s_thr[0]
-                    elif c_rs < cutlass.Int32(kK):
-                        s_thr[2] = s_thr[0]
+                    s_thr[0] = s_thr[2]
+                    s_iscalars[1] = cutlass.Int32(3)  # plateau terminal
                 cute.arch.barrier()
-                rs = rs + cutlass.Int32(1)
+                self.block_count_ge(
+                    input_row,
+                    slice_start,
+                    slice_end,
+                    s_thr[0],
+                    smem_ptcnt,
+                    smem_wcnt,
+                    s_iscalars,
+                    s_cluster_partial,
+                    tidx,
+                    warp_id,
+                    lane,
+                    smem_input=smem_input,
+                    do_cluster_sync=do_cluster_sync,
+                )
+                cute.arch.barrier()
 
         # ---- Warp prefix sum over smem_ptcnt ----
         # my_total_qual = per-thread count cached by last block_count_ge.
@@ -2391,12 +2663,13 @@ class GvrTopKKernel:
                     )
                 output_indices_row[i10] = self._smem_ld(cutlass.Int32, vals_base, i10)
                 i10 = i10 + cutlass.Int32(num_threads)
-            i11 = cand_count + tidx
-            while i11 < cutlass.Int32(kK):
-                if cutlass.const_expr(self.return_output_values):
-                    output_values_row[i11] = self.dtype(self.NEG_FLT_MAX)
-                output_indices_row[i11] = cutlass.Int32(-1)
-                i11 = i11 + cutlass.Int32(num_threads)
+            if s_iscalars[6] == cutlass.Int32(0):  # plateau fill completes done=3
+                i11 = cand_count + tidx
+                while i11 < cutlass.Int32(kK):
+                    if cutlass.const_expr(self.return_output_values):
+                        output_values_row[i11] = self.dtype(self.NEG_FLT_MAX)
+                    output_indices_row[i11] = cutlass.Int32(-1)
+                    i11 = i11 + cutlass.Int32(num_threads)
 
     # ------------------------------------------------------------------
     # Main kernel — one CTA per row
@@ -2614,9 +2887,12 @@ class GvrTopKKernel:
         #   [4] out_count
         #   [5] local cand_count  (per-CTA snapshot before cluster all-reduce;
         #                          consumed by the kernel-level cluster handoff)
+        #   [6] plateau flag  (done==3 captured BEFORE Phase 4, which reuses
+        #                      the scalar slots as snap scratch)
+        #   [7] plateau fill ticket counter (post-P4 tie-class completion)
         s_iscalars = smem.allocate_tensor(
             element_type=cutlass.Int32,
-            layout=cute.make_ordered_layout((6,), order=(0,)),
+            layout=cute.make_ordered_layout((8,), order=(0,)),
             byte_alignment=16,
         )
         # Per-CTA DSMEM scratch for the cluster all-reduce of cand_count:
@@ -2863,109 +3139,202 @@ class GvrTopKKernel:
             lane,
         )
 
-        # Degenerate threshold init: val_hi <= -self.FLT_MAX or val_lo >= val_hi.
-        # When preIdx values produce an unusable bracket (e.g. all -inf or
-        # identical), skip Phase 2-4 and emit identity output instead.
+        # Degenerate hint (all gathered values identical or out of range):
+        # reset to a synthetic bracket and fall through instead of emitting
+        # row[0:K]; the Phase-3 repair guarantees the answer, so the hint only
+        # affects speed. cnt_hi is seeded with top_k (not 0) so Phase 2's
+        # budget-collapse guard (`cnt_hi < kK`) cannot fire on this
+        # UNMEASURED bracket — a smaller seed would let the collapse mint a
+        # plateau terminal from a count that was never measured.
         v_lo = s_thr[1]
         v_hi = s_thr[2]
         if v_hi <= cutlass.Float32(self.NEG_FLT_MAX) or v_lo >= v_hi:
-            if cutlass.const_expr(cluster_size == 1):
-                if tidx == 0:
-                    top_k = cutlass.const_expr(self.top_k)
-                    # Emit identity output (first min(top_k, N) indices)
-                    emit_count = cutlass.Int32(top_k) if cutlass.Int32(top_k) < N else N
-                    je = cutlass.Int32(0)
-                    while je < emit_count:
-                        output_indices_row[je] = je
-                        if cutlass.const_expr(self.return_output_values):
-                            output_values_row[je] = input_row[je]
-                        je = je + cutlass.Int32(1)
-            else:
-                # cs>1: all cluster CTAs enter _run_phases; only leader writes.
-                if is_leader & (tidx == cutlass.Int32(0)):
-                    top_k = cutlass.const_expr(self.top_k)
-                    # Emit identity output (first min(top_k, N) indices)
-                    emit_count = cutlass.Int32(top_k) if cutlass.Int32(top_k) < N else N
-                    je = cutlass.Int32(0)
-                    while je < emit_count:
-                        output_indices_row[je] = je
-                        if cutlass.const_expr(self.return_output_values):
-                            output_values_row[je] = input_row[je]
-                        je = je + cutlass.Int32(1)
-        else:
-            # Stage this CTA's slice into SMEM once before Phase 2's
-            # 6-10 secant iters re-scan it. Phase 1 (preIdx) uses
-            # scatter-loads OUTSIDE this slice, so it stays on GMEM.
-            if cutlass.const_expr(self.enable_smem_cache):
-                self.load_slice_to_smem(
-                    input_row,
-                    slice_start,
-                    slice_end,
-                    smem_input,
-                    tidx,
-                )
-
-            # ---- Phase 2: secant threshold search ----
-            self.phase2_secant_search(
+            if tidx == 0:
+                s_thr[0] = cutlass.Float32(0.0)
+                s_thr[1] = cutlass.Float32(-1.0)
+                s_thr[2] = cutlass.Float32(1.0)
+                s_iscalars[2] = N  # cnt_lo
+                s_iscalars[3] = cutlass.Int32(self.top_k)  # cnt_hi
+            cute.arch.barrier()
+        # Stage this CTA's slice into SMEM once before Phase 2's
+        # 6-10 secant iters re-scan it. Phase 1 (preIdx) uses
+        # scatter-loads OUTSIDE this slice, so it stays on GMEM.
+        if cutlass.const_expr(self.enable_smem_cache):
+            self.load_slice_to_smem(
                 input_row,
-                N,
                 slice_start,
                 slice_end,
-                smem_ptcnt,
-                smem_wcnt,
-                s_thr,
-                s_iscalars,
-                s_cluster_partial,
+                smem_input,
                 tidx,
-                warp_id,
-                lane,
-                do_cluster_sync=do_cluster_sync,
-                smem_input=smem_input,
             )
 
-            # Cluster handoff #1 (end of Phase 2). Skipped when
-            # do_cluster_sync is False (cs=1 or short-row degrade).
-            if cutlass.const_expr(cluster_size > 1):
-                if do_cluster_sync:
-                    cute.arch.cluster_arrive_relaxed()
-                    cute.arch.cluster_wait()
+        # ---- Phase 2: secant threshold search ----
+        self.phase2_secant_search(
+            input_row,
+            N,
+            slice_start,
+            slice_end,
+            smem_ptcnt,
+            smem_wcnt,
+            s_thr,
+            s_iscalars,
+            s_cluster_partial,
+            tidx,
+            warp_id,
+            lane,
+            do_cluster_sync=do_cluster_sync,
+            smem_input=smem_input,
+        )
 
-            # ---- Phase 3: cluster-parallel candidate collect ----
-            self.phase3_collect_candidates(
-                input_row,
-                N,
-                slice_start,
-                slice_end,
+        # Cluster handoff #1 (end of Phase 2). Skipped when
+        # do_cluster_sync is False (cs=1 or short-row degrade).
+        if cutlass.const_expr(cluster_size > 1):
+            if do_cluster_sync:
+                cute.arch.cluster_arrive_relaxed()
+                cute.arch.cluster_wait()
+
+        # ---- Phase 3: cluster-parallel candidate collect ----
+        self.phase3_collect_candidates(
+            input_row,
+            N,
+            slice_start,
+            slice_end,
+            smem_keys,
+            smem_vals,
+            smem_ptcnt,
+            smem_wcnt,
+            s_thr,
+            s_iscalars,
+            s_cluster_partial,
+            tidx,
+            warp_id,
+            lane,
+            do_cluster_sync=do_cluster_sync,
+            smem_input=smem_input,
+        )
+
+        # Cluster handoff #2: leader's DSMEM gather of peer
+        # smem_keys/smem_vals. Skipped at do_cluster_sync=False.
+        if cutlass.const_expr(cluster_size > 1):
+            if do_cluster_sync:
+                cute.arch.cluster_arrive()
+                cute.arch.cluster_wait()
+
+        # Phase 4 runs on the leader only. const_expr (compile-
+        # time eliminated) split from runtime so cs=1 gets a flat
+        # code path with no leader/sync checks.
+        # Pre-init cand_count_p4 so CuTe DSL sees a stable Int32 type
+        # across the runtime ``if is_leader:`` branch in cs>1 mode
+        # (DSL forbids first-assigning a variable inside a dynamic if).
+        cand_count_p4 = cutlass.Int32(0)
+        if cutlass.const_expr(cluster_size == 1):
+            # cs=1: the single CTA per row IS the leader.
+            # Capture the P2/P3 terminal BEFORE Phase 4 (P4 snap state may
+            # overwrite scalar slots; the flag must survive to the fill).
+            if tidx == cutlass.Int32(0):
+                s_iscalars[6] = cutlass.Int32(0)
+                if s_iscalars[1] == cutlass.Int32(3):
+                    s_iscalars[6] = cutlass.Int32(1)
+            cute.arch.barrier()
+            cand_count_p4 = min(s_iscalars[0], cutlass.Int32(self.kC))
+            self.phase4_histogram_snap(
                 smem_keys,
                 smem_vals,
-                smem_ptcnt,
+                smem_hist,
                 smem_wcnt,
                 s_thr,
                 s_iscalars,
-                s_cluster_partial,
+                output_values_row,
+                output_indices_row,
+                cand_count_p4,
                 tidx,
                 warp_id,
                 lane,
-                do_cluster_sync=do_cluster_sync,
-                smem_input=smem_input,
             )
-
-            # Cluster handoff #2: leader's DSMEM gather of peer
-            # smem_keys/smem_vals. Skipped at do_cluster_sync=False.
-            if cutlass.const_expr(cluster_size > 1):
+            # ---- plateau fill (done == 3): complete the row from the
+            # bitwise-equal plateau class. The terminal is only set on an
+            # ADJACENT-FLOAT bracket, so every value in [s_thr[1], s_thr[0])
+            # is bitwise-equal; Phase 4 has already emitted the
+            # cnt(>= s_thr[0]) sure winners, and ANY (K - count)-subset of
+            # the tie class is a valid tie-aware completion. Ticket counter
+            # lives in the DEDICATED s_iscalars[7].
+            if s_iscalars[6] == cutlass.Int32(1):
+                pv_lo = s_thr[1]
+                pv_hi = s_thr[0]
+                if tidx == cutlass.Int32(0):
+                    # cand_count_p4 was captured BEFORE Phase 4; s_iscalars[0]
+                    # is snap scratch by now (same hazard as the flag).
+                    s_iscalars[7] = cand_count_p4
+                cute.arch.barrier()
+                ifp = tidx
+                while ifp < N:
+                    vfp = cutlass.Float32(0.0)
+                    if cutlass.const_expr(self.dtype == cutlass.Float32):
+                        vfp = input_row[ifp]
+                    else:
+                        vfp = cutlass.Float32(input_row[ifp])
+                    if vfp >= pv_lo and vfp < pv_hi:
+                        pfill = atomicAdd(
+                            s_iscalars.iterator + cutlass.Int32(7), cutlass.Int32(1)
+                        )
+                        if pfill < cutlass.Int32(self.top_k):
+                            if cutlass.const_expr(self.return_output_values):
+                                output_values_row[pfill] = self.dtype(vfp)
+                            output_indices_row[pfill] = ifp
+                    ifp = ifp + cutlass.Int32(self.num_threads)
+                cute.arch.barrier()
+        else:
+            # cs>1: only the leader (CTA 0 in cluster) runs Phase 4.
+            if is_leader:
                 if do_cluster_sync:
-                    cute.arch.cluster_arrive()
-                    cute.arch.cluster_wait()
+                    # DSMEM-gather peer candidates into the leader's
+                    # smem_keys/smem_vals. Layout: leader's chunk goes
+                    # to [0 .. leader_local_cnt); each peer r's chunk
+                    # appends the next peer_r_local_cnt entries.
+                    local_cnt_self = s_iscalars[5]
+                    local_iscalars_ptr = s_iscalars.iterator + cutlass.Int32(5)
+                    smem_keys_iter = smem_keys.iterator
+                    smem_vals_iter = smem_vals.iterator
+                    base_offset = local_cnt_self
+                    for peer in cutlass.range_constexpr(1, cluster_size):
+                        peer_iscalars_addr = mapa_shared_cluster(
+                            local_iscalars_ptr, cutlass.Int32(peer)
+                        )
+                        peer_cnt = ld_shared_cluster_i32(peer_iscalars_addr)
+                        # Cap to kC (defense-in-depth vs. the
+                        # done==2 bracket-exhaustion path).
+                        peer_cnt = min(peer_cnt, cutlass.Int32(self.kC))
+                        i_gather = tidx
+                        while i_gather < peer_cnt:
+                            peer_key_addr = mapa_shared_cluster(
+                                smem_keys_iter + i_gather, cutlass.Int32(peer)
+                            )
+                            peer_val_addr = mapa_shared_cluster(
+                                smem_vals_iter + i_gather, cutlass.Int32(peer)
+                            )
+                            k_val = ld_shared_cluster_f32(peer_key_addr)
+                            v_val = ld_shared_cluster_i32(peer_val_addr)
+                            dst = base_offset + i_gather
+                            if dst < cutlass.Int32(self.kC):
+                                smem_keys[dst] = k_val
+                                smem_vals[dst] = v_val
+                            i_gather = i_gather + cutlass.Int32(num_threads)
+                        base_offset = base_offset + peer_cnt
+                    # Reset s_iscalars[0] to cluster-wide cand_count.
+                    if tidx == cutlass.Int32(0):
+                        s_iscalars[0] = base_offset
+                    cute.arch.barrier()
+                # else: short-row degrade — leader (CTA 0) already
+                # holds the full row's candidates in its own
+                # smem_keys/smem_vals (no peers to gather from).
 
-            # Phase 4 runs on the leader only. const_expr (compile-
-            # time eliminated) split from runtime so cs=1 gets a flat
-            # code path with no leader/sync checks.
-            # Pre-init cand_count_p4 so CuTe DSL sees a stable Int32 type
-            # across the runtime ``if is_leader:`` branch in cs>1 mode
-            # (DSL forbids first-assigning a variable inside a dynamic if).
-            cand_count_p4 = cutlass.Int32(0)
-            if cutlass.const_expr(cluster_size == 1):
-                # cs=1: the single CTA per row IS the leader.
+                # ---- Phase 4: histogram snap + writeback ----
+                # Capture the P2/P3 terminal BEFORE Phase 4 (see cs=1 path).
+                if tidx == cutlass.Int32(0):
+                    s_iscalars[6] = cutlass.Int32(0)
+                    if s_iscalars[1] == cutlass.Int32(3):
+                        s_iscalars[6] = cutlass.Int32(1)
+                cute.arch.barrier()
                 cand_count_p4 = min(s_iscalars[0], cutlass.Int32(self.kC))
                 self.phase4_histogram_snap(
                     smem_keys,
@@ -2981,67 +3350,33 @@ class GvrTopKKernel:
                     warp_id,
                     lane,
                 )
-            else:
-                # cs>1: only the leader (CTA 0 in cluster) runs Phase 4.
-                if is_leader:
-                    if do_cluster_sync:
-                        # DSMEM-gather peer candidates into the leader's
-                        # smem_keys/smem_vals. Layout: leader's chunk goes
-                        # to [0 .. leader_local_cnt); each peer r's chunk
-                        # appends the next peer_r_local_cnt entries.
-                        local_cnt_self = s_iscalars[5]
-                        local_iscalars_ptr = s_iscalars.iterator + cutlass.Int32(5)
-                        smem_keys_iter = smem_keys.iterator
-                        smem_vals_iter = smem_vals.iterator
-                        base_offset = local_cnt_self
-                        for peer in cutlass.range_constexpr(1, cluster_size):
-                            peer_iscalars_addr = mapa_shared_cluster(
-                                local_iscalars_ptr, cutlass.Int32(peer)
+                # ---- plateau fill (done == 3): see the cs=1 path. The
+                # leader scans the FULL row [0, N) from GMEM (correct for
+                # both slice modes; the plateau class is row-global).
+                if s_iscalars[6] == cutlass.Int32(1):
+                    pv_lo = s_thr[1]
+                    pv_hi = s_thr[0]
+                    if tidx == cutlass.Int32(0):
+                        s_iscalars[7] = cand_count_p4
+                    cute.arch.barrier()
+                    ifp = tidx
+                    while ifp < N:
+                        vfp = cutlass.Float32(0.0)
+                        if cutlass.const_expr(self.dtype == cutlass.Float32):
+                            vfp = input_row[ifp]
+                        else:
+                            vfp = cutlass.Float32(input_row[ifp])
+                        if vfp >= pv_lo and vfp < pv_hi:
+                            pfill = atomicAdd(
+                                s_iscalars.iterator + cutlass.Int32(7),
+                                cutlass.Int32(1),
                             )
-                            peer_cnt = ld_shared_cluster_i32(peer_iscalars_addr)
-                            # Cap to kC (defense-in-depth vs. the
-                            # done==2 bracket-exhaustion path).
-                            peer_cnt = min(peer_cnt, cutlass.Int32(self.kC))
-                            i_gather = tidx
-                            while i_gather < peer_cnt:
-                                peer_key_addr = mapa_shared_cluster(
-                                    smem_keys_iter + i_gather, cutlass.Int32(peer)
-                                )
-                                peer_val_addr = mapa_shared_cluster(
-                                    smem_vals_iter + i_gather, cutlass.Int32(peer)
-                                )
-                                k_val = ld_shared_cluster_f32(peer_key_addr)
-                                v_val = ld_shared_cluster_i32(peer_val_addr)
-                                dst = base_offset + i_gather
-                                if dst < cutlass.Int32(self.kC):
-                                    smem_keys[dst] = k_val
-                                    smem_vals[dst] = v_val
-                                i_gather = i_gather + cutlass.Int32(num_threads)
-                            base_offset = base_offset + peer_cnt
-                        # Reset s_iscalars[0] to cluster-wide cand_count.
-                        if tidx == cutlass.Int32(0):
-                            s_iscalars[0] = base_offset
-                        cute.arch.barrier()
-                    # else: short-row degrade — leader (CTA 0) already
-                    # holds the full row's candidates in its own
-                    # smem_keys/smem_vals (no peers to gather from).
-
-                    # ---- Phase 4: histogram snap + writeback ----
-                    cand_count_p4 = min(s_iscalars[0], cutlass.Int32(self.kC))
-                    self.phase4_histogram_snap(
-                        smem_keys,
-                        smem_vals,
-                        smem_hist,
-                        smem_wcnt,
-                        s_thr,
-                        s_iscalars,
-                        output_values_row,
-                        output_indices_row,
-                        cand_count_p4,
-                        tidx,
-                        warp_id,
-                        lane,
-                    )
+                            if pfill < cutlass.Int32(self.top_k):
+                                if cutlass.const_expr(self.return_output_values):
+                                    output_values_row[pfill] = self.dtype(vfp)
+                                output_indices_row[pfill] = ifp
+                        ifp = ifp + cutlass.Int32(self.num_threads)
+                    cute.arch.barrier()
 
         # Final cluster barrier: keep peer CTAs (and their SMEM) alive
         # until the leader's gather + Phase 4 finish. Skipped at

--- a/flashinfer/topk_varlen/kernels/gvr_topk_decode.py
+++ b/flashinfer/topk_varlen/kernels/gvr_topk_decode.py
@@ -1506,7 +1506,13 @@ class GvrTopKKernel:
             # Two-sided repair: the old retry only guarded overflow, so an
             # undershooting threshold shipped a -1-padded, silently wrong
             # top-K. Anchor the untested bracket end at a float extreme, then
-            # bisect on the signed order-key image (provable collapse).
+            # bisect on the signed order-key image (provable collapse). The
+            # lower anchor is the true minimum key, -inf, not -FLT_MAX: a row
+            # with fewer than K values >= -FLT_MAX (all -inf, or a short
+            # finite head over a -inf tail) has count(>= -FLT_MAX) < K, which
+            # broke the "val_lo admits >= kK" invariant below and left its
+            # slots unwritten. -inf is an ordinary (non-NaN) key for the
+            # signed order-key mapping, so the bisection is unchanged.
             if tidx == 0:
                 c0 = s_iscalars[0]
                 if c0 > cutlass.Int32(kCC):
@@ -1514,7 +1520,7 @@ class GvrTopKKernel:
                     s_thr[2] = cutlass.Float32(self.FLT_MAX)
                 elif c0 < cutlass.Int32(kK):
                     s_thr[2] = s_thr[0]
-                    s_thr[1] = cutlass.Float32(self.NEG_FLT_MAX)
+                    s_thr[1] = cutlass.Float32(float("-inf"))
             cute.arch.barrier()
 
             rs = cutlass.Int32(0)
@@ -2798,6 +2804,14 @@ class GvrTopKKernel:
             N = actual_kv_len
         else:
             N = actual_kv_len // cutlass.Int32(self.compress_ratio)
+        # Clamp to the physical row width. seq_lens is the dynamic side (read on
+        # device, grows every decode step) and the logits width is the static
+        # side (fixed at allocation / graph capture); a row whose length has
+        # outgrown the width holds only its first `width` scores, so rank those
+        # instead of reading past the row (and the tensor).
+        n_cols = input_data.shape[1]
+        if N > n_cols:
+            N = n_cols
 
         # Slice per-row views.
         input_row = input_data[row_idx, None]

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -55,6 +55,7 @@ Backend choices
 
 import functools
 import math
+import warnings
 from typing import Literal, Optional, Tuple
 
 import torch
@@ -68,6 +69,7 @@ from ..cute_dsl.availability import is_cute_dsl_available
 _CUTE_DSL_AVAILABLE = is_cute_dsl_available()
 
 from ..utils import (
+    BackendSupportedError,
     _get_cache_buf,
     backend_requirement,
     get_device_sm_count,
@@ -166,8 +168,44 @@ def _radix_cutlass_top_k_varlen_check(
     load_balance=True,
     workspace=None,
 ):  # extra kwargs mirror the public signature; unused by the check
-    """Radix masked-fallback: runs on all supported SM tiers."""
-    return True
+    """Radix masked-fallback: runs on all supported SM tiers, on contiguous
+    logits (the CUDA launcher checks contiguity; gating here lets ``auto``
+    pick a backend that handles strided views instead)."""
+    return logits.is_contiguous()
+
+
+def _hint_problem(pre_idx, logits, seq_lens, top_k) -> Optional[str]:
+    """Describe what is wrong with a caller-provided ``pre_idx``, or None.
+
+    The hint contract shared by the ``gvr`` and ``gvr_2`` kernels (both
+    compile it as a compact, 16-byte-aligned ``int32[batch, top_k]`` fake
+    tensor on the logits device): a hint that breaks it is treated as absent
+    by the checkers (so ``auto`` routes hint-free) and is dropped with a
+    RuntimeWarning by the API body. Any of these would otherwise surface as a
+    kernel-side RuntimeError or a DSL conversion error from the default path.
+    """
+    if not isinstance(pre_idx, torch.Tensor):
+        return f"not a tensor ({type(pre_idx).__name__})"
+    if logits.dim() != 2 or seq_lens.dim() != 1:
+        # the API body rejects these with a ValueError; the checkers (which
+        # run first) must not trip over them here
+        return "logits/seq_lens malformed (validated by the API body)"
+    if pre_idx.dim() != 2:
+        return f"expected a 2-D tensor, got {pre_idx.dim()}-D"
+    if pre_idx.dtype != torch.int32:
+        return f"expected int32, got {pre_idx.dtype}"
+    if not pre_idx.is_cuda or pre_idx.device != logits.device:
+        return f"expected a CUDA tensor on {logits.device}, got {pre_idx.device}"
+    expected = (seq_lens.shape[0], top_k)
+    if tuple(pre_idx.shape) != expected:
+        # run_varlen derives k from pre_idx.shape[1]; a mismatched width would
+        # silently select pre_idx.shape[1] elements instead of top_k.
+        return f"expected shape {expected} (one row per request), got {tuple(pre_idx.shape)}"
+    if not pre_idx.is_contiguous():
+        return "not contiguous"
+    if pre_idx.data_ptr() & 15:
+        return "base pointer not 16-byte aligned (shifted view)"
+    return None
 
 
 @supported_compute_capability(_GVR_CCS)
@@ -190,7 +228,11 @@ def _gvr_top_k_varlen_check(
     Used by backend="auto" routing: returning False here causes the heuristic to
     fall back to radix or radix_cutlass rather than reaching GVR and crashing.
     """
-    if not (_cute_dsl_ready(logits.device) and pre_idx is not None):
+    if not (
+        _cute_dsl_ready(logits.device)
+        and pre_idx is not None
+        and _hint_problem(pre_idx, logits, seq_lens, top_k) is None
+    ):
         return False
     # GvrParams only has entries for top_k in {512, 1024, 2048}; other values
     # raise inside the kernel's __init__ during compilation.
@@ -231,7 +273,11 @@ def _gvr2_top_k_varlen_check(
     Mirrors the TRT-LLM ``run_varlen`` hard contract so backend="auto" (and an
     explicit backend="gvr_2") never reaches a kernel-side RuntimeError.
     """
-    if not (_cute_dsl_ready(logits.device) and pre_idx is not None):
+    if not (
+        _cute_dsl_ready(logits.device)
+        and pre_idx is not None
+        and _hint_problem(pre_idx, logits, seq_lens, top_k) is None
+    ):
         return False
     # fp32 only: the upstream self-sampling kernels declare bf16/fp16 a
     # follow-up (run_varlen raises on any other dtype).
@@ -240,16 +286,16 @@ def _gvr2_top_k_varlen_check(
     # Validated K domain (matches the upstream dispatch tuning + dsa.py gate).
     if top_k not in (512, 1024, 2048):
         return False
-    if pre_idx.shape[1] != top_k:
-        # run_varlen derives k from pre_idx; a mismatched hint width would
-        # silently select pre_idx.shape[1] elements instead of top_k.
-        return False
     if compress_ratio not in (1, 4):
         return False
     # float4 row loads: row stride must be a multiple of 4 and the base
     # 16-byte aligned (fresh torch allocations always are; sliced views may
-    # not be). Wider-than-N row strides are accepted (paged arenas).
-    if logits.stride(1) != 1:
+    # not be). Wider-than-N row strides are accepted (paged arenas); rows that
+    # overlap (stride(0) < shape[1], e.g. an expand view) are not a layout the
+    # kernel can address — it derives the row pitch from stride(0).
+    if logits.dim() != 2 or logits.stride(1) != 1:
+        return False
+    if logits.shape[0] > 1 and logits.stride(0) < logits.shape[1]:
         return False
     npad = logits.stride(0) if logits.shape[0] > 1 else logits.shape[1]
     if npad % 4 != 0:
@@ -1115,7 +1161,11 @@ def _radix_top_k_varlen_check(
     load_balance=True,
     workspace=None,
 ):
-    """CuTe DSL multi-CTA radix: Blackwell-plus only, no pre_idx required."""
+    """CuTe DSL multi-CTA radix: Blackwell-plus only, no pre_idx required.
+    Overlapping row layouts (stride(0) < shape[1]) fail the kernel's stride
+    contract, so they are gated here and ``auto`` falls through."""
+    if logits.dim() == 2 and logits.shape[0] > 1 and logits.stride(0) < logits.shape[1]:
+        return False
     return _cute_dsl_ready(logits.device)
 
 
@@ -1408,7 +1458,10 @@ def top_k_varlen(
     seq_lens : torch.Tensor
         1-D ``int32`` tensor of shape ``(num_rows // next_n,)`` with the
         effective KV-cache length per request.  Logits at or beyond
-        ``seq_lens[i]`` are excluded from the search.
+        ``seq_lens[i]`` are excluded from the search. A row whose length
+        exceeds the logits width (the dynamic length has outgrown the static
+        buffer, e.g. under CUDA-graph replay) is clamped to the width by every
+        backend: only the scores present in the buffer are ranked.
     top_k : int
         Number of top elements per row.  GVR backend supports
         ``{512, 1024, 2048}``; radix backend has no restriction.
@@ -1420,7 +1473,12 @@ def top_k_varlen(
         internally applies a ``+1`` offset (DSv3.2) so the previous step's
         indices land correctly in the current step's grown KV-cache space.
         ``pre_idx[:, 0]`` must be the argmax index.
-        Required by the ``"gvr"`` backend; ignored by ``"radix_cutlass"``.
+        Required by the ``"gvr"`` and ``"gvr_2"`` backends; ignored by the
+        radix backends. Must be a contiguous, 16-byte-aligned int32 CUDA
+        tensor on ``logits.device`` of shape ``[seq_lens.shape[0], top_k]``:
+        a hint that violates this is **discarded with a RuntimeWarning** and
+        the call runs hint-free (``auto`` picks a hint-free backend; an
+        explicit ``"gvr"`` / ``"gvr_2"`` request is refused).
     compress_ratio : int, optional
         KV-index compression factor (``1`` for DSv3.2, ``4`` for DSv4).
         Default ``1``.
@@ -1430,10 +1488,15 @@ def top_k_varlen(
         When ``True`` also return the selected logit values.
         Default ``False``.
     out_indices : torch.Tensor, optional
-        Pre-allocated ``int32[num_rows, top_k]`` output buffer.
+        Pre-allocated ``int32[num_rows, top_k]`` output buffer: contiguous,
+        16-byte aligned, on ``logits.device``, of that shape or a 1-D buffer
+        of exactly ``num_rows * top_k`` elements (viewed in place and returned
+        as its ``[num_rows, top_k]`` view over the same storage, not as the
+        caller's object); a wider, taller or otherwise shaped buffer raises
+        ``ValueError``.
     out_values : torch.Tensor, optional
-        Pre-allocated values buffer (same dtype as ``logits``).
-        Only used when ``return_values=True``.
+        Pre-allocated values buffer (same dtype as ``logits``, same layout
+        rules as ``out_indices``). Only used when ``return_values=True``.
     backend : {"radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter", "auto"}, optional
         Backend to use.  Default ``"auto"``.
 
@@ -1519,16 +1582,24 @@ def top_k_varlen(
         For the ``"gvr_2"`` backend the optional key ``"gvr2_workspace"``
         (CUDA tensor of at least
         ``flashinfer.topk_varlen.kernels.gvr2_topk_host.workspace_bytes()``
-        = 20,973,568 bytes, zero-initialized before first use, 8-byte
-        aligned) overrides the per-device cached slab — needed only when
-        concurrent streams on one device may both take the multi-CTA SPLIT
-        path.
+        = 20,973,568 bytes, zero-initialized before first use, 16-byte
+        aligned) overrides the per-device cached slab.
 
         .. warning::
             Do **not** share the same workspace dict across concurrent CUDA
             streams — each stream must have its own workspace to avoid races
-            on the device tensors.  When ``workspace`` is ``None`` (default)
-            buffers are allocated locally and are safe for any concurrency.
+            on the device tensors.  For the ``"gvr"`` backend, ``workspace=None``
+            (default) allocates per call and is safe for any concurrency.
+            For ``"gvr_2"``, ``workspace=None`` resolves to **one slab per
+            device**, shared by every launch on that device: it holds the
+            cross-CTA counters, offsets and candidate buffer of the multi-CTA
+            streaming path (selected by the kernel's ``route()`` from row
+            count, envelope and ``top_k``; small batches with long rows), so
+            two such launches in flight at once — two eager streams, or two
+            CUDA graphs replayed concurrently — race on it. Every concurrently
+            active stream, and every CUDA graph that may replay concurrently
+            with another launch, must pass its own ``"gvr2_workspace"``;
+            stream-ordered use needs nothing.
 
     Returns
     -------
@@ -1540,8 +1611,19 @@ def top_k_varlen(
     Raises
     ------
     BackendSupportedError
-        If the requested backend is not supported on the current device or
-        the required inputs (e.g. ``pre_idx``) are missing.
+        If the requested backend is not supported on the current device, or
+        an explicit ``"gvr"`` / ``"gvr_2"`` request has no usable ``pre_idx``.
+    ValueError
+        If ``logits`` / ``seq_lens`` / ``next_n`` violate the shape, dtype or
+        grouping contract, an ``out_indices`` / ``out_values`` buffer is
+        outside the contract above, or an explicit backend's checker rejects
+        the problem (reported as "Problem size is not supported").
+
+    Warns
+    -----
+    RuntimeWarning
+        ``pre_idx`` was malformed and has been discarded; the call ran
+        hint-free.
 
     Examples
     --------
@@ -1574,8 +1656,20 @@ def top_k_varlen(
     --------
     flashinfer.top_k : General-purpose radix/clusters top-K (uniform lengths).
     """
-    assert logits.is_cuda and logits.dim() == 2, "logits must be a 2-D CUDA tensor"
-    assert seq_lens.is_cuda and seq_lens.dim() == 1 and seq_lens.dtype == torch.int32
+    # Real exceptions (not asserts) so every contract below also holds under
+    # `python -O`; the API body still runs under skip_check=True.
+    if not (isinstance(logits, torch.Tensor) and logits.is_cuda and logits.dim() == 2):
+        raise ValueError("logits must be a 2-D CUDA tensor")
+    if not (
+        isinstance(seq_lens, torch.Tensor)
+        and seq_lens.is_cuda
+        and seq_lens.dim() == 1
+        and seq_lens.dtype == torch.int32
+    ):
+        raise ValueError(
+            "seq_lens must be a 1-D int32 CUDA tensor"
+            + (f", got {seq_lens.dtype}" if isinstance(seq_lens, torch.Tensor) else "")
+        )
     # Grouped-row ABI, shared by every backend: row r belongs to sequence
     # r // next_n, so seq_lens must hold exactly one entry per group. Validated
     # here (not in the per-backend checkers) because a violation is a silent
@@ -1593,11 +1687,81 @@ def top_k_varlen(
             f"row // next_n -> sequence; for per-row lengths pass next_n=1 "
             f"with one seq_lens entry per row."
         )
+    num_rows = logits.shape[0]
+
+    # A malformed hint is discarded, loudly: the call runs hint-free (the
+    # checkers above already treated it as absent, so `auto` never selected a
+    # hint-consuming backend for it) instead of failing inside a kernel. An
+    # explicit backend="gvr"/"gvr_2" request with a malformed hint is refused
+    # by its checker when checks run, and by the guard after backend
+    # resolution below under skip_check=True.
+    if pre_idx is not None:
+        problem = _hint_problem(pre_idx, logits, seq_lens, top_k)
+        if problem is not None:
+            tail = (
+                "Fix the caller: with a well-formed hint auto can use the gvr_2 / "
+                "gvr paths, which are several times faster on hinted fp32 shapes."
+                if backend == "auto"
+                else f"backend={backend!r} never consumes the hint; the result is "
+                "unaffected, but fix the caller."
+            )
+            warnings.warn(
+                f"top_k_varlen: pre_idx is malformed ({problem}); the hint is "
+                f"DISCARDED and this call runs hint-free (int32[{seq_lens.shape[0]}, "
+                f"{top_k}] contiguous CUDA tensor on {logits.device} expected). {tail}",
+                RuntimeWarning,
+                stacklevel=2,  # attributed to the decorator wrapper; the text names the fix
+            )
+            pre_idx = None
+
+    # Caller-provided output buffers: every DSL backend writes a compact,
+    # 16-byte-aligned [num_rows, top_k] block. Accepted: exactly that shape,
+    # or any contiguous buffer holding exactly num_rows * top_k elements
+    # (e.g. a flat one), which is viewed to [num_rows, top_k] in place — same
+    # storage, no copy, stable CUDA-graph destination. Anything else is a
+    # contract violation here rather than a silent re-layout (the gvr_2 host
+    # used to pack a wider buffer at stride top_k) or a DSL conversion error.
+    def _check_out(name, buf, dt):
+        if not (
+            isinstance(buf, torch.Tensor)
+            and buf.is_cuda
+            and buf.device == logits.device
+        ):
+            raise ValueError(f"{name} must be a CUDA tensor on {logits.device}")
+        if buf.dtype != dt:
+            raise ValueError(f"{name} must have dtype {dt}, got {buf.dtype}")
+        if not buf.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+        if buf.data_ptr() & 15:
+            raise ValueError(f"{name} must be 16-byte aligned (not a shifted view)")
+        if tuple(buf.shape) == (num_rows, top_k):
+            return buf
+        if buf.dim() != 1 or buf.numel() != num_rows * top_k:
+            # any other 2-D shape with the right element count (e.g. the
+            # transposed shape) would be a silent re-layout: refuse it
+            raise ValueError(
+                f"{name} must have shape ({num_rows}, {top_k}) or be a 1-D buffer "
+                f"of exactly {num_rows * top_k} elements, got {tuple(buf.shape)}"
+            )
+        return buf.view(num_rows, top_k)
+
+    if out_indices is not None:
+        out_indices = _check_out("out_indices", out_indices, torch.int32)
+    if return_values and out_values is not None:
+        out_values = _check_out("out_values", out_values, logits.dtype)
 
     if backend == "auto":
         backend = top_k_varlen.suitable_auto_backends[0]
+    if pre_idx is None and backend in ("gvr", "gvr_2"):
+        # reachable under skip_check=True (the checkers did not run) with a
+        # missing or just-discarded hint: refuse here instead of handing None
+        # to a kernel host
+        raise BackendSupportedError(
+            f"backend={backend!r} requires a well-formed pre_idx hint "
+            f"(int32[{seq_lens.shape[0]}, {top_k}] contiguous CUDA tensor on "
+            f"{logits.device}); none is usable for this call"
+        )
 
-    num_rows = logits.shape[0]
     if out_indices is None:
         out_indices = torch.empty(
             (num_rows, top_k), dtype=torch.int32, device=logits.device

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -31,9 +31,9 @@ Backend choices
                        or Rubin sm_107), nvidia-cutlass-dsl, and a
                        ``pre_idx`` hint from the previous decode step.
 ``"gvr_2"``          — self-sampling GVR V2 (sample-calibrated threshold
-                       ladders; TRT-LLM PR #17821 port). Requires datacenter
-                       Blackwell (sm_100/103), nvidia-cutlass-dsl, ``pre_idx``,
-                       and fp32 logits.
+                       ladders; TRT-LLM PR #17821 port). Requires a datacentre
+                       Blackwell-class GPU (sm_100/103, or Rubin sm_107),
+                       nvidia-cutlass-dsl, ``pre_idx``, and fp32 logits.
 ``"radix_cutlass"``  — masked-radix fallback; masks logits to ``seq_lens`` then
                        calls the FlashInfer CUTLASS radix top-K.  Runs on any GPU.
 ``"radix_filter"``   — filtered-radix (coarse histogram → filter → on-chip
@@ -227,7 +227,7 @@ def _gvr2_top_k_varlen_check(
     Mirrors the TRT-LLM ``run_varlen`` hard contract so backend="auto" (and an
     explicit backend="gvr_2") never reaches a kernel-side RuntimeError.
     """
-    if not (_CUTE_DSL_AVAILABLE and pre_idx is not None):
+    if not (_cute_dsl_ready(logits.device) and pre_idx is not None):
         return False
     # fp32 only: the upstream self-sampling kernels declare bf16/fp16 a
     # follow-up (run_varlen raises on any other dtype).
@@ -1335,7 +1335,9 @@ def top_k_varlen(
     return_values: bool = False,
     out_indices: Optional[torch.Tensor] = None,
     out_values: Optional[torch.Tensor] = None,
-    backend: Literal["radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter", "auto"] = "auto",
+    backend: Literal[
+        "radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter", "auto"
+    ] = "auto",
     load_balance: bool = True,
     workspace: Optional[dict] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
@@ -1403,7 +1405,8 @@ def top_k_varlen(
         ``"gvr_2"``         — self-sampling GVR V2 (TRT-LLM PR #17821 port):
                               sample-calibrated threshold ladders, exact
                               tie-interchangeable top-K, one launch per batch.
-                              Datacenter Blackwell (sm_100/103) only; requires
+                              Datacentre Blackwell-class only (sm_100/103, or
+                              Rubin sm_107); requires
                               ``pre_idx`` (hints steer sampling, never
                               exactness) and fp32 logits;
                               ``top_k`` in {512, 1024, 2048}. ``load_balance``

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -30,6 +30,10 @@ Backend choices
                        Requires a datacentre Blackwell-class GPU (sm_100/103,
                        or Rubin sm_107), nvidia-cutlass-dsl, and a
                        ``pre_idx`` hint from the previous decode step.
+``"gvr_2"``          — self-sampling GVR V2 (sample-calibrated threshold
+                       ladders; TRT-LLM PR #17821 port). Requires datacenter
+                       Blackwell (sm_100/103), nvidia-cutlass-dsl, ``pre_idx``,
+                       and fp32 logits.
 ``"radix_cutlass"``  — masked-radix fallback; masks logits to ``seq_lens`` then
                        calls the FlashInfer CUTLASS radix top-K.  Runs on any GPU.
 ``"radix_filter"``   — filtered-radix (coarse histogram → filter → on-chip
@@ -37,7 +41,7 @@ Backend choices
                        Datacentre Blackwell-class (sm_100/103/107) only;
                        requires nvidia-cutlass-dsl >= 4.8 (see below);
                        opt-in — never chosen by ``"auto"``.
-``"auto"``           — GVR (if pre_idx provided) > radix (Blackwell) >
+``"auto"``           — GVR (if pre_idx provided) > gvr_2 > radix (Blackwell) >
                        radix_cutlass (default).
 """
 
@@ -199,6 +203,54 @@ def _gvr_top_k_varlen_check(
     return True
 
 
+@supported_compute_capability(_GVR_CCS)
+def _gvr2_top_k_varlen_check(
+    logits,
+    seq_lens,
+    top_k,
+    pre_idx=None,
+    compress_ratio=1,
+    next_n=1,
+    return_values=False,
+    out_indices=None,
+    out_values=None,
+    backend="auto",
+    load_balance=True,
+    workspace=None,
+):
+    """Return True only when the self-sampling GVR V2 port can run this config.
+
+    Mirrors the TRT-LLM ``run_varlen`` hard contract so backend="auto" (and an
+    explicit backend="gvr_2") never reaches a kernel-side RuntimeError.
+    """
+    if not (_CUTE_DSL_AVAILABLE and pre_idx is not None):
+        return False
+    # fp32 only: the upstream self-sampling kernels declare bf16/fp16 a
+    # follow-up (run_varlen raises on any other dtype).
+    if logits.dtype != torch.float32:
+        return False
+    # Validated K domain (matches the upstream dispatch tuning + dsa.py gate).
+    if top_k not in (512, 1024, 2048):
+        return False
+    if pre_idx.shape[1] != top_k:
+        # run_varlen derives k from pre_idx; a mismatched hint width would
+        # silently select pre_idx.shape[1] elements instead of top_k.
+        return False
+    if compress_ratio not in (1, 4):
+        return False
+    # float4 row loads: row stride must be a multiple of 4 and the base
+    # 16-byte aligned (fresh torch allocations always are; sliced views may
+    # not be). Wider-than-N row strides are accepted (paged arenas).
+    if logits.stride(1) != 1:
+        return False
+    npad = logits.stride(0) if logits.shape[0] > 1 else logits.shape[1]
+    if npad % 4 != 0:
+        return False
+    if logits.is_cuda and (logits.data_ptr() & 15):
+        return False
+    return True
+
+
 def _top_k_varlen_heuristic(
     suitable_backends,
     logits: torch.Tensor,
@@ -214,7 +266,11 @@ def _top_k_varlen_heuristic(
     load_balance: bool = True,
     workspace=None,
 ):
-    """GVR (needs pre_idx) > radix (CuTe DSL, Blackwell) > radix_cutlass (all GPUs).
+    """GVR (needs pre_idx) > gvr_2 > radix (CuTe DSL, Blackwell) > radix_cutlass.
+
+    gvr_2 sits behind gvr until the perf comparison between the two settles the
+    default; since gvr supports a superset of gvr_2's dtypes, auto currently
+    only reaches gvr_2 when gvr is unsuitable.
 
     The full signature must be spelled out (not **kwargs) so that the decorator can
     call this function with positional args on the skip_check=True path without
@@ -229,7 +285,9 @@ def _top_k_varlen_heuristic(
     # roughly N >= 64K with enough rows on SM100, wider on SM107); until
     # that rule exists it is explicit-only, as documented in the module
     # docstring.
-    return [b for b in ("gvr", "radix", "radix_cutlass") if b in suitable_backends]
+    return [
+        b for b in ("gvr", "gvr_2", "radix", "radix_cutlass") if b in suitable_backends
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -848,6 +906,49 @@ def _run_gvr(
 
 
 # ---------------------------------------------------------------------------
+# Internal: gvr_2 (self-sampling GVR V2) backend implementation
+# ---------------------------------------------------------------------------
+
+
+def _run_gvr2(
+    logits: torch.Tensor,
+    pre_idx: torch.Tensor,
+    seq_lens: torch.Tensor,
+    top_k: int,
+    next_n: int,
+    compress_ratio: int,
+    return_output_values: bool,
+    out_indices: torch.Tensor,
+    out_values: Optional[torch.Tensor],
+    workspace: Optional[dict] = None,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """Self-sampling GVR V2: one launch for the whole batch via the per-row
+    in-kernel varlen engine (TRT-LLM ``run_varlen`` port).
+
+    ``max_seq_len`` is derived from the logits row width (in uncompressed
+    token space, hence ``* compress_ratio``), which is capture-stable — the
+    call performs NO host reads of device data and is CUDA-graph safe once
+    the launcher for this shape has been compiled (warm up before capture).
+    The kernel reads each request's ``seq_lens`` on device and re-derives its
+    sampling ladder per row, so no LJF sort or prepare kernel is needed.
+    """
+    from .kernels import gvr2_topk_host
+
+    gvr2_topk_host.run_varlen(
+        logits,
+        pre_idx,
+        seq_lens,
+        out_indices,
+        next_n=next_n,
+        compress_ratio=compress_ratio,
+        values=out_values if return_output_values else None,
+        max_seq_len=logits.shape[1] * compress_ratio,
+        workspace=workspace.get("gvr2_workspace") if workspace else None,
+    )
+    return out_indices, (out_values if return_output_values else None)
+
+
+# ---------------------------------------------------------------------------
 # Internal: radix_cutlass (masked-radix CUTLASS) backend implementation
 # ---------------------------------------------------------------------------
 
@@ -1173,6 +1274,7 @@ def _run_radix_filter(
     {
         "radix": _radix_top_k_varlen_check,
         "gvr": _gvr_top_k_varlen_check,
+        "gvr_2": _gvr2_top_k_varlen_check,
         "radix_cutlass": _radix_cutlass_top_k_varlen_check,
         "radix_filter": _radix_filter_top_k_varlen_check,
     },
@@ -1189,7 +1291,7 @@ def top_k_varlen(
     return_values: bool = False,
     out_indices: Optional[torch.Tensor] = None,
     out_values: Optional[torch.Tensor] = None,
-    backend: Literal["radix", "gvr", "radix_cutlass", "radix_filter", "auto"] = "auto",
+    backend: Literal["radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter", "auto"] = "auto",
     load_balance: bool = True,
     workspace: Optional[dict] = None,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
@@ -1244,7 +1346,7 @@ def top_k_varlen(
     out_values : torch.Tensor, optional
         Pre-allocated values buffer (same dtype as ``logits``).
         Only used when ``return_values=True``.
-    backend : {"radix", "gvr", "radix_cutlass", "auto"}, optional
+    backend : {"radix", "gvr", "gvr_2", "radix_cutlass", "auto"}, optional
         Backend to use.  Default ``"auto"``.
 
         ``"radix"``         — CuTe DSL single-pass multi-CTA radix top-K
@@ -1254,10 +1356,19 @@ def top_k_varlen(
         ``"gvr"``           — GVR kernel (Blackwell sm_100+ only; requires
                               ``pre_idx``). ``load_balance`` selects the LB vs
                               single-CTA path.
+        ``"gvr_2"``         — self-sampling GVR V2 (TRT-LLM PR #17821 port):
+                              sample-calibrated threshold ladders, exact
+                              tie-interchangeable top-K, one launch per batch.
+                              Datacenter Blackwell (sm_100/103) only; requires
+                              ``pre_idx`` (hints steer sampling, never
+                              exactness) and fp32 logits;
+                              ``top_k`` in {512, 1024, 2048}. ``load_balance``
+                              is ignored (the kernel families load-balance
+                              internally).
         ``"radix_cutlass"`` — Masked CUTLASS radix top-K (all GPUs, no
                               ``pre_idx`` needed).
-        ``"auto"``          — GVR (if ``pre_idx`` supplied) > radix (Blackwell)
-                              > radix_cutlass.
+        ``"auto"``          — GVR (if ``pre_idx`` supplied) > gvr_2 > radix
+                              (Blackwell) > radix_cutlass.
     load_balance : bool, optional
         Selects the GVR kernel path (ignored by the radix backend).  Default
         ``True``.
@@ -1284,6 +1395,14 @@ def top_k_varlen(
         * ``"gvr_order_row"``: shape ``(M,)`` where ``M`` is the smallest
           power of 2 in ``[64, 1024]`` that is ``>= seq_lens.shape[0]``.
         * ``"gvr_counters"``: shape ``(2,)``.
+
+        For the ``"gvr_2"`` backend the optional key ``"gvr2_workspace"``
+        (CUDA tensor of at least
+        ``flashinfer.topk_varlen.kernels.gvr2_topk_host.workspace_bytes()``
+        = 20,973,568 bytes, zero-initialized before first use, 8-byte
+        aligned) overrides the per-device cached slab — needed only when
+        concurrent streams on one device may both take the multi-CTA SPLIT
+        path.
 
         .. warning::
             Do **not** share the same workspace dict across concurrent CUDA
@@ -1407,6 +1526,19 @@ def top_k_varlen(
                 out_indices,
                 out_values,
             )
+    elif backend == "gvr_2":
+        out_i, out_v = _run_gvr2(
+            logits,
+            pre_idx,
+            seq_lens,
+            top_k,
+            next_n,
+            compress_ratio,
+            return_values,
+            out_indices,
+            out_values,
+            workspace=workspace,
+        )
     elif backend == "radix_cutlass":
         out_i, out_v = _run_radix_cutlass(
             logits,
@@ -1432,7 +1564,7 @@ def top_k_varlen(
     else:
         raise ValueError(
             f"Unknown backend: {backend!r}. "
-            f"Expected 'radix', 'gvr', 'radix_cutlass', or 'radix_filter'."
+            f"Expected 'radix', 'gvr', 'gvr_2', 'radix_cutlass', or 'radix_filter'."
         )
 
     return out_i, out_v

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1458,13 +1458,10 @@ def top_k_varlen(
                               geometry with one eager call before capture
                               (an uncompiled launcher raises loudly under
                               capture); replays may change ``seq_lens``
-                              CONTENTS freely in either direction. Upstream
-                              caveat (reproduced
-                              bit-identically by the TRT-LLM implementation):
-                              literal ``+inf`` logits may not be selected;
-                              all finite values and ``-inf`` are tie-aware
-                              exact, and NaN ordering is
-                              implementation-specific.
+                              CONTENTS freely in either direction. All finite
+                              values, ``+inf`` and ``-inf`` are tie-aware
+                              exact (TRT-LLM #18501/#18625 ported); NaN
+                              ordering is implementation-specific.
         ``"radix_cutlass"`` — Masked CUTLASS radix top-K (all GPUs, no
                               ``pre_idx`` needed).
         ``"radix_filter"``  — DKG filtered-radix top-K (coarse histogram →

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -41,8 +41,12 @@ Backend choices
                        Datacentre Blackwell-class (sm_100/103/107) only;
                        requires nvidia-cutlass-dsl >= 4.8 (see below);
                        opt-in — never chosen by ``"auto"``.
-``"auto"``           — GVR (if pre_idx provided) > gvr_2 > radix (Blackwell) >
-                       radix_cutlass (default).
+``"auto"``           — shape/dtype-aware ranking that tracks the measured
+                       per-config winner (see ``_top_k_varlen_heuristic``):
+                       gvr_2 for hinted fp32; gvr only for large hinted
+                       batches of long rows; radix otherwise, with
+                       radix_cutlass preferred in its fp32 big-batch/long-row
+                       corner and as the universal fallback.
 """
 
 import functools
@@ -266,15 +270,33 @@ def _top_k_varlen_heuristic(
     load_balance: bool = True,
     workspace=None,
 ):
-    """GVR (needs pre_idx) > gvr_2 > radix (CuTe DSL, Blackwell) > radix_cutlass.
+    """Shape/dtype-aware ranking so auto tracks the measured per-config winner.
 
-    gvr_2 sits behind gvr until the perf comparison between the two settles the
-    default; since gvr supports a superset of gvr_2's dtypes, auto currently
-    only reaches gvr_2 when gvr is unsuitable.
+    Grounded in a 500+-cell B200 sweep (uniform/mixed/short lengths,
+    K in {512, 1024, 2048}, B in [1, 256], N in [1K, 128K], fp32/bf16/fp16,
+    cr in {1, 4}, next_n in {1, 2}; see PR #4811). Decision rules, using only
+    capture-stable host facts (dtype, logits width N, request count B):
+
+    1. fp32 + pre_idx: gvr_2 first — it won 211/213 measured cells (geomean
+       2.1-3.8x over every other backend) and ~1.00x vs its TRT-LLM origin.
+    2. gvr vs radix (when a hint is given but gvr_2 is unsuitable, and for
+       every bf16/fp16 hinted call): gvr only pays off when the batch is
+       large AND rows are long — B*N >= 2^22 (fp32) / 2^23 (bf16/fp16).
+       Below that radix wins by up to 2.8x; above it gvr wins by 1.03-1.76x.
+    3. radix vs radix_cutlass: the masked-CUTLASS fallback only wins the
+       fp32 big corner (N >= 65536 AND B*N >= 2^23, by up to 2.8x); radix
+       wins everywhere else, and always wins for bf16/fp16 (1.2-3.2x).
+
+    Known static blind spot: batches whose rows are mostly FAR shorter than
+    N (detectable only by reading seq_lens contents — a D2H sync auto must
+    not pay) favor radix over gvr_2 at large N; callers in that regime
+    should pass backend="radix" explicitly.
 
     The full signature must be spelled out (not **kwargs) so that the decorator can
     call this function with positional args on the skip_check=True path without
     raising TypeError.  Mirrors the pattern used by _heuristic_func_mm_fp4.
+    Tolerates logits/seq_lens=None (hardware-independent unit tests) by
+    falling back to a static order.
     """
     # "radix_filter" is deliberately absent: its checker accepts a strict
     # subset of radix's configurations and its CC list is a subset of
@@ -285,9 +307,31 @@ def _top_k_varlen_heuristic(
     # roughly N >= 64K with enough rows on SM100, wider on SM107); until
     # that rule exists it is explicit-only, as documented in the module
     # docstring.
-    return [
-        b for b in ("gvr", "gvr_2", "radix", "radix_cutlass") if b in suitable_backends
-    ]
+    if logits is None or seq_lens is None or logits.dim() != 2 or seq_lens.dim() != 1:
+        # None / malformed tensors: static fallback order. Malformed shapes
+        # must fall through so the API's own validation asserts fire (the
+        # heuristic must never be the thing that rejects bad input).
+        order = ["gvr_2", "gvr", "radix", "radix_cutlass"]
+        return [b for b in order if b in suitable_backends]
+
+    fp32 = logits.dtype == torch.float32
+    n_cols = logits.shape[1]
+    batch = seq_lens.shape[0]
+    elems = batch * n_cols
+    gvr_first = elems >= ((1 << 22) if fp32 else (1 << 23))
+    cutlass_first = fp32 and n_cols >= 65536 and elems >= (1 << 23)
+
+    order = ["gvr_2"]
+    if gvr_first:
+        order.append("gvr")
+    if cutlass_first:
+        order += ["radix_cutlass", "radix"]
+    else:
+        order += ["radix", "radix_cutlass"]
+    if "gvr" not in order:
+        # small-problem fallback rank: radix > gvr > radix_cutlass
+        order.insert(order.index("radix") + 1, "gvr")
+    return [b for b in order if b in suitable_backends]
 
 
 # ---------------------------------------------------------------------------
@@ -1364,11 +1408,24 @@ def top_k_varlen(
                               exactness) and fp32 logits;
                               ``top_k`` in {512, 1024, 2048}. ``load_balance``
                               is ignored (the kernel families load-balance
-                              internally).
+                              internally). Upstream caveat (reproduced
+                              bit-identically by the TRT-LLM implementation):
+                              literal ``+inf`` logits may not be selected;
+                              all finite values and ``-inf`` are tie-aware
+                              exact, and NaN ordering is
+                              implementation-specific.
         ``"radix_cutlass"`` — Masked CUTLASS radix top-K (all GPUs, no
                               ``pre_idx`` needed).
-        ``"auto"``          — GVR (if ``pre_idx`` supplied) > gvr_2 > radix
-                              (Blackwell) > radix_cutlass.
+        ``"auto"``          — shape/dtype-aware selection tracking the
+                              measured per-config winner: gvr_2 for hinted
+                              fp32; gvr only when ``batch * max_seq_len`` is
+                              large (>= 2^22 fp32 / 2^23 half precision);
+                              radix otherwise, with radix_cutlass preferred
+                              in its fp32 big-batch/long-row corner. Batches
+                              whose rows are mostly far shorter than
+                              ``max_seq_len`` are a known blind spot (auto
+                              cannot read ``seq_lens`` without a sync);
+                              prefer ``backend="radix"`` there.
     load_balance : bool, optional
         Selects the GVR kernel path (ignored by the radix backend).  Default
         ``True``.

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1408,7 +1408,13 @@ def top_k_varlen(
                               exactness) and fp32 logits;
                               ``top_k`` in {512, 1024, 2048}. ``load_balance``
                               is ignored (the kernel families load-balance
-                              internally). Upstream caveat (reproduced
+                              internally). CUDA graphs: warm up each
+                              (num_rows, N, top_k, next_n, compress_ratio)
+                              geometry with one eager call before capture
+                              (an uncompiled launcher raises loudly under
+                              capture); replays may change ``seq_lens``
+                              CONTENTS freely in either direction. Upstream
+                              caveat (reproduced
                               bit-identically by the TRT-LLM implementation):
                               literal ``+inf`` logits may not be selected;
                               all finite values and ``-inf`` are tie-aware

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -39,14 +39,18 @@ Backend choices
 ``"radix_filter"``   — filtered-radix (coarse histogram → filter → on-chip
                        refine); hint-free like ``"radix"``, large-N specialist.
                        Datacentre Blackwell-class (sm_100/103/107) only;
-                       requires nvidia-cutlass-dsl >= 4.8 (see below);
-                       opt-in — never chosen by ``"auto"``.
+                       requires nvidia-cutlass-dsl >= 4.8 (see below).
+                       ``"auto"`` admits it in the measured large-N regions
+                       (see ``_top_k_varlen_heuristic``); a ``pre_idx`` is
+                       accepted and ignored (the kernel takes no hint).
 ``"auto"``           — shape/dtype-aware ranking that tracks the measured
                        per-config winner (see ``_top_k_varlen_heuristic``):
-                       gvr_2 for hinted fp32; gvr only for large hinted
-                       batches of long rows; radix otherwise, with
-                       radix_cutlass preferred in its fp32 big-batch/long-row
-                       corner and as the universal fallback.
+                       gvr_2 for hinted fp32; radix_filter for hint-free
+                       fp32 from 32K columns up and for the mid/large bf16 and
+                       fp16 regions; gvr only for large hinted batches of
+                       mid/long rows; radix otherwise, with radix_cutlass
+                       preferred in its fp32 big-batch/long-row corner and as
+                       the universal fallback.
 """
 
 import functools
@@ -287,6 +291,27 @@ def _top_k_varlen_heuristic(
        fp32 big corner (N >= 65536 AND B*N >= 2^23, by up to 2.8x); radix
        wins everywhere else, and always wins for bf16/fp16 (1.2-3.2x).
 
+    Refined by the auto-vs-oracle study (B100/B200 and Rubin; N 8K..1M,
+    K in {1024, 2048}, fp32/bf16, hinted and hint-free, uniform/mixed/short
+    lengths, CUDA-graph timing; PR #4811, section 7), which measured auto's
+    efficiency = best-of-all / auto per cell:
+
+    4. radix_filter is admitted ahead of radix/radix_cutlass where it was the
+       fastest hint-free backend on SM100 (hint-free fp32 efficiency
+       0.83 -> ~0.98, bf16 0.86 -> ~0.97):
+         fp32: N >= 32K, except the single-row case at N >= 512K (radix
+               wins there); and every N once B >= 256;
+         half: 32K <= N <= 128K for B <= 16; N >= 128K for B >= 64;
+               N <= 8K for B >= 256.
+       One rule for every arch: radix_filter's margins are larger on SM107,
+       so the SM100 crossover is conservative there.
+    5. gvr (V1) for half precision only when B >= 256 and 32K <= N <= 512K
+       (it beats radix/radix_filter there by 1.1-1.4x); the previous
+       B*N >= 2^23 rule picked it at B <= 64 for N >= 512K, where it loses
+       1.5-7x to radix. The fp32 gvr rule (B*N >= 2^22) is unchanged and
+       only matters when gvr_2 is unsuitable; radix_filter ranks ahead of
+       gvr there (1.2-3x faster in fp32).
+
     Known static blind spot: batches whose rows are mostly FAR shorter than
     N (detectable only by reading seq_lens contents — a D2H sync auto must
     not pay) favor radix over gvr_2 at large N; callers in that regime
@@ -298,19 +323,11 @@ def _top_k_varlen_heuristic(
     Tolerates logits/seq_lens=None (hardware-independent unit tests) by
     falling back to a static order.
     """
-    # "radix_filter" is deliberately absent: its checker accepts a strict
-    # subset of radix's configurations and its CC list is a subset of
-    # radix's, so listed after radix it could never be chosen (a dead
-    # entry), and listed before radix it would regress the small-row and
-    # small-batch regions where radix wins. Making it auto-selectable needs
-    # a shape/architecture-aware crossover rule (it wins at large N --
-    # roughly N >= 64K with enough rows on SM100, wider on SM107); until
-    # that rule exists it is explicit-only, as documented in the module
-    # docstring.
     if logits is None or seq_lens is None or logits.dim() != 2 or seq_lens.dim() != 1:
-        # None / malformed tensors: static fallback order. Malformed shapes
-        # must fall through so the API's own validation asserts fire (the
-        # heuristic must never be the thing that rejects bad input).
+        # None / malformed tensors: static fallback order (no shape to justify
+        # radix_filter, so it stays out). Malformed shapes must fall through
+        # so the API's own validation asserts fire (the heuristic must never
+        # be the thing that rejects bad input).
         order = ["gvr_2", "gvr", "radix", "radix_cutlass"]
         return [b for b in order if b in suitable_backends]
 
@@ -318,12 +335,31 @@ def _top_k_varlen_heuristic(
     n_cols = logits.shape[1]
     batch = seq_lens.shape[0]
     elems = batch * n_cols
-    gvr_first = elems >= ((1 << 22) if fp32 else (1 << 23))
+    if fp32:
+        rf_first = batch >= 256 or (n_cols >= 32768 and (batch > 1 or n_cols <= 131072))
+        gvr_first = elems >= (1 << 22)
+    else:
+        rf_first = (
+            (batch <= 16 and 32768 <= n_cols <= 131072)
+            or (batch >= 64 and n_cols >= 131072)
+            or (batch >= 256 and n_cols <= 8192)
+        )
+        gvr_first = batch >= 256 and 32768 <= n_cols <= 524288
     cutlass_first = fp32 and n_cols >= 65536 and elems >= (1 << 23)
 
     order = ["gvr_2"]
-    if gvr_first:
-        order.append("gvr")
+    if fp32:
+        # radix_filter beats gvr in every measured fp32 cell (1.2-3x)
+        if rf_first:
+            order.append("radix_filter")
+        if gvr_first:
+            order.append("gvr")
+    else:
+        # in its half-precision window gvr edges radix_filter (B=256, 32K-512K)
+        if gvr_first:
+            order.append("gvr")
+        if rf_first:
+            order.append("radix_filter")
     if cutlass_first:
         order += ["radix_cutlass", "radix"]
     else:
@@ -1216,17 +1252,18 @@ def _radix_filter_top_k_varlen_check(
 ):
     """Return True only when the vendored DKG kernel covers this configuration.
 
-    Upstream's decode wrapper has no ``compress_ratio`` and no ``pre_idx``
-    parameter at all, so those are hard exclusions rather than tuning knobs --
-    returning False here makes an explicit ``backend="radix_filter"`` call fail
-    at backend validation instead of silently ignoring the argument or failing
-    deep inside the kernel constructor.
+    Upstream's decode wrapper has no ``compress_ratio`` parameter, so that is
+    a hard exclusion rather than a tuning knob -- returning False here makes
+    an explicit ``backend="radix_filter"`` call fail at backend validation
+    instead of failing deep inside the kernel constructor. A ``pre_idx`` is
+    accepted and ignored, exactly as ``radix`` and ``radix_cutlass`` treat it:
+    the hint is optional steering for the GVR family, never a correctness
+    input, so a hinted caller can use (or be routed by ``auto`` to) any
+    hint-free backend.
     """
     if not _cute_dsl_ready(logits.device):
         return False
     if not _radix_filter_kernel_dsl_ok():
-        return False
-    if pre_idx is not None:
         return False
     # Vendored kernel bound: FilteredTopKKernelVarlen rejects top_k outside
     # [1, 16384]; enforce it here so the failure is a backend-validation error.
@@ -1348,10 +1385,15 @@ def top_k_varlen(
 
     Backend selection
     -----------------
-    ``backend="auto"`` (default) chooses GVR when available (Blackwell +
-    ``pre_idx`` supplied), else the CuTe DSL ``radix`` backend on Blackwell,
-    else the ``radix_cutlass`` masked fallback.  Force a specific backend with
-    ``backend="radix"``, ``backend="gvr"``, or ``backend="radix_cutlass"``.
+    ``backend="auto"`` (default) ranks the backends that can run the call by
+    shape and dtype (see ``_top_k_varlen_heuristic``): ``gvr_2`` for hinted
+    fp32 on datacentre Blackwell-class GPUs, ``radix_filter`` in the
+    measured large-N regions, ``gvr`` for large hinted half-precision
+    batches of mid-length rows, otherwise the CuTe DSL ``radix`` backend on
+    Blackwell, with the ``radix_cutlass`` masked fallback in its fp32 big
+    corner and on every other GPU.  Force a specific backend with
+    ``backend="radix"``, ``"gvr"``, ``"gvr_2"``, ``"radix_filter"`` or
+    ``"radix_cutlass"``.
 
     Parameters
     ----------
@@ -1392,7 +1434,7 @@ def top_k_varlen(
     out_values : torch.Tensor, optional
         Pre-allocated values buffer (same dtype as ``logits``).
         Only used when ``return_values=True``.
-    backend : {"radix", "gvr", "gvr_2", "radix_cutlass", "auto"}, optional
+    backend : {"radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter", "auto"}, optional
         Backend to use.  Default ``"auto"``.
 
         ``"radix"``         — CuTe DSL single-pass multi-CTA radix top-K
@@ -1425,16 +1467,31 @@ def top_k_varlen(
                               implementation-specific.
         ``"radix_cutlass"`` — Masked CUTLASS radix top-K (all GPUs, no
                               ``pre_idx`` needed).
+        ``"radix_filter"``  — DKG filtered-radix top-K (coarse histogram →
+                              filter → on-chip refine): hint-free like
+                              ``"radix"``, fp32/fp16/bf16, ``top_k`` in
+                              [1, 16384], ``compress_ratio == 1`` only,
+                              row-relative indices only (no fused page-table
+                              transform, nondeterministic ties). Datacentre
+                              Blackwell-class (sm_100/103/107); requires
+                              nvidia-cutlass-dsl >= 4.8. ``pre_idx`` is
+                              accepted and ignored (the kernel takes no
+                              hint), as for ``"radix"`` and
+                              ``"radix_cutlass"``.
         ``"auto"``          — shape/dtype-aware selection tracking the
                               measured per-config winner: gvr_2 for hinted
-                              fp32; gvr only when ``batch * max_seq_len`` is
-                              large (>= 2^22 fp32 / 2^23 half precision);
-                              radix otherwise, with radix_cutlass preferred
-                              in its fp32 big-batch/long-row corner. Batches
-                              whose rows are mostly far shorter than
-                              ``max_seq_len`` are a known blind spot (auto
-                              cannot read ``seq_lens`` without a sync);
-                              prefer ``backend="radix"`` there.
+                              fp32; radix_filter for hint-free fp32 from 32K
+                              columns up (all N once ``batch >= 256``) and
+                              for the bf16/fp16 mid/large regions; gvr for
+                              fp32 when ``batch * max_seq_len >= 2^22`` and
+                              for half precision only when ``batch >= 256``
+                              with 32K-512K columns; radix otherwise, with
+                              radix_cutlass preferred in its fp32
+                              big-batch/long-row corner. Batches whose rows
+                              are mostly far shorter than ``max_seq_len`` are
+                              a known blind spot (auto cannot read
+                              ``seq_lens`` without a sync); prefer
+                              ``backend="radix"`` there.
     load_balance : bool, optional
         Selects the GVR kernel path (ignored by the radix backend).  Default
         ``True``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,6 +131,9 @@ exclude = [
   # and they differ in length).
   "flashinfer/topk_varlen/kernels/filtered_topk_util.py",
   "flashinfer/topk_varlen/kernels/filtered_topk_decode.py",
+  # Self-sampling GVR V2: verbatim TRT-LLM drops (see the ruff exclude note).
+  "flashinfer/topk_varlen/kernels/gvr2_topk_decode.py",
+  "flashinfer/topk_varlen/kernels/gvr2_topk_host.py",
   "build/",
 ]
 
@@ -153,6 +156,8 @@ extend-exclude = [
   "flashinfer/moe_ep/kernel_src/cutedsl_megamoe/src",
   "flashinfer/topk_varlen/kernels/gvr_topk_decode.py",
   "flashinfer/topk_varlen/kernels/gvr_topk_decode_lb.py",
+  "flashinfer/topk_varlen/kernels/gvr2_topk_decode.py",
+  "flashinfer/topk_varlen/kernels/gvr2_topk_host.py",
   "flashinfer/topk_varlen/kernels/block_scan.py",
   "flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src",
   "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py",

--- a/tests/topk_varlen/test_gvr_threshold_repair.py
+++ b/tests/topk_varlen/test_gvr_threshold_repair.py
@@ -127,6 +127,65 @@ def test_gvr_hostile_hint(top_k, hint, load_balance):
     _assert_exact_topk(indices, logits, seq_lens, top_k, compress_ratio=cr)
 
 
+def _run_gvr_filled(logits, seq_lens, top_k, load_balance):
+    """Run gvr into a -7-filled buffer and check every slot was written with a
+    unique in-range index (the only contract an all-tie row can have)."""
+    rows, n = logits.shape
+    gen = torch.Generator(device=_DEV).manual_seed(rows * n + top_k)
+    hint = torch.randint(
+        0, n, (rows, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    out = torch.full((rows, top_k), -7, dtype=torch.int32, device=_DEV)
+    flashinfer.top_k_varlen(
+        logits,
+        seq_lens,
+        top_k,
+        pre_idx=hint,
+        out_indices=out,
+        backend="gvr",
+        load_balance=load_balance,
+    )
+    torch.cuda.synchronize()
+    assert int((out == -7).sum()) == 0, "unwritten output slots"
+    assert bool(((out >= 0) & (out < n)).all()), "index out of range"
+    for r in range(rows):
+        assert int(torch.unique(out[r]).numel()) == top_k, f"row {r}: duplicate indices"
+    return out
+
+
+@requires_gvr
+@pytest.mark.parametrize("load_balance", [True, False])
+def test_gvr_rows_below_neg_flt_max(load_balance):
+    """Rows with fewer than K values above -FLT_MAX (all -inf, or a few finite
+    values followed by a -inf tail) used to come back with unwritten slots:
+    the two-sided repair anchored the lower bracket end at -FLT_MAX, so
+    count(>= val_lo) < K contradicted the collapse invariant and the plateau
+    fill never ran. The anchor is now -inf. Any K unique in-range indices are
+    a valid answer for an all-tie row; every finite value must be selected in
+    the partial row."""
+    for rows, n, k in [(1, 8192, 1024), (4, 8192, 512), (2, 32768, 1024)]:
+        logits = torch.full((rows, n), float("-inf"), device=_DEV)
+        seq_lens = torch.full((rows,), n, dtype=torch.int32, device=_DEV)
+        _run_gvr_filled(logits, seq_lens, k, load_balance)
+    # one all -inf row inside a normal batch: the other rows stay exact
+    rows, n, k = 4, 8192, 1024
+    torch.manual_seed(5)
+    logits = torch.randn(rows, n, device=_DEV)
+    logits[2] = float("-inf")
+    seq_lens = torch.full((rows,), n, dtype=torch.int32, device=_DEV)
+    out = _run_gvr_filled(logits, seq_lens, k, load_balance)
+    for r in (0, 1, 3):
+        got = torch.sort(logits[r][out[r].long()], descending=True).values
+        ref = torch.sort(torch.topk(logits[r], k).values, descending=True).values
+        assert torch.equal(got, ref), f"row {r}: inexact"
+    # 10 finite values + -inf tail, N > K: the 10 must all be selected
+    logits = torch.full((1, n), float("-inf"), device=_DEV)
+    logits[0, :10] = torch.arange(10, device=_DEV).float()
+    seq_lens = torch.full((1,), n, dtype=torch.int32, device=_DEV)
+    out = _run_gvr_filled(logits, seq_lens, k, load_balance)
+    assert set(range(10)) <= set(out[0].tolist()), "finite values dropped"
+
+
 @requires_gvr
 @pytest.mark.parametrize("n_pos", [3, 100, 1000])
 def test_gvr_relu_sparse_plateau(n_pos):

--- a/tests/topk_varlen/test_gvr_threshold_repair.py
+++ b/tests/topk_varlen/test_gvr_threshold_repair.py
@@ -1,0 +1,211 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GVR (V1) non-converged threshold-search repair regressions.
+
+Port of TRT-LLM PR #18094's regression suite (plus the FlashInfer-found
+short-row case) onto ``top_k_varlen(backend="gvr")``. Before the repair,
+these inputs made the Phase-2/3 threshold search terminate without a
+threshold whose count lands in ``[K, kC]``, and the kernel then shipped a
+silently wrong top-K: identity indices ``row[0:K]`` (degenerate hints),
+or an underfilled row whose untouched output slots keep stale/-1 garbage
+(hostile hints, tie plateaus wider than kC, rows with ``N_eff = K + 1``).
+
+The correctness contract checked here is tie-interchangeable EXACT top-K:
+unique in-range indices whose gathered-value multiset bitwise-equals the
+``torch.topk`` value multiset.
+"""
+
+import pytest
+import torch
+
+try:
+    import flashinfer
+    from flashinfer.utils import get_compute_capability
+
+    _FLASHINFER_AVAILABLE = True
+except ImportError:
+    _FLASHINFER_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _FLASHINFER_AVAILABLE, reason="flashinfer not importable"
+)
+
+
+def _cute_dsl_available() -> bool:
+    import importlib.util
+
+    return (
+        importlib.util.find_spec("cutlass") is not None
+        and importlib.util.find_spec("cutlass.cute") is not None
+    )
+
+
+def _gvr_hw_supported() -> bool:
+    if not (_FLASHINFER_AVAILABLE and torch.cuda.is_available()):
+        return False
+    major, minor = get_compute_capability(torch.device("cuda"))
+    return (
+        flashinfer.top_k_varlen.is_backend_supported("gvr", major * 10 + minor)
+        and _cute_dsl_available()
+    )
+
+
+requires_gvr = pytest.mark.skipif(
+    not _gvr_hw_supported(),
+    reason="gvr requires Blackwell (sm_100/103) + nvidia-cutlass-dsl",
+)
+
+_DEV = "cuda"
+
+
+def _assert_exact_topk(indices, logits, seq_lens, top_k, next_n=1, compress_ratio=1):
+    """Per-row tie-aware exactness for rows with N_eff > top_k."""
+    sl = seq_lens.cpu().tolist()
+    for r in range(indices.shape[0]):
+        n_eff = min(
+            (sl[r // next_n] - next_n + (r % next_n) + 1) // compress_ratio,
+            logits.shape[1],
+        )
+        assert n_eff > top_k, "test rows must be non-degenerate"
+        idx = indices[r].to(torch.int64)
+        assert int(idx.min()) >= 0, f"row {r}: negative index (underfilled row)"
+        assert int(idx.max()) < n_eff, f"row {r}: index past N_eff"
+        assert int(torch.unique(idx).numel()) == top_k, f"row {r}: duplicate indices"
+        got = torch.sort(logits[r].float().gather(0, idx) + 0.0, descending=True).values
+        ref = torch.sort(
+            torch.topk(logits[r, :n_eff].float(), top_k).values + 0.0,
+            descending=True,
+        ).values
+        assert torch.equal(got, ref), f"row {r}: top-K value multiset mismatch"
+
+
+def _make_hint(kind, flat_row, n_idx_space, top_k):
+    """Hint tensors in COMPRESSED index space [0, n_idx_space)."""
+    if kind == "bottom_k":
+        # bracket entirely below the answer
+        return torch.topk(flat_row, top_k, largest=False).indices.int()
+    if kind == "uniform":
+        # all-identical hint -> degenerate bracket (the old row[0:K] emit)
+        return torch.full((top_k,), n_idx_space // 2, dtype=torch.int32, device=_DEV)
+    if kind == "random":
+        return torch.randint(0, n_idx_space, (top_k,), dtype=torch.int32, device=_DEV)
+    raise ValueError(kind)
+
+
+@requires_gvr
+@pytest.mark.parametrize("top_k", [512, 1024, 2048])
+@pytest.mark.parametrize("hint", ["bottom_k", "uniform", "random"])
+@pytest.mark.parametrize("load_balance", [True, False])
+def test_gvr_hostile_hint(top_k, hint, load_balance):
+    """Hints that don't straddle the true K-th value must not affect
+    exactness (they may only slow the search)."""
+    N, cr = 65536, 4
+    torch.manual_seed(1234)
+    logits = torch.randn(1, N, dtype=torch.float32, device=_DEV)
+    pre_idx = _make_hint(hint, logits[0], N, top_k).unsqueeze(0)
+    seq_lens = torch.full((1,), N * cr, dtype=torch.int32, device=_DEV)
+    indices, _ = flashinfer.top_k_varlen(
+        logits,
+        seq_lens,
+        top_k,
+        pre_idx=pre_idx,
+        compress_ratio=cr,
+        backend="gvr",
+        load_balance=load_balance,
+    )
+    _assert_exact_topk(indices, logits, seq_lens, top_k, compress_ratio=cr)
+
+
+@requires_gvr
+@pytest.mark.parametrize("n_pos", [3, 100, 1000])
+def test_gvr_relu_sparse_plateau(n_pos):
+    """ReLU-sparse rows: n_pos < K positives over an exact-0.0 plateau wider
+    than the candidate buffer. No threshold has count in [K, kC]; the old
+    fail-soft returned (top_k - n_pos) trailing -1 slots."""
+    top_k, N = 2048, 32768
+    torch.manual_seed(61)
+    row = torch.zeros(N, dtype=torch.float32, device=_DEV)
+    pos = torch.randperm(N, device=_DEV)[:n_pos]
+    row[pos] = torch.rand(n_pos, device=_DEV) + 1.0
+    logits = row.unsqueeze(0)
+    pre_idx = torch.topk(row, top_k).indices.int().unsqueeze(0)
+    seq_lens = torch.full((1,), N, dtype=torch.int32, device=_DEV)
+    indices, _ = flashinfer.top_k_varlen(
+        logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr"
+    )
+    _assert_exact_topk(indices, logits, seq_lens, top_k)
+
+
+@requires_gvr
+@pytest.mark.parametrize("next_n", [2, 4])
+@pytest.mark.parametrize("hint", ["bottom_k", "uniform"])
+def test_gvr_mtp_hostile_hint(next_n, hint):
+    """MTP geometry (per-row N_eff arithmetic) with the repair firing on
+    every row; per-request kv_len differs by one token to exercise the
+    mod-cr boundary."""
+    top_k, N, cr, n_req = 512, 65536, 4, 2
+    torch.manual_seed(7)
+    num_rows = n_req * next_n
+    logits = torch.randn(num_rows, N, dtype=torch.float32, device=_DEV)
+    hint_row = _make_hint(hint, logits[0], N, top_k)
+    pre_idx = hint_row.unsqueeze(0).expand(n_req, top_k).contiguous()
+    seq_lens = torch.tensor([N * cr, N * cr - 1], dtype=torch.int32, device=_DEV)
+    indices, _ = flashinfer.top_k_varlen(
+        logits,
+        seq_lens,
+        top_k,
+        pre_idx=pre_idx,
+        next_n=next_n,
+        compress_ratio=cr,
+        backend="gvr",
+    )
+    _assert_exact_topk(
+        indices, logits, seq_lens, top_k, next_n=next_n, compress_ratio=cr
+    )
+
+
+@requires_gvr
+@pytest.mark.parametrize("batch", [16, 64, 256])
+@pytest.mark.parametrize("load_balance", [True, False])
+def test_gvr_neff_kplus1_rows(batch, load_balance):
+    """FlashInfer-found case: batches where most rows have N_eff = K + 1
+    (the acceptance window is a knife-edge) shipped out-of-range indices.
+    Mirrors the failing sweep config (short scenario, N=8192, K=1024)."""
+    N, top_k = 8192, 1024
+    seed = batch * 7 + N // 64
+    gen = torch.Generator(device=_DEV).manual_seed(seed)
+    logits = torch.randn(batch, N, generator=gen, device=_DEV, dtype=torch.float32)
+    seq_lens = torch.randint(
+        top_k + 1, max(N // 8, top_k + 2), (batch,), generator=gen, device=_DEV
+    ).int()
+    seq_lens[: max(batch // 4, 1)] = N
+    pre_idx = torch.zeros(batch, top_k, dtype=torch.int32, device=_DEV)
+    sl = seq_lens.cpu().tolist()
+    for b in range(batch):
+        n0 = min(sl[b], N)
+        true_top = torch.topk(logits[b, :n0], min(top_k, n0)).indices.int()
+        pre_idx[b] = torch.randint(
+            0, n0, (top_k,), generator=gen, device=_DEV, dtype=torch.int32
+        )
+        n_hit = int(min(top_k, n0) * 0.6)
+        pre_idx[b, :n_hit] = true_top[:n_hit]
+    indices, _ = flashinfer.top_k_varlen(
+        logits,
+        seq_lens,
+        top_k,
+        pre_idx=pre_idx,
+        backend="gvr",
+        load_balance=load_balance,
+    )
+    _assert_exact_topk(indices, logits, seq_lens, top_k)

--- a/tests/topk_varlen/test_radix_filter.py
+++ b/tests/topk_varlen/test_radix_filter.py
@@ -384,17 +384,17 @@ def test_out_buffers_written_in_place():
         assert bool((logits[b][sel.long()] >= kth - 1e-4).all())
 
 
-def test_checker_rejects_pre_idx_and_oob_top_k():
-    """Explicit radix_filter calls must fail backend validation, not deeper.
+def test_checker_ignores_pre_idx_and_rejects_oob_top_k():
+    """pre_idx is optional steering for the GVR family, so a hinted caller may
+    use radix_filter (explicitly or via auto) exactly like radix and
+    radix_cutlass: the hint is accepted and ignored and the result stays
+    exact. The vendored kernel only supports top_k in [1, 16384]; an oversized
+    top_k must fail at backend validation (message-matched to the
+    @backend_requirement rejection), not as the kernel constructor's
+    ValueError deep inside the launch.
 
-    The checker docstring advertises pre_idx as a hard exclusion and the
-    vendored kernel only supports top_k in [1, 16384], but neither was
-    enforced: a non-None pre_idx was silently ignored (the kernel ran without
-    the hint) and an oversized top_k surfaced as the kernel constructor's
-    ValueError instead of a backend-validation error. Message-matched to the
-    @backend_requirement rejection so the pre-fix behaviors cannot pass.
-
-    Regression for PR #4621 review round 2 (checker constraints).
+    Regression for PR #4621 review round 2 (top_k bound) and PR #4811
+    (hinted callers may pick hint-free backends).
     """
     device = torch.device("cuda")
     _skip_unless_radix_filter(device)
@@ -403,11 +403,16 @@ def test_checker_rejects_pre_idx_and_oob_top_k():
     logits = torch.randn(8, 32768, dtype=torch.float32, device=device)
     seq_lens = torch.full((8,), 32768, dtype=torch.int32, device=device)
 
-    pre = torch.zeros(8, 4096, dtype=torch.int32, device=device)
-    with pytest.raises(ValueError, match=r"Problem size is not supported"):
-        flashinfer.top_k_varlen(
-            logits, seq_lens, 1024, pre_idx=pre, backend="radix_filter"
-        )
+    pre = torch.zeros(8, 1024, dtype=torch.int32, device=device)
+    idx, _ = flashinfer.top_k_varlen(
+        logits, seq_lens, 1024, pre_idx=pre, backend="radix_filter"
+    )
+    torch.cuda.synchronize()
+    got = torch.sort(logits.gather(1, idx.long()), dim=1, descending=True).values
+    ref = torch.sort(
+        torch.topk(logits, 1024, dim=1).values, dim=1, descending=True
+    ).values
+    assert torch.equal(got, ref), "hinted radix_filter call must stay exact"
     with pytest.raises(ValueError, match=r"Problem size is not supported"):
         flashinfer.top_k_varlen(logits, seq_lens, 16385, backend="radix_filter")
 

--- a/tests/topk_varlen/test_topk_varlen.py
+++ b/tests/topk_varlen/test_topk_varlen.py
@@ -1259,6 +1259,64 @@ def test_backend_heuristic_priority():
         "radix",
     ]
     assert order(["radix_cutlass"], torch.float32, 1, 4096) == ["radix_cutlass"]
+
+    # radix_filter admission (auto-vs-oracle study, PR #4811): hint-free fp32
+    # from 32K columns up, except the single-row case at >= 512K, and at every
+    # N once B >= 256 (ahead of the fp32 radix_cutlass corner).
+    hf = ["radix_cutlass", "radix", "radix_filter"]
+    assert order(hf, torch.float32, 16, 32768) == [
+        "radix_filter",
+        "radix",
+        "radix_cutlass",
+    ]
+    assert order(hf, torch.float32, 16, 8192) == ["radix", "radix_cutlass"]
+    assert order(hf, torch.float32, 1, 65536) == [
+        "radix_filter",
+        "radix",
+        "radix_cutlass",
+    ]
+    assert order(hf, torch.float32, 1, 524288) == ["radix", "radix_cutlass"]
+    assert order(hf, torch.float32, 256, 8192) == [
+        "radix_filter",
+        "radix",
+        "radix_cutlass",
+    ]
+    assert order(hf, torch.float32, 256, 131072) == [
+        "radix_filter",
+        "radix_cutlass",
+        "radix",
+    ]
+    # fp32 with a hint but gvr_2 unsuitable: radix_filter ranks ahead of gvr.
+    assert order(hf + ["gvr"], torch.float32, 64, 131072)[:2] == ["radix_filter", "gvr"]
+    # half precision: gvr only for B >= 256 with 32K-512K columns (the old
+    # B*N >= 2^23 rule picked it at B=16 x 2M, a 7x loss to radix); radix_filter
+    # in the mid band for small batches and from 128K up for B >= 64.
+    hh = ["gvr", "radix", "radix_cutlass", "radix_filter"]
+    assert order(hh, torch.bfloat16, 16, 2097152) == ["radix", "gvr", "radix_cutlass"]
+    assert order(hh, torch.bfloat16, 256, 131072) == [
+        "gvr",
+        "radix_filter",
+        "radix",
+        "radix_cutlass",
+    ]
+    assert order(hh, torch.bfloat16, 256, 32768) == ["gvr", "radix", "radix_cutlass"]
+    assert order(hh, torch.bfloat16, 64, 524288) == [
+        "radix_filter",
+        "radix",
+        "gvr",
+        "radix_cutlass",
+    ]
+    assert order(hf, torch.float16, 16, 65536) == [
+        "radix_filter",
+        "radix",
+        "radix_cutlass",
+    ]
+    assert order(hf, torch.bfloat16, 64, 8192) == ["radix", "radix_cutlass"]
+    assert order(hf, torch.bfloat16, 256, 8192) == [
+        "radix_filter",
+        "radix",
+        "radix_cutlass",
+    ]
     # None tensors (skip_check / doc examples): static fallback order.
     assert _top_k_varlen_heuristic(all4, None, None, None) == [
         "gvr_2",

--- a/tests/topk_varlen/test_topk_varlen.py
+++ b/tests/topk_varlen/test_topk_varlen.py
@@ -1009,6 +1009,7 @@ def test_radix_preallocated_outputs(return_values):
         ("radix_cutlass", None),
         ("gvr", True),
         ("gvr", False),
+        ("gvr_2", None),
     ],
 )
 def test_out_values_ignored_when_return_values_false(backend, load_balance):
@@ -1017,9 +1018,11 @@ def test_out_values_ignored_when_return_values_false(backend, load_balance):
     _compile_radix specialises the kernel on return_output_values: when False the
     compiled signature has None for the values slot.  Passing a real tensor there
     (without the 'out_values if return_output_values else None' guard) causes a
-    type mismatch.  Covers all three backends plus both GVR load-balance paths.
+    type mismatch.  Covers all backends plus both GVR load-balance paths.
     """
-    dtype, top_k, N, batch_size = torch.bfloat16, 512, 8192, 4
+    # gvr_2 is fp32-only; the other backends keep the original bf16 coverage.
+    dtype = torch.float32 if backend == "gvr_2" else torch.bfloat16
+    top_k, N, batch_size = 512, 8192, 4
     logits, pre_idx, seq_lens = _make_inputs(batch_size, N, top_k, dtype, seed=99)
     # Pre-allocate a values buffer but deliberately do NOT set return_values=True.
     out_v = torch.full((batch_size, top_k), float("nan"), dtype=dtype, device="cuda")
@@ -1028,6 +1031,8 @@ def test_out_values_ignored_when_return_values_false(backend, load_balance):
     if backend == "gvr":
         kwargs["pre_idx"] = pre_idx
         kwargs["load_balance"] = load_balance
+    elif backend == "gvr_2":
+        kwargs["pre_idx"] = pre_idx
 
     ret_i, ret_v = flashinfer.top_k_varlen(logits, seq_lens, top_k, **kwargs)
     torch.cuda.synchronize()
@@ -1194,7 +1199,7 @@ def test_cuda_graph_gvr(load_balance):
 
 
 def test_backend_heuristic_priority():
-    """Auto-selection priority is gvr > radix (CuTe DSL) > radix_cutlass.
+    """Auto-selection priority is gvr > gvr_2 > radix (CuTe DSL) > radix_cutlass.
 
     Hardware-independent: exercises the heuristic directly so a regression in
     the backend ordering (e.g. from a future rename) is caught even off-GPU.
@@ -1207,11 +1212,18 @@ def test_backend_heuristic_priority():
     assert (
         _top_k_varlen_heuristic(["gvr", "radix", "radix_cutlass"], *dummy)[0] == "gvr"
     )
+    assert (
+        _top_k_varlen_heuristic(["gvr_2", "radix", "radix_cutlass"], *dummy)[0]
+        == "gvr_2"
+    )
     assert _top_k_varlen_heuristic(["radix", "radix_cutlass"], *dummy)[0] == "radix"
     assert _top_k_varlen_heuristic(["radix_cutlass"], *dummy)[0] == "radix_cutlass"
     # order is preserved regardless of the suitable-set ordering
-    assert _top_k_varlen_heuristic(["radix_cutlass", "radix", "gvr"], *dummy) == [
+    assert _top_k_varlen_heuristic(
+        ["radix_cutlass", "radix", "gvr_2", "gvr"], *dummy
+    ) == [
         "gvr",
+        "gvr_2",
         "radix",
         "radix_cutlass",
     ]
@@ -1219,7 +1231,7 @@ def test_backend_heuristic_priority():
 
 @requires_blackwell
 def test_cross_backend_value_consistency():
-    """radix, radix_cutlass, and gvr select the same top-K *value* multiset.
+    """radix, radix_cutlass, gvr, and gvr_2 select the same top-K *value* multiset.
 
     Compares sorted selected values (not indices) so ties don't cause spurious
     failures. fp32 keeps ties rare; any real divergence between backends fails.
@@ -1231,17 +1243,24 @@ def test_cross_backend_value_consistency():
     idx_g, _ = flashinfer.top_k_varlen(
         logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr"
     )
+    idx_g2, _ = flashinfer.top_k_varlen(
+        logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr_2"
+    )
     torch.cuda.synchronize()
     lf = logits.float()
     for row in range(batch_size):
         vr = lf[row][idx_r[row].long()].sort(descending=True).values
         vc = lf[row][idx_c[row].long()].sort(descending=True).values
         vg = lf[row][idx_g[row].long()].sort(descending=True).values
+        vg2 = lf[row][idx_g2[row].long()].sort(descending=True).values
         assert torch.allclose(vr, vc, rtol=1e-4, atol=1e-4), (
             f"row={row}: radix vs radix_cutlass value multisets differ"
         )
         assert torch.allclose(vr, vg, rtol=1e-4, atol=1e-4), (
             f"row={row}: radix vs gvr value multisets differ"
+        )
+        assert torch.allclose(vr, vg2, rtol=1e-4, atol=1e-4), (
+            f"row={row}: radix vs gvr_2 value multisets differ"
         )
 
 

--- a/tests/topk_varlen/test_topk_varlen.py
+++ b/tests/topk_varlen/test_topk_varlen.py
@@ -1199,31 +1199,70 @@ def test_cuda_graph_gvr(load_balance):
 
 
 def test_backend_heuristic_priority():
-    """Auto-selection priority is gvr > gvr_2 > radix (CuTe DSL) > radix_cutlass.
+    """Auto-selection is shape/dtype-aware and tracks the measured winners.
 
-    Hardware-independent: exercises the heuristic directly so a regression in
-    the backend ordering (e.g. from a future rename) is caught even off-GPU.
+    Hardware-independent: exercises the heuristic directly with meta tensors
+    (only .dtype/.shape are read) so a regression in the decision rules is
+    caught even off-GPU. The boundaries are grounded in the B200 sweep
+    documented on the heuristic itself.
     """
     from flashinfer.topk_varlen.topk_varlen import _top_k_varlen_heuristic
 
-    # The heuristic only uses suitable_backends; pass None for the tensor/scalar
-    # args required by the full signature (needed so skip_check=True works).
-    dummy = (None, None, None)
-    assert (
-        _top_k_varlen_heuristic(["gvr", "radix", "radix_cutlass"], *dummy)[0] == "gvr"
-    )
-    assert (
-        _top_k_varlen_heuristic(["gvr_2", "radix", "radix_cutlass"], *dummy)[0]
-        == "gvr_2"
-    )
-    assert _top_k_varlen_heuristic(["radix", "radix_cutlass"], *dummy)[0] == "radix"
-    assert _top_k_varlen_heuristic(["radix_cutlass"], *dummy)[0] == "radix_cutlass"
-    # order is preserved regardless of the suitable-set ordering
-    assert _top_k_varlen_heuristic(
-        ["radix_cutlass", "radix", "gvr_2", "gvr"], *dummy
-    ) == [
-        "gvr",
+    def order(suitable, dtype, batch, n_cols):
+        logits = torch.empty(batch, n_cols, dtype=dtype, device="meta")
+        seq_lens = torch.empty(batch, dtype=torch.int32, device="meta")
+        return _top_k_varlen_heuristic(suitable, logits, seq_lens, 1024)
+
+    all4 = ["radix_cutlass", "radix", "gvr_2", "gvr"]  # unordered on purpose
+
+    # fp32 + hint: gvr_2 always first; small problems rank radix over gvr.
+    assert order(all4, torch.float32, 1, 8192) == [
         "gvr_2",
+        "radix",
+        "gvr",
+        "radix_cutlass",
+    ]
+    # fp32 large batch x long rows: gvr ahead of radix; the fp32 big corner
+    # (N >= 64K and B*N >= 2^23) ranks radix_cutlass over radix.
+    assert order(all4, torch.float32, 256, 131072) == [
+        "gvr_2",
+        "gvr",
+        "radix_cutlass",
+        "radix",
+    ]
+    # B*N = 2^23 but N < 64K: gvr first, radix over radix_cutlass.
+    assert order(all4, torch.float32, 256, 32768) == [
+        "gvr_2",
+        "gvr",
+        "radix",
+        "radix_cutlass",
+    ]
+    # bf16 (gvr_2 never suitable): radix wins everywhere below B*N = 2^23...
+    assert order(["gvr", "radix", "radix_cutlass"], torch.bfloat16, 64, 65536) == [
+        "radix",
+        "gvr",
+        "radix_cutlass",
+    ]
+    # ...and gvr only above it; radix_cutlass never leads in half precision.
+    assert order(["gvr", "radix", "radix_cutlass"], torch.bfloat16, 256, 131072) == [
+        "gvr",
+        "radix",
+        "radix_cutlass",
+    ]
+    # no-hint fallbacks
+    assert order(["radix", "radix_cutlass"], torch.bfloat16, 256, 131072) == [
+        "radix",
+        "radix_cutlass",
+    ]
+    assert order(["radix", "radix_cutlass"], torch.float32, 256, 131072) == [
+        "radix_cutlass",
+        "radix",
+    ]
+    assert order(["radix_cutlass"], torch.float32, 1, 4096) == ["radix_cutlass"]
+    # None tensors (skip_check / doc examples): static fallback order.
+    assert _top_k_varlen_heuristic(all4, None, None, None) == [
+        "gvr_2",
+        "gvr",
         "radix",
         "radix_cutlass",
     ]

--- a/tests/topk_varlen/test_topk_varlen.py
+++ b/tests/topk_varlen/test_topk_varlen.py
@@ -1379,16 +1379,161 @@ def test_unknown_backend_rejected():
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")
 def test_input_validation():
-    """1-D logits and non-int32 seq_lens are rejected by the up-front asserts."""
+    """1-D logits and non-int32 seq_lens are rejected with ValueErrors (real
+    exceptions with a message, so the checks also hold under ``python -O``)."""
     top_k = 512
     logits = torch.randn(4, 4096, dtype=torch.bfloat16, device="cuda")
     seq_lens = torch.full((4,), 4096, dtype=torch.int32, device="cuda")
     # logits must be 2-D
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="2-D CUDA"):
         flashinfer.top_k_varlen(logits[0], seq_lens[:1], top_k)
     # seq_lens must be int32
-    with pytest.raises(AssertionError):
+    with pytest.raises(ValueError, match="int32"):
         flashinfer.top_k_varlen(logits, seq_lens.long(), top_k)
+
+
+def _malformed_hints(batch, top_k):
+    dev = "cuda"
+    return {
+        "transposed": torch.zeros(top_k, batch, dtype=torch.int32, device=dev).t(),
+        "wrong_batch": torch.zeros(batch // 2, top_k, dtype=torch.int32, device=dev),
+        "wrong_width": torch.zeros(batch, top_k // 2, dtype=torch.int32, device=dev),
+        "int64": torch.zeros(batch, top_k, dtype=torch.int64, device=dev),
+        "cpu": torch.zeros(batch, top_k, dtype=torch.int32),
+        "misaligned": torch.zeros(batch * top_k + 4, dtype=torch.int32, device=dev)[
+            1 : 1 + batch * top_k
+        ].view(batch, top_k),
+        "three_d": torch.zeros(batch, top_k, 1, dtype=torch.int32, device=dev),
+    }
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")
+@pytest.mark.parametrize(
+    "kind",
+    [
+        "transposed",
+        "wrong_batch",
+        "wrong_width",
+        "int64",
+        "cpu",
+        "misaligned",
+        "three_d",
+    ],
+)
+def test_malformed_hint_is_discarded_with_warning(kind):
+    """A malformed ``pre_idx`` (wrong shape, dtype, device, layout or
+    alignment) is dropped with a RuntimeWarning and the call runs hint-free
+    and exact, under ``auto`` and under an explicit hint-free backend. The
+    hint-consuming backends refuse the call up front instead of failing
+    inside the kernel (they cannot run without a hint)."""
+    from flashinfer.utils import BackendSupportedError
+
+    batch, n, top_k = 4, 8192, 1024
+    torch.manual_seed(11)
+    logits = torch.randn(batch, n, dtype=torch.float32, device="cuda")
+    seq_lens = torch.full((batch,), n, dtype=torch.int32, device="cuda")
+    bad = _malformed_hints(batch, top_k)[kind]
+    ref = torch.sort(torch.topk(logits, top_k, dim=1).values, dim=1).values
+    with pytest.warns(RuntimeWarning, match="pre_idx"):
+        indices, _ = flashinfer.top_k_varlen(logits, seq_lens, top_k, pre_idx=bad)
+    assert bool(((indices >= 0) & (indices < n)).all()), "index out of range"
+    assert torch.equal(torch.sort(logits.gather(1, indices.long()), dim=1).values, ref)
+    # explicit hint-free backend (radix on Blackwell+, radix_cutlass elsewhere):
+    # the hint is dropped with the same warning and the result stays exact
+    major, minor = torch.cuda.get_device_capability()
+    cc = major * 10 + minor
+    hint_free = (
+        "radix"
+        if flashinfer.top_k_varlen.is_backend_supported("radix", cc)
+        else "radix_cutlass"
+    )
+    with pytest.warns(RuntimeWarning, match="pre_idx"):
+        indices, _ = flashinfer.top_k_varlen(
+            logits, seq_lens, top_k, pre_idx=bad, backend=hint_free
+        )
+    assert bool(((indices >= 0) & (indices < n)).all()), "index out of range"
+    assert torch.equal(torch.sort(logits.gather(1, indices.long()), dim=1).values, ref)
+    # explicit hint-consuming backends: refused by their checker up front
+    # (the @backend_requirement decorator reports a failed explicit-backend
+    # check as ValueError("Problem size is not supported ..."))
+    for backend in ("gvr", "gvr_2"):
+        if flashinfer.top_k_varlen.is_backend_supported(backend, major * 10 + minor):
+            with pytest.raises(
+                (BackendSupportedError, ValueError), match="not supported"
+            ):
+                flashinfer.top_k_varlen(
+                    logits, seq_lens, top_k, pre_idx=bad, backend=backend
+                )
+            # skip_check=True bypasses the checkers: the body must still refuse
+            # instead of handing the discarded hint (None) to the kernel host
+            with (
+                pytest.warns(RuntimeWarning, match="pre_idx"),
+                pytest.raises(BackendSupportedError, match="well-formed"),
+            ):
+                flashinfer.top_k_varlen(
+                    logits,
+                    seq_lens,
+                    top_k,
+                    pre_idx=bad,
+                    backend=backend,
+                    skip_check=True,
+                )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")
+def test_output_buffer_contract():
+    """Caller-provided ``out_indices`` / ``out_values`` must be contiguous, on
+    the logits device, of the right dtype and exactly ``[num_rows, top_k]``;
+    anything else is a ValueError. The gvr_2 host used to accept a wider
+    buffer and pack the result into it at stride ``top_k``, so rows 0 and 1
+    of the caller's buffer held two result rows each and the rest stayed
+    untouched."""
+    batch, n, top_k = 4, 8192, 1024
+    logits = torch.randn(batch, n, dtype=torch.float32, device="cuda")
+    seq_lens = torch.full((batch,), n, dtype=torch.int32, device="cuda")
+    bad = {
+        "wider": torch.empty(batch, 2 * top_k, dtype=torch.int32, device="cuda"),
+        "taller": torch.empty(2 * batch, top_k, dtype=torch.int32, device="cuda"),
+        "short_flat": torch.empty(batch * top_k - 1, dtype=torch.int32, device="cuda"),
+        # right element count, wrong 2-D shape: would be a silent re-layout
+        "transposed_shape": torch.empty(top_k, batch, dtype=torch.int32, device="cuda"),
+        "misaligned": torch.empty(batch * top_k + 4, dtype=torch.int32, device="cuda")[
+            1 : 1 + batch * top_k
+        ].view(batch, top_k),
+        "int64": torch.empty(batch, top_k, dtype=torch.int64, device="cuda"),
+        "non_contiguous": torch.empty(
+            top_k, batch, dtype=torch.int32, device="cuda"
+        ).t(),
+        "cpu": torch.empty(batch, top_k, dtype=torch.int32),
+    }
+    for buf in bad.values():
+        with pytest.raises(ValueError, match="out_indices"):
+            flashinfer.top_k_varlen(logits, seq_lens, top_k, out_indices=buf)
+    with pytest.raises(ValueError, match="out_values"):
+        flashinfer.top_k_varlen(
+            logits,
+            seq_lens,
+            top_k,
+            return_values=True,
+            out_values=torch.empty(batch, top_k, dtype=torch.bfloat16, device="cuda"),
+        )
+    # a flat buffer with exactly num_rows * top_k elements is viewed in place
+    # (the contract the radix_filter in-place test relies on), for every backend
+    flat_i = torch.full((batch * top_k,), -7, dtype=torch.int32, device="cuda")
+    idx, _ = flashinfer.top_k_varlen(logits, seq_lens, top_k, out_indices=flat_i)
+    assert idx.data_ptr() == flat_i.data_ptr() and tuple(idx.shape) == (batch, top_k)
+    assert int((flat_i == -7).sum()) == 0
+    good_i = torch.empty(batch, top_k, dtype=torch.int32, device="cuda")
+    good_v = torch.empty(batch, top_k, dtype=torch.float32, device="cuda")
+    idx, vals = flashinfer.top_k_varlen(
+        logits,
+        seq_lens,
+        top_k,
+        return_values=True,
+        out_indices=good_i,
+        out_values=good_v,
+    )
+    assert idx.data_ptr() == good_i.data_ptr() and vals.data_ptr() == good_v.data_ptr()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -969,6 +969,110 @@ def test_gvr2_posinf_reg_clus(batch, n_valid, mode):
         assert torch.equal(got, ref), "selected value multiset differs from torch.topk"
 
 
+@requires_gvr2
+@pytest.mark.parametrize(
+    "kv", [200, 256, 100000], ids=["in_range", "equal_width", "oversized"]
+)
+def test_gvr2_width_below_k(kv):
+    """Logits narrower than top_k + 1: every row is short and must come back
+    as identity + -1 tail whatever seq_lens says. The launcher used to hand
+    the register families max(N, top_k + 1) as the row-read bound, so an
+    oversized kv length made them read top_k + 1 elements at a 256-element
+    row stride (into the next row, then past the tensor) and rank the
+    garbage; row 2 is poisoned so a cross-row read from row 1 shows up."""
+    rows, n, top_k = 3, 256, 512
+    gen = torch.Generator(device=_DEV).manual_seed(7)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    logits[2] = 3e38
+    seq_lens = torch.full((rows,), kv, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.full((rows, top_k), -1, dtype=torch.int32, device=_DEV)
+    indices, values = _run_gvr2(logits, seq_lens, top_k, pre_idx, return_values=True)
+    _check_varlen_rows(logits, indices, [min(kv, n)] * rows, top_k, values=values)
+
+
+@requires_gvr2
+def test_gvr2_sequential_warmup_populates_exact_launchers():
+    """warmup_varlen keyed its completion on the per-engine representative
+    rows, so a second call adding a row count that maps to an already-warmed
+    engine returned before that row count's launcher existed, and a CUDA-graph
+    capture at that row count failed with the launcher-cache-miss error."""
+    top_k, msl = 512, 8192
+    npad = _round64(msl)
+    rows = 61  # a row count no other test warms, so the precondition below holds
+
+    def has_launcher(r):
+        return any(
+            k[0] == r and k[1] == npad and k[2] == top_k for k in _host._VARLEN_CACHE
+        )
+
+    _host.warmup_varlen(top_k, msl, num_rows_list=[64])
+    assert not has_launcher(rows), (
+        "precondition: the 61-row launcher must not exist yet"
+    )
+    _host.warmup_varlen(top_k, msl, num_rows_list=[rows, 64])
+    assert has_launcher(rows), "61-row launcher missing after sequential warmup"
+    logits = torch.zeros(rows, npad, device=_DEV)
+    kv_lens = torch.full((rows,), msl, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.zeros(rows, top_k, dtype=torch.int32, device=_DEV)
+    out = torch.empty(rows, top_k, dtype=torch.int32, device=_DEV)
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g, stream=s):
+            _host.run_varlen(logits, pre_idx, kv_lens, out, max_seq_len=msl)
+    torch.cuda.synchronize()
+
+
+@requires_gvr2
+def test_gvr2_rejects_overlapping_rows():
+    """stride(0) < shape[1] (an expand view) is not a row-major layout the
+    kernel can address; the checker used to derive npad = 0 from it and
+    auto ranked gvr_2 first for the call."""
+    from flashinfer.topk_varlen import topk_varlen as tv
+    from flashinfer.utils import BackendSupportedError
+
+    base = torch.randn(1, 8192, device=_DEV)
+    x = base.expand(2, -1)
+    seq_lens = torch.full((2,), 8192, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.full((2, 1024), -1, dtype=torch.int32, device=_DEV)
+    assert not tv._gvr2_top_k_varlen_check(x, seq_lens, 1024, pre_idx=pre_idx)
+    # a failed explicit-backend check surfaces as the decorator's
+    # ValueError("Problem size is not supported ...")
+    with pytest.raises((BackendSupportedError, ValueError), match="not supported"):
+        _run_gvr2(x, seq_lens, 1024, pre_idx)
+    out = torch.empty(2, 1024, dtype=torch.int32, device=_DEV)
+    with pytest.raises(RuntimeError, match="overlap"):
+        _host.run_varlen(x, pre_idx, seq_lens, out, max_seq_len=8192)
+    # auto skips gvr_2 and radix (both gated) and lands on a backend that
+    # handles the view (gvr or radix_filter): the result is exact
+    indices, _ = flashinfer.top_k_varlen(x, seq_lens, 1024, pre_idx=pre_idx)
+    ref = torch.sort(torch.topk(base[0], 1024).values).values
+    for r in range(2):
+        assert torch.equal(torch.sort(base[0][indices[r].long()]).values, ref)
+
+
+@requires_gvr2
+def test_gvr2_workspace_must_be_16_byte_aligned():
+    """The compiled workspace ABI assumes 16-byte alignment; the host check
+    used to accept 8 and let the DSL refuse the launch."""
+    logits = torch.zeros(1, 4096, device=_DEV)
+    buf = torch.zeros(_host.WS_BYTES + 16, dtype=torch.uint8, device=_DEV)
+    _host.validate_run_ws(buf[16 : 16 + _host.WS_BYTES], logits)
+    with pytest.raises(RuntimeError, match="16-byte"):
+        _host.validate_run_ws(buf[8 : 8 + _host.WS_BYTES], logits)
+    # pre_idx / indices declare the same 16-byte ABI: a shifted contiguous view
+    # is refused by the host with a FlashInfer message (was a DSL error)
+    seq_lens = torch.full((1,), 4096, dtype=torch.int32, device=_DEV)
+    good = torch.zeros(1, 1024, dtype=torch.int32, device=_DEV)
+    shifted = torch.zeros(1024 + 4, dtype=torch.int32, device=_DEV)[1:1025].view(
+        1, 1024
+    )
+    with pytest.raises(RuntimeError, match="16-byte"):
+        _host.run_varlen(logits, shifted, seq_lens, good.clone(), max_seq_len=4096)
+    with pytest.raises(RuntimeError, match="16-byte"):
+        _host.run_varlen(logits, good, seq_lens, shifted, max_seq_len=4096)
+
+
 # ---------------------------------------------------------------------------
 # route dispatch: pure-Python fuzz (CPU-only, no GPU required)
 # ---------------------------------------------------------------------------

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -857,14 +857,57 @@ def test_gvr2_neginf_tail_completeness():
 
 
 @requires_gvr2
+@pytest.mark.parametrize(
+    "n_valid,top_k,positions",
+    [
+        (4096, 1024, [1000]),  # in the register fold window (DKG issue #58 case A)
+        (4096, 1024, [3000]),  # outside the window
+        (4096, 512, [1000]),  # regimg flavor
+        (4096, 2048, [1000]),  # plain reg (no img)
+        (
+            4096,
+            1024,
+            list(range(0, 4096, 4))[:1029],
+        ),  # more +inf than K: every slot +inf
+    ],
+    ids=["in_window", "out_of_window", "k512", "k2048", "ties_gt_k"],
+)
+def test_gvr2_posinf_completeness(n_valid, top_k, positions):
+    """Port of TRT-LLM PR #18625's regression (register family, DKG issue #58):
+    a +inf inside the row drives the hint-free bracket maximum to +inf, the
+    bracket width becomes infinite, the classify scale rcp(width) becomes 0
+    and every value folds into bin 0, so the whole-bin emit dropped the +inf.
+    The infinite width must now fail the collapse guard and take the
+    key-space escape, where fkey(+inf) is the maximum key. In-window and
+    out-of-window +inf, the regimg / plain-reg flavors and a more-than-K-ties
+    row are pinned; N=4096 keeps the register families."""
+    gen = torch.Generator(device=_DEV).manual_seed(top_k + n_valid)
+    logits = torch.randn((1, n_valid), generator=gen, device=_DEV) * 2.0
+    logits[0, positions] = float("inf")
+    seq_lens = torch.full((1,), n_valid, dtype=torch.int32, device=_DEV)
+    ref_vals = torch.topk(logits, top_k, dim=1).values
+    for pre_idx in (
+        torch.topk(logits, top_k, dim=1).indices.int().contiguous(),
+        torch.full((1, top_k), -1, dtype=torch.int32, device=_DEV),
+    ):
+        out = torch.full((1, top_k), -7, dtype=torch.int32, device=_DEV)
+        _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out)
+        torch.cuda.synchronize()
+        assert int((out == -7).sum()) == 0, "unwritten output slots"
+        n_inf = int(torch.isinf(logits[0][out[0].long()]).sum())
+        assert n_inf == min(top_k, len(positions)), "+inf dropped from the top-k"
+        _check_exact(logits, out, n_valid, ref_vals)
+
+
+@requires_gvr2
 @pytest.mark.xfail(
-    reason="UPSTREAM CAVEAT (TRT-LLM #17821 kernels, reproduced bit-identically "
-    "by the upstream implementation on the same inputs): literal +inf logits "
-    "are not selected in at least the clustered-register family. All finite "
+    reason="UPSTREAM CAVEAT: the clustered-register family (GvrRegClusKernel) "
+    "still drops literal +inf logits. TRT-LLM PR #18625 fixed the register "
+    "family (ported here; see test_gvr2_posinf_completeness) but left reg_clus "
+    "with the same collapsing bracket; tracked in DKG issue #58. All finite "
     "values — including 3.1e38 > the 3e38 pad sentinel — and -inf are "
-    "tie-aware exact (covered by test_gvr2_adversarial_patterns). Same class "
-    "as the documented NaN implementation-specific ordering.",
-    strict=False,  # family-dependent: some shapes handle +inf correctly
+    "tie-aware exact (covered by test_gvr2_adversarial_patterns).",
+    strict=True,  # deterministic: fixed shape, seed and family on B100/B200/Rubin
 )
 def test_gvr2_plus_inf_upstream_caveat():
     n_valid, batch, top_k = 32768, 4, 1024

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -441,7 +441,7 @@ def test_gvr2_workspace_override():
 
 def _assert_family(rows, msl_c, top_k, next_n, cr, want):
     """The varlen launcher must admit the same family the free route picks."""
-    key = (rows, msl_c, top_k, msl_c, next_n, cr)
+    key = (rows, msl_c, top_k, msl_c, next_n, cr, _host._arch_token())
     lc = _host._VARLEN_CACHE.get(key)
     assert lc is not None, f"launcher not cached for {key}"
     assert lc[0] == want, f"family {lc[0]} != {want} for {key}"
@@ -510,8 +510,12 @@ def test_gvr2_cuda_graph():
     with torch.cuda.graph(g):
         _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out_i)
 
-    for step in range(5):
-        kv = [min(v + 517 * step, msl) for v in kv0]
+    # Replays must survive BOTH directions of in-place length change (a
+    # schedule valid only for growth is a classic replay hazard): grow for a
+    # few steps, then shrink back below the short-path boundary.
+    deltas = [0, 517, 1034, 1551, -400, -1200]
+    for d in deltas:
+        kv = [min(max(v + d, 0), msl) for v in kv0]
         seq_lens.copy_(torch.tensor(kv, dtype=torch.int32, device=_DEV))
         logits.copy_(torch.randn(batch, msl, generator=gen, device=_DEV) - 2.0)
         out_i.fill_(-7)
@@ -548,6 +552,36 @@ def test_gvr2_warmup_then_capture():
 # ---------------------------------------------------------------------------
 # backend registration / guards / cross-backend
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")
+def test_next_n_row_relationship_validated_up_front():
+    """The grouped next_n ABI (rows == batch * next_n, next_n >= 1) must be
+    rejected by the public API's own validation for EVERY backend — kernels
+    index seq_lens[row // next_n], so a mismatch reads the wrong request's
+    length (or out of bounds) rather than failing loudly."""
+    logits = torch.randn(4, 4096, dtype=torch.float32, device=_DEV)
+    seq_lens = torch.full((4,), 4096, dtype=torch.int32, device=_DEV)  # != 4/2
+    with pytest.raises(ValueError, match="seq_lens.shape"):
+        flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=2)
+    with pytest.raises(ValueError, match="next_n"):
+        flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=0)
+
+
+@requires_gvr2
+def test_gvr2_empty_batch():
+    """B=0 must be a well-formed no-op through the public API (both the
+    explicit backend and auto), returning a (0, top_k) result — not a crash
+    in scheduling, compilation, or the heuristic."""
+    logits = torch.empty(0, 8192, dtype=torch.float32, device=_DEV)
+    seq_lens = torch.empty(0, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.empty(0, 512, dtype=torch.int32, device=_DEV)
+    for backend in ("gvr_2", "auto"):
+        indices, values = flashinfer.top_k_varlen(
+            logits, seq_lens, 512, pre_idx=pre_idx, backend=backend
+        )
+        assert tuple(indices.shape) == (0, 512)
+        assert values is None
 
 
 @requires_gvr2

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -737,8 +737,8 @@ def _adversarial_logits(pattern, rows, N, top_k, gen):
         return x
     if pattern == "huge_flood_gt_k":
         # near-FLT_MAX flood (3.1e38 > the kernel's 3e38 pad sentinel):
-        # more huge values than slots. Literal +inf is NOT used here — the
-        # upstream kernel drops +inf (see test_gvr2_plus_inf_upstream_caveat).
+        # more huge values than slots. Literal +inf is covered separately by
+        # test_gvr2_posinf_completeness / test_gvr2_posinf_reg_clus.
         x = torch.randn(rows, N, generator=gen, device=_DEV)
         n_huge = top_k + top_k // 2
         for r in range(rows):
@@ -900,29 +900,73 @@ def test_gvr2_posinf_completeness(n_valid, top_k, positions):
 
 
 @requires_gvr2
-@pytest.mark.xfail(
-    reason="UPSTREAM CAVEAT: the clustered-register family (GvrRegClusKernel) "
-    "still drops literal +inf logits. TRT-LLM PR #18625 fixed the register "
-    "family (ported here; see test_gvr2_posinf_completeness) but left reg_clus "
-    "with the same collapsing bracket; tracked in DKG issue #58. All finite "
-    "values — including 3.1e38 > the 3e38 pad sentinel — and -inf are "
-    "tie-aware exact (covered by test_gvr2_adversarial_patterns).",
-    strict=True,  # deterministic: fixed shape, seed and family on B100/B200/Rubin
+@pytest.mark.parametrize(
+    "batch,n_valid,mode",
+    [
+        (4, 32768, "in_sample"),  # +inf among the first K columns (hint-free sample)
+        (4, 32768, "out_of_sample"),  # +inf at column 30000
+        (4, 65536, "in_sample"),  # crossing bin > CS*CMPC: degen path already exact
+        (4, 32768, "quarter_random"),  # K/4 random +inf per row, random hint
+    ],
+    ids=["in_sample_32k", "out_of_sample_32k", "in_sample_64k", "quarter_random_32k"],
 )
-def test_gvr2_plus_inf_upstream_caveat():
-    n_valid, batch, top_k = 32768, 4, 1024
-    gen = torch.Generator(device=_DEV).manual_seed(1000)
-    logits = torch.randn(batch, n_valid, generator=gen, device=_DEV)
-    for r in range(batch):
-        pos = torch.randperm(n_valid, generator=gen, device=_DEV)[: top_k // 4]
-        logits[r, pos] = float("inf")
+def test_gvr2_posinf_reg_clus(batch, n_valid, mode):
+    """Port of TRT-LLM PR #18625's second commit (clustered-register family,
+    DKG issue #58): a sampled +inf made the reg_clus bracket width infinite,
+    the pre-fix guard accepted it, the classify scale became 0, every finite
+    value landed in bin 1 and the +inf became NaN in the trash bin and was
+    never staged, so the output was the true top-K with the +inf replaced by
+    the (K+1)-th value (all slots valid). Rows above CS*CMPC = 32K columns took
+    the whole-row ``degen`` path and were already exact; the fix routes an
+    infinite-width bracket there too. With a hint the +inf is in the sample
+    (oracle) or the sentinel bracket is installed (-1), so every variant must
+    now be exact for both hints. 4 x 32K, K=1024 is the reg_clus route."""
+    top_k = 1024
+    gen = torch.Generator(device=_DEV).manual_seed(n_valid + batch)
+    logits = torch.randn(batch, n_valid, generator=gen, device=_DEV) * 2.0
+    if mode == "quarter_random":
+        for r in range(batch):
+            pos = torch.randperm(n_valid, generator=gen, device=_DEV)[: top_k // 4]
+            logits[r, pos] = float("inf")
+    else:
+        logits[:, 1000 if mode == "in_sample" else 30000] = float("inf")
+    n_inf = int(torch.isinf(logits[0]).sum())
     seq_lens = torch.full((batch,), n_valid, dtype=torch.int32, device=_DEV)
-    pre_idx = torch.randint(
-        0, n_valid, (batch, top_k), generator=gen, device=_DEV, dtype=torch.int32
-    )
-    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
-    got_inf = torch.isinf(logits.gather(1, indices.long().clamp_min(0)))
-    assert int(got_inf.sum()) == batch * (top_k // 4), "+inf logits were dropped"
+    ref = torch.sort(
+        torch.topk(logits, top_k, dim=1).values, dim=1, descending=True
+    ).values
+    hints = [
+        torch.topk(logits, top_k, dim=1).indices.int().contiguous(),
+        torch.full((batch, top_k), -1, dtype=torch.int32, device=_DEV),
+    ]
+    if mode == "quarter_random":
+        hints.append(
+            torch.randint(
+                0,
+                n_valid,
+                (batch, top_k),
+                generator=gen,
+                device=_DEV,
+                dtype=torch.int32,
+            )
+        )
+    for pre_idx in hints:
+        out = torch.full((batch, top_k), -7, dtype=torch.int32, device=_DEV)
+        _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out)
+        torch.cuda.synchronize()
+        assert int((out == -7).sum()) == 0, "unwritten output slots"
+        assert bool(((out >= 0) & (out < n_valid)).all()), "index out of range"
+        for r in range(batch):
+            assert torch.unique(out[r]).numel() == top_k, (
+                f"duplicate indices in row {r}"
+            )
+        sel = logits.gather(1, out.long())
+        assert torch.equal(
+            torch.isinf(sel).sum(dim=1),
+            torch.full((batch,), min(top_k, n_inf), device=_DEV),
+        ), "+inf dropped from the top-k"
+        got = torch.sort(sel, dim=1, descending=True).values
+        assert torch.equal(got, ref), "selected value multiset differs from torch.topk"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -569,17 +569,20 @@ def test_gvr2_rejects_bad_top_k():
 
 
 @requires_gvr2
-def test_gvr2_auto_never_preempts_gvr():
-    """With fp32 + pre_idx both gvr and gvr_2 are suitable; auto must keep
-    gvr first (gvr_2 stays opt-in until the perf comparison settles)."""
+def test_gvr2_auto_selects_gvr2():
+    """With fp32 + pre_idx, auto must pick gvr_2 first (it won 211/213
+    measured cells; see the heuristic's docstring)."""
     logits = torch.randn(4, 8192, dtype=torch.float32, device=_DEV)
     seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
     pre_idx = torch.zeros(4, 512, dtype=torch.int32, device=_DEV)
     pre_idx[:, 0] = logits.argmax(dim=-1).int()
-    flashinfer.top_k_varlen(logits, seq_lens, 512, pre_idx=pre_idx, backend="auto")
+    indices, _ = flashinfer.top_k_varlen(
+        logits, seq_lens, 512, pre_idx=pre_idx, backend="auto"
+    )
     order = flashinfer.top_k_varlen.suitable_auto_backends
-    assert order[0] == "gvr"
-    assert "gvr_2" in order
+    assert order[0] == "gvr_2"
+    assert "gvr" in order
+    _check_varlen_rows(logits, indices, [8192] * 4, 512)
 
 
 @requires_gvr2
@@ -618,19 +621,22 @@ def _adversarial_logits(pattern, rows, N, top_k, gen):
         pick = torch.rand(rows, N, generator=gen, device=_DEV) < 0.3
         x[pick] = 2.0
         return x
-    if pattern == "inf_flood_gt_k":
+    if pattern == "huge_flood_gt_k":
+        # near-FLT_MAX flood (3.1e38 > the kernel's 3e38 pad sentinel):
+        # more huge values than slots. Literal +inf is NOT used here — the
+        # upstream kernel drops +inf (see test_gvr2_plus_inf_upstream_caveat).
         x = torch.randn(rows, N, generator=gen, device=_DEV)
-        n_inf = top_k + top_k // 2  # more +inf than slots
+        n_huge = top_k + top_k // 2
         for r in range(rows):
-            pos = torch.randperm(N, generator=gen, device=_DEV)[:n_inf]
-            x[r, pos] = float("inf")
+            pos = torch.randperm(N, generator=gen, device=_DEV)[:n_huge]
+            x[r, pos] = 3.1e38
         return x
-    if pattern == "inf_flood_lt_k":
+    if pattern == "huge_flood_lt_k":
         x = torch.randn(rows, N, generator=gen, device=_DEV)
         for r in range(rows):
             pos = torch.randperm(N, generator=gen, device=_DEV)[: top_k // 4]
-            x[r, pos] = float("inf")
-        x[:, 0] = float("-inf")  # a -inf below everything
+            x[r, pos] = 3.1e38
+        x[:, 0] = float("-inf")  # a -inf below everything (supported)
         return x
     if pattern == "quantized4":
         lv = torch.tensor([-2.0, -0.5, 0.5, 2.0], device=_DEV)
@@ -649,8 +655,8 @@ def _adversarial_logits(pattern, rows, N, top_k, gen):
     [
         "constant",
         "two_values",
-        "inf_flood_gt_k",
-        "inf_flood_lt_k",
+        "huge_flood_gt_k",
+        "huge_flood_lt_k",
         "quantized4",
         "denormal",
     ],
@@ -658,7 +664,17 @@ def _adversarial_logits(pattern, rows, N, top_k, gen):
 @pytest.mark.parametrize("n_valid,batch", [(32768, 4), (131072, 1)])
 def test_gvr2_adversarial_patterns(pattern, n_valid, batch):
     top_k = 1024
-    gen = torch.Generator(device=_DEV).manual_seed(hash(pattern) % 2**31)
+    # Fixed per-pattern seeds (hash() is randomized per process; using it made
+    # this test nondeterministic).
+    seeds = {
+        "constant": 101,
+        "two_values": 202,
+        "huge_flood_gt_k": 303,
+        "huge_flood_lt_k": 404,
+        "quantized4": 505,
+        "denormal": 606,
+    }
+    gen = torch.Generator(device=_DEV).manual_seed(seeds[pattern])
     logits = _adversarial_logits(pattern, batch, n_valid, top_k, gen)
     seq_lens = torch.full((batch,), n_valid, dtype=torch.int32, device=_DEV)
     pre_idx = torch.randint(
@@ -667,6 +683,32 @@ def test_gvr2_adversarial_patterns(pattern, n_valid, batch):
     ref_vals = torch.topk(logits, top_k, dim=1).values
     indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
     _check_exact(logits, indices, n_valid, ref_vals)
+
+
+@requires_gvr2
+@pytest.mark.xfail(
+    reason="UPSTREAM CAVEAT (TRT-LLM #17821 kernels, reproduced bit-identically "
+    "by the upstream implementation on the same inputs): literal +inf logits "
+    "are not selected in at least the clustered-register family. All finite "
+    "values — including 3.1e38 > the 3e38 pad sentinel — and -inf are "
+    "tie-aware exact (covered by test_gvr2_adversarial_patterns). Same class "
+    "as the documented NaN implementation-specific ordering.",
+    strict=False,  # family-dependent: some shapes handle +inf correctly
+)
+def test_gvr2_plus_inf_upstream_caveat():
+    n_valid, batch, top_k = 32768, 4, 1024
+    gen = torch.Generator(device=_DEV).manual_seed(1000)
+    logits = torch.randn(batch, n_valid, generator=gen, device=_DEV)
+    for r in range(batch):
+        pos = torch.randperm(n_valid, generator=gen, device=_DEV)[: top_k // 4]
+        logits[r, pos] = float("inf")
+    seq_lens = torch.full((batch,), n_valid, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.randint(
+        0, n_valid, (batch, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    got_inf = torch.isinf(logits.gather(1, indices.long().clamp_min(0)))
+    assert int(got_inf.sum()) == batch * (top_k // 4), "+inf logits were dropped"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -67,7 +67,8 @@ def _gvr2_hw_supported() -> bool:
 _IS_GVR2_CAPABLE = _gvr2_hw_supported()
 requires_gvr2 = pytest.mark.skipif(
     not _IS_GVR2_CAPABLE,
-    reason="gvr_2 requires datacenter Blackwell (sm_100/103) + nvidia-cutlass-dsl",
+    reason="gvr_2 requires datacenter Blackwell (sm_100/103, Rubin sm_107) "
+    "+ nvidia-cutlass-dsl",
 )
 
 _DEV = "cuda"
@@ -413,6 +414,85 @@ def test_gvr2_noncontiguous_arena_view():
 
 
 @requires_gvr2
+@pytest.mark.parametrize(
+    "rows,msl",
+    [
+        (16, 131008),  # streaming main, R=9 split
+        (256, 8128),  # streaming main, R=1
+        (16, 8128),  # register-resident
+        (16, 65472),  # clustered register-resident
+        (64, 131008),  # cluster split
+    ],
+)
+def test_gvr2_arena_view_oversized_seq_lens(rows, msl):
+    """A kv length beyond the logical row width must clamp to the WIDTH, not
+    to the arena row stride: on a 256-rounded arena view the columns in
+    [width, stride) belong to other data and must never be classified (radix
+    parity — ``seq_lens`` is clamped to ``logits.shape[1]``). The arena tail
+    is poisoned with +3e38 so a stride-clamped family fails the multiset."""
+    top_k = 1024
+    stride = (msl + 255) // 256 * 256
+    assert stride > msl
+    gen = torch.Generator(device=_DEV).manual_seed(11)
+    arena = torch.randn(rows, stride, generator=gen, device=_DEV) - 2.0
+    arena[:, msl:] = 3e38  # arena tail: outside every row's logical width
+    logits = arena[:, :msl]
+    assert not logits.is_contiguous()
+    kv = [stride + 777 if r % 2 == 0 else msl - 64 * (r % 5) for r in range(rows)]
+    seq_lens = torch.tensor(kv, dtype=torch.int32, device=_DEV)
+    n_r = _row_valid_lens(kv, rows, 1, 1, msl)  # clamps to the width
+    for r in range(rows):
+        logits[r, n_r[r] :] = 3e38
+    pre_idx = torch.randint(
+        0, top_k, (rows, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    _check_varlen_rows(logits, indices, n_r, top_k)
+
+
+@pytest.mark.skipif(
+    not (
+        _FLASHINFER_AVAILABLE
+        and torch.cuda.is_available()
+        and torch.cuda.device_count() >= 2
+    ),
+    reason="needs two CUDA devices",
+)
+def test_gvr2_logits_on_non_current_device():
+    """Launch with logits on a device that is NOT torch.cuda.current_device():
+    the launcher cache key, the DSL compile target and the launch itself must
+    all follow the tensor's device — a heterogeneous multi-GPU process must
+    never reuse or run an engine compiled for another architecture."""
+    if not _cute_dsl_available():
+        pytest.skip("nvidia-cutlass-dsl not installed")
+    cur = torch.cuda.current_device()
+    capable = []
+    for i in range(torch.cuda.device_count()):
+        if i == cur:
+            continue
+        major, minor = get_compute_capability(torch.device(f"cuda:{i}"))
+        if flashinfer.top_k_varlen.is_backend_supported("gvr_2", major * 10 + minor):
+            capable.append(i)
+    if not capable:
+        pytest.skip("no gvr_2-capable device other than the current one")
+    dev = torch.device(f"cuda:{capable[0]}")
+    rows, n_valid, top_k = 4, 16384, 1024
+    gen = torch.Generator(device=dev).manual_seed(3)
+    logits = torch.randn(rows, n_valid, generator=gen, device=dev) - 2.0
+    seq_lens = torch.full((rows,), n_valid, dtype=torch.int32, device=dev)
+    pre_idx = torch.randint(
+        0, n_valid, (rows, top_k), generator=gen, device=dev, dtype=torch.int32
+    )
+    indices, _ = flashinfer.top_k_varlen(
+        logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr_2"
+    )
+    torch.cuda.synchronize(dev)
+    assert indices.device == logits.device
+    assert torch.cuda.current_device() == cur, "entry must restore the current device"
+    _check_exact(logits, indices, n_valid, torch.topk(logits, top_k, dim=1).values)
+
+
+@requires_gvr2
 def test_gvr2_workspace_override():
     """Caller-provided workspace (multi-stream escape hatch) must agree with
     the default per-device slab."""
@@ -562,7 +642,7 @@ def test_next_n_row_relationship_validated_up_front():
     length (or out of bounds) rather than failing loudly."""
     logits = torch.randn(4, 4096, dtype=torch.float32, device=_DEV)
     seq_lens = torch.full((4,), 4096, dtype=torch.int32, device=_DEV)  # != 4/2
-    with pytest.raises(ValueError, match="seq_lens.shape"):
+    with pytest.raises(ValueError, match=r"seq_lens\.shape"):
         flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=2)
     with pytest.raises(ValueError, match="next_n"):
         flashinfer.top_k_varlen(logits, seq_lens, 512, next_n=0)
@@ -589,7 +669,7 @@ def test_gvr2_rejects_non_fp32():
     logits = torch.randn(4, 8192, dtype=torch.bfloat16, device=_DEV)
     seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
     pre_idx = torch.zeros(4, 512, dtype=torch.int32, device=_DEV)
-    with pytest.raises(Exception, match="not supported|Problem size"):
+    with pytest.raises(Exception, match=r"not supported|Problem size"):
         flashinfer.top_k_varlen(logits, seq_lens, 512, pre_idx=pre_idx, backend="gvr_2")
 
 
@@ -598,7 +678,7 @@ def test_gvr2_rejects_bad_top_k():
     logits = torch.randn(4, 8192, dtype=torch.float32, device=_DEV)
     seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
     pre_idx = torch.zeros(4, 768, dtype=torch.int32, device=_DEV)
-    with pytest.raises(Exception, match="not supported|Problem size"):
+    with pytest.raises(Exception, match=r"not supported|Problem size"):
         flashinfer.top_k_varlen(logits, seq_lens, 768, pre_idx=pre_idx, backend="gvr_2")
 
 

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -799,6 +799,63 @@ def test_gvr2_adversarial_patterns(pattern, n_valid, batch):
     _check_exact(logits, indices, n_valid, ref_vals)
 
 
+def _check_complete_exact(out, logits, n_valid, ref_vals, sentinel):
+    """Every output slot written (no sentinel left), then tie-aware exact."""
+    torch.cuda.synchronize()
+    assert int((out == sentinel).sum()) == 0, "unwritten output slots"
+    _check_exact(logits, out, n_valid, ref_vals)
+
+
+@requires_gvr2
+@pytest.mark.parametrize("n_valid", [3072, 4096], ids=["n3072", "n4096"])
+def test_gvr2_high_anchor_hint_completeness(n_valid):
+    """Port of TRT-LLM PR #18501's first regression (register family): anchor-only
+    hints whose gathered values all sit ABOVE the true k-th value -- an argmax
+    anchor over the all-zero cold-start hint buffer, with row[0] = second-max so
+    the hint-derived bracket holds exactly two entries -- make the classify
+    histogram total fall short of k. The kernel must then escape to the
+    key-space ranking instead of stopping at the histogram total (pre-fix:
+    out[tot:k) left unwritten, 130,304 of 131,072 slots per cell here). The
+    shapes pin the vulnerable non-BRL reg variant (BRL classify clamps
+    out-of-bracket values into bin 0 and cannot under-count)."""
+    top_k, bs = 512, 256
+    gen = torch.Generator(device=_DEV).manual_seed(top_k + n_valid)
+    logits = torch.randn((bs, n_valid), generator=gen, dtype=torch.float32, device=_DEV)
+    logits[:, 0] = torch.topk(logits, 2, dim=1).values[:, 1]  # bracket = [2nd max, max]
+    ref_vals = torch.topk(logits, top_k, dim=1).values
+    pre_idx = torch.zeros((bs, top_k), dtype=torch.int32, device=_DEV)
+    pre_idx[:, 0] = logits.argmax(dim=1).to(torch.int32)
+    seq_lens = torch.full((bs,), n_valid, dtype=torch.int32, device=_DEV)
+    out = torch.full((bs, top_k), -7, dtype=torch.int32, device=_DEV)
+    _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out)
+    _check_complete_exact(out, logits, n_valid, ref_vals, -7)
+
+
+@requires_gvr2
+def test_gvr2_neginf_tail_completeness():
+    """Port of TRT-LLM PR #18501's second regression: an in-window -inf in the
+    row's tail column (n_valid % 4 == 1, so that column lives outside the
+    float4 register batch) drags the hint-free DEG bracket to -inf, every
+    classify product becomes NaN and the histogram total is zero (pre-fix:
+    whole rows unwritten). Odd rows keep fewer than top_k finite entries so the
+    -inf tie class exercises the escape's fill-lane bound (pre-fix: duplicate
+    indices from the -inf fill lanes of the last partial float4)."""
+    top_k, bs, npad, n_valid = 1024, 256, 4096, 4093
+    gen = torch.Generator(device=_DEV).manual_seed(top_k + n_valid)
+    logits = torch.randn((bs, npad), generator=gen, dtype=torch.float32, device=_DEV)
+    logits[:, n_valid:] = 3e38  # poison past the window
+    logits[:, n_valid - 1] = float("-inf")  # in-window -inf in the tail column
+    logits[1::2, 500:n_valid] = float("-inf")  # odd rows: n_finite < top_k
+    masked = logits.clone()
+    masked[:, n_valid:] = float("-inf")
+    ref_vals = torch.topk(masked, top_k, dim=1).values
+    pre_idx = torch.zeros((bs, top_k), dtype=torch.int32, device=_DEV)
+    seq_lens = torch.full((bs,), n_valid, dtype=torch.int32, device=_DEV)
+    out = torch.full((bs, top_k), -7, dtype=torch.int32, device=_DEV)
+    _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out)
+    _check_complete_exact(out, logits, n_valid, ref_vals, -7)
+
+
 @requires_gvr2
 @pytest.mark.xfail(
     reason="UPSTREAM CAVEAT (TRT-LLM #17821 kernels, reproduced bit-identically "

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -1,0 +1,743 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the ``gvr_2`` (self-sampling GVR V2) top_k_varlen backend.
+
+Ported from TRT-LLM's ``test_gvr_selfsampling_topk.py`` (PR #17821) onto the
+FlashInfer ``top_k_varlen(backend="gvr_2")`` API. The correctness contract is
+tie-interchangeable EXACT top-K:
+
+* selected indices unique and inside the row's valid prefix;
+* the sorted multiset of gathered values bitwise-equals the sorted
+  ``torch.topk`` values (signed zeros normalized via ``+ 0.0``);
+* short rows (``n <= top_k``): identity indices ``{0..n-1}`` + ``-1`` tail
+  (values tail = ``-FLT_MAX``);
+* per-row tails beyond each row's valid prefix are poisoned with ``+3e38`` so
+  any out-of-bounds read corrupts the multiset and fails loudly.
+
+The route-dispatch fuzz tests are CPU-only (pure-Python host dispatch).
+"""
+
+import pytest
+import torch
+
+try:
+    import flashinfer
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+    from flashinfer.utils import get_compute_capability
+
+    _FLASHINFER_AVAILABLE = True
+except ImportError:
+    _FLASHINFER_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not _FLASHINFER_AVAILABLE, reason="flashinfer not importable"
+)
+
+
+def _cute_dsl_available() -> bool:
+    import importlib.util
+
+    return (
+        importlib.util.find_spec("cutlass") is not None
+        and importlib.util.find_spec("cutlass.cute") is not None
+    )
+
+
+def _gvr2_hw_supported() -> bool:
+    if not (_FLASHINFER_AVAILABLE and torch.cuda.is_available()):
+        return False
+    major, minor = get_compute_capability(torch.device("cuda"))
+    return (
+        flashinfer.top_k_varlen.is_backend_supported("gvr_2", major * 10 + minor)
+        and _cute_dsl_available()
+    )
+
+
+_IS_GVR2_CAPABLE = _gvr2_hw_supported()
+requires_gvr2 = pytest.mark.skipif(
+    not _IS_GVR2_CAPABLE,
+    reason="gvr_2 requires datacenter Blackwell (sm_100/103) + nvidia-cutlass-dsl",
+)
+
+_DEV = "cuda"
+_FMIN = -3.4028234663852886e38  # torch.finfo(torch.float32).min
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _round64(n: int) -> int:
+    return (n + 63) // 64 * 64
+
+
+def _row_valid_lens(seq_lens_host, rows, next_n, cr, n_cap):
+    """Mirror of the per-row device formula (uncompressed seq_lens in)."""
+    out = []
+    for r in range(rows):
+        n = (seq_lens_host[r // next_n] - next_n + (r % next_n) + 1) // cr
+        out.append(min(max(n, 0), n_cap))
+    return out
+
+
+def _make_case(batch_size, n_valid, top_k, seed, hit_ratio=0.6):
+    """Batch-uniform case: fp32 randn-2.0 logits, 64-rounded width, poisoned
+    tail, hint = 60% true top-K prefix + random valid indices."""
+    gen = torch.Generator(device=_DEV).manual_seed(seed)
+    npad = _round64(n_valid)
+    logits = torch.randn(batch_size, npad, generator=gen, device=_DEV) - 2.0
+    logits[:, n_valid:] = 3e38  # poison: an OOB read corrupts the multiset
+    k_eff = min(top_k, n_valid)
+    ref = torch.topk(logits[:, :n_valid], k_eff, dim=1)
+    n_hit = int(k_eff * hit_ratio)
+    pre_idx = torch.randint(
+        0, n_valid, (batch_size, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    pre_idx[:, :n_hit] = ref.indices[:, :n_hit].int()
+    seq_lens = torch.full((batch_size,), n_valid, dtype=torch.int32, device=_DEV)
+    return logits, seq_lens, pre_idx, ref.values
+
+
+def _check_exact(logits, indices, n_valid, ref_vals):
+    """Tie-aware exactness: unique in-range indices + bitwise value-multiset
+    equality (signed zeros normalized)."""
+    top_k = indices.shape[1]
+    idx64 = indices.to(torch.int64)
+    assert int(idx64.min()) >= 0, "negative output index"
+    assert int(idx64.max()) < n_valid, "output index past n_valid"
+    for row in range(indices.shape[0]):
+        assert int(torch.unique(idx64[row]).numel()) == top_k, (
+            f"row {row}: duplicate indices"
+        )
+    got = torch.gather(logits, 1, idx64)
+    got_sorted = torch.sort(got + 0.0, dim=1, descending=True).values
+    ref_sorted = torch.sort(ref_vals + 0.0, dim=1, descending=True).values
+    assert torch.equal(got_sorted, ref_sorted), (
+        "top-K value multiset mismatch (inexact or padding read)"
+    )
+
+
+def _check_varlen_rows(logits, indices, n_r, top_k, values=None):
+    """Per-row varlen oracle: short rows = identity + -1 tail; long rows =
+    tie-aware exact."""
+    for r in range(indices.shape[0]):
+        n = n_r[r]
+        if n <= top_k:
+            head = indices[r, :n].to(torch.int64) if n > 0 else None
+            if n > 0:
+                assert torch.equal(
+                    torch.sort(head).values, torch.arange(n, device=_DEV)
+                ), f"row {r}: short-path head not a permutation of arange({n})"
+            assert bool((indices[r, n:] == -1).all()), f"row {r}: tail not -1"
+            if values is not None:
+                if n > 0:
+                    assert torch.equal(values[r, :n], logits[r, :n]), (
+                        f"row {r}: short-path values head"
+                    )
+                assert bool((values[r, n:] == _FMIN).all()), (
+                    f"row {r}: values tail not -FLT_MAX"
+                )
+        else:
+            idx = indices[r].to(torch.int64)
+            assert int(idx.min()) >= 0 and int(idx.max()) < n, f"row {r}: range"
+            assert int(torch.unique(idx).numel()) == top_k, f"row {r}: dups"
+            ref = torch.topk(logits[r, :n], top_k).values
+            got = torch.sort(
+                torch.gather(logits[r], 0, idx) + 0.0, descending=True
+            ).values
+            assert torch.equal(got, torch.sort(ref + 0.0, descending=True).values), (
+                f"row {r} inexact"
+            )
+            if values is not None:
+                assert torch.equal(values[r], torch.gather(logits[r], 0, idx)), (
+                    f"row {r}: values mismatch"
+                )
+
+
+def _make_varlen_case(kv, next_n, cr, top_k, seed, msl_c=None):
+    """Ragged case in the FlashInfer contract: uncompressed per-request
+    seq_lens, compressed-space logits of width msl_c (4-aligned)."""
+    gen = torch.Generator(device=_DEV).manual_seed(seed)
+    batch = len(kv)
+    rows = batch * next_n
+    if msl_c is None:
+        msl_c = _round64(max(max(kv) // cr, top_k + 1))
+    logits = torch.randn(rows, msl_c, generator=gen, device=_DEV) - 2.0
+    seq_lens = torch.tensor(kv, dtype=torch.int32, device=_DEV)
+    n_r = _row_valid_lens(kv, rows, next_n, cr, msl_c)
+    for r in range(rows):
+        logits[r, n_r[r] :] = 3e38  # per-row poison
+    pre_idx = torch.zeros(batch, top_k, dtype=torch.int32, device=_DEV)
+    for b in range(batch):
+        lo = max(min(n_r[b * next_n : (b + 1) * next_n]), 1)
+        pre_idx[b] = torch.randint(
+            0, lo, (top_k,), generator=gen, device=_DEV, dtype=torch.int32
+        )
+    return logits, seq_lens, pre_idx, n_r, msl_c
+
+
+def _run_gvr2(logits, seq_lens, top_k, pre_idx, **kw):
+    return flashinfer.top_k_varlen(
+        logits, seq_lens, top_k, pre_idx=pre_idx, backend="gvr_2", **kw
+    )
+
+
+# ---------------------------------------------------------------------------
+# batch-uniform exactness (via uniform seq_lens)
+# ---------------------------------------------------------------------------
+
+# gate-edge (131075/131076 straddle the K=2048 hint-band gate), small-N floor,
+# mid band, deployment-envelope top — from the upstream suite.
+_CASES = [
+    (512, 4099),
+    (512, 65536),
+    (512, 262143),
+    (1024, 16387),
+    (1024, 131072),
+    (2048, 4111),
+    (2048, 131075),
+    (2048, 131076),
+    (2048, 262144),
+]
+
+
+@requires_gvr2
+@pytest.mark.parametrize("top_k,n_valid", _CASES)
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_gvr2_exactness(top_k, n_valid, batch_size):
+    seed = n_valid * 31 + top_k + batch_size
+    logits, seq_lens, pre_idx, ref_vals = _make_case(batch_size, n_valid, top_k, seed)
+    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    _check_exact(logits, indices, n_valid, ref_vals)
+
+
+_SHORT_CASES = [
+    (512, 256),
+    (512, 511),
+    (512, 512),
+    (1024, 64),
+    (1024, 1024),
+    (2048, 1000),
+    (2048, 2047),
+    (2048, 2048),
+]
+
+
+@requires_gvr2
+@pytest.mark.parametrize("top_k,n_valid", _SHORT_CASES)
+@pytest.mark.parametrize("batch_size", [1, 4])
+def test_gvr2_short_path(top_k, n_valid, batch_size):
+    seed = top_k + n_valid
+    logits, seq_lens, pre_idx, _ = _make_case(batch_size, n_valid, top_k, seed)
+    indices, values = _run_gvr2(logits, seq_lens, top_k, pre_idx, return_values=True)
+    n_r = [n_valid] * batch_size
+    _check_varlen_rows(logits, indices, n_r, top_k, values=values)
+
+
+@requires_gvr2
+@pytest.mark.parametrize("top_k,n_valid", [(512, 8192), (1024, 32768)])
+def test_gvr2_values_output(top_k, n_valid):
+    logits, seq_lens, pre_idx, ref_vals = _make_case(4, n_valid, top_k, seed=42)
+    indices, values = _run_gvr2(logits, seq_lens, top_k, pre_idx, return_values=True)
+    _check_exact(logits, indices, n_valid, ref_vals)
+    assert values is not None and values.dtype == torch.float32
+    idx64 = indices.to(torch.int64)
+    assert torch.equal(values, torch.gather(logits, 1, idx64))
+
+
+@requires_gvr2
+@pytest.mark.parametrize(
+    "hint_kind",
+    ["all_zero", "all_same", "all_max", "half_dup", "minus_one_tail", "all_minus_one"],
+)
+@pytest.mark.parametrize("top_k,n_valid", [(512, 8192), (2048, 131075)])
+def test_gvr2_degenerate_hints(hint_kind, top_k, n_valid):
+    """Hints steer the sampling ladder but never exactness — degenerate hints
+    must not affect the output contract."""
+    logits, seq_lens, pre_idx, ref_vals = _make_case(2, n_valid, top_k, seed=7)
+    if hint_kind == "all_zero":
+        pre_idx.zero_()
+    elif hint_kind == "all_same":
+        pre_idx.fill_(1234)
+    elif hint_kind == "all_max":
+        pre_idx.fill_(n_valid - 1)
+    elif hint_kind == "half_dup":
+        pre_idx[:, top_k // 2 :] = pre_idx[:, : top_k // 2]
+    elif hint_kind == "minus_one_tail":
+        pre_idx[:, top_k // 2 :] = -1
+    elif hint_kind == "all_minus_one":
+        pre_idx.fill_(-1)
+    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    _check_exact(logits, indices, n_valid, ref_vals)
+
+
+# ---------------------------------------------------------------------------
+# varlen production contract
+# ---------------------------------------------------------------------------
+
+_VARLEN_CASES = [
+    # (kv, next_n, cr, top_k)
+    ([33000, 8200, 300], 1, 1, 512),  # cr1 hetero + short row
+    ([131075, 32800, 2000], 1, 4, 512),  # cr4 hetero (compressed index space)
+    ([9000, 5001], 2, 1, 512),  # cr1 MTP-2
+    ([65540], 4, 4, 1024),  # cr4 MTP-4 (boundary-crossing rows)
+    ([40000, 7003], 3, 4, 512),  # cr4 next_n=3 (formula must generalize)
+]
+
+
+@requires_gvr2
+@pytest.mark.parametrize("kv,next_n,cr,top_k", _VARLEN_CASES)
+@pytest.mark.parametrize("with_values", [False, True])
+def test_gvr2_varlen(kv, next_n, cr, top_k, with_values):
+    seed = sum(kv) + next_n + cr
+    logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(kv, next_n, cr, top_k, seed)
+    indices, values = _run_gvr2(
+        logits,
+        seq_lens,
+        top_k,
+        pre_idx,
+        next_n=next_n,
+        compress_ratio=cr,
+        return_values=with_values,
+    )
+    _check_varlen_rows(logits, indices, n_r, top_k, values=values)
+
+
+@requires_gvr2
+def test_gvr2_zero_kv_slot():
+    """kv_len = 0 (evicted CUDA-graph slot) and kv_len < next_n (zero-window)
+    rows emit all -1; live rows in the same launch stay exact."""
+    for kv, next_n in ([[0, 40000], 2], [[1, 33000], 2], [[3, 65540, 0], 4]):
+        top_k = 512
+        logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(
+            kv, next_n, 1, top_k, seed=13
+        )
+        indices, _ = _run_gvr2(
+            logits, seq_lens, top_k, pre_idx, next_n=next_n, compress_ratio=1
+        )
+        _check_varlen_rows(logits, indices, n_r, top_k)
+
+
+@requires_gvr2
+def test_gvr2_launch_modes():
+    """Streaming-main SPLIT + TSH-floor domain (16 rows) and BLK=512 wide
+    batch (200 rows)."""
+    for rows, base, step, top_k in ((16, 40000, 977, 1024), (200, 6000, 64, 512)):
+        kv = [base + step * i for i in range(rows)]
+        logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(
+            kv, 1, 1, top_k, seed=rows
+        )
+        indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+        _check_varlen_rows(logits, indices, n_r, top_k)
+
+
+@requires_gvr2
+def test_gvr2_heterogeneous_lengths_main():
+    """304 rows (BLK=256 non-split main) with random per-request lengths
+    spanning long/mid/short/n<=k/zero-window; each row checked against its
+    own prefix topk. Strongest single portable test from upstream."""
+    rows, top_k, msl_c, cr, next_n = 304, 1024, 65536, 4, 1
+    gen = torch.Generator(device=_DEV).manual_seed(1000 + rows)
+    kv = []
+    for i in range(rows):
+        m = i % 5
+        if m == 0:
+            kv.append(
+                int(
+                    torch.randint(
+                        msl_c * cr // 2, msl_c * cr, (1,), generator=gen, device=_DEV
+                    )
+                )
+            )
+        elif m == 1:
+            kv.append(
+                int(
+                    torch.randint(
+                        top_k * cr + 1,
+                        msl_c * cr // 2,
+                        (1,),
+                        generator=gen,
+                        device=_DEV,
+                    )
+                )
+            )
+        elif m == 2:
+            kv.append(
+                int(torch.randint(1, top_k * cr, (1,), generator=gen, device=_DEV))
+            )
+        elif m == 3:
+            kv.append(top_k * cr)  # n == k boundary
+        else:
+            kv.append(0)  # zero-window
+    logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(
+        kv, next_n, cr, top_k, seed=rows, msl_c=msl_c
+    )
+    indices, _ = _run_gvr2(
+        logits, seq_lens, top_k, pre_idx, next_n=next_n, compress_ratio=cr
+    )
+    _check_varlen_rows(logits, indices, n_r, top_k)
+
+
+@requires_gvr2
+def test_gvr2_noncontiguous_arena_view():
+    """Column-sliced logits view (row stride > width, 256-rounded arena — the
+    DSL paged-MQA layout) must stay exact; only stride(1)==1 is required."""
+    rows, msl, top_k = 8, 8300, 512
+    stride = (msl + 255) // 256 * 256
+    gen = torch.Generator(device=_DEV).manual_seed(5)
+    arena = torch.randn(rows, stride, generator=gen, device=_DEV) - 2.0
+    logits = arena[:, :msl]
+    assert not logits.is_contiguous()
+    kv = [8300, 8000, 6000, 4000, 2000, 513, 512, 100]
+    seq_lens = torch.tensor(kv, dtype=torch.int32, device=_DEV)
+    n_r = _row_valid_lens(kv, rows, 1, 1, msl)
+    for r in range(rows):
+        logits[r, n_r[r] :] = 3e38
+    pre_idx = torch.randint(
+        0, 100, (rows, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    _check_varlen_rows(logits, indices, n_r, top_k)
+
+
+@requires_gvr2
+def test_gvr2_workspace_override():
+    """Caller-provided workspace (multi-stream escape hatch) must agree with
+    the default per-device slab."""
+    kv, top_k = [131075, 32800, 2000], 512
+    logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(kv, 1, 1, top_k, seed=17)
+    idx_default, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    ws_bytes = _host.workspace_bytes()
+    ws = torch.zeros(ws_bytes, dtype=torch.uint8, device=_DEV)
+    idx_ws, _ = _run_gvr2(
+        logits, seq_lens, top_k, pre_idx, workspace={"gvr2_workspace": ws}
+    )
+    _check_varlen_rows(logits, idx_ws, n_r, top_k)
+    got_d = torch.sort(
+        torch.gather(logits, 1, idx_default.long().clamp_min(0)), dim=1
+    ).values
+    got_w = torch.sort(
+        torch.gather(logits, 1, idx_ws.long().clamp_min(0)), dim=1
+    ).values
+    assert torch.equal(got_d, got_w)
+
+
+# ---------------------------------------------------------------------------
+# kernel-family admission parity (dispatch tiers) + oracle
+# ---------------------------------------------------------------------------
+
+
+def _assert_family(rows, msl_c, top_k, next_n, cr, want):
+    """The varlen launcher must admit the same family the free route picks."""
+    key = (rows, msl_c, top_k, msl_c, next_n, cr)
+    lc = _host._VARLEN_CACHE.get(key)
+    assert lc is not None, f"launcher not cached for {key}"
+    assert lc[0] == want, f"family {lc[0]} != {want} for {key}"
+
+
+@requires_gvr2
+@pytest.mark.parametrize(
+    "rows,msl_c,top_k,next_n,cr,family",
+    [
+        (8, 131072, 1024, 4, 4, "reg_clus"),  # clustered register-resident
+        (8, 6144, 512, 1, 4, "reg"),  # register-resident
+        (8, 3072, 512, 1, 4, "reg"),  # regimg flavor (cached as "reg")
+        (64, 131072, 1024, 1, 1, "clus"),  # CS=2 cluster split
+        (32, 131072, 1024, 1, 1, "clus"),  # CS=4 cluster split
+        (304, 65536, 1024, 1, 1, "main"),  # BLK=256 wide-batch main
+    ],
+)
+def test_gvr2_family_parity_and_oracle(rows, msl_c, top_k, next_n, cr, family):
+    assert rows % next_n == 0
+    batch = rows // next_n
+    gen = torch.Generator(device=_DEV).manual_seed(rows + msl_c)
+    kv = [
+        int(torch.randint(1, msl_c * cr + 1, (1,), generator=gen, device=_DEV))
+        for _ in range(batch)
+    ]
+    kv[0] = msl_c * cr  # pin the envelope so route sees the full width
+    logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(
+        kv, next_n, cr, top_k, seed=rows, msl_c=msl_c
+    )
+    indices, _ = _run_gvr2(
+        logits, seq_lens, top_k, pre_idx, next_n=next_n, compress_ratio=cr
+    )
+    _assert_family(rows, msl_c, top_k, next_n, cr, family)
+    _check_varlen_rows(logits, indices, n_r, top_k)
+
+
+# ---------------------------------------------------------------------------
+# CUDA graph capture / replay
+# ---------------------------------------------------------------------------
+
+
+@requires_gvr2
+def test_gvr2_cuda_graph():
+    """Warmup → capture → replay with in-place-growing seq_lens, including a
+    row crossing the n<=k short-path boundary inside the graph."""
+    batch, msl, top_k = 8, 131072, 1024
+    gen = torch.Generator(device=_DEV).manual_seed(23)
+    logits = torch.randn(batch, msl, generator=gen, device=_DEV) - 2.0
+    kv0 = [100000, 65536, 40000, 8000, 2000, 1023, 1024, 131072]
+    seq_lens = torch.tensor(kv0, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.randint(
+        0, 1000, (batch, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    out_i = torch.full((batch, top_k), -7, dtype=torch.int32, device=_DEV)
+
+    # warmup on a side stream: JIT + workspace/launcher caches populate
+    # outside capture
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out_i)
+    torch.cuda.current_stream().wait_stream(s)
+    torch.cuda.synchronize()
+
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out_i)
+
+    for step in range(5):
+        kv = [min(v + 517 * step, msl) for v in kv0]
+        seq_lens.copy_(torch.tensor(kv, dtype=torch.int32, device=_DEV))
+        logits.copy_(torch.randn(batch, msl, generator=gen, device=_DEV) - 2.0)
+        out_i.fill_(-7)
+        g.replay()
+        torch.cuda.synchronize()
+        n_r = _row_valid_lens(kv, batch, 1, 1, msl)
+        _check_varlen_rows(logits, out_i, n_r, top_k)
+
+
+@requires_gvr2
+def test_gvr2_warmup_then_capture():
+    """warmup_varlen must pre-compile the launcher so capture works without an
+    eager call at the captured geometry (row_stride pinned to the logits
+    width, since FlashInfer's envelope is the logits row width)."""
+    batch, msl, top_k = 4, 32768, 512
+    _host.warmup_varlen(
+        top_k, msl, compress_ratio=1, next_n=1, num_rows_list=(batch,), row_stride=msl
+    )
+    gen = torch.Generator(device=_DEV).manual_seed(29)
+    logits = torch.randn(batch, msl, generator=gen, device=_DEV) - 2.0
+    kv = [msl, 20000, 5000, 600]
+    seq_lens = torch.tensor(kv, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.zeros(batch, top_k, dtype=torch.int32, device=_DEV)
+    out_i = torch.empty(batch, top_k, dtype=torch.int32, device=_DEV)
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        _run_gvr2(logits, seq_lens, top_k, pre_idx, out_indices=out_i)
+    g.replay()
+    torch.cuda.synchronize()
+    _check_varlen_rows(logits, out_i, _row_valid_lens(kv, batch, 1, 1, msl), top_k)
+
+
+# ---------------------------------------------------------------------------
+# backend registration / guards / cross-backend
+# ---------------------------------------------------------------------------
+
+
+@requires_gvr2
+def test_gvr2_rejects_non_fp32():
+    logits = torch.randn(4, 8192, dtype=torch.bfloat16, device=_DEV)
+    seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.zeros(4, 512, dtype=torch.int32, device=_DEV)
+    with pytest.raises(Exception, match="not supported|Problem size"):
+        flashinfer.top_k_varlen(logits, seq_lens, 512, pre_idx=pre_idx, backend="gvr_2")
+
+
+@requires_gvr2
+def test_gvr2_rejects_bad_top_k():
+    logits = torch.randn(4, 8192, dtype=torch.float32, device=_DEV)
+    seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.zeros(4, 768, dtype=torch.int32, device=_DEV)
+    with pytest.raises(Exception, match="not supported|Problem size"):
+        flashinfer.top_k_varlen(logits, seq_lens, 768, pre_idx=pre_idx, backend="gvr_2")
+
+
+@requires_gvr2
+def test_gvr2_auto_never_preempts_gvr():
+    """With fp32 + pre_idx both gvr and gvr_2 are suitable; auto must keep
+    gvr first (gvr_2 stays opt-in until the perf comparison settles)."""
+    logits = torch.randn(4, 8192, dtype=torch.float32, device=_DEV)
+    seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.zeros(4, 512, dtype=torch.int32, device=_DEV)
+    pre_idx[:, 0] = logits.argmax(dim=-1).int()
+    flashinfer.top_k_varlen(logits, seq_lens, 512, pre_idx=pre_idx, backend="auto")
+    order = flashinfer.top_k_varlen.suitable_auto_backends
+    assert order[0] == "gvr"
+    assert "gvr_2" in order
+
+
+@requires_gvr2
+def test_gvr2_cross_backend_value_consistency():
+    """Sorted selected-value multisets must agree across gvr_2, gvr, radix,
+    and radix_cutlass on the same fp32 inputs."""
+    top_k, n_valid = 512, 32768
+    logits, seq_lens, pre_idx, _ = _make_case(4, n_valid, top_k, seed=3)
+    logits = logits[:, :n_valid].contiguous()  # drop the poison pad
+    seq_lens = torch.full((4,), n_valid, dtype=torch.int32, device=_DEV)
+    vals = {}
+    for backend in ("gvr_2", "gvr", "radix", "radix_cutlass"):
+        idx, _ = flashinfer.top_k_varlen(
+            logits, seq_lens, top_k, pre_idx=pre_idx, backend=backend
+        )
+        vals[backend] = torch.sort(
+            torch.gather(logits, 1, idx.long()), dim=1, descending=True
+        ).values
+    for backend in ("gvr", "radix", "radix_cutlass"):
+        assert torch.equal(vals["gvr_2"], vals[backend]), f"gvr_2 vs {backend}"
+
+
+# ---------------------------------------------------------------------------
+# adversarial value patterns (mass ties / inf floods / denormals)
+# ---------------------------------------------------------------------------
+# Random-logits tests cannot see tie-handling or extreme-value bugs. The
+# upstream contract: finite inputs INCLUDING +/-inf and denormals are
+# tie-aware exact; only NaN ordering is implementation-specific (untested).
+
+
+def _adversarial_logits(pattern, rows, N, top_k, gen):
+    if pattern == "constant":
+        return torch.full((rows, N), 1.5, device=_DEV)
+    if pattern == "two_values":
+        x = torch.full((rows, N), -1.0, device=_DEV)
+        pick = torch.rand(rows, N, generator=gen, device=_DEV) < 0.3
+        x[pick] = 2.0
+        return x
+    if pattern == "inf_flood_gt_k":
+        x = torch.randn(rows, N, generator=gen, device=_DEV)
+        n_inf = top_k + top_k // 2  # more +inf than slots
+        for r in range(rows):
+            pos = torch.randperm(N, generator=gen, device=_DEV)[:n_inf]
+            x[r, pos] = float("inf")
+        return x
+    if pattern == "inf_flood_lt_k":
+        x = torch.randn(rows, N, generator=gen, device=_DEV)
+        for r in range(rows):
+            pos = torch.randperm(N, generator=gen, device=_DEV)[: top_k // 4]
+            x[r, pos] = float("inf")
+        x[:, 0] = float("-inf")  # a -inf below everything
+        return x
+    if pattern == "quantized4":
+        lv = torch.tensor([-2.0, -0.5, 0.5, 2.0], device=_DEV)
+        return lv[torch.randint(0, 4, (rows, N), generator=gen, device=_DEV)]
+    if pattern == "denormal":
+        # magnitudes straddling the subnormal range
+        x = torch.randn(rows, N, generator=gen, device=_DEV) * 1e-40
+        x[:, : top_k // 2] = 1e-38  # some normals on top
+        return x
+    raise ValueError(pattern)
+
+
+@requires_gvr2
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "constant",
+        "two_values",
+        "inf_flood_gt_k",
+        "inf_flood_lt_k",
+        "quantized4",
+        "denormal",
+    ],
+)
+@pytest.mark.parametrize("n_valid,batch", [(32768, 4), (131072, 1)])
+def test_gvr2_adversarial_patterns(pattern, n_valid, batch):
+    top_k = 1024
+    gen = torch.Generator(device=_DEV).manual_seed(hash(pattern) % 2**31)
+    logits = _adversarial_logits(pattern, batch, n_valid, top_k, gen)
+    seq_lens = torch.full((batch,), n_valid, dtype=torch.int32, device=_DEV)
+    pre_idx = torch.randint(
+        0, n_valid, (batch, top_k), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    ref_vals = torch.topk(logits, top_k, dim=1).values
+    indices, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
+    _check_exact(logits, indices, n_valid, ref_vals)
+
+
+# ---------------------------------------------------------------------------
+# route dispatch: pure-Python fuzz (CPU-only, no GPU required)
+# ---------------------------------------------------------------------------
+
+
+def test_gvr2_route_factorization_fuzz():
+    """route_split(b,n,npad,k) must reproduce route() exactly — the lossless
+    static/dynamic factorization the varlen engine's per-row re-derivation
+    relies on."""
+    checked = 0
+    npad = 1 << 20
+    for k in (512, 1024, 2048):
+        bases = (
+            2 * k,
+            3 * k,
+            4 * k + 64,
+            2560,
+            4096,
+            8192,
+            16384,
+            4 * 1024,
+            4 * 4096,
+            4 * 32768,
+            65536,
+            131072,
+            262144,
+        )
+        for b in (1, 8, 16, 64, 148, 296, 1024):
+            ns = set()
+            for base in bases:
+                for d in range(-4, 5):
+                    n = base + d
+                    if k < n <= npad:
+                        ns.add(n)
+            ns.update(range(k + 1, npad, 4999))
+            s = (b * 2654435761 + k) % (1 << 31)
+            for _ in range(400):
+                s = (s * 1103515245 + 12345) % (1 << 31)
+                ns.add(k + 1 + s % (npad - k - 1))
+            for n in sorted(ns):
+                assert _host.route_split(b, n, npad, k) == _host.route(b, n, npad, k), (
+                    b,
+                    n,
+                    npad,
+                    k,
+                )
+                checked += 1
+    assert checked > 10_000
+
+
+def test_gvr2_route_bands_contiguous():
+    bands = _host.route_bands(8, 262144, 1024)
+    lo_expect = 1024 + 1
+    for lo, hi, st in bands:
+        assert lo == lo_expect, (lo, lo_expect)
+        assert hi >= lo
+        lo_expect = hi + 1
+        for f in _host._DYN_RT[st["kernel"]]:
+            assert f not in st["rt"], (st["kernel"], f)
+    assert lo_expect == 262144 + 1
+
+
+def test_gvr2_route_pure_and_total():
+    for k in (512, 1024, 2048):
+        for b in (1, 4, 16, 64, 148, 296, 512, 1024, 4096, 8192):
+            for n in (k + 1, 4096, 65536, 262144, 1 << 20):
+                if n <= k:
+                    continue
+                plan = _host.route(b, n, (n + 63) // 64 * 64, k)
+                assert plan["kernel"] in ("main", "reg", "regimg", "clus", "reg_clus")
+                assert plan["block"] >= 128
+                assert plan["grid"][0] >= 1

--- a/tests/topk_varlen/test_topk_varlen_serving.py
+++ b/tests/topk_varlen/test_topk_varlen_serving.py
@@ -1,0 +1,540 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Serving-pattern harness for ``top_k_varlen``.
+
+The shape-level suites check exactness one launch at a time. A DeepSeek-style
+sparse-attention indexer in a serving engine (the SGLang DSA indexer is the
+model here) drives the top-k differently, and several review findings on this
+API were only visible under those patterns:
+
+* several CUDA streams / CUDA graphs in flight on one device (the gvr_2
+  default workspace is one slab per device);
+* a top-k issued on a side stream with ``wait_stream`` hand-offs (dual-stream
+  indexer overlap);
+* CUDA graphs captured at a padded batch and replayed with fewer live rows,
+  padded rows carrying a zero length and a static caller-owned output buffer
+  whose padded rows must read back as ``-1``;
+* the MLA "select all" path: scores of width ``top_k`` that are all zero, rows
+  no longer than ``top_k``, expecting ``[0 .. len-1, -1, ...]``;
+* the previous step's indices reused as the hint one token later;
+* the engine's own top-k contract (mask beyond the row length, ``-1`` for
+  masked picks) versus this API's contract for rows with fewer than
+  ``top_k`` finite values.
+
+Each test runs on every backend that the device and inputs admit.
+"""
+
+import pytest
+import torch
+
+try:
+    import flashinfer
+    from flashinfer.topk_varlen import topk_varlen as _tv
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+    from flashinfer.utils import get_compute_capability
+
+    _FLASHINFER_AVAILABLE = True
+except ImportError:
+    _FLASHINFER_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not (_FLASHINFER_AVAILABLE and torch.cuda.is_available()),
+    reason="flashinfer + CUDA required",
+)
+
+_DEV = "cuda"
+_FMIN = -3.4028234663852886e38
+_ALL = ("radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter")
+_CHECKERS = {
+    "radix": "_radix_top_k_varlen_check",
+    "gvr": "_gvr_top_k_varlen_check",
+    "gvr_2": "_gvr2_top_k_varlen_check",
+    "radix_cutlass": "_radix_cutlass_top_k_varlen_check",
+    "radix_filter": "_radix_filter_top_k_varlen_check",
+}
+
+
+def _cc() -> int:
+    major, minor = get_compute_capability(torch.device(_DEV))
+    return major * 10 + minor
+
+
+def _available(logits, seq_lens, top_k, pre_idx=None, **kw):
+    """Backends whose checker admits this exact call on this device."""
+    out = []
+    for name in _ALL:
+        if not flashinfer.top_k_varlen.is_backend_supported(name, _cc()):
+            continue
+        if getattr(_tv, _CHECKERS[name])(
+            logits, seq_lens, top_k, pre_idx=pre_idx, **kw
+        ):
+            out.append(name)
+    return out
+
+
+def _hint(logits, top_k, seed):
+    gen = torch.Generator(device=_DEV).manual_seed(seed)
+    return torch.randint(
+        0,
+        logits.shape[1],
+        (logits.shape[0], top_k),
+        generator=gen,
+        device=_DEV,
+        dtype=torch.int32,
+    )
+
+
+def _check_rows(logits, indices, lens, top_k, values=None, who=""):
+    """Per-row oracle: short rows (len <= top_k) are identity + -1 tail; long
+    rows are unique in-range indices whose value multiset equals torch.topk."""
+    for r in range(indices.shape[0]):
+        n = int(lens[r])
+        row = indices[r].to(torch.int64)
+        tag = f"{who} row {r} (len {n})"
+        if n <= top_k:
+            if n > 0:
+                assert torch.equal(
+                    torch.sort(row[:n]).values, torch.arange(n, device=_DEV)
+                ), f"{tag}: short-row head is not a permutation of arange({n})"
+            assert bool((row[n:] == -1).all()), f"{tag}: short-row tail not -1"
+            if values is not None:
+                assert bool((values[r, n:] == _FMIN).all()), f"{tag}: values tail"
+            continue
+        assert int(row.min()) >= 0 and int(row.max()) < n, (
+            f"{tag}: index range (min {int(row.min())}, max {int(row.max())})"
+        )
+        assert int(torch.unique(row).numel()) == top_k, f"{tag}: duplicate indices"
+        got = torch.sort(logits[r].gather(0, row) + 0.0, descending=True).values
+        ref = torch.sort(
+            torch.topk(logits[r, :n], top_k).values + 0.0, descending=True
+        ).values
+        assert torch.equal(got, ref), f"{tag}: value multiset differs from torch.topk"
+
+
+# ---------------------------------------------------------------------------
+# 1. concurrency on one device
+# ---------------------------------------------------------------------------
+
+
+def _split_case(streams, launches):
+    """Inputs for the gvr_2 streaming SPLIT family (the only family that touches
+    the workspace); skips if this device routes the shape elsewhere."""
+    rows, n, k = 16, 131072, 512
+    lc = _host._varlen_launcher(rows, n, k, n, 1, 1)
+    if not (lc[0] == "main" and lc[2][5] > 1):
+        pytest.skip(f"shape routes to {lc[0]} (no workspace use) on this device")
+    gen = torch.Generator(device=_DEV).manual_seed(0)
+    work = []
+    for _ in range(streams):
+        logits = torch.randn(rows, n, generator=gen, device=_DEV)
+        seq = torch.randint(
+            40000, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+        )
+        pre = torch.full((rows, k), -1, dtype=torch.int32, device=_DEV)
+        outs = [
+            torch.full((rows, k), -7, dtype=torch.int32, device=_DEV)
+            for _ in range(launches)
+        ]
+        ws = torch.zeros(_host.workspace_bytes(), dtype=torch.uint8, device=_DEV)
+        work.append((logits, seq, pre, outs, ws))
+    return rows, k, work
+
+
+def _concurrent_graph_replays(private_workspace, streams=4, launches=8, rounds=6):
+    rows, k, work = _split_case(streams, launches)
+    cuda_streams = [torch.cuda.Stream() for _ in range(streams)]
+
+    def launch(w, out):
+        logits, seq, pre, _, ws = w
+        flashinfer.top_k_varlen(
+            logits,
+            seq,
+            k,
+            pre_idx=pre,
+            out_indices=out,
+            backend="gvr_2",
+            workspace={"gvr2_workspace": ws} if private_workspace else None,
+        )
+
+    for w in work:  # compile eagerly before capture
+        launch(w, w[3][0])
+    torch.cuda.synchronize()
+    graphs = []
+    for s, w in enumerate(work):
+        g = torch.cuda.CUDAGraph()
+        with (
+            torch.cuda.stream(cuda_streams[s]),
+            torch.cuda.graph(g, stream=cuda_streams[s]),
+        ):
+            for out in w[3]:
+                launch(w, out)
+        graphs.append(g)
+    torch.cuda.synchronize()
+    bad = 0
+    for _ in range(rounds):
+        for w in work:
+            for out in w[3]:
+                out.fill_(-7)
+        torch.cuda.synchronize()
+        for s, g in enumerate(graphs):
+            with torch.cuda.stream(cuda_streams[s]):
+                g.replay()
+        torch.cuda.synchronize()
+        for logits, seq, _, outs, _ in work:
+            for out in outs:
+                for r in range(rows):
+                    idx = out[r].long()
+                    n = int(seq[r])
+                    ok = bool(((idx >= 0) & (idx < n)).all()) and torch.equal(
+                        torch.sort(logits[r][idx]).values,
+                        torch.sort(torch.topk(logits[r, :n], k).values).values,
+                    )
+                    bad += 0 if ok else 1
+    return bad, rounds * streams * launches * rows
+
+
+@pytest.mark.skipif(
+    not _FLASHINFER_AVAILABLE
+    or not flashinfer.top_k_varlen.is_backend_supported("gvr_2", _cc()),
+    reason="gvr_2 unsupported on this device",
+)
+def test_gvr2_concurrent_graph_replays_private_workspaces():
+    """The documented contract: every concurrently replayed graph carries its
+    own gvr2_workspace, so four graphs of eight SPLIT launches each, replayed
+    concurrently on four streams, stay exact."""
+    bad, total = _concurrent_graph_replays(private_workspace=True)
+    assert bad == 0, f"{bad}/{total} rows corrupted with private workspaces"
+
+
+@pytest.mark.skipif(
+    not _FLASHINFER_AVAILABLE
+    or not flashinfer.top_k_varlen.is_backend_supported("gvr_2", _cc()),
+    reason="gvr_2 unsupported on this device",
+)
+@pytest.mark.xfail(
+    strict=False,
+    reason="DOCUMENTED HAZARD: workspace=None resolves to one gvr_2 slab per "
+    "device, so concurrently replayed graphs race on its counters and candidate "
+    "buffer (measured 17/5120 corrupted rows on B100). Flips to XPASS if a "
+    "per-stream/per-graph default ever lands; callers must pass a workspace.",
+)
+def test_gvr2_default_workspace_shared_across_concurrent_graphs():
+    bad, total = _concurrent_graph_replays(private_workspace=False)
+    assert bad == 0, f"{bad}/{total} rows corrupted through the shared default slab"
+
+
+def test_side_stream_handoff_every_backend():
+    """Dual-stream indexer pattern: the top-k is issued on a side stream after a
+    wait_stream hand-off from the producer and the consumer waits on it again.
+    One launch in flight at a time, so every backend must be exact with its
+    default workspace."""
+    rows, n, top_k = 8, 16384, 1024
+    gen = torch.Generator(device=_DEV).manual_seed(21)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    lens = torch.randint(
+        top_k + 1, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    pre = _hint(logits, top_k, 22)
+    side = torch.cuda.Stream()
+    ran = []
+    for backend in _available(logits, lens, top_k, pre_idx=pre):
+        out = torch.full((rows, top_k), -7, dtype=torch.int32, device=_DEV)
+        main = torch.cuda.current_stream()
+        side.wait_stream(main)
+        with torch.cuda.stream(side):
+            flashinfer.top_k_varlen(
+                logits, lens, top_k, pre_idx=pre, out_indices=out, backend=backend
+            )
+        main.wait_stream(side)
+        consumed = out.clone()  # consumer on the main stream
+        torch.cuda.synchronize()
+        _check_rows(logits, consumed, lens.tolist(), top_k)
+        ran.append(backend)
+    assert ran, "no backend available"
+
+
+# ---------------------------------------------------------------------------
+# 2. CUDA graphs the way a serving engine replays them
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["radix", "gvr", "gvr_2", "radix_cutlass"])
+def test_graph_padded_rows_static_out_buffer(backend):
+    """Capture at a padded batch with a caller-owned static output buffer, then
+    replay with 8, 5, 2 and 8 live rows: padded rows carry seq_len 0 and must
+    read back as -1 (the engine's sentinel), live rows stay exact, and the
+    buffer identity never changes. Lengths also grow and shrink between
+    replays."""
+    if not flashinfer.top_k_varlen.is_backend_supported(backend, _cc()):
+        pytest.skip(f"{backend} unsupported on this device")
+    rows_pad, n, top_k = 8, 8192, 512
+    gen = torch.Generator(device=_DEV).manual_seed(31)
+    logits = torch.randn(rows_pad, n, generator=gen, device=_DEV)
+    base = torch.randint(
+        top_k + 1, n - 600, (rows_pad,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    seq_lens = base.clone()
+    pre = _hint(logits, top_k, 32)
+    if backend not in _available(logits, seq_lens, top_k, pre_idx=pre):
+        pytest.skip(f"{backend} checker rejects this configuration here")
+    out = torch.full((rows_pad, top_k), -7, dtype=torch.int32, device=_DEV)
+    kw = dict(pre_idx=pre, out_indices=out, backend=backend)
+    flashinfer.top_k_varlen(logits, seq_lens, top_k, **kw)  # warm-up / compile
+    torch.cuda.synchronize()
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(g, stream=s):
+            ret, _ = flashinfer.top_k_varlen(logits, seq_lens, top_k, **kw)
+    assert ret.data_ptr() == out.data_ptr()
+    for live, delta in ((8, 0), (5, 300), (2, -250), (8, 500), (0, 0)):
+        lens = base + delta
+        lens[live:] = 0
+        seq_lens.copy_(lens)
+        out.fill_(-7)
+        g.replay()
+        torch.cuda.synchronize()
+        _check_rows(logits, out, lens.tolist(), top_k)
+
+
+# ---------------------------------------------------------------------------
+# 3. indexer-specific inputs
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("top_k", [512, 1024, 2048])
+def test_select_all_dummy_logits(top_k):
+    """MLA path of the indexer: scores of width exactly top_k, all zero (every
+    value tied), rows no longer than top_k. Every backend must return
+    [0 .. len-1] followed by -1, for lengths 0, 1, top_k // 2 and top_k."""
+    lens_list = [0, 1, top_k // 2, top_k]
+    rows = len(lens_list)
+    logits = torch.zeros(rows, top_k, device=_DEV)
+    lens = torch.tensor(lens_list, dtype=torch.int32, device=_DEV)
+    pre = torch.full((rows, top_k), -1, dtype=torch.int32, device=_DEV)
+    ran = []
+    for backend in _available(logits, lens, top_k, pre_idx=pre):
+        out = torch.full((rows, top_k), -7, dtype=torch.int32, device=_DEV)
+        flashinfer.top_k_varlen(
+            logits, lens, top_k, pre_idx=pre, out_indices=out, backend=backend
+        )
+        torch.cuda.synchronize()
+        _check_rows(logits, out, lens_list, top_k)
+        ran.append(backend)
+    assert ran
+
+
+@pytest.mark.parametrize("backend", ["gvr", "gvr_2"])
+def test_previous_step_indices_as_hint(backend):
+    """Decode step t+1 reuses step t's indices as the hint while every request
+    grew by one token and the scores changed: exactness must not depend on how
+    stale the hint is."""
+    if not flashinfer.top_k_varlen.is_backend_supported(backend, _cc()):
+        pytest.skip(f"{backend} unsupported on this device")
+    rows, n, top_k = 6, 32768, 1024
+    gen = torch.Generator(device=_DEV).manual_seed(41)
+    lens = torch.randint(
+        top_k + 1, n - 8, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    pre = _hint(logits, top_k, 42)
+    if backend not in _available(logits, lens, top_k, pre_idx=pre):
+        pytest.skip(f"{backend} checker rejects this configuration here")
+    idx, _ = flashinfer.top_k_varlen(logits, lens, top_k, pre_idx=pre, backend=backend)
+    _check_rows(logits, idx, lens.tolist(), top_k)
+    for _ in range(4):
+        lens = lens + 1
+        logits = torch.randn(rows, n, generator=gen, device=_DEV)
+        idx, _ = flashinfer.top_k_varlen(
+            logits, lens, top_k, pre_idx=idx.contiguous(), backend=backend
+        )
+        torch.cuda.synchronize()
+        _check_rows(logits, idx, lens.tolist(), top_k)
+
+
+def _engine_reference(logits, lens, top_k):
+    """The serving engine's unfused top-k contract (SGLang `_topk_unfused`):
+    mask columns at or beyond the row length to -inf, torch.topk, and -1 for
+    every pick whose score is -inf."""
+    rows, n = logits.shape
+    cols = torch.arange(n, device=_DEV).unsqueeze(0)
+    masked = logits.masked_fill(cols >= lens.unsqueeze(1), float("-inf"))
+    scores, idx = torch.topk(masked, top_k, dim=1)
+    return idx.masked_fill(scores == float("-inf"), -1)
+
+
+def test_engine_reference_parity_and_masked_token_boundary():
+    """Decode-shaped batch compared with the engine's own reference. Rows with
+    at least top_k finite scores must agree as value multisets. Rows where the
+    engine masked tokens to -inf so that fewer than top_k finite scores remain
+    expose an integration boundary: the engine's contract returns -1 for the
+    -inf picks, this API returns top_k valid indices that include -inf columns
+    (they are the largest remaining values). The finite picks must agree; an
+    adapter that needs the engine's -1 semantics has to post-process, and this
+    test pins both halves so the boundary stays visible."""
+    rows, n, top_k = 6, 16384, 1024
+    gen = torch.Generator(device=_DEV).manual_seed(51)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    lens = torch.randint(
+        top_k + 200, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    # engine-style masking of "init/local" tokens inside the window
+    logits[:, :100] = float("-inf")
+    # row 5: only columns 100..899 stay finite inside its 4096-wide window
+    lens[5] = 4096
+    logits[5, 900:] = float("-inf")
+    n_finite_5 = int(torch.isfinite(logits[5, : int(lens[5])]).sum())
+    assert n_finite_5 == 800 < top_k
+    pre = _hint(logits, top_k, 52)
+    ref = _engine_reference(logits, lens, top_k)
+    ran = []
+    for backend in _available(logits, lens, top_k, pre_idx=pre):
+        out, _ = flashinfer.top_k_varlen(
+            logits, lens, top_k, pre_idx=pre, backend=backend
+        )
+        torch.cuda.synchronize()
+        for r in range(rows):
+            n_r = int(lens[r])
+            row = out[r].long()
+            assert int(row.min()) >= 0 and int(row.max()) < n_r, (
+                f"{backend} row {r}: range"
+            )
+            assert int(torch.unique(row).numel()) == top_k, f"{backend} row {r}: dups"
+            got = logits[r].gather(0, row)
+            if r < 5:
+                exp = logits[r].gather(0, ref[r].long())
+                assert torch.equal(
+                    torch.sort(got, descending=True).values,
+                    torch.sort(exp, descending=True).values,
+                ), f"{backend} row {r}: differs from the engine reference"
+            else:
+                finite_got = set(row[torch.isfinite(got)].tolist())
+                finite_ref = set(ref[r][ref[r] >= 0].tolist())
+                assert finite_got == finite_ref, f"{backend} row 5: finite picks differ"
+                assert (
+                    int((ref[r] == -1).sum()) == top_k - n_finite_5
+                )  # the engine pads with -1 ...
+                assert bool((row >= 0).all())  # ... this API fills with -inf columns
+        ran.append(backend)
+    assert ran
+
+
+# ---------------------------------------------------------------------------
+# 4. metadata and scale the engine actually produces
+# ---------------------------------------------------------------------------
+
+
+def _check_long_rows_vectorized(logits, out, lens, top_k):
+    """Batched oracle for rows that are all longer than top_k: unique in-range
+    indices and a per-row value multiset equal to torch.topk over the valid
+    prefix (columns at or beyond the row length masked to -inf)."""
+    rows, n = logits.shape
+    idx = out.long()
+    lens_col = lens.to(torch.int64).unsqueeze(1)
+    assert bool(((idx >= 0) & (idx < lens_col)).all()), "index out of range"
+    assert bool(
+        (
+            torch.sort(idx, dim=1).values[:, 1:]
+            != torch.sort(idx, dim=1).values[:, :-1]
+        ).all()
+    ), "duplicate indices"
+    cols = torch.arange(n, device=_DEV).unsqueeze(0)
+    masked = logits.masked_fill(cols >= lens_col, float("-inf"))
+    ref = torch.sort(torch.topk(masked, top_k, dim=1).values, dim=1).values
+    got = torch.sort(logits.gather(1, idx), dim=1).values
+    assert torch.equal(got, ref), "value multiset differs from torch.topk"
+
+
+@pytest.mark.parametrize("next_n", [1, 2])
+@pytest.mark.parametrize(
+    "backend", ["radix", "gvr", "gvr_2", "radix_cutlass", "radix_filter"]
+)
+def test_unclipped_lengths(backend, next_n):
+    """The engine hands the top-k its unclipped per-request cache lengths, which
+    can exceed the width of the score buffer for that step (the dynamic length
+    outgrows the static envelope, e.g. under CUDA-graph replay). Every backend
+    must clamp each row to the buffer width, after the next_n row adjustment,
+    and stay exact; rows within the width are unaffected. This harness found
+    gvr (both load-balance modes) and radix_filter reading past the row here
+    (compute-sanitizer: invalid global reads, indices >= width); both now
+    clamp in the kernel."""
+    if not flashinfer.top_k_varlen.is_backend_supported(backend, _cc()):
+        pytest.skip(f"{backend} unsupported on this device")
+    batch, n, top_k = 6, 8192, 1024
+    rows = batch * next_n
+    gen = torch.Generator(device=_DEV).manual_seed(61)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    lens = torch.tensor(
+        [100000, 8192, 8193, 5000, 200000, 1500], dtype=torch.int32, device=_DEV
+    )
+    pre = _hint(logits, top_k, 62)[:batch]
+    if backend not in _available(logits, lens, top_k, pre_idx=pre, next_n=next_n):
+        pytest.skip(f"{backend} checker rejects this configuration here")
+    row_lens = [
+        min(int(lens[r // next_n]) - next_n + (r % next_n) + 1, n) for r in range(rows)
+    ]
+    variants = (
+        [{"load_balance": True}, {"load_balance": False}] if backend == "gvr" else [{}]
+    )
+    for kw in variants:
+        out, _ = flashinfer.top_k_varlen(
+            logits, lens, top_k, pre_idx=pre, next_n=next_n, backend=backend, **kw
+        )
+        torch.cuda.synchronize()
+        _check_rows(logits, out, row_lens, top_k, who=f"{backend} {kw} next_n={next_n}")
+
+
+@pytest.mark.parametrize("rows,n,top_k", [(1024, 8192, 512), (4096, 8192, 2048)])
+def test_large_batch_every_backend(rows, n, top_k):
+    """Serving batches reach thousands of requests (the engine's own kernel
+    tests go to 4096 rows). Every backend that admits the shape must be exact
+    there: this crosses gvr's load-balance cap and gvr_2's wide/narrow routing
+    split (b > 148)."""
+    gen = torch.Generator(device=_DEV).manual_seed(71)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    lens = torch.randint(
+        top_k + 1, n + 1, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    pre = _hint(logits, top_k, 72)
+    ran = []
+    for backend in _available(logits, lens, top_k, pre_idx=pre):
+        out, _ = flashinfer.top_k_varlen(
+            logits, lens, top_k, pre_idx=pre, backend=backend
+        )
+        torch.cuda.synchronize()
+        _check_long_rows_vectorized(logits, out, lens, top_k)
+        ran.append(backend)
+    assert ran
+
+
+def test_heavily_tied_scores_every_backend():
+    """Quantized scores with a few distinct values (dense ties at the k-th
+    value) must still give an exact value multiset on every backend; which of
+    the tied columns is picked is unspecified."""
+    rows, n, top_k = 8, 16384, 1024
+    gen = torch.Generator(device=_DEV).manual_seed(81)
+    logits = torch.randint(0, 16, (rows, n), generator=gen, device=_DEV).float()
+    lens = torch.randint(
+        top_k + 1, n + 1, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    pre = _hint(logits, top_k, 82)
+    ran = []
+    for backend in _available(logits, lens, top_k, pre_idx=pre):
+        out, _ = flashinfer.top_k_varlen(
+            logits, lens, top_k, pre_idx=pre, backend=backend
+        )
+        torch.cuda.synchronize()
+        _check_long_rows_vectorized(logits, out, lens, top_k)
+        ran.append(backend)
+    assert ran


### PR DESCRIPTION
# feat(topk): self-sampling GVR V2 backend, oracle-tracking `auto`, and the V1 threshold repair

Three commits, one arc: port TRT-LLM's self-sampling GVR V2 top-K decode as a new `top_k_varlen` backend, make `backend="auto"` track the measured per-config winner, and fix the correctness bug in the existing V1 `gvr` backend that the new benchmark sweep uncovered.

## 1. `gvr_2` — self-sampling GVR V2 port (NVIDIA/TensorRT-LLM#17821, commit `ed94d4cfbf`)

**Algorithm** — V1 GVR guesses its selection threshold from the previous step's `pre_idx` hint and pays full-row refinement rescans when the hint is stale. V2 instead derives a *bracketed ladder* of candidate thresholds from an in-kernel sample of the row itself (Floyd–Rivest-style) and resolves exact, tie-interchangeable top-K in a **single streaming pass**; exactness is guaranteed by count-crossing invariants, never by the estimate, and the hint survives only as a degenerate-case anchor. Four kernel families (streaming `main` with multi-CTA SPLIT, register-resident `reg`/`regimg`, clustered `clus`/`reg_clus`) are chosen by a pure host dispatch `route(b, n, npad, k)`; per-request lengths are read **on device**, so one launch serves the whole ragged batch — no prepare kernel, no LJF sort, no host reads (sync-free and CUDA-graph safe; the length envelope comes from the logits row width).

**Port notes**
- `flashinfer/topk_varlen/kernels/gvr2_topk_decode.py` (device) and `gvr2_topk_host.py` (dispatch/workspace/entry) are near-verbatim upstream drops, excluded from ruff/mypy like the repo's other verbatim kernel ports so future syncs stay mechanical. Local changes: module rename, provenance notes, a `_persist()` hook routing the four `get_compiled*` builders through the persistent CuTe-DSL kernel cache (the upstream compile closures already use `--enable-tvm-ffi` + fully symbolic shapes, matching the cache's TVM-FFI reload convention), and a fixed missing kv-arg in the `regclus_topk` debug entry.
- Backend contract: fp32 logits only (bf16/fp16 are an upstream follow-up), `top_k ∈ {512, 1024, 2048}`, `compress_ratio ∈ {1, 4}`, `pre_idx` required with width == `top_k`, datacenter Blackwell (sm_100/103). The ~21 MB per-device workspace slab is zero-initialized once and self-restoring; multi-stream callers can pass `workspace={"gvr2_workspace": ...}`.
- Upstream caveat found by this PR's adversarial tests and reproduced **bit-identically by the TRT-LLM implementation**: literal `+inf` logits may not be selected (at least in the clustered-register family); all finite values — including 3.1e38, above the kernel's 3e38 pad sentinel — and `-inf` are tie-aware exact. Documented in the API docs + a non-strict `xfail` (`test_gvr2_plus_inf_upstream_caveat`) that flips visible if a future upstream sync fixes it. Same class as upstream's implementation-specific NaN ordering.

**Performance** (B200, fp32, CUDA-graph timing, tie-aware output validation before every timing; 213 configs across uniform/mixed/short lengths, K ∈ {512, 1024, 2048}, B ∈ [1, 256], N ∈ [1K, 128K], cr ∈ {1, 4}, next_n ∈ {1, 2}):

| vs backend | geomean | gvr_2 faster | range |
|---|---|---|---|
| `gvr` (existing, LB) | **2.58×** | 210/211 | 0.47–6.23× |
| `gvr` (non-LB) | 3.80× | 210/211 | 0.76–10.94× |
| `radix` (CuTe DSL) | 2.13× | 211/213 | 0.30–10.05× |
| `radix_cutlass` | 3.29× | 211/213 | 0.56–5.92× |
| TRT-LLM upstream twin (port parity) | **1.00×** | — | 0.95–1.05× |

The only losing regime is batches whose rows are mostly barely longer than K (upstream's own documented short-row trade-off).

## 2. Shape/dtype-aware `auto` (oracle-tracking)

The previous static gvr-first `auto` never reached `gvr_2`, always picked `gvr` for hinted bf16/fp16 where `radix` wins by up to 2.8×, and never reached `radix_cutlass` in its fp32 big corner (up to 2.8×). The new ranking uses only capture-stable host facts (dtype, N, B — never `seq_lens` contents, which would cost a D2H sync), derived from a 500+-cell sweep:

1. hinted fp32 → **`gvr_2`**;
2. `gvr` outranks `radix` only when `B·N ≥ 2²²` (fp32) / `2²³` (bf16/fp16);
3. `radix_cutlass` outranks `radix` only in the fp32 corner `N ≥ 65536` and `B·N ≥ 2²³`; in half precision `radix` always leads.

**Validated on 100 off-grid configs** (shapes never used to fit the thresholds), regret = t(auto's pick) / t(fastest backend):

| policy | geomean | max | oracle hits |
|---|---|---|---|
| new | **1.004×** | 1.16× | 97/100 |
| old | 1.317× (hinted 1.694×) | 3.05× | 55/100 |

Documented static blind spot: mostly-short rows inside a wide N favor `radix` but are indistinguishable without reading `seq_lens`; such callers should pass `backend="radix"` explicitly. `benchmarks/bench_topk_varlen_gvr2.py` (new comparison benchmark, with an upstream-twin mode) gained `--dtype`; the bf16/fp16 sweeps drove rules 2–3.

## 3. V1 `gvr` threshold-search repair (folded from #4813)

This PR's sweep found the existing `gvr` backend shipping silently wrong top-K when its Phase-2 threshold search terminates without converging: identity indices `row[0:K]` on degenerate hint brackets, or underfilled rows (stale/−1 output slots) on hostile hints, tie plateaus wider than the candidate buffer, and `N_eff = K+1` batches. Fixed by porting the correctness-relevant subset of three upstream commits FlashInfer's V1 snapshot (~Jul 22) predates:

- NVIDIA/TensorRT-LLM#16457 + #16877: the tie-plateau layer — adjacent-float bracket terminal (`done=3`) in both `phase2_secant_search` copies, `s_iscalars (6,)→(8,)`, plateau flag/ticket, gated Branch-C pad, and a post-Phase-4 fill completing the row from the bitwise-equal tie class;
- NVIDIA/TensorRT-LLM#18094 (the upstream tip for this kernel, verified via live GitHub): the two-sided repair — Phase 3's overflow-only retry becomes an anchored bisection on the signed fp32 order-key image (provable collapse in ≤32 steps), handling undershoot, restoring to `val_lo` when a collapse ends under K, and handing collapsed plateaus to the `done=3` machinery; the degenerate-hint identity emit becomes a synthetic-bracket fall-through, so correctness no longer depends on the hint at all.

Both LB paths are covered automatically (`GvrTopKLBKernel` reuses `GvrTopKKernel.run_one_row`). Before/after: the fix is ~4% *faster* geomean in the converging common case (the repair shrinks oversized candidate sets) and turns the previously-wrong regimes correct at 1.1–7× cost (their old timings were the price of not computing the answer). Full A/B table and root-cause discussion preserved in the #4813 thread. Ported with a 3-lens adversarial review against the upstream reference (port fidelity, DSL/barrier execution, FlashInfer-divergence interactions) — all clean.

## Testing

- `tests/topk_varlen/test_topk_varlen_gvr2.py` (79 tests): tie-aware exactness with poisoned pads, short-row identity+pad contract, degenerate hints, varlen/MTP/compress-ratio grids, zero-kv-slot rows, per-family admission parity, CUDA-graph capture/replay with in-place growing `seq_lens`, warmup-then-capture, non-contiguous arena views, workspace override, adversarial tie/huge-value/denormal patterns, a >10k-point `route_split == route` dispatch fuzz, and the `+inf` caveat xfail.
- `tests/topk_varlen/test_gvr_threshold_repair.py` (31 tests): upstream #18094's regression patterns on the FlashInfer API (hostile/degenerate hints × K × LB modes, ReLU-sparse plateaus, MTP hostile hints) plus the FlashInfer-found `N_eff = K+1` case — all fail pre-fix.
- Cross-backend value-multiset consistency and the shape-aware heuristic-priority unit test (meta tensors, runs off-GPU) extended in `test_topk_varlen.py`.
- Results: see section 4 for the post-rebase sweep on SM80/89/90/100 (B200 and B100)/107 (Rubin)/120.

## 4. Rubin (SM107) enablement and rebase onto #4621

Rebased onto current `main`, which now includes #4621 (Rubin support for `top_k_varlen` plus the `radix_filter` backend). Conflicts were confined to `topk_varlen.py` (docstrings, the backend `Literal`/registration, the `auto` heuristic body, and the `next_n` validation), `pyproject.toml`, and `.pre-commit-config.yaml` (both sides added vendored-kernel exclusions; union kept). Resolutions of note:

- The `next_n`/`seq_lens` grouped-row validation lands as #4621's `ValueError` raises (they hold under `python -O`); this branch's equivalent asserts were dropped and its up-front-validation test now expects `ValueError`.
- `auto` keeps this branch's shape-aware ranking; `radix_filter` stays explicit-only, with #4621's rationale comment retained.

`gvr_2` on Rubin (commit `feat(topk): enable gvr_2 on Rubin (SM107)`):

- Admission comes through the shared `_GVR_CCS = [100, 103, 107]` list from #4621; the gvr_2 checker now uses #4621's per-device `_cute_dsl_ready()` probe instead of the process-wide DSL flag, so a DSL predating the device degrades `auto` cleanly.
- No kernel changes: the device module uses only family-portable ops (no `tcgen05` / block-scaled MMA), so the same source compiles for `sm_107a`; the compile target follows the current device and the persistent CuTe-DSL cache is arch-namespaced.
- The host router's `148` (B200 SM count, mirrored from the upstream CUDA dispatch) is documented as an occupancy heuristic only; on Rubin's 208 SMs the same constants are conservative, never incorrect. Per-arch retuning is a perf follow-up.

Verification after the rebase (full `tests/topk_varlen/`, which now includes #4621's `test_radix_filter.py`):

| Arch | GPU | `tests/topk_varlen/` at `9f518813` (identical to the swept tree except one unused loop index in a test) |
|---|---|---|
| SM80 | A100-PCIE-40GB | 54 passed, 203 skipped |
| SM89 | L40S | 54 passed, 203 skipped |
| SM90 | H100 NVL | 54 passed, 203 skipped |
| SM100 | B200 | 252 passed, 3 skipped, 2 xfailed |
| SM100 | B100 | 252 passed, 3 skipped, 2 xfailed |
| **SM107** | **Rubin GR100** | **253 passed, 2 skipped, 2 xfailed** (7 min 19 s cold, including the first `sm_107a` compiles of every gvr_2 family) |
| SM120 | RTX 5080 | 54 passed, 203 skipped |

The skips on SM100/107 are all in `test_radix_filter.py` (two need a second visible GPU; one wants an async-TMA default that is active on SM107 but not SM100, hence Rubin's extra pass). The two xfails are the known upstream caveats (radix_filter's padded-merge tie, gvr_2's `+inf`). Every gvr_2 test ran on SM100 and SM107.

Basic perf after the rebase (`benchmarks/bench_topk_varlen_gvr2.py`, fp32, K = 1024, B ∈ {1, 16, 64, 256}, N ∈ {8K, 32K, 128K}, uniform and mixed lengths, CUDA-graph timing, tie-aware validation before every timing):

| GPU | vs `gvr` | vs `radix` | vs `radix_cutlass` | gvr_2 wins |
|---|---|---|---|---|
| B100 (SM100) | 2.40× | 2.49× | 3.40× | 24/24 vs each |
| Rubin GR100 (SM107) | 2.31× | 2.55× | 3.37× | 24/24 vs each |

Consistent with the B200 sweep in section 1, and Rubin lands there with the router's B200 occupancy constants untouched.

## Follow-ups (out of scope)

- Consider an `N_eff`-aware escape for gvr_2's short-row regime if it is ever promoted for length-skewed workloads.
- bf16/fp16 gvr_2 tracks the upstream roadmap; once ported, the V1 `gvr` backend's last winning corner (hinted bf16/fp16 at large B·N) disappears and it can be deprecated.
- Report the `+inf` selection caveat upstream (reproducer in the xfail test).

AI-assisted (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the GVR V2 backend for variable-length top-k operations on supported Blackwell hardware.
  - Added support for variable sequence lengths, returned values, workspace controls, warmup, and CUDA Graph workflows.
  - Added automatic backend selection based on input shape and data type.
  - Added a configurable benchmark for comparing top-k implementations.

- **Bug Fixes**
  - Improved handling of ties, plateaus, sparse results, short rows, and challenging threshold-search cases.
  - Added validation and clearer handling for unsupported configurations.

- **Tests**
  - Expanded correctness, consistency, validation, and CUDA Graph coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 5. Review follow-up (`ea069804`)

Addresses the open review threads:

* **Row-length clamp on arena views.** `gvr_main`'s varlen prologue clamped each row's kv-derived length to the row stride; the other three families clamp to the envelope. It now clamps to the envelope too (carried in the previously dead `n` launch slot), so an oversized `seq_lens` value on a wider-stride view can never classify arena columns in `[width, stride)`. Contiguous inputs are unchanged. New test `test_gvr2_arena_view_oversized_seq_lens` covers all families; it fails on the previous kernel for both `gvr_main` parametrisations.
* **Heterogeneous multi-GPU processes.** `run` / `run_ws` / `run_varlen` re-enter under `torch.cuda.device(logits.device)` when the logits are not on the current device, so the launcher cache key, the DSL compile target and the launch agree by construction. Every gvr_2 `cute.compile` also passes an explicit `--gpu-arch` for the current device: the DSL otherwise detects its target once per process from device 0, so a kernel compiled while another device is current was built for device 0's architecture and failed to load (`cudaErrorNoKernelImageForDevice`). New test `test_gvr2_logits_on_non_current_device` (exercised with device 0 = L40S, device 1 = B100; failed before both fixes).
* Benchmark: `mixed`/`short` rows drawn from the documented domain, GVR-family backends report `n/a` outside `top_k ∈ {512, 1024, 2048}`, summary no longer requires `fi_gvr2`; `benchmarks/routines/topk_varlen.py` drops `gvr_2` when `max_seq_len % 4 != 0`; raw-string regex patterns in tests.
* The `+inf` caveat stays an `xfail` with the upstream tracking issue; see the thread for the rationale.

**Public API note.** The "potential breaking change" advisory is the `backend` `Literal` gaining the `"gvr_2"` member. That is additive: every previously valid call, including positional ones, is unchanged.

## 6. Known kernel defect: DKG issue #58 (`+inf` / NaN dropped) and the TRT-LLM #18501 port (`8e76f056`)

While validating this port I filed DKG issue #58 (internal GitLab, `dlarch-fastkernels/dynamic-kernel-generator`) against the upstream self-sampling GVR V2 kernel: a row containing a literal `+inf` returns a top-k without it, and NaN is not ranked on top the way `torch.topk` does. The result does not depend on hint quality (oracle and `-1` hints fail identically). The `+inf` case is inside the kernel's documented "finite + inf exact" contract; the NaN case is a torch-parity gap (upstream documents NaN ordering as implementation-specific).

The kernel owner pointed at TensorRT-LLM PR #18501 as the latest fix. **Reproduced on this branch and ported here** (register family `GvrTopkRegKernel.kern`, verbatim apart from our module rename): count-crossing enforcement when the hint-derived bracket makes the histogram total fall short of k, a radix-descent escape replacing the 32-step key-space bisection, and the `-inf` fill-lane bound. Before the port, the two upstream regressions were severe on this branch: a cold-start hint buffer (all zeros plus an argmax anchor) left 130,304 of 131,072 output slots unwritten across 256 rows, and an in-window `-inf` in a row's tail column left every row entirely unwritten. After the port both are exact with every slot written, on B100, B200 and Rubin (`test_gvr2_high_anchor_hint_completeness`, `test_gvr2_neginf_tail_completeness`).

**`+inf` closed (`48572ef2` + `274fad3e`):** the kernel owner's follow-up TensorRT-LLM PR #18625 is ported in full. Its first commit fixes `GvrTopkRegKernel.kern` (an infinite bracket width fails the collapse guard and the row takes the key-space escape); its second commit, written after the repro posted on DKG issue #58, fixes `GvrRegClusKernel.kern` the same way (bounded guard, and an infinite-width bracket forces the whole-row `degen` fallback instead of the collapsed histogram, which used to turn the `+inf` into NaN in the trash bin and return the true top-K with the `+inf` replaced by the (K+1)-th value). Verified on B200, B100 and Rubin against upstream at `9f920331` and through `top_k_varlen(backend="gvr_2")`: `+inf` inside or outside the bracket sample, K in {512, 1024, 2048}, more `+inf` than K, the 4 x 32K and 4 x 64K `reg_clus` shapes, with oracle, `-1` and random hints; `main` and `clus` were already exact. `test_gvr2_posinf_completeness` (register family) and `test_gvr2_posinf_reg_clus` (clustered-register family, replaces the former strict `xfail`) pin it; the API docstring caveat is gone. NaN ordering stays implementation-specific upstream, although NaN now ranks on top in every shape tested. Perf of the reg_clus hunks (B100, graph replay, 5 alternating passes, deterministic to the nanosecond): 4 x 32K +2.5%, 8 x 32K +2.8% (about 0.15 us each), 16 x 32K and the register family unchanged.

## 7. `auto` heuristic refinement (`993f6c9e`): radix_filter admission and the half-precision gvr rule

Measured `auto` against an oracle (fastest explicit backend per cell, CUDA-graph replay, tie-aware validation) over 4 batch sizes x 5 lengths (8K..1M) x uniform/mixed/short lengths x hinted/hint-free, fp32 and bf16, K=1024, on B100/B200 (SM100) and Rubin (SM107). Efficiency = best-of-all time / auto time (1.00 = auto matched the oracle). Findings and the resulting rules (one rule set for every arch; the SM100 crossovers are conservative on SM107, where radix_filter's margins are larger):

* Hinted fp32 (the DSA decode path) was already at 0.95-1.00: gvr_2 first stays. The remaining sub-0.95 cells are rows whose valid length is within 1-4 of K, a register-family fallback path (perf follow-up).
* Hint-free fp32 sat at 0.83 (SM100) / 0.72 (SM107) and bf16 at 0.86 / 0.82 purely because `radix_filter` was excluded from `auto` while being the fastest hint-free backend in most cells from 32K columns up. It is now admitted where it measured fastest: fp32 for N >= 32K (except the single-row case at N >= 512K) and at every N once B >= 256; half precision for 32K <= N <= 128K with B <= 16, N >= 128K with B >= 64, and N <= 8K with B >= 256. Its checker no longer rejects `pre_idx`: the hint is optional steering for the GVR family, so a hinted caller may use any hint-free backend, explicitly or via `auto`, exactly as radix and radix_cutlass already allowed; the hint is accepted and ignored.
* One genuine ranking error: for half precision the old `B*N >= 2^23` rule chose gvr (V1) at B <= 64 for N >= 512K, where it loses 1.5-7x to radix (16 rows x 2M: 1518 us vs 210 us). gvr is now chosen for half precision only when B >= 256 and 32K <= N <= 512K, where it measured fastest. The fp32 gvr rule is unchanged (it only matters when gvr_2 is unsuitable; radix_filter ranks ahead of it there).

Re-measured with the refined heuristic (cells >= 0.95 in parentheses; worst remaining cell listed):

| dtype, K | hint | GPU | before | after | worst cell after |
|---|---|---|---|---|---|
| fp32, K=1024 | yes | SM100 (B100) | 0.95 (46/48) | **0.99** (57/60) | short B=64 N=8K |
| fp32, K=1024 | yes | SM107 (Rubin) | 0.95 (45/48) | not re-measured (GPU shared with another job at the time; same rule set, radix_filter's margins are larger on SM107 so the SM100 crossovers are conservative there) | |
| fp32, K=1024 | no | SM100 (B100) | 0.83 (19/48) | **0.99** (58/60) | short B=256 N=128K |
| bf16, K=1024 | yes | SM100 (B100) | 0.92 (29/48) | **0.97** (53/60) | short B=64 N=1024K |
| bf16, K=1024 | no | SM100 (B100) | 0.86 (26/48) | **1.00** (59/60) | mixed B=16 N=128K |

`test_backend_heuristic_priority` pins the new boundaries off-GPU; the public docstring's `backend` section now documents `radix_filter` and the refined `auto` order.

## 8. SGLang comparison -> two dispatch rungs and hint-free `gvr_2` (`117415eb`)

An SGLang report ("gvr_v2 slower than `topk_transform_512_v2` at 32K with c4") was reproduced with their input recipe (fp32 randn logits, compressed widths padded to 64, uniform and variable lengths, perfect previous-step hint, identity page table, CUDA-graph replay medians, K = 512). Every comparison below ran in ONE process on ONE isolated computelab node (B200: 1000 W part, driver 610.57; B300: SM103 600 W part, driver 595.58), three columns per cell: sglang `topk_v2`, `gvr_2` with the upstream dispatch, `gvr_2` with this commit. Both `gvr_2` variants were value-multiset exact in every cell.

**Finding.** The claim held in one band only: compressed width 6144-8192, where `gvr_2` was 3-7% slower at bs <= 128 and 13-21% slower at bs 256; it was already 8-45% faster at every other width from 4096 to 131072. The cause is the dispatch, not the kernels: for `1024 < n4 <= 4096` the upstream `route()` runs every `wide` row on the VPT=4 register kernel (two empty float4 slots per thread up to n = 8192) and sends b > 148 to the streaming slab.

**Change (FlashInfer-local rungs in `route()`, reported upstream as DKG issue #61):** `n4 <= 2048` and `b <= 148` -> `_reg(1024, 2, 1, 2*NB)`; `n4 <= 2048` and `148 < b <= 296` (one wave at MINB=2) -> `_reg(512, 4, 2, NB)` with `NBSEL` following so `IMGOFF == NBH`; b > 296 keeps the slab (at b = 512 the two trade places by shape). Same-node A/B on B100, B200, B300 and Rubin: 18-20% faster in the wide band for K in {512, 1024, 2048}, 1.3-1.7x at b = 160-256.

sglang `topk_v2` time / `gvr_2` time (> 1 = `gvr_2` faster), uniform lengths, bs 1 / 16 / 64 / 128 / 256:

| compressed width | B200 upstream dispatch | B200 this commit | B300 upstream dispatch | B300 this commit |
|---|---|---|---|---|
| 4096 | 1.08 / 1.08 / 1.08 / 1.09 / 1.24 | 1.01 / 1.08 / 1.08 / 1.09 / 1.24 | 1.08 / 1.06 / 1.04 / 1.06 / 1.24 | 1.01 / 1.06 / 1.04 / 1.06 / 1.24 |
| 6144 | 0.95 / 0.95 / 0.95 / 0.95 / 0.80 | 1.14 / 1.14 / 1.14 / 1.14 / 1.30 | 0.92 / 0.93 / 0.93 / 0.93 / 0.79 | 1.12 / 1.12 / 1.12 / 1.12 / 1.31 |
| 8192 | 0.96 / 0.97 / 0.99 / 0.98 / 0.84 | 1.17 / 1.19 / 1.20 / 1.19 / 1.39 | 0.93 / 0.97 / 0.97 / 0.96 / 0.87 | 1.16 / 1.21 / 1.20 / 1.17 / 1.38 |
| 12288 | 1.10 / 1.15 / 1.15 / 1.16 / 1.01 | 1.16 / 1.15 / 1.15 / 1.17 / 1.01 | 1.11 / 1.11 / 1.13 / 1.15 / 0.96 | 1.17 / 1.13 / 1.14 / 1.15 / 0.96 |
| 16384 | 1.23 / 1.26 / 1.28 / 1.28 / 1.17 | 1.23 / 1.26 / 1.28 / 1.28 / 1.17 | 1.25 / 1.25 / 1.32 / 1.63 / 1.19 | 1.25 / 1.24 / 1.32 / 1.61 / 1.19 |
| 32768 | 1.59 / 1.70 / 1.45 / 1.27 / 1.41 | 1.65 / 1.70 / 1.45 / 1.27 / 1.41 | 1.67 / 1.77 / 1.51 / 1.29 / 1.47 | 1.61 / 1.75 / 1.49 / 1.29 / 1.47 |
| 131072 | 1.47 / 1.44 / 2.33 / 2.00 / 1.80 | 1.47 / 1.44 / 2.33 / 2.00 / 1.80 | 1.52 / 1.13 / 2.39 / 2.04 / 2.08 | 1.52 / 1.13 / 2.38 / 2.04 / 2.09 |

Faster-or-equal cells vs sglang, 49 uniform + 28 variable-length per GPU: B200 35 -> 49 uniform, 19 -> 26 variable-length; B300 34 -> 48, 16 -> 23; Rubin (SM107, 208 SMs, same job layout in the cu135 container) 35 -> 49, 19 -> 26. Rubin ratios with this commit, uniform, bs 1 / 16 / 64 / 128 / 256: width 4096 1.05 / 1.10 / 1.11 / 1.12 / 1.05; 6144 1.13 / 1.13 / 1.12 / 1.11 / 1.55; 8192 1.17 / 1.19 / 1.18 / 1.18 / 1.49; 12288 1.15 / 1.11 / 1.12 / 1.12 / 1.37; 16384 1.23 / 1.23 / 1.27 / 1.26 / 1.48; 32768 1.92 / 1.91 / 1.66 / 1.39 / 1.69; 131072 1.63 / 1.12 / 2.87 / 2.31 / 2.89. The remaining misses are bs 256 at width 12288 (0.96-1.01, the second CTA wave of the new rung) and few-row variable-length cells at width 4096 (about 1 us total; sglang's short-row early exit is 0.3-0.5 us cheaper). Absolute at the reported cell (width 8192, B200): sglang 4.27-4.48 us vs `gvr_2` 3.62-3.76 us for bs 1-128; 6.77 vs 4.89 us at bs 256. Note that sglang's kernel fuses the page-table transform, so it does slightly more work per call.

**SM-count-aware register band + second wave (`f15221e5`).** Tuning the same band on B300 (sm_103, 160 SMs) and Rubin (sm_107, 208 SMs) showed the remaining losses sat exactly where `route()`'s hard-coded 148 (the B200 SM count) mis-sizes a wave on other parts. `route(b, n, npad, k, sms=148)` now takes the device SM count (`_sm_count()`, part of both launcher cache keys) for the register-band tests only: `wide = b <= sms`, the `QC`/`CURE` flags, and the BLK=512 rung's cutoff (`b <= 2*sms`, plus a second wave `b <= 4*sms` for n >= 6144, where it still beats the slab: B200 b=512 +11-12%, and the ragged-row 6144-8192 x 320-400 cells the slab lost by up to 22%). The streaming constants stay at 148 on every part: scaling them made the 131072 x 192-256 slab cells 3-28% slower on B300 and Rubin. Tried and rejected: swapping the `regimg` flavour for plain `reg` at n <= 4K (+5%..-12% by cell and hint quality), clustered-register configs for 8K < n <= 16K at b > sms (2-4x slower), `_reg(1024, 4, 1)` for the second wave of 8K-16K (mixed). Same-node vs sglang after this commit, 84 uniform (bs 1-512, 7 widths) + 48 variable-length cells per GPU, gvr_2 faster-or-equal: B200 83/84 and 45/48 (upstream routing: 65 / 35); B300 82/84 and 43/48 (62 / 31); Rubin 84/84 and 46/48 (58 / 31). What sglang still wins: 1-4 randomly short rows at width 4096 (~1 us calls, its short-row early exit is 0.3-0.5 us cheaper); the second CTA wave at width 12288 (B200 bs160 0.99; B300 bs256 0.97, bs320 0.91); B300 ragged rows at width 4096 for bs 16-64 (0.96-0.99) and width 5120 at bs320 (0.93-0.97 on B200/B300, the lower half of the band where the second wave loses on uniform rows).

**Hint-free `gvr_2`.** `pre_idx` is now optional for `gvr_2`: `run_varlen(pre_idx=None, top_k=K)` runs on a cached `arange(k)` table (`_hint_free_pre_idx`, per (device, k), grown eagerly, refused under CUDA-graph capture, pre-sized by `warmup_varlen`). The kernels use the hint only as a sampling anchor, so the result is exact; measured hint-free vs perfect-hint on isolated B200/B300 and on B100/Rubin: within ~10% on most cells, and 1.5-5x ahead of `radix` / `radix_filter` everywhere except K >= 2048, N <= 4096, B = 1 (radix_filter 1.3x faster). `auto` therefore ranks `gvr_2` first for fp32 with or without a hint, with that one cell carved out to `radix_filter`; a malformed hint on `backend="gvr_2"` is discarded with the existing RuntimeWarning and the call still runs on `gvr_2`; the "requires pre_idx" refusal now applies to `gvr` only.

Tests added: hint-free exactness on every kernel family incl. short/MTP/cr=4 rows, hint-free CUDA-graph replay with table-growth refusal, host `top_k` contract, the two rungs (tuple, NBH == IMGOFF, one-wave cutoff, `route_split` parity), auto order with and without a hint, per-backend malformed-hint behaviour. Gate before push: full `tests/topk_varlen` on A100, L40S, H100, B100, DRIVE P2021, RTX 5080, Rubin and isolated computelab B200 and B300 (322-323 passed on SM100-class, 74-77 elsewhere, 2 known xfails).