### PR TITLE
feat(cake_backend): add grouped MXFP8 quantization

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         # Source-export directories are checksum-attested generated artifacts;
         # formatting them would break parity with their producer manifests.
         exclude: |
-          (?x)^(3rdparty/.*|flashinfer/jit/aot_config.py|csrc/cake_vsa/.*|csrc/dcp/.*)$
+          (?x)^(3rdparty/.*|flashinfer/jit/aot_config.py|csrc/cake_vsa/.*|csrc/cake_grouped_mxfp8_quantize/.*|csrc/dcp/.*)$
 
   -   repo: https://github.com/pre-commit/mirrors-mypy
       rev: 'v1.17.1'  # Use the sha / tag you want to point at

--- a/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
+++ b/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
@@ -53,11 +53,15 @@ def _require_environment() -> tuple[tuple[int, int], str]:
     except (ImportError, RuntimeError) as error:
         raise RuntimeError("reportable timings require cupti-python >= 13") from error
     if int(cupti_version.split(".", 1)[0]) < 13:
-        raise RuntimeError(f"reportable timings require cupti-python >= 13, got {cupti_version}")
+        raise RuntimeError(
+            f"reportable timings require cupti-python >= 13, got {cupti_version}"
+        )
     if not is_cake_grouped_mxfp8_quantize_available(
         torch.bfloat16, torch.device("cuda", torch.cuda.current_device())
     ):
-        raise RuntimeError("an exported Cake BF16 grouped MXFP8 profile is not installed")
+        raise RuntimeError(
+            "an exported Cake BF16 grouped MXFP8 profile is not installed"
+        )
     if not is_cuda_tile_available():
         raise RuntimeError("the cuTile grouped MXFP8 baseline is not available")
     return capability, cupti_version
@@ -169,7 +173,9 @@ def main() -> None:
     parser.add_argument("--json", type=Path)
     args = parser.parse_args()
     if args.warmup_ms < 100 or args.benchmark_ms < 1000:
-        raise ValueError("reportable runs require >=100 ms warmup and >=1000 ms measurement")
+        raise ValueError(
+            "reportable runs require >=100 ms warmup and >=1000 ms measurement"
+        )
 
     wall_start = time.perf_counter()
     capability, cupti_version = _require_environment()

--- a/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
+++ b/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
@@ -1,7 +1,8 @@
-"""Strict cold-L2 CUPTI benchmark for grouped MXFP8 public backends.
+"""Strict cold-L2 CUPTI benchmark for grouped MXFP8 quantization kernels.
 
-The timed boundary is one complete eager ``mxfp8_grouped_quantize`` call,
-including output allocation and every GPU activity attributed to that call.
+Both arms use preallocated outputs and prepared scheduling metadata.  The
+timed boundary contains exactly one quantization-kernel launch; cuTile prefix
+construction and all Python/output-allocation work stay outside that boundary.
 CUDA-event and CUDA-graph timing fallbacks are deliberately rejected.
 """
 
@@ -16,11 +17,15 @@ from pathlib import Path
 
 import torch
 
-import flashinfer
 import flashinfer.testing.utils as timing_utils
 from flashinfer.cutile import is_cuda_tile_available
 from flashinfer.jit.cake_grouped_mxfp8_quantize import (
+    get_cake_grouped_mxfp8_quantize_module,
     is_cake_grouped_mxfp8_quantize_available,
+)
+from flashinfer.quantization.kernels.cutile.mxfp8_grouped_quantize_cutile import (
+    build_mxfp8_grouped_quant_prefix_schedule,
+    mxfp8_grouped_quantize_cutile_with_prefix_schedule,
 )
 
 
@@ -103,7 +108,7 @@ def _measure_strict_cupti(call, *, warmup_ms: int, benchmark_ms: int) -> dict:
         "timing_backend": "CUPTI activity",
         "cold_l2": True,
         "cuda_graph": False,
-        "activity_scope": "first_to_last_correlated_GPU_activity_in_one_public_call",
+        "activity_scope": "one_quantization_kernel_with_preallocated_outputs",
         "samples_ms": samples,
         "sample_count": len(samples),
         "median_ms": float(statistics.median(samples)),
@@ -115,20 +120,67 @@ def _run_shape(shape: tuple[int, int, int], warmup_ms: int, benchmark_ms: int) -
     generator = torch.Generator(device="cuda").manual_seed(20260829 + sum(shape))
     x = torch.randn(shape, generator=generator, dtype=torch.bfloat16, device="cuda")
     mask = torch.full((batch,), rows, dtype=torch.int32, device="cuda")
-
-    cutile_q, cutile_sf = flashinfer.mxfp8_grouped_quantize(x, mask, backend="cutile")
-    cake_q, cake_sf = flashinfer.mxfp8_grouped_quantize(x, mask, backend="cake")
-    torch.cuda.synchronize()
-    torch.testing.assert_close(
-        cake_q.contiguous().view(torch.uint8),
-        cutile_q.contiguous().view(torch.uint8),
-        rtol=0,
-        atol=0,
-    )
     padded_k = (columns + 127) // 128 * 128
+    padded_m = (rows + 127) // 128 * 128
+    scale_k = padded_k // 32
 
-    def valid_scales(sf):
-        physical = sf.permute(5, 2, 4, 0, 1, 3)
+    if padded_k == columns:
+        input_tensor = x.contiguous()
+    else:
+        input_tensor = x.new_zeros((batch, rows, padded_k))
+        input_tensor[:, :, :columns] = x
+
+    problem_sizes = torch.empty((batch, 3), dtype=torch.int32, device="cuda")
+    problem_sizes[:, 0] = mask
+    problem_sizes[:, 1] = 0
+    problem_sizes[:, 2] = padded_k
+    group_ids = torch.arange(batch, dtype=torch.int32, device="cuda")
+    expert_offsets = group_ids * rows
+    blockscale_offsets = group_ids * padded_m
+    prefix_schedule = build_mxfp8_grouped_quant_prefix_schedule(
+        input_tensor.view(batch * rows, padded_k), problem_sizes
+    )
+
+    cutile_q = torch.empty(
+        (batch, rows, padded_k), dtype=torch.float8_e4m3fn, device="cuda"
+    )
+    cutile_sf = torch.empty(
+        (batch, padded_m, scale_k), dtype=torch.uint8, device="cuda"
+    )
+    cake_q = torch.empty_like(cutile_q)
+    cake_sf = torch.empty_like(cutile_sf)
+
+    cake_module = get_cake_grouped_mxfp8_quantize_module(x.dtype, x.device)
+    stream = int(torch.cuda.current_stream(x.device).cuda_stream)
+
+    def run_cutile_kernel():
+        mxfp8_grouped_quantize_cutile_with_prefix_schedule(
+            input_tensor.view(batch * rows, padded_k),
+            problem_sizes,
+            expert_offsets,
+            blockscale_offsets,
+            cutile_q.view(batch * rows, padded_k),
+            cutile_sf,
+            prefix_schedule,
+        )
+
+    def run_cake_kernel():
+        cake_module.run(input_tensor, mask, cake_q, cake_sf, stream)
+
+    run_cutile_kernel()
+    run_cake_kernel()
+    torch.cuda.synchronize()
+
+    for group in range(batch):
+        valid_rows = int(mask[group].item())
+        torch.testing.assert_close(
+            cake_q[group, :valid_rows].view(torch.uint8),
+            cutile_q[group, :valid_rows].view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+
+    def valid_scales(physical):
         m_tiles = (rows + 127) // 128
         k_tiles = padded_k // 128
         unswizzled = physical.reshape(batch, m_tiles, k_tiles, 32, 4, 4)
@@ -139,27 +191,24 @@ def _run_shape(shape: tuple[int, int, int], warmup_ms: int, benchmark_ms: int) -
         valid_scales(cake_sf), valid_scales(cutile_sf), rtol=0, atol=0
     )
 
-    retained = {}
-
-    def make_call(backend):
-        def call():
-            retained[backend] = flashinfer.mxfp8_grouped_quantize(
-                x, mask, backend=backend
-            )
-
-        return call
-
-    arms = {}
-    for backend in ("cutile", "cake"):
-        arms[backend] = _measure_strict_cupti(
-            make_call(backend), warmup_ms=warmup_ms, benchmark_ms=benchmark_ms
-        )
+    arms = {
+        "cutile": _measure_strict_cupti(
+            run_cutile_kernel, warmup_ms=warmup_ms, benchmark_ms=benchmark_ms
+        ),
+        "cake": _measure_strict_cupti(
+            run_cake_kernel, warmup_ms=warmup_ms, benchmark_ms=benchmark_ms
+        ),
+    }
     return {
         "shape": {"B": batch, "M": rows, "K": columns},
         "dtype": "bfloat16",
         "mask": "full",
         "correctness": "exact_bits_and_scales",
-        "timed_boundary": "one_complete_eager_public_API_call",
+        "timed_boundary": (
+            "one_quantization_kernel_with_preallocated_outputs_and_"
+            "prebuilt_cutile_prefix"
+        ),
+        "expected_gpu_activity_count_per_call": 1,
         "arms": arms,
         "cake_speedup": arms["cutile"]["median_ms"] / arms["cake"]["median_ms"],
     }
@@ -183,7 +232,7 @@ def main() -> None:
     shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
     rows = [_run_shape(shape, args.warmup_ms, args.benchmark_ms) for shape in shapes]
     report = {
-        "schema": "flashinfer-grouped-mxfp8-backend-comparison-v1",
+        "schema": "flashinfer-grouped-mxfp8-kernel-comparison-v2",
         "gpu": properties.name,
         "compute_capability": list(capability),
         "clock_rate_khz": getattr(properties, "clock_rate", None),

--- a/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
+++ b/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
@@ -1,0 +1,199 @@
+"""Strict cold-L2 CUPTI benchmark for grouped MXFP8 public backends.
+
+The timed boundary is one complete eager ``mxfp8_grouped_quantize`` call,
+including output allocation and every GPU activity attributed to that call.
+CUDA-event and CUDA-graph timing fallbacks are deliberately rejected.
+"""
+
+import argparse
+import json
+import math
+import statistics
+import time
+import warnings
+from importlib.metadata import version
+from pathlib import Path
+
+import torch
+
+import flashinfer
+import flashinfer.testing.utils as timing_utils
+from flashinfer.cutile import is_cuda_tile_available
+from flashinfer.jit.cake_grouped_mxfp8_quantize import (
+    is_cake_grouped_mxfp8_quantize_available,
+)
+
+
+DEFAULT_SHAPES = ((2, 256, 4096),)
+
+
+def _parse_shape(text: str) -> tuple[int, int, int]:
+    try:
+        batch, rows, columns = (int(value) for value in text.lower().split("x"))
+    except (TypeError, ValueError) as error:
+        raise argparse.ArgumentTypeError("shape must use BxMxK syntax") from error
+    if batch <= 0 or rows <= 0 or columns <= 0 or columns % 32:
+        raise argparse.ArgumentTypeError("B/M/K must be positive and K divisible by 32")
+    return batch, rows, columns
+
+
+def _require_environment() -> tuple[tuple[int, int], str]:
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    capability = torch.cuda.get_device_capability()
+    if capability not in ((10, 0), (10, 3)):
+        raise RuntimeError(
+            "this benchmark requires exact compute capability 10.0 or 10.3, "
+            f"got {capability[0]}.{capability[1]}"
+        )
+    try:
+        from cupti import cupti  # noqa: F401
+
+        cupti_version = version("cupti-python")
+    except (ImportError, RuntimeError) as error:
+        raise RuntimeError("reportable timings require cupti-python >= 13") from error
+    if int(cupti_version.split(".", 1)[0]) < 13:
+        raise RuntimeError(f"reportable timings require cupti-python >= 13, got {cupti_version}")
+    if not is_cake_grouped_mxfp8_quantize_available(
+        torch.bfloat16, torch.device("cuda", torch.cuda.current_device())
+    ):
+        raise RuntimeError("an exported Cake BF16 grouped MXFP8 profile is not installed")
+    if not is_cuda_tile_available():
+        raise RuntimeError("the cuTile grouped MXFP8 baseline is not available")
+    return capability, cupti_version
+
+
+def _measure_strict_cupti(call, *, warmup_ms: int, benchmark_ms: int) -> dict:
+    def reject_fallback(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("CUPTI fallback is forbidden for reportable timings")
+
+    original_event = timing_utils.bench_gpu_time_with_cuda_event
+    original_graph = timing_utils.bench_gpu_time_with_cudagraph
+    timing_utils.bench_gpu_time_with_cuda_event = reject_fallback
+    timing_utils.bench_gpu_time_with_cudagraph = reject_fallback
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            measured = timing_utils.bench_gpu_time(
+                call,
+                enable_cupti=True,
+                cold_l2_cache=True,
+                use_cuda_graph=False,
+                dry_run_iters=None,
+                repeat_iters=None,
+                dry_run_time_ms=warmup_ms,
+                repeat_time_ms=benchmark_ms,
+            )
+    finally:
+        timing_utils.bench_gpu_time_with_cudagraph = original_graph
+        timing_utils.bench_gpu_time_with_cuda_event = original_event
+
+    fallback = [item for item in caught if "Falling back" in str(item.message)]
+    if fallback:
+        raise RuntimeError(str(fallback[0].message))
+    samples = [float(value) for value in measured]
+    if not samples or any(not math.isfinite(value) or value <= 0 for value in samples):
+        raise RuntimeError(f"invalid CUPTI samples: {samples}")
+    return {
+        "timing_backend": "CUPTI activity",
+        "cold_l2": True,
+        "cuda_graph": False,
+        "activity_scope": "first_to_last_correlated_GPU_activity_in_one_public_call",
+        "samples_ms": samples,
+        "sample_count": len(samples),
+        "median_ms": float(statistics.median(samples)),
+    }
+
+
+def _run_shape(shape: tuple[int, int, int], warmup_ms: int, benchmark_ms: int) -> dict:
+    batch, rows, columns = shape
+    generator = torch.Generator(device="cuda").manual_seed(20260829 + sum(shape))
+    x = torch.randn(shape, generator=generator, dtype=torch.bfloat16, device="cuda")
+    mask = torch.full((batch,), rows, dtype=torch.int32, device="cuda")
+
+    cutile_q, cutile_sf = flashinfer.mxfp8_grouped_quantize(x, mask, backend="cutile")
+    cake_q, cake_sf = flashinfer.mxfp8_grouped_quantize(x, mask, backend="cake")
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        cake_q.contiguous().view(torch.uint8),
+        cutile_q.contiguous().view(torch.uint8),
+        rtol=0,
+        atol=0,
+    )
+    padded_k = (columns + 127) // 128 * 128
+
+    def valid_scales(sf):
+        physical = sf.permute(5, 2, 4, 0, 1, 3)
+        m_tiles = (rows + 127) // 128
+        k_tiles = padded_k // 128
+        unswizzled = physical.reshape(batch, m_tiles, k_tiles, 32, 4, 4)
+        unswizzled = unswizzled.transpose(2, 4)
+        return unswizzled.reshape(batch, m_tiles * 128, k_tiles * 4)[:, :rows]
+
+    torch.testing.assert_close(
+        valid_scales(cake_sf), valid_scales(cutile_sf), rtol=0, atol=0
+    )
+
+    retained = {}
+
+    def make_call(backend):
+        def call():
+            retained[backend] = flashinfer.mxfp8_grouped_quantize(
+                x, mask, backend=backend
+            )
+
+        return call
+
+    arms = {}
+    for backend in ("cutile", "cake"):
+        arms[backend] = _measure_strict_cupti(
+            make_call(backend), warmup_ms=warmup_ms, benchmark_ms=benchmark_ms
+        )
+    return {
+        "shape": {"B": batch, "M": rows, "K": columns},
+        "dtype": "bfloat16",
+        "mask": "full",
+        "correctness": "exact_bits_and_scales",
+        "timed_boundary": "one_complete_eager_public_API_call",
+        "arms": arms,
+        "cake_speedup": arms["cutile"]["median_ms"] / arms["cake"]["median_ms"],
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--shape", action="append", type=_parse_shape)
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--benchmark-ms", type=int, default=1000)
+    parser.add_argument("--json", type=Path)
+    args = parser.parse_args()
+    if args.warmup_ms < 100 or args.benchmark_ms < 1000:
+        raise ValueError("reportable runs require >=100 ms warmup and >=1000 ms measurement")
+
+    wall_start = time.perf_counter()
+    capability, cupti_version = _require_environment()
+    properties = torch.cuda.get_device_properties(torch.cuda.current_device())
+    shapes = tuple(args.shape) if args.shape else DEFAULT_SHAPES
+    rows = [_run_shape(shape, args.warmup_ms, args.benchmark_ms) for shape in shapes]
+    report = {
+        "schema": "flashinfer-grouped-mxfp8-backend-comparison-v1",
+        "gpu": properties.name,
+        "compute_capability": list(capability),
+        "clock_rate_khz": properties.clock_rate,
+        "cupti_python_version": cupti_version,
+        "timing_backend": "CUPTI activity",
+        "cold_l2": True,
+        "warmup_ms_per_arm": args.warmup_ms,
+        "benchmark_ms_per_arm": args.benchmark_ms,
+        "rows": rows,
+        "physical_wall_time_s": time.perf_counter() - wall_start,
+    }
+    print(json.dumps(report, indent=2))
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(report, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
+++ b/benchmarks/bench_grouped_mxfp8_quantize_backend_comparison.py
@@ -180,7 +180,7 @@ def main() -> None:
         "schema": "flashinfer-grouped-mxfp8-backend-comparison-v1",
         "gpu": properties.name,
         "compute_capability": list(capability),
-        "clock_rate_khz": properties.clock_rate,
+        "clock_rate_khz": getattr(properties, "clock_rate", None),
         "cupti_python_version": cupti_version,
         "timing_backend": "CUPTI activity",
         "cold_l2": True,

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_bf16_device.cu
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_bf16_device.cu
@@ -1,14 +1,511 @@
-// FLASHINFER_CAKE_GROUPED_MXFP8_DEVICE_PLACEHOLDER
-//
-// Replace this file with the generated BF16 row2d program. It must define:
-//
-//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_row2d_bf16(
-//       const bf16* input, const int32_t* mask, fp8_e4m3* quantized,
-//       uint8_t* scales, int32_t M, int32_t K, int32_t PADDED_K,
-//       int32_t PM_TILES, int32_t PK_TILES, int32_t BLOCKS_PER_ROW,
-//       uint64_t TOTAL_TASKS);
-//
-// Pointer pointee spellings may use generated private aliases; the host shim
-// launches through cudaLaunchKernel and therefore binds the pointer ABI by
-// address. Shape parameters are checked before int32 narrowing and all device
-// offsets and TOTAL_TASKS must remain 64-bit.
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+#define IS_BF16 1
+
+#include <math_constants.h>
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+    float c;
+    asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+    return c;
+}
+
+
+__device__ __forceinline__ float warp_reduce_max(float val) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        val = max_noftz(val, __shfl_xor_sync(0xFFFFFFFF, val, offset));
+    return val;
+}
+
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        val += __shfl_xor_sync(0xFFFFFFFF, val, offset);
+    return val;
+}
+
+
+__device__ __forceinline__ float row_max_reduce(float2 acc) {
+    return max_noftz(acc.x, acc.y);
+}
+
+
+__device__ __forceinline__ void row_max_x32_accum(const float* sv, float2& acc) {
+    #pragma unroll
+    for (int j = 0; j < 16; j++) {
+        if (j % 2 == 0)
+            acc.x = max_noftz(acc.x, max_noftz(sv[j*2], sv[j*2+1]));
+        else
+            acc.y = max_noftz(acc.y, max_noftz(sv[j*2], sv[j*2+1]));
+    }
+}
+
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+    #pragma unroll
+    for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+
+__device__ __forceinline__ unsigned int __as_u32(float v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "f"(v));
+    return u;
+}
+__device__ __forceinline__ unsigned int __as_u32(__nv_bfloat162 v) {
+    return *reinterpret_cast<const unsigned int*>(&v);
+}
+__device__ __forceinline__ unsigned int __as_u32(unsigned int v) { return v; }
+__device__ __forceinline__ unsigned int __as_u32(int v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "r"(v));
+    return u;
+}
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_cake_grouped_mxfp8_quantize_row2d_bf16(__nv_bfloat16* __restrict__ x, int* __restrict__ mask, uint8_t* __restrict__ quantized, uint8_t* __restrict__ scales, int M, int K, int PADDED_K, int PM_TILES, int PK_TILES, int BLOCKS_PER_ROW, unsigned long long TOTAL_TASKS)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    unsigned int group = blockIdx.z;
+    unsigned int row = blockIdx.y;
+    unsigned int block_col = blockIdx.x * 128 + tid;
+    if (block_col < (unsigned int)BLOCKS_PER_ROW) {
+        int _vec_load_0[1];
+        {
+            _vec_load_0[0] = *reinterpret_cast<const int*>(mask + group);
+        }
+        int valid_rows = _vec_load_0[0];
+        if (row < (unsigned int)valid_rows) {
+            unsigned long long global_row = (unsigned long long)group * (unsigned long long)M + (unsigned long long)row;
+            unsigned int k0 = block_col * 32;
+            float values[32];
+            if (k0 < (unsigned int)K) {
+                unsigned long long x_offset = global_row * (unsigned long long)K + (unsigned long long)k0;
+                {
+                    {
+                        const void* _v8p_0 = (const void*)(x + (x_offset));
+                        uint32_t _v8_0_0[8];
+                        asm volatile(
+                            "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(_v8_0_0[0]), "=r"(_v8_0_0[1]), "=r"(_v8_0_0[2]), "=r"(_v8_0_0[3]), "=r"(_v8_0_0[4]), "=r"(_v8_0_0[5]), "=r"(_v8_0_0[6]), "=r"(_v8_0_0[7]) : "l"((const char*)_v8p_0 + 0) : "memory");
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 0])[0]), "=f"((&values[0 + 0])[1])
+                            : "r"(_v8_0_0[0]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 2])[0]), "=f"((&values[0 + 2])[1])
+                            : "r"(_v8_0_0[1]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 4])[0]), "=f"((&values[0 + 4])[1])
+                            : "r"(_v8_0_0[2]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 6])[0]), "=f"((&values[0 + 6])[1])
+                            : "r"(_v8_0_0[3]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 8])[0]), "=f"((&values[0 + 8])[1])
+                            : "r"(_v8_0_0[4]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 10])[0]), "=f"((&values[0 + 10])[1])
+                            : "r"(_v8_0_0[5]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 12])[0]), "=f"((&values[0 + 12])[1])
+                            : "r"(_v8_0_0[6]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 14])[0]), "=f"((&values[0 + 14])[1])
+                            : "r"(_v8_0_0[7]));
+                        uint32_t _v8_0_1[8];
+                        asm volatile(
+                            "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(_v8_0_1[0]), "=r"(_v8_0_1[1]), "=r"(_v8_0_1[2]), "=r"(_v8_0_1[3]), "=r"(_v8_0_1[4]), "=r"(_v8_0_1[5]), "=r"(_v8_0_1[6]), "=r"(_v8_0_1[7]) : "l"((const char*)_v8p_0 + 32) : "memory");
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 16])[0]), "=f"((&values[0 + 16])[1])
+                            : "r"(_v8_0_1[0]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 18])[0]), "=f"((&values[0 + 18])[1])
+                            : "r"(_v8_0_1[1]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 20])[0]), "=f"((&values[0 + 20])[1])
+                            : "r"(_v8_0_1[2]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 22])[0]), "=f"((&values[0 + 22])[1])
+                            : "r"(_v8_0_1[3]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 24])[0]), "=f"((&values[0 + 24])[1])
+                            : "r"(_v8_0_1[4]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 26])[0]), "=f"((&values[0 + 26])[1])
+                            : "r"(_v8_0_1[5]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 28])[0]), "=f"((&values[0 + 28])[1])
+                            : "r"(_v8_0_1[6]));
+                        asm volatile(
+                            "{\n\t"
+                            "shl.b32 %0, %2, 16;\n\t"
+                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                            "}\n"
+                            : "=f"((&values[0 + 30])[0]), "=f"((&values[0 + 30])[1])
+                            : "r"(_v8_0_1[7]));
+                    }
+                }
+            } else {
+                #pragma unroll
+                for (int element = 0; element < 32; element++) {
+                    values[element] = 0.0f;
+                }
+            }
+            float magnitudes[32];
+            #pragma unroll
+            for (int element_1 = 0; element_1 < 32; element_1++) {
+                magnitudes[element_1] = values[element_1];
+            }
+            float _fabs_0 = fabsf(magnitudes[0]);
+            magnitudes[0] = _fabs_0;
+            float _fabs_1 = fabsf(magnitudes[1]);
+            magnitudes[1] = _fabs_1;
+            float _fabs_2 = fabsf(magnitudes[2]);
+            magnitudes[2] = _fabs_2;
+            float _fabs_3 = fabsf(magnitudes[3]);
+            magnitudes[3] = _fabs_3;
+            float _fabs_4 = fabsf(magnitudes[4]);
+            magnitudes[4] = _fabs_4;
+            float _fabs_5 = fabsf(magnitudes[5]);
+            magnitudes[5] = _fabs_5;
+            float _fabs_6 = fabsf(magnitudes[6]);
+            magnitudes[6] = _fabs_6;
+            float _fabs_7 = fabsf(magnitudes[7]);
+            magnitudes[7] = _fabs_7;
+            float _fabs_8 = fabsf(magnitudes[8]);
+            magnitudes[8] = _fabs_8;
+            float _fabs_9 = fabsf(magnitudes[9]);
+            magnitudes[9] = _fabs_9;
+            float _fabs_10 = fabsf(magnitudes[10]);
+            magnitudes[10] = _fabs_10;
+            float _fabs_11 = fabsf(magnitudes[11]);
+            magnitudes[11] = _fabs_11;
+            float _fabs_12 = fabsf(magnitudes[12]);
+            magnitudes[12] = _fabs_12;
+            float _fabs_13 = fabsf(magnitudes[13]);
+            magnitudes[13] = _fabs_13;
+            float _fabs_14 = fabsf(magnitudes[14]);
+            magnitudes[14] = _fabs_14;
+            float _fabs_15 = fabsf(magnitudes[15]);
+            magnitudes[15] = _fabs_15;
+            float _fabs_16 = fabsf(magnitudes[16]);
+            magnitudes[16] = _fabs_16;
+            float _fabs_17 = fabsf(magnitudes[17]);
+            magnitudes[17] = _fabs_17;
+            float _fabs_18 = fabsf(magnitudes[18]);
+            magnitudes[18] = _fabs_18;
+            float _fabs_19 = fabsf(magnitudes[19]);
+            magnitudes[19] = _fabs_19;
+            float _fabs_20 = fabsf(magnitudes[20]);
+            magnitudes[20] = _fabs_20;
+            float _fabs_21 = fabsf(magnitudes[21]);
+            magnitudes[21] = _fabs_21;
+            float _fabs_22 = fabsf(magnitudes[22]);
+            magnitudes[22] = _fabs_22;
+            float _fabs_23 = fabsf(magnitudes[23]);
+            magnitudes[23] = _fabs_23;
+            float _fabs_24 = fabsf(magnitudes[24]);
+            magnitudes[24] = _fabs_24;
+            float _fabs_25 = fabsf(magnitudes[25]);
+            magnitudes[25] = _fabs_25;
+            float _fabs_26 = fabsf(magnitudes[26]);
+            magnitudes[26] = _fabs_26;
+            float _fabs_27 = fabsf(magnitudes[27]);
+            magnitudes[27] = _fabs_27;
+            float _fabs_28 = fabsf(magnitudes[28]);
+            magnitudes[28] = _fabs_28;
+            float _fabs_29 = fabsf(magnitudes[29]);
+            magnitudes[29] = _fabs_29;
+            float _fabs_30 = fabsf(magnitudes[30]);
+            magnitudes[30] = _fabs_30;
+            float _fabs_31 = fabsf(magnitudes[31]);
+            magnitudes[31] = _fabs_31;
+            float2 _reg_reduce_max2_1 = {-CAKE_INF, -CAKE_INF};
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[0], magnitudes[1]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[2], magnitudes[3]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[4], magnitudes[5]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[6], magnitudes[7]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[8], magnitudes[9]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[10], magnitudes[11]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[12], magnitudes[13]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[14], magnitudes[15]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[16], magnitudes[17]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[18], magnitudes[19]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[20], magnitudes[21]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[22], magnitudes[23]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[24], magnitudes[25]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[26], magnitudes[27]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[28], magnitudes[29]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[30], magnitudes[31]));
+            float magnitudes_max = row_max_reduce(_reg_reduce_max2_1);
+            float absmax = magnitudes_max;
+            float scale = absmax / 448.0f;
+            unsigned int scale_bits = __as_u32(scale);
+            unsigned int exponent = scale_bits >> 23 & 255;
+            unsigned int mantissa = scale_bits & 8388607;
+            unsigned int has_mantissa = ((mantissa != 0) ? 1 : 0);
+            unsigned int normal = ((exponent != 0) ? 1 : 0);
+            unsigned int large_subnormal = ((mantissa > 4194304) ? 1 : 0);
+            unsigned int _min_0 = ((exponent + (has_mantissa & (normal | large_subnormal))) < (254) ? (exponent + (has_mantissa & (normal | large_subnormal))) : (254));
+            unsigned int scale_byte = _min_0;
+            unsigned int inverse_nonzero_bits = 254 - scale_byte << 23;
+            unsigned int zero_bits = 0;
+            unsigned int inverse_bits = ((scale_byte == 0) ? zero_bits : inverse_nonzero_bits);
+            float inverse = 0.0f;
+            inverse = reinterpret_cast<float*>(&inverse_bits)[0];
+            const float2 _scale2_2 = {inverse, inverse};
+            #pragma unroll
+            for (int _ls = 0; _ls < 16; _ls++)
+                mul_f32x2_inplace(&reinterpret_cast<float2*>(values)[_ls], _scale2_2);
+            unsigned long long task = global_row * (unsigned long long)BLOCKS_PER_ROW + (unsigned long long)block_col;
+            unsigned long long q_offset = task * 32;
+            {
+                unsigned int _fp8_pk[8];
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[0]) : "f"(values[0 + 0]), "f"(values[0 + 1]), "f"(values[0 + 2]), "f"(values[0 + 3]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[1]) : "f"(values[0 + 4]), "f"(values[0 + 5]), "f"(values[0 + 6]), "f"(values[0 + 7]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[2]) : "f"(values[0 + 8]), "f"(values[0 + 9]), "f"(values[0 + 10]), "f"(values[0 + 11]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[3]) : "f"(values[0 + 12]), "f"(values[0 + 13]), "f"(values[0 + 14]), "f"(values[0 + 15]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[4]) : "f"(values[0 + 16]), "f"(values[0 + 17]), "f"(values[0 + 18]), "f"(values[0 + 19]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[5]) : "f"(values[0 + 20]), "f"(values[0 + 21]), "f"(values[0 + 22]), "f"(values[0 + 23]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[6]) : "f"(values[0 + 24]), "f"(values[0 + 25]), "f"(values[0 + 26]), "f"(values[0 + 27]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[7]) : "f"(values[0 + 28]), "f"(values[0 + 29]), "f"(values[0 + 30]), "f"(values[0 + 31]));
+                asm volatile(
+                    "st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "l"(reinterpret_cast<unsigned char*>(quantized + q_offset) + (0)), "r"(_fp8_pk[0]), "r"(_fp8_pk[1]), "r"(_fp8_pk[2]), "r"(_fp8_pk[3]), "r"(_fp8_pk[4]), "r"(_fp8_pk[5]), "r"(_fp8_pk[6]), "r"(_fp8_pk[7]) : "memory");
+            }
+            unsigned int m_tile = row / 128;
+            unsigned int row_in_tile = row - m_tile * 128;
+            unsigned int k_tile = block_col / 4;
+            unsigned int scale_col = block_col - k_tile * 4;
+            unsigned long long tile_linear = ((unsigned long long)group * (unsigned long long)PM_TILES + (unsigned long long)m_tile) * (unsigned long long)PK_TILES + (unsigned long long)k_tile;
+            unsigned long long scale_offset = tile_linear * 512 + (unsigned long long)(row_in_tile & 31) * 16 + (unsigned long long)(row_in_tile >> 5) * 4 + (unsigned long long)scale_col;
+            *(reinterpret_cast<unsigned char*>(scales + scale_offset) + (0)) = (unsigned char)(scale_byte);
+        }
+    }
+}
+
+} // extern "C"

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_bf16_device.cu
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_bf16_device.cu
@@ -1,0 +1,14 @@
+// FLASHINFER_CAKE_GROUPED_MXFP8_DEVICE_PLACEHOLDER
+//
+// Replace this file with the generated BF16 row2d program. It must define:
+//
+//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_bf16(
+//       const bf16* input, const int32_t* mask, fp8_e4m3* quantized,
+//       uint8_t* scales, int32_t M, int32_t K, int32_t PADDED_K,
+//       int32_t PM_TILES, int32_t PK_TILES, int32_t BLOCKS_PER_ROW,
+//       uint64_t TOTAL_TASKS);
+//
+// Pointer pointee spellings may use generated private aliases; the host shim
+// launches through cudaLaunchKernel and therefore binds the pointer ABI by
+// address. Shape parameters are checked before int32 narrowing and all device
+// offsets and TOTAL_TASKS must remain 64-bit.

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_bf16_device.cu
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_bf16_device.cu
@@ -2,7 +2,7 @@
 //
 // Replace this file with the generated BF16 row2d program. It must define:
 //
-//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_bf16(
+//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_row2d_bf16(
 //       const bf16* input, const int32_t* mask, fp8_e4m3* quantized,
 //       uint8_t* scales, int32_t M, int32_t K, int32_t PADDED_K,
 //       int32_t PM_TILES, int32_t PK_TILES, int32_t BLOCKS_PER_ROW,

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_binding.cuh
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_binding.cuh
@@ -35,7 +35,9 @@
 #define uint64_t cake_grouped_mxfp8_generated_uint64_t
 #define int16_t cake_grouped_mxfp8_generated_int16_t
 #define int32_t cake_grouped_mxfp8_generated_int32_t
+#define CUtensorMap cake_grouped_mxfp8_generated_CUtensorMap
 #include CAKE_GROUPED_MXFP8_BODY_FILE
+#undef CUtensorMap
 #undef uint8_t
 #undef uint16_t
 #undef uint32_t

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_binding.cuh
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_binding.cuh
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#pragma once
+
+#ifndef CAKE_GROUPED_MXFP8_BODY_FILE
+#error "CAKE_GROUPED_MXFP8_BODY_FILE must name one generated device body"
+#endif
+#ifndef CAKE_GROUPED_MXFP8_KERNEL
+#error "CAKE_GROUPED_MXFP8_KERNEL must name the generated kernel symbol"
+#endif
+#ifndef CAKE_GROUPED_MXFP8_INPUT_DLTYPE
+#error "CAKE_GROUPED_MXFP8_INPUT_DLTYPE must name the input DLDataType"
+#endif
+#ifndef FLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR
+#error "FLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR must be 0 or 3"
+#endif
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <climits>
+#include <cstdint>
+#include <limits>
+
+#include "tvm_ffi_utils.h"
+
+// Generated programs carry private fixed-width aliases. Rename them at the
+// include boundary so they cannot collide with CUDA or TVM FFI headers.
+#define uint8_t cake_grouped_mxfp8_generated_uint8_t
+#define uint16_t cake_grouped_mxfp8_generated_uint16_t
+#define uint32_t cake_grouped_mxfp8_generated_uint32_t
+#define uint64_t cake_grouped_mxfp8_generated_uint64_t
+#define int16_t cake_grouped_mxfp8_generated_int16_t
+#define int32_t cake_grouped_mxfp8_generated_int32_t
+#include CAKE_GROUPED_MXFP8_BODY_FILE
+#undef uint8_t
+#undef uint16_t
+#undef uint32_t
+#undef uint64_t
+#undef int16_t
+#undef int32_t
+
+#include "cake_grouped_mxfp8_quantize_launch.cuh"
+
+namespace flashinfer::cake_grouped_mxfp8_quantize {
+
+inline void CheckCuda(cudaError_t status, const char* operation) {
+  TVM_FFI_ICHECK(status == cudaSuccess) << operation << " failed: " << cudaGetErrorString(status);
+}
+
+inline int64_t RoundUp(int64_t value, int64_t alignment) {
+  TVM_FFI_ICHECK(value >= 0 && value <= std::numeric_limits<int64_t>::max() - alignment + 1)
+      << "shape is too large to pad safely";
+  return (value + alignment - 1) / alignment * alignment;
+}
+
+inline uint64_t CheckedProduct(uint64_t lhs, uint64_t rhs, const char* name) {
+  TVM_FFI_ICHECK(rhs == 0 || lhs <= std::numeric_limits<uint64_t>::max() / rhs)
+      << name << " overflows uint64";
+  return lhs * rhs;
+}
+
+inline void CheckTarget(int32_t device_id) {
+  static_assert(FLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR == 0 ||
+                    FLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR == 3,
+                "Cake grouped MXFP8 target minor must be 0 or 3");
+  int major = 0;
+  int minor = 0;
+  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
+            "cudaDeviceGetAttribute(major)");
+  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
+            "cudaDeviceGetAttribute(minor)");
+  TVM_FFI_ICHECK(major == 10 && minor == FLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR)
+      << "this Cake grouped MXFP8 module requires exact compute capability 10."
+      << FLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR << ", got " << major << "." << minor;
+}
+
+void Run(TensorView input, TensorView mask, TensorView quantized, TensorView scales,
+         int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+  CHECK_CUDA(input);
+  CHECK_CUDA(mask);
+  CHECK_CUDA(quantized);
+  CHECK_CUDA(scales);
+  CHECK_DEVICE(input, mask);
+  CHECK_DEVICE(input, quantized);
+  CHECK_DEVICE(input, scales);
+  ffi::CUDADeviceGuard device_guard(input.device().device_id);
+  CheckTarget(input.device().device_id);
+
+  CHECK_INPUT_TYPE(input, CAKE_GROUPED_MXFP8_INPUT_DLTYPE);
+  CHECK_INPUT_TYPE(mask, dl_int32);
+  CHECK_INPUT_TYPE(quantized, dl_float8_e4m3fn);
+  CHECK_INPUT_TYPE(scales, dl_uint8);
+  CHECK_CONTIGUOUS(input);
+  CHECK_CONTIGUOUS(mask);
+  CHECK_CONTIGUOUS(quantized);
+  CHECK_CONTIGUOUS(scales);
+
+  TVM_FFI_ICHECK(input.ndim() == 3) << "input must have shape [B,M,K]";
+  const int64_t batch64 = input.size(0);
+  const int64_t rows64 = input.size(1);
+  const int64_t columns64 = input.size(2);
+  TVM_FFI_ICHECK(batch64 >= 0 && rows64 >= 0 && columns64 > 0 && columns64 % kQuantBlock == 0)
+      << "input must have non-negative B/M and positive K divisible by 32";
+  TVM_FFI_ICHECK(mask.ndim() == 1 && mask.size(0) == batch64)
+      << "mask must be contiguous int32 [B]";
+
+  const int64_t padded_rows64 = RoundUp(rows64, kScaleTileM);
+  const int64_t padded_columns64 = RoundUp(columns64, kScaleTileK);
+  TVM_FFI_ICHECK(quantized.ndim() == 3 && quantized.size(0) == batch64 &&
+                 quantized.size(1) == rows64 && quantized.size(2) == padded_columns64)
+      << "quantized must have physical shape [B,M,padded_K]";
+  TVM_FFI_ICHECK(scales.ndim() == 3 && scales.size(0) == batch64 &&
+                 scales.size(1) == padded_rows64 && scales.size(2) == padded_columns64 / kQuantBlock)
+      << "scales must have physical shape [B,padded_M,padded_K/32]";
+
+  TVM_FFI_ICHECK(batch64 <= INT_MAX && rows64 <= INT_MAX && columns64 <= INT_MAX &&
+                 padded_columns64 <= INT_MAX)
+      << "generated grouped MXFP8 shape parameters must fit int32";
+  int max_grid_y = 0;
+  int max_grid_z = 0;
+  CheckCuda(cudaDeviceGetAttribute(&max_grid_y, cudaDevAttrMaxGridDimY, input.device().device_id),
+            "cudaDeviceGetAttribute(maxGridDimY)");
+  CheckCuda(cudaDeviceGetAttribute(&max_grid_z, cudaDevAttrMaxGridDimZ, input.device().device_id),
+            "cudaDeviceGetAttribute(maxGridDimZ)");
+  TVM_FFI_ICHECK(rows64 <= max_grid_y && batch64 <= max_grid_z)
+      << "B/M exceed the generated row2d CUDA grid limits";
+
+  const int32_t batch = static_cast<int32_t>(batch64);
+  const int32_t rows = static_cast<int32_t>(rows64);
+  const int32_t columns = static_cast<int32_t>(columns64);
+  const int32_t padded_columns = static_cast<int32_t>(padded_columns64);
+  const int32_t padded_m_tiles = static_cast<int32_t>(padded_rows64 / kScaleTileM);
+  const int32_t padded_k_tiles = static_cast<int32_t>(padded_columns64 / kScaleTileK);
+  const int32_t blocks_per_row = padded_columns / kQuantBlock;
+  uint64_t total_tasks = CheckedProduct(static_cast<uint64_t>(batch64),
+                                        static_cast<uint64_t>(rows64), "B*M");
+  total_tasks = CheckedProduct(total_tasks, static_cast<uint64_t>(blocks_per_row),
+                               "B*M*blocks_per_row");
+
+  CheckCuda(Launch(input.data_ptr(), reinterpret_cast<const int32_t*>(mask.data_ptr()),
+                   quantized.data_ptr(), reinterpret_cast<uint8_t*>(scales.data_ptr()), batch,
+                   rows, columns, padded_columns, padded_m_tiles, padded_k_tiles,
+                   blocks_per_row, total_tasks, reinterpret_cast<cudaStream_t>(cuda_stream)),
+            "Cake grouped MXFP8 launch");
+}
+
+}  // namespace flashinfer::cake_grouped_mxfp8_quantize
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::cake_grouped_mxfp8_quantize::Run);

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_f16_device.cu
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_f16_device.cu
@@ -1,0 +1,14 @@
+// FLASHINFER_CAKE_GROUPED_MXFP8_DEVICE_PLACEHOLDER
+//
+// Replace this file with the generated FP16 row2d program. It must define:
+//
+//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_f16(
+//       const half* input, const int32_t* mask, fp8_e4m3* quantized,
+//       uint8_t* scales, int32_t M, int32_t K, int32_t PADDED_K,
+//       int32_t PM_TILES, int32_t PK_TILES, int32_t BLOCKS_PER_ROW,
+//       uint64_t TOTAL_TASKS);
+//
+// Pointer pointee spellings may use generated private aliases; the host shim
+// launches through cudaLaunchKernel and therefore binds the pointer ABI by
+// address. Shape parameters are checked before int32 narrowing and all device
+// offsets and TOTAL_TASKS must remain 64-bit.

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_f16_device.cu
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_f16_device.cu
@@ -1,14 +1,575 @@
-// FLASHINFER_CAKE_GROUPED_MXFP8_DEVICE_PLACEHOLDER
-//
-// Replace this file with the generated FP16 row2d program. It must define:
-//
-//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_row2d_f16(
-//       const half* input, const int32_t* mask, fp8_e4m3* quantized,
-//       uint8_t* scales, int32_t M, int32_t K, int32_t PADDED_K,
-//       int32_t PM_TILES, int32_t PK_TILES, int32_t BLOCKS_PER_ROW,
-//       uint64_t TOTAL_TASKS);
-//
-// Pointer pointee spellings may use generated private aliases; the host shim
-// launches through cudaLaunchKernel and therefore binds the pointer ABI by
-// address. Shape parameters are checked before int32 narrowing and all device
-// offsets and TOTAL_TASKS must remain 64-bit.
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) CakeTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) CakeTensorMapPack { CakeTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#define CAKE_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+#define IS_BF16 0
+
+#include <math_constants.h>
+
+__device__ __forceinline__ float max_noftz(float a, float b) {
+    float c;
+    asm("max.f32 %0, %1, %2;" : "=f"(c) : "f"(a), "f"(b));
+    return c;
+}
+
+
+__device__ __forceinline__ float warp_reduce_max(float val) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        val = max_noftz(val, __shfl_xor_sync(0xFFFFFFFF, val, offset));
+    return val;
+}
+
+
+__device__ __forceinline__ float warp_reduce_sum(float val) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1)
+        val += __shfl_xor_sync(0xFFFFFFFF, val, offset);
+    return val;
+}
+
+
+__device__ __forceinline__ float row_max_reduce(float2 acc) {
+    return max_noftz(acc.x, acc.y);
+}
+
+
+__device__ __forceinline__ void row_max_x32_accum(const float* sv, float2& acc) {
+    #pragma unroll
+    for (int j = 0; j < 16; j++) {
+        if (j % 2 == 0)
+            acc.x = max_noftz(acc.x, max_noftz(sv[j*2], sv[j*2+1]));
+        else
+            acc.y = max_noftz(acc.y, max_noftz(sv[j*2], sv[j*2+1]));
+    }
+}
+
+
+__device__ __forceinline__ void fma_f32x2_inplace(float2* a, float2 b, float2 c) {
+    unsigned long long r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(r)
+        : "l"(*(unsigned long long*)a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    *(unsigned long long*)a = r;
+}
+
+__device__ __forceinline__ void mul_f32x2_inplace(float2* a, float2 b) {
+    asm("mul.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void add_f32x2_inplace(float2* a, float2 b) {
+    asm("add.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ void sub_f32x2_inplace(float2* a, float2 b) {
+    asm("sub.rn.ftz.f32x2 %0, %0, %1;"
+        : "+l"(*(unsigned long long*)a) : "l"(*(unsigned long long*)&b));
+}
+
+__device__ __forceinline__ float2 add_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("add.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ float2 sub_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("sub.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+__device__ __forceinline__ void fma_scale_x32(
+    float* sv, const float2* scale2, const float2* neg_max2)
+{
+    float2* sv_2 = reinterpret_cast<float2*>(sv);
+    #pragma unroll
+    for (int j = 0; j < 16; j++)
+        fma_f32x2_inplace(&sv_2[j], *scale2, *neg_max2);
+}
+
+__device__ __forceinline__ float2 fma_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm("fma.rn.ftz.f32x2 %0, %1, %2, %3;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 fma_sub_f32x2(float2 a, float2 b, float2 c) {
+    float2 r;
+    asm volatile("{\n\t"
+        ".reg .f32 _c0, _c1;\n\t"
+        ".reg .b64 _neg_c;\n\t"
+        "mov.b64 {_c0, _c1}, %3;\n\t"
+        "neg.f32 _c0, _c0;\n\t"
+        "neg.f32 _c1, _c1;\n\t"
+        "mov.b64 _neg_c, {_c0, _c1};\n\t"
+        "fma.rn.ftz.f32x2 %0, %1, %2, _neg_c;\n\t"
+        "}\n"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b),
+          "l"(*(unsigned long long*)&c));
+    return r;
+}
+
+__device__ __forceinline__ float2 mul_f32x2(float2 a, float2 b) {
+    float2 r;
+    asm("mul.rn.ftz.f32x2 %0, %1, %2;"
+        : "=l"(*(unsigned long long*)&r)
+        : "l"(*(unsigned long long*)&a), "l"(*(unsigned long long*)&b));
+    return r;
+}
+
+// ex2_emulation_f32x2 defined in softmax_frag_exp2_cast helper (or standalone)
+
+
+__device__ __forceinline__ unsigned int __as_u32(float v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "f"(v));
+    return u;
+}
+__device__ __forceinline__ unsigned int __as_u32(__nv_bfloat162 v) {
+    return *reinterpret_cast<const unsigned int*>(&v);
+}
+__device__ __forceinline__ unsigned int __as_u32(unsigned int v) { return v; }
+__device__ __forceinline__ unsigned int __as_u32(int v) {
+    unsigned int u;
+    asm("mov.b32 %0, %1;" : "=r"(u) : "r"(v));
+    return u;
+}
+
+extern "C" {
+
+__global__ __launch_bounds__(128) void
+kernel_cake_grouped_mxfp8_quantize_row2d_f16(__nv_bfloat16* __restrict__ x, int* __restrict__ mask, uint8_t* __restrict__ quantized, uint8_t* __restrict__ scales, int M, int K, int PADDED_K, int PM_TILES, int PK_TILES, int BLOCKS_PER_ROW, unsigned long long TOTAL_TASKS)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    unsigned int group = blockIdx.z;
+    unsigned int row = blockIdx.y;
+    unsigned int block_col = blockIdx.x * 128 + tid;
+    if (block_col < (unsigned int)BLOCKS_PER_ROW) {
+        int _vec_load_0[1];
+        {
+            _vec_load_0[0] = *reinterpret_cast<const int*>(mask + group);
+        }
+        int valid_rows = _vec_load_0[0];
+        if (row < (unsigned int)valid_rows) {
+            unsigned long long global_row = (unsigned long long)group * (unsigned long long)M + (unsigned long long)row;
+            unsigned int k0 = block_col * 32;
+            float values[32];
+            if (k0 < (unsigned int)K) {
+                unsigned long long x_offset = global_row * (unsigned long long)K + (unsigned long long)k0;
+                {
+                    {
+                        const void* _v8p_0 = (const void*)(x + (x_offset));
+                        uint32_t _v8_0_0[8];
+                        asm volatile(
+                            "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(_v8_0_0[0]), "=r"(_v8_0_0[1]), "=r"(_v8_0_0[2]), "=r"(_v8_0_0[3]), "=r"(_v8_0_0[4]), "=r"(_v8_0_0[5]), "=r"(_v8_0_0[6]), "=r"(_v8_0_0[7]) : "l"((const char*)_v8p_0 + 0) : "memory");
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 0]))
+                            : "r"(_v8_0_0[0]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 2]))
+                            : "r"(_v8_0_0[1]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 4]))
+                            : "r"(_v8_0_0[2]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 6]))
+                            : "r"(_v8_0_0[3]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 8]))
+                            : "r"(_v8_0_0[4]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 10]))
+                            : "r"(_v8_0_0[5]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 12]))
+                            : "r"(_v8_0_0[6]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 14]))
+                            : "r"(_v8_0_0[7]));
+                        uint32_t _v8_0_1[8];
+                        asm volatile(
+                            "ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+                            : "=r"(_v8_0_1[0]), "=r"(_v8_0_1[1]), "=r"(_v8_0_1[2]), "=r"(_v8_0_1[3]), "=r"(_v8_0_1[4]), "=r"(_v8_0_1[5]), "=r"(_v8_0_1[6]), "=r"(_v8_0_1[7]) : "l"((const char*)_v8p_0 + 32) : "memory");
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 16]))
+                            : "r"(_v8_0_1[0]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 18]))
+                            : "r"(_v8_0_1[1]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 20]))
+                            : "r"(_v8_0_1[2]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 22]))
+                            : "r"(_v8_0_1[3]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 24]))
+                            : "r"(_v8_0_1[4]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 26]))
+                            : "r"(_v8_0_1[5]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 28]))
+                            : "r"(_v8_0_1[6]));
+                        asm volatile(
+                            "{\n\t"
+                            ".reg .b16 h_lo, h_hi;\n\t"
+                            ".reg .b32 f_lo, f_hi;\n\t"
+                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                            "}\n"
+                            : "=l"(*reinterpret_cast<unsigned long long*>(&values[0 + 30]))
+                            : "r"(_v8_0_1[7]));
+                    }
+                }
+            } else {
+                #pragma unroll
+                for (int element = 0; element < 32; element++) {
+                    values[element] = 0.0f;
+                }
+            }
+            float magnitudes[32];
+            #pragma unroll
+            for (int element_1 = 0; element_1 < 32; element_1++) {
+                magnitudes[element_1] = values[element_1];
+            }
+            float _fabs_0 = fabsf(magnitudes[0]);
+            magnitudes[0] = _fabs_0;
+            float _fabs_1 = fabsf(magnitudes[1]);
+            magnitudes[1] = _fabs_1;
+            float _fabs_2 = fabsf(magnitudes[2]);
+            magnitudes[2] = _fabs_2;
+            float _fabs_3 = fabsf(magnitudes[3]);
+            magnitudes[3] = _fabs_3;
+            float _fabs_4 = fabsf(magnitudes[4]);
+            magnitudes[4] = _fabs_4;
+            float _fabs_5 = fabsf(magnitudes[5]);
+            magnitudes[5] = _fabs_5;
+            float _fabs_6 = fabsf(magnitudes[6]);
+            magnitudes[6] = _fabs_6;
+            float _fabs_7 = fabsf(magnitudes[7]);
+            magnitudes[7] = _fabs_7;
+            float _fabs_8 = fabsf(magnitudes[8]);
+            magnitudes[8] = _fabs_8;
+            float _fabs_9 = fabsf(magnitudes[9]);
+            magnitudes[9] = _fabs_9;
+            float _fabs_10 = fabsf(magnitudes[10]);
+            magnitudes[10] = _fabs_10;
+            float _fabs_11 = fabsf(magnitudes[11]);
+            magnitudes[11] = _fabs_11;
+            float _fabs_12 = fabsf(magnitudes[12]);
+            magnitudes[12] = _fabs_12;
+            float _fabs_13 = fabsf(magnitudes[13]);
+            magnitudes[13] = _fabs_13;
+            float _fabs_14 = fabsf(magnitudes[14]);
+            magnitudes[14] = _fabs_14;
+            float _fabs_15 = fabsf(magnitudes[15]);
+            magnitudes[15] = _fabs_15;
+            float _fabs_16 = fabsf(magnitudes[16]);
+            magnitudes[16] = _fabs_16;
+            float _fabs_17 = fabsf(magnitudes[17]);
+            magnitudes[17] = _fabs_17;
+            float _fabs_18 = fabsf(magnitudes[18]);
+            magnitudes[18] = _fabs_18;
+            float _fabs_19 = fabsf(magnitudes[19]);
+            magnitudes[19] = _fabs_19;
+            float _fabs_20 = fabsf(magnitudes[20]);
+            magnitudes[20] = _fabs_20;
+            float _fabs_21 = fabsf(magnitudes[21]);
+            magnitudes[21] = _fabs_21;
+            float _fabs_22 = fabsf(magnitudes[22]);
+            magnitudes[22] = _fabs_22;
+            float _fabs_23 = fabsf(magnitudes[23]);
+            magnitudes[23] = _fabs_23;
+            float _fabs_24 = fabsf(magnitudes[24]);
+            magnitudes[24] = _fabs_24;
+            float _fabs_25 = fabsf(magnitudes[25]);
+            magnitudes[25] = _fabs_25;
+            float _fabs_26 = fabsf(magnitudes[26]);
+            magnitudes[26] = _fabs_26;
+            float _fabs_27 = fabsf(magnitudes[27]);
+            magnitudes[27] = _fabs_27;
+            float _fabs_28 = fabsf(magnitudes[28]);
+            magnitudes[28] = _fabs_28;
+            float _fabs_29 = fabsf(magnitudes[29]);
+            magnitudes[29] = _fabs_29;
+            float _fabs_30 = fabsf(magnitudes[30]);
+            magnitudes[30] = _fabs_30;
+            float _fabs_31 = fabsf(magnitudes[31]);
+            magnitudes[31] = _fabs_31;
+            float2 _reg_reduce_max2_1 = {-CAKE_INF, -CAKE_INF};
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[0], magnitudes[1]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[2], magnitudes[3]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[4], magnitudes[5]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[6], magnitudes[7]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[8], magnitudes[9]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[10], magnitudes[11]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[12], magnitudes[13]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[14], magnitudes[15]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[16], magnitudes[17]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[18], magnitudes[19]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[20], magnitudes[21]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[22], magnitudes[23]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[24], magnitudes[25]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[26], magnitudes[27]));
+            _reg_reduce_max2_1.x = max_noftz(_reg_reduce_max2_1.x, max_noftz(magnitudes[28], magnitudes[29]));
+            _reg_reduce_max2_1.y = max_noftz(_reg_reduce_max2_1.y, max_noftz(magnitudes[30], magnitudes[31]));
+            float magnitudes_max = row_max_reduce(_reg_reduce_max2_1);
+            float absmax = magnitudes_max;
+            float scale = absmax / 448.0f;
+            unsigned int scale_bits = __as_u32(scale);
+            unsigned int exponent = scale_bits >> 23 & 255;
+            unsigned int mantissa = scale_bits & 8388607;
+            unsigned int has_mantissa = ((mantissa != 0) ? 1 : 0);
+            unsigned int normal = ((exponent != 0) ? 1 : 0);
+            unsigned int large_subnormal = ((mantissa > 4194304) ? 1 : 0);
+            unsigned int _min_0 = ((exponent + (has_mantissa & (normal | large_subnormal))) < (254) ? (exponent + (has_mantissa & (normal | large_subnormal))) : (254));
+            unsigned int scale_byte = _min_0;
+            unsigned int inverse_nonzero_bits = 254 - scale_byte << 23;
+            unsigned int zero_bits = 0;
+            unsigned int inverse_bits = ((scale_byte == 0) ? zero_bits : inverse_nonzero_bits);
+            float inverse = 0.0f;
+            inverse = reinterpret_cast<float*>(&inverse_bits)[0];
+            const float2 _scale2_2 = {inverse, inverse};
+            #pragma unroll
+            for (int _ls = 0; _ls < 16; _ls++)
+                mul_f32x2_inplace(&reinterpret_cast<float2*>(values)[_ls], _scale2_2);
+            unsigned long long task = global_row * (unsigned long long)BLOCKS_PER_ROW + (unsigned long long)block_col;
+            unsigned long long q_offset = task * 32;
+            {
+                unsigned int _fp8_pk[8];
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[0]) : "f"(values[0 + 0]), "f"(values[0 + 1]), "f"(values[0 + 2]), "f"(values[0 + 3]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[1]) : "f"(values[0 + 4]), "f"(values[0 + 5]), "f"(values[0 + 6]), "f"(values[0 + 7]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[2]) : "f"(values[0 + 8]), "f"(values[0 + 9]), "f"(values[0 + 10]), "f"(values[0 + 11]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[3]) : "f"(values[0 + 12]), "f"(values[0 + 13]), "f"(values[0 + 14]), "f"(values[0 + 15]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[4]) : "f"(values[0 + 16]), "f"(values[0 + 17]), "f"(values[0 + 18]), "f"(values[0 + 19]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[5]) : "f"(values[0 + 20]), "f"(values[0 + 21]), "f"(values[0 + 22]), "f"(values[0 + 23]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[6]) : "f"(values[0 + 24]), "f"(values[0 + 25]), "f"(values[0 + 26]), "f"(values[0 + 27]));
+                asm("{\n\t"
+                    ".reg .b16 _lo, _hi;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _lo, %2, %1;\n\t"
+                    "cvt.rn.satfinite.e4m3x2.f32 _hi, %4, %3;\n\t"
+                    "mov.b32 %0, {_lo, _hi};\n\t"
+                    "}\n"
+                    : "=r"(_fp8_pk[7]) : "f"(values[0 + 28]), "f"(values[0 + 29]), "f"(values[0 + 30]), "f"(values[0 + 31]));
+                asm volatile(
+                    "st.global.v8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
+                    :: "l"(reinterpret_cast<unsigned char*>(quantized + q_offset) + (0)), "r"(_fp8_pk[0]), "r"(_fp8_pk[1]), "r"(_fp8_pk[2]), "r"(_fp8_pk[3]), "r"(_fp8_pk[4]), "r"(_fp8_pk[5]), "r"(_fp8_pk[6]), "r"(_fp8_pk[7]) : "memory");
+            }
+            unsigned int m_tile = row / 128;
+            unsigned int row_in_tile = row - m_tile * 128;
+            unsigned int k_tile = block_col / 4;
+            unsigned int scale_col = block_col - k_tile * 4;
+            unsigned long long tile_linear = ((unsigned long long)group * (unsigned long long)PM_TILES + (unsigned long long)m_tile) * (unsigned long long)PK_TILES + (unsigned long long)k_tile;
+            unsigned long long scale_offset = tile_linear * 512 + (unsigned long long)(row_in_tile & 31) * 16 + (unsigned long long)(row_in_tile >> 5) * 4 + (unsigned long long)scale_col;
+            *(reinterpret_cast<unsigned char*>(scales + scale_offset) + (0)) = (unsigned char)(scale_byte);
+        }
+    }
+}
+
+} // extern "C"

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_f16_device.cu
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_f16_device.cu
@@ -2,7 +2,7 @@
 //
 // Replace this file with the generated FP16 row2d program. It must define:
 //
-//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_f16(
+//   extern "C" __global__ void kernel_cake_grouped_mxfp8_quantize_row2d_f16(
 //       const half* input, const int32_t* mask, fp8_e4m3* quantized,
 //       uint8_t* scales, int32_t M, int32_t K, int32_t PADDED_K,
 //       int32_t PM_TILES, int32_t PK_TILES, int32_t BLOCKS_PER_ROW,

--- a/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_launch.cuh
+++ b/csrc/cake_grouped_mxfp8_quantize/cake_grouped_mxfp8_quantize_launch.cuh
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+namespace flashinfer::cake_grouped_mxfp8_quantize {
+
+constexpr int32_t kThreads = 128;
+constexpr int32_t kQuantBlock = 32;
+constexpr int32_t kScaleTileM = 128;
+constexpr int32_t kScaleTileK = 128;
+
+inline cudaError_t Launch(const void* input, const int32_t* mask, void* quantized,
+                          uint8_t* scales, int32_t batch, int32_t rows, int32_t columns,
+                          int32_t padded_columns, int32_t padded_m_tiles,
+                          int32_t padded_k_tiles, int32_t blocks_per_row,
+                          uint64_t total_tasks, cudaStream_t stream) {
+  if (batch == 0 || rows == 0 || blocks_per_row == 0) {
+    return cudaSuccess;
+  }
+  const dim3 grid((static_cast<uint32_t>(blocks_per_row) + kThreads - 1) / kThreads,
+                  static_cast<uint32_t>(rows), static_cast<uint32_t>(batch));
+  const dim3 block(kThreads, 1, 1);
+
+  const void* input_arg = input;
+  const int32_t* mask_arg = mask;
+  void* quantized_arg = quantized;
+  uint8_t* scales_arg = scales;
+  void* args[] = {&input_arg,
+                  &mask_arg,
+                  &quantized_arg,
+                  &scales_arg,
+                  &rows,
+                  &columns,
+                  &padded_columns,
+                  &padded_m_tiles,
+                  &padded_k_tiles,
+                  &blocks_per_row,
+                  &total_tasks};
+  return cudaLaunchKernel(reinterpret_cast<const void*>(CAKE_GROUPED_MXFP8_KERNEL), grid, block,
+                          args, 0, stream);
+}
+
+}  // namespace flashinfer::cake_grouped_mxfp8_quantize

--- a/flashinfer/jit/cake_grouped_mxfp8_quantize.py
+++ b/flashinfer/jit/cake_grouped_mxfp8_quantize.py
@@ -34,7 +34,9 @@ def _get_csrc_dir() -> Path:
     installed = jit_env.FLASHINFER_CSRC_DIR / "cake_grouped_mxfp8_quantize"
     if installed.exists():
         return installed
-    checkout = Path(__file__).resolve().parents[2] / "csrc" / "cake_grouped_mxfp8_quantize"
+    checkout = (
+        Path(__file__).resolve().parents[2] / "csrc" / "cake_grouped_mxfp8_quantize"
+    )
     if checkout.exists():
         return checkout
     raise FileNotFoundError(
@@ -140,7 +142,9 @@ def gen_cake_grouped_mxfp8_quantize_module(
             )
 
     uri = f"cake_grouped_mxfp8_quantize_{input_name}_{target}"
-    binding = jit_env.FLASHINFER_GEN_SRC_DIR / uri / "cake_grouped_mxfp8_quantize_binding.cu"
+    binding = (
+        jit_env.FLASHINFER_GEN_SRC_DIR / uri / "cake_grouped_mxfp8_quantize_binding.cu"
+    )
     write_if_different(binding, _binding_source(input_name))
     spec = gen_jit_spec(
         name=uri,

--- a/flashinfer/jit/cake_grouped_mxfp8_quantize.py
+++ b/flashinfer/jit/cake_grouped_mxfp8_quantize.py
@@ -1,0 +1,174 @@
+"""JIT loader for generated Blackwell grouped MXFP8 quantization kernels."""
+
+import functools
+from pathlib import Path
+from typing import Literal
+
+import torch
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec, logger, sm100a_nvcc_flags, sm103a_nvcc_flags
+from .utils import write_if_different
+
+CakeGroupedMXFP8Target = Literal["sm100a", "sm103a"]
+CakeGroupedMXFP8Input = Literal["bfloat16", "float16"]
+
+_PLACEHOLDER_MARKER = "FLASHINFER_CAKE_GROUPED_MXFP8_DEVICE_PLACEHOLDER"
+_TARGET_FLAGS = {"sm100a": sm100a_nvcc_flags, "sm103a": sm103a_nvcc_flags}
+_TARGET_MINOR = {"sm100a": 0, "sm103a": 3}
+_INPUT_METADATA = {
+    "bfloat16": (
+        "cake_grouped_mxfp8_quantize_bf16_device.cu",
+        "kernel_cake_grouped_mxfp8_quantize_bf16",
+        "dl_bfloat16",
+    ),
+    "float16": (
+        "cake_grouped_mxfp8_quantize_f16_device.cu",
+        "kernel_cake_grouped_mxfp8_quantize_f16",
+        "dl_float16",
+    ),
+}
+
+
+def _get_csrc_dir() -> Path:
+    installed = jit_env.FLASHINFER_CSRC_DIR / "cake_grouped_mxfp8_quantize"
+    if installed.exists():
+        return installed
+    checkout = Path(__file__).resolve().parents[2] / "csrc" / "cake_grouped_mxfp8_quantize"
+    if checkout.exists():
+        return checkout
+    raise FileNotFoundError(
+        "Cake grouped MXFP8 sources were not found. Checked:\n"
+        f"  - {installed}\n"
+        f"  - {checkout}"
+    )
+
+
+def cake_grouped_mxfp8_target(device: torch.device) -> CakeGroupedMXFP8Target:
+    major, minor = torch.cuda.get_device_capability(device)
+    if (major, minor) == (10, 0):
+        return "sm100a"
+    if (major, minor) == (10, 3):
+        return "sm103a"
+    raise RuntimeError(
+        "the Cake grouped MXFP8 backend requires exact compute capability "
+        f"10.0 or 10.3, got {major}.{minor}"
+    )
+
+
+def _input_name(dtype: torch.dtype) -> CakeGroupedMXFP8Input:
+    if dtype == torch.bfloat16:
+        return "bfloat16"
+    if dtype == torch.float16:
+        return "float16"
+    raise TypeError(f"unsupported Cake grouped MXFP8 input dtype: {dtype}")
+
+
+def _device_source(input_name: CakeGroupedMXFP8Input) -> Path:
+    return _get_csrc_dir() / _INPUT_METADATA[input_name][0]
+
+
+def is_cake_grouped_mxfp8_quantize_available(
+    dtype: torch.dtype, device: torch.device
+) -> bool:
+    """Return whether a generated body is installed for this dtype/device."""
+
+    try:
+        cake_grouped_mxfp8_target(device)
+        source = _device_source(_input_name(dtype))
+        return source.is_file() and _PLACEHOLDER_MARKER not in source.read_text()
+    except (FileNotFoundError, RuntimeError, TypeError, OSError):
+        return False
+
+
+def _binding_source(
+    input_name: CakeGroupedMXFP8Input,
+) -> str:
+    body, symbol, dl_dtype = _INPUT_METADATA[input_name]
+    return f"""\
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#define CAKE_GROUPED_MXFP8_BODY_FILE "{body}"
+#define CAKE_GROUPED_MXFP8_KERNEL {symbol}
+#define CAKE_GROUPED_MXFP8_INPUT_DLTYPE {dl_dtype}
+#include "cake_grouped_mxfp8_quantize_binding.cuh"
+"""
+
+
+@functools.cache
+def gen_cake_grouped_mxfp8_quantize_module(
+    input_name: CakeGroupedMXFP8Input,
+    target: CakeGroupedMXFP8Target,
+) -> JitSpec:
+    if input_name not in _INPUT_METADATA:
+        raise ValueError(f"unsupported Cake grouped MXFP8 input: {input_name}")
+    if target not in _TARGET_FLAGS:
+        raise ValueError(f"unsupported Cake grouped MXFP8 target: {target}")
+
+    csrc_dir = _get_csrc_dir()
+    body = _device_source(input_name)
+    if not body.is_file():
+        raise FileNotFoundError(f"generated Cake grouped MXFP8 body not found: {body}")
+    if _PLACEHOLDER_MARKER in body.read_text():
+        raise RuntimeError(
+            "the Cake grouped MXFP8 device body is a placeholder; install an "
+            f"exported {input_name} profile before selecting backend='cake'"
+        )
+    for required in (
+        "cake_grouped_mxfp8_quantize_binding.cuh",
+        "cake_grouped_mxfp8_quantize_launch.cuh",
+    ):
+        if not (csrc_dir / required).is_file():
+            raise FileNotFoundError(
+                f"Cake grouped MXFP8 host source not found: {csrc_dir / required}"
+            )
+
+    uri = f"cake_grouped_mxfp8_quantize_{input_name}_{target}"
+    binding = jit_env.FLASHINFER_GEN_SRC_DIR / uri / "cake_grouped_mxfp8_quantize_binding.cu"
+    write_if_different(binding, _binding_source(input_name))
+    spec = gen_jit_spec(
+        name=uri,
+        sources=[binding],
+        extra_cuda_cflags=[
+            *_TARGET_FLAGS[target],
+            f"-DFLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR={_TARGET_MINOR[target]}",
+        ],
+        extra_include_paths=[csrc_dir, csrc_dir.parent],
+    )
+    logger.info(
+        "Generated Cake grouped MXFP8 %s %s JIT spec: %s",
+        input_name,
+        target,
+        spec.name,
+    )
+    return spec
+
+
+@functools.cache
+def load_cake_grouped_mxfp8_quantize_module(
+    input_name: CakeGroupedMXFP8Input,
+    target: CakeGroupedMXFP8Target,
+):
+    module = gen_cake_grouped_mxfp8_quantize_module(input_name, target).build_and_load()
+    logger.info("Loaded Cake grouped MXFP8 %s %s module", input_name, target)
+    return module
+
+
+def get_cake_grouped_mxfp8_quantize_module(dtype: torch.dtype, device: torch.device):
+    return load_cake_grouped_mxfp8_quantize_module(
+        _input_name(dtype), cake_grouped_mxfp8_target(device)
+    )
+
+
+__all__ = [
+    "CakeGroupedMXFP8Input",
+    "CakeGroupedMXFP8Target",
+    "cake_grouped_mxfp8_target",
+    "gen_cake_grouped_mxfp8_quantize_module",
+    "get_cake_grouped_mxfp8_quantize_module",
+    "is_cake_grouped_mxfp8_quantize_available",
+    "load_cake_grouped_mxfp8_quantize_module",
+]

--- a/flashinfer/jit/cake_grouped_mxfp8_quantize.py
+++ b/flashinfer/jit/cake_grouped_mxfp8_quantize.py
@@ -44,6 +44,19 @@ def _get_csrc_dir() -> Path:
     )
 
 
+def _get_include_dir() -> Path:
+    if jit_env.FLASHINFER_INCLUDE_DIR.exists():
+        return jit_env.FLASHINFER_INCLUDE_DIR
+    checkout = Path(__file__).resolve().parents[2] / "include"
+    if checkout.exists():
+        return checkout
+    raise FileNotFoundError(
+        "FlashInfer headers were not found. Checked:\n"
+        f"  - {jit_env.FLASHINFER_INCLUDE_DIR}\n"
+        f"  - {checkout}"
+    )
+
+
 def cake_grouped_mxfp8_target(device: torch.device) -> CakeGroupedMXFP8Target:
     major, minor = torch.cuda.get_device_capability(device)
     if (major, minor) == (10, 0):
@@ -136,7 +149,7 @@ def gen_cake_grouped_mxfp8_quantize_module(
             *_TARGET_FLAGS[target],
             f"-DFLASHINFER_CAKE_GROUPED_MXFP8_TARGET_MINOR={_TARGET_MINOR[target]}",
         ],
-        extra_include_paths=[csrc_dir, csrc_dir.parent],
+        extra_include_paths=[csrc_dir, csrc_dir.parent, _get_include_dir()],
     )
     logger.info(
         "Generated Cake grouped MXFP8 %s %s JIT spec: %s",

--- a/flashinfer/jit/cake_grouped_mxfp8_quantize.py
+++ b/flashinfer/jit/cake_grouped_mxfp8_quantize.py
@@ -19,12 +19,12 @@ _TARGET_MINOR = {"sm100a": 0, "sm103a": 3}
 _INPUT_METADATA = {
     "bfloat16": (
         "cake_grouped_mxfp8_quantize_bf16_device.cu",
-        "kernel_cake_grouped_mxfp8_quantize_bf16",
+        "kernel_cake_grouped_mxfp8_quantize_row2d_bf16",
         "dl_bfloat16",
     ),
     "float16": (
         "cake_grouped_mxfp8_quantize_f16_device.cu",
-        "kernel_cake_grouped_mxfp8_quantize_f16",
+        "kernel_cake_grouped_mxfp8_quantize_row2d_f16",
         "dl_float16",
     ),
 }

--- a/flashinfer/quantization/fp8_quantization.py
+++ b/flashinfer/quantization/fp8_quantization.py
@@ -456,8 +456,10 @@ def _mxfp8_grouped_quantize_cake(
             f"profile for dtype={a.dtype} and target={target}; use the default "
             "backend='cutile' until that profile is installed"
         )
-    return get_cake_mxfp8_grouped_quantization_module().cake_mxfp8_grouped_quantize_impl(
-        a, mask
+    return (
+        get_cake_mxfp8_grouped_quantization_module().cake_mxfp8_grouped_quantize_impl(
+            a, mask
+        )
     )
 
 
@@ -506,9 +508,7 @@ def mxfp8_grouped_quantize(
     """
 
     if backend not in ("cutile", "cake"):
