### PR TITLE
feat(cake_bgmv): add deterministic prepared Blackwell MoE backend

### DIFF
--- a/benchmarks/bench_blackwell_bgmv_moe.py
+++ b/benchmarks/bench_blackwell_bgmv_moe.py
@@ -207,7 +207,10 @@ def main():
     report = {
         "gpu": torch.cuda.get_device_name(),
         "timing": "CUPTI GPU activity span, cold L2",
-        "scope": "zero + shrink + expand",
+        "scope": (
+            "initialized-output pipeline: baseline zero + shrink + expand; "
+            "prepared backend total-store shrink + expand"
+        ),
         "rows": rows,
         "baseline_geomean_us": baseline_geomean_us,
         "candidate_geomean_us": candidate_geomean_us,

--- a/benchmarks/bench_blackwell_bgmv_moe.py
+++ b/benchmarks/bench_blackwell_bgmv_moe.py
@@ -125,9 +125,7 @@ def _run_shape(hidden_size: int, num_tokens: int, repeat_time_ms: int):
     ) = inputs
     num_pairs = int(sorted_token_ids.numel())
 
-    baseline_shrink = torch.empty(
-        1, num_pairs, 32, dtype=x.dtype, device=x.device
-    )
+    baseline_shrink = torch.empty(1, num_pairs, 32, dtype=x.dtype, device=x.device)
     baseline_output = torch.empty(
         num_tokens, hidden_size, dtype=torch.float32, device=x.device
     )

--- a/benchmarks/bench_blackwell_bgmv_moe.py
+++ b/benchmarks/bench_blackwell_bgmv_moe.py
@@ -1,0 +1,222 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Cold-L2 CUPTI benchmark for the prepared SM100 BGMV MoE backend."""
+
+import argparse
+import json
+import math
+import statistics
+import warnings
+
+import torch
+
+from flashinfer.fused_moe.bgmv_moe import (
+    bgmv_moe_expand,
+    bgmv_moe_shrink,
+    fill_w_ptr,
+    prepare_bgmv_moe,
+)
+from flashinfer.testing.utils import bench_gpu_time_with_cupti
+
+
+SHAPES = [
+    (hidden_size, num_tokens)
+    for hidden_size in (3072, 2688)
+    for num_tokens in (1, 4, 8, 32, 256, 512, 1024)
+]
+
+
+def _make_inputs(hidden_size: int, num_tokens: int):
+    torch.manual_seed(42)
+    device = "cuda"
+    dtype = torch.bfloat16
+    rank = 32
+    num_experts = 128
+    num_loras = 8
+    top_k = 2
+    num_pairs = num_tokens * top_k
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device) * 0.1
+    lora_a = (
+        torch.randn(
+            num_loras,
+            num_experts,
+            rank,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+        )
+        * 0.01
+    )
+    lora_b = (
+        torch.randn(
+            num_loras,
+            num_experts,
+            hidden_size,
+            rank,
+            dtype=dtype,
+            device=device,
+        )
+        * 0.01
+    )
+    sorted_token_ids = torch.arange(
+        num_tokens, dtype=torch.int64, device=device
+    ).repeat_interleave(top_k)
+    expert_ids = torch.randint(
+        0, num_experts, (num_pairs,), dtype=torch.int64, device=device
+    )
+    lora_indices = torch.randint(
+        0, num_loras, (num_tokens,), dtype=torch.int64, device=device
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    ).reshape(-1)
+    return (
+        x,
+        [lora_a],
+        [lora_b],
+        sorted_token_ids,
+        expert_ids,
+        lora_indices,
+        topk_weights,
+        num_experts,
+    )
+
+
+def _cupti_median_us(fn, repeat_time_ms: int) -> float:
+    # The testing helper warns before silently falling back to CUDA Events.
+    # Treat that warning as an error so reportable rows remain CUPTI-only.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        samples_ms = bench_gpu_time_with_cupti(
+            fn,
+            dry_run_time_ms=100,
+            repeat_time_ms=repeat_time_ms,
+            cold_l2_cache=True,
+            use_cuda_graph=False,
+        )
+    return 1000.0 * float(statistics.median(samples_ms))
+
+
+def _run_shape(hidden_size: int, num_tokens: int, repeat_time_ms: int):
+    inputs = _make_inputs(hidden_size, num_tokens)
+    (
+        x,
+        lora_a_weights,
+        lora_b_weights,
+        sorted_token_ids,
+        expert_ids,
+        lora_indices,
+        topk_weights,
+        num_experts,
+    ) = inputs
+    num_pairs = int(sorted_token_ids.numel())
+
+    baseline_shrink = torch.empty(
+        1, num_pairs, 32, dtype=x.dtype, device=x.device
+    )
+    baseline_output = torch.empty(
+        num_tokens, hidden_size, dtype=torch.float32, device=x.device
+    )
+    w_ptr_a = torch.empty(1, num_experts, dtype=torch.int64, device=x.device)
+    w_ptr_b = torch.empty(1, num_experts, dtype=torch.int64, device=x.device)
+    lora_stride_a = fill_w_ptr(w_ptr_a, lora_a_weights[0], num_experts, 0)
+    lora_stride_b = fill_w_ptr(w_ptr_b, lora_b_weights[0], num_experts, 0)
+    slice_start_loc = torch.zeros(1, dtype=torch.int64, device=x.device)
+
+    def baseline():
+        baseline_shrink.zero_()
+        baseline_output.zero_()
+        bgmv_moe_shrink(
+            baseline_shrink,
+            x,
+            w_ptr_a,
+            sorted_token_ids,
+            expert_ids,
+            lora_indices,
+            lora_stride_a,
+        )
+        bgmv_moe_expand(
+            baseline_output,
+            baseline_shrink,
+            w_ptr_b,
+            sorted_token_ids,
+            expert_ids,
+            topk_weights,
+            lora_indices,
+            slice_start_loc,
+            [hidden_size],
+            lora_stride_b,
+        )
+
+    plan = prepare_bgmv_moe(*inputs, backend="blackwell")
+    candidate_output = plan.run()
+    baseline()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        candidate_output,
+        baseline_output,
+        atol=1e-2,
+        rtol=1e-2,
+    )
+
+    baseline_us = _cupti_median_us(baseline, repeat_time_ms)
+    candidate_us = _cupti_median_us(plan.run, repeat_time_ms)
+    return {
+        "hidden_size": hidden_size,
+        "num_tokens": num_tokens,
+        "rank": 32,
+        "num_experts": 128,
+        "top_k": 2,
+        "num_loras": 8,
+        "dtype": "bfloat16",
+        "baseline_us": baseline_us,
+        "candidate_us": candidate_us,
+        "speedup": baseline_us / candidate_us,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repeat-time-ms", type=int, default=1000)
+    args = parser.parse_args()
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability() != (10, 0):
+        raise RuntimeError("this benchmark requires an exact SM100 CUDA device")
+
+    rows = [
+        _run_shape(hidden_size, num_tokens, args.repeat_time_ms)
+        for hidden_size, num_tokens in SHAPES
+    ]
+    baseline_geomean_us = math.exp(
+        sum(math.log(row["baseline_us"]) for row in rows) / len(rows)
+    )
+    candidate_geomean_us = math.exp(
+        sum(math.log(row["candidate_us"]) for row in rows) / len(rows)
+    )
+    report = {
+        "gpu": torch.cuda.get_device_name(),
+        "timing": "CUPTI GPU activity span, cold L2",
+        "scope": "zero + shrink + expand",
+        "rows": rows,
+        "baseline_geomean_us": baseline_geomean_us,
+        "candidate_geomean_us": candidate_geomean_us,
+        "geomean_speedup": baseline_geomean_us / candidate_geomean_us,
+    }
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
@@ -27,7 +27,8 @@ typedef short int int16_t;
 struct __align__(128) BlackwellTensorMap {
   uint64_t opaque[16];
 };
-template <int N> struct __align__(128) BlackwellTensorMapPack {
+template <int N>
+struct __align__(128) BlackwellTensorMapPack {
   BlackwellTensorMap maps[N];
 };
 
@@ -39,9 +40,7 @@ typedef struct __align__(64) {
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
   int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-               : "=r"(result)
-               : "r"(x));
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
   return result;
 }
 
@@ -63,12 +62,11 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -81,11 +79,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 24576);
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
   const int w_smem_addr = smem + 24576;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
   const int warp_partials_addr = smem + 221184;
 
   // === Task calls (dependency order) ===
@@ -125,27 +123,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
         if (k_base < 2688) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
                   (tokens[pp_1] * 2688 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    2688 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -173,23 +165,22 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
       int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 2688) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           "shl.b32 %0, %2, 16;\n\t"
-                           "and.b32 %1, %2, 0xffff0000;\n\t"
-                           "}\n"
-                           : "=f"((&x_values[_pair * 2])[0]),
-                             "=f"((&x_values[_pair * 2])[1])
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -199,31 +190,28 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 2688) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
-                                rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             "shl.b32 %0, %2, 16;\n\t"
-                             "and.b32 %1, %2, 0xffff0000;\n\t"
-                             "}\n"
-                             : "=f"((&w_values[_pair * 2])[0]),
-                               "=f"((&w_values[_pair * 2])[1])
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -257,14 +245,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
       for (int pp_3 = 0; pp_3 < 4; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 2688) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
-                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -275,13 +261,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
-                                          1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -295,16 +278,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
       int owner_rr = lane % 8;
       int pair_1 = pair_block * 4 + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16 *>(
-              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2bfloat16_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -339,12 +321,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -357,11 +338,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 4096);
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
   const int w_smem_addr = smem + 4096;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
   const int warp_partials_addr = smem + 36864;
 
   // === Task calls (dependency order) ===
@@ -401,27 +382,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
         if (k_base < 2688) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
                   (tokens[pp_1] * 2688 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    2688 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -449,23 +424,22 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
       int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 2688) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           "shl.b32 %0, %2, 16;\n\t"
-                           "and.b32 %1, %2, 0xffff0000;\n\t"
-                           "}\n"
-                           : "=f"((&x_values[_pair * 2])[0]),
-                             "=f"((&x_values[_pair * 2])[1])
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -475,31 +449,28 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 2688) {
-            int w_thread_base =
-                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             "shl.b32 %0, %2, 16;\n\t"
-                             "and.b32 %1, %2, 0xffff0000;\n\t"
-                             "}\n"
-                             : "=f"((&w_values[_pair * 2])[0]),
-                               "=f"((&w_values[_pair * 2])[1])
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -533,14 +504,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
       for (int pp_3 = 0; pp_3 < 1; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 2688) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
-                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -551,12 +520,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -570,16 +537,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
       int owner_rr = lane % 8;
       int pair_1 = pair_block + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16 *>(
-              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2bfloat16_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -608,13 +574,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_
 
 extern "C" {
 
-__global__
-__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -627,7 +592,7 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -653,13 +618,11 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -675,44 +638,37 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               "shl.b32 %0, %2, 16;\n\t"
-                               "and.b32 %1, %2, 0xffff0000;\n\t"
-                               "}\n"
-                               : "=f"((&activation_values[_pair * 2])[0]),
-                                 "=f"((&activation_values[_pair * 2])[1])
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -728,16 +684,16 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
             float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
             total = _fma_1;
           }
-          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
-                                                 output_offset + output_col)) +
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
             (0)) = total;
         }
       } else if (output_col < 2688) {
@@ -752,15 +708,14 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
                     (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -775,21 +730,18 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
                 }
               }
               long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col_1;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index_1 + 0);
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -806,29 +758,25 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                              route_partial_1);
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                 route_partial_1 = _fma_2;
               }
             }
-            float _fma_3 =
-                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
             total_1 = _fma_3;
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total_1;
       }
     } else if (output_col < 2688) {
-      *(reinterpret_cast<float *>(
-            y_accum + (token * output_stride + output_offset + output_col)) +
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
         (0)) = 0.0f;
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -847,11 +795,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h2688_r32_t128(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -876,15 +824,14 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
               int rank_col = rank_block * 8;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                    (pair * 32 + rank_col) + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) +
+                    0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -899,21 +846,18 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -929,15 +873,13 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element],
-                                         _vec_load_1[element], partial);
+                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
                 partial = _fma_0;
               }
             }
-            atomicAdd(
-                &y_accum[token * (long long)output_stride +
-                         (long long)output_offset + (long long)output_col],
-                partial * topk_weights[pair]);
+            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
+                               (long long)output_col],
+                      partial * topk_weights[pair]);
           }
         }
       }
@@ -945,7 +887,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -961,13 +903,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -980,7 +921,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1006,13 +947,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
           if (tid < 8) {
             int stage_route = tid / 4;
             int stage_rank_block = tid % 4;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    shrink_stage_addr +
-                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
           }
           asm volatile("cp.async.commit_group;");
           asm volatile("cp.async.wait_group 0;");
@@ -1026,44 +965,37 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               "shl.b32 %0, %2, 16;\n\t"
-                               "and.b32 %1, %2, 0xffff0000;\n\t"
-                               "}\n"
-                               : "=f"((&activation_values[_pair * 2])[0]),
-                                 "=f"((&activation_values[_pair * 2])[1])
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1079,8 +1011,8 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
@@ -1098,15 +1030,14 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
                 int rank_col_1 = rank_block_1 * 8;
                 float _vec_load_1[8];
                 {
-                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
                       (pair_1 * 32 + rank_col_1) + 0);
                   uint4 _vld_1[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t *_vpairs_1 =
-                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1121,21 +1052,18 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
                   }
                 }
                 long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                     (long long)output_col) *
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
                         32 +
                     (long long)rank_col_1;
                 float _vec_load_2[8];
                 {
-                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                      weight_index_1 + 0);
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
                   uint4 _vld_2[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t *_vpairs_2 =
-                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1152,30 +1080,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h268
 #pragma unroll
                 for (int element_1 = 0; element_1 < 8; element_1++) {
                   float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                                route_partial_1);
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                   route_partial_1 = _fma_2;
                 }
               }
-              float _fma_3 =
-                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
               total = _fma_3;
             }
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total;
       } else {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -1198,11 +1122,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -1215,7 +1139,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1252,13 +1176,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -1272,46 +1194,39 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
           for (int rank_block = 0; rank_block < 4; rank_block++) {
             int rank_col = rank_block * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 3]))
-                : "r"(shrink_stage_addr +
-                      (unsigned int)((route * 32 + rank_col) * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             "shl.b32 %0, %2, 16;\n\t"
-                             "and.b32 %1, %2, 0xffff0000;\n\t"
-                             "}\n"
-                             : "=f"((&activation_values[_pair * 2])[0]),
-                               "=f"((&activation_values[_pair * 2])[1])
-                             : "r"(activation_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&activation_values[_pair * 2])[0]),
+                      "=f"((&activation_values[_pair * 2])[1])
+                    : "r"(activation_carriers[_pair]));
               }
             }
             if (valid0 != 0) {
               long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col0) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index0 + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1327,28 +1242,25 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial0);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
                 route_partial0 = _fma_0;
               }
             }
             if (valid1 != 0) {
               long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col1) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index1 + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1365,20 +1277,17 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_1 =
-                    __fmaf_rn(activation_values[element_1],
-                              _vec_load_1[element_1], route_partial1);
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
                 route_partial1 = _fma_1;
               }
             }
           }
           if (valid0 != 0) {
-            float _fma_2 =
-                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
             total0 = _fma_2;
           }
           if (valid1 != 0) {
-            float _fma_3 =
-                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
             total1 = _fma_3;
           }
         }
@@ -1394,15 +1303,14 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
                     (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1417,22 +1325,19 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
                 }
               }
               if (valid0 != 0) {
-                long long weight_index0_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                     (long long)output_col0) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_3[8];
                 {
-                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                      weight_index0_1 + 0);
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
                   uint4 _vld_3[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t *_vpairs_3 =
-                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1449,28 +1354,24 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_2 = 0; element_2 < 8; element_2++) {
                   float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
-                                route_partial0_1);
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
                   route_partial0_1 = _fma_4;
                 }
               }
               if (valid1 != 0) {
-                long long weight_index1_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                     (long long)output_col1) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_4[8];
                 {
-                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                      weight_index1_1 + 0);
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
                   uint4 _vld_4[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t *_vpairs_4 =
-                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1487,51 +1388,48 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_3 = 0; element_3 < 8; element_3++) {
                   float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
-                                route_partial1_1);
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
                   route_partial1_1 = _fma_5;
                 }
               }
             }
             if (valid0 != 0) {
-              float _fma_6 =
-                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
               total0 = _fma_6;
             }
             if (valid1 != 0) {
-              float _fma_7 =
-                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
               total1 = _fma_7;
             }
           }
         }
       }
       if (valid0 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = total0;
       }
       if (valid1 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = total1;
       }
     } else {
       if (output_col0 < 2688) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = 0.0f;
       }
       if (output_col1 < 2688) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
@@ -1,0 +1,1259 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Generated source for FlashInfer.
+// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Target: sm_100a; compile flags: none.
+// Generated file; do not edit manually.
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#include <math_constants.h>
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 24576
+#define SMEM_X_SMEM_STRIDE 24576
+#define SMEM_W_SMEM_OFF 24576
+#define SMEM_W_SMEM_STAGE_BYTES 196608
+#define SMEM_W_SMEM_STRIDE 196608
+#define SMEM_WARP_PARTIALS_OFF 221184
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 512
+#define SMEM_WARP_PARTIALS_STRIDE 512
+#define SMEM_TOTAL 221696
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 4096
+#define SMEM_X_SMEM_STRIDE 4096
+#define SMEM_W_SMEM_OFF 4096
+#define SMEM_W_SMEM_STAGE_BYTES 32768
+#define SMEM_W_SMEM_STRIDE 32768
+#define SMEM_WARP_PARTIALS_OFF 36864
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 128
+#define SMEM_WARP_PARTIALS_STRIDE 128
+#define SMEM_TOTAL 36992
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 64
+
+extern "C" {
+
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 2688) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 2688) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 2688) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h2688_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int pair = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    if (pair < num_pairs) {
+        if (output_col < 2688) {
+            long long token = sorted_token_ids[pair];
+            if (token >= 0) {
+                if (token < (long long)num_tokens) {
+                    long long lora_id = lora_indices[token];
+                    if (lora_id >= 0) {
+                        long long expert = expert_ids[pair];
+                        float partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
+                                partial = _fma_0;
+                            }
+                        }
+                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        if (output_col < 2688) {
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 2688) {
+                valid0 = 1;
+            }
+            if (output_col1 < 2688) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
+        } else {
+            if (output_col0 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
+            }
+            if (output_col1 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
@@ -17,26 +17,32 @@
 // Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
-template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
+template <int N> struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+               : "=r"(result)
+               : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,197 +63,245 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    2688 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           "shl.b32 %0, %2, 16;\n\t"
+                           "and.b32 %1, %2, 0xffff0000;\n\t"
+                           "}\n"
+                           : "=f"((&x_values[_pair * 2])[0]),
+                             "=f"((&x_values[_pair * 2])[1])
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
+                                rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             "shl.b32 %0, %2, 16;\n\t"
+                             "and.b32 %1, %2, 0xffff0000;\n\t"
+                             "}\n"
+                             : "=f"((&w_values[_pair * 2])[0]),
+                               "=f"((&w_values[_pair * 2])[1])
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
+                                          1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16 *>(
+              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -285,197 +339,244 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    2688 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           "shl.b32 %0, %2, 16;\n\t"
+                           "and.b32 %1, %2, 0xffff0000;\n\t"
+                           "}\n"
+                           : "=f"((&x_values[_pair * 2])[0]),
+                             "=f"((&x_values[_pair * 2])[1])
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base =
+                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             "shl.b32 %0, %2, 16;\n\t"
+                             "and.b32 %1, %2, 0xffff0000;\n\t"
+                             "}\n"
+                             : "=f"((&w_values[_pair * 2])[0]),
+                               "=f"((&w_values[_pair * 2])[1])
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16 *>(
+              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -507,177 +608,224 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 2688) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 2688) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 2688) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+        if (output_col < 2688) {
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               "shl.b32 %0, %2, 16;\n\t"
+                               "and.b32 %1, %2, 0xffff0000;\n\t"
+                               "}\n"
+                               : "=f"((&activation_values[_pair * 2])[0]),
+                                 "=f"((&activation_values[_pair * 2])[1])
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
+                                                 output_offset + output_col)) +
+            (0)) = total;
+        }
+      } else if (output_col < 2688) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                              route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 =
+                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 2688) {
+      *(reinterpret_cast<float *>(
+            y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
 } // extern "C"
@@ -697,85 +845,104 @@ kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(float* __restrict__ y
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h2688_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h2688_r32_t128(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // === Task calls (dependency order) ===
-    int pair = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    if (pair < num_pairs) {
-        if (output_col < 2688) {
-            long long token = sorted_token_ids[pair];
-            if (token >= 0) {
-                if (token < (long long)num_tokens) {
-                    long long lora_id = lora_indices[token];
-                    if (lora_id >= 0) {
-                        long long expert = expert_ids[pair];
-                        float partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                                partial = _fma_0;
-                            }
-                        }
-                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
-                    }
+  // === Task calls (dependency order) ===
+  int pair = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  if (pair < num_pairs) {
+    if (output_col < 2688) {
+      long long token = sorted_token_ids[pair];
+      if (token >= 0) {
+        if (token < (long long)num_tokens) {
+          long long lora_id = lora_indices[token];
+          if (lora_id >= 0) {
+            long long expert = expert_ids[pair];
+            float partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    (pair * 32 + rank_col) + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
                 }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(_vec_load_0[element],
+                                         _vec_load_1[element], partial);
+                partial = _fma_0;
+              }
             }
+            atomicAdd(
+                &y_accum[token * (long long)output_stride +
+                         (long long)output_offset + (long long)output_col],
+                partial * topk_weights[pair]);
+          }
         }
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -794,173 +961,218 @@ kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h2688_r32_t128(float* __restri
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        if (output_col < 2688) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 2688) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
+          }
         }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    shrink_stage_addr +
+                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               "shl.b32 %0, %2, 16;\n\t"
+                               "and.b32 %1, %2, 0xffff0000;\n\t"
+                               "}\n"
+                               : "=f"((&activation_values[_pair * 2])[0]),
+                                 "=f"((&activation_values[_pair * 2])[1])
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                      (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t *_vpairs_1 =
+                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                     (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                      weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t *_vpairs_2 =
+                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                                route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 =
+                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
+            }
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -984,267 +1196,339 @@ kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(float* __restrict__ y_acc
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 2688) {
-                valid0 = 1;
-            }
-            if (output_col1 < 2688) {
-                valid1 = 1;
-            }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 2688) {
+        valid0 = 1;
+      }
+      if (output_col1 < 2688) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 3]))
+                : "r"(shrink_stage_addr +
+                      (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             "shl.b32 %0, %2, 16;\n\t"
+                             "and.b32 %1, %2, 0xffff0000;\n\t"
+                             "}\n"
+                             : "=f"((&activation_values[_pair * 2])[0]),
+                               "=f"((&activation_values[_pair * 2])[1])
+                             : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1],
+                              _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 =
+                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 =
+                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                     (long long)output_col0) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                      weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t *_vpairs_3 =
+                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
+                                route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                     (long long)output_col1) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                      weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t *_vpairs_4 =
+                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
+                                route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 =
+                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 =
+                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 2688) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 2688) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
@@ -14,34 +14,29 @@
  * limitations under the License.
  */
 // Generated source for FlashInfer.
-// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int int32_t;
-typedef short int int16_t;
-struct __align__(128) BlackwellTensorMap {
-  uint64_t opaque[16];
-};
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
 template <int N>
-struct __align__(128) BlackwellTensorMapPack {
-  BlackwellTensorMap maps[N];
-};
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
 
-typedef struct __align__(64) {
-  uint64_t opaque[16];
-} CUtensorMap;
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-  int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
-  return result;
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
 }
 
 #include <math_constants.h>
@@ -62,231 +57,200 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
-  const int w_smem_addr = smem + 24576;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-  const int warp_partials_addr = smem + 221184;
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[4];
-  long long experts[4];
-  long long loras[4];
-  int valid[4];
-#pragma unroll
-  for (int pp = 0; pp < 4; pp++) {
-    int pair = pair_block * 4 + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 2688) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                  (tokens[pp_1] * 2688 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         2688 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
-                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 2;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 2688) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  "shl.b32 %0, %2, 16;\n\t"
-                  "and.b32 %1, %2, 0xffff0000;\n\t"
-                  "}\n"
-                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 2688) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    "shl.b32 %0, %2, 16;\n\t"
-                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                    "}\n"
-                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 32) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 3 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 2688) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                             (tokens[pp_3] * 2688 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      2688 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 32) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block * 4 + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
-                                           (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2bfloat16_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -321,231 +285,200 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
-  const int w_smem_addr = smem + 4096;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-  const int warp_partials_addr = smem + 36864;
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[1];
-  long long experts[1];
-  long long loras[1];
-  int valid[1];
-#pragma unroll
-  for (int pp = 0; pp < 1; pp++) {
-    int pair = pair_block + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 2688) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                  (tokens[pp_1] * 2688 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         2688 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                                           rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 1;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 2688) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  "shl.b32 %0, %2, 16;\n\t"
-                  "and.b32 %1, %2, 0xffff0000;\n\t"
-                  "}\n"
-                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 2688) {
-            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    "shl.b32 %0, %2, 16;\n\t"
-                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                    "}\n"
-                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 8) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 2 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 2688) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                             (tokens[pp_3] * 2688 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      2688 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 8) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
-                                           (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2bfloat16_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -574,209 +507,372 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 64 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
             }
-          }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 2688) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 2688) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 2688) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
         }
-      }
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
         if (output_col < 2688) {
-          float total = 0.0f;
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      "shl.b32 %0, %2, 16;\n\t"
-                      "and.b32 %1, %2, 0xffff0000;\n\t"
-                      "}\n"
-                      : "=f"((&activation_values[_pair * 2])[0]),
-                        "=f"((&activation_values[_pair * 2])[1])
-                      : "r"(activation_carriers[_pair]));
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (num_pairs == num_tokens * 2) {
+                    if (pair_base + 1 < num_pairs) {
+                        if (sorted_token_ids[pair_base] == (long long)token) {
+                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                                contiguous = 1;
+                            }
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
                 }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
-          *(reinterpret_cast<float*>(y_accum +
-                                     (token * output_stride + output_offset + output_col)) +
-            (0)) = total;
         }
-      } else if (output_col < 2688) {
-        float total_1 = 0.0f;
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-              long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col_1;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                route_partial_1 = _fma_2;
-              }
-            }
-            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-            total_1 = _fma_3;
-          }
-        }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total_1;
-      }
-    } else if (output_col < 2688) {
-      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-        (0)) = 0.0f;
     }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -789,112 +885,6 @@ __global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token
 
 #define BLACKWELL_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h2688_r32_t128(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // === Task calls (dependency order) ===
-  int pair = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  if (pair < num_pairs) {
-    if (output_col < 2688) {
-      long long token = sorted_token_ids[pair];
-      if (token >= 0) {
-        if (token < (long long)num_tokens) {
-          long long lora_id = lora_indices[token];
-          if (lora_id >= 0) {
-            long long expert = expert_ids[pair];
-            float partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) +
-                    0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                partial = _fma_0;
-              }
-            }
-            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
-                               (long long)output_col],
-                      partial * topk_weights[pair]);
-          }
-        }
-      }
-    }
-  }
-}
-
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef THREADS
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
 #define SMEM_SHRINK_STAGE_OFF 0
 #define SMEM_SHRINK_STAGE_STAGE_BYTES 128
 #define SMEM_SHRINK_STAGE_STRIDE 128
@@ -903,535 +893,270 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    if (output_col < 2688) {
-      long long lora_id = lora_indices[token];
-      if (lora_id >= 0) {
-        int pair_base = token * 2;
-        int contiguous = 0;
-        if (num_pairs == num_tokens * 2) {
-          if (pair_base + 1 < num_pairs) {
-            if (sorted_token_ids[pair_base] == (long long)token) {
-              if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                contiguous = 1;
-              }
-            }
-          }
-        }
-        float total = 0.0f;
-        if (contiguous != 0) {
-          if (tid < 8) {
-            int stage_route = tid / 4;
-            int stage_rank_block = tid % 4;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             shrink_stage_addr +
-                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-          }
-          asm volatile("cp.async.commit_group;");
-          asm volatile("cp.async.wait_group 0;");
-          __syncthreads();
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      "shl.b32 %0, %2, 16;\n\t"
-                      "and.b32 %1, %2, 0xffff0000;\n\t"
-                      "}\n"
-                      : "=f"((&activation_values[_pair * 2])[0]),
-                        "=f"((&activation_values[_pair * 2])[1])
-                      : "r"(activation_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 2688) {
+                valid0 = 1;
+            }
+            if (output_col1 < 2688) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
         } else {
-#pragma unroll 1
-          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-            if (sorted_token_ids[pair_1] == (long long)token) {
-              long long expert_1 = expert_ids[pair_1];
-              float route_partial_1 = 0.0f;
-#pragma unroll
-              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                int rank_col_1 = rank_block_1 * 8;
-                float _vec_load_1[8];
-                {
-                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                      (pair_1 * 32 + rank_col_1) + 0);
-                  uint4 _vld_1[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_1[_pair]));
-                    }
-                  }
-                }
-                long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
-                        32 +
-                    (long long)rank_col_1;
-                float _vec_load_2[8];
-                {
-                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                  uint4 _vld_2[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_2[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_1 = 0; element_1 < 8; element_1++) {
-                  float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                  route_partial_1 = _fma_2;
-                }
-              }
-              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-              total = _fma_3;
+            if (output_col0 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
             }
-          }
+            if (output_col1 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
         }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total;
-      } else {
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = 0.0f;
-      }
     }
-  }
 }
 
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // Kernel setup ops
-  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
-
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col0 = blockIdx.y * 256 + tid;
-  int output_col1 = output_col0 + 128;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
-            }
-          }
-        }
-      }
-      int valid0 = 0;
-      int valid1 = 0;
-      if (output_col0 < 2688) {
-        valid0 = 1;
-      }
-      if (output_col1 < 2688) {
-        valid1 = 1;
-      }
-      float total0 = 0.0f;
-      float total1 = 0.0f;
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
-#pragma unroll
-        for (int route = 0; route < 2; route++) {
-          int pair = pair_base + route;
-          long long expert = expert_ids[pair];
-          float route_partial0 = 0.0f;
-          float route_partial1 = 0.0f;
-#pragma unroll
-          for (int rank_block = 0; rank_block < 4; rank_block++) {
-            int rank_col = rank_block * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    "shl.b32 %0, %2, 16;\n\t"
-                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                    "}\n"
-                    : "=f"((&activation_values[_pair * 2])[0]),
-                      "=f"((&activation_values[_pair * 2])[1])
-                    : "r"(activation_carriers[_pair]));
-              }
-            }
-            if (valid0 != 0) {
-              long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                route_partial0 = _fma_0;
-              }
-            }
-            if (valid1 != 0) {
-              long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_1 =
-                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                route_partial1 = _fma_1;
-              }
-            }
-          }
-          if (valid0 != 0) {
-            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-            total0 = _fma_2;
-          }
-          if (valid1 != 0) {
-            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-            total1 = _fma_3;
-          }
-        }
-      } else {
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial0_1 = 0.0f;
-            float route_partial1_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-              if (valid0 != 0) {
-                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                                             (long long)output_col0) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_3[8];
-                {
-                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
-                  uint4 _vld_3[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_3[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_2 = 0; element_2 < 8; element_2++) {
-                  float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                  route_partial0_1 = _fma_4;
-                }
-              }
-              if (valid1 != 0) {
-                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                                             (long long)output_col1) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_4[8];
-                {
-                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
-                  uint4 _vld_4[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_4[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_3 = 0; element_3 < 8; element_3++) {
-                  float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                  route_partial1_1 = _fma_5;
-                }
-              }
-            }
-            if (valid0 != 0) {
-              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-              total0 = _fma_6;
-            }
-            if (valid1 != 0) {
-              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-              total1 = _fma_7;
-            }
-          }
-        }
-      }
-      if (valid0 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = total0;
-      }
-      if (valid1 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = total1;
-      }
-    } else {
-      if (output_col0 < 2688) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = 0.0f;
-      }
-      if (output_col1 < 2688) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = 0.0f;
-      }
-    }
-  }
-}
-
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
@@ -935,10 +935,12 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_toke
       if (lora_id >= 0) {
         int pair_base = token * 2;
         int contiguous = 0;
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
           }
         }

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h2688_sm100a.cu
@@ -17,26 +17,31 @@
 // Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,200 +62,231 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -285,200 +321,231 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p4_s3(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -507,372 +574,209 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h2688_r32_p1_s2(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 2688) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 2688) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 2688) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
-    }
-}
-
-} // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
-
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
-
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
         if (output_col < 2688) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (num_pairs == num_tokens * 2) {
-                    if (pair_base + 1 < num_pairs) {
-                        if (sorted_token_ids[pair_base] == (long long)token) {
-                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                                contiguous = 1;
-                            }
-                        }
-                    }
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
                 }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
                 }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
+            (0)) = total;
         }
+      } else if (output_col < 2688) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 2688) {
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -893,270 +797,535 @@ kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(float* __restrict__ y_acc
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 2688) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 2688) {
-                valid0 = 1;
+          }
+        }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
-            if (output_col1 < 2688) {
-                valid1 = 1;
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                      (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
             }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
+
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
+            }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 2688) {
+        valid0 = 1;
+      }
+      if (output_col1 < 2688) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&activation_values[_pair * 2])[0]),
+                      "=f"((&activation_values[_pair * 2])[1])
+                    : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 2688) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 2688) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
@@ -17,26 +17,31 @@
 // Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,200 +62,231 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -285,200 +321,231 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -507,372 +574,209 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 3072) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 3072) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 3072) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
-    }
-}
-
-} // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
-
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
-
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
         if (output_col < 3072) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (num_pairs == num_tokens * 2) {
-                    if (pair_base + 1 < num_pairs) {
-                        if (sorted_token_ids[pair_base] == (long long)token) {
-                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                                contiguous = 1;
-                            }
-                        }
-                    }
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
                 }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
                 }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
+            (0)) = total;
         }
+      } else if (output_col < 3072) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 3072) {
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -893,270 +797,535 @@ kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(float* __restrict__ y_acc
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 3072) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 3072) {
-                valid0 = 1;
+          }
+        }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
-            if (output_col1 < 3072) {
-                valid1 = 1;
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                      (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
             }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
+
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
+            }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 3072) {
+        valid0 = 1;
+      }
+      if (output_col1 < 3072) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&activation_values[_pair * 2])[0]),
+                      "=f"((&activation_values[_pair * 2])[1])
+                    : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 3072) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 3072) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
@@ -14,34 +14,29 @@
  * limitations under the License.
  */
 // Generated source for FlashInfer.
-// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int int32_t;
-typedef short int int16_t;
-struct __align__(128) BlackwellTensorMap {
-  uint64_t opaque[16];
-};
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
 template <int N>
-struct __align__(128) BlackwellTensorMapPack {
-  BlackwellTensorMap maps[N];
-};
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
 
-typedef struct __align__(64) {
-  uint64_t opaque[16];
-} CUtensorMap;
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-  int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
-  return result;
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
 }
 
 #include <math_constants.h>
@@ -62,231 +57,200 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
-  const int w_smem_addr = smem + 24576;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-  const int warp_partials_addr = smem + 221184;
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[4];
-  long long experts[4];
-  long long loras[4];
-  int valid[4];
-#pragma unroll
-  for (int pp = 0; pp < 4; pp++) {
-    int pair = pair_block * 4 + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 3072) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                  (tokens[pp_1] * 3072 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         3072 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
-                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 2;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 3072) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  "shl.b32 %0, %2, 16;\n\t"
-                  "and.b32 %1, %2, 0xffff0000;\n\t"
-                  "}\n"
-                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 3072) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    "shl.b32 %0, %2, 16;\n\t"
-                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                    "}\n"
-                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 32) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 3 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 3072) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                             (tokens[pp_3] * 3072 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      3072 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 32) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block * 4 + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
-                                           (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2bfloat16_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -321,231 +285,200 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
-  const int w_smem_addr = smem + 4096;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-  const int warp_partials_addr = smem + 36864;
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[1];
-  long long experts[1];
-  long long loras[1];
-  int valid[1];
-#pragma unroll
-  for (int pp = 0; pp < 1; pp++) {
-    int pair = pair_block + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 3072) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                  (tokens[pp_1] * 3072 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         3072 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                                           rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 1;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 3072) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  "shl.b32 %0, %2, 16;\n\t"
-                  "and.b32 %1, %2, 0xffff0000;\n\t"
-                  "}\n"
-                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 3072) {
-            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    "shl.b32 %0, %2, 16;\n\t"
-                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                    "}\n"
-                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 8) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 2 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 3072) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
-                             (tokens[pp_3] * 3072 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      3072 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 8) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
-                                           (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2bfloat16_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -574,209 +507,372 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 64 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
             }
-          }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 3072) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 3072) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 3072) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
         }
-      }
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
         if (output_col < 3072) {
-          float total = 0.0f;
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      "shl.b32 %0, %2, 16;\n\t"
-                      "and.b32 %1, %2, 0xffff0000;\n\t"
-                      "}\n"
-                      : "=f"((&activation_values[_pair * 2])[0]),
-                        "=f"((&activation_values[_pair * 2])[1])
-                      : "r"(activation_carriers[_pair]));
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (num_pairs == num_tokens * 2) {
+                    if (pair_base + 1 < num_pairs) {
+                        if (sorted_token_ids[pair_base] == (long long)token) {
+                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                                contiguous = 1;
+                            }
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
                 }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
-          *(reinterpret_cast<float*>(y_accum +
-                                     (token * output_stride + output_offset + output_col)) +
-            (0)) = total;
         }
-      } else if (output_col < 3072) {
-        float total_1 = 0.0f;
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-              long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col_1;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                route_partial_1 = _fma_2;
-              }
-            }
-            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-            total_1 = _fma_3;
-          }
-        }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total_1;
-      }
-    } else if (output_col < 3072) {
-      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-        (0)) = 0.0f;
     }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -789,112 +885,6 @@ __global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token
 
 #define BLACKWELL_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h3072_r32_t128(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // === Task calls (dependency order) ===
-  int pair = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  if (pair < num_pairs) {
-    if (output_col < 3072) {
-      long long token = sorted_token_ids[pair];
-      if (token >= 0) {
-        if (token < (long long)num_tokens) {
-          long long lora_id = lora_indices[token];
-          if (lora_id >= 0) {
-            long long expert = expert_ids[pair];
-            float partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) +
-                    0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                partial = _fma_0;
-              }
-            }
-            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
-                               (long long)output_col],
-                      partial * topk_weights[pair]);
-          }
-        }
-      }
-    }
-  }
-}
-
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef THREADS
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
 #define SMEM_SHRINK_STAGE_OFF 0
 #define SMEM_SHRINK_STAGE_STAGE_BYTES 128
 #define SMEM_SHRINK_STAGE_STRIDE 128
@@ -903,535 +893,270 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    if (output_col < 3072) {
-      long long lora_id = lora_indices[token];
-      if (lora_id >= 0) {
-        int pair_base = token * 2;
-        int contiguous = 0;
-        if (num_pairs == num_tokens * 2) {
-          if (pair_base + 1 < num_pairs) {
-            if (sorted_token_ids[pair_base] == (long long)token) {
-              if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                contiguous = 1;
-              }
-            }
-          }
-        }
-        float total = 0.0f;
-        if (contiguous != 0) {
-          if (tid < 8) {
-            int stage_route = tid / 4;
-            int stage_rank_block = tid % 4;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             shrink_stage_addr +
-                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                         "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-          }
-          asm volatile("cp.async.commit_group;");
-          asm volatile("cp.async.wait_group 0;");
-          __syncthreads();
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      "shl.b32 %0, %2, 16;\n\t"
-                      "and.b32 %1, %2, 0xffff0000;\n\t"
-                      "}\n"
-                      : "=f"((&activation_values[_pair * 2])[0]),
-                        "=f"((&activation_values[_pair * 2])[1])
-                      : "r"(activation_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 3072) {
+                valid0 = 1;
+            }
+            if (output_col1 < 3072) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
         } else {
-#pragma unroll 1
-          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-            if (sorted_token_ids[pair_1] == (long long)token) {
-              long long expert_1 = expert_ids[pair_1];
-              float route_partial_1 = 0.0f;
-#pragma unroll
-              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                int rank_col_1 = rank_block_1 * 8;
-                float _vec_load_1[8];
-                {
-                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                      (pair_1 * 32 + rank_col_1) + 0);
-                  uint4 _vld_1[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_1[_pair]));
-                    }
-                  }
-                }
-                long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
-                        32 +
-                    (long long)rank_col_1;
-                float _vec_load_2[8];
-                {
-                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                  uint4 _vld_2[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_2[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_1 = 0; element_1 < 8; element_1++) {
-                  float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                  route_partial_1 = _fma_2;
-                }
-              }
-              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-              total = _fma_3;
+            if (output_col0 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
             }
-          }
+            if (output_col1 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
         }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total;
-      } else {
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = 0.0f;
-      }
     }
-  }
 }
 
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // Kernel setup ops
-  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
-
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col0 = blockIdx.y * 256 + tid;
-  int output_col1 = output_col0 + 128;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
-            }
-          }
-        }
-      }
-      int valid0 = 0;
-      int valid1 = 0;
-      if (output_col0 < 3072) {
-        valid0 = 1;
-      }
-      if (output_col1 < 3072) {
-        valid1 = 1;
-      }
-      float total0 = 0.0f;
-      float total1 = 0.0f;
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
-#pragma unroll
-        for (int route = 0; route < 2; route++) {
-          int pair = pair_base + route;
-          long long expert = expert_ids[pair];
-          float route_partial0 = 0.0f;
-          float route_partial1 = 0.0f;
-#pragma unroll
-          for (int rank_block = 0; rank_block < 4; rank_block++) {
-            int rank_col = rank_block * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    "shl.b32 %0, %2, 16;\n\t"
-                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                    "}\n"
-                    : "=f"((&activation_values[_pair * 2])[0]),
-                      "=f"((&activation_values[_pair * 2])[1])
-                    : "r"(activation_carriers[_pair]));
-              }
-            }
-            if (valid0 != 0) {
-              long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                route_partial0 = _fma_0;
-              }
-            }
-            if (valid1 != 0) {
-              long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_1 =
-                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                route_partial1 = _fma_1;
-              }
-            }
-          }
-          if (valid0 != 0) {
-            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-            total0 = _fma_2;
-          }
-          if (valid1 != 0) {
-            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-            total1 = _fma_3;
-          }
-        }
-      } else {
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial0_1 = 0.0f;
-            float route_partial1_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        "shl.b32 %0, %2, 16;\n\t"
-                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                        "}\n"
-                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
-                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-              if (valid0 != 0) {
-                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                                             (long long)output_col0) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_3[8];
-                {
-                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
-                  uint4 _vld_3[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_3[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_2 = 0; element_2 < 8; element_2++) {
-                  float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                  route_partial0_1 = _fma_4;
-                }
-              }
-              if (valid1 != 0) {
-                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                                             (long long)output_col1) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_4[8];
-                {
-                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
-                  uint4 _vld_4[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          "shl.b32 %0, %2, 16;\n\t"
-                          "and.b32 %1, %2, 0xffff0000;\n\t"
-                          "}\n"
-                          : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]),
-                            "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
-                          : "r"(_vpairs_4[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_3 = 0; element_3 < 8; element_3++) {
-                  float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                  route_partial1_1 = _fma_5;
-                }
-              }
-            }
-            if (valid0 != 0) {
-              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-              total0 = _fma_6;
-            }
-            if (valid1 != 0) {
-              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-              total1 = _fma_7;
-            }
-          }
-        }
-      }
-      if (valid0 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = total0;
-      }
-      if (valid1 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = total1;
-      }
-    } else {
-      if (output_col0 < 3072) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = 0.0f;
-      }
-      if (output_col1 < 3072) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = 0.0f;
-      }
-    }
-  }
-}
-
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
@@ -17,26 +17,32 @@
 // Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
-template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
+template <int N> struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+               : "=r"(result)
+               : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,197 +63,245 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    3072 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           "shl.b32 %0, %2, 16;\n\t"
+                           "and.b32 %1, %2, 0xffff0000;\n\t"
+                           "}\n"
+                           : "=f"((&x_values[_pair * 2])[0]),
+                             "=f"((&x_values[_pair * 2])[1])
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
+                                rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             "shl.b32 %0, %2, 16;\n\t"
+                             "and.b32 %1, %2, 0xffff0000;\n\t"
+                             "}\n"
+                             : "=f"((&w_values[_pair * 2])[0]),
+                               "=f"((&w_values[_pair * 2])[1])
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
+                                          1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16 *>(
+              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -285,197 +339,244 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    3072 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                "shl.b32 %0, %2, 16;\n\t"
-                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                "}\n"
-                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           "shl.b32 %0, %2, 16;\n\t"
+                           "and.b32 %1, %2, 0xffff0000;\n\t"
+                           "}\n"
+                           : "=f"((&x_values[_pair * 2])[0]),
+                             "=f"((&x_values[_pair * 2])[1])
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base =
+                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             "shl.b32 %0, %2, 16;\n\t"
+                             "and.b32 %1, %2, 0xffff0000;\n\t"
+                             "}\n"
+                             : "=f"((&w_values[_pair * 2])[0]),
+                               "=f"((&w_values[_pair * 2])[1])
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__nv_bfloat16 *>(
+              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2bfloat16_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -507,177 +608,224 @@ kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(uint16_t* __restrict__ sh
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 3072) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 3072) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 3072) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+        if (output_col < 3072) {
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               "shl.b32 %0, %2, 16;\n\t"
+                               "and.b32 %1, %2, 0xffff0000;\n\t"
+                               "}\n"
+                               : "=f"((&activation_values[_pair * 2])[0]),
+                                 "=f"((&activation_values[_pair * 2])[1])
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
+                                                 output_offset + output_col)) +
+            (0)) = total;
+        }
+      } else if (output_col < 3072) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                              route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 =
+                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 3072) {
+      *(reinterpret_cast<float *>(
+            y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
 } // extern "C"
@@ -697,85 +845,104 @@ kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(float* __restrict__ y
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h3072_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h3072_r32_t128(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // === Task calls (dependency order) ===
-    int pair = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    if (pair < num_pairs) {
-        if (output_col < 3072) {
-            long long token = sorted_token_ids[pair];
-            if (token >= 0) {
-                if (token < (long long)num_tokens) {
-                    long long lora_id = lora_indices[token];
-                    if (lora_id >= 0) {
-                        long long expert = expert_ids[pair];
-                        float partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                                partial = _fma_0;
-                            }
-                        }
-                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
-                    }
+  // === Task calls (dependency order) ===
+  int pair = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  if (pair < num_pairs) {
+    if (output_col < 3072) {
+      long long token = sorted_token_ids[pair];
+      if (token >= 0) {
+        if (token < (long long)num_tokens) {
+          long long lora_id = lora_indices[token];
+          if (lora_id >= 0) {
+            long long expert = expert_ids[pair];
+            float partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    (pair * 32 + rank_col) + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
                 }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(_vec_load_0[element],
+                                         _vec_load_1[element], partial);
+                partial = _fma_0;
+              }
             }
+            atomicAdd(
+                &y_accum[token * (long long)output_stride +
+                         (long long)output_offset + (long long)output_col],
+                partial * topk_weights[pair]);
+          }
         }
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -794,173 +961,218 @@ kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h3072_r32_t128(float* __restri
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        if (output_col < 3072) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        "shl.b32 %0, %2, 16;\n\t"
-                                        "and.b32 %1, %2, 0xffff0000;\n\t"
-                                        "}\n"
-                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 3072) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
+          }
         }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    shrink_stage_addr +
+                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               "shl.b32 %0, %2, 16;\n\t"
+                               "and.b32 %1, %2, 0xffff0000;\n\t"
+                               "}\n"
+                               : "=f"((&activation_values[_pair * 2])[0]),
+                                 "=f"((&activation_values[_pair * 2])[1])
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                      (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t *_vpairs_1 =
+                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                     (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                      weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t *_vpairs_2 =
+                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                                route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 =
+                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
+            }
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -984,267 +1196,339 @@ kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(float* __restrict__ y_acc
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 3072) {
-                valid0 = 1;
-            }
-            if (output_col1 < 3072) {
-                valid1 = 1;
-            }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    "shl.b32 %0, %2, 16;\n\t"
-                                    "and.b32 %1, %2, 0xffff0000;\n\t"
-                                    "}\n"
-                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            "shl.b32 %0, %2, 16;\n\t"
-                                            "and.b32 %1, %2, 0xffff0000;\n\t"
-                                            "}\n"
-                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                "shl.b32 %0, %2, 16;\n\t"
-                                                "and.b32 %1, %2, 0xffff0000;\n\t"
-                                                "}\n"
-                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 3072) {
+        valid0 = 1;
+      }
+      if (output_col1 < 3072) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 3]))
+                : "r"(shrink_stage_addr +
+                      (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             "shl.b32 %0, %2, 16;\n\t"
+                             "and.b32 %1, %2, 0xffff0000;\n\t"
+                             "}\n"
+                             : "=f"((&activation_values[_pair * 2])[0]),
+                               "=f"((&activation_values[_pair * 2])[1])
+                             : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                    weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1],
+                              _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 =
+                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 =
+                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        "shl.b32 %0, %2, 16;\n\t"
+                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                        "}\n"
+                        : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]),
+                          "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                     (long long)output_col0) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                      weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t *_vpairs_3 =
+                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
+                                route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                     (long long)output_col1) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
+                      weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t *_vpairs_4 =
+                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          "shl.b32 %0, %2, 16;\n\t"
+                          "and.b32 %1, %2, 0xffff0000;\n\t"
+                          "}\n"
+                          : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]),
+                            "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
+                                route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 =
+                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 =
+                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 3072) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 3072) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
@@ -27,7 +27,8 @@ typedef short int int16_t;
 struct __align__(128) BlackwellTensorMap {
   uint64_t opaque[16];
 };
-template <int N> struct __align__(128) BlackwellTensorMapPack {
+template <int N>
+struct __align__(128) BlackwellTensorMapPack {
   BlackwellTensorMap maps[N];
 };
 
@@ -39,9 +40,7 @@ typedef struct __align__(64) {
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
   int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-               : "=r"(result)
-               : "r"(x));
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
   return result;
 }
 
@@ -63,12 +62,11 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -81,11 +79,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 24576);
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
   const int w_smem_addr = smem + 24576;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
   const int warp_partials_addr = smem + 221184;
 
   // === Task calls (dependency order) ===
@@ -125,27 +123,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
         if (k_base < 3072) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
                   (tokens[pp_1] * 3072 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    3072 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -173,23 +165,22 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
       int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 3072) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           "shl.b32 %0, %2, 16;\n\t"
-                           "and.b32 %1, %2, 0xffff0000;\n\t"
-                           "}\n"
-                           : "=f"((&x_values[_pair * 2])[0]),
-                             "=f"((&x_values[_pair * 2])[1])
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -199,31 +190,28 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 3072) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
-                                rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             "shl.b32 %0, %2, 16;\n\t"
-                             "and.b32 %1, %2, 0xffff0000;\n\t"
-                             "}\n"
-                             : "=f"((&w_values[_pair * 2])[0]),
-                               "=f"((&w_values[_pair * 2])[1])
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -257,14 +245,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
       for (int pp_3 = 0; pp_3 < 4; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 3072) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
-                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -275,13 +261,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
-                                          1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -295,16 +278,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
       int owner_rr = lane % 8;
       int pair_1 = pair_block * 4 + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16 *>(
-              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2bfloat16_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -339,12 +321,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -357,11 +338,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *x_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __nv_bfloat16 *w_smem = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 4096);
+  __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
   const int w_smem_addr = smem + 4096;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
   const int warp_partials_addr = smem + 36864;
 
   // === Task calls (dependency order) ===
@@ -401,27 +382,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
         if (k_base < 3072) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
                   (tokens[pp_1] * 3072 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    3072 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -449,23 +424,22 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
       int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 3072) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           "shl.b32 %0, %2, 16;\n\t"
-                           "and.b32 %1, %2, 0xffff0000;\n\t"
-                           "}\n"
-                           : "=f"((&x_values[_pair * 2])[0]),
-                             "=f"((&x_values[_pair * 2])[1])
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  "shl.b32 %0, %2, 16;\n\t"
+                  "and.b32 %1, %2, 0xffff0000;\n\t"
+                  "}\n"
+                  : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -475,31 +449,28 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 3072) {
-            int w_thread_base =
-                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             "shl.b32 %0, %2, 16;\n\t"
-                             "and.b32 %1, %2, 0xffff0000;\n\t"
-                             "}\n"
-                             : "=f"((&w_values[_pair * 2])[0]),
-                               "=f"((&w_values[_pair * 2])[1])
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -533,14 +504,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
       for (int pp_3 = 0; pp_3 < 1; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 3072) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(x_raw) +
-                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -551,12 +520,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __nv_bfloat16 *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -570,16 +537,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
       int owner_rr = lane % 8;
       int pair_1 = pair_block + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__nv_bfloat16 *>(
-              reinterpret_cast<__nv_bfloat16 *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) +
+                                           (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2bfloat16_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -608,13 +574,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_
 
 extern "C" {
 
-__global__
-__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -627,7 +592,7 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -653,13 +618,11 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -675,44 +638,37 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               "shl.b32 %0, %2, 16;\n\t"
-                               "and.b32 %1, %2, 0xffff0000;\n\t"
-                               "}\n"
-                               : "=f"((&activation_values[_pair * 2])[0]),
-                                 "=f"((&activation_values[_pair * 2])[1])
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -728,16 +684,16 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
             float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
             total = _fma_1;
           }
-          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
-                                                 output_offset + output_col)) +
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
             (0)) = total;
         }
       } else if (output_col < 3072) {
@@ -752,15 +708,14 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
                     (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -775,21 +730,18 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
                 }
               }
               long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col_1;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index_1 + 0);
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -806,29 +758,25 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                              route_partial_1);
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                 route_partial_1 = _fma_2;
               }
             }
-            float _fma_3 =
-                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
             total_1 = _fma_3;
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total_1;
       }
     } else if (output_col < 3072) {
-      *(reinterpret_cast<float *>(
-            y_accum + (token * output_stride + output_offset + output_col)) +
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
         (0)) = 0.0f;
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -847,11 +795,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h3072_r32_t128(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -876,15 +824,14 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
               int rank_col = rank_block * 8;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                    (pair * 32 + rank_col) + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) +
+                    0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -899,21 +846,18 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -929,15 +873,13 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element],
-                                         _vec_load_1[element], partial);
+                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
                 partial = _fma_0;
               }
             }
-            atomicAdd(
-                &y_accum[token * (long long)output_stride +
-                         (long long)output_offset + (long long)output_col],
-                partial * topk_weights[pair]);
+            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
+                               (long long)output_col],
+                      partial * topk_weights[pair]);
           }
         }
       }
@@ -945,7 +887,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -961,13 +903,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -980,7 +921,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1006,13 +947,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
           if (tid < 8) {
             int stage_route = tid / 4;
             int stage_rank_block = tid % 4;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    shrink_stage_addr +
-                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
           }
           asm volatile("cp.async.commit_group;");
           asm volatile("cp.async.wait_group 0;");
@@ -1026,44 +965,37 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               "shl.b32 %0, %2, 16;\n\t"
-                               "and.b32 %1, %2, 0xffff0000;\n\t"
-                               "}\n"
-                               : "=f"((&activation_values[_pair * 2])[0]),
-                                 "=f"((&activation_values[_pair * 2])[1])
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      "shl.b32 %0, %2, 16;\n\t"
+                      "and.b32 %1, %2, 0xffff0000;\n\t"
+                      "}\n"
+                      : "=f"((&activation_values[_pair * 2])[0]),
+                        "=f"((&activation_values[_pair * 2])[1])
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1079,8 +1011,8 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
@@ -1098,15 +1030,14 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
                 int rank_col_1 = rank_block_1 * 8;
                 float _vec_load_1[8];
                 {
-                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
                       (pair_1 * 32 + rank_col_1) + 0);
                   uint4 _vld_1[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t *_vpairs_1 =
-                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1121,21 +1052,18 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
                   }
                 }
                 long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                     (long long)output_col) *
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
                         32 +
                     (long long)rank_col_1;
                 float _vec_load_2[8];
                 {
-                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                      weight_index_1 + 0);
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
                   uint4 _vld_2[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t *_vpairs_2 =
-                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1152,30 +1080,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_bf16_h307
 #pragma unroll
                 for (int element_1 = 0; element_1 < 8; element_1++) {
                   float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                                route_partial_1);
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                   route_partial_1 = _fma_2;
                 }
               }
-              float _fma_3 =
-                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
               total = _fma_3;
             }
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total;
       } else {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -1198,11 +1122,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -1215,7 +1139,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __nv_bfloat16 *shrink_stage = reinterpret_cast<__nv_bfloat16 *>(smem_raw + 0);
+  __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1252,13 +1176,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -1272,46 +1194,39 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
           for (int rank_block = 0; rank_block < 4; rank_block++) {
             int rank_col = rank_block * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 3]))
-                : "r"(shrink_stage_addr +
-                      (unsigned int)((route * 32 + rank_col) * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             "shl.b32 %0, %2, 16;\n\t"
-                             "and.b32 %1, %2, 0xffff0000;\n\t"
-                             "}\n"
-                             : "=f"((&activation_values[_pair * 2])[0]),
-                               "=f"((&activation_values[_pair * 2])[1])
-                             : "r"(activation_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    "shl.b32 %0, %2, 16;\n\t"
+                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                    "}\n"
+                    : "=f"((&activation_values[_pair * 2])[0]),
+                      "=f"((&activation_values[_pair * 2])[1])
+                    : "r"(activation_carriers[_pair]));
               }
             }
             if (valid0 != 0) {
               long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col0) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index0 + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1327,28 +1242,25 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial0);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
                 route_partial0 = _fma_0;
               }
             }
             if (valid1 != 0) {
               long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col1) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                    weight_index1 + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1365,20 +1277,17 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_1 =
-                    __fmaf_rn(activation_values[element_1],
-                              _vec_load_1[element_1], route_partial1);
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
                 route_partial1 = _fma_1;
               }
             }
           }
           if (valid0 != 0) {
-            float _fma_2 =
-                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
             total0 = _fma_2;
           }
           if (valid1 != 0) {
-            float _fma_3 =
-                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
             total1 = _fma_3;
           }
         }
@@ -1394,15 +1303,14 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __nv_bfloat16 *>(shrink_raw) +
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __nv_bfloat16*>(shrink_raw) +
                     (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
                     asm volatile(
@@ -1417,22 +1325,19 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
                 }
               }
               if (valid0 != 0) {
-                long long weight_index0_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                     (long long)output_col0) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_3[8];
                 {
-                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                      weight_index0_1 + 0);
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
                   uint4 _vld_3[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t *_vpairs_3 =
-                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1449,28 +1354,24 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_2 = 0; element_2 < 8; element_2++) {
                   float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
-                                route_partial0_1);
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
                   route_partial0_1 = _fma_4;
                 }
               }
               if (valid1 != 0) {
-                long long weight_index1_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                     (long long)output_col1) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_4[8];
                 {
-                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __nv_bfloat16 *>(lora_b_raw) +
-                      weight_index1_1 + 0);
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
                   uint4 _vld_4[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t *_vpairs_4 =
-                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1487,51 +1388,48 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_3 = 0; element_3 < 8; element_3++) {
                   float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
-                                route_partial1_1);
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
                   route_partial1_1 = _fma_5;
                 }
               }
             }
             if (valid0 != 0) {
-              float _fma_6 =
-                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
               total0 = _fma_6;
             }
             if (valid1 != 0) {
-              float _fma_7 =
-                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
               total1 = _fma_7;
             }
           }
         }
       }
       if (valid0 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = total0;
       }
       if (valid1 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = total1;
       }
     } else {
       if (output_col0 < 3072) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = 0.0f;
       }
       if (output_col1 < 3072) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
@@ -935,10 +935,12 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_toke
       if (lora_id >= 0) {
         int pair_base = token * 2;
         int contiguous = 0;
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
           }
         }

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_bf16_h3072_sm100a.cu
@@ -1,0 +1,1259 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Generated source for FlashInfer.
+// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Target: sm_100a; compile flags: none.
+// Generated file; do not edit manually.
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#include <math_constants.h>
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 24576
+#define SMEM_X_SMEM_STRIDE 24576
+#define SMEM_W_SMEM_OFF 24576
+#define SMEM_W_SMEM_STAGE_BYTES 196608
+#define SMEM_W_SMEM_STRIDE 196608
+#define SMEM_WARP_PARTIALS_OFF 221184
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 512
+#define SMEM_WARP_PARTIALS_STRIDE 512
+#define SMEM_TOTAL 221696
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 4096
+#define SMEM_X_SMEM_STRIDE 4096
+#define SMEM_W_SMEM_OFF 4096
+#define SMEM_W_SMEM_STAGE_BYTES 32768
+#define SMEM_W_SMEM_STRIDE 32768
+#define SMEM_WARP_PARTIALS_OFF 36864
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 128
+#define SMEM_WARP_PARTIALS_STRIDE 128
+#define SMEM_TOTAL 36992
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_bf16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* x_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __nv_bfloat16* w_smem = reinterpret_cast<__nv_bfloat16*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                "shl.b32 %0, %2, 16;\n\t"
+                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                "}\n"
+                                : "=f"((&x_values[_pair * 2])[0]), "=f"((&x_values[_pair * 2])[1])
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&w_values[_pair * 2])[0]), "=f"((&w_values[_pair * 2])[1])
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__nv_bfloat16*>(reinterpret_cast<__nv_bfloat16*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2bfloat16_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 64
+
+extern "C" {
+
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 3072) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 3072) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 3072) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_pair_owned_bf16_h3072_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int pair = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    if (pair < num_pairs) {
+        if (output_col < 3072) {
+            long long token = sorted_token_ids[pair];
+            if (token >= 0) {
+                if (token < (long long)num_tokens) {
+                    long long lora_id = lora_indices[token];
+                    if (lora_id >= 0) {
+                        long long expert = expert_ids[pair];
+                        float partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair * 32 + rank_col) + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
+                                partial = _fma_0;
+                            }
+                        }
+                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        if (output_col < 3072) {
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        "shl.b32 %0, %2, 16;\n\t"
+                                        "and.b32 %1, %2, 0xffff0000;\n\t"
+                                        "}\n"
+                                        : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_bf16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __nv_bfloat16* shrink_stage = reinterpret_cast<__nv_bfloat16*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 3072) {
+                valid0 = 1;
+            }
+            if (output_col1 < 3072) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    "shl.b32 %0, %2, 16;\n\t"
+                                    "and.b32 %1, %2, 0xffff0000;\n\t"
+                                    "}\n"
+                                    : "=f"((&activation_values[_pair * 2])[0]), "=f"((&activation_values[_pair * 2])[1])
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_0[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_1[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            "shl.b32 %0, %2, 16;\n\t"
+                                            "and.b32 %1, %2, 0xffff0000;\n\t"
+                                            "}\n"
+                                            : "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_2[0 + _blk * 8 + _pair * 2])[1])
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_3[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __nv_bfloat16*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                "shl.b32 %0, %2, 16;\n\t"
+                                                "and.b32 %1, %2, 0xffff0000;\n\t"
+                                                "}\n"
+                                                : "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[0]), "=f"((&_vec_load_4[0 + _blk * 8 + _pair * 2])[1])
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
+        } else {
+            if (output_col0 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
+            }
+            if (output_col1 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
@@ -198,9 +198,9 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
   auto* x_ptr = static_cast<unsigned short*>(x.data_ptr());
   auto* a_ptr = static_cast<unsigned short*>(lora_a.data_ptr());
   auto* b_ptr = static_cast<unsigned short*>(lora_b.data_ptr());
-  auto* token_ptr = static_cast<int64_t*>(sorted_token_ids.data_ptr());
-  auto* expert_ptr = static_cast<int64_t*>(expert_ids.data_ptr());
-  auto* lora_ptr = static_cast<int64_t*>(lora_indices.data_ptr());
+  auto* token_ptr = static_cast<long long*>(sorted_token_ids.data_ptr());
+  auto* expert_ptr = static_cast<long long*>(expert_ids.data_ptr());
+  auto* lora_ptr = static_cast<long long*>(lora_indices.data_ptr());
   auto* weight_ptr = static_cast<float*>(topk_weights.data_ptr());
 
   if (schedule == Schedule::kPairOwnedT128) {

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
@@ -81,8 +81,8 @@ constexpr int32_t kHidden = BLACKWELL_BGMV_MOE_HIDDEN;
 constexpr int32_t kRank = 32;
 constexpr int32_t kShrinkThreads = 128;
 constexpr int32_t kShrinkDecodePairsPerBlock = 4;
-constexpr int32_t kShrinkDecodeSmemBytes = 28160;
-constexpr int32_t kShrinkPrefillSmemBytes = 4736;
+constexpr int32_t kShrinkDecodeSmemBytes = 221696;
+constexpr int32_t kShrinkPrefillSmemBytes = 36992;
 constexpr int32_t kExpandSmemBytes = 128;
 
 enum class Schedule : int32_t {
@@ -105,6 +105,25 @@ inline void CheckExactSM100(int32_t device_id) {
             "cudaDeviceGetAttribute(minor)");
   TVM_FFI_ICHECK(major == 10 && minor == 0)
       << "Blackwell BGMV MoE requires exact compute capability 10.0, got " << major << "." << minor;
+}
+
+void Configure() {
+  int32_t device_id = 0;
+  CheckCuda(cudaGetDevice(&device_id), "cudaGetDevice");
+  CheckExactSM100(device_id);
+
+  int32_t max_dynamic_smem = 0;
+  CheckCuda(
+      cudaDeviceGetAttribute(&max_dynamic_smem, cudaDevAttrMaxSharedMemoryPerBlockOptin, device_id),
+      "cudaDeviceGetAttribute(max opt-in shared memory)");
+  TVM_FFI_ICHECK(max_dynamic_smem >= kShrinkDecodeSmemBytes)
+      << "Blackwell BGMV MoE decode shrink requires " << kShrinkDecodeSmemBytes
+      << " bytes of dynamic shared memory, but device " << device_id << " supports "
+      << max_dynamic_smem;
+  CheckCuda(
+      cudaFuncSetAttribute(BLACKWELL_BGMV_MOE_SHRINK_DECODE,
+                           cudaFuncAttributeMaxDynamicSharedMemorySize, kShrinkDecodeSmemBytes),
+      "cudaFuncSetAttribute(Blackwell BGMV MoE decode shrink)");
 }
 
 inline void CheckCompact(const TensorView& tensor, const char* name) {
@@ -250,4 +269,5 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
 }  // namespace blackwell_bgmv_moe
 }  // namespace flashinfer
 
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(configure, flashinfer::blackwell_bgmv_moe::Configure);
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::blackwell_bgmv_moe::Run);

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
@@ -35,15 +35,13 @@
 #error "BLACKWELL_BGMV_MOE_EXPAND_PAIR must name the generated kernel symbol"
 #endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64
-#error                                                                         \
-    "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 must name the generated kernel symbol"
+#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 must name the generated kernel symbol"
 #endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN
 #error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN must name the generated kernel symbol"
 #endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL
-#error                                                                         \
-    "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL must name the generated kernel symbol"
+#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL must name the generated kernel symbol"
 #endif
 
 #include <cuda.h>
@@ -94,37 +92,32 @@ enum class Schedule : int32_t {
   kTokenOwnedDualCol = 3,
 };
 
-inline void CheckCuda(cudaError_t status, const char *operation) {
-  TVM_FFI_ICHECK(status == cudaSuccess)
-      << operation << " failed: " << cudaGetErrorString(status);
+inline void CheckCuda(cudaError_t status, const char* operation) {
+  TVM_FFI_ICHECK(status == cudaSuccess) << operation << " failed: " << cudaGetErrorString(status);
 }
 
 inline void CheckExactSM100(int32_t device_id) {
   int major = 0;
   int minor = 0;
-  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor,
-                                   device_id),
+  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
             "cudaDeviceGetAttribute(major)");
-  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor,
-                                   device_id),
+  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
             "cudaDeviceGetAttribute(minor)");
   TVM_FFI_ICHECK(major == 10 && minor == 0)
-      << "Blackwell BGMV MoE requires exact compute capability 10.0, got "
-      << major << "." << minor;
+      << "Blackwell BGMV MoE requires exact compute capability 10.0, got " << major << "." << minor;
 }
 
-inline void CheckCompact(const TensorView &tensor, const char *name) {
+inline void CheckCompact(const TensorView& tensor, const char* name) {
   CHECK_CONTIGUOUS(tensor);
   TVM_FFI_ICHECK(tensor.numel() <= std::numeric_limits<int32_t>::max())
       << name << " exceeds the generated kernel's int32 index range";
 }
 
-void Run(TensorView y_accum, TensorView shrink_out, TensorView x,
-         TensorView lora_a, TensorView lora_b, TensorView sorted_token_ids,
-         TensorView expert_ids, TensorView lora_indices,
-         TensorView topk_weights, int64_t schedule_value, int64_t cuda_stream) {
-  TVM_FFI_ICHECK(cuda_stream >= 0)
-      << "cuda_stream must be a non-negative stream handle";
+void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lora_a,
+         TensorView lora_b, TensorView sorted_token_ids, TensorView expert_ids,
+         TensorView lora_indices, TensorView topk_weights, int64_t schedule_value,
+         int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
   CHECK_CUDA(x);
   const int32_t device_id = x.device().device_id;
   ffi::CUDADeviceGuard device_guard(device_id);
@@ -172,20 +165,16 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x,
   TVM_FFI_ICHECK(shrink_out.ndim() == 3 && shrink_out.size(0) == 1 &&
                  shrink_out.size(1) == num_pairs && shrink_out.size(2) == kRank)
       << "shrink_out must have shape [1, num_pairs, 32]";
-  TVM_FFI_ICHECK(y_accum.ndim() == 2 && y_accum.size(0) == num_tokens &&
-                 y_accum.size(1) == kHidden)
+  TVM_FFI_ICHECK(y_accum.ndim() == 2 && y_accum.size(0) == num_tokens && y_accum.size(1) == kHidden)
       << "y_accum must have shape [num_tokens, " << kHidden << "]";
-  TVM_FFI_ICHECK(lora_a.ndim() == 4 && lora_a.size(0) > 0 &&
-                 lora_a.size(1) > 0 && lora_a.size(2) == kRank &&
-                 lora_a.size(3) == kHidden)
-      << "lora_a must have shape [num_loras, num_experts, 32, " << kHidden
-      << "]";
+  TVM_FFI_ICHECK(lora_a.ndim() == 4 && lora_a.size(0) > 0 && lora_a.size(1) > 0 &&
+                 lora_a.size(2) == kRank && lora_a.size(3) == kHidden)
+      << "lora_a must have shape [num_loras, num_experts, 32, " << kHidden << "]";
   const int32_t num_experts = static_cast<int32_t>(lora_a.size(1));
   TVM_FFI_ICHECK(lora_b.ndim() == 4 && lora_b.size(0) == lora_a.size(0) &&
                  lora_b.size(1) == num_experts && lora_b.size(2) == kHidden &&
                  lora_b.size(3) == kRank)
-      << "lora_b must have shape [num_loras, num_experts, " << kHidden
-      << ", 32]";
+      << "lora_b must have shape [num_loras, num_experts, " << kHidden << ", 32]";
 
   CheckCompact(x, "x");
   CheckCompact(y_accum, "y_accum");
@@ -197,43 +186,38 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x,
   CheckCompact(lora_indices, "lora_indices");
   CheckCompact(topk_weights, "topk_weights");
 
-  TVM_FFI_ICHECK(
-      schedule_value >= static_cast<int64_t>(Schedule::kPairOwnedT128) &&
-      schedule_value <= static_cast<int64_t>(Schedule::kTokenOwnedDualCol))
+  TVM_FFI_ICHECK(schedule_value >= static_cast<int64_t>(Schedule::kPairOwnedT128) &&
+                 schedule_value <= static_cast<int64_t>(Schedule::kTokenOwnedDualCol))
       << "invalid Blackwell BGMV MoE schedule id: " << schedule_value;
   const auto schedule = static_cast<Schedule>(schedule_value);
   const auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
-  auto *y_ptr = static_cast<float *>(y_accum.data_ptr());
-  auto *shrink_ptr = static_cast<unsigned short *>(shrink_out.data_ptr());
-  auto *x_ptr = static_cast<unsigned short *>(x.data_ptr());
-  auto *a_ptr = static_cast<unsigned short *>(lora_a.data_ptr());
-  auto *b_ptr = static_cast<unsigned short *>(lora_b.data_ptr());
-  auto *token_ptr = static_cast<long long *>(sorted_token_ids.data_ptr());
-  auto *expert_ptr = static_cast<long long *>(expert_ids.data_ptr());
-  auto *lora_ptr = static_cast<long long *>(lora_indices.data_ptr());
-  auto *weight_ptr = static_cast<float *>(topk_weights.data_ptr());
+  auto* y_ptr = static_cast<float*>(y_accum.data_ptr());
+  auto* shrink_ptr = static_cast<unsigned short*>(shrink_out.data_ptr());
+  auto* x_ptr = static_cast<unsigned short*>(x.data_ptr());
+  auto* a_ptr = static_cast<unsigned short*>(lora_a.data_ptr());
+  auto* b_ptr = static_cast<unsigned short*>(lora_b.data_ptr());
+  auto* token_ptr = static_cast<long long*>(sorted_token_ids.data_ptr());
+  auto* expert_ptr = static_cast<long long*>(expert_ids.data_ptr());
+  auto* lora_ptr = static_cast<long long*>(lora_indices.data_ptr());
+  auto* weight_ptr = static_cast<float*>(topk_weights.data_ptr());
 
   if (schedule == Schedule::kPairOwnedT128) {
-    CheckCuda(
-        cudaMemsetAsync(y_ptr, 0, y_accum.numel() * sizeof(float), stream),
-        "Blackwell BGMV MoE output initialization");
+    CheckCuda(cudaMemsetAsync(y_ptr, 0, y_accum.numel() * sizeof(float), stream),
+              "Blackwell BGMV MoE output initialization");
   }
 
   const dim3 shrink_block(kShrinkThreads, 1, 1);
   if (num_pairs <= 32) {
-    const dim3 shrink_grid((num_pairs + kShrinkDecodePairsPerBlock - 1) /
-                               kShrinkDecodePairsPerBlock,
-                           kRank / 8, 1);
-    BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<shrink_grid, shrink_block,
-                                       kShrinkDecodeSmemBytes, stream>>>(
-        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs,
-        num_experts, num_tokens);
+    const dim3 shrink_grid(
+        (num_pairs + kShrinkDecodePairsPerBlock - 1) / kShrinkDecodePairsPerBlock, kRank / 8, 1);
+    BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<shrink_grid, shrink_block, kShrinkDecodeSmemBytes, stream>>>(
+        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs, num_experts,
+        num_tokens);
   } else {
     const dim3 shrink_grid(num_pairs, kRank / 8, 1);
-    BLACKWELL_BGMV_MOE_SHRINK_PREFILL<<<shrink_grid, shrink_block,
-                                        kShrinkPrefillSmemBytes, stream>>>(
-        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs,
-        num_experts, num_tokens);
+    BLACKWELL_BGMV_MOE_SHRINK_PREFILL<<<shrink_grid, shrink_block, kShrinkPrefillSmemBytes,
+                                        stream>>>(shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr,
+                                                  lora_ptr, num_pairs, num_experts, num_tokens);
   }
   CheckCuda(cudaGetLastError(), "Blackwell BGMV MoE shrink launch");
 
@@ -242,29 +226,28 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x,
   if (schedule == Schedule::kPairOwnedT128) {
     const dim3 grid(num_pairs, (kHidden + 127) / 128, 1);
     BLACKWELL_BGMV_MOE_EXPAND_PAIR<<<grid, 128, 0, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
-        num_pairs, num_experts, num_tokens, output_stride, output_offset);
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
   } else if (schedule == Schedule::kTokenOwnedT64) {
     const dim3 grid(num_tokens, (kHidden + 63) / 64, 1);
     BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64<<<grid, 64, kExpandSmemBytes, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
-        num_pairs, num_experts, num_tokens, output_stride, output_offset);
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
   } else if (schedule == Schedule::kTokenOwned) {
     const dim3 grid(num_tokens, (kHidden + 127) / 128, 1);
     BLACKWELL_BGMV_MOE_EXPAND_TOKEN<<<grid, 128, kExpandSmemBytes, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
-        num_pairs, num_experts, num_tokens, output_stride, output_offset);
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
   } else {
     const dim3 grid(num_tokens, (kHidden + 255) / 256, 1);
-    BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<grid, 128, kExpandSmemBytes,
-                                           stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
-        num_pairs, num_experts, num_tokens, output_stride, output_offset);
+    BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<grid, 128, kExpandSmemBytes, stream>>>(
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
   }
   CheckCuda(cudaGetLastError(), "Blackwell BGMV MoE expand launch");
 }
 
-} // namespace blackwell_bgmv_moe
-} // namespace flashinfer
+}  // namespace blackwell_bgmv_moe
+}  // namespace flashinfer
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::blackwell_bgmv_moe::Run);

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
@@ -35,13 +35,15 @@
 #error "BLACKWELL_BGMV_MOE_EXPAND_PAIR must name the generated kernel symbol"
 #endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64
-#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 must name the generated kernel symbol"
+#error                                                                         \
+    "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 must name the generated kernel symbol"
 #endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN
 #error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN must name the generated kernel symbol"
 #endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL
-#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL must name the generated kernel symbol"
+#error                                                                         \
+    "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL must name the generated kernel symbol"
 #endif
 
 #include <cuda.h>
@@ -92,7 +94,7 @@ enum class Schedule : int32_t {
   kTokenOwnedDualCol = 3,
 };
 
-inline void CheckCuda(cudaError_t status, const char* operation) {
+inline void CheckCuda(cudaError_t status, const char *operation) {
   TVM_FFI_ICHECK(status == cudaSuccess)
       << operation << " failed: " << cudaGetErrorString(status);
 }
@@ -100,25 +102,29 @@ inline void CheckCuda(cudaError_t status, const char* operation) {
 inline void CheckExactSM100(int32_t device_id) {
   int major = 0;
   int minor = 0;
-  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
+  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor,
+                                   device_id),
             "cudaDeviceGetAttribute(major)");
-  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
+  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor,
+                                   device_id),
             "cudaDeviceGetAttribute(minor)");
   TVM_FFI_ICHECK(major == 10 && minor == 0)
-      << "Blackwell BGMV MoE requires exact compute capability 10.0, got " << major << "." << minor;
+      << "Blackwell BGMV MoE requires exact compute capability 10.0, got "
+      << major << "." << minor;
 }
 
-inline void CheckCompact(const TensorView& tensor, const char* name) {
+inline void CheckCompact(const TensorView &tensor, const char *name) {
   CHECK_CONTIGUOUS(tensor);
   TVM_FFI_ICHECK(tensor.numel() <= std::numeric_limits<int32_t>::max())
       << name << " exceeds the generated kernel's int32 index range";
 }
 
-void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lora_a,
-         TensorView lora_b, TensorView sorted_token_ids, TensorView expert_ids,
-         TensorView lora_indices, TensorView topk_weights, int64_t schedule_value,
-         int64_t cuda_stream) {
-  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+void Run(TensorView y_accum, TensorView shrink_out, TensorView x,
+         TensorView lora_a, TensorView lora_b, TensorView sorted_token_ids,
+         TensorView expert_ids, TensorView lora_indices,
+         TensorView topk_weights, int64_t schedule_value, int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0)
+      << "cuda_stream must be a non-negative stream handle";
   CHECK_CUDA(x);
   const int32_t device_id = x.device().device_id;
   ffi::CUDADeviceGuard device_guard(device_id);
@@ -169,14 +175,17 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
   TVM_FFI_ICHECK(y_accum.ndim() == 2 && y_accum.size(0) == num_tokens &&
                  y_accum.size(1) == kHidden)
       << "y_accum must have shape [num_tokens, " << kHidden << "]";
-  TVM_FFI_ICHECK(lora_a.ndim() == 4 && lora_a.size(0) > 0 && lora_a.size(1) > 0 &&
-                 lora_a.size(2) == kRank && lora_a.size(3) == kHidden)
-      << "lora_a must have shape [num_loras, num_experts, 32, " << kHidden << "]";
+  TVM_FFI_ICHECK(lora_a.ndim() == 4 && lora_a.size(0) > 0 &&
+                 lora_a.size(1) > 0 && lora_a.size(2) == kRank &&
+                 lora_a.size(3) == kHidden)
+      << "lora_a must have shape [num_loras, num_experts, 32, " << kHidden
+      << "]";
   const int32_t num_experts = static_cast<int32_t>(lora_a.size(1));
   TVM_FFI_ICHECK(lora_b.ndim() == 4 && lora_b.size(0) == lora_a.size(0) &&
                  lora_b.size(1) == num_experts && lora_b.size(2) == kHidden &&
                  lora_b.size(3) == kRank)
-      << "lora_b must have shape [num_loras, num_experts, " << kHidden << ", 32]";
+      << "lora_b must have shape [num_loras, num_experts, " << kHidden
+      << ", 32]";
 
   CheckCompact(x, "x");
   CheckCompact(y_accum, "y_accum");
@@ -188,24 +197,26 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
   CheckCompact(lora_indices, "lora_indices");
   CheckCompact(topk_weights, "topk_weights");
 
-  TVM_FFI_ICHECK(schedule_value >= static_cast<int64_t>(Schedule::kPairOwnedT128) &&
-                 schedule_value <= static_cast<int64_t>(Schedule::kTokenOwnedDualCol))
+  TVM_FFI_ICHECK(
+      schedule_value >= static_cast<int64_t>(Schedule::kPairOwnedT128) &&
+      schedule_value <= static_cast<int64_t>(Schedule::kTokenOwnedDualCol))
       << "invalid Blackwell BGMV MoE schedule id: " << schedule_value;
   const auto schedule = static_cast<Schedule>(schedule_value);
   const auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
-  auto* y_ptr = static_cast<float*>(y_accum.data_ptr());
-  auto* shrink_ptr = static_cast<unsigned short*>(shrink_out.data_ptr());
-  auto* x_ptr = static_cast<unsigned short*>(x.data_ptr());
-  auto* a_ptr = static_cast<unsigned short*>(lora_a.data_ptr());
-  auto* b_ptr = static_cast<unsigned short*>(lora_b.data_ptr());
-  auto* token_ptr = static_cast<long long*>(sorted_token_ids.data_ptr());
-  auto* expert_ptr = static_cast<long long*>(expert_ids.data_ptr());
-  auto* lora_ptr = static_cast<long long*>(lora_indices.data_ptr());
-  auto* weight_ptr = static_cast<float*>(topk_weights.data_ptr());
+  auto *y_ptr = static_cast<float *>(y_accum.data_ptr());
+  auto *shrink_ptr = static_cast<unsigned short *>(shrink_out.data_ptr());
+  auto *x_ptr = static_cast<unsigned short *>(x.data_ptr());
+  auto *a_ptr = static_cast<unsigned short *>(lora_a.data_ptr());
+  auto *b_ptr = static_cast<unsigned short *>(lora_b.data_ptr());
+  auto *token_ptr = static_cast<long long *>(sorted_token_ids.data_ptr());
+  auto *expert_ptr = static_cast<long long *>(expert_ids.data_ptr());
+  auto *lora_ptr = static_cast<long long *>(lora_indices.data_ptr());
+  auto *weight_ptr = static_cast<float *>(topk_weights.data_ptr());
 
   if (schedule == Schedule::kPairOwnedT128) {
-    CheckCuda(cudaMemsetAsync(y_ptr, 0, y_accum.numel() * sizeof(float), stream),
-              "Blackwell BGMV MoE output initialization");
+    CheckCuda(
+        cudaMemsetAsync(y_ptr, 0, y_accum.numel() * sizeof(float), stream),
+        "Blackwell BGMV MoE output initialization");
   }
 
   const dim3 shrink_block(kShrinkThreads, 1, 1);
@@ -213,14 +224,16 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
     const dim3 shrink_grid((num_pairs + kShrinkDecodePairsPerBlock - 1) /
                                kShrinkDecodePairsPerBlock,
                            kRank / 8, 1);
-    BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<shrink_grid, shrink_block, kShrinkDecodeSmemBytes, stream>>>(
-        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs, num_experts,
-        num_tokens);
+    BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<shrink_grid, shrink_block,
+                                       kShrinkDecodeSmemBytes, stream>>>(
+        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs,
+        num_experts, num_tokens);
   } else {
     const dim3 shrink_grid(num_pairs, kRank / 8, 1);
-    BLACKWELL_BGMV_MOE_SHRINK_PREFILL<<<shrink_grid, shrink_block, kShrinkPrefillSmemBytes, stream>>>(
-        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs, num_experts,
-        num_tokens);
+    BLACKWELL_BGMV_MOE_SHRINK_PREFILL<<<shrink_grid, shrink_block,
+                                        kShrinkPrefillSmemBytes, stream>>>(
+        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs,
+        num_experts, num_tokens);
   }
   CheckCuda(cudaGetLastError(), "Blackwell BGMV MoE shrink launch");
 
@@ -229,28 +242,29 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
   if (schedule == Schedule::kPairOwnedT128) {
     const dim3 grid(num_pairs, (kHidden + 127) / 128, 1);
     BLACKWELL_BGMV_MOE_EXPAND_PAIR<<<grid, 128, 0, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
-        num_experts, num_tokens, output_stride, output_offset);
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
+        num_pairs, num_experts, num_tokens, output_stride, output_offset);
   } else if (schedule == Schedule::kTokenOwnedT64) {
     const dim3 grid(num_tokens, (kHidden + 63) / 64, 1);
     BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64<<<grid, 64, kExpandSmemBytes, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
-        num_experts, num_tokens, output_stride, output_offset);
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
+        num_pairs, num_experts, num_tokens, output_stride, output_offset);
   } else if (schedule == Schedule::kTokenOwned) {
     const dim3 grid(num_tokens, (kHidden + 127) / 128, 1);
     BLACKWELL_BGMV_MOE_EXPAND_TOKEN<<<grid, 128, kExpandSmemBytes, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
-        num_experts, num_tokens, output_stride, output_offset);
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
+        num_pairs, num_experts, num_tokens, output_stride, output_offset);
   } else {
     const dim3 grid(num_tokens, (kHidden + 255) / 256, 1);
-    BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<grid, 128, kExpandSmemBytes, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
-        num_experts, num_tokens, output_stride, output_offset);
+    BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<grid, 128, kExpandSmemBytes,
+                                           stream>>>(
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr,
+        num_pairs, num_experts, num_tokens, output_stride, output_offset);
   }
   CheckCuda(cudaGetLastError(), "Blackwell BGMV MoE expand launch");
 }
 
-}  // namespace blackwell_bgmv_moe
-}  // namespace flashinfer
+} // namespace blackwell_bgmv_moe
+} // namespace flashinfer
 
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::blackwell_bgmv_moe::Run);

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef BLACKWELL_BGMV_MOE_BODY_FILE
+#error "BLACKWELL_BGMV_MOE_BODY_FILE must name one generated BGMV MoE body"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_HIDDEN
+#error "BLACKWELL_BGMV_MOE_HIDDEN must describe the generated hidden size"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_INPUT_DTYPE
+#error "BLACKWELL_BGMV_MOE_INPUT_DTYPE must describe the generated input dtype"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_SHRINK_DECODE
+#error "BLACKWELL_BGMV_MOE_SHRINK_DECODE must name the generated kernel symbol"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_SHRINK_PREFILL
+#error "BLACKWELL_BGMV_MOE_SHRINK_PREFILL must name the generated kernel symbol"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_EXPAND_PAIR
+#error "BLACKWELL_BGMV_MOE_EXPAND_PAIR must name the generated kernel symbol"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64
+#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 must name the generated kernel symbol"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN
+#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN must name the generated kernel symbol"
+#endif
+#ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL
+#error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL must name the generated kernel symbol"
+#endif
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <limits>
+
+#include "tvm_ffi_utils.h"
+
+// The generated source owns private fixed-width aliases and a tensor-map
+// stand-in. Rename them at the include boundary to avoid CUDA-header clashes.
+#define uint8_t blackwell_bgmv_generated_uint8_t
+#define uint16_t blackwell_bgmv_generated_uint16_t
+#define uint32_t blackwell_bgmv_generated_uint32_t
+#define uint64_t blackwell_bgmv_generated_uint64_t
+#define int32_t blackwell_bgmv_generated_int32_t
+#define int16_t blackwell_bgmv_generated_int16_t
+#define BlackwellTensorMap blackwell_bgmv_generated_BlackwellTensorMap
+#define BlackwellTensorMapPack blackwell_bgmv_generated_BlackwellTensorMapPack
+#define CUtensorMap blackwell_bgmv_generated_CUtensorMap
+#include BLACKWELL_BGMV_MOE_BODY_FILE
+#undef uint8_t
+#undef uint16_t
+#undef uint32_t
+#undef uint64_t
+#undef int32_t
+#undef int16_t
+#undef BlackwellTensorMap
+#undef BlackwellTensorMapPack
+#undef CUtensorMap
+
+namespace flashinfer {
+namespace blackwell_bgmv_moe {
+
+constexpr int32_t kHidden = BLACKWELL_BGMV_MOE_HIDDEN;
+constexpr int32_t kRank = 32;
+constexpr int32_t kShrinkThreads = 128;
+constexpr int32_t kShrinkDecodePairsPerBlock = 4;
+constexpr int32_t kShrinkDecodeSmemBytes = 28160;
+constexpr int32_t kShrinkPrefillSmemBytes = 4736;
+constexpr int32_t kExpandSmemBytes = 128;
+
+enum class Schedule : int32_t {
+  kPairOwnedT128 = 0,
+  kTokenOwnedT64 = 1,
+  kTokenOwned = 2,
+  kTokenOwnedDualCol = 3,
+};
+
+inline void CheckCuda(cudaError_t status, const char* operation) {
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << operation << " failed: " << cudaGetErrorString(status);
+}
+
+inline void CheckExactSM100(int32_t device_id) {
+  int major = 0;
+  int minor = 0;
+  CheckCuda(cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, device_id),
+            "cudaDeviceGetAttribute(major)");
+  CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
+            "cudaDeviceGetAttribute(minor)");
+  TVM_FFI_ICHECK(major == 10 && minor == 0)
+      << "Blackwell BGMV MoE requires exact compute capability 10.0, got " << major << "." << minor;
+}
+
+inline void CheckCompact(const TensorView& tensor, const char* name) {
+  CHECK_CONTIGUOUS(tensor);
+  TVM_FFI_ICHECK(tensor.numel() <= std::numeric_limits<int32_t>::max())
+      << name << " exceeds the generated kernel's int32 index range";
+}
+
+void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lora_a,
+         TensorView lora_b, TensorView sorted_token_ids, TensorView expert_ids,
+         TensorView lora_indices, TensorView topk_weights, int64_t schedule_value,
+         int64_t cuda_stream) {
+  TVM_FFI_ICHECK(cuda_stream >= 0) << "cuda_stream must be a non-negative stream handle";
+  CHECK_CUDA(x);
+  const int32_t device_id = x.device().device_id;
+  ffi::CUDADeviceGuard device_guard(device_id);
+  CheckExactSM100(device_id);
+
+  CHECK_CUDA(y_accum);
+  CHECK_CUDA(shrink_out);
+  CHECK_CUDA(lora_a);
+  CHECK_CUDA(lora_b);
+  CHECK_CUDA(sorted_token_ids);
+  CHECK_CUDA(expert_ids);
+  CHECK_CUDA(lora_indices);
+  CHECK_CUDA(topk_weights);
+  CHECK_DEVICE(x, y_accum);
+  CHECK_DEVICE(x, shrink_out);
+  CHECK_DEVICE(x, lora_a);
+  CHECK_DEVICE(x, lora_b);
+  CHECK_DEVICE(x, sorted_token_ids);
+  CHECK_DEVICE(x, expert_ids);
+  CHECK_DEVICE(x, lora_indices);
+  CHECK_DEVICE(x, topk_weights);
+
+  CHECK_INPUT_TYPE(x, BLACKWELL_BGMV_MOE_INPUT_DTYPE);
+  CHECK_INPUT_TYPE(shrink_out, BLACKWELL_BGMV_MOE_INPUT_DTYPE);
+  CHECK_INPUT_TYPE(lora_a, BLACKWELL_BGMV_MOE_INPUT_DTYPE);
+  CHECK_INPUT_TYPE(lora_b, BLACKWELL_BGMV_MOE_INPUT_DTYPE);
+  CHECK_INPUT_TYPE(y_accum, dl_float32);
+  CHECK_INPUT_TYPE(topk_weights, dl_float32);
+  CHECK_INPUT_TYPE(sorted_token_ids, dl_int64);
+  CHECK_INPUT_TYPE(expert_ids, dl_int64);
+  CHECK_INPUT_TYPE(lora_indices, dl_int64);
+
+  TVM_FFI_ICHECK(x.ndim() == 2 && x.size(0) > 0 && x.size(1) == kHidden)
+      << "x must have shape [num_tokens, " << kHidden << "]";
+  const int32_t num_tokens = static_cast<int32_t>(x.size(0));
+  TVM_FFI_ICHECK(sorted_token_ids.ndim() == 1 && sorted_token_ids.size(0) > 0)
+      << "sorted_token_ids must be a non-empty rank-1 tensor";
+  const int32_t num_pairs = static_cast<int32_t>(sorted_token_ids.size(0));
+  TVM_FFI_ICHECK(expert_ids.ndim() == 1 && expert_ids.size(0) == num_pairs)
+      << "expert_ids must have shape [num_pairs]";
+  TVM_FFI_ICHECK(topk_weights.ndim() == 1 && topk_weights.size(0) == num_pairs)
+      << "topk_weights must have shape [num_pairs]";
+  TVM_FFI_ICHECK(lora_indices.ndim() == 1 && lora_indices.size(0) == num_tokens)
+      << "lora_indices must have shape [num_tokens]";
+  TVM_FFI_ICHECK(shrink_out.ndim() == 3 && shrink_out.size(0) == 1 &&
+                 shrink_out.size(1) == num_pairs && shrink_out.size(2) == kRank)
+      << "shrink_out must have shape [1, num_pairs, 32]";
+  TVM_FFI_ICHECK(y_accum.ndim() == 2 && y_accum.size(0) == num_tokens &&
+                 y_accum.size(1) == kHidden)
+      << "y_accum must have shape [num_tokens, " << kHidden << "]";
+  TVM_FFI_ICHECK(lora_a.ndim() == 4 && lora_a.size(0) > 0 && lora_a.size(1) > 0 &&
+                 lora_a.size(2) == kRank && lora_a.size(3) == kHidden)
+      << "lora_a must have shape [num_loras, num_experts, 32, " << kHidden << "]";
+  const int32_t num_experts = static_cast<int32_t>(lora_a.size(1));
+  TVM_FFI_ICHECK(lora_b.ndim() == 4 && lora_b.size(0) == lora_a.size(0) &&
+                 lora_b.size(1) == num_experts && lora_b.size(2) == kHidden &&
+                 lora_b.size(3) == kRank)
+      << "lora_b must have shape [num_loras, num_experts, " << kHidden << ", 32]";
+
+  CheckCompact(x, "x");
+  CheckCompact(y_accum, "y_accum");
+  CheckCompact(shrink_out, "shrink_out");
+  CheckCompact(lora_a, "lora_a");
+  CheckCompact(lora_b, "lora_b");
+  CheckCompact(sorted_token_ids, "sorted_token_ids");
+  CheckCompact(expert_ids, "expert_ids");
+  CheckCompact(lora_indices, "lora_indices");
+  CheckCompact(topk_weights, "topk_weights");
+
+  TVM_FFI_ICHECK(schedule_value >= static_cast<int64_t>(Schedule::kPairOwnedT128) &&
+                 schedule_value <= static_cast<int64_t>(Schedule::kTokenOwnedDualCol))
+      << "invalid Blackwell BGMV MoE schedule id: " << schedule_value;
+  const auto schedule = static_cast<Schedule>(schedule_value);
+  const auto stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+  auto* y_ptr = static_cast<float*>(y_accum.data_ptr());
+  auto* shrink_ptr = static_cast<unsigned short*>(shrink_out.data_ptr());
+  auto* x_ptr = static_cast<unsigned short*>(x.data_ptr());
+  auto* a_ptr = static_cast<unsigned short*>(lora_a.data_ptr());
+  auto* b_ptr = static_cast<unsigned short*>(lora_b.data_ptr());
+  auto* token_ptr = static_cast<int64_t*>(sorted_token_ids.data_ptr());
+  auto* expert_ptr = static_cast<int64_t*>(expert_ids.data_ptr());
+  auto* lora_ptr = static_cast<int64_t*>(lora_indices.data_ptr());
+  auto* weight_ptr = static_cast<float*>(topk_weights.data_ptr());
+
+  if (schedule == Schedule::kPairOwnedT128) {
+    CheckCuda(cudaMemsetAsync(y_ptr, 0, y_accum.numel() * sizeof(float), stream),
+              "Blackwell BGMV MoE output initialization");
+  }
+
+  const dim3 shrink_block(kShrinkThreads, 1, 1);
+  if (num_pairs <= 32) {
+    const dim3 shrink_grid((num_pairs + kShrinkDecodePairsPerBlock - 1) /
+                               kShrinkDecodePairsPerBlock,
+                           kRank / 8, 1);
+    BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<shrink_grid, shrink_block, kShrinkDecodeSmemBytes, stream>>>(
+        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs, num_experts,
+        num_tokens);
+  } else {
+    const dim3 shrink_grid(num_pairs, kRank / 8, 1);
+    BLACKWELL_BGMV_MOE_SHRINK_PREFILL<<<shrink_grid, shrink_block, kShrinkPrefillSmemBytes, stream>>>(
+        shrink_ptr, x_ptr, a_ptr, token_ptr, expert_ptr, lora_ptr, num_pairs, num_experts,
+        num_tokens);
+  }
+  CheckCuda(cudaGetLastError(), "Blackwell BGMV MoE shrink launch");
+
+  const int32_t output_stride = kHidden;
+  const int32_t output_offset = 0;
+  if (schedule == Schedule::kPairOwnedT128) {
+    const dim3 grid(num_pairs, (kHidden + 127) / 128, 1);
+    BLACKWELL_BGMV_MOE_EXPAND_PAIR<<<grid, 128, 0, stream>>>(
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
+  } else if (schedule == Schedule::kTokenOwnedT64) {
+    const dim3 grid(num_tokens, (kHidden + 63) / 64, 1);
+    BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64<<<grid, 64, kExpandSmemBytes, stream>>>(
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
+  } else if (schedule == Schedule::kTokenOwned) {
+    const dim3 grid(num_tokens, (kHidden + 127) / 128, 1);
+    BLACKWELL_BGMV_MOE_EXPAND_TOKEN<<<grid, 128, kExpandSmemBytes, stream>>>(
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
+  } else {
+    const dim3 grid(num_tokens, (kHidden + 255) / 256, 1);
+    BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<grid, 128, kExpandSmemBytes, stream>>>(
+        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
+        num_experts, num_tokens, output_stride, output_offset);
+  }
+  CheckCuda(cudaGetLastError(), "Blackwell BGMV MoE expand launch");
+}
+
+}  // namespace blackwell_bgmv_moe
+}  // namespace flashinfer
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(run, flashinfer::blackwell_bgmv_moe::Run);

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_binding.cuh
@@ -31,9 +31,6 @@
 #ifndef BLACKWELL_BGMV_MOE_SHRINK_PREFILL
 #error "BLACKWELL_BGMV_MOE_SHRINK_PREFILL must name the generated kernel symbol"
 #endif
-#ifndef BLACKWELL_BGMV_MOE_EXPAND_PAIR
-#error "BLACKWELL_BGMV_MOE_EXPAND_PAIR must name the generated kernel symbol"
-#endif
 #ifndef BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64
 #error "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 must name the generated kernel symbol"
 #endif
@@ -86,10 +83,9 @@ constexpr int32_t kShrinkPrefillSmemBytes = 36992;
 constexpr int32_t kExpandSmemBytes = 128;
 
 enum class Schedule : int32_t {
-  kPairOwnedT128 = 0,
-  kTokenOwnedT64 = 1,
-  kTokenOwned = 2,
-  kTokenOwnedDualCol = 3,
+  kTokenOwnedT64 = 0,
+  kTokenOwned = 1,
+  kTokenOwnedDualCol = 2,
 };
 
 inline void CheckCuda(cudaError_t status, const char* operation) {
@@ -205,7 +201,7 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
   CheckCompact(lora_indices, "lora_indices");
   CheckCompact(topk_weights, "topk_weights");
 
-  TVM_FFI_ICHECK(schedule_value >= static_cast<int64_t>(Schedule::kPairOwnedT128) &&
+  TVM_FFI_ICHECK(schedule_value >= static_cast<int64_t>(Schedule::kTokenOwnedT64) &&
                  schedule_value <= static_cast<int64_t>(Schedule::kTokenOwnedDualCol))
       << "invalid Blackwell BGMV MoE schedule id: " << schedule_value;
   const auto schedule = static_cast<Schedule>(schedule_value);
@@ -219,11 +215,6 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
   auto* expert_ptr = static_cast<long long*>(expert_ids.data_ptr());
   auto* lora_ptr = static_cast<long long*>(lora_indices.data_ptr());
   auto* weight_ptr = static_cast<float*>(topk_weights.data_ptr());
-
-  if (schedule == Schedule::kPairOwnedT128) {
-    CheckCuda(cudaMemsetAsync(y_ptr, 0, y_accum.numel() * sizeof(float), stream),
-              "Blackwell BGMV MoE output initialization");
-  }
 
   const dim3 shrink_block(kShrinkThreads, 1, 1);
   if (num_pairs <= 32) {
@@ -242,12 +233,7 @@ void Run(TensorView y_accum, TensorView shrink_out, TensorView x, TensorView lor
 
   const int32_t output_stride = kHidden;
   const int32_t output_offset = 0;
-  if (schedule == Schedule::kPairOwnedT128) {
-    const dim3 grid(num_pairs, (kHidden + 127) / 128, 1);
-    BLACKWELL_BGMV_MOE_EXPAND_PAIR<<<grid, 128, 0, stream>>>(
-        y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,
-        num_experts, num_tokens, output_stride, output_offset);
-  } else if (schedule == Schedule::kTokenOwnedT64) {
+  if (schedule == Schedule::kTokenOwnedT64) {
     const dim3 grid(num_tokens, (kHidden + 63) / 64, 1);
     BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64<<<grid, 64, kExpandSmemBytes, stream>>>(
         y_ptr, shrink_ptr, b_ptr, token_ptr, expert_ptr, lora_ptr, weight_ptr, num_pairs,

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
@@ -27,7 +27,8 @@ typedef short int int16_t;
 struct __align__(128) BlackwellTensorMap {
   uint64_t opaque[16];
 };
-template <int N> struct __align__(128) BlackwellTensorMapPack {
+template <int N>
+struct __align__(128) BlackwellTensorMapPack {
   BlackwellTensorMap maps[N];
 };
 
@@ -39,9 +40,7 @@ typedef struct __align__(64) {
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
   int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-               : "=r"(result)
-               : "r"(x));
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
   return result;
 }
 
@@ -63,12 +62,11 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -81,11 +79,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 24576);
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
   const int w_smem_addr = smem + 24576;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
   const int warp_partials_addr = smem + 221184;
 
   // === Task calls (dependency order) ===
@@ -125,27 +123,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
         if (k_base < 2688) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
                   (tokens[pp_1] * 2688 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    2688 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -173,27 +165,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
       int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 2688) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           ".reg .b16 h_lo, h_hi;\n\t"
-                           ".reg .b32 f_lo, f_hi;\n\t"
-                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                           "cvt.f32.f16 f_lo, h_lo;\n\t"
-                           "cvt.f32.f16 f_hi, h_hi;\n\t"
-                           "mov.b64 %0, {f_lo, f_hi};\n\t"
-                           "}\n"
-                           : "=l"(*reinterpret_cast<unsigned long long *>(
-                               &x_values[_pair * 2]))
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -203,35 +194,32 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 2688) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
-                                rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             ".reg .b16 h_lo, h_hi;\n\t"
-                             ".reg .b32 f_lo, f_hi;\n\t"
-                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                             "cvt.f32.f16 f_lo, h_lo;\n\t"
-                             "cvt.f32.f16 f_hi, h_hi;\n\t"
-                             "mov.b64 %0, {f_lo, f_hi};\n\t"
-                             "}\n"
-                             : "=l"(*reinterpret_cast<unsigned long long *>(
-                                 &w_values[_pair * 2]))
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -265,14 +253,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
       for (int pp_3 = 0; pp_3 < 4; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 2688) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(x_raw) +
-                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -283,13 +269,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
-                                          1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -303,16 +286,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
       int owner_rr = lane % 8;
       int pair_1 = pair_block * 4 + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half *>(
-              reinterpret_cast<__half *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2half_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -347,12 +329,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -365,11 +346,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 4096);
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
   const int w_smem_addr = smem + 4096;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
   const int warp_partials_addr = smem + 36864;
 
   // === Task calls (dependency order) ===
@@ -409,27 +390,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
         if (k_base < 2688) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
                   (tokens[pp_1] * 2688 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    2688 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -457,27 +432,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
       int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 2688) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           ".reg .b16 h_lo, h_hi;\n\t"
-                           ".reg .b32 f_lo, f_hi;\n\t"
-                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                           "cvt.f32.f16 f_lo, h_lo;\n\t"
-                           "cvt.f32.f16 f_hi, h_hi;\n\t"
-                           "mov.b64 %0, {f_lo, f_hi};\n\t"
-                           "}\n"
-                           : "=l"(*reinterpret_cast<unsigned long long *>(
-                               &x_values[_pair * 2]))
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -487,35 +461,32 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 2688) {
-            int w_thread_base =
-                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             ".reg .b16 h_lo, h_hi;\n\t"
-                             ".reg .b32 f_lo, f_hi;\n\t"
-                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                             "cvt.f32.f16 f_lo, h_lo;\n\t"
-                             "cvt.f32.f16 f_hi, h_hi;\n\t"
-                             "mov.b64 %0, {f_lo, f_hi};\n\t"
-                             "}\n"
-                             : "=l"(*reinterpret_cast<unsigned long long *>(
-                                 &w_values[_pair * 2]))
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -549,14 +520,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
       for (int pp_3 = 0; pp_3 < 1; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 2688) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(x_raw) +
-                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -567,12 +536,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -586,16 +553,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
       int owner_rr = lane % 8;
       int pair_1 = pair_block + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half *>(
-              reinterpret_cast<__half *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2half_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -624,13 +590,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p
 
 extern "C" {
 
-__global__
-__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -643,7 +608,7 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -669,13 +634,11 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -691,76 +654,69 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               ".reg .b16 h_lo, h_hi;\n\t"
-                               ".reg .b32 f_lo, f_hi;\n\t"
-                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                               "cvt.f32.f16 f_lo, h_lo;\n\t"
-                               "cvt.f32.f16 f_hi, h_hi;\n\t"
-                               "mov.b64 %0, {f_lo, f_hi};\n\t"
-                               "}\n"
-                               : "=l"(*reinterpret_cast<unsigned long long *>(
-                                   &activation_values[_pair * 2]))
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
             float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
             total = _fma_1;
           }
-          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
-                                                 output_offset + output_col)) +
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
             (0)) = total;
         }
       } else if (output_col < 2688) {
@@ -775,89 +731,82 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_1[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
                   }
                 }
               }
               long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col_1;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index_1 + 0);
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_2[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                              route_partial_1);
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                 route_partial_1 = _fma_2;
               }
             }
-            float _fma_3 =
-                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
             total_1 = _fma_3;
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total_1;
       }
     } else if (output_col < 2688) {
-      *(reinterpret_cast<float *>(
-            y_accum + (token * output_stride + output_offset + output_col)) +
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
         (0)) = 0.0f;
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -876,11 +825,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h2688_r32_t128(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -905,74 +854,69 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
               int rank_col = rank_block * 8;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(shrink_raw) +
-                    (pair * 32 + rank_col) + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_1[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element],
-                                         _vec_load_1[element], partial);
+                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
                 partial = _fma_0;
               }
             }
-            atomicAdd(
-                &y_accum[token * (long long)output_stride +
-                         (long long)output_offset + (long long)output_col],
-                partial * topk_weights[pair]);
+            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
+                               (long long)output_col],
+                      partial * topk_weights[pair]);
           }
         }
       }
@@ -980,7 +924,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -996,13 +940,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -1015,7 +958,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1041,13 +984,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
           if (tid < 8) {
             int stage_route = tid / 4;
             int stage_rank_block = tid % 4;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    shrink_stage_addr +
-                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(shrink_raw) +
-                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
           }
           asm volatile("cp.async.commit_group;");
           asm volatile("cp.async.wait_group 0;");
@@ -1061,68 +1002,61 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               ".reg .b16 h_lo, h_hi;\n\t"
-                               ".reg .b32 f_lo, f_hi;\n\t"
-                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                               "cvt.f32.f16 f_lo, h_lo;\n\t"
-                               "cvt.f32.f16 f_hi, h_hi;\n\t"
-                               "mov.b64 %0, {f_lo, f_hi};\n\t"
-                               "}\n"
-                               : "=l"(*reinterpret_cast<unsigned long long *>(
-                                   &activation_values[_pair * 2]))
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
@@ -1140,15 +1074,13 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
                 int rank_col_1 = rank_block_1 * 8;
                 float _vec_load_1[8];
                 {
-                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(shrink_raw) +
-                      (pair_1 * 32 + rank_col_1) + 0);
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
                   uint4 _vld_1[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t *_vpairs_1 =
-                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1160,28 +1092,25 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_1[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_1[_pair]));
                     }
                   }
                 }
                 long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                     (long long)output_col) *
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
                         32 +
                     (long long)rank_col_1;
                 float _vec_load_2[8];
                 {
-                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(lora_b_raw) +
-                      weight_index_1 + 0);
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
                   uint4 _vld_2[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t *_vpairs_2 =
-                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1193,7 +1122,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_2[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_2[_pair]));
                     }
@@ -1202,30 +1131,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688
 #pragma unroll
                 for (int element_1 = 0; element_1 < 8; element_1++) {
                   float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                                route_partial_1);
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                   route_partial_1 = _fma_2;
                 }
               }
-              float _fma_3 =
-                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
               total = _fma_3;
             }
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total;
       } else {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -1248,11 +1173,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -1265,7 +1190,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1302,13 +1227,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -1322,123 +1245,111 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
           for (int rank_block = 0; rank_block < 4; rank_block++) {
             int rank_col = rank_block * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 3]))
-                : "r"(shrink_stage_addr +
-                      (unsigned int)((route * 32 + rank_col) * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             ".reg .b16 h_lo, h_hi;\n\t"
-                             ".reg .b32 f_lo, f_hi;\n\t"
-                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                             "cvt.f32.f16 f_lo, h_lo;\n\t"
-                             "cvt.f32.f16 f_hi, h_hi;\n\t"
-                             "mov.b64 %0, {f_lo, f_hi};\n\t"
-                             "}\n"
-                             : "=l"(*reinterpret_cast<unsigned long long *>(
-                                 &activation_values[_pair * 2]))
-                             : "r"(activation_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                    : "r"(activation_carriers[_pair]));
               }
             }
             if (valid0 != 0) {
               long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col0) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index0 + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial0);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
                 route_partial0 = _fma_0;
               }
             }
             if (valid1 != 0) {
               long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 +
-                   (long long)output_col1) *
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index1 + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_1[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_1 =
-                    __fmaf_rn(activation_values[element_1],
-                              _vec_load_1[element_1], route_partial1);
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
                 route_partial1 = _fma_1;
               }
             }
           }
           if (valid0 != 0) {
-            float _fma_2 =
-                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
             total0 = _fma_2;
           }
           if (valid1 != 0) {
-            float _fma_3 =
-                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
             total1 = _fma_3;
           }
         }
@@ -1454,48 +1365,44 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_2[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
                   }
                 }
               }
               if (valid0 != 0) {
-                long long weight_index0_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                     (long long)output_col0) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_3[8];
                 {
-                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(lora_b_raw) +
-                      weight_index0_1 + 0);
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
                   uint4 _vld_3[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t *_vpairs_3 =
-                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1507,7 +1414,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_3[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_3[_pair]));
                     }
@@ -1516,28 +1423,24 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_2 = 0; element_2 < 8; element_2++) {
                   float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
-                                route_partial0_1);
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
                   route_partial0_1 = _fma_4;
                 }
               }
               if (valid1 != 0) {
-                long long weight_index1_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                     (long long)output_col1) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_4[8];
                 {
-                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(lora_b_raw) +
-                      weight_index1_1 + 0);
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
                   uint4 _vld_4[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t *_vpairs_4 =
-                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1549,7 +1452,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_4[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_4[_pair]));
                     }
@@ -1558,51 +1461,48 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_3 = 0; element_3 < 8; element_3++) {
                   float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
-                                route_partial1_1);
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
                   route_partial1_1 = _fma_5;
                 }
               }
             }
             if (valid0 != 0) {
-              float _fma_6 =
-                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
               total0 = _fma_6;
             }
             if (valid1 != 0) {
-              float _fma_7 =
-                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
               total1 = _fma_7;
             }
           }
         }
       }
       if (valid0 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = total0;
       }
       if (valid1 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = total1;
       }
     } else {
       if (output_col0 < 2688) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = 0.0f;
       }
       if (output_col1 < 2688) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
@@ -1,0 +1,1339 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Generated source for FlashInfer.
+// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Target: sm_100a; compile flags: none.
+// Generated file; do not edit manually.
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#include <math_constants.h>
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 24576
+#define SMEM_X_SMEM_STRIDE 24576
+#define SMEM_W_SMEM_OFF 24576
+#define SMEM_W_SMEM_STAGE_BYTES 196608
+#define SMEM_W_SMEM_STRIDE 196608
+#define SMEM_WARP_PARTIALS_OFF 221184
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 512
+#define SMEM_WARP_PARTIALS_STRIDE 512
+#define SMEM_TOTAL 221696
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 4096
+#define SMEM_X_SMEM_STRIDE 4096
+#define SMEM_W_SMEM_OFF 4096
+#define SMEM_W_SMEM_STAGE_BYTES 32768
+#define SMEM_W_SMEM_STRIDE 32768
+#define SMEM_WARP_PARTIALS_OFF 36864
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 128
+#define SMEM_WARP_PARTIALS_STRIDE 128
+#define SMEM_TOTAL 36992
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 64
+
+extern "C" {
+
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 2688) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 2688) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 2688) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h2688_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int pair = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    if (pair < num_pairs) {
+        if (output_col < 2688) {
+            long long token = sorted_token_ids[pair];
+            if (token >= 0) {
+                if (token < (long long)num_tokens) {
+                    long long lora_id = lora_indices[token];
+                    if (lora_id >= 0) {
+                        long long expert = expert_ids[pair];
+                        float partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
+                                partial = _fma_0;
+                            }
+                        }
+                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        if (output_col < 2688) {
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 2688) {
+                valid0 = 1;
+            }
+            if (output_col1 < 2688) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
+        } else {
+            if (output_col0 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
+            }
+            if (output_col1 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
@@ -14,34 +14,29 @@
  * limitations under the License.
  */
 // Generated source for FlashInfer.
-// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int int32_t;
-typedef short int int16_t;
-struct __align__(128) BlackwellTensorMap {
-  uint64_t opaque[16];
-};
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
 template <int N>
-struct __align__(128) BlackwellTensorMapPack {
-  BlackwellTensorMap maps[N];
-};
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
 
-typedef struct __align__(64) {
-  uint64_t opaque[16];
-} CUtensorMap;
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-  int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
-  return result;
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
 }
 
 #include <math_constants.h>
@@ -62,239 +57,208 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
-  const int w_smem_addr = smem + 24576;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-  const int warp_partials_addr = smem + 221184;
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[4];
-  long long experts[4];
-  long long loras[4];
-  int valid[4];
-#pragma unroll
-  for (int pp = 0; pp < 4; pp++) {
-    int pair = pair_block * 4 + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 2688) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __half*>(x_raw) +
-                  (tokens[pp_1] * 2688 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         2688 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
-                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 2;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 2688) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  ".reg .b16 h_lo, h_hi;\n\t"
-                  ".reg .b32 f_lo, f_hi;\n\t"
-                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                  "cvt.f32.f16 f_lo, h_lo;\n\t"
-                  "cvt.f32.f16 f_hi, h_hi;\n\t"
-                  "mov.b64 %0, {f_lo, f_hi};\n\t"
-                  "}\n"
-                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 2688) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    ".reg .b16 h_lo, h_hi;\n\t"
-                    ".reg .b32 f_lo, f_hi;\n\t"
-                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                    "}\n"
-                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 32) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 3 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 2688) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(x_raw) +
-                             (tokens[pp_3] * 2688 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      2688 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 32) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block * 4 + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
-                                    (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2half_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -329,239 +293,208 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
-  const int w_smem_addr = smem + 4096;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-  const int warp_partials_addr = smem + 36864;
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[1];
-  long long experts[1];
-  long long loras[1];
-  int valid[1];
-#pragma unroll
-  for (int pp = 0; pp < 1; pp++) {
-    int pair = pair_block + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 2688) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __half*>(x_raw) +
-                  (tokens[pp_1] * 2688 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         2688 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                                           rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 1;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 2688) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  ".reg .b16 h_lo, h_hi;\n\t"
-                  ".reg .b32 f_lo, f_hi;\n\t"
-                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                  "cvt.f32.f16 f_lo, h_lo;\n\t"
-                  "cvt.f32.f16 f_hi, h_hi;\n\t"
-                  "mov.b64 %0, {f_lo, f_hi};\n\t"
-                  "}\n"
-                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 2688) {
-            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    ".reg .b16 h_lo, h_hi;\n\t"
-                    ".reg .b32 f_lo, f_hi;\n\t"
-                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                    "}\n"
-                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 2688) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 2688) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 2688) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 2688) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 8) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 2 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 2688) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(x_raw) +
-                             (tokens[pp_3] * 2688 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      2688 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 8) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
-                                    (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2half_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -590,223 +523,404 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 64 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
             }
-          }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 2688) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 2688) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 2688) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
         }
-      }
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
         if (output_col < 2688) {
-          float total = 0.0f;
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      ".reg .b16 h_lo, h_hi;\n\t"
-                      ".reg .b32 f_lo, f_hi;\n\t"
-                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                      "cvt.f32.f16 f_lo, h_lo;\n\t"
-                      "cvt.f32.f16 f_hi, h_hi;\n\t"
-                      "mov.b64 %0, {f_lo, f_hi};\n\t"
-                      "}\n"
-                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                      : "r"(activation_carriers[_pair]));
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (num_pairs == num_tokens * 2) {
+                    if (pair_base + 1 < num_pairs) {
+                        if (sorted_token_ids[pair_base] == (long long)token) {
+                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                                contiguous = 1;
+                            }
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
                 }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
-          *(reinterpret_cast<float*>(y_accum +
-                                     (token * output_stride + output_offset + output_col)) +
-            (0)) = total;
         }
-      } else if (output_col < 2688) {
-        float total_1 = 0.0f;
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-              long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col_1;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                route_partial_1 = _fma_2;
-              }
-            }
-            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-            total_1 = _fma_3;
-          }
-        }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total_1;
-      }
-    } else if (output_col < 2688) {
-      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-        (0)) = 0.0f;
     }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -819,119 +933,6 @@ __global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token
 
 #define BLACKWELL_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h2688_r32_t128(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // === Task calls (dependency order) ===
-  int pair = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  if (pair < num_pairs) {
-    if (output_col < 2688) {
-      long long token = sorted_token_ids[pair];
-      if (token >= 0) {
-        if (token < (long long)num_tokens) {
-          long long lora_id = lora_indices[token];
-          if (lora_id >= 0) {
-            long long expert = expert_ids[pair];
-            float partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                partial = _fma_0;
-              }
-            }
-            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
-                               (long long)output_col],
-                      partial * topk_weights[pair]);
-          }
-        }
-      }
-    }
-  }
-}
-
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef THREADS
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
 #define SMEM_SHRINK_STAGE_OFF 0
 #define SMEM_SHRINK_STAGE_STAGE_BYTES 128
 #define SMEM_SHRINK_STAGE_STRIDE 128
@@ -940,571 +941,294 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    if (output_col < 2688) {
-      long long lora_id = lora_indices[token];
-      if (lora_id >= 0) {
-        int pair_base = token * 2;
-        int contiguous = 0;
-        if (num_pairs == num_tokens * 2) {
-          if (pair_base + 1 < num_pairs) {
-            if (sorted_token_ids[pair_base] == (long long)token) {
-              if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                contiguous = 1;
-              }
-            }
-          }
-        }
-        float total = 0.0f;
-        if (contiguous != 0) {
-          if (tid < 8) {
-            int stage_route = tid / 4;
-            int stage_rank_block = tid % 4;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             shrink_stage_addr +
-                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                         "l"(reinterpret_cast<const __half*>(shrink_raw) +
-                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-          }
-          asm volatile("cp.async.commit_group;");
-          asm volatile("cp.async.wait_group 0;");
-          __syncthreads();
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      ".reg .b16 h_lo, h_hi;\n\t"
-                      ".reg .b32 f_lo, f_hi;\n\t"
-                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                      "cvt.f32.f16 f_lo, h_lo;\n\t"
-                      "cvt.f32.f16 f_hi, h_hi;\n\t"
-                      "mov.b64 %0, {f_lo, f_hi};\n\t"
-                      "}\n"
-                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                      : "r"(activation_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 2688) {
+                valid0 = 1;
+            }
+            if (output_col1 < 2688) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
         } else {
-#pragma unroll 1
-          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-            if (sorted_token_ids[pair_1] == (long long)token) {
-              long long expert_1 = expert_ids[pair_1];
-              float route_partial_1 = 0.0f;
-#pragma unroll
-              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                int rank_col_1 = rank_block_1 * 8;
-                float _vec_load_1[8];
-                {
-                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                  uint4 _vld_1[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_1[_pair]));
-                    }
-                  }
-                }
-                long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
-                        32 +
-                    (long long)rank_col_1;
-                float _vec_load_2[8];
-                {
-                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                  uint4 _vld_2[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_2[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_1 = 0; element_1 < 8; element_1++) {
-                  float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                  route_partial_1 = _fma_2;
-                }
-              }
-              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-              total = _fma_3;
+            if (output_col0 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
             }
-          }
+            if (output_col1 < 2688) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
         }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total;
-      } else {
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = 0.0f;
-      }
     }
-  }
 }
 
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // Kernel setup ops
-  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
-
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col0 = blockIdx.y * 256 + tid;
-  int output_col1 = output_col0 + 128;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
-            }
-          }
-        }
-      }
-      int valid0 = 0;
-      int valid1 = 0;
-      if (output_col0 < 2688) {
-        valid0 = 1;
-      }
-      if (output_col1 < 2688) {
-        valid1 = 1;
-      }
-      float total0 = 0.0f;
-      float total1 = 0.0f;
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
-#pragma unroll
-        for (int route = 0; route < 2; route++) {
-          int pair = pair_base + route;
-          long long expert = expert_ids[pair];
-          float route_partial0 = 0.0f;
-          float route_partial1 = 0.0f;
-#pragma unroll
-          for (int rank_block = 0; rank_block < 4; rank_block++) {
-            int rank_col = rank_block * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    ".reg .b16 h_lo, h_hi;\n\t"
-                    ".reg .b32 f_lo, f_hi;\n\t"
-                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                    "}\n"
-                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                    : "r"(activation_carriers[_pair]));
-              }
-            }
-            if (valid0 != 0) {
-              long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                route_partial0 = _fma_0;
-              }
-            }
-            if (valid1 != 0) {
-              long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_1 =
-                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                route_partial1 = _fma_1;
-              }
-            }
-          }
-          if (valid0 != 0) {
-            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-            total0 = _fma_2;
-          }
-          if (valid1 != 0) {
-            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-            total1 = _fma_3;
-          }
-        }
-      } else {
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial0_1 = 0.0f;
-            float route_partial1_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-              if (valid0 != 0) {
-                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                                             (long long)output_col0) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_3[8];
-                {
-                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
-                  uint4 _vld_3[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_3[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_3[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_2 = 0; element_2 < 8; element_2++) {
-                  float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                  route_partial0_1 = _fma_4;
-                }
-              }
-              if (valid1 != 0) {
-                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
-                                             (long long)output_col1) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_4[8];
-                {
-                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
-                  uint4 _vld_4[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_4[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_4[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_3 = 0; element_3 < 8; element_3++) {
-                  float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                  route_partial1_1 = _fma_5;
-                }
-              }
-            }
-            if (valid0 != 0) {
-              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-              total0 = _fma_6;
-            }
-            if (valid1 != 0) {
-              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-              total1 = _fma_7;
-            }
-          }
-        }
-      }
-      if (valid0 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = total0;
-      }
-      if (valid1 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = total1;
-      }
-    } else {
-      if (output_col0 < 2688) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = 0.0f;
-      }
-      if (output_col1 < 2688) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = 0.0f;
-      }
-    }
-  }
-}
-
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
@@ -17,26 +17,31 @@
 // Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,208 +62,239 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -293,208 +329,239 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         2688 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -523,404 +590,223 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 2688) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 2688) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 2688) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
-    }
-}
-
-} // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
-
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
-
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
         if (output_col < 2688) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (num_pairs == num_tokens * 2) {
-                    if (pair_base + 1 < num_pairs) {
-                        if (sorted_token_ids[pair_base] == (long long)token) {
-                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                                contiguous = 1;
-                            }
-                        }
-                    }
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
                 }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
+                  }
                 }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
+            (0)) = total;
         }
+      } else if (output_col < 2688) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 2688) {
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -941,294 +827,571 @@ kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(float* __restrict__ y_accu
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 2688) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 2688) {
-                valid0 = 1;
+          }
+        }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
-            if (output_col1 < 2688) {
-                valid1 = 1;
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
             }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
+
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
+            }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 2688) {
+        valid0 = 1;
+      }
+      if (output_col1 < 2688) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                    : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 2688) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 2688) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
@@ -17,26 +17,32 @@
 // Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
-template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
+template <int N> struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+               : "=r"(result)
+               : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,205 +63,253 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    2688 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           ".reg .b16 h_lo, h_hi;\n\t"
+                           ".reg .b32 f_lo, f_hi;\n\t"
+                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                           "cvt.f32.f16 f_lo, h_lo;\n\t"
+                           "cvt.f32.f16 f_hi, h_hi;\n\t"
+                           "mov.b64 %0, {f_lo, f_hi};\n\t"
+                           "}\n"
+                           : "=l"(*reinterpret_cast<unsigned long long *>(
+                               &x_values[_pair * 2]))
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
+                                rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             ".reg .b16 h_lo, h_hi;\n\t"
+                             ".reg .b32 f_lo, f_hi;\n\t"
+                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                             "cvt.f32.f16 f_lo, h_lo;\n\t"
+                             "cvt.f32.f16 f_hi, h_hi;\n\t"
+                             "mov.b64 %0, {f_lo, f_hi};\n\t"
+                             "}\n"
+                             : "=l"(*reinterpret_cast<unsigned long long *>(
+                                 &w_values[_pair * 2]))
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(x_raw) +
+                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
+                                          1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half *>(
+              reinterpret_cast<__half *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -293,205 +347,252 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p4_s3(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 2688) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 2688 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 2688 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 2688) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  (tokens[pp_1] * 2688 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    2688 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 2688) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 2688) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 2688) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 2688 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 2688 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 2688) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           ".reg .b16 h_lo, h_hi;\n\t"
+                           ".reg .b32 f_lo, f_hi;\n\t"
+                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                           "cvt.f32.f16 f_lo, h_lo;\n\t"
+                           "cvt.f32.f16 f_hi, h_hi;\n\t"
+                           "mov.b64 %0, {f_lo, f_hi};\n\t"
+                           "}\n"
+                           : "=l"(*reinterpret_cast<unsigned long long *>(
+                               &x_values[_pair * 2]))
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 2688) {
+            int w_thread_base =
+                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             ".reg .b16 h_lo, h_hi;\n\t"
+                             ".reg .b32 f_lo, f_hi;\n\t"
+                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                             "cvt.f32.f16 f_lo, h_lo;\n\t"
+                             "cvt.f32.f16 f_hi, h_hi;\n\t"
+                             "mov.b64 %0, {f_lo, f_hi};\n\t"
+                             "}\n"
+                             : "=l"(*reinterpret_cast<unsigned long long *>(
+                                 &w_values[_pair * 2]))
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 2688) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(x_raw) +
+                    (tokens[pp_3] * 2688 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      2688 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half *>(
+              reinterpret_cast<__half *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -523,193 +624,237 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h2688_r32_p1_s2(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 2688) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 2688) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 2688) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+        if (output_col < 2688) {
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               ".reg .b16 h_lo, h_hi;\n\t"
+                               ".reg .b32 f_lo, f_hi;\n\t"
+                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                               "cvt.f32.f16 f_lo, h_lo;\n\t"
+                               "cvt.f32.f16 f_hi, h_hi;\n\t"
+                               "mov.b64 %0, {f_lo, f_hi};\n\t"
+                               "}\n"
+                               : "=l"(*reinterpret_cast<unsigned long long *>(
+                                   &activation_values[_pair * 2]))
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
+                                                 output_offset + output_col)) +
+            (0)) = total;
+        }
+      } else if (output_col < 2688) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                              route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 =
+                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 2688) {
+      *(reinterpret_cast<float *>(
+            y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
 } // extern "C"
@@ -729,93 +874,110 @@ kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h2688_r32(float* __restrict__ y_
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h2688_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h2688_r32_t128(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // === Task calls (dependency order) ===
-    int pair = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    if (pair < num_pairs) {
-        if (output_col < 2688) {
-            long long token = sorted_token_ids[pair];
-            if (token >= 0) {
-                if (token < (long long)num_tokens) {
-                    long long lora_id = lora_indices[token];
-                    if (lora_id >= 0) {
-                        long long expert = expert_ids[pair];
-                        float partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                                partial = _fma_0;
-                            }
-                        }
-                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
-                    }
+  // === Task calls (dependency order) ===
+  int pair = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  if (pair < num_pairs) {
+    if (output_col < 2688) {
+      long long token = sorted_token_ids[pair];
+      if (token >= 0) {
+        if (token < (long long)num_tokens) {
+          long long lora_id = lora_indices[token];
+          if (lora_id >= 0) {
+            long long expert = expert_ids[pair];
+            float partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(shrink_raw) +
+                    (pair * 32 + rank_col) + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
                 }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(_vec_load_0[element],
+                                         _vec_load_1[element], partial);
+                partial = _fma_0;
+              }
             }
+            atomicAdd(
+                &y_accum[token * (long long)output_stride +
+                         (long long)output_offset + (long long)output_col],
+                partial * topk_weights[pair]);
+          }
         }
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -834,189 +996,233 @@ kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h2688_r32_t128(float* __restric
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        if (output_col < 2688) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 2688) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
+          }
         }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    shrink_stage_addr +
+                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(shrink_raw) +
+                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               ".reg .b16 h_lo, h_hi;\n\t"
+                               ".reg .b32 f_lo, f_hi;\n\t"
+                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                               "cvt.f32.f16 f_lo, h_lo;\n\t"
+                               "cvt.f32.f16 f_hi, h_hi;\n\t"
+                               "mov.b64 %0, {f_lo, f_hi};\n\t"
+                               "}\n"
+                               : "=l"(*reinterpret_cast<unsigned long long *>(
+                                   &activation_values[_pair * 2]))
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(shrink_raw) +
+                      (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t *_vpairs_1 =
+                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                     (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(lora_b_raw) +
+                      weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t *_vpairs_2 =
+                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                                route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 =
+                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
+            }
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -1040,291 +1246,360 @@ kernel_flashinfer_bgmv_moe_expand_token_f16_h2688_r32(float* __restrict__ y_accu
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h2688_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 2688) {
-                valid0 = 1;
-            }
-            if (output_col1 < 2688) {
-                valid1 = 1;
-            }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 2688 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 2688 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 2688) {
+        valid0 = 1;
+      }
+      if (output_col1 < 2688) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 3]))
+                : "r"(shrink_stage_addr +
+                      (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             ".reg .b16 h_lo, h_hi;\n\t"
+                             ".reg .b32 f_lo, f_hi;\n\t"
+                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                             "cvt.f32.f16 f_lo, h_lo;\n\t"
+                             "cvt.f32.f16 f_hi, h_hi;\n\t"
+                             "mov.b64 %0, {f_lo, f_hi};\n\t"
+                             "}\n"
+                             : "=l"(*reinterpret_cast<unsigned long long *>(
+                                 &activation_values[_pair * 2]))
+                             : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 2688 +
+                   (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1],
+                              _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 2688) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 =
+                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 =
+                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                     (long long)output_col0) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(lora_b_raw) +
+                      weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t *_vpairs_3 =
+                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
+                                route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 2688 +
+                     (long long)output_col1) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(lora_b_raw) +
+                      weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t *_vpairs_4 =
+                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
+                                route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 =
+                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 =
+                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 2688) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 2688) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h2688_sm100a.cu
@@ -972,10 +972,12 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_toke
       if (lora_id >= 0) {
         int pair_base = token * 2;
         int contiguous = 0;
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
           }
         }

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
@@ -1,0 +1,1339 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// Generated source for FlashInfer.
+// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Target: sm_100a; compile flags: none.
+// Generated file; do not edit manually.
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
+typedef unsigned long long uint64_t;
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+template <int N>
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+
+#include <cuda_bf16.h>
+
+__device__ __forceinline__ int make_warp_uniform(int x) {
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
+}
+
+#include <math_constants.h>
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 24576
+#define SMEM_X_SMEM_STRIDE 24576
+#define SMEM_W_SMEM_OFF 24576
+#define SMEM_W_SMEM_STAGE_BYTES 196608
+#define SMEM_W_SMEM_STRIDE 196608
+#define SMEM_WARP_PARTIALS_OFF 221184
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 512
+#define SMEM_WARP_PARTIALS_STRIDE 512
+#define SMEM_TOTAL 221696
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_X_SMEM_OFF 0
+#define SMEM_X_SMEM_STAGE_BYTES 4096
+#define SMEM_X_SMEM_STRIDE 4096
+#define SMEM_W_SMEM_OFF 4096
+#define SMEM_W_SMEM_STAGE_BYTES 32768
+#define SMEM_W_SMEM_STRIDE 32768
+#define SMEM_WARP_PARTIALS_OFF 36864
+#define SMEM_WARP_PARTIALS_STAGE_BYTES 128
+#define SMEM_WARP_PARTIALS_STRIDE 128
+#define SMEM_TOTAL 36992
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
+
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
+            }
+        }
+    }
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
+    if (warp == 0) {
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_TOTAL
+#undef SMEM_WARP_PARTIALS_OFF
+#undef SMEM_WARP_PARTIALS_STAGE_BYTES
+#undef SMEM_WARP_PARTIALS_STRIDE
+#undef SMEM_W_SMEM_OFF
+#undef SMEM_W_SMEM_STAGE_BYTES
+#undef SMEM_W_SMEM_STRIDE
+#undef SMEM_X_SMEM_OFF
+#undef SMEM_X_SMEM_STAGE_BYTES
+#undef SMEM_X_SMEM_STRIDE
+#undef THREADS
+#undef w_smem_addr
+#undef warp_partials_addr
+#undef x_smem_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 64
+
+extern "C" {
+
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 3072) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 3072) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 3072) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h3072_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // === Task calls (dependency order) ===
+    int pair = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    if (pair < num_pairs) {
+        if (output_col < 3072) {
+            long long token = sorted_token_ids[pair];
+            if (token >= 0) {
+                if (token < (long long)num_tokens) {
+                    long long lora_id = lora_indices[token];
+                    if (lora_id >= 0) {
+                        long long expert = expert_ids[pair];
+                        float partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
+                                partial = _fma_0;
+                            }
+                        }
+                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
+                    }
+                }
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef THREADS
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        if (output_col < 3072) {
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
+            }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 3072) {
+                valid0 = 1;
+            }
+            if (output_col1 < 3072) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
+        } else {
+            if (output_col0 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
+            }
+            if (output_col1 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
+        }
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
@@ -27,7 +27,8 @@ typedef short int int16_t;
 struct __align__(128) BlackwellTensorMap {
   uint64_t opaque[16];
 };
-template <int N> struct __align__(128) BlackwellTensorMapPack {
+template <int N>
+struct __align__(128) BlackwellTensorMapPack {
   BlackwellTensorMap maps[N];
 };
 
@@ -39,9 +40,7 @@ typedef struct __align__(64) {
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
   int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-               : "=r"(result)
-               : "r"(x));
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
   return result;
 }
 
@@ -63,12 +62,11 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -81,11 +79,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 24576);
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
   const int w_smem_addr = smem + 24576;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
   const int warp_partials_addr = smem + 221184;
 
   // === Task calls (dependency order) ===
@@ -125,27 +123,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
         if (k_base < 3072) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
                   (tokens[pp_1] * 3072 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    3072 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -173,27 +165,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
       int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 3072) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           ".reg .b16 h_lo, h_hi;\n\t"
-                           ".reg .b32 f_lo, f_hi;\n\t"
-                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                           "cvt.f32.f16 f_lo, h_lo;\n\t"
-                           "cvt.f32.f16 f_hi, h_hi;\n\t"
-                           "mov.b64 %0, {f_lo, f_hi};\n\t"
-                           "}\n"
-                           : "=l"(*reinterpret_cast<unsigned long long *>(
-                               &x_values[_pair * 2]))
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -203,35 +194,32 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 3072) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
-                                rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             ".reg .b16 h_lo, h_hi;\n\t"
-                             ".reg .b32 f_lo, f_hi;\n\t"
-                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                             "cvt.f32.f16 f_lo, h_lo;\n\t"
-                             "cvt.f32.f16 f_hi, h_hi;\n\t"
-                             "mov.b64 %0, {f_lo, f_hi};\n\t"
-                             "}\n"
-                             : "=l"(*reinterpret_cast<unsigned long long *>(
-                                 &w_values[_pair * 2]))
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -265,14 +253,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
       for (int pp_3 = 0; pp_3 < 4; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 3072) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(x_raw) +
-                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -283,13 +269,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
-                                          1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -303,16 +286,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
       int owner_rr = lane % 8;
       int pair_1 = pair_block * 4 + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half *>(
-              reinterpret_cast<__half *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2half_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -347,12 +329,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(
-    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
-    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    int num_pairs, int num_experts, int num_tokens) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -365,11 +346,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
   const int x_smem_addr = smem + 0;
-  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 4096);
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
   const int w_smem_addr = smem + 4096;
-  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
   const int warp_partials_addr = smem + 36864;
 
   // === Task calls (dependency order) ===
@@ -409,27 +390,21 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
         if (k_base < 3072) {
           asm volatile(
               "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr +
-                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
                   (tokens[pp_1] * 3072 + (long long)k_base)));
 #pragma unroll
           for (int rr = 0; rr < 8; rr++) {
             int rank_row = rank_base + rr;
-            long long weight_index =
-                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                 (long long)rank_row) *
-                    3072 +
-                (long long)k_base;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    w_smem_addr +
-                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                    rr * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                    weight_index));
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
           }
         }
       }
@@ -457,27 +432,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
       int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
       if (valid[pp_2] != 0) {
         if (k_base_1 < 3072) {
-          asm volatile(
-              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
-                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
-              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
           {
 #pragma unroll
             for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile("{\n\t"
-                           ".reg .b16 h_lo, h_hi;\n\t"
-                           ".reg .b32 f_lo, f_hi;\n\t"
-                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                           "cvt.f32.f16 f_lo, h_lo;\n\t"
-                           "cvt.f32.f16 f_hi, h_hi;\n\t"
-                           "mov.b64 %0, {f_lo, f_hi};\n\t"
-                           "}\n"
-                           : "=l"(*reinterpret_cast<unsigned long long *>(
-                               &x_values[_pair * 2]))
-                           : "r"(x_carriers[_pair]));
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
             }
           }
         }
@@ -487,35 +461,32 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
         float partial = 0.0f;
         if (valid[pp_2] != 0) {
           if (k_base_1 < 3072) {
-            int w_thread_base =
-                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
-                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             ".reg .b16 h_lo, h_hi;\n\t"
-                             ".reg .b32 f_lo, f_hi;\n\t"
-                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                             "cvt.f32.f16 f_lo, h_lo;\n\t"
-                             "cvt.f32.f16 f_hi, h_hi;\n\t"
-                             "mov.b64 %0, {f_lo, f_hi};\n\t"
-                             "}\n"
-                             : "=l"(*reinterpret_cast<unsigned long long *>(
-                                 &w_values[_pair * 2]))
-                             : "r"(w_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
               }
             }
 #pragma unroll
             for (int element = 0; element < 8; element++) {
-              float _fma_0 =
-                  __fmaf_rn(x_values[element], w_values[element], partial);
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
               partial = _fma_0;
             }
           }
@@ -549,14 +520,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
       for (int pp_3 = 0; pp_3 < 1; pp_3++) {
         if (valid[pp_3] != 0) {
           if (refill_k < 3072) {
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    x_smem_addr +
-                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                    pp_3 * 1024 + tid * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(x_raw) +
-                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
 #pragma unroll
             for (int rr_2 = 0; rr_2 < 8; rr_2++) {
               int rank_row_1 = rank_base + rr_2;
@@ -567,12 +536,10 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
                   (long long)refill_k;
               asm volatile(
                   "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr +
-                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                     2)),
-                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
-                      weight_index_1));
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
             }
           }
         }
@@ -586,16 +553,15 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
       int owner_rr = lane % 8;
       int pair_1 = pair_block + owner_pp;
       if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half *>(
-              reinterpret_cast<__half *>(shrink_out_raw) +
-              (pair_1 * 32 + rank_base + owner_rr)) +
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
           (0)) = __float2half_rn(owned_accum);
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -624,13 +590,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p
 
 extern "C" {
 
-__global__
-__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -643,7 +608,7 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -669,13 +634,11 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -691,76 +654,69 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               ".reg .b16 h_lo, h_hi;\n\t"
-                               ".reg .b32 f_lo, f_hi;\n\t"
-                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                               "cvt.f32.f16 f_lo, h_lo;\n\t"
-                               "cvt.f32.f16 f_hi, h_hi;\n\t"
-                               "mov.b64 %0, {f_lo, f_hi};\n\t"
-                               "}\n"
-                               : "=l"(*reinterpret_cast<unsigned long long *>(
-                                   &activation_values[_pair * 2]))
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
             float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
             total = _fma_1;
           }
-          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
-                                                 output_offset + output_col)) +
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
             (0)) = total;
         }
       } else if (output_col < 3072) {
@@ -775,89 +731,82 @@ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_1[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
                   }
                 }
               }
               long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col_1;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index_1 + 0);
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_2[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                              route_partial_1);
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                 route_partial_1 = _fma_2;
               }
             }
-            float _fma_3 =
-                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
             total_1 = _fma_3;
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total_1;
       }
     } else if (output_col < 3072) {
-      *(reinterpret_cast<float *>(
-            y_accum + (token * output_stride + output_offset + output_col)) +
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
         (0)) = 0.0f;
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -876,11 +825,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h3072_r32_t128(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -905,74 +854,69 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
               int rank_col = rank_block * 8;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(shrink_raw) +
-                    (pair * 32 + rank_col) + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_1[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element],
-                                         _vec_load_1[element], partial);
+                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
                 partial = _fma_0;
               }
             }
-            atomicAdd(
-                &y_accum[token * (long long)output_stride +
-                         (long long)output_offset + (long long)output_col],
-                partial * topk_weights[pair]);
+            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
+                               (long long)output_col],
+                      partial * topk_weights[pair]);
           }
         }
       }
@@ -980,7 +924,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -996,13 +940,12 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
 
 extern "C" {
 
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -1015,7 +958,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1041,13 +984,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
           if (tid < 8) {
             int stage_route = tid / 4;
             int stage_rank_block = tid % 4;
-            asm volatile(
-                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                    shrink_stage_addr +
-                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                   2)),
-                "l"(reinterpret_cast<const __half *>(shrink_raw) +
-                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
           }
           asm volatile("cp.async.commit_group;");
           asm volatile("cp.async.wait_group 0;");
@@ -1061,68 +1002,61 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
             for (int rank_block = 0; rank_block < 4; rank_block++) {
               int rank_col = rank_block * 8;
               asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t *>(
-                                 &activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr +
-                                 (unsigned int)((route * 32 + rank_col) * 2)));
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
               {
 #pragma unroll
                 for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile("{\n\t"
-                               ".reg .b16 h_lo, h_hi;\n\t"
-                               ".reg .b32 f_lo, f_hi;\n\t"
-                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                               "cvt.f32.f16 f_lo, h_lo;\n\t"
-                               "cvt.f32.f16 f_hi, h_hi;\n\t"
-                               "mov.b64 %0, {f_lo, f_hi};\n\t"
-                               "}\n"
-                               : "=l"(*reinterpret_cast<unsigned long long *>(
-                                   &activation_values[_pair * 2]))
-                               : "r"(activation_carriers[_pair]));
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
                 }
               }
               long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
                 route_partial = _fma_0;
               }
             }
@@ -1140,15 +1074,13 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
                 int rank_col_1 = rank_block_1 * 8;
                 float _vec_load_1[8];
                 {
-                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(shrink_raw) +
-                      (pair_1 * 32 + rank_col_1) + 0);
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
                   uint4 _vld_1[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t *_vpairs_1 =
-                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1160,28 +1092,25 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_1[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_1[_pair]));
                     }
                   }
                 }
                 long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                     (long long)output_col) *
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
                         32 +
                     (long long)rank_col_1;
                 float _vec_load_2[8];
                 {
-                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(lora_b_raw) +
-                      weight_index_1 + 0);
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
                   uint4 _vld_2[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t *_vpairs_2 =
-                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1193,7 +1122,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_2[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_2[_pair]));
                     }
@@ -1202,30 +1131,26 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072
 #pragma unroll
                 for (int element_1 = 0; element_1 < 8; element_1++) {
                   float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
-                                route_partial_1);
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
                   route_partial_1 = _fma_2;
                 }
               }
-              float _fma_3 =
-                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
               total = _fma_3;
             }
           }
         }
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = total;
       } else {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col)) +
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -1248,11 +1173,11 @@ extern "C" {
 
 __global__
 __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(
-    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
-    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
-    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
-    float *__restrict__ topk_weights, int num_pairs, int num_experts,
-    int num_tokens, int output_stride, int output_offset) {
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
   const int tid = threadIdx.x;
   const int warp = make_warp_uniform(tid / 32);
   const int lane = tid % 32;
@@ -1265,7 +1190,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
   const int num_bids = gridDim.x;
 
   // Kernel setup ops
-  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
   const int shrink_stage_addr = smem + 0;
 
   // === Task calls (dependency order) ===
@@ -1302,13 +1227,11 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
         if (tid < 8) {
           int stage_route = tid / 4;
           int stage_rank_block = tid % 4;
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  shrink_stage_addr +
-                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
-                                 2)),
-              "l"(reinterpret_cast<const __half *>(shrink_raw) +
-                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
         }
         asm volatile("cp.async.commit_group;");
         asm volatile("cp.async.wait_group 0;");
@@ -1322,123 +1245,111 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
           for (int rank_block = 0; rank_block < 4; rank_block++) {
             int rank_col = rank_block * 8;
-            asm volatile(
-                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 1])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 2])),
-                  "=r"(*reinterpret_cast<uint32_t *>(
-                      &activation_carriers[(0) + 3]))
-                : "r"(shrink_stage_addr +
-                      (unsigned int)((route * 32 + rank_col) * 2)));
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
             {
 #pragma unroll
               for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile("{\n\t"
-                             ".reg .b16 h_lo, h_hi;\n\t"
-                             ".reg .b32 f_lo, f_hi;\n\t"
-                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                             "cvt.f32.f16 f_lo, h_lo;\n\t"
-                             "cvt.f32.f16 f_hi, h_hi;\n\t"
-                             "mov.b64 %0, {f_lo, f_hi};\n\t"
-                             "}\n"
-                             : "=l"(*reinterpret_cast<unsigned long long *>(
-                                 &activation_values[_pair * 2]))
-                             : "r"(activation_carriers[_pair]));
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                    : "r"(activation_carriers[_pair]));
               }
             }
             if (valid0 != 0) {
               long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col0) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) *
                       32 +
                   (long long)rank_col;
               float _vec_load_0[8];
               {
-                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index0 + 0);
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
                 uint4 _vld_0[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t *_vpairs_0 =
-                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_0[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(activation_values[element],
-                                         _vec_load_0[element], route_partial0);
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
                 route_partial0 = _fma_0;
               }
             }
             if (valid1 != 0) {
               long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 +
-                   (long long)output_col1) *
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) *
                       32 +
                   (long long)rank_col;
               float _vec_load_1[8];
               {
-                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(lora_b_raw) +
-                    weight_index1 + 0);
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
                 uint4 _vld_1[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t *_vpairs_1 =
-                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_1[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
                   }
                 }
               }
 #pragma unroll
               for (int element_1 = 0; element_1 < 8; element_1++) {
                 float _fma_1 =
-                    __fmaf_rn(activation_values[element_1],
-                              _vec_load_1[element_1], route_partial1);
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
                 route_partial1 = _fma_1;
               }
             }
           }
           if (valid0 != 0) {
-            float _fma_2 =
-                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
             total0 = _fma_2;
           }
           if (valid1 != 0) {
-            float _fma_3 =
-                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
             total1 = _fma_3;
           }
         }
@@ -1454,48 +1365,44 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
               int rank_col_1 = rank_block_1 * 8;
               float _vec_load_2[8];
               {
-                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
-                    reinterpret_cast<const __half *>(shrink_raw) +
-                    (pair_1 * 32 + rank_col_1) + 0);
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
                 uint4 _vld_2[1];
 #pragma unroll
                 for (int _blk = 0; _blk < 1; _blk++) {
                   _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t *_vpairs_2 =
-                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
 #pragma unroll
                   for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile("{\n\t"
-                                 ".reg .b16 h_lo, h_hi;\n\t"
-                                 ".reg .b32 f_lo, f_hi;\n\t"
-                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                 "}\n"
-                                 : "=l"(*reinterpret_cast<unsigned long long *>(
-                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                 : "r"(_vpairs_2[_pair]));
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
                   }
                 }
               }
               if (valid0 != 0) {
-                long long weight_index0_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                     (long long)output_col0) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_3[8];
                 {
-                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(lora_b_raw) +
-                      weight_index0_1 + 0);
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
                   uint4 _vld_3[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t *_vpairs_3 =
-                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1507,7 +1414,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_3[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_3[_pair]));
                     }
@@ -1516,28 +1423,24 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_2 = 0; element_2 < 8; element_2++) {
                   float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
-                                route_partial0_1);
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
                   route_partial0_1 = _fma_4;
                 }
               }
               if (valid1 != 0) {
-                long long weight_index1_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                     (long long)output_col1) *
-                        32 +
-                    (long long)rank_col_1;
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
                 float _vec_load_4[8];
                 {
-                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
-                      reinterpret_cast<const __half *>(lora_b_raw) +
-                      weight_index1_1 + 0);
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
                   uint4 _vld_4[1];
 #pragma unroll
                   for (int _blk = 0; _blk < 1; _blk++) {
                     _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t *_vpairs_4 =
-                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
 #pragma unroll
                     for (int _pair = 0; _pair < 4; _pair++) {
                       asm volatile(
@@ -1549,7 +1452,7 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
                           "cvt.f32.f16 f_hi, h_hi;\n\t"
                           "mov.b64 %0, {f_lo, f_hi};\n\t"
                           "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
                               &_vec_load_4[0 + _blk * 8 + _pair * 2]))
                           : "r"(_vpairs_4[_pair]));
                     }
@@ -1558,51 +1461,48 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_
 #pragma unroll
                 for (int element_3 = 0; element_3 < 8; element_3++) {
                   float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
-                                route_partial1_1);
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
                   route_partial1_1 = _fma_5;
                 }
               }
             }
             if (valid0 != 0) {
-              float _fma_6 =
-                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
               total0 = _fma_6;
             }
             if (valid1 != 0) {
-              float _fma_7 =
-                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
               total1 = _fma_7;
             }
           }
         }
       }
       if (valid0 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = total0;
       }
       if (valid1 != 0) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = total1;
       }
     } else {
       if (output_col0 < 3072) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col0)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
           (0)) = 0.0f;
       }
       if (output_col1 < 3072) {
-        *(reinterpret_cast<float *>(
-              y_accum + (token * output_stride + output_offset + output_col1)) +
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
           (0)) = 0.0f;
       }
     }
   }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
@@ -17,26 +17,32 @@
 // Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
-template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
+template <int N> struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+               : "=r"(result)
+               : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,205 +63,253 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    3072 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           ".reg .b16 h_lo, h_hi;\n\t"
+                           ".reg .b32 f_lo, f_hi;\n\t"
+                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                           "cvt.f32.f16 f_lo, h_lo;\n\t"
+                           "cvt.f32.f16 f_hi, h_hi;\n\t"
+                           "mov.b64 %0, {f_lo, f_hi};\n\t"
+                           "}\n"
+                           : "=l"(*reinterpret_cast<unsigned long long *>(
+                               &x_values[_pair * 2]))
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 +
+                                rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             ".reg .b16 h_lo, h_hi;\n\t"
+                             ".reg .b32 f_lo, f_hi;\n\t"
+                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                             "cvt.f32.f16 f_lo, h_lo;\n\t"
+                             "cvt.f32.f16 f_hi, h_hi;\n\t"
+                             "mov.b64 %0, {f_lo, f_hi};\n\t"
+                             "}\n"
+                             : "=l"(*reinterpret_cast<unsigned long long *>(
+                                 &w_values[_pair * 2]))
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(x_raw) +
+                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 *
+                                          1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half *>(
+              reinterpret_cast<__half *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -293,205 +347,252 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(
+    uint16_t *__restrict__ shrink_out_raw, uint16_t *__restrict__ x_raw,
+    uint16_t *__restrict__ lora_a_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    int num_pairs, int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __half *x_smem = reinterpret_cast<__half *>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half *w_smem = reinterpret_cast<__half *>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float *warp_partials = reinterpret_cast<float *>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr +
+                  (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index =
+                ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                 (long long)rank_row) *
+                    3072 +
+                (long long)k_base;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    w_smem_addr +
+                    (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                    rr * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                    weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile(
+              "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+              : "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[0])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 1])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 2])),
+                "=r"(*reinterpret_cast<uint32_t *>(&x_carriers[(0) + 3]))
+              : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile("{\n\t"
+                           ".reg .b16 h_lo, h_hi;\n\t"
+                           ".reg .b32 f_lo, f_hi;\n\t"
+                           "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                           "cvt.f32.f16 f_lo, h_lo;\n\t"
+                           "cvt.f32.f16 f_hi, h_hi;\n\t"
+                           "mov.b64 %0, {f_lo, f_hi};\n\t"
+                           "}\n"
+                           : "=l"(*reinterpret_cast<unsigned long long *>(
+                               &x_values[_pair * 2]))
+                           : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base =
+                tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(&w_carriers[(0) + 3]))
+                : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             ".reg .b16 h_lo, h_hi;\n\t"
+                             ".reg .b32 f_lo, f_hi;\n\t"
+                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                             "cvt.f32.f16 f_lo, h_lo;\n\t"
+                             "cvt.f32.f16 f_hi, h_hi;\n\t"
+                             "mov.b64 %0, {f_lo, f_hi};\n\t"
+                             "}\n"
+                             : "=l"(*reinterpret_cast<unsigned long long *>(
+                                 &w_values[_pair * 2]))
+                             : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 =
+                  __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    x_smem_addr +
+                    (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                    pp_3 * 1024 + tid * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(x_raw) +
+                    (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr +
+                      (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                      pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                     2)),
+                  "l"(reinterpret_cast<const __half *>(lora_a_raw) +
+                      weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half *>(
+              reinterpret_cast<__half *>(shrink_out_raw) +
+              (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
 } // extern "C"
@@ -523,193 +624,237 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 3072) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 3072) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 3072) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+        if (output_col < 3072) {
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               ".reg .b16 h_lo, h_hi;\n\t"
+                               ".reg .b32 f_lo, f_hi;\n\t"
+                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                               "cvt.f32.f16 f_lo, h_lo;\n\t"
+                               "cvt.f32.f16 f_hi, h_hi;\n\t"
+                               "mov.b64 %0, {f_lo, f_hi};\n\t"
+                               "}\n"
+                               : "=l"(*reinterpret_cast<unsigned long long *>(
+                                   &activation_values[_pair * 2]))
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float *>(y_accum + (token * output_stride +
+                                                 output_offset + output_col)) +
+            (0)) = total;
+        }
+      } else if (output_col < 3072) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                              route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 =
+                __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 3072) {
+      *(reinterpret_cast<float *>(
+            y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
 } // extern "C"
@@ -729,93 +874,110 @@ kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(float* __restrict__ y_
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h3072_r32_t128(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h3072_r32_t128(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // === Task calls (dependency order) ===
-    int pair = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    if (pair < num_pairs) {
-        if (output_col < 3072) {
-            long long token = sorted_token_ids[pair];
-            if (token >= 0) {
-                if (token < (long long)num_tokens) {
-                    long long lora_id = lora_indices[token];
-                    if (lora_id >= 0) {
-                        long long expert = expert_ids[pair];
-                        float partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                                partial = _fma_0;
-                            }
-                        }
-                        atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset + (long long)output_col], partial * topk_weights[pair]);
-                    }
+  // === Task calls (dependency order) ===
+  int pair = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  if (pair < num_pairs) {
+    if (output_col < 3072) {
+      long long token = sorted_token_ids[pair];
+      if (token >= 0) {
+        if (token < (long long)num_tokens) {
+          long long lora_id = lora_indices[token];
+          if (lora_id >= 0) {
+            long long expert = expert_ids[pair];
+            float partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(shrink_raw) +
+                    (pair * 32 + rank_col) + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
                 }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(_vec_load_0[element],
+                                         _vec_load_1[element], partial);
+                partial = _fma_0;
+              }
             }
+            atomicAdd(
+                &y_accum[token * (long long)output_stride +
+                         (long long)output_offset + (long long)output_col],
+                partial * topk_weights[pair]);
+          }
         }
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -834,189 +996,233 @@ kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h3072_r32_t128(float* __restric
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        if (output_col < 3072) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 3072) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
+          }
         }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile(
+                "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                    shrink_stage_addr +
+                    (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                   2)),
+                "l"(reinterpret_cast<const __half *>(shrink_raw) +
+                    ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t *>(
+                                 &activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr +
+                                 (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile("{\n\t"
+                               ".reg .b16 h_lo, h_hi;\n\t"
+                               ".reg .b32 f_lo, f_hi;\n\t"
+                               "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                               "cvt.f32.f16 f_lo, h_lo;\n\t"
+                               "cvt.f32.f16 f_hi, h_hi;\n\t"
+                               "mov.b64 %0, {f_lo, f_hi};\n\t"
+                               "}\n"
+                               : "=l"(*reinterpret_cast<unsigned long long *>(
+                                   &activation_values[_pair * 2]))
+                               : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
+            }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(shrink_raw) +
+                      (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t *_vpairs_1 =
+                        reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                     (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(lora_b_raw) +
+                      weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t *_vpairs_2 =
+                        reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1],
+                                route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 =
+                  __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
+            }
+          }
+        }
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"
@@ -1040,291 +1246,360 @@ kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(float* __restrict__ y_accu
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(
+    float *__restrict__ y_accum, uint16_t *__restrict__ shrink_raw,
+    uint16_t *__restrict__ lora_b_raw, long long *__restrict__ sorted_token_ids,
+    long long *__restrict__ expert_ids, long long *__restrict__ lora_indices,
+    float *__restrict__ topk_weights, int num_pairs, int num_experts,
+    int num_tokens, int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half *shrink_stage = reinterpret_cast<__half *>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 3072) {
-                valid0 = 1;
-            }
-            if (output_col1 < 3072) {
-                valid1 = 1;
-            }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 3072) {
+        valid0 = 1;
+      }
+      if (output_col1 < 3072) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  shrink_stage_addr +
+                  (unsigned int)((stage_route * 32 + stage_rank_block * 8) *
+                                 2)),
+              "l"(reinterpret_cast<const __half *>(shrink_raw) +
+                  ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile(
+                "ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                : "=r"(*reinterpret_cast<uint32_t *>(&activation_carriers[0])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 1])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 2])),
+                  "=r"(*reinterpret_cast<uint32_t *>(
+                      &activation_carriers[(0) + 3]))
+                : "r"(shrink_stage_addr +
+                      (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile("{\n\t"
+                             ".reg .b16 h_lo, h_hi;\n\t"
+                             ".reg .b32 f_lo, f_hi;\n\t"
+                             "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                             "cvt.f32.f16 f_lo, h_lo;\n\t"
+                             "cvt.f32.f16 f_hi, h_hi;\n\t"
+                             "mov.b64 %0, {f_lo, f_hi};\n\t"
+                             "}\n"
+                             : "=l"(*reinterpret_cast<unsigned long long *>(
+                                 &activation_values[_pair * 2]))
+                             : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4 *_vptr_0 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t *_vpairs_0 =
+                      reinterpret_cast<uint32_t *>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 = __fmaf_rn(activation_values[element],
+                                         _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 +
+                   (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4 *_vptr_1 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(lora_b_raw) +
+                    weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t *_vpairs_1 =
+                      reinterpret_cast<uint32_t *>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1],
+                              _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 =
+                __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 =
+                __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4 *_vptr_2 = reinterpret_cast<const uint4 *>(
+                    reinterpret_cast<const __half *>(shrink_raw) +
+                    (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t *_vpairs_2 =
+                      reinterpret_cast<uint32_t *>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile("{\n\t"
+                                 ".reg .b16 h_lo, h_hi;\n\t"
+                                 ".reg .b32 f_lo, f_hi;\n\t"
+                                 "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                 "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                 "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                 "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                 "}\n"
+                                 : "=l"(*reinterpret_cast<unsigned long long *>(
+                                     &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                 : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                     (long long)output_col0) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4 *_vptr_3 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(lora_b_raw) +
+                      weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t *_vpairs_3 =
+                        reinterpret_cast<uint32_t *>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2],
+                                route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                     (long long)output_col1) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4 *_vptr_4 = reinterpret_cast<const uint4 *>(
+                      reinterpret_cast<const __half *>(lora_b_raw) +
+                      weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t *_vpairs_4 =
+                        reinterpret_cast<uint32_t *>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long *>(
+                              &_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3],
+                                route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 =
+                  __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 =
+                  __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 3072) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 3072) {
+        *(reinterpret_cast<float *>(
+              y_accum + (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
 } // extern "C"

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
@@ -972,10 +972,12 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_toke
       if (lora_id >= 0) {
         int pair_base = token * 2;
         int contiguous = 0;
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
           }
         }

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
@@ -17,26 +17,31 @@
 // Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char        int8_t;
-typedef unsigned char      uint8_t;
-typedef unsigned short     uint16_t;
-typedef unsigned int       uint32_t;
+typedef signed char int8_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int         int32_t;
-typedef short int          int16_t;
-struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
+typedef signed int int32_t;
+typedef short int int16_t;
+struct __align__(128) BlackwellTensorMap {
+  uint64_t opaque[16];
+};
 template <int N>
-struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
+struct __align__(128) BlackwellTensorMapPack {
+  BlackwellTensorMap maps[N];
+};
 
-typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
+typedef struct __align__(64) {
+  uint64_t opaque[16];
+} CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-    int result;
-    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
-                 : "=r"(result) : "r"(x));
-    return result;
+  int result;
+  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
+  return result;
 }
 
 #include <math_constants.h>
@@ -57,208 +62,239 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
-    const int w_smem_addr = smem + 24576;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-    const int warp_partials_addr = smem + 221184;
+  // Kernel setup ops
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
+  const int w_smem_addr = smem + 24576;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+  const int warp_partials_addr = smem + 221184;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[4];
-    long long experts[4];
-    long long loras[4];
-    int valid[4];
-    #pragma unroll
-    for (int pp = 0; pp < 4; pp++) {
-        int pair = pair_block * 4 + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[4];
+  long long experts[4];
+  long long loras[4];
+  int valid[4];
+#pragma unroll
+  for (int pp = 0; pp < 4; pp++) {
+    int pair = pair_block * 4 + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
+                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 2;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 32) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 3 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 2;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 32) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block * 4 + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 32) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 3 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 32) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block * 4 + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -293,208 +329,239 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(
+    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
+    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
+    int num_experts, int num_tokens) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-    const int x_smem_addr = smem + 0;
-    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
-    const int w_smem_addr = smem + 4096;
-    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-    const int warp_partials_addr = smem + 36864;
+  // Kernel setup ops
+  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+  const int x_smem_addr = smem + 0;
+  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
+  const int w_smem_addr = smem + 4096;
+  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+  const int warp_partials_addr = smem + 36864;
 
-    // === Task calls (dependency order) ===
-    int pair_block = blockIdx.x;
-    int rank_block = blockIdx.y;
-    int rank_base = rank_block * 8;
-    long long tokens[1];
-    long long experts[1];
-    long long loras[1];
-    int valid[1];
-    #pragma unroll
-    for (int pp = 0; pp < 1; pp++) {
-        int pair = pair_block + pp;
-        tokens[pp] = -1;
-        experts[pp] = -1;
-        loras[pp] = -1;
-        valid[pp] = 0;
-        if (pair < num_pairs) {
-            tokens[pp] = sorted_token_ids[pair];
-            experts[pp] = expert_ids[pair];
-            if (tokens[pp] >= 0) {
-                if (tokens[pp] < (long long)num_tokens) {
-                    loras[pp] = lora_indices[tokens[pp]];
-                    if (loras[pp] >= 0) {
-                        valid[pp] = 1;
-                    }
-                }
-            }
+  // === Task calls (dependency order) ===
+  int pair_block = blockIdx.x;
+  int rank_block = blockIdx.y;
+  int rank_base = rank_block * 8;
+  long long tokens[1];
+  long long experts[1];
+  long long loras[1];
+  int valid[1];
+#pragma unroll
+  for (int pp = 0; pp < 1; pp++) {
+    int pair = pair_block + pp;
+    tokens[pp] = -1;
+    experts[pp] = -1;
+    loras[pp] = -1;
+    valid[pp] = 0;
+    if (pair < num_pairs) {
+      tokens[pp] = sorted_token_ids[pair];
+      experts[pp] = expert_ids[pair];
+      if (tokens[pp] >= 0) {
+        if (tokens[pp] < (long long)num_tokens) {
+          loras[pp] = lora_indices[tokens[pp]];
+          if (loras[pp] >= 0) {
+            valid[pp] = 1;
+          }
         }
+      }
     }
-    #pragma unroll
-    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-        int k_base = tile * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-            if (valid[pp_1] != 0) {
-                if (k_base < 3072) {
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
-                    #pragma unroll
-                    for (int rr = 0; rr < 8; rr++) {
-                        int rank_row = rank_base + rr;
-                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-                    }
-                }
-            }
+  }
+#pragma unroll
+  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+    int k_base = tile * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+      if (valid[pp_1] != 0) {
+        if (k_base < 3072) {
+          asm volatile(
+              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
+              "l"(reinterpret_cast<const __half*>(x_raw) +
+                  (tokens[pp_1] * 3072 + (long long)k_base)));
+#pragma unroll
+          for (int rr = 0; rr < 8; rr++) {
+            int rank_row = rank_base + rr;
+            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
+                                      (long long)rank_row) *
+                                         3072 +
+                                     (long long)k_base;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
+                                                           rr * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+          }
         }
-        asm volatile("cp.async.commit_group;");
+      }
     }
-    float owned_accum = 0.0f;
-    unsigned int x_carriers[4];
-    unsigned int w_carriers[4];
-    float x_values[8];
-    float w_values[8];
-    #pragma unroll
-    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-        if (3 - tile_1 - 1 == 0) {
-            asm volatile("cp.async.wait_group 0;");
-        } else if (3 - tile_1 - 1 == 1) {
-            asm volatile("cp.async.wait_group 1;");
-        } else {
-            asm volatile("cp.async.wait_group 1;");
-        }
-        __syncthreads();
-        int k_base_1 = tile_1 * 1024 + tid * 8;
-        #pragma unroll
-        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-            if (valid[pp_2] != 0) {
-                if (k_base_1 < 3072) {
-                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-                    {
-                        #pragma unroll
-                        for (int _pair = 0; _pair < 4; _pair++) {
-                            asm volatile(
-                                "{\n\t"
-                                ".reg .b16 h_lo, h_hi;\n\t"
-                                ".reg .b32 f_lo, f_hi;\n\t"
-                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                "}\n"
-                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                                : "r"(x_carriers[_pair]));
-                        }
-                    }
-                }
-            }
-            #pragma unroll
-            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-                float partial = 0.0f;
-                if (valid[pp_2] != 0) {
-                    if (k_base_1 < 3072) {
-                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                                    : "r"(w_carriers[_pair]));
-                            }
-                        }
-                        #pragma unroll
-                        for (int element = 0; element < 8; element++) {
-                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-                            partial = _fma_0;
-                        }
-                    }
-                }
-                float _warp_reduce_0 = partial;
-                #pragma unroll
-                for (int offset = 16; offset > 0; offset >>= 1)
-                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-                partial = _warp_reduce_0;
-                if (lane == 0) {
-                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-                }
-            }
-        }
-        __syncthreads();
-        if (warp == 0) {
-            if (lane < 8) {
-                int owner_index = lane;
-                float cta_partial = 0.0f;
-                #pragma unroll
-                for (int source_warp = 0; source_warp < 4; source_warp++) {
-                    cta_partial += warp_partials[owner_index * 4 + source_warp];
-                }
-                owned_accum += cta_partial;
-            }
-        }
-        __syncthreads();
-        if (tile_1 + ((1) ? 2 : 3) < 3) {
-            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-            #pragma unroll
-            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-                if (valid[pp_3] != 0) {
-                    if (refill_k < 3072) {
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
-                        #pragma unroll
-                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-                            int rank_row_1 = rank_base + rr_2;
-                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
-                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
-                        }
-                    }
-                }
-            }
-            asm volatile("cp.async.commit_group;");
-        }
+    asm volatile("cp.async.commit_group;");
+  }
+  float owned_accum = 0.0f;
+  unsigned int x_carriers[4];
+  unsigned int w_carriers[4];
+  float x_values[8];
+  float w_values[8];
+#pragma unroll
+  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+    if (3 - tile_1 - 1 == 0) {
+      asm volatile("cp.async.wait_group 0;");
+    } else if (3 - tile_1 - 1 == 1) {
+      asm volatile("cp.async.wait_group 1;");
+    } else {
+      asm volatile("cp.async.wait_group 1;");
     }
+    __syncthreads();
+    int k_base_1 = tile_1 * 1024 + tid * 8;
+#pragma unroll
+    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+      if (valid[pp_2] != 0) {
+        if (k_base_1 < 3072) {
+          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
+                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+          {
+#pragma unroll
+            for (int _pair = 0; _pair < 4; _pair++) {
+              asm volatile(
+                  "{\n\t"
+                  ".reg .b16 h_lo, h_hi;\n\t"
+                  ".reg .b32 f_lo, f_hi;\n\t"
+                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                  "cvt.f32.f16 f_lo, h_lo;\n\t"
+                  "cvt.f32.f16 f_hi, h_hi;\n\t"
+                  "mov.b64 %0, {f_lo, f_hi};\n\t"
+                  "}\n"
+                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                  : "r"(x_carriers[_pair]));
+            }
+          }
+        }
+      }
+#pragma unroll
+      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+        float partial = 0.0f;
+        if (valid[pp_2] != 0) {
+          if (k_base_1 < 3072) {
+            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                    : "r"(w_carriers[_pair]));
+              }
+            }
+#pragma unroll
+            for (int element = 0; element < 8; element++) {
+              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+              partial = _fma_0;
+            }
+          }
+        }
+        float _warp_reduce_0 = partial;
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1)
+          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+        partial = _warp_reduce_0;
+        if (lane == 0) {
+          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+        }
+      }
+    }
+    __syncthreads();
     if (warp == 0) {
-        if (lane < 8) {
-            int owner_pp = lane / 8;
-            int owner_rr = lane % 8;
-            int pair_1 = pair_block + owner_pp;
-            if (pair_1 < num_pairs) {
-                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
-            }
+      if (lane < 8) {
+        int owner_index = lane;
+        float cta_partial = 0.0f;
+#pragma unroll
+        for (int source_warp = 0; source_warp < 4; source_warp++) {
+          cta_partial += warp_partials[owner_index * 4 + source_warp];
         }
+        owned_accum += cta_partial;
+      }
     }
+    __syncthreads();
+    if (tile_1 + ((1) ? 2 : 3) < 3) {
+      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+#pragma unroll
+      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+        if (valid[pp_3] != 0) {
+          if (refill_k < 3072) {
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
+                                                           pp_3 * 1024 + tid * 8) *
+                                                          2)),
+                         "l"(reinterpret_cast<const __half*>(x_raw) +
+                             (tokens[pp_3] * 3072 + (long long)refill_k)));
+#pragma unroll
+            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+              int rank_row_1 = rank_base + rr_2;
+              long long weight_index_1 =
+                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
+                   (long long)rank_row_1) *
+                      3072 +
+                  (long long)refill_k;
+              asm volatile(
+                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
+                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
+                                                   2)),
+                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+            }
+          }
+        }
+      }
+      asm volatile("cp.async.commit_group;");
+    }
+  }
+  if (warp == 0) {
+    if (lane < 8) {
+      int owner_pp = lane / 8;
+      int owner_rr = lane % 8;
+      int pair_1 = pair_block + owner_pp;
+      if (pair_1 < num_pairs) {
+        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
+                                    (pair_1 * 32 + rank_base + owner_rr)) +
+          (0)) = __float2half_rn(owned_accum);
+      }
+    }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -523,404 +590,223 @@ kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(uint16_t* __restrict__ shr
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 64 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 64 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
             }
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                if (output_col < 3072) {
-                    float total = 0.0f;
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-                }
-            } else if (output_col < 3072) {
-                float total_1 = 0.0f;
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                route_partial_1 = _fma_2;
-                            }
-                        }
-                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-                        total_1 = _fma_3;
-                    }
-                }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
-            }
-        } else if (output_col < 3072) {
-            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+          }
         }
-    }
-}
-
-} // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
-
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
-
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
-
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col = blockIdx.y * 128 + tid;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
+      }
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
         if (output_col < 3072) {
-            long long lora_id = lora_indices[token];
-            if (lora_id >= 0) {
-                int pair_base = token * 2;
-                int contiguous = 0;
-                if (num_pairs == num_tokens * 2) {
-                    if (pair_base + 1 < num_pairs) {
-                        if (sorted_token_ids[pair_base] == (long long)token) {
-                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                                contiguous = 1;
-                            }
-                        }
-                    }
+          float total = 0.0f;
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
                 }
-                float total = 0.0f;
-                if (contiguous != 0) {
-                    if (tid < 8) {
-                        int stage_route = tid / 4;
-                        int stage_rank_block = tid % 4;
-                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                    }
-                    asm volatile("cp.async.commit_group;");
-                    asm volatile("cp.async.wait_group 0;");
-                    __syncthreads();
-                    #pragma unroll
-                    for (int route = 0; route < 2; route++) {
-                        int pair = pair_base + route;
-                        long long expert = expert_ids[pair];
-                        float route_partial = 0.0f;
-                        #pragma unroll
-                        for (int rank_block = 0; rank_block < 4; rank_block++) {
-                            int rank_col = rank_block * 8;
-                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                            {
-                                #pragma unroll
-                                for (int _pair = 0; _pair < 4; _pair++) {
-                                    asm volatile(
-                                        "{\n\t"
-                                        ".reg .b16 h_lo, h_hi;\n\t"
-                                        ".reg .b32 f_lo, f_hi;\n\t"
-                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                        "}\n"
-                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                        : "r"(activation_carriers[_pair]));
-                                }
-                            }
-                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                                route_partial = _fma_0;
-                            }
-                        }
-                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-                        total = _fma_1;
-                    }
-                } else {
-                    #pragma unroll 1
-                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                        if (sorted_token_ids[pair_1] == (long long)token) {
-                            long long expert_1 = expert_ids[pair_1];
-                            float route_partial_1 = 0.0f;
-                            #pragma unroll
-                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                                int rank_col_1 = rank_block_1 * 8;
-                                float _vec_load_1[8];
-                                {
-                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                    uint4 _vld_1[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_1[_blk] = _vptr_1[_blk];
-                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_1[_pair]));
-                                        }
-                                    }
-                                }
-                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
-                                float _vec_load_2[8];
-                                {
-                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                                    uint4 _vld_2[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_2[_blk] = _vptr_2[_blk];
-                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_2[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_1 = 0; element_1 < 8; element_1++) {
-                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                                    route_partial_1 = _fma_2;
-                                }
-                            }
-                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-                            total = _fma_3;
-                        }
-                    }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
+                  }
                 }
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
-            } else {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+          *(reinterpret_cast<float*>(y_accum +
+                                     (token * output_stride + output_offset + output_col)) +
+            (0)) = total;
         }
+      } else if (output_col < 3072) {
+        float total_1 = 0.0f;
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+              long long weight_index_1 =
+                  ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col_1;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_2 =
+                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                route_partial_1 = _fma_2;
+              }
+            }
+            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+            total_1 = _fma_3;
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total_1;
+      }
+    } else if (output_col < 3072) {
+      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+        (0)) = 0.0f;
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -941,294 +827,571 @@ kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(float* __restrict__ y_accu
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void
-kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
-{
-    const int tid = threadIdx.x;
-    const int warp = make_warp_uniform(tid / 32);
-    const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
 
-    extern __shared__ __align__(1024) char smem_raw[];
-    int smem;
-    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-    const int bid = blockIdx.x;
-    const int num_bids = gridDim.x;
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
 
-    // Kernel setup ops
-    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-    const int shrink_stage_addr = smem + 0;
+  // Kernel setup ops
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
 
-    // === Task calls (dependency order) ===
-    int token = blockIdx.x;
-    int output_col0 = blockIdx.y * 256 + tid;
-    int output_col1 = output_col0 + 128;
-    unsigned int activation_carriers[4];
-    float activation_values[8];
-    if (token < num_tokens) {
-        long long lora_id = lora_indices[token];
-        if (lora_id >= 0) {
-            int pair_base = token * 2;
-            int contiguous = 0;
-            if (num_pairs == num_tokens * 2) {
-                if (pair_base + 1 < num_pairs) {
-                    if (sorted_token_ids[pair_base] == (long long)token) {
-                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                            contiguous = 1;
-                        }
-                    }
-                }
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col = blockIdx.y * 128 + tid;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    if (output_col < 3072) {
+      long long lora_id = lora_indices[token];
+      if (lora_id >= 0) {
+        int pair_base = token * 2;
+        int contiguous = 0;
+        if (num_pairs == num_tokens * 2) {
+          if (pair_base + 1 < num_pairs) {
+            if (sorted_token_ids[pair_base] == (long long)token) {
+              if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                contiguous = 1;
+              }
             }
-            int valid0 = 0;
-            int valid1 = 0;
-            if (output_col0 < 3072) {
-                valid0 = 1;
+          }
+        }
+        float total = 0.0f;
+        if (contiguous != 0) {
+          if (tid < 8) {
+            int stage_route = tid / 4;
+            int stage_rank_block = tid % 4;
+            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                             shrink_stage_addr +
+                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                         "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+          }
+          asm volatile("cp.async.commit_group;");
+          asm volatile("cp.async.wait_group 0;");
+          __syncthreads();
+#pragma unroll
+          for (int route = 0; route < 2; route++) {
+            int pair = pair_base + route;
+            long long expert = expert_ids[pair];
+            float route_partial = 0.0f;
+#pragma unroll
+            for (int rank_block = 0; rank_block < 4; rank_block++) {
+              int rank_col = rank_block * 8;
+              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+              {
+#pragma unroll
+                for (int _pair = 0; _pair < 4; _pair++) {
+                  asm volatile(
+                      "{\n\t"
+                      ".reg .b16 h_lo, h_hi;\n\t"
+                      ".reg .b32 f_lo, f_hi;\n\t"
+                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                      "cvt.f32.f16 f_lo, h_lo;\n\t"
+                      "cvt.f32.f16 f_hi, h_hi;\n\t"
+                      "mov.b64 %0, {f_lo, f_hi};\n\t"
+                      "}\n"
+                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                      : "r"(activation_carriers[_pair]));
+                }
+              }
+              long long weight_index =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                route_partial = _fma_0;
+              }
             }
-            if (output_col1 < 3072) {
-                valid1 = 1;
+            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+            total = _fma_1;
+          }
+        } else {
+#pragma unroll 1
+          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+            if (sorted_token_ids[pair_1] == (long long)token) {
+              long long expert_1 = expert_ids[pair_1];
+              float route_partial_1 = 0.0f;
+#pragma unroll
+              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                int rank_col_1 = rank_block_1 * 8;
+                float _vec_load_1[8];
+                {
+                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                  uint4 _vld_1[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_1[_blk] = _vptr_1[_blk];
+                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_1[_pair]));
+                    }
+                  }
+                }
+                long long weight_index_1 =
+                    ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
+                        32 +
+                    (long long)rank_col_1;
+                float _vec_load_2[8];
+                {
+                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                  uint4 _vld_2[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_2[_blk] = _vptr_2[_blk];
+                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_2[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_1 = 0; element_1 < 8; element_1++) {
+                  float _fma_2 =
+                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                  route_partial_1 = _fma_2;
+                }
+              }
+              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+              total = _fma_3;
             }
-            float total0 = 0.0f;
-            float total1 = 0.0f;
-            if (contiguous != 0) {
-                if (tid < 8) {
-                    int stage_route = tid / 4;
-                    int stage_rank_block = tid % 4;
-                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
-                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-                }
-                asm volatile("cp.async.commit_group;");
-                asm volatile("cp.async.wait_group 0;");
-                __syncthreads();
-                #pragma unroll
-                for (int route = 0; route < 2; route++) {
-                    int pair = pair_base + route;
-                    long long expert = expert_ids[pair];
-                    float route_partial0 = 0.0f;
-                    float route_partial1 = 0.0f;
-                    #pragma unroll
-                    for (int rank_block = 0; rank_block < 4; rank_block++) {
-                        int rank_col = rank_block * 8;
-                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-                        {
-                            #pragma unroll
-                            for (int _pair = 0; _pair < 4; _pair++) {
-                                asm volatile(
-                                    "{\n\t"
-                                    ".reg .b16 h_lo, h_hi;\n\t"
-                                    ".reg .b32 f_lo, f_hi;\n\t"
-                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                    "}\n"
-                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                                    : "r"(activation_carriers[_pair]));
-                            }
-                        }
-                        if (valid0 != 0) {
-                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
-                            float _vec_load_0[8];
-                            {
-                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
-                                uint4 _vld_0[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_0[_blk] = _vptr_0[_blk];
-                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_0[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element = 0; element < 8; element++) {
-                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                                route_partial0 = _fma_0;
-                            }
-                        }
-                        if (valid1 != 0) {
-                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
-                            float _vec_load_1[8];
-                            {
-                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
-                                uint4 _vld_1[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_1[_blk] = _vptr_1[_blk];
-                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_1[_pair]));
-                                    }
-                                }
-                            }
-                            #pragma unroll
-                            for (int element_1 = 0; element_1 < 8; element_1++) {
-                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                                route_partial1 = _fma_1;
-                            }
-                        }
-                    }
-                    if (valid0 != 0) {
-                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-                        total0 = _fma_2;
-                    }
-                    if (valid1 != 0) {
-                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-                        total1 = _fma_3;
-                    }
-                }
-            } else {
-                #pragma unroll 1
-                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-                    if (sorted_token_ids[pair_1] == (long long)token) {
-                        long long expert_1 = expert_ids[pair_1];
-                        float route_partial0_1 = 0.0f;
-                        float route_partial1_1 = 0.0f;
-                        #pragma unroll
-                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                            int rank_col_1 = rank_block_1 * 8;
-                            float _vec_load_2[8];
-                            {
-                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                                uint4 _vld_2[1];
-                                #pragma unroll
-                                for (int _blk = 0; _blk < 1; _blk++) {
-                                    _vld_2[_blk] = _vptr_2[_blk];
-                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-                                    #pragma unroll
-                                    for (int _pair = 0; _pair < 4; _pair++) {
-                                        asm volatile(
-                                            "{\n\t"
-                                            ".reg .b16 h_lo, h_hi;\n\t"
-                                            ".reg .b32 f_lo, f_hi;\n\t"
-                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                            "}\n"
-                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                                            : "r"(_vpairs_2[_pair]));
-                                    }
-                                }
-                            }
-                            if (valid0 != 0) {
-                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
-                                float _vec_load_3[8];
-                                {
-                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
-                                    uint4 _vld_3[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_3[_blk] = _vptr_3[_blk];
-                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_3[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_2 = 0; element_2 < 8; element_2++) {
-                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                                    route_partial0_1 = _fma_4;
-                                }
-                            }
-                            if (valid1 != 0) {
-                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
-                                float _vec_load_4[8];
-                                {
-                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
-                                    uint4 _vld_4[1];
-                                    #pragma unroll
-                                    for (int _blk = 0; _blk < 1; _blk++) {
-                                        _vld_4[_blk] = _vptr_4[_blk];
-                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-                                        #pragma unroll
-                                        for (int _pair = 0; _pair < 4; _pair++) {
-                                            asm volatile(
-                                                "{\n\t"
-                                                ".reg .b16 h_lo, h_hi;\n\t"
-                                                ".reg .b32 f_lo, f_hi;\n\t"
-                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
-                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
-                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
-                                                "}\n"
-                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
-                                                : "r"(_vpairs_4[_pair]));
-                                        }
-                                    }
-                                }
-                                #pragma unroll
-                                for (int element_3 = 0; element_3 < 8; element_3++) {
-                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                                    route_partial1_1 = _fma_5;
-                                }
-                            }
-                        }
-                        if (valid0 != 0) {
-                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-                            total0 = _fma_6;
-                        }
-                        if (valid1 != 0) {
-                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-                            total1 = _fma_7;
-                        }
-                    }
-                }
+          }
+        }
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = total;
+      } else {
+        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
+          (0)) = 0.0f;
+      }
+    }
+  }
+}
+
+}  // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__
+__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(
+    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
+    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
+    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
+    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
+    int output_stride, int output_offset) {
+  const int tid = threadIdx.x;
+  const int warp = make_warp_uniform(tid / 32);
+  const int lane = tid % 32;
+
+  extern __shared__ __align__(1024) char smem_raw[];
+  int smem;
+  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+  const int bid = blockIdx.x;
+  const int num_bids = gridDim.x;
+
+  // Kernel setup ops
+  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+  const int shrink_stage_addr = smem + 0;
+
+  // === Task calls (dependency order) ===
+  int token = blockIdx.x;
+  int output_col0 = blockIdx.y * 256 + tid;
+  int output_col1 = output_col0 + 128;
+  unsigned int activation_carriers[4];
+  float activation_values[8];
+  if (token < num_tokens) {
+    long long lora_id = lora_indices[token];
+    if (lora_id >= 0) {
+      int pair_base = token * 2;
+      int contiguous = 0;
+      if (num_pairs == num_tokens * 2) {
+        if (pair_base + 1 < num_pairs) {
+          if (sorted_token_ids[pair_base] == (long long)token) {
+            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+              contiguous = 1;
+            }
+          }
+        }
+      }
+      int valid0 = 0;
+      int valid1 = 0;
+      if (output_col0 < 3072) {
+        valid0 = 1;
+      }
+      if (output_col1 < 3072) {
+        valid1 = 1;
+      }
+      float total0 = 0.0f;
+      float total1 = 0.0f;
+      if (contiguous != 0) {
+        if (tid < 8) {
+          int stage_route = tid / 4;
+          int stage_rank_block = tid % 4;
+          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
+                           shrink_stage_addr +
+                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
+                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
+                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+        }
+        asm volatile("cp.async.commit_group;");
+        asm volatile("cp.async.wait_group 0;");
+        __syncthreads();
+#pragma unroll
+        for (int route = 0; route < 2; route++) {
+          int pair = pair_base + route;
+          long long expert = expert_ids[pair];
+          float route_partial0 = 0.0f;
+          float route_partial1 = 0.0f;
+#pragma unroll
+          for (int rank_block = 0; rank_block < 4; rank_block++) {
+            int rank_col = rank_block * 8;
+            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
+                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+            {
+#pragma unroll
+              for (int _pair = 0; _pair < 4; _pair++) {
+                asm volatile(
+                    "{\n\t"
+                    ".reg .b16 h_lo, h_hi;\n\t"
+                    ".reg .b32 f_lo, f_hi;\n\t"
+                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                    "}\n"
+                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                    : "r"(activation_carriers[_pair]));
+              }
             }
             if (valid0 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+              long long weight_index0 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_0[8];
+              {
+                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
+                uint4 _vld_0[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_0[_blk] = _vptr_0[_blk];
+                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_0[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element = 0; element < 8; element++) {
+                float _fma_0 =
+                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                route_partial0 = _fma_0;
+              }
             }
             if (valid1 != 0) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+              long long weight_index1 =
+                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) *
+                      32 +
+                  (long long)rank_col;
+              float _vec_load_1[8];
+              {
+                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
+                uint4 _vld_1[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_1[_blk] = _vptr_1[_blk];
+                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_1[_pair]));
+                  }
+                }
+              }
+#pragma unroll
+              for (int element_1 = 0; element_1 < 8; element_1++) {
+                float _fma_1 =
+                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                route_partial1 = _fma_1;
+              }
             }
-        } else {
-            if (output_col0 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
-            }
-            if (output_col1 < 3072) {
-                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
-            }
+          }
+          if (valid0 != 0) {
+            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+            total0 = _fma_2;
+          }
+          if (valid1 != 0) {
+            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+            total1 = _fma_3;
+          }
         }
+      } else {
+#pragma unroll 1
+        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+          if (sorted_token_ids[pair_1] == (long long)token) {
+            long long expert_1 = expert_ids[pair_1];
+            float route_partial0_1 = 0.0f;
+            float route_partial1_1 = 0.0f;
+#pragma unroll
+            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+              int rank_col_1 = rank_block_1 * 8;
+              float _vec_load_2[8];
+              {
+                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
+                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                uint4 _vld_2[1];
+#pragma unroll
+                for (int _blk = 0; _blk < 1; _blk++) {
+                  _vld_2[_blk] = _vptr_2[_blk];
+                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+#pragma unroll
+                  for (int _pair = 0; _pair < 4; _pair++) {
+                    asm volatile(
+                        "{\n\t"
+                        ".reg .b16 h_lo, h_hi;\n\t"
+                        ".reg .b32 f_lo, f_hi;\n\t"
+                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                        "}\n"
+                        : "=l"(*reinterpret_cast<unsigned long long*>(
+                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                        : "r"(_vpairs_2[_pair]));
+                  }
+                }
+              }
+              if (valid0 != 0) {
+                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col0) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_3[8];
+                {
+                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
+                  uint4 _vld_3[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_3[_blk] = _vptr_3[_blk];
+                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_3[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_2 = 0; element_2 < 8; element_2++) {
+                  float _fma_4 =
+                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                  route_partial0_1 = _fma_4;
+                }
+              }
+              if (valid1 != 0) {
+                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
+                                             (long long)output_col1) *
+                                                32 +
+                                            (long long)rank_col_1;
+                float _vec_load_4[8];
+                {
+                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
+                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
+                  uint4 _vld_4[1];
+#pragma unroll
+                  for (int _blk = 0; _blk < 1; _blk++) {
+                    _vld_4[_blk] = _vptr_4[_blk];
+                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+#pragma unroll
+                    for (int _pair = 0; _pair < 4; _pair++) {
+                      asm volatile(
+                          "{\n\t"
+                          ".reg .b16 h_lo, h_hi;\n\t"
+                          ".reg .b32 f_lo, f_hi;\n\t"
+                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                          "cvt.f32.f16 f_lo, h_lo;\n\t"
+                          "cvt.f32.f16 f_hi, h_hi;\n\t"
+                          "mov.b64 %0, {f_lo, f_hi};\n\t"
+                          "}\n"
+                          : "=l"(*reinterpret_cast<unsigned long long*>(
+                              &_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                          : "r"(_vpairs_4[_pair]));
+                    }
+                  }
+                }
+#pragma unroll
+                for (int element_3 = 0; element_3 < 8; element_3++) {
+                  float _fma_5 =
+                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                  route_partial1_1 = _fma_5;
+                }
+              }
+            }
+            if (valid0 != 0) {
+              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+              total0 = _fma_6;
+            }
+            if (valid1 != 0) {
+              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+              total1 = _fma_7;
+            }
+          }
+        }
+      }
+      if (valid0 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = total0;
+      }
+      if (valid1 != 0) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = total1;
+      }
+    } else {
+      if (output_col0 < 3072) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col0)) +
+          (0)) = 0.0f;
+      }
+      if (output_col1 < 3072) {
+        *(reinterpret_cast<float*>(y_accum +
+                                   (token * output_stride + output_offset + output_col1)) +
+          (0)) = 0.0f;
+      }
     }
+  }
 }
 
-} // extern "C"
+}  // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
+++ b/csrc/blackwell_bgmv_moe/sm100a/blackwell_bgmv_moe_f16_h3072_sm100a.cu
@@ -14,34 +14,29 @@
  * limitations under the License.
  */
 // Generated source for FlashInfer.
-// Bundle: Blackwell BGMV MoE shrink and expand benchmark portfolio.
+// Bundle: Blackwell BGMV MoE shrink and deterministic expand portfolio.
 // Target: sm_100a; compile flags: none.
 // Generated file; do not edit manually.
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef unsigned short uint16_t;
-typedef unsigned int uint32_t;
+typedef signed char        int8_t;
+typedef unsigned char      uint8_t;
+typedef unsigned short     uint16_t;
+typedef unsigned int       uint32_t;
 typedef unsigned long long uint64_t;
-typedef signed int int32_t;
-typedef short int int16_t;
-struct __align__(128) BlackwellTensorMap {
-  uint64_t opaque[16];
-};
+typedef signed int         int32_t;
+typedef short int          int16_t;
+struct __align__(128) BlackwellTensorMap { uint64_t opaque[16]; };
 template <int N>
-struct __align__(128) BlackwellTensorMapPack {
-  BlackwellTensorMap maps[N];
-};
+struct __align__(128) BlackwellTensorMapPack { BlackwellTensorMap maps[N]; };
 
-typedef struct __align__(64) {
-  uint64_t opaque[16];
-} CUtensorMap;
+typedef struct __align__(64) { uint64_t opaque[16]; } CUtensorMap;
 
 #include <cuda_bf16.h>
 
 __device__ __forceinline__ int make_warp_uniform(int x) {
-  int result;
-  asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;" : "=r"(result) : "r"(x));
-  return result;
+    int result;
+    asm volatile("shfl.sync.idx.b32 %0, %1, 0, 0x1F, 0xFFFFFFFF;"
+                 : "=r"(result) : "r"(x));
+    return result;
 }
 
 #include <math_constants.h>
@@ -62,239 +57,208 @@ __device__ __forceinline__ int make_warp_uniform(int x) {
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p4_s3(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
-  const int w_smem_addr = smem + 24576;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
-  const int warp_partials_addr = smem + 221184;
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 24576);
+    const int w_smem_addr = smem + 24576;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 221184);
+    const int warp_partials_addr = smem + 221184;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[4];
-  long long experts[4];
-  long long loras[4];
-  int valid[4];
-#pragma unroll
-  for (int pp = 0; pp < 4; pp++) {
-    int pair = pair_block * 4 + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 4; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 3072) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __half*>(x_raw) +
-                  (tokens[pp_1] * 3072 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         3072 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 +
-                                                           pp_1 * 8 * 1024 + rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 2;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 4; pp_2++) {
-      int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 3072) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  ".reg .b16 h_lo, h_hi;\n\t"
-                  ".reg .b32 f_lo, f_hi;\n\t"
-                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                  "cvt.f32.f16 f_lo, h_lo;\n\t"
-                  "cvt.f32.f16 f_hi, h_hi;\n\t"
-                  "mov.b64 %0, {f_lo, f_hi};\n\t"
-                  "}\n"
-                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[4];
+    long long experts[4];
+    long long loras[4];
+    int valid[4];
+    #pragma unroll
+    for (int pp = 0; pp < 4; pp++) {
+        int pair = pair_block * 4 + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 3072) {
-            int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    ".reg .b16 h_lo, h_hi;\n\t"
-                    ".reg .b32 f_lo, f_hi;\n\t"
-                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                    "}\n"
-                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 3 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 4; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 3 * 4 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 3 * 4 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 2;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 4; pp_2++) {
+            int x_thread_base = tile_1 % 3 * 4 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 3 * 4 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 32) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 3 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 4; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 32) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 3 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 3 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 4; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 3072) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(x_raw) +
-                             (tokens[pp_3] * 3072 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      3072 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 3 : 3)) % 3 * 4 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+        if (lane < 32) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block * 4 + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 32) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block * 4 + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
-                                    (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2half_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -329,239 +293,208 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(
-    uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw,
-    uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs,
-    int num_experts, int num_tokens) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_shrink_f16_h3072_r32_p1_s2(uint16_t* __restrict__ shrink_out_raw, uint16_t* __restrict__ x_raw, uint16_t* __restrict__ lora_a_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, int num_pairs, int num_experts, int num_tokens)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
-  const int x_smem_addr = smem + 0;
-  __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
-  const int w_smem_addr = smem + 4096;
-  float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
-  const int warp_partials_addr = smem + 36864;
+    // Kernel setup ops
+    __half* x_smem = reinterpret_cast<__half*>(smem_raw + 0);
+    const int x_smem_addr = smem + 0;
+    __half* w_smem = reinterpret_cast<__half*>(smem_raw + 4096);
+    const int w_smem_addr = smem + 4096;
+    float* warp_partials = reinterpret_cast<float*>(smem_raw + 36864);
+    const int warp_partials_addr = smem + 36864;
 
-  // === Task calls (dependency order) ===
-  int pair_block = blockIdx.x;
-  int rank_block = blockIdx.y;
-  int rank_base = rank_block * 8;
-  long long tokens[1];
-  long long experts[1];
-  long long loras[1];
-  int valid[1];
-#pragma unroll
-  for (int pp = 0; pp < 1; pp++) {
-    int pair = pair_block + pp;
-    tokens[pp] = -1;
-    experts[pp] = -1;
-    loras[pp] = -1;
-    valid[pp] = 0;
-    if (pair < num_pairs) {
-      tokens[pp] = sorted_token_ids[pair];
-      experts[pp] = expert_ids[pair];
-      if (tokens[pp] >= 0) {
-        if (tokens[pp] < (long long)num_tokens) {
-          loras[pp] = lora_indices[tokens[pp]];
-          if (loras[pp] >= 0) {
-            valid[pp] = 1;
-          }
-        }
-      }
-    }
-  }
-#pragma unroll
-  for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
-    int k_base = tile * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_1 = 0; pp_1 < 1; pp_1++) {
-      if (valid[pp_1] != 0) {
-        if (k_base < 3072) {
-          asm volatile(
-              "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                  x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)),
-              "l"(reinterpret_cast<const __half*>(x_raw) +
-                  (tokens[pp_1] * 3072 + (long long)k_base)));
-#pragma unroll
-          for (int rr = 0; rr < 8; rr++) {
-            int rank_row = rank_base + rr;
-            long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 +
-                                      (long long)rank_row) *
-                                         3072 +
-                                     (long long)k_base;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 +
-                                                           rr * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
-          }
-        }
-      }
-    }
-    asm volatile("cp.async.commit_group;");
-  }
-  float owned_accum = 0.0f;
-  unsigned int x_carriers[4];
-  unsigned int w_carriers[4];
-  float x_values[8];
-  float w_values[8];
-#pragma unroll
-  for (int tile_1 = 0; tile_1 < 3; tile_1++) {
-    if (3 - tile_1 - 1 == 0) {
-      asm volatile("cp.async.wait_group 0;");
-    } else if (3 - tile_1 - 1 == 1) {
-      asm volatile("cp.async.wait_group 1;");
-    } else {
-      asm volatile("cp.async.wait_group 1;");
-    }
-    __syncthreads();
-    int k_base_1 = tile_1 * 1024 + tid * 8;
-#pragma unroll
-    for (int pp_2 = 0; pp_2 < 1; pp_2++) {
-      int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
-      if (valid[pp_2] != 0) {
-        if (k_base_1 < 3072) {
-          asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                       : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])),
-                         "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
-                       : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
-          {
-#pragma unroll
-            for (int _pair = 0; _pair < 4; _pair++) {
-              asm volatile(
-                  "{\n\t"
-                  ".reg .b16 h_lo, h_hi;\n\t"
-                  ".reg .b32 f_lo, f_hi;\n\t"
-                  "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                  "cvt.f32.f16 f_lo, h_lo;\n\t"
-                  "cvt.f32.f16 f_hi, h_hi;\n\t"
-                  "mov.b64 %0, {f_lo, f_hi};\n\t"
-                  "}\n"
-                  : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
-                  : "r"(x_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int pair_block = blockIdx.x;
+    int rank_block = blockIdx.y;
+    int rank_base = rank_block * 8;
+    long long tokens[1];
+    long long experts[1];
+    long long loras[1];
+    int valid[1];
+    #pragma unroll
+    for (int pp = 0; pp < 1; pp++) {
+        int pair = pair_block + pp;
+        tokens[pp] = -1;
+        experts[pp] = -1;
+        loras[pp] = -1;
+        valid[pp] = 0;
+        if (pair < num_pairs) {
+            tokens[pp] = sorted_token_ids[pair];
+            experts[pp] = expert_ids[pair];
+            if (tokens[pp] >= 0) {
+                if (tokens[pp] < (long long)num_tokens) {
+                    loras[pp] = lora_indices[tokens[pp]];
+                    if (loras[pp] >= 0) {
+                        valid[pp] = 1;
+                    }
+                }
             }
-          }
         }
-      }
-#pragma unroll
-      for (int rr_1 = 0; rr_1 < 8; rr_1++) {
-        float partial = 0.0f;
-        if (valid[pp_2] != 0) {
-          if (k_base_1 < 3072) {
-            int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
-                         : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    ".reg .b16 h_lo, h_hi;\n\t"
-                    ".reg .b32 f_lo, f_hi;\n\t"
-                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                    "}\n"
-                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
-                    : "r"(w_carriers[_pair]));
-              }
-            }
-#pragma unroll
-            for (int element = 0; element < 8; element++) {
-              float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
-              partial = _fma_0;
-            }
-          }
-        }
-        float _warp_reduce_0 = partial;
-#pragma unroll
-        for (int offset = 16; offset > 0; offset >>= 1)
-          _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
-        partial = _warp_reduce_0;
-        if (lane == 0) {
-          warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
-        }
-      }
     }
-    __syncthreads();
+    #pragma unroll
+    for (int tile = 0; tile < ((1) ? 2 : 3); tile++) {
+        int k_base = tile * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_1 = 0; pp_1 < 1; pp_1++) {
+            if (valid[pp_1] != 0) {
+                if (k_base < 3072) {
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(x_smem_addr + (unsigned int)((tile % 2 * 1024 + pp_1 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_1] * 3072 + (long long)k_base)));
+                    #pragma unroll
+                    for (int rr = 0; rr < 8; rr++) {
+                        int rank_row = rank_base + rr;
+                        long long weight_index = ((loras[pp_1] * (long long)num_experts + experts[pp_1]) * 32 + (long long)rank_row) * 3072 + (long long)k_base;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(w_smem_addr + (unsigned int)((tile % 2 * 8 * 1024 + pp_1 * 8 * 1024 + rr * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index));
+                    }
+                }
+            }
+        }
+        asm volatile("cp.async.commit_group;");
+    }
+    float owned_accum = 0.0f;
+    unsigned int x_carriers[4];
+    unsigned int w_carriers[4];
+    float x_values[8];
+    float w_values[8];
+    #pragma unroll
+    for (int tile_1 = 0; tile_1 < 3; tile_1++) {
+        if (3 - tile_1 - 1 == 0) {
+            asm volatile("cp.async.wait_group 0;");
+        } else if (3 - tile_1 - 1 == 1) {
+            asm volatile("cp.async.wait_group 1;");
+        } else {
+            asm volatile("cp.async.wait_group 1;");
+        }
+        __syncthreads();
+        int k_base_1 = tile_1 * 1024 + tid * 8;
+        #pragma unroll
+        for (int pp_2 = 0; pp_2 < 1; pp_2++) {
+            int x_thread_base = tile_1 % 2 * 1024 + pp_2 * 1024 + tid * 8;
+            if (valid[pp_2] != 0) {
+                if (k_base_1 < 3072) {
+                    asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                        : "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&x_carriers[(0) + 3]))
+                        : "r"(x_smem_addr + (unsigned int)(x_thread_base * 2)));
+                    {
+                        #pragma unroll
+                        for (int _pair = 0; _pair < 4; _pair++) {
+                            asm volatile(
+                                "{\n\t"
+                                ".reg .b16 h_lo, h_hi;\n\t"
+                                ".reg .b32 f_lo, f_hi;\n\t"
+                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                "}\n"
+                                : "=l"(*reinterpret_cast<unsigned long long*>(&x_values[_pair * 2]))
+                                : "r"(x_carriers[_pair]));
+                        }
+                    }
+                }
+            }
+            #pragma unroll
+            for (int rr_1 = 0; rr_1 < 8; rr_1++) {
+                float partial = 0.0f;
+                if (valid[pp_2] != 0) {
+                    if (k_base_1 < 3072) {
+                        int w_thread_base = tile_1 % 2 * 8 * 1024 + pp_2 * 8 * 1024 + rr_1 * 1024 + tid * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&w_carriers[(0) + 3]))
+                            : "r"(w_smem_addr + (unsigned int)(w_thread_base * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&w_values[_pair * 2]))
+                                    : "r"(w_carriers[_pair]));
+                            }
+                        }
+                        #pragma unroll
+                        for (int element = 0; element < 8; element++) {
+                            float _fma_0 = __fmaf_rn(x_values[element], w_values[element], partial);
+                            partial = _fma_0;
+                        }
+                    }
+                }
+                float _warp_reduce_0 = partial;
+                #pragma unroll
+                for (int offset = 16; offset > 0; offset >>= 1)
+                    _warp_reduce_0 += __shfl_xor_sync(0xFFFFFFFF, _warp_reduce_0, offset);
+                partial = _warp_reduce_0;
+                if (lane == 0) {
+                    warp_partials[(pp_2 * 8 + rr_1) * 4 + warp] = partial;
+                }
+            }
+        }
+        __syncthreads();
+        if (warp == 0) {
+            if (lane < 8) {
+                int owner_index = lane;
+                float cta_partial = 0.0f;
+                #pragma unroll
+                for (int source_warp = 0; source_warp < 4; source_warp++) {
+                    cta_partial += warp_partials[owner_index * 4 + source_warp];
+                }
+                owned_accum += cta_partial;
+            }
+        }
+        __syncthreads();
+        if (tile_1 + ((1) ? 2 : 3) < 3) {
+            int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
+            #pragma unroll
+            for (int pp_3 = 0; pp_3 < 1; pp_3++) {
+                if (valid[pp_3] != 0) {
+                    if (refill_k < 3072) {
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 + pp_3 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(x_raw) + (tokens[pp_3] * 3072 + (long long)refill_k)));
+                        #pragma unroll
+                        for (int rr_2 = 0; rr_2 < 8; rr_2++) {
+                            int rank_row_1 = rank_base + rr_2;
+                            long long weight_index_1 = ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 + (long long)rank_row_1) * 3072 + (long long)refill_k;
+                            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                                :: "r"(w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 + pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) * 2)), "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+                        }
+                    }
+                }
+            }
+            asm volatile("cp.async.commit_group;");
+        }
+    }
     if (warp == 0) {
-      if (lane < 8) {
-        int owner_index = lane;
-        float cta_partial = 0.0f;
-#pragma unroll
-        for (int source_warp = 0; source_warp < 4; source_warp++) {
-          cta_partial += warp_partials[owner_index * 4 + source_warp];
-        }
-        owned_accum += cta_partial;
-      }
-    }
-    __syncthreads();
-    if (tile_1 + ((1) ? 2 : 3) < 3) {
-      int refill_k = (tile_1 + ((1) ? 2 : 3)) * 1024 + tid * 8;
-#pragma unroll
-      for (int pp_3 = 0; pp_3 < 1; pp_3++) {
-        if (valid[pp_3] != 0) {
-          if (refill_k < 3072) {
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             x_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 1024 +
-                                                           pp_3 * 1024 + tid * 8) *
-                                                          2)),
-                         "l"(reinterpret_cast<const __half*>(x_raw) +
-                             (tokens[pp_3] * 3072 + (long long)refill_k)));
-#pragma unroll
-            for (int rr_2 = 0; rr_2 < 8; rr_2++) {
-              int rank_row_1 = rank_base + rr_2;
-              long long weight_index_1 =
-                  ((loras[pp_3] * (long long)num_experts + experts[pp_3]) * 32 +
-                   (long long)rank_row_1) *
-                      3072 +
-                  (long long)refill_k;
-              asm volatile(
-                  "cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                      w_smem_addr + (unsigned int)(((tile_1 + ((1) ? 2 : 3)) % 2 * 8 * 1024 +
-                                                    pp_3 * 8 * 1024 + rr_2 * 1024 + tid * 8) *
-                                                   2)),
-                  "l"(reinterpret_cast<const __half*>(lora_a_raw) + weight_index_1));
+        if (lane < 8) {
+            int owner_pp = lane / 8;
+            int owner_rr = lane % 8;
+            int pair_1 = pair_block + owner_pp;
+            if (pair_1 < num_pairs) {
+                *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) + (pair_1 * 32 + rank_base + owner_rr)) + (0)) = __float2half_rn(owned_accum);
             }
-          }
         }
-      }
-      asm volatile("cp.async.commit_group;");
     }
-  }
-  if (warp == 0) {
-    if (lane < 8) {
-      int owner_pp = lane / 8;
-      int owner_rr = lane % 8;
-      int pair_1 = pair_block + owner_pp;
-      if (pair_1 < num_pairs) {
-        *(reinterpret_cast<__half*>(reinterpret_cast<__half*>(shrink_out_raw) +
-                                    (pair_1 * 32 + rank_base + owner_rr)) +
-          (0)) = __float2half_rn(owned_accum);
-      }
-    }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -590,223 +523,404 @@ __global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_shrink_f16_
 
 extern "C" {
 
-__global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(64, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_t64_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 64 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 64 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
+                }
             }
-          }
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                if (output_col < 3072) {
+                    float total = 0.0f;
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                    *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+                }
+            } else if (output_col < 3072) {
+                float total_1 = 0.0f;
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                route_partial_1 = _fma_2;
+                            }
+                        }
+                        float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
+                        total_1 = _fma_3;
+                    }
+                }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total_1;
+            }
+        } else if (output_col < 3072) {
+            *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
         }
-      }
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
+    }
+}
+
+} // extern "C"
+
+#undef BLACKWELL_INF
+#undef NUM_MAIN_STAGES
+#undef SMEM_SHRINK_STAGE_OFF
+#undef SMEM_SHRINK_STAGE_STAGE_BYTES
+#undef SMEM_SHRINK_STAGE_STRIDE
+#undef SMEM_TOTAL
+#undef THREADS
+#undef shrink_stage_addr
+
+#define BLACKWELL_INF CUDART_INF_F
+#define NUM_MAIN_STAGES 1
+#define SMEM_SHRINK_STAGE_OFF 0
+#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
+#define SMEM_SHRINK_STAGE_STRIDE 128
+#define SMEM_TOTAL 128
+#define THREADS 128
+
+extern "C" {
+
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
+
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
+
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
+
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col = blockIdx.y * 128 + tid;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
         if (output_col < 3072) {
-          float total = 0.0f;
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      ".reg .b16 h_lo, h_hi;\n\t"
-                      ".reg .b32 f_lo, f_hi;\n\t"
-                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                      "cvt.f32.f16 f_lo, h_lo;\n\t"
-                      "cvt.f32.f16 f_hi, h_hi;\n\t"
-                      "mov.b64 %0, {f_lo, f_hi};\n\t"
-                      "}\n"
-                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                      : "r"(activation_carriers[_pair]));
+            long long lora_id = lora_indices[token];
+            if (lora_id >= 0) {
+                int pair_base = token * 2;
+                int contiguous = 0;
+                if (num_pairs == num_tokens * 2) {
+                    if (pair_base + 1 < num_pairs) {
+                        if (sorted_token_ids[pair_base] == (long long)token) {
+                            if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                                contiguous = 1;
+                            }
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
+                float total = 0.0f;
+                if (contiguous != 0) {
+                    if (tid < 8) {
+                        int stage_route = tid / 4;
+                        int stage_rank_block = tid % 4;
+                        asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                            :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                    }
+                    asm volatile("cp.async.commit_group;");
+                    asm volatile("cp.async.wait_group 0;");
+                    __syncthreads();
+                    #pragma unroll
+                    for (int route = 0; route < 2; route++) {
+                        int pair = pair_base + route;
+                        long long expert = expert_ids[pair];
+                        float route_partial = 0.0f;
+                        #pragma unroll
+                        for (int rank_block = 0; rank_block < 4; rank_block++) {
+                            int rank_col = rank_block * 8;
+                            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                                : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                                : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                            {
+                                #pragma unroll
+                                for (int _pair = 0; _pair < 4; _pair++) {
+                                    asm volatile(
+                                        "{\n\t"
+                                        ".reg .b16 h_lo, h_hi;\n\t"
+                                        ".reg .b32 f_lo, f_hi;\n\t"
+                                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                        "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                        "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                        "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                        "}\n"
+                                        : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                        : "r"(activation_carriers[_pair]));
+                                }
+                            }
+                            long long weight_index = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
+                                route_partial = _fma_0;
+                            }
+                        }
+                        float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
+                        total = _fma_1;
+                    }
+                } else {
+                    #pragma unroll 1
+                    for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                        if (sorted_token_ids[pair_1] == (long long)token) {
+                            long long expert_1 = expert_ids[pair_1];
+                            float route_partial_1 = 0.0f;
+                            #pragma unroll
+                            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                                int rank_col_1 = rank_block_1 * 8;
+                                float _vec_load_1[8];
+                                {
+                                    const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                    uint4 _vld_1[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_1[_blk] = _vptr_1[_blk];
+                                        uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_1[_pair]));
+                                        }
+                                    }
+                                }
+                                long long weight_index_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) * 32 + (long long)rank_col_1;
+                                float _vec_load_2[8];
+                                {
+                                    const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
+                                    uint4 _vld_2[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_2[_blk] = _vptr_2[_blk];
+                                        uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_2[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_1 = 0; element_1 < 8; element_1++) {
+                                    float _fma_2 = __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
+                                    route_partial_1 = _fma_2;
+                                }
+                            }
+                            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
+                            total = _fma_3;
+                        }
+                    }
                 }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = total;
+            } else {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) + (0)) = 0.0f;
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
-          *(reinterpret_cast<float*>(y_accum +
-                                     (token * output_stride + output_offset + output_col)) +
-            (0)) = total;
         }
-      } else if (output_col < 3072) {
-        float total_1 = 0.0f;
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-              long long weight_index_1 =
-                  ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col_1;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_2 =
-                    __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                route_partial_1 = _fma_2;
-              }
-            }
-            float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total_1);
-            total_1 = _fma_3;
-          }
-        }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total_1;
-      }
-    } else if (output_col < 3072) {
-      *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-        (0)) = 0.0f;
     }
-  }
 }
 
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES
@@ -819,119 +933,6 @@ __global__ __launch_bounds__(64, 1) void kernel_flashinfer_bgmv_moe_expand_token
 
 #define BLACKWELL_INF CUDART_INF_F
 #define NUM_MAIN_STAGES 1
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_h3072_r32_t128(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // === Task calls (dependency order) ===
-  int pair = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  if (pair < num_pairs) {
-    if (output_col < 3072) {
-      long long token = sorted_token_ids[pair];
-      if (token >= 0) {
-        if (token < (long long)num_tokens) {
-          long long lora_id = lora_indices[token];
-          if (lora_id >= 0) {
-            long long expert = expert_ids[pair];
-            float partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(shrink_raw) + (pair * 32 + rank_col) + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 = __fmaf_rn(_vec_load_0[element], _vec_load_1[element], partial);
-                partial = _fma_0;
-              }
-            }
-            atomicAdd(&y_accum[token * (long long)output_stride + (long long)output_offset +
-                               (long long)output_col],
-                      partial * topk_weights[pair]);
-          }
-        }
-      }
-    }
-  }
-}
-
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef THREADS
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
 #define SMEM_SHRINK_STAGE_OFF 0
 #define SMEM_SHRINK_STAGE_STAGE_BYTES 128
 #define SMEM_SHRINK_STAGE_STRIDE 128
@@ -940,571 +941,294 @@ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_pair_owned_f16_
 
 extern "C" {
 
-__global__ __launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_f16_h3072_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
+__global__ __launch_bounds__(128, 1) void
+kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw, uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids, long long* __restrict__ expert_ids, long long* __restrict__ lora_indices, float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens, int output_stride, int output_offset)
+{
+    const int tid = threadIdx.x;
+    const int warp = make_warp_uniform(tid / 32);
+    const int lane = tid % 32;
 
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
+    extern __shared__ __align__(1024) char smem_raw[];
+    int smem;
+    smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
 
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
+    const int bid = blockIdx.x;
+    const int num_bids = gridDim.x;
 
-  // Kernel setup ops
-  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
+    // Kernel setup ops
+    __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
+    const int shrink_stage_addr = smem + 0;
 
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col = blockIdx.y * 128 + tid;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    if (output_col < 3072) {
-      long long lora_id = lora_indices[token];
-      if (lora_id >= 0) {
-        int pair_base = token * 2;
-        int contiguous = 0;
-        if (num_pairs == num_tokens * 2) {
-          if (pair_base + 1 < num_pairs) {
-            if (sorted_token_ids[pair_base] == (long long)token) {
-              if (sorted_token_ids[pair_base + 1] == (long long)token) {
-                contiguous = 1;
-              }
-            }
-          }
-        }
-        float total = 0.0f;
-        if (contiguous != 0) {
-          if (tid < 8) {
-            int stage_route = tid / 4;
-            int stage_rank_block = tid % 4;
-            asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                             shrink_stage_addr +
-                             (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                         "l"(reinterpret_cast<const __half*>(shrink_raw) +
-                             ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-          }
-          asm volatile("cp.async.commit_group;");
-          asm volatile("cp.async.wait_group 0;");
-          __syncthreads();
-#pragma unroll
-          for (int route = 0; route < 2; route++) {
-            int pair = pair_base + route;
-            long long expert = expert_ids[pair];
-            float route_partial = 0.0f;
-#pragma unroll
-            for (int rank_block = 0; rank_block < 4; rank_block++) {
-              int rank_col = rank_block * 8;
-              asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                           : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                             "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                           : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-              {
-#pragma unroll
-                for (int _pair = 0; _pair < 4; _pair++) {
-                  asm volatile(
-                      "{\n\t"
-                      ".reg .b16 h_lo, h_hi;\n\t"
-                      ".reg .b32 f_lo, f_hi;\n\t"
-                      "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                      "cvt.f32.f16 f_lo, h_lo;\n\t"
-                      "cvt.f32.f16 f_hi, h_hi;\n\t"
-                      "mov.b64 %0, {f_lo, f_hi};\n\t"
-                      "}\n"
-                      : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                      : "r"(activation_carriers[_pair]));
+    // === Task calls (dependency order) ===
+    int token = blockIdx.x;
+    int output_col0 = blockIdx.y * 256 + tid;
+    int output_col1 = output_col0 + 128;
+    unsigned int activation_carriers[4];
+    float activation_values[8];
+    if (token < num_tokens) {
+        long long lora_id = lora_indices[token];
+        if (lora_id >= 0) {
+            int pair_base = token * 2;
+            int contiguous = 0;
+            if (num_pairs == num_tokens * 2) {
+                if (pair_base + 1 < num_pairs) {
+                    if (sorted_token_ids[pair_base] == (long long)token) {
+                        if (sorted_token_ids[pair_base + 1] == (long long)token) {
+                            contiguous = 1;
+                        }
+                    }
                 }
-              }
-              long long weight_index =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial);
-                route_partial = _fma_0;
-              }
             }
-            float _fma_1 = __fmaf_rn(route_partial, topk_weights[pair], total);
-            total = _fma_1;
-          }
+            int valid0 = 0;
+            int valid1 = 0;
+            if (output_col0 < 3072) {
+                valid0 = 1;
+            }
+            if (output_col1 < 3072) {
+                valid1 = 1;
+            }
+            float total0 = 0.0f;
+            float total1 = 0.0f;
+            if (contiguous != 0) {
+                if (tid < 8) {
+                    int stage_route = tid / 4;
+                    int stage_rank_block = tid % 4;
+                    asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;"
+                        :: "r"(shrink_stage_addr + (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)), "l"(reinterpret_cast<const __half*>(shrink_raw) + ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
+                }
+                asm volatile("cp.async.commit_group;");
+                asm volatile("cp.async.wait_group 0;");
+                __syncthreads();
+                #pragma unroll
+                for (int route = 0; route < 2; route++) {
+                    int pair = pair_base + route;
+                    long long expert = expert_ids[pair];
+                    float route_partial0 = 0.0f;
+                    float route_partial1 = 0.0f;
+                    #pragma unroll
+                    for (int rank_block = 0; rank_block < 4; rank_block++) {
+                        int rank_col = rank_block * 8;
+                        asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
+                            : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])), "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
+                            : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
+                        {
+                            #pragma unroll
+                            for (int _pair = 0; _pair < 4; _pair++) {
+                                asm volatile(
+                                    "{\n\t"
+                                    ".reg .b16 h_lo, h_hi;\n\t"
+                                    ".reg .b32 f_lo, f_hi;\n\t"
+                                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                    "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                    "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                    "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                    "}\n"
+                                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
+                                    : "r"(activation_carriers[_pair]));
+                            }
+                        }
+                        if (valid0 != 0) {
+                            long long weight_index0 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) * 32 + (long long)rank_col;
+                            float _vec_load_0[8];
+                            {
+                                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
+                                uint4 _vld_0[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_0[_blk] = _vptr_0[_blk];
+                                    uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_0[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_0[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element = 0; element < 8; element++) {
+                                float _fma_0 = __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
+                                route_partial0 = _fma_0;
+                            }
+                        }
+                        if (valid1 != 0) {
+                            long long weight_index1 = ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) * 32 + (long long)rank_col;
+                            float _vec_load_1[8];
+                            {
+                                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
+                                uint4 _vld_1[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_1[_blk] = _vptr_1[_blk];
+                                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_1[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_1[_pair]));
+                                    }
+                                }
+                            }
+                            #pragma unroll
+                            for (int element_1 = 0; element_1 < 8; element_1++) {
+                                float _fma_1 = __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
+                                route_partial1 = _fma_1;
+                            }
+                        }
+                    }
+                    if (valid0 != 0) {
+                        float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
+                        total0 = _fma_2;
+                    }
+                    if (valid1 != 0) {
+                        float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
+                        total1 = _fma_3;
+                    }
+                }
+            } else {
+                #pragma unroll 1
+                for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
+                    if (sorted_token_ids[pair_1] == (long long)token) {
+                        long long expert_1 = expert_ids[pair_1];
+                        float route_partial0_1 = 0.0f;
+                        float route_partial1_1 = 0.0f;
+                        #pragma unroll
+                        for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
+                            int rank_col_1 = rank_block_1 * 8;
+                            float _vec_load_2[8];
+                            {
+                                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
+                                uint4 _vld_2[1];
+                                #pragma unroll
+                                for (int _blk = 0; _blk < 1; _blk++) {
+                                    _vld_2[_blk] = _vptr_2[_blk];
+                                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
+                                    #pragma unroll
+                                    for (int _pair = 0; _pair < 4; _pair++) {
+                                        asm volatile(
+                                            "{\n\t"
+                                            ".reg .b16 h_lo, h_hi;\n\t"
+                                            ".reg .b32 f_lo, f_hi;\n\t"
+                                            "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                            "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                            "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                            "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                            "}\n"
+                                            : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_2[0 + _blk * 8 + _pair * 2]))
+                                            : "r"(_vpairs_2[_pair]));
+                                    }
+                                }
+                            }
+                            if (valid0 != 0) {
+                                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col0) * 32 + (long long)rank_col_1;
+                                float _vec_load_3[8];
+                                {
+                                    const uint4* _vptr_3 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
+                                    uint4 _vld_3[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_3[_blk] = _vptr_3[_blk];
+                                        uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_3[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_3[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_2 = 0; element_2 < 8; element_2++) {
+                                    float _fma_4 = __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
+                                    route_partial0_1 = _fma_4;
+                                }
+                            }
+                            if (valid1 != 0) {
+                                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col1) * 32 + (long long)rank_col_1;
+                                float _vec_load_4[8];
+                                {
+                                    const uint4* _vptr_4 = reinterpret_cast<const uint4*>(reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
+                                    uint4 _vld_4[1];
+                                    #pragma unroll
+                                    for (int _blk = 0; _blk < 1; _blk++) {
+                                        _vld_4[_blk] = _vptr_4[_blk];
+                                        uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
+                                        #pragma unroll
+                                        for (int _pair = 0; _pair < 4; _pair++) {
+                                            asm volatile(
+                                                "{\n\t"
+                                                ".reg .b16 h_lo, h_hi;\n\t"
+                                                ".reg .b32 f_lo, f_hi;\n\t"
+                                                "mov.b32 {h_lo, h_hi}, %1;\n\t"
+                                                "cvt.f32.f16 f_lo, h_lo;\n\t"
+                                                "cvt.f32.f16 f_hi, h_hi;\n\t"
+                                                "mov.b64 %0, {f_lo, f_hi};\n\t"
+                                                "}\n"
+                                                : "=l"(*reinterpret_cast<unsigned long long*>(&_vec_load_4[0 + _blk * 8 + _pair * 2]))
+                                                : "r"(_vpairs_4[_pair]));
+                                        }
+                                    }
+                                }
+                                #pragma unroll
+                                for (int element_3 = 0; element_3 < 8; element_3++) {
+                                    float _fma_5 = __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
+                                    route_partial1_1 = _fma_5;
+                                }
+                            }
+                        }
+                        if (valid0 != 0) {
+                            float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
+                            total0 = _fma_6;
+                        }
+                        if (valid1 != 0) {
+                            float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
+                            total1 = _fma_7;
+                        }
+                    }
+                }
+            }
+            if (valid0 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = total0;
+            }
+            if (valid1 != 0) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = total1;
+            }
         } else {
-#pragma unroll 1
-          for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-            if (sorted_token_ids[pair_1] == (long long)token) {
-              long long expert_1 = expert_ids[pair_1];
-              float route_partial_1 = 0.0f;
-#pragma unroll
-              for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-                int rank_col_1 = rank_block_1 * 8;
-                float _vec_load_1[8];
-                {
-                  const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                  uint4 _vld_1[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_1[_blk] = _vptr_1[_blk];
-                    uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_1[_pair]));
-                    }
-                  }
-                }
-                long long weight_index_1 =
-                    ((lora_id * (long long)num_experts + expert_1) * 3072 + (long long)output_col) *
-                        32 +
-                    (long long)rank_col_1;
-                float _vec_load_2[8];
-                {
-                  const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index_1 + 0);
-                  uint4 _vld_2[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_2[_blk] = _vptr_2[_blk];
-                    uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_2[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_1 = 0; element_1 < 8; element_1++) {
-                  float _fma_2 =
-                      __fmaf_rn(_vec_load_1[element_1], _vec_load_2[element_1], route_partial_1);
-                  route_partial_1 = _fma_2;
-                }
-              }
-              float _fma_3 = __fmaf_rn(route_partial_1, topk_weights[pair_1], total);
-              total = _fma_3;
+            if (output_col0 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col0)) + (0)) = 0.0f;
             }
-          }
+            if (output_col1 < 3072) {
+                *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col1)) + (0)) = 0.0f;
+            }
         }
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = total;
-      } else {
-        *(reinterpret_cast<float*>(y_accum + (token * output_stride + output_offset + output_col)) +
-          (0)) = 0.0f;
-      }
     }
-  }
 }
 
-}  // extern "C"
-
-#undef BLACKWELL_INF
-#undef NUM_MAIN_STAGES
-#undef SMEM_SHRINK_STAGE_OFF
-#undef SMEM_SHRINK_STAGE_STAGE_BYTES
-#undef SMEM_SHRINK_STAGE_STRIDE
-#undef SMEM_TOTAL
-#undef THREADS
-#undef shrink_stage_addr
-
-#define BLACKWELL_INF CUDART_INF_F
-#define NUM_MAIN_STAGES 1
-#define SMEM_SHRINK_STAGE_OFF 0
-#define SMEM_SHRINK_STAGE_STAGE_BYTES 128
-#define SMEM_SHRINK_STAGE_STRIDE 128
-#define SMEM_TOTAL 128
-#define THREADS 128
-
-extern "C" {
-
-__global__
-__launch_bounds__(128, 1) void kernel_flashinfer_bgmv_moe_expand_token_dual_col_f16_h3072_r32(
-    float* __restrict__ y_accum, uint16_t* __restrict__ shrink_raw,
-    uint16_t* __restrict__ lora_b_raw, long long* __restrict__ sorted_token_ids,
-    long long* __restrict__ expert_ids, long long* __restrict__ lora_indices,
-    float* __restrict__ topk_weights, int num_pairs, int num_experts, int num_tokens,
-    int output_stride, int output_offset) {
-  const int tid = threadIdx.x;
-  const int warp = make_warp_uniform(tid / 32);
-  const int lane = tid % 32;
-
-  extern __shared__ __align__(1024) char smem_raw[];
-  int smem;
-  smem = (int)(unsigned long long)__cvta_generic_to_shared(smem_raw);
-
-  const int bid = blockIdx.x;
-  const int num_bids = gridDim.x;
-
-  // Kernel setup ops
-  __half* shrink_stage = reinterpret_cast<__half*>(smem_raw + 0);
-  const int shrink_stage_addr = smem + 0;
-
-  // === Task calls (dependency order) ===
-  int token = blockIdx.x;
-  int output_col0 = blockIdx.y * 256 + tid;
-  int output_col1 = output_col0 + 128;
-  unsigned int activation_carriers[4];
-  float activation_values[8];
-  if (token < num_tokens) {
-    long long lora_id = lora_indices[token];
-    if (lora_id >= 0) {
-      int pair_base = token * 2;
-      int contiguous = 0;
-      if (num_pairs == num_tokens * 2) {
-        if (pair_base + 1 < num_pairs) {
-          if (sorted_token_ids[pair_base] == (long long)token) {
-            if (sorted_token_ids[pair_base + 1] == (long long)token) {
-              contiguous = 1;
-            }
-          }
-        }
-      }
-      int valid0 = 0;
-      int valid1 = 0;
-      if (output_col0 < 3072) {
-        valid0 = 1;
-      }
-      if (output_col1 < 3072) {
-        valid1 = 1;
-      }
-      float total0 = 0.0f;
-      float total1 = 0.0f;
-      if (contiguous != 0) {
-        if (tid < 8) {
-          int stage_route = tid / 4;
-          int stage_rank_block = tid % 4;
-          asm volatile("cp.async.cg.shared::cta.global [%0], [%1], 16;" ::"r"(
-                           shrink_stage_addr +
-                           (unsigned int)((stage_route * 32 + stage_rank_block * 8) * 2)),
-                       "l"(reinterpret_cast<const __half*>(shrink_raw) +
-                           ((pair_base + stage_route) * 32 + stage_rank_block * 8)));
-        }
-        asm volatile("cp.async.commit_group;");
-        asm volatile("cp.async.wait_group 0;");
-        __syncthreads();
-#pragma unroll
-        for (int route = 0; route < 2; route++) {
-          int pair = pair_base + route;
-          long long expert = expert_ids[pair];
-          float route_partial0 = 0.0f;
-          float route_partial1 = 0.0f;
-#pragma unroll
-          for (int rank_block = 0; rank_block < 4; rank_block++) {
-            int rank_col = rank_block * 8;
-            asm volatile("ld.shared.v4.b32 {%0,%1,%2,%3}, [%4];"
-                         : "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[0])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 1])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 2])),
-                           "=r"(*reinterpret_cast<uint32_t*>(&activation_carriers[(0) + 3]))
-                         : "r"(shrink_stage_addr + (unsigned int)((route * 32 + rank_col) * 2)));
-            {
-#pragma unroll
-              for (int _pair = 0; _pair < 4; _pair++) {
-                asm volatile(
-                    "{\n\t"
-                    ".reg .b16 h_lo, h_hi;\n\t"
-                    ".reg .b32 f_lo, f_hi;\n\t"
-                    "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                    "cvt.f32.f16 f_lo, h_lo;\n\t"
-                    "cvt.f32.f16 f_hi, h_hi;\n\t"
-                    "mov.b64 %0, {f_lo, f_hi};\n\t"
-                    "}\n"
-                    : "=l"(*reinterpret_cast<unsigned long long*>(&activation_values[_pair * 2]))
-                    : "r"(activation_carriers[_pair]));
-              }
-            }
-            if (valid0 != 0) {
-              long long weight_index0 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col0) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_0[8];
-              {
-                const uint4* _vptr_0 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index0 + 0);
-                uint4 _vld_0[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_0[_blk] = _vptr_0[_blk];
-                  uint32_t* _vpairs_0 = reinterpret_cast<uint32_t*>(&_vld_0[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_0[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_0[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element = 0; element < 8; element++) {
-                float _fma_0 =
-                    __fmaf_rn(activation_values[element], _vec_load_0[element], route_partial0);
-                route_partial0 = _fma_0;
-              }
-            }
-            if (valid1 != 0) {
-              long long weight_index1 =
-                  ((lora_id * (long long)num_experts + expert) * 3072 + (long long)output_col1) *
-                      32 +
-                  (long long)rank_col;
-              float _vec_load_1[8];
-              {
-                const uint4* _vptr_1 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(lora_b_raw) + weight_index1 + 0);
-                uint4 _vld_1[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_1[_blk] = _vptr_1[_blk];
-                  uint32_t* _vpairs_1 = reinterpret_cast<uint32_t*>(&_vld_1[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_1[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_1[_pair]));
-                  }
-                }
-              }
-#pragma unroll
-              for (int element_1 = 0; element_1 < 8; element_1++) {
-                float _fma_1 =
-                    __fmaf_rn(activation_values[element_1], _vec_load_1[element_1], route_partial1);
-                route_partial1 = _fma_1;
-              }
-            }
-          }
-          if (valid0 != 0) {
-            float _fma_2 = __fmaf_rn(route_partial0, topk_weights[pair], total0);
-            total0 = _fma_2;
-          }
-          if (valid1 != 0) {
-            float _fma_3 = __fmaf_rn(route_partial1, topk_weights[pair], total1);
-            total1 = _fma_3;
-          }
-        }
-      } else {
-#pragma unroll 1
-        for (int pair_1 = 0; pair_1 < num_pairs; pair_1++) {
-          if (sorted_token_ids[pair_1] == (long long)token) {
-            long long expert_1 = expert_ids[pair_1];
-            float route_partial0_1 = 0.0f;
-            float route_partial1_1 = 0.0f;
-#pragma unroll
-            for (int rank_block_1 = 0; rank_block_1 < 4; rank_block_1++) {
-              int rank_col_1 = rank_block_1 * 8;
-              float _vec_load_2[8];
-              {
-                const uint4* _vptr_2 = reinterpret_cast<const uint4*>(
-                    reinterpret_cast<const __half*>(shrink_raw) + (pair_1 * 32 + rank_col_1) + 0);
-                uint4 _vld_2[1];
-#pragma unroll
-                for (int _blk = 0; _blk < 1; _blk++) {
-                  _vld_2[_blk] = _vptr_2[_blk];
-                  uint32_t* _vpairs_2 = reinterpret_cast<uint32_t*>(&_vld_2[_blk]);
-#pragma unroll
-                  for (int _pair = 0; _pair < 4; _pair++) {
-                    asm volatile(
-                        "{\n\t"
-                        ".reg .b16 h_lo, h_hi;\n\t"
-                        ".reg .b32 f_lo, f_hi;\n\t"
-                        "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                        "cvt.f32.f16 f_lo, h_lo;\n\t"
-                        "cvt.f32.f16 f_hi, h_hi;\n\t"
-                        "mov.b64 %0, {f_lo, f_hi};\n\t"
-                        "}\n"
-                        : "=l"(*reinterpret_cast<unsigned long long*>(
-                            &_vec_load_2[0 + _blk * 8 + _pair * 2]))
-                        : "r"(_vpairs_2[_pair]));
-                  }
-                }
-              }
-              if (valid0 != 0) {
-                long long weight_index0_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                                             (long long)output_col0) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_3[8];
-                {
-                  const uint4* _vptr_3 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index0_1 + 0);
-                  uint4 _vld_3[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_3[_blk] = _vptr_3[_blk];
-                    uint32_t* _vpairs_3 = reinterpret_cast<uint32_t*>(&_vld_3[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_3[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_3[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_2 = 0; element_2 < 8; element_2++) {
-                  float _fma_4 =
-                      __fmaf_rn(_vec_load_2[element_2], _vec_load_3[element_2], route_partial0_1);
-                  route_partial0_1 = _fma_4;
-                }
-              }
-              if (valid1 != 0) {
-                long long weight_index1_1 = ((lora_id * (long long)num_experts + expert_1) * 3072 +
-                                             (long long)output_col1) *
-                                                32 +
-                                            (long long)rank_col_1;
-                float _vec_load_4[8];
-                {
-                  const uint4* _vptr_4 = reinterpret_cast<const uint4*>(
-                      reinterpret_cast<const __half*>(lora_b_raw) + weight_index1_1 + 0);
-                  uint4 _vld_4[1];
-#pragma unroll
-                  for (int _blk = 0; _blk < 1; _blk++) {
-                    _vld_4[_blk] = _vptr_4[_blk];
-                    uint32_t* _vpairs_4 = reinterpret_cast<uint32_t*>(&_vld_4[_blk]);
-#pragma unroll
-                    for (int _pair = 0; _pair < 4; _pair++) {
-                      asm volatile(
-                          "{\n\t"
-                          ".reg .b16 h_lo, h_hi;\n\t"
-                          ".reg .b32 f_lo, f_hi;\n\t"
-                          "mov.b32 {h_lo, h_hi}, %1;\n\t"
-                          "cvt.f32.f16 f_lo, h_lo;\n\t"
-                          "cvt.f32.f16 f_hi, h_hi;\n\t"
-                          "mov.b64 %0, {f_lo, f_hi};\n\t"
-                          "}\n"
-                          : "=l"(*reinterpret_cast<unsigned long long*>(
-                              &_vec_load_4[0 + _blk * 8 + _pair * 2]))
-                          : "r"(_vpairs_4[_pair]));
-                    }
-                  }
-                }
-#pragma unroll
-                for (int element_3 = 0; element_3 < 8; element_3++) {
-                  float _fma_5 =
-                      __fmaf_rn(_vec_load_2[element_3], _vec_load_4[element_3], route_partial1_1);
-                  route_partial1_1 = _fma_5;
-                }
-              }
-            }
-            if (valid0 != 0) {
-              float _fma_6 = __fmaf_rn(route_partial0_1, topk_weights[pair_1], total0);
-              total0 = _fma_6;
-            }
-            if (valid1 != 0) {
-              float _fma_7 = __fmaf_rn(route_partial1_1, topk_weights[pair_1], total1);
-              total1 = _fma_7;
-            }
-          }
-        }
-      }
-      if (valid0 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = total0;
-      }
-      if (valid1 != 0) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = total1;
-      }
-    } else {
-      if (output_col0 < 3072) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col0)) +
-          (0)) = 0.0f;
-      }
-      if (output_col1 < 3072) {
-        *(reinterpret_cast<float*>(y_accum +
-                                   (token * output_stride + output_offset + output_col1)) +
-          (0)) = 0.0f;
-      }
-    }
-  }
-}
-
-}  // extern "C"
+} // extern "C"
 
 #undef BLACKWELL_INF
 #undef NUM_MAIN_STAGES

--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -56,6 +56,8 @@ top of a Mixture-of-Experts layer (shrink + expand).
     :toctree: ../generated
 
     bgmv_moe
+    prepare_bgmv_moe
+    BGMVMoEBlackwellPlan
     bgmv_moe_shrink
     bgmv_moe_expand
     bgmv_moe_gemm1_lora_delta

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -110,6 +110,11 @@ from .jit.fused_moe import (
     gen_trtllm_gen_routing_module,
 )
 from .jit.bgmv_moe import gen_bgmv_moe_module
+from .jit.blackwell_bgmv_moe import (
+    BLACKWELL_BGMV_MOE_DTYPES,
+    BLACKWELL_BGMV_MOE_HIDDEN_SIZES,
+    gen_blackwell_bgmv_moe_module,
+)
 from .jit.monomoe import gen_monomoe_module
 from .jit.cute_sm120_mxfp8_groupwise import gen_gemm_sm120_module_cute_mxfp8
 from .jit.gemm import (
@@ -671,6 +676,12 @@ def gen_all_modules(
         jit_specs.append(gen_gemm_module())
         # Multi-LoRA MoE BGMV kernel
         jit_specs.append(gen_bgmv_moe_module())
+        if sm_capabilities.get("sm100a_exact", False):
+            jit_specs.extend(
+                gen_blackwell_bgmv_moe_module(hidden_size, dtype)
+                for hidden_size in BLACKWELL_BGMV_MOE_HIDDEN_SIZES
+                for dtype in BLACKWELL_BGMV_MOE_DTYPES
+            )
         # DSv4 hash-based MoE routing (SM-portable)
         jit_specs.append(gen_hash_topk_module())
         if has_sm90:

--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -138,11 +138,13 @@ from .trtllm_gen_routing import (  # noqa: F401
 )
 
 from .bgmv_moe import (  # noqa: F401
+    BGMVMoEBlackwellPlan as BGMVMoEBlackwellPlan,
     bgmv_moe as bgmv_moe,
     bgmv_moe_shrink as bgmv_moe_shrink,
     bgmv_moe_expand as bgmv_moe_expand,
     fill_w_ptr as fill_w_ptr,
     has_bgmv_moe as has_bgmv_moe,
+    prepare_bgmv_moe as prepare_bgmv_moe,
 )
 from .moe_lora_delta import (  # noqa: F401
     bgmv_moe_gemm1_lora_delta as bgmv_moe_gemm1_lora_delta,
@@ -270,12 +272,14 @@ __all__ = [
     "TrtllmGenRoutingResult",
     "trtllm_gen_routing",
     "bgmv_moe",
+    "BGMVMoEBlackwellPlan",
     "bgmv_moe_shrink",
     "bgmv_moe_expand",
     "bgmv_moe_gemm1_lora_delta",
     "bgmv_moe_gemm2_lora_delta",
     "fill_w_ptr",
     "has_bgmv_moe",
+    "prepare_bgmv_moe",
     "mono_moe",
     "has_monomoe",
     "alloc_scratchpad",

--- a/flashinfer/fused_moe/bgmv_moe.py
+++ b/flashinfer/fused_moe/bgmv_moe.py
@@ -371,7 +371,9 @@ def prepare_bgmv_moe(
 
     This optimized path currently supports one LoRA slice, rank 32, hidden
     sizes 2688 or 3072, BF16/FP16 inputs, and exact SM100 devices. Routing may
-    be arbitrary; the contiguous top-k=2 layout takes the optimized fast path.
+    be arbitrary; each output has one owner that accumulates routes in fixed
+    input order, so identical prepared replays are bitwise reproducible. The
+    contiguous top-k=2 layout takes the optimized fast path.
 
     Args:
         x: Input activations with shape ``[num_tokens, hidden_size]``.

--- a/flashinfer/fused_moe/bgmv_moe.py
+++ b/flashinfer/fused_moe/bgmv_moe.py
@@ -263,9 +263,9 @@ class BGMVMoEBlackwellPlan:
                 topk_weights,
             )
         )
-        self._graph = None
-        self._capture_stream = None
-        self._owner_stream = None
+        self._graph: Optional[torch.cuda.CUDAGraph] = None
+        self._capture_stream: Optional[torch.cuda.Stream] = None
+        self._owner_stream: Optional[torch.cuda.Stream] = None
         self._lock = threading.RLock()
 
     def _validate_binding(self) -> None:
@@ -314,7 +314,8 @@ class BGMVMoEBlackwellPlan:
 
         with self._lock:
             replay_stream = torch.cuda.current_stream(self.x.device)
-            if self._graph is None:
+            graph = self._graph
+            if graph is None:
                 capture_stream = torch.cuda.Stream(device=self.x.device)
                 capture_stream.wait_stream(replay_stream)
                 capture_stream.synchronize()
@@ -333,7 +334,7 @@ class BGMVMoEBlackwellPlan:
                 raise RuntimeError(
                     "BGMVMoEBlackwellPlan must replay on its original CUDA stream"
                 )
-            self._graph.replay()
+            graph.replay()
         return self.y_accum
 
     def close(self) -> None:
@@ -371,10 +372,31 @@ def prepare_bgmv_moe(
     This optimized path currently supports one LoRA slice, rank 32, hidden
     sizes 2688 or 3072, BF16/FP16 inputs, and exact SM100 devices. Routing may
     be arbitrary; the contiguous top-k=2 layout takes the optimized fast path.
+
+    Args:
+        x: Input activations with shape ``[num_tokens, hidden_size]``.
+        lora_a_weights: One LoRA-A tensor with shape
+            ``[num_loras, num_experts, 32, hidden_size]``.
+        lora_b_weights: One LoRA-B tensor with shape
+            ``[num_loras, num_experts, hidden_size, 32]``.
+        sorted_token_ids: Routed token indices with shape ``[num_pairs]``.
+        expert_ids: Expert index for each routed pair.
+        lora_indices: LoRA index for each input token.
+        topk_weights: FP32 routing weight for each routed pair.
+        num_experts: Number of experts in both LoRA tensors.
+        backend: Backend selector. Only ``"blackwell"`` is supported.
+        shrink_out: Optional pointer-stable FP32 shrink workspace.
+        y_accum: Optional pointer-stable FP32 output accumulator.
+
+    Returns:
+        A reusable graph-backed execution plan whose ``run`` method returns
+        the FP32 accumulated output.
     """
 
     if backend != "blackwell":
