### PR TITLE
fix: avoid non-deterministic output by locking file writes in benchmarks (closes #4704)

### DIFF
--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -76,21 +76,32 @@ def run_test(args):
 
     # Write results to output file if specified
     if args.output_path is not None:
-        with open(args.output_path, "a") as fout:
-            for cur_res in res:
-                for key in full_output_columns:
-                    # Backfill every output column the routine didn't set: from
-                    # args when available, else "".  Covers columns belonging to
-                    # other routines (e.g. attention's s_qo) that would otherwise
-                    # KeyError below.  Routine-set values are preserved.
-                    if key not in cur_res or cur_res[key] == "":
-                        cur_res[key] = getattr(args, key, "")
+        # Ensure atomic writes when multiple processes write to the same file
+        import os
+        import fcntl
 
-                output_line = ",".join(
-                    [str(cur_res[col]) for col in full_output_columns]
-                )
-                fout.write(output_line + "\n")
-            fout.flush()
+        lock_path = args.output_path + ".lock"
+        lock_fd = open(lock_path, "w")
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX)
+            with open(args.output_path, "a") as fout:
+                for cur_res in res:
+                    for key in full_output_columns:
+                        # Backfill every output column the routine didn't set: from
+                        # args when available, else "".  Covers columns belonging to
+                        # other routines (e.g. attention's s_qo) that would otherwise
+                        # KeyError below.  Routine-set values are preserved.
+                        if key not in cur_res or cur_res[key] == "":
+                            cur_res[key] = getattr(args, key, "")
+
+                    output_line = ",".join(
+                        [str(cur_res[col]) for col in full_output_columns]
+                    )
+                    fout.write(output_line + "\n")
+                fout.flush()
+        finally:
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+            lock_fd.close()
     return
 
 


### PR DESCRIPTION
## What

The GDN prefill benchmark on SM100 shows non-deterministic test results: identical runs either pass all tests or fail all tests. Investigation reveals that the benchmark output writing in `run_test` uses a simple append-mode file open without any locking. When multiple test invocations run in parallel (e.g., through the benchmark's multiprocessing), concurrent writes to the same output file can interleave, corrupting the CSV output and causing the test driver to misinterpret results, leading to nondeterministic pass/fail.

## Fix

Added a file lock (using `fcntl.flock` on Linux) around the entire write operation to ensure that each result block is written atomically. A separate lock file (`<output_path>.lock`) is used to avoid interference with the actual output file. The lock is acquired before opening the output file and released after the write completes (or on exception), guaranteeing serialized writes across processes.

This fix also sets a precedent for other likely write paths in the benchmark utilities (e.g., unit test result collection) that may suffer from the same issue.

Closes #4704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple benchmark runs append results concurrently.
  * Ensured benchmark result files are properly unlocked and closed after writing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->