-        raise ValueError(
-            f"Unsupported backend for mxfp8_grouped_quantize: {backend!r}"
-        )
+        raise ValueError(f"Unsupported backend for mxfp8_grouped_quantize: {backend!r}")
     if a.dim() != 3:
         raise ValueError("a must be a 3D tensor with shape [B, M, K]")
     if not a.is_cuda:

--- a/flashinfer/quantization/fp8_quantization.py
+++ b/flashinfer/quantization/fp8_quantization.py
@@ -377,10 +377,68 @@ def get_mxfp8_grouped_quantization_module():
     )
 
 
+@functools.cache
+def get_cake_mxfp8_grouped_quantization_module():
+    """Register the generated Cake grouped MXFP8 op and fake metadata twin."""
+
+    @register_custom_op(
+        "flashinfer::cake_mxfp8_grouped_quantize",
+        mutates_args=(),
+    )
+    def cake_mxfp8_grouped_quantize_impl(
+        a: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        from ..jit.cake_grouped_mxfp8_quantize import (
+            get_cake_grouped_mxfp8_quantize_module,
+        )
+
+        b, m, k = a.shape
+        padded_k = _round_up(k, 128)
+        padded_m = _round_up(m, 128)
+        scale_k = padded_k // 32
+        input_tensor = a.contiguous()
+        mask_tensor = mask.contiguous()
+        output = torch.empty(
+            (b, m, padded_k),
+            dtype=torch.float8_e4m3fn,
+            device=a.device,
+        )
+        output_scales = torch.empty(
+            (b, padded_m, scale_k),
+            dtype=torch.uint8,
+            device=a.device,
+        )
+
+        module = get_cake_grouped_mxfp8_quantize_module(a.dtype, a.device)
+        stream = int(torch.cuda.current_stream(a.device).cuda_stream)
+        module.run(input_tensor, mask_tensor, output, output_scales, stream)
+
+        output = output.permute(1, 2, 0)
+        output_scales = output_scales.view(b, padded_m // 128, scale_k // 4, 32, 4, 4)
+        output_scales = output_scales.permute(3, 4, 1, 5, 2, 0)
+        return output, output_scales
+
+    @register_fake_op("flashinfer::cake_mxfp8_grouped_quantize")
+    def _fake_cake_mxfp8_grouped_quantize(
+        a: torch.Tensor,
+        mask: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return get_mxfp8_grouped_quantization_module()._fake_mxfp8_grouped_quantize(
+            a, mask
+        )
+
+    return SimpleNamespace(
+        cake_mxfp8_grouped_quantize_impl=cake_mxfp8_grouped_quantize_impl,
+        _fake_cake_mxfp8_grouped_quantize=_fake_cake_mxfp8_grouped_quantize,
+    )
+
+
 @flashinfer_api(trace=mxfp8_grouped_quantize_trace)
 def mxfp8_grouped_quantize(
     a: torch.Tensor,
     mask: torch.Tensor,
+    backend: Literal["cutile", "cake"] = "cutile",
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""Quantize grouped inputs to MXFP8 with UE8M0 block scales.
 
@@ -398,6 +456,12 @@ def mxfp8_grouped_quantize(
         CUDA-graph capture. Out-of-range values are undefined behavior. The
         kernel writes scale factors with bounds checking disabled, so
         ``mask[i] > M`` corrupts neighboring groups or writes out of bounds.
+    backend : {``"cutile"``, ``"cake"``}
+        Implementation backend. ``"cutile"`` remains the default and fallback
+        path. ``"cake"`` explicitly selects a generated, exact-architecture
+        Blackwell profile and raises a clear error when that profile is not
+        installed; runtime launch failures are never silently retried through a
+        different implementation.
 
     Returns
     -------
@@ -414,6 +478,10 @@ def mxfp8_grouped_quantize(
         The consumer must use the same ``mask`` and read only the valid rows.
     """
 
+    if backend not in ("cutile", "cake"):
+        raise ValueError(
+            f"Unsupported backend for mxfp8_grouped_quantize: {backend!r}"
+        )
     if a.dim() != 3:
         raise ValueError("a must be a 3D tensor with shape [B, M, K]")
     if not a.is_cuda:
@@ -433,17 +501,37 @@ def mxfp8_grouped_quantize(
     if major < 10:
         raise RuntimeError("mxfp8_grouped_quantize requires SM100 or newer")
 
-    if not is_cuda_tile_available():
-        raise RuntimeError(
-            "mxfp8_grouped_quantize requires the cuTile backend; install "
-            "cuda-tile>=1.4.0 and ensure the tileiras compiler is available."
+    if backend == "cutile":
+        if not is_cuda_tile_available():
+            raise RuntimeError(
+                "mxfp8_grouped_quantize requires the cuTile backend; install "
+                "cuda-tile>=1.4.0 and ensure the tileiras compiler is available."
+            )
+        _, _, k = a.shape
+        if k % 32 != 0:
+            raise ValueError(f"K must be divisible by 32, got {k}")
+        return get_mxfp8_grouped_quantization_module().mxfp8_grouped_quantize_impl(
+            a, mask
         )
+
+    from ..jit.cake_grouped_mxfp8_quantize import (
+        cake_grouped_mxfp8_target,
+        is_cake_grouped_mxfp8_quantize_available,
+    )
 
     _, _, k = a.shape
     if k % 32 != 0:
         raise ValueError(f"K must be divisible by 32, got {k}")
-
-    return get_mxfp8_grouped_quantization_module().mxfp8_grouped_quantize_impl(a, mask)
+    target = cake_grouped_mxfp8_target(a.device)
+    if not is_cake_grouped_mxfp8_quantize_available(a.dtype, a.device):
+        raise RuntimeError(
+            "backend='cake' requires an installed generated grouped MXFP8 "
+            f"profile for dtype={a.dtype} and target={target}; use the default "
+            "backend='cutile' until that profile is installed"
+        )
+    return get_cake_mxfp8_grouped_quantization_module().cake_mxfp8_grouped_quantize_impl(
+        a, mask
+    )
 
 
 @flashinfer_api

--- a/flashinfer/quantization/fp8_quantization.py
+++ b/flashinfer/quantization/fp8_quantization.py
@@ -434,6 +434,33 @@ def get_cake_mxfp8_grouped_quantization_module():
     )
 
 
+def _mxfp8_grouped_quantize_cake(
+    a: torch.Tensor,
+    mask: torch.Tensor,
+    *,
+    backend: Literal["cake"],
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Dispatch an already validated request to an installed Cake profile."""
+
+    if backend != "cake":
+        raise ValueError(f"internal Cake dispatch received backend={backend!r}")
+    from ..jit.cake_grouped_mxfp8_quantize import (
+        cake_grouped_mxfp8_target,
+        is_cake_grouped_mxfp8_quantize_available,
+    )
+
+    target = cake_grouped_mxfp8_target(a.device)
+    if not is_cake_grouped_mxfp8_quantize_available(a.dtype, a.device):
+        raise RuntimeError(
+            "backend='cake' requires an installed generated grouped MXFP8 "
+            f"profile for dtype={a.dtype} and target={target}; use the default "
+            "backend='cutile' until that profile is installed"
+        )
+    return get_cake_mxfp8_grouped_quantization_module().cake_mxfp8_grouped_quantize_impl(
+        a, mask
+    )
+
+
 @flashinfer_api(trace=mxfp8_grouped_quantize_trace)
 def mxfp8_grouped_quantize(
     a: torch.Tensor,
@@ -514,24 +541,10 @@ def mxfp8_grouped_quantize(
             a, mask
         )
 
-    from ..jit.cake_grouped_mxfp8_quantize import (
-        cake_grouped_mxfp8_target,
-        is_cake_grouped_mxfp8_quantize_available,
-    )
-
     _, _, k = a.shape
     if k % 32 != 0:
         raise ValueError(f"K must be divisible by 32, got {k}")
-    target = cake_grouped_mxfp8_target(a.device)
-    if not is_cake_grouped_mxfp8_quantize_available(a.dtype, a.device):
-        raise RuntimeError(
-            "backend='cake' requires an installed generated grouped MXFP8 "
-            f"profile for dtype={a.dtype} and target={target}; use the default "
-            "backend='cutile' until that profile is installed"
-        )
-    return get_cake_mxfp8_grouped_quantization_module().cake_mxfp8_grouped_quantize_impl(
-        a, mask
-    )
+    return _mxfp8_grouped_quantize_cake(a, mask, backend="cake")
 
 
 @flashinfer_api

--- a/flashinfer/trace/templates/quantize.py
+++ b/flashinfer/trace/templates/quantize.py
@@ -1046,7 +1046,7 @@ mxfp8_grouped_quantize_trace = TraceTemplate(
     op_type="quantization",
     name_prefix="mxfp8_grouped_quantize",
     description=(
-        "Grouped MXFP8 quantization (cuTile, SM100+): [B, M, K] bf16/fp16 -> "
+        "Grouped MXFP8 quantization (SM100+): [B, M, K] bf16/fp16 -> "
         "fp8_e4m3fn activations + UE8M0 block scales, laid out for the masked "
         "grouped GEMM. K is padded up to a multiple of 128 for the kernel."
     ),

--- a/tests/utils/test_fp8_quantize.py
+++ b/tests/utils/test_fp8_quantize.py
@@ -586,9 +586,7 @@ def test_mxfp8_grouped_quantize_backend_validation():
         mxfp8_grouped_quantize(a, mask, backend="unknown")
 
 
-@pytest.mark.parametrize(
-    "batch_shape", [(1, 120, 64), (2, 256, 4096), (3, 200, 160)]
-)
+@pytest.mark.parametrize("batch_shape", [(1, 120, 64), (2, 256, 4096), (3, 200, 160)])
 def test_mxfp8_grouped_quantize_cake_fake_op_metadata(batch_shape):
     """The Cake registered fake preserves the public grouped-GEMM ABI."""
     from flashinfer.quantization.fp8_quantization import (
@@ -621,7 +619,9 @@ def test_mxfp8_grouped_quantize_cake_exact(batch_shape, dtype):
     if not torch.cuda.is_available():
         pytest.skip("CUDA is not available")
     if not is_cake_grouped_mxfp8_available(dtype):
-        pytest.skip(f"a generated Cake grouped MXFP8 profile for {dtype} is not installed")
+        pytest.skip(
+            f"a generated Cake grouped MXFP8 profile for {dtype} is not installed"
+        )
 
     torch.manual_seed(20260829)
     b, m, k = batch_shape
@@ -645,9 +645,7 @@ def test_mxfp8_grouped_quantize_cake_exact(batch_shape, dtype):
             rtol=0,
             atol=0,
         )
-        got_scale = _unswizzle_mxfp8_scales_128x4(
-            out_scale[group], m, padded_k
-        )
+        got_scale = _unswizzle_mxfp8_scales_128x4(out_scale[group], m, padded_k)
         expected_scale = _unswizzle_mxfp8_scales_128x4(ref_scale, m, padded_k)
         torch.testing.assert_close(
             got_scale[:valid_rows], expected_scale[:valid_rows], rtol=0, atol=0
@@ -690,9 +688,12 @@ def test_mxfp8_grouped_quantize_cake_cuda_graph_and_streams():
         (stream_b_q, eager_q),
         (stream_b_sf, eager_sf),
     ):
-        torch.testing.assert_close(got.contiguous().view(torch.uint8),
-                                   expected.contiguous().view(torch.uint8),
-                                   rtol=0, atol=0)
+        torch.testing.assert_close(
+            got.contiguous().view(torch.uint8),
+            expected.contiguous().view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
 
 
 @pytest.mark.parametrize("batch_shape", [(2, 128, 128), (3, 256, 160)])

--- a/tests/utils/test_fp8_quantize.py
+++ b/tests/utils/test_fp8_quantize.py
@@ -665,7 +665,7 @@ def test_mxfp8_grouped_quantize_cake_cuda_graph_and_streams():
     torch.manual_seed(20260829)
     shape = (2, 256, 4096)
     x = torch.randn(shape, dtype=torch.bfloat16, device="cuda")
-    mask = torch.tensor([shape[1], shape[1] // 2], dtype=torch.int32, device="cuda")
+    mask = torch.full((shape[0],), shape[1], dtype=torch.int32, device="cuda")
     eager_q, eager_sf = mxfp8_grouped_quantize(x, mask, backend="cake")
     torch.cuda.synchronize()
 

--- a/tests/utils/test_fp8_quantize.py
+++ b/tests/utils/test_fp8_quantize.py
@@ -39,6 +39,22 @@ def is_cutile_available():
         return False
 
 
+def is_cake_grouped_mxfp8_available(dtype):
+    """Check whether a generated Cake profile is installed for this GPU."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        from flashinfer.jit.cake_grouped_mxfp8_quantize import (
+            is_cake_grouped_mxfp8_quantize_available,
+        )
+
+        return is_cake_grouped_mxfp8_quantize_available(
+            dtype, torch.device("cuda", torch.cuda.current_device())
+        )
+    except (ImportError, RuntimeError):
+        return False
+
+
 def _is_mxfp8_supported(device: torch.device) -> bool:
     """Check if MXFP8 quantization is supported on this device.
 
@@ -236,15 +252,18 @@ def _skip_if_low_vram_for_grouped_overflow():
         )
 
 
+@pytest.mark.parametrize("backend", ["cutile", "cake"])
 @torch.inference_mode()
-def test_mxfp8_grouped_quantize_int32_offset_overflow():
+def test_mxfp8_grouped_quantize_int32_offset_overflow(backend):
     """Grouped MXFP8 quantize must handle group bases above 2**31 elements."""
     if not torch.cuda.is_available():
         pytest.skip("CUDA is not available")
     if not _is_mxfp8_supported(torch.device("cuda:0")):
         pytest.skip("mxfp8 grouped quantization requires compute capability >= 10")
-    if not is_cutile_available():
+    if backend == "cutile" and not is_cutile_available():
         pytest.skip("cuda.tile is not available")
+    if backend == "cake" and not is_cake_grouped_mxfp8_available(_OVERFLOW_DTYPE):
+        pytest.skip("a generated Cake BF16 grouped MXFP8 profile is not installed")
     _skip_if_low_vram_for_grouped_overflow()
 
     torch.manual_seed(0)
@@ -255,7 +274,7 @@ def test_mxfp8_grouped_quantize_int32_offset_overflow():
     # Full masks make the overflowing groups write output.
     mask = torch.full((b,), m, dtype=torch.int32, device="cuda")
 
-    out, _out_scale = mxfp8_grouped_quantize(x, mask)
+    out, _out_scale = mxfp8_grouped_quantize(x, mask, backend=backend)
     out = out.permute(2, 0, 1)  # -> [b, m, padded_k]
     torch.cuda.synchronize()  # Surface async illegal-address errors.
     assert out.shape == (b, m, padded_k)
@@ -557,6 +576,123 @@ def test_mxfp8_grouped_quantize_fake_op_metadata(batch_shape):
     assert out.stride() == (padded_k, 1, m * padded_k)
     assert sf.shape == (32, 4, padded_m // 128, 4, padded_k // 128, b)
     assert sf.dtype == torch.uint8
+
+
+def test_mxfp8_grouped_quantize_backend_validation():
+    """Reject unknown backends before attempting device-specific dispatch."""
+    a = torch.empty((2, 4, 32), dtype=torch.bfloat16, device="meta")
+    mask = torch.empty((2,), dtype=torch.int32, device="meta")
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        mxfp8_grouped_quantize(a, mask, backend="unknown")
+
+
+@pytest.mark.parametrize(
+    "batch_shape", [(1, 120, 64), (2, 256, 4096), (3, 200, 160)]
+)
+def test_mxfp8_grouped_quantize_cake_fake_op_metadata(batch_shape):
+    """The Cake registered fake preserves the public grouped-GEMM ABI."""
+    from flashinfer.quantization.fp8_quantization import (
+        get_cake_mxfp8_grouped_quantization_module,
+    )
+
+    b, m, k = batch_shape
+    a = torch.empty((b, m, k), dtype=torch.bfloat16, device="meta")
+    mask = torch.empty((b,), dtype=torch.int32, device="meta")
+    out, sf = (
+        get_cake_mxfp8_grouped_quantization_module()._fake_cake_mxfp8_grouped_quantize(
+            a, mask
+        )
+    )
+
+    padded_k = (k + 127) // 128 * 128
+    padded_m = (m + 127) // 128 * 128
+    assert out.shape == (m, padded_k, b)
+    assert out.dtype == torch.float8_e4m3fn
+    assert out.stride() == (padded_k, 1, m * padded_k)
+    assert sf.shape == (32, 4, padded_m // 128, 4, padded_k // 128, b)
+    assert sf.dtype == torch.uint8
+
+
+@pytest.mark.parametrize("batch_shape", [(2, 256, 4096), (3, 200, 160)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_mxfp8_grouped_quantize_cake_exact(batch_shape, dtype):
+    """Generated Cake profiles must match valid output bits and scale bytes."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if not is_cake_grouped_mxfp8_available(dtype):
+        pytest.skip(f"a generated Cake grouped MXFP8 profile for {dtype} is not installed")
+
+    torch.manual_seed(20260829)
+    b, m, k = batch_shape
+    x = (torch.randn(batch_shape, dtype=torch.float32, device="cuda") * 16).to(dtype)
+    mask_values = [0, m] if b == 2 else [m, m // 2, max(1, m - 7)]
+    mask = torch.tensor(mask_values, dtype=torch.int32, device="cuda")
+    out, out_scale = mxfp8_grouped_quantize(x, mask, backend="cake")
+    out = out.permute(2, 0, 1)
+    out_scale = out_scale.permute(5, 2, 4, 0, 1, 3)
+    padded_k = (k + 127) // 128 * 128
+
+    for group, valid_rows in enumerate(mask_values):
+        if valid_rows == 0:
+            continue
+        ref, ref_scale = mxfp8_quantize_reference(
+            x[group], alignment=128, sf_swizzle_layout=SfLayout.layout_128x4
+        )
+        torch.testing.assert_close(
+            out[group, :valid_rows].contiguous().view(torch.uint8),
+            ref[:valid_rows].contiguous().view(torch.uint8),
+            rtol=0,
+            atol=0,
+        )
+        got_scale = _unswizzle_mxfp8_scales_128x4(
+            out_scale[group], m, padded_k
+        )
+        expected_scale = _unswizzle_mxfp8_scales_128x4(ref_scale, m, padded_k)
+        torch.testing.assert_close(
+            got_scale[:valid_rows], expected_scale[:valid_rows], rtol=0, atol=0
+        )
+
+
+@torch.inference_mode()
+def test_mxfp8_grouped_quantize_cake_cuda_graph_and_streams():
+    """Cake launches use the caller stream and remain CUDA-graph replay safe."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+    if not is_cake_grouped_mxfp8_available(torch.bfloat16):
+        pytest.skip("a generated Cake BF16 grouped MXFP8 profile is not installed")
+
+    torch.manual_seed(20260829)
+    shape = (2, 256, 4096)
+    x = torch.randn(shape, dtype=torch.bfloat16, device="cuda")
+    mask = torch.tensor([shape[1], shape[1] // 2], dtype=torch.int32, device="cuda")
+    eager_q, eager_sf = mxfp8_grouped_quantize(x, mask, backend="cake")
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_q, graph_sf = mxfp8_grouped_quantize(x, mask, backend="cake")
+    graph.replay()
+
+    stream_a = torch.cuda.Stream()
+    stream_b = torch.cuda.Stream()
+    with torch.cuda.stream(stream_a):
+        stream_a_q, stream_a_sf = mxfp8_grouped_quantize(x, mask, backend="cake")
+    with torch.cuda.stream(stream_b):
+        stream_b_q, stream_b_sf = mxfp8_grouped_quantize(x, mask, backend="cake")
+    torch.cuda.synchronize()
+
+    for got, expected in (
+        (graph_q, eager_q),
+        (graph_sf, eager_sf),
+        (stream_a_q, eager_q),
+        (stream_a_sf, eager_sf),
+        (stream_b_q, eager_q),
+        (stream_b_sf, eager_sf),
+    ):
+        torch.testing.assert_close(got.contiguous().view(torch.uint8),
+                                   expected.contiguous().view(torch.uint8),
+                                   rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("batch_shape", [(2, 128, 128), (3, 256, 160)])


### PR DESCRIPTION
## Summary

- add an explicit `backend="cake"` path for grouped MXFP8 quantization on SM100 and SM103 while keeping `backend="cutile"` as the default
- preserve the physical grouped-GEMM output ABI, exact E4M3/UE8M0 results, ragged masks, CUDA Graph reuse, concurrent streams, and 64-bit offsets
- JIT-compile deterministic generated BF16/FP16 CUDA sources with exact architecture routing and fail closed when no matching generated profile exists
- add correctness coverage and a strict cold-L2 CUPTI kernel benchmark with preallocated outputs and prepared scheduling metadata

## Validation

- B200: `33 passed, 720 deselected`
- B300: `33 passed, 720 deselected`
- BF16/FP16 quantized bits and scale bytes match exactly on valid rows
- CUDA 13.3 memcheck and synccheck: `ERROR SUMMARY: 0 errors` for the exported device programs on B200 and B300

Strict cold-L2 CUPTI kernel-only results for `B=2, M=256, K=4096, BF16`:

| GPU | cuTile persistent quant kernel | Cake quant kernel | Speedup |
| --- | ---: | ---: | ---: |
| B200 | 0.018880 ms | 0.003872 ms | 4.8760x |
| B300 | 0.018943 ms | 0.003712 ms | 5.1032x |

The cross-architecture geomean speedup is 4.9883x. Both arms use preallocated outputs. The cuTile prefix schedule and all output allocation/Python work are outside the timed region, so each CUPTI sample contains one quantization-kernel launch. The B200 run collected 9,987 cuTile and 12,568 Cake samples; the B300 run collected 10,093 cuTile and 12,377 Cake samples.

## SGLang end-to-end validation

The merged FlashInfer revision was also validated through SGLang on an NVIDIA
B200 with
[`zianglih/Qwen3-30B-A3B-Instruct-2507-MXFP8`](https://huggingface.co/zianglih/Qwen3-30B-A3B-Instruct-2507-MXFP8/tree/827030bc4576a86b26b01b72879ce320368cffc0).
The run pinned SGLang to
[`3538850f2d9bd4ee6d35b3c99f4c24b83200d3f9`](https://github.com/sgl-project/sglang/commit/3538850f2d9bd4ee6d35b3c99f4c24b83200d3f9)
and FlashInfer to this PR's merge commit,
[`93151678bcd020310aac1b764eb83a994de957dd`](https://github.com/flashinfer-ai/flashinfer/commit/93151678bcd020310aac1b764eb83a994de957dd).
The SGLang checkout also carried the pending integration overlay that adapts
SGLang's compact expert layout to FlashInfer's public dense grouped API and
exposes explicit `cake` and `cutile` selector values.
Server logs confirmed that both `backend="cake"` and `backend="cutile"` were
used without fallback. Formal collection disabled receipts and profilers.

### Accuracy and output agreement

| Workload | cuTile | Cake | Output agreement |
| --- | ---: | ---: | ---: |
| GSM8K strict exact match | 1110/1319 (84.1547%) | 1110/1319 (84.1547%) | 1319/1319 |
| GSM8K flexible exact match | 1140/1319 (86.4291%) | 1140/1319 (86.4291%) | 1319/1319 |
| LongBench 21-task macro score | 43.45 | 43.44 | 4739/4750 |

The 11 LongBench output differences changed only three task scores at two-decimal
precision: `multifieldqa_en` was 50.74/50.52, `multifieldqa_zh` was 60.93/60.97,
and `vcsum` was 10.84/10.85 for cuTile/Cake respectively. The other 18 task
scores were identical at two-decimal precision.

### End-to-end performance

| Workload | Backend | Active-request time | Completion throughput | Cake/cuTile speedup |
| --- | --- | ---: | ---: | ---: |
| GSM8K | cuTile | 1465.075742 s | 142.814459 tok/s | — |
| GSM8K | Cake | 1420.770346 s | 147.267995 tok/s | 1.031184x |
| LongBench | cuTile | 4196.685612 s | 110.529366 tok/s | — |
| LongBench | Cake | 4255.507120 s | 109.003930 tok/s | 0.986178x |
| Combined | cuTile | 5661.761354 s | 118.883676 tok/s | — |
| Combined | Cake | 5676.277466 s | 118.581413 tok/s | 0.997443x |

For GSM8K, active-request time is the sum of sequential HTTP batch wall times.
For LongBench, it is the union of concurrent per-request intervals. Both exclude
model/server startup, client setup, task gaps, and resume/allocation gaps. These
model-level results are therefore distinct from the cold-L2, kernel-only speedups
reported above: Cake was 3.12% faster on GSM8K, 1.38% slower on LongBench, and
0.26% slower overall by active-request time.
