### PR TITLE
fix(tests/gemm): drop the extra argument to print_all_on_failure

### DIFF
--- a/tests/gemm/test_sm_constraint_gemm.py
+++ b/tests/gemm/test_sm_constraint_gemm.py
@@ -96,7 +96,7 @@ def test_sm_constraint_gemm(M, N, K, alpha, beta, num_sms, dtype, EPILOGUE_SUBTI
     )
     if not torch_vs_triton_persistent:
         print_all_on_failure(
-            a, b, c_unmodified, c_torch, c_naive, c_persistent, c_descriptor, out_dtype
+            a, b, c_unmodified, c_torch, c_naive, c_persistent, c_descriptor
         )
         print("compare c_torch and c_persistent")
         print_max_diff_on_failure(c_torch, c_persistent, out_dtype)
@@ -127,7 +127,7 @@ def test_sm_constraint_gemm(M, N, K, alpha, beta, num_sms, dtype, EPILOGUE_SUBTI
     )
     if not naive_vs_persistent:
         print_all_on_failure(
-            a, b, c_unmodified, c_torch, c_naive, c_persistent, c_descriptor, out_dtype
+            a, b, c_unmodified, c_torch, c_naive, c_persistent, c_descriptor
         )
         print("compare c_naive and c_persistent")
         print_max_diff_on_failure(c_naive, c_persistent, out_dtype)


### PR DESCRIPTION
## Problem

`print_all_on_failure` in `tests/gemm/test_sm_constraint_gemm.py` takes seven
parameters:

```python
def print_all_on_failure(
    a, b, c_unmodified, c_torch, c_naive, c_persistent, c_descriptor
):
```

Two of its four call sites pass **eight** — an extra `out_dtype`:

| Line | Args | |
|---|---|---|
| 98 | 8 | ❌ `..., c_descriptor, out_dtype` |
| 110 | 7 | ✅ |
| 129 | 8 | ❌ `..., c_descriptor, out_dtype` |
| 143 | 7 | ✅ |

Both bad sites sit inside `if not <allclose>:` blocks, i.e. they run **only when
a tolerance check has already failed**. So on a real numerical regression the
test does not print the tensors and then fail on the assert — it dies first with

```
TypeError: print_all_on_failure() takes 7 positional arguments but 8 were given
```

which replaces the diagnostic output with an unrelated error and hides the
failure it was meant to explain.

`out_dtype` is not something `print_all_on_failure` uses; it belongs to
`print_max_diff_on_failure(target1, target2, out_dtype)`, which is called on the
very next line at each of these sites. It looks like a copy/paste from there.

## Fix

Drop the extra argument at the two sites, matching the two that are already
correct. Test-only, no production code touched.

Verified `ruff format --diff` and `ruff check` are clean on the patched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed test failure reporting so constraint GEMM tests correctly display diagnostic information when an assertion fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->