-        raise ValueError(f"prepare_bgmv_moe only supports backend='blackwell', got {backend}")
+        raise ValueError(
+            f"prepare_bgmv_moe only supports backend='blackwell', got {backend}"
+        )
     if not torch.cuda.is_available() or torch.cuda.get_device_capability(x.device) != (
         10,
         0,
@@ -459,7 +481,11 @@ def prepare_bgmv_moe(
             f"y_accum must have shape {expected_output} and dtype torch.float32"
         )
     for name, tensor in (("shrink_out", shrink_out), ("y_accum", y_accum)):
-        if not tensor.is_cuda or tensor.device != x.device or not tensor.is_contiguous():
+        if (
+            not tensor.is_cuda
+            or tensor.device != x.device
+            or not tensor.is_contiguous()
+        ):
             raise ValueError(f"{name} must be a contiguous tensor on {x.device}")
 
     from ..jit.blackwell_bgmv_moe import (

--- a/flashinfer/fused_moe/bgmv_moe.py
+++ b/flashinfer/fused_moe/bgmv_moe.py
@@ -397,9 +397,10 @@ def prepare_bgmv_moe(
         raise ValueError(
             f"prepare_bgmv_moe only supports backend='blackwell', got {backend}"
         )
-    if not torch.cuda.is_available() or torch.cuda.get_device_capability(x.device) != (
-        10,
-        0,
+    if (
+        not torch.cuda.is_available()
+        or not x.is_cuda
+        or torch.cuda.get_device_capability(x.device) != (10, 0)
     ):
         capability = (
             torch.cuda.get_device_capability(x.device)
@@ -465,6 +466,11 @@ def prepare_bgmv_moe(
     ):
         if tensor.dtype != torch.int64:
             raise ValueError(f"{name} must have dtype torch.int64")
+    if bool(((expert_ids < 0) | (expert_ids >= num_experts)).any()):
+        raise ValueError("expert_ids values must be in [0, num_experts)")
+    num_loras = int(lora_a.shape[0])
+    if bool(((lora_indices < -1) | (lora_indices >= num_loras)).any()):
+        raise ValueError("lora_indices values must be -1 or in [0, num_loras)")
 
     expected_shrink = (1, num_pairs, 32)
     if shrink_out is None:

--- a/flashinfer/fused_moe/bgmv_moe.py
+++ b/flashinfer/fused_moe/bgmv_moe.py
@@ -15,7 +15,8 @@ limitations under the License.
 """
 
 import functools
-from typing import List, Optional
+import threading
+from typing import List, Literal, Optional
 
 import torch
 
@@ -195,6 +196,295 @@ def fill_w_ptr(
     return weights.stride(0)
 
 
+def _blackwell_tensor_signature(tensor: torch.Tensor) -> tuple:
+    return (
+        int(tensor.data_ptr()),
+        tuple(int(dim) for dim in tensor.shape),
+        tuple(int(stride) for stride in tensor.stride()),
+        tensor.dtype,
+        tensor.device,
+    )
+
+
+def _blackwell_dtype_name(dtype: torch.dtype) -> Literal["bfloat16", "float16"]:
+    if dtype == torch.bfloat16:
+        return "bfloat16"
+    if dtype == torch.float16:
+        return "float16"
+    raise ValueError(f"Blackwell BGMV MoE requires BF16 or FP16, got {dtype}")
+
+
+class BGMVMoEBlackwellPlan:
+    """Pointer-stable SM100 BGMV MoE shrink+expand execution plan.
+
+    The plan owns caller-visible FP32 accumulation and shrink workspaces. Its
+    first eager ``run`` captures the exact launch sequence into a CUDA Graph;
+    later calls replay that graph on the same stream. If called while an outer
+    CUDA Graph is being captured, the constituent kernels are enqueued directly.
+    """
+
+    def __init__(
+        self,
+        module,
+        *,
+        y_accum: torch.Tensor,
+        shrink_out: torch.Tensor,
+        x: torch.Tensor,
+        lora_a: torch.Tensor,
+        lora_b: torch.Tensor,
+        sorted_token_ids: torch.Tensor,
+        expert_ids: torch.Tensor,
+        lora_indices: torch.Tensor,
+        topk_weights: torch.Tensor,
+        schedule_id: int,
+    ) -> None:
+        self._module = module
+        self.y_accum = y_accum
+        self.shrink_out = shrink_out
+        self.x = x
+        self.lora_a = lora_a
+        self.lora_b = lora_b
+        self.sorted_token_ids = sorted_token_ids
+        self.expert_ids = expert_ids
+        self.lora_indices = lora_indices
+        self.topk_weights = topk_weights
+        self.schedule_id = schedule_id
+        self._bound_signatures = tuple(
+            _blackwell_tensor_signature(tensor)
+            for tensor in (
+                y_accum,
+                shrink_out,
+                x,
+                lora_a,
+                lora_b,
+                sorted_token_ids,
+                expert_ids,
+                lora_indices,
+                topk_weights,
+            )
+        )
+        self._graph = None
+        self._capture_stream = None
+        self._owner_stream = None
+        self._lock = threading.RLock()
+
+    def _validate_binding(self) -> None:
+        current = tuple(
+            _blackwell_tensor_signature(tensor)
+            for tensor in (
+                self.y_accum,
+                self.shrink_out,
+                self.x,
+                self.lora_a,
+                self.lora_b,
+                self.sorted_token_ids,
+                self.expert_ids,
+                self.lora_indices,
+                self.topk_weights,
+            )
+        )
+        if current != self._bound_signatures:
+            raise RuntimeError(
+                "BGMVMoEBlackwellPlan tensor storage, shape, stride, dtype, or "
+                "device changed after preparation"
+            )
+
+    def _launch(self) -> None:
+        self._module.run(
+            self.y_accum,
+            self.shrink_out,
+            self.x,
+            self.lora_a,
+            self.lora_b,
+            self.sorted_token_ids,
+            self.expert_ids,
+            self.lora_indices,
+            self.topk_weights,
+            self.schedule_id,
+            int(torch.cuda.current_stream(self.x.device).cuda_stream),
+        )
+
+    def run(self) -> torch.Tensor:
+        """Run or replay the prepared zero+shrink+expand pipeline."""
+
+        self._validate_binding()
+        if torch.cuda.is_current_stream_capturing():
+            self._launch()
+            return self.y_accum
+
+        with self._lock:
+            replay_stream = torch.cuda.current_stream(self.x.device)
+            if self._graph is None:
+                capture_stream = torch.cuda.Stream(device=self.x.device)
+                capture_stream.wait_stream(replay_stream)
+                capture_stream.synchronize()
+                graph = torch.cuda.CUDAGraph(keep_graph=True)
+                with torch.cuda.graph(
+                    graph,
+                    stream=capture_stream,
+                    capture_error_mode="thread_local",
+                ):
+                    self._launch()
+                graph.instantiate()
+                self._graph = graph
+                self._capture_stream = capture_stream
+                self._owner_stream = replay_stream
+            elif replay_stream != self._owner_stream:
+                raise RuntimeError(
+                    "BGMVMoEBlackwellPlan must replay on its original CUDA stream"
+                )
+            self._graph.replay()
+        return self.y_accum
+
+    def close(self) -> None:
+        """Release graph resources after pending replay work completes."""
+
+        with self._lock:
+            if self._graph is None:
+                return
+            self._owner_stream.synchronize()
+            reset = getattr(self._graph, "reset", None)
+            if callable(reset):
+                reset()
+            self._graph = None
+            self._capture_stream = None
+            self._owner_stream = None
+
+
+@flashinfer_api
+def prepare_bgmv_moe(
+    x: torch.Tensor,
+    lora_a_weights: List[torch.Tensor],
+    lora_b_weights: List[torch.Tensor],
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    lora_indices: torch.Tensor,
+    topk_weights: torch.Tensor,
+    num_experts: int,
+    *,
+    backend: Literal["blackwell"] = "blackwell",
+    shrink_out: Optional[torch.Tensor] = None,
+    y_accum: Optional[torch.Tensor] = None,
+) -> BGMVMoEBlackwellPlan:
+    """Prepare the generated SM100 BGMV MoE pipeline for graph replay.
+
+    This optimized path currently supports one LoRA slice, rank 32, hidden
+    sizes 2688 or 3072, BF16/FP16 inputs, and exact SM100 devices. Routing may
+    be arbitrary; the contiguous top-k=2 layout takes the optimized fast path.
+    """
+
+    if backend != "blackwell":
+        raise ValueError(f"prepare_bgmv_moe only supports backend='blackwell', got {backend}")
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(x.device) != (
+        10,
+        0,
+    ):
+        capability = (
+            torch.cuda.get_device_capability(x.device)
+            if torch.cuda.is_available() and x.is_cuda
+            else None
+        )
+        raise ValueError(
+            "Blackwell BGMV MoE requires an exact SM100 CUDA device; "
+            f"got capability={capability}"
+        )
+    if len(lora_a_weights) != 1 or len(lora_b_weights) != 1:
+        raise ValueError("Blackwell BGMV MoE currently requires exactly one LoRA slice")
+    if x.ndim != 2:
+        raise ValueError(f"x must have shape [tokens, hidden], got {tuple(x.shape)}")
+    num_tokens, hidden_size = (int(dim) for dim in x.shape)
+    dtype_name = _blackwell_dtype_name(x.dtype)
+    lora_a = lora_a_weights[0]
+    lora_b = lora_b_weights[0]
+    if lora_a.ndim != 4 or lora_b.ndim != 4:
+        raise ValueError("LoRA weights must have rank 4")
+    if int(lora_a.shape[0]) != int(lora_b.shape[0]):
+        raise ValueError("LoRA-A and LoRA-B must have the same num_loras dimension")
+    if int(lora_a.shape[1]) != num_experts or int(lora_b.shape[1]) != num_experts:
+        raise ValueError("num_experts must match both LoRA weight tensors")
+    if tuple(lora_a.shape[2:]) != (32, hidden_size):
+        raise ValueError(
+            "LoRA-A must have shape [num_loras, num_experts, 32, hidden_size]"
+        )
+    if tuple(lora_b.shape[2:]) != (hidden_size, 32):
+        raise ValueError(
+            "LoRA-B must have shape [num_loras, num_experts, hidden_size, 32]"
+        )
+    if lora_a.dtype != x.dtype or lora_b.dtype != x.dtype:
+        raise ValueError("x and both LoRA weight tensors must have the same dtype")
+    num_pairs = int(sorted_token_ids.numel())
+    if sorted_token_ids.ndim != 1 or num_pairs <= 0:
+        raise ValueError("sorted_token_ids must be a non-empty rank-1 tensor")
+    if expert_ids.shape != sorted_token_ids.shape:
+        raise ValueError("expert_ids must have the same shape as sorted_token_ids")
+    if topk_weights.shape != sorted_token_ids.shape:
+        raise ValueError("topk_weights must have the same shape as sorted_token_ids")
+    if tuple(lora_indices.shape) != (num_tokens,):
+        raise ValueError("lora_indices must have shape [num_tokens]")
+    if topk_weights.dtype != torch.float32:
+        raise ValueError("topk_weights must have dtype torch.float32")
+    for name, tensor in (
+        ("x", x),
+        ("lora_a", lora_a),
+        ("lora_b", lora_b),
+        ("sorted_token_ids", sorted_token_ids),
+        ("expert_ids", expert_ids),
+        ("lora_indices", lora_indices),
+        ("topk_weights", topk_weights),
+    ):
+        if not tensor.is_cuda or tensor.device != x.device:
+            raise ValueError(f"{name} must be on {x.device}")
+        if not tensor.is_contiguous():
+            raise ValueError(f"{name} must be contiguous")
+    for name, tensor in (
+        ("sorted_token_ids", sorted_token_ids),
+        ("expert_ids", expert_ids),
+        ("lora_indices", lora_indices),
+    ):
+        if tensor.dtype != torch.int64:
+            raise ValueError(f"{name} must have dtype torch.int64")
+
+    expected_shrink = (1, num_pairs, 32)
+    if shrink_out is None:
+        shrink_out = torch.empty(expected_shrink, dtype=x.dtype, device=x.device)
+    if tuple(shrink_out.shape) != expected_shrink or shrink_out.dtype != x.dtype:
+        raise ValueError(
+            f"shrink_out must have shape {expected_shrink} and dtype {x.dtype}"
+        )
+    expected_output = (num_tokens, hidden_size)
+    if y_accum is None:
+        y_accum = torch.empty(expected_output, dtype=torch.float32, device=x.device)
+    if tuple(y_accum.shape) != expected_output or y_accum.dtype != torch.float32:
+        raise ValueError(
+            f"y_accum must have shape {expected_output} and dtype torch.float32"
+        )
+    for name, tensor in (("shrink_out", shrink_out), ("y_accum", y_accum)):
+        if not tensor.is_cuda or tensor.device != x.device or not tensor.is_contiguous():
+            raise ValueError(f"{name} must be a contiguous tensor on {x.device}")
+
+    from ..jit.blackwell_bgmv_moe import (
+        BLACKWELL_BGMV_MOE_SCHEDULE_IDS,
+        get_blackwell_bgmv_moe_module,
+        select_blackwell_bgmv_moe_schedule,
+    )
+
+    schedule = select_blackwell_bgmv_moe_schedule(hidden_size, num_tokens)
+    module = get_blackwell_bgmv_moe_module(hidden_size, dtype_name)
+    return BGMVMoEBlackwellPlan(
+        module,
+        y_accum=y_accum,
+        shrink_out=shrink_out,
+        x=x,
+        lora_a=lora_a,
+        lora_b=lora_b,
+        sorted_token_ids=sorted_token_ids,
+        expert_ids=expert_ids,
+        lora_indices=lora_indices,
+        topk_weights=topk_weights,
+        schedule_id=BLACKWELL_BGMV_MOE_SCHEDULE_IDS[schedule],
+    )
+
+
 @flashinfer_api
 def bgmv_moe(
     x: torch.Tensor,
@@ -225,7 +515,6 @@ def bgmv_moe(
         topk_weights: Routing weights for each pair [num_pairs].
         num_experts: Number of experts.
         output_dim: Total output dimension. If None, inferred from lora_b_weights.
-
     Returns:
         Output tensor [num_tokens, total_feat_out] with LoRA deltas.
     """

--- a/flashinfer/jit/__init__.py
+++ b/flashinfer/jit/__init__.py
@@ -137,6 +137,12 @@ from .nvfp4_attention_sm120 import (
 )
 from .bgmv_moe import gen_bgmv_moe_module as gen_bgmv_moe_module
 from .bgmv_moe import load_bgmv_moe_module as load_bgmv_moe_module
+from .blackwell_bgmv_moe import (
+    gen_blackwell_bgmv_moe_module as gen_blackwell_bgmv_moe_module,
+)
+from .blackwell_bgmv_moe import (
+    load_blackwell_bgmv_moe_module as load_blackwell_bgmv_moe_module,
+)
 from .monomoe import gen_monomoe_module as gen_monomoe_module
 from .monomoe import load_monomoe_module as load_monomoe_module
 

--- a/flashinfer/jit/blackwell_bgmv_moe.py
+++ b/flashinfer/jit/blackwell_bgmv_moe.py
@@ -1,0 +1,239 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""JIT registration for the generated SM100 BGMV MoE programs."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+from typing import Literal, NamedTuple
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec, logger, sm100a_nvcc_flags
+from .utils import write_if_different
+
+BlackwellBGMVMoEDType = Literal["bfloat16", "float16"]
+BlackwellBGMVMoESchedule = Literal[
+    "pair_owned_t128",
+    "token_owned_t64",
+    "token_owned",
+    "token_owned_dual_col",
+]
+
+BLACKWELL_BGMV_MOE_HIDDEN_SIZES = (2688, 3072)
+BLACKWELL_BGMV_MOE_DTYPES: tuple[BlackwellBGMVMoEDType, ...] = (
+    "bfloat16",
+    "float16",
+)
+BLACKWELL_BGMV_MOE_SCHEDULE_IDS: dict[BlackwellBGMVMoESchedule, int] = {
+    "pair_owned_t128": 0,
+    "token_owned_t64": 1,
+    "token_owned": 2,
+    "token_owned_dual_col": 3,
+}
+
+
+class BlackwellBGMVMoEMetadata(NamedTuple):
+    body: str
+    shrink_decode_symbol: str
+    shrink_prefill_symbol: str
+    pair_owned_symbol: str
+    token_t64_symbol: str
+    token_symbol: str
+    token_dual_col_symbol: str
+
+
+def _dtype_tag(dtype: BlackwellBGMVMoEDType) -> str:
+    if dtype == "bfloat16":
+        return "bf16"
+    if dtype == "float16":
+        return "f16"
+    raise ValueError(f"unsupported Blackwell BGMV MoE dtype: {dtype}")
+
+
+def _metadata(hidden_size: int, dtype: BlackwellBGMVMoEDType) -> BlackwellBGMVMoEMetadata:
+    if hidden_size not in BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
+        raise ValueError(
+            "Blackwell BGMV MoE hidden_size must be 2688 or 3072, got "
+            f"{hidden_size}"
+        )
+    tag = _dtype_tag(dtype)
+    return BlackwellBGMVMoEMetadata(
+        body=f"blackwell_bgmv_moe_{tag}_h{hidden_size}_sm100a.cu",
+        shrink_decode_symbol=(
+            f"kernel_flashinfer_bgmv_moe_shrink_{tag}_h{hidden_size}_r32_p4_s3"
+        ),
+        shrink_prefill_symbol=(
+            f"kernel_flashinfer_bgmv_moe_shrink_{tag}_h{hidden_size}_r32_p1_s2"
+        ),
+        pair_owned_symbol=(
+            "kernel_flashinfer_bgmv_moe_expand_pair_owned_"
+            f"{tag}_h{hidden_size}_r32_t128"
+        ),
+        token_t64_symbol=(
+            f"kernel_flashinfer_bgmv_moe_expand_token_t64_{tag}_h{hidden_size}_r32"
+        ),
+        token_symbol=(
+            f"kernel_flashinfer_bgmv_moe_expand_token_{tag}_h{hidden_size}_r32"
+        ),
+        token_dual_col_symbol=(
+            "kernel_flashinfer_bgmv_moe_expand_token_dual_col_"
+            f"{tag}_h{hidden_size}_r32"
+        ),
+    )
+
+
+def select_blackwell_bgmv_moe_schedule(
+    hidden_size: int,
+    num_tokens: int,
+) -> BlackwellBGMVMoESchedule:
+    """Return the measured selector for the supported rank-32 portfolio."""
+
+    if hidden_size not in BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
+        raise ValueError(
+            "Blackwell BGMV MoE hidden_size must be 2688 or 3072, got "
+            f"{hidden_size}"
+        )
+    if num_tokens <= 0:
+        raise ValueError(f"num_tokens must be positive, got {num_tokens}")
+
+    if (hidden_size == 3072 and num_tokens in (1, 4, 8)) or (
+        hidden_size == 2688 and num_tokens in (1, 8)
+    ):
+        return "token_owned_t64"
+    if hidden_size == 2688 and num_tokens == 4:
+        return "pair_owned_t128"
+    if hidden_size == 3072 and num_tokens in (512, 1024):
+        return "token_owned_dual_col"
+    if hidden_size == 2688 and num_tokens == 1024:
+        return "token_owned_dual_col"
+    return "token_owned"
+
+
+def _get_csrc_dir() -> Path:
+    installed = jit_env.FLASHINFER_CSRC_DIR / "blackwell_bgmv_moe" / "sm100a"
+    if installed.is_dir():
+        return installed
+    checkout = (
+        Path(__file__).resolve().parents[2] / "csrc" / "blackwell_bgmv_moe" / "sm100a"
+    )
+    if checkout.is_dir():
+        return checkout
+    raise FileNotFoundError(
+        "generated Blackwell BGMV MoE sources were not found. Checked:\n"
+        f"  - {installed}\n  - {checkout}"
+    )
+
+
+def get_blackwell_bgmv_moe_uri(
+    hidden_size: int,
+    dtype: BlackwellBGMVMoEDType,
+) -> str:
+    tag = _dtype_tag(dtype)
+    if hidden_size not in BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
+        raise ValueError(
+            "Blackwell BGMV MoE hidden_size must be 2688 or 3072, got "
+            f"{hidden_size}"
+        )
+    return f"blackwell_bgmv_moe_{tag}_h{hidden_size}_sm100a"
+
+
+def _binding_source(metadata: BlackwellBGMVMoEMetadata, hidden_size: int) -> str:
+    input_dtype = "dl_bfloat16" if "_bf16_" in metadata.body else "dl_float16"
+    return f"""\
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+ * Licensed under the Apache License, Version 2.0.
+ */
+
+#define BLACKWELL_BGMV_MOE_BODY_FILE \"{metadata.body}\"
+#define BLACKWELL_BGMV_MOE_HIDDEN {hidden_size}
+#define BLACKWELL_BGMV_MOE_INPUT_DTYPE {input_dtype}
+#define BLACKWELL_BGMV_MOE_SHRINK_DECODE {metadata.shrink_decode_symbol}
+#define BLACKWELL_BGMV_MOE_SHRINK_PREFILL {metadata.shrink_prefill_symbol}
+#define BLACKWELL_BGMV_MOE_EXPAND_PAIR {metadata.pair_owned_symbol}
+#define BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 {metadata.token_t64_symbol}
+#define BLACKWELL_BGMV_MOE_EXPAND_TOKEN {metadata.token_symbol}
+#define BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL {metadata.token_dual_col_symbol}
+
+#include \"blackwell_bgmv_moe_binding.cuh\"
+"""
+
+
+@functools.cache
+def gen_blackwell_bgmv_moe_module(
+    hidden_size: int,
+    dtype: BlackwellBGMVMoEDType,
+) -> JitSpec:
+    metadata = _metadata(hidden_size, dtype)
+    csrc_dir = _get_csrc_dir()
+    body = csrc_dir / metadata.body
+    binding_header = csrc_dir / "blackwell_bgmv_moe_binding.cuh"
+    if not body.is_file():
+        raise FileNotFoundError(f"generated Blackwell BGMV MoE body not found: {body}")
+    if not binding_header.is_file():
+        raise FileNotFoundError(
+            f"Blackwell BGMV MoE binding header not found: {binding_header}"
+        )
+
+    uri = get_blackwell_bgmv_moe_uri(hidden_size, dtype)
+    binding = jit_env.FLASHINFER_GEN_SRC_DIR / uri / "blackwell_bgmv_moe_binding.cu"
+    write_if_different(binding, _binding_source(metadata, hidden_size))
+    spec = gen_jit_spec(
+        name=uri,
+        sources=[binding],
+        extra_cuda_cflags=[*sm100a_nvcc_flags, "-use_fast_math"],
+        extra_include_paths=[csrc_dir],
+    )
+    logger.info("Generated Blackwell BGMV MoE JIT spec: %s", spec.name)
+    return spec
+
+
+@functools.cache
+def load_blackwell_bgmv_moe_module(
+    hidden_size: int,
+    dtype: BlackwellBGMVMoEDType,
+):
+    module = gen_blackwell_bgmv_moe_module(hidden_size, dtype).build_and_load()
+    logger.info(
+        "Loaded Blackwell BGMV MoE module for hidden_size=%d, dtype=%s",
+        hidden_size,
+        dtype,
+    )
+    return module
+
+
+def get_blackwell_bgmv_moe_module(
+    hidden_size: int,
+    dtype: BlackwellBGMVMoEDType,
+):
+    return load_blackwell_bgmv_moe_module(hidden_size, dtype)
+
+
+__all__ = [
+    "BLACKWELL_BGMV_MOE_DTYPES",
+    "BLACKWELL_BGMV_MOE_HIDDEN_SIZES",
+    "BLACKWELL_BGMV_MOE_SCHEDULE_IDS",
+    "BlackwellBGMVMoEDType",
+    "BlackwellBGMVMoEMetadata",
+    "BlackwellBGMVMoESchedule",
+    "gen_blackwell_bgmv_moe_module",
+    "get_blackwell_bgmv_moe_module",
+    "get_blackwell_bgmv_moe_uri",
+    "load_blackwell_bgmv_moe_module",
+    "select_blackwell_bgmv_moe_schedule",
+]

--- a/flashinfer/jit/blackwell_bgmv_moe.py
+++ b/flashinfer/jit/blackwell_bgmv_moe.py
@@ -223,6 +223,7 @@ def load_blackwell_bgmv_moe_module(
     dtype: BlackwellBGMVMoEDType,
 ):
     module = gen_blackwell_bgmv_moe_module(hidden_size, dtype).build_and_load()
+    module.configure()
     logger.info(
         "Loaded Blackwell BGMV MoE module for hidden_size=%d, dtype=%s",
         hidden_size,

--- a/flashinfer/jit/blackwell_bgmv_moe.py
+++ b/flashinfer/jit/blackwell_bgmv_moe.py
@@ -136,6 +136,23 @@ def _get_csrc_dir() -> Path:
     )
 
 
+def _get_include_dir() -> Path:
+    """Locate FlashInfer headers in installed and source checkouts."""
+
+    if jit_env.FLASHINFER_INCLUDE_DIR.exists():
+        return jit_env.FLASHINFER_INCLUDE_DIR
+
+    checkout = Path(__file__).resolve().parents[2] / "include"
+    if checkout.exists():
+        return checkout
+
+    raise FileNotFoundError(
+        "FlashInfer headers were not found. Checked:\n"
+        f"  - {jit_env.FLASHINFER_INCLUDE_DIR}\n"
+        f"  - {checkout}"
+    )
+
+
 def get_blackwell_bgmv_moe_uri(
     hidden_size: int,
     dtype: BlackwellBGMVMoEDType,
@@ -177,6 +194,7 @@ def gen_blackwell_bgmv_moe_module(
 ) -> JitSpec:
     metadata = _metadata(hidden_size, dtype)
     csrc_dir = _get_csrc_dir()
+    include_dir = _get_include_dir()
     body = csrc_dir / metadata.body
     binding_header = csrc_dir / "blackwell_bgmv_moe_binding.cuh"
     if not body.is_file():
@@ -193,7 +211,7 @@ def gen_blackwell_bgmv_moe_module(
         name=uri,
         sources=[binding],
         extra_cuda_cflags=[*sm100a_nvcc_flags, "-use_fast_math"],
-        extra_include_paths=[csrc_dir],
+        extra_include_paths=[csrc_dir, include_dir],
     )
     logger.info("Generated Blackwell BGMV MoE JIT spec: %s", spec.name)
     return spec

--- a/flashinfer/jit/blackwell_bgmv_moe.py
+++ b/flashinfer/jit/blackwell_bgmv_moe.py
@@ -26,7 +26,6 @@ from .utils import write_if_different
 
 BlackwellBGMVMoEDType = Literal["bfloat16", "float16"]
 BlackwellBGMVMoESchedule = Literal[
-    "pair_owned_t128",
     "token_owned_t64",
     "token_owned",
     "token_owned_dual_col",
@@ -38,10 +37,9 @@ BLACKWELL_BGMV_MOE_DTYPES: tuple[BlackwellBGMVMoEDType, ...] = (
     "float16",
 )
 BLACKWELL_BGMV_MOE_SCHEDULE_IDS: dict[BlackwellBGMVMoESchedule, int] = {
-    "pair_owned_t128": 0,
-    "token_owned_t64": 1,
-    "token_owned": 2,
-    "token_owned_dual_col": 3,
+    "token_owned_t64": 0,
+    "token_owned": 1,
+    "token_owned_dual_col": 2,
 }
 
 
@@ -49,7 +47,6 @@ class BlackwellBGMVMoEMetadata(NamedTuple):
     body: str
     shrink_decode_symbol: str
     shrink_prefill_symbol: str
-    pair_owned_symbol: str
     token_t64_symbol: str
     token_symbol: str
     token_dual_col_symbol: str
@@ -79,10 +76,6 @@ def _metadata(
         shrink_prefill_symbol=(
             f"kernel_flashinfer_bgmv_moe_shrink_{tag}_h{hidden_size}_r32_p1_s2"
         ),
-        pair_owned_symbol=(
-            "kernel_flashinfer_bgmv_moe_expand_pair_owned_"
-            f"{tag}_h{hidden_size}_r32_t128"
-        ),
         token_t64_symbol=(
             f"kernel_flashinfer_bgmv_moe_expand_token_t64_{tag}_h{hidden_size}_r32"
         ),
@@ -109,11 +102,9 @@ def select_blackwell_bgmv_moe_schedule(
         raise ValueError(f"num_tokens must be positive, got {num_tokens}")
 
     if (hidden_size == 3072 and num_tokens in (1, 4, 8)) or (
-        hidden_size == 2688 and num_tokens in (1, 8)
+        hidden_size == 2688 and num_tokens in (1, 4, 8)
     ):
         return "token_owned_t64"
-    if hidden_size == 2688 and num_tokens == 4:
-        return "pair_owned_t128"
     if hidden_size == 3072 and num_tokens in (512, 1024):
         return "token_owned_dual_col"
     if hidden_size == 2688 and num_tokens == 1024:
@@ -178,7 +169,6 @@ def _binding_source(metadata: BlackwellBGMVMoEMetadata, hidden_size: int) -> str
 #define BLACKWELL_BGMV_MOE_INPUT_DTYPE {input_dtype}
 #define BLACKWELL_BGMV_MOE_SHRINK_DECODE {metadata.shrink_decode_symbol}
 #define BLACKWELL_BGMV_MOE_SHRINK_PREFILL {metadata.shrink_prefill_symbol}
-#define BLACKWELL_BGMV_MOE_EXPAND_PAIR {metadata.pair_owned_symbol}
 #define BLACKWELL_BGMV_MOE_EXPAND_TOKEN_T64 {metadata.token_t64_symbol}
 #define BLACKWELL_BGMV_MOE_EXPAND_TOKEN {metadata.token_symbol}
 #define BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL {metadata.token_dual_col_symbol}

--- a/flashinfer/jit/blackwell_bgmv_moe.py
+++ b/flashinfer/jit/blackwell_bgmv_moe.py
@@ -14,8 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-"""JIT registration for the generated SM100 BGMV MoE programs."""
-
 from __future__ import annotations
 
 import functools
@@ -65,11 +63,12 @@ def _dtype_tag(dtype: BlackwellBGMVMoEDType) -> str:
     raise ValueError(f"unsupported Blackwell BGMV MoE dtype: {dtype}")
 
 
-def _metadata(hidden_size: int, dtype: BlackwellBGMVMoEDType) -> BlackwellBGMVMoEMetadata:
+def _metadata(
+    hidden_size: int, dtype: BlackwellBGMVMoEDType
+) -> BlackwellBGMVMoEMetadata:
     if hidden_size not in BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
         raise ValueError(
-            "Blackwell BGMV MoE hidden_size must be 2688 or 3072, got "
-            f"{hidden_size}"
+            f"Blackwell BGMV MoE hidden_size must be 2688 or 3072, got {hidden_size}"
         )
     tag = _dtype_tag(dtype)
     return BlackwellBGMVMoEMetadata(
@@ -91,8 +90,7 @@ def _metadata(hidden_size: int, dtype: BlackwellBGMVMoEDType) -> BlackwellBGMVMo
             f"kernel_flashinfer_bgmv_moe_expand_token_{tag}_h{hidden_size}_r32"
         ),
         token_dual_col_symbol=(
-            "kernel_flashinfer_bgmv_moe_expand_token_dual_col_"
-            f"{tag}_h{hidden_size}_r32"
+            f"kernel_flashinfer_bgmv_moe_expand_token_dual_col_{tag}_h{hidden_size}_r32"
         ),
     )
 
@@ -105,8 +103,7 @@ def select_blackwell_bgmv_moe_schedule(
 
     if hidden_size not in BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
         raise ValueError(
-            "Blackwell BGMV MoE hidden_size must be 2688 or 3072, got "
-            f"{hidden_size}"
+            f"Blackwell BGMV MoE hidden_size must be 2688 or 3072, got {hidden_size}"
         )
     if num_tokens <= 0:
         raise ValueError(f"num_tokens must be positive, got {num_tokens}")
@@ -146,8 +143,7 @@ def get_blackwell_bgmv_moe_uri(
     tag = _dtype_tag(dtype)
     if hidden_size not in BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
         raise ValueError(
-            "Blackwell BGMV MoE hidden_size must be 2688 or 3072, got "
-            f"{hidden_size}"
+            f"Blackwell BGMV MoE hidden_size must be 2688 or 3072, got {hidden_size}"
         )
     return f"blackwell_bgmv_moe_{tag}_h{hidden_size}_sm100a"
 

--- a/flashinfer/jit/blackwell_bgmv_moe.py
+++ b/flashinfer/jit/blackwell_bgmv_moe.py
@@ -211,7 +211,7 @@ def gen_blackwell_bgmv_moe_module(
         name=uri,
         sources=[binding],
         extra_cuda_cflags=[*sm100a_nvcc_flags, "-use_fast_math"],
-        extra_include_paths=[csrc_dir, include_dir],
+        extra_include_paths=[csrc_dir, csrc_dir.parents[1], include_dir],
     )
     logger.info("Generated Blackwell BGMV MoE JIT spec: %s", spec.name)
     return spec

--- a/tests/jit/test_blackwell_bgmv_moe_jit.py
+++ b/tests/jit/test_blackwell_bgmv_moe_jit.py
@@ -1,0 +1,97 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+from flashinfer.jit import blackwell_bgmv_moe
+from flashinfer.jit import core as jit_core
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "num_tokens", "expected"),
+    [
+        (3072, 1, "token_owned_t64"),
+        (3072, 4, "token_owned_t64"),
+        (3072, 8, "token_owned_t64"),
+        (3072, 32, "token_owned"),
+        (3072, 256, "token_owned"),
+        (3072, 512, "token_owned_dual_col"),
+        (3072, 1024, "token_owned_dual_col"),
+        (2688, 1, "token_owned_t64"),
+        (2688, 4, "pair_owned_t128"),
+        (2688, 8, "token_owned_t64"),
+        (2688, 32, "token_owned"),
+        (2688, 256, "token_owned"),
+        (2688, 512, "token_owned"),
+        (2688, 1024, "token_owned_dual_col"),
+    ],
+)
+def test_selector_matches_measured_shape_portfolio(
+    hidden_size, num_tokens, expected
+):
+    assert (
+        blackwell_bgmv_moe.select_blackwell_bgmv_moe_schedule(hidden_size, num_tokens)
+        == expected
+    )
+
+
+def test_selector_rejects_unsupported_shapes():
+    with pytest.raises(ValueError, match="hidden_size"):
+        blackwell_bgmv_moe.select_blackwell_bgmv_moe_schedule(2048, 32)
+    with pytest.raises(ValueError, match="positive"):
+        blackwell_bgmv_moe.select_blackwell_bgmv_moe_schedule(3072, 0)
+
+
+@pytest.mark.parametrize("hidden_size", blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_HIDDEN_SIZES)
+@pytest.mark.parametrize("dtype", blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_DTYPES)
+def test_jit_spec_binds_generated_sm100_source(
+    monkeypatch, tmp_path, hidden_size, dtype
+):
+    monkeypatch.setattr(
+        jit_core.current_compilation_context,
+        "TARGET_CUDA_ARCHS",
+        {(10, "0a")},
+    )
+    monkeypatch.setattr(blackwell_bgmv_moe.jit_env, "FLASHINFER_GEN_SRC_DIR", tmp_path)
+    blackwell_bgmv_moe.gen_blackwell_bgmv_moe_module.cache_clear()
+
+    spec = blackwell_bgmv_moe.gen_blackwell_bgmv_moe_module(hidden_size, dtype)
+    uri = blackwell_bgmv_moe.get_blackwell_bgmv_moe_uri(hidden_size, dtype)
+    metadata = blackwell_bgmv_moe._metadata(hidden_size, dtype)
+
+    assert spec.name == uri
+    assert spec.sources == [tmp_path / uri / "blackwell_bgmv_moe_binding.cu"]
+    assert "-gencode=arch=compute_100a,code=sm_100a" in spec.extra_cuda_cflags
+    assert "-use_fast_math" in spec.extra_cuda_cflags
+    body = (blackwell_bgmv_moe._get_csrc_dir() / metadata.body).read_text()
+    for symbol in metadata[1:]:
+        assert symbol in body
+    binding = spec.sources[0].read_text()
+    assert f'#define BLACKWELL_BGMV_MOE_BODY_FILE "{metadata.body}"' in binding
+    assert f"#define BLACKWELL_BGMV_MOE_HIDDEN {hidden_size}" in binding
+    assert '#include "blackwell_bgmv_moe_binding.cuh"' in binding
+    blackwell_bgmv_moe.gen_blackwell_bgmv_moe_module.cache_clear()
+
+
+def test_binding_preserves_graph_and_tensor_contracts():
+    binding = (
+        blackwell_bgmv_moe._get_csrc_dir() / "blackwell_bgmv_moe_binding.cuh"
+    ).read_text()
+    assert "CheckExactSM100" in binding
+    assert "cudaMemsetAsync" in binding
+    assert "BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<" in binding
+    assert "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<" in binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run" in binding

--- a/tests/jit/test_blackwell_bgmv_moe_jit.py
+++ b/tests/jit/test_blackwell_bgmv_moe_jit.py
@@ -76,6 +76,7 @@ def test_jit_spec_binds_generated_sm100_source(
     assert spec.sources == [tmp_path / uri / "blackwell_bgmv_moe_binding.cu"]
     assert "-gencode=arch=compute_100a,code=sm_100a" in spec.extra_cuda_cflags
     assert "-use_fast_math" in spec.extra_cuda_cflags
+    assert blackwell_bgmv_moe._get_csrc_dir().parents[1] in spec.extra_include_dirs
     assert blackwell_bgmv_moe._get_include_dir() in spec.extra_include_dirs
     body = (blackwell_bgmv_moe._get_csrc_dir() / metadata.body).read_text()
     for symbol in metadata[1:]:

--- a/tests/jit/test_blackwell_bgmv_moe_jit.py
+++ b/tests/jit/test_blackwell_bgmv_moe_jit.py
@@ -39,9 +39,7 @@ from flashinfer.jit import core as jit_core
         (2688, 1024, "token_owned_dual_col"),
     ],
 )
-def test_selector_matches_measured_shape_portfolio(
-    hidden_size, num_tokens, expected
-):
+def test_selector_matches_measured_shape_portfolio(hidden_size, num_tokens, expected):
     assert (
         blackwell_bgmv_moe.select_blackwell_bgmv_moe_schedule(hidden_size, num_tokens)
         == expected
@@ -55,7 +53,9 @@ def test_selector_rejects_unsupported_shapes():
         blackwell_bgmv_moe.select_blackwell_bgmv_moe_schedule(3072, 0)
 
 
-@pytest.mark.parametrize("hidden_size", blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_HIDDEN_SIZES)
+@pytest.mark.parametrize(
+    "hidden_size", blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_HIDDEN_SIZES
+)
 @pytest.mark.parametrize("dtype", blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_DTYPES)
 def test_jit_spec_binds_generated_sm100_source(
     monkeypatch, tmp_path, hidden_size, dtype

--- a/tests/jit/test_blackwell_bgmv_moe_jit.py
+++ b/tests/jit/test_blackwell_bgmv_moe_jit.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import re
+
 import pytest
 
 from flashinfer.jit import blackwell_bgmv_moe
@@ -93,7 +95,21 @@ def test_binding_preserves_graph_and_tensor_contracts():
         blackwell_bgmv_moe._get_csrc_dir() / "blackwell_bgmv_moe_binding.cuh"
     ).read_text()
     assert "CheckExactSM100" in binding
+    assert "kShrinkDecodeSmemBytes = 221696" in binding
+    assert "kShrinkPrefillSmemBytes = 36992" in binding
+    assert "cudaDevAttrMaxSharedMemoryPerBlockOptin" in binding
+    assert "cudaFuncAttributeMaxDynamicSharedMemorySize" in binding
     assert "cudaMemsetAsync" in binding
     assert "BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<" in binding
     assert "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<" in binding
+    assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(configure" in binding
     assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(run" in binding
+
+    for hidden_size in blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_HIDDEN_SIZES:
+        for dtype in blackwell_bgmv_moe.BLACKWELL_BGMV_MOE_DTYPES:
+            body = (
+                blackwell_bgmv_moe._get_csrc_dir()
+                / blackwell_bgmv_moe._metadata(hidden_size, dtype).body
+            ).read_text()
+            smem_totals = re.findall(r"#define SMEM_TOTAL (\d+)", body)
+            assert smem_totals[:2] == ["221696", "36992"]

--- a/tests/jit/test_blackwell_bgmv_moe_jit.py
+++ b/tests/jit/test_blackwell_bgmv_moe_jit.py
@@ -33,7 +33,7 @@ from flashinfer.jit import core as jit_core
         (3072, 512, "token_owned_dual_col"),
         (3072, 1024, "token_owned_dual_col"),
         (2688, 1, "token_owned_t64"),
-        (2688, 4, "pair_owned_t128"),
+        (2688, 4, "token_owned_t64"),
         (2688, 8, "token_owned_t64"),
         (2688, 32, "token_owned"),
         (2688, 256, "token_owned"),
@@ -99,7 +99,8 @@ def test_binding_preserves_graph_and_tensor_contracts():
     assert "kShrinkPrefillSmemBytes = 36992" in binding
     assert "cudaDevAttrMaxSharedMemoryPerBlockOptin" in binding
     assert "cudaFuncAttributeMaxDynamicSharedMemorySize" in binding
-    assert "cudaMemsetAsync" in binding
+    assert "cudaMemsetAsync" not in binding
+    assert "EXPAND_PAIR" not in binding
     assert "BLACKWELL_BGMV_MOE_SHRINK_DECODE<<<" in binding
     assert "BLACKWELL_BGMV_MOE_EXPAND_TOKEN_DUAL<<<" in binding
     assert "TVM_FFI_DLL_EXPORT_TYPED_FUNC(configure" in binding
@@ -113,3 +114,5 @@ def test_binding_preserves_graph_and_tensor_contracts():
             ).read_text()
             smem_totals = re.findall(r"#define SMEM_TOTAL (\d+)", body)
             assert smem_totals[:2] == ["221696", "36992"]
+            assert "atomicAdd(" not in body
+            assert "expand_pair_owned" not in body

--- a/tests/jit/test_blackwell_bgmv_moe_jit.py
+++ b/tests/jit/test_blackwell_bgmv_moe_jit.py
@@ -76,6 +76,7 @@ def test_jit_spec_binds_generated_sm100_source(
     assert spec.sources == [tmp_path / uri / "blackwell_bgmv_moe_binding.cu"]
     assert "-gencode=arch=compute_100a,code=sm_100a" in spec.extra_cuda_cflags
     assert "-use_fast_math" in spec.extra_cuda_cflags
+    assert blackwell_bgmv_moe._get_include_dir() in spec.extra_include_dirs
     body = (blackwell_bgmv_moe._get_csrc_dir() / metadata.body).read_text()
     for symbol in metadata[1:]:
         assert symbol in body

--- a/tests/moe/test_blackwell_bgmv_moe.py
+++ b/tests/moe/test_blackwell_bgmv_moe.py
@@ -1,0 +1,194 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+from flashinfer.fused_moe.bgmv_moe import prepare_bgmv_moe
+
+
+_PERF_SHAPES = [
+    (hidden_size, num_tokens, torch.bfloat16)
+    for hidden_size in (3072, 2688)
+    for num_tokens in (1, 4, 8, 32, 256, 512, 1024)
+]
+_FP16_SHAPES = [
+    (3072, 8, torch.float16),
+    (2688, 4, torch.float16),
+]
+
+
+def _require_sm100():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is unavailable")
+    if torch.cuda.get_device_capability() != (10, 0):
+        pytest.skip("generated Blackwell BGMV MoE tests require exact SM100")
+
+
+def _make_inputs(hidden_size, num_tokens, dtype, *, arbitrary_routes=False):
+    torch.manual_seed(42)
+    device = "cuda"
+    rank = 32
+    num_experts = 128
+    num_loras = 2
+    top_k = 2
+    num_pairs = num_tokens * top_k
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device=device) * 0.1
+    lora_a = (
+        torch.randn(
+            num_loras,
+            num_experts,
+            rank,
+            hidden_size,
+            dtype=dtype,
+            device=device,
+        )
+        * 0.01
+    )
+    lora_b = (
+        torch.randn(
+            num_loras,
+            num_experts,
+            hidden_size,
+            rank,
+            dtype=dtype,
+            device=device,
+        )
+        * 0.01
+    )
+    sorted_token_ids = torch.arange(
+        num_tokens, dtype=torch.int64, device=device
+    ).repeat_interleave(top_k)
+    expert_ids = torch.randint(
+        0, num_experts, (num_pairs,), dtype=torch.int64, device=device
+    )
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, dtype=torch.float32, device=device), dim=-1
+    ).reshape(-1)
+    lora_indices = torch.randint(
+        0, num_loras, (num_tokens,), dtype=torch.int64, device=device
+    )
+    if num_tokens > 1:
+        lora_indices[0] = -1
+    if arbitrary_routes:
+        order = torch.randperm(num_pairs, device=device)
+        sorted_token_ids = sorted_token_ids[order].contiguous()
+        expert_ids = expert_ids[order].contiguous()
+        topk_weights = topk_weights[order].contiguous()
+    return (
+        x,
+        [lora_a],
+        [lora_b],
+        sorted_token_ids,
+        expert_ids,
+        lora_indices,
+        topk_weights,
+        num_experts,
+    )
+
+
+def _reference(inputs):
+    (
+        x,
+        lora_a_weights,
+        lora_b_weights,
+        sorted_token_ids,
+        expert_ids,
+        lora_indices,
+        topk_weights,
+        _num_experts,
+    ) = inputs
+    lora_a = lora_a_weights[0]
+    lora_b = lora_b_weights[0]
+    num_tokens, hidden_size = x.shape
+    output = torch.zeros(num_tokens, hidden_size, dtype=torch.float32, device=x.device)
+    valid = (sorted_token_ids >= 0) & (sorted_token_ids < num_tokens)
+    valid_pairs = torch.nonzero(valid, as_tuple=False).flatten()
+    for start in range(0, valid_pairs.numel(), 64):
+        pair_ids = valid_pairs[start : start + 64]
+        tokens = sorted_token_ids[pair_ids]
+        loras = lora_indices[tokens]
+        active = loras >= 0
+        if not bool(active.any()):
+            continue
+        pair_ids = pair_ids[active]
+        tokens = tokens[active]
+        loras = loras[active]
+        experts = expert_ids[pair_ids]
+        a = lora_a[loras, experts].float()
+        shrink = torch.bmm(x[tokens].float().unsqueeze(1), a.transpose(1, 2)).squeeze(1)
+        b = lora_b[loras, experts].float()
+        delta = torch.bmm(b, shrink.unsqueeze(2)).squeeze(2)
+        delta *= topk_weights[pair_ids].unsqueeze(1)
+        output.index_add_(0, tokens, delta)
+    return output
+
+
+@pytest.mark.parametrize(
+    ("hidden_size", "num_tokens", "dtype"), _PERF_SHAPES + _FP16_SHAPES
+)
+def test_prepared_pipeline_matches_reference(hidden_size, num_tokens, dtype):
+    _require_sm100()
+    inputs = _make_inputs(hidden_size, num_tokens, dtype)
+    expected = _reference(inputs)
+    plan = prepare_bgmv_moe(*inputs, backend="blackwell")
+    actual = plan.run()
+    torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+    # Replays keep exact pointers but consume current tensor contents.
+    inputs[0].mul_(0.75)
+    expected_replay = _reference(inputs)
+    actual_replay = plan.run()
+    torch.testing.assert_close(actual_replay, expected_replay, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("num_tokens", [4, 32])
+def test_arbitrary_route_order_and_nondefault_stream(dtype, num_tokens):
+    _require_sm100()
+    inputs = _make_inputs(2688, num_tokens, dtype, arbitrary_routes=True)
+    expected = _reference(inputs)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        plan = prepare_bgmv_moe(*inputs, backend="blackwell")
+        actual = plan.run()
+    stream.synchronize()
+    torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_invalid_pair_padding_and_outer_graph_capture(dtype):
+    _require_sm100()
+    inputs = list(_make_inputs(3072, 8, dtype))
+    device = inputs[0].device
+    inputs[3] = torch.cat(
+        [inputs[3], torch.tensor([-1, 8], dtype=torch.int64, device=device)]
+    )
+    inputs[4] = torch.cat(
+        [inputs[4], torch.zeros(2, dtype=torch.int64, device=device)]
+    )
+    inputs[6] = torch.cat(
+        [inputs[6], torch.zeros(2, dtype=torch.float32, device=device)]
+    )
+    inputs = tuple(inputs)
+    expected = _reference(inputs)
+    plan = prepare_bgmv_moe(*inputs, backend="blackwell")
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        actual = plan.run()
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)

--- a/tests/moe/test_blackwell_bgmv_moe.py
+++ b/tests/moe/test_blackwell_bgmv_moe.py
@@ -190,3 +190,56 @@ def test_invalid_pair_padding_and_outer_graph_capture(dtype):
     graph.replay()
     torch.cuda.synchronize()
     torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_extra_valid_route_uses_general_path(dtype):
+    _require_sm100()
+    inputs = list(_make_inputs(2688, 32, dtype))
+    device = inputs[0].device
+    inputs[3] = torch.cat(
+        [inputs[3], torch.tensor([0], dtype=torch.int64, device=device)]
+    )
+    inputs[4] = torch.cat(
+        [inputs[4], torch.tensor([0], dtype=torch.int64, device=device)]
+    )
+    inputs[6] = torch.cat(
+        [inputs[6], torch.tensor([0.25], dtype=torch.float32, device=device)]
+    )
+    inputs = tuple(inputs)
+    expected = _reference(inputs)
+    actual = prepare_bgmv_moe(*inputs, backend="blackwell").run()
+    torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+
+def test_cpu_input_reports_device_requirement():
+    x = torch.empty((1, 2688), dtype=torch.bfloat16)
+    empty_i64 = torch.empty((1,), dtype=torch.int64)
+    empty_f32 = torch.empty((1,), dtype=torch.float32)
+    with pytest.raises(ValueError, match="exact SM100 CUDA device"):
+        prepare_bgmv_moe(
+            x,
+            [],
+            [],
+            empty_i64,
+            empty_i64,
+            empty_i64,
+            empty_f32,
+            1,
+            backend="blackwell",
+        )
+
+
+@pytest.mark.parametrize(
+    ("tensor_index", "value", "message"),
+    [
+        (4, 128, "expert_ids values"),
+        (5, 2, "lora_indices values"),
+    ],
+)
+def test_invalid_routing_indices_rejected(tensor_index, value, message):
+    _require_sm100()
+    inputs = list(_make_inputs(2688, 4, torch.bfloat16))
+    inputs[tensor_index][0] = value
+    with pytest.raises(ValueError, match=message):
+        prepare_bgmv_moe(*inputs, backend="blackwell")

--- a/tests/moe/test_blackwell_bgmv_moe.py
+++ b/tests/moe/test_blackwell_bgmv_moe.py
@@ -177,9 +177,7 @@ def test_invalid_pair_padding_and_outer_graph_capture(dtype):
     inputs[3] = torch.cat(
         [inputs[3], torch.tensor([-1, 8], dtype=torch.int64, device=device)]
     )
-    inputs[4] = torch.cat(
-        [inputs[4], torch.zeros(2, dtype=torch.int64, device=device)]
-    )
+    inputs[4] = torch.cat([inputs[4], torch.zeros(2, dtype=torch.int64, device=device)])
     inputs[6] = torch.cat(
         [inputs[6], torch.zeros(2, dtype=torch.float32, device=device)]
     )

--- a/tests/moe/test_blackwell_bgmv_moe.py
+++ b/tests/moe/test_blackwell_bgmv_moe.py
@@ -84,7 +84,12 @@ def _make_inputs(hidden_size, num_tokens, dtype, *, arbitrary_routes=False):
     if num_tokens > 1:
         lora_indices[0] = -1
     if arbitrary_routes:
-        order = torch.randperm(num_pairs, device=device)
+        order = (
+            torch.arange(num_pairs, dtype=torch.int64, device=device)
+            .reshape(num_tokens, top_k)
+            .transpose(0, 1)
+            .reshape(-1)
+        )
         sorted_token_ids = sorted_token_ids[order].contiguous()
         expert_ids = expert_ids[order].contiguous()
         topk_weights = topk_weights[order].contiguous()
@@ -167,6 +172,21 @@ def test_arbitrary_route_order_and_nondefault_stream(dtype, num_tokens):
         actual = plan.run()
     stream.synchronize()
     torch.testing.assert_close(actual, expected, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_prepared_pipeline_is_bitwise_reproducible(dtype):
+    _require_sm100()
+    inputs = _make_inputs(2688, 4, dtype, arbitrary_routes=True)
+    expected = _reference(inputs)
+    plan = prepare_bgmv_moe(*inputs, backend="blackwell")
+    first = plan.run().clone()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(first, expected, atol=1e-2, rtol=1e-2)
+    for _ in range(7):
+        replay = plan.run().clone()
+        torch.cuda.synchronize()
+        assert torch.equal(replay, first)
 
 
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])


### PR DESCRIPTION
## Description

This PR adds an opt-in prepared implementation for the BGMV MoE shrink +
expand pipeline on exact SM100 GPUs.

The integration includes:

- generated BF16 and FP16 device programs for hidden sizes 2688 and 3072;
- an SM100-only JIT/AOT registration separate from the portable BGMV module;
- `prepare_bgmv_moe(..., backend="blackwell")`, which owns pointer-stable
  workspaces and replays the full pipeline as one CUDA Graph launch;
- deterministic expand accumulation: each output token has one owner and
  routed pairs are reduced in fixed input order, with no output atomics;
- exact arbitrary-routing, padding, inactive-LoRA, extra-route, and
  multi-slice semantics;
- unit, graph-replay, non-default-stream, JIT registration, and benchmark
  coverage;
- unchanged behavior and signature for the existing high-level `bgmv_moe()`
  path.

Unsupported shapes and architectures fail closed instead of silently selecting
the generated backend.

## Performance

Measurement setup:

- GPU: NVIDIA GB200, compute capability 10.0
- baseline: FlashInfer source revision
  `1bc1cd99461e61fe99a4a35aa873879ac08130b5`
- dtype: BF16
- rank: 32
- experts: 128
- top-k: 2
- LoRA adapters: 8
- slices: 1
- timing: same-session, interleaved, cold-L2 CUPTI GPU activity span
- measured boundary: output initialization + shrink + expand

| Hidden | Tokens | Existing path (us) | Blackwell prepared (us) | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 3072 | 1 | 47.616 | 16.287 | 2.92356x |
| 3072 | 4 | 61.728 | 18.656 | 3.30875x |
| 3072 | 8 | 61.632 | 19.136 | 3.22074x |
| 3072 | 32 | 54.304 | 13.312 | 4.07933x |
| 3072 | 256 | 111.423 | 43.552 | 2.55839x |
| 3072 | 512 | 174.943 | 68.735 | 2.54518x |
| 3072 | 1024 | 306.495 | 116.255 | 2.63640x |
| 2688 | 1 | 58.112 | 16.384 | 3.54688x |
| 2688 | 4 | 75.808 | 19.200 | 3.94833x |
| 2688 | 8 | 76.639 | 19.424 | 3.94558x |
| 2688 | 32 | 53.600 | 12.928 | 4.14604x |
| 2688 | 256 | 113.504 | 41.152 | 2.75816x |
| 2688 | 512 | 175.696 | 64.896 | 2.70734x |
| 2688 | 1024 | 307.679 | 108.288 | 2.84130x |
| **Geometric mean** |  | **96.9973** | **30.5449** | **3.17557x** |

All 14 rows passed the all-shapes performance gate; the minimum observed
speedup was `2.54518x`.

Reproduce with:

```bash
FLASHINFER_DISABLE_VERSION_CHECK=1 \
python benchmarks/bench_blackwell_bgmv_moe.py --repeat-time-ms 1000
```

The benchmark treats a CUPTI-to-CUDA-Event fallback warning as an error.

## Tests

- [x] BF16 and FP16 reference checks use `atol=1e-2`, `rtol=1e-2`.
- [x] The GPU/JIT suite passes 49/49.
- [x] All 14 benchmark shapes pass correctness and CUPTI measurement.
- [x] Eight BF16/FP16 replays are bitwise identical.
- [x] Non-default stream, CUDA Graph capture/replay, unsupported fallback, and
  arbitrary routing are covered.
- [x] Changed-file pre-commit checks pass.

## Reviewer notes

The generated CUDA files are intentionally frozen and compiled only for exact
SM100. The prepared plan binds tensor storage, shape, stride, dtype, device, and
stream identity so graph replay cannot silently reuse stale pointers.
