### PR TITLE
perf(moe): reuse GEMM1 tile amax for per-token NVFP4

### DIFF
--- a/flashinfer/cute_dsl/fp4_common.py
+++ b/flashinfer/cute_dsl/fp4_common.py
@@ -596,6 +596,30 @@ def habs2(x: Uint32, *, loc=None, ip=None) -> Uint32:
 
 
 @dsl_user_op
+def half2_max_abs(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Return the per-lane maximum magnitude of two packed FP16x2 words.
+
+    ``max.xorsign.abs`` has maximumNumber behavior: a single NaN yields the
+    numeric operand.  Its result sign is the xor of the input signs and is not
+    a magnitude sign, so callers must clear each surviving lane's sign bit
+    before interpreting the final result.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "max.xorsign.abs.f16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
 def hmax2(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
     """Half2 max - element-wise max of 2 fp16 pairs."""
     return Uint32(
@@ -718,6 +742,30 @@ def bfloat2_habs2(x: Uint32, *, loc=None, ip=None) -> Uint32:
             has_side_effects=False,
             is_align_stack=False,
             asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def bfloat2_max_abs(a: Uint32, b: Uint32, *, loc=None, ip=None) -> Uint32:
+    """Return the per-lane maximum magnitude of two packed BF16x2 words.
+
+    ``max.xorsign.abs`` has maximumNumber behavior: a single NaN yields the
+    numeric operand.  Its result sign is the xor of the input signs and is not
+    a magnitude sign, so callers must clear each surviving lane's sign bit
+    before interpreting the final result.
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [Uint32(a).ir_value(loc=loc, ip=ip), Uint32(b).ir_value(loc=loc, ip=ip)],
+            "max.xorsign.abs.bf16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
         )
     )
 

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -50,6 +50,7 @@ from flashinfer.quantization.quantization_cute_dsl_utils import (
     float_to_ue8m0_fast,
     ue8m0_to_inv_scale_fast,
 )
+from flashinfer.cute_dsl.fp4_common import fabs_f32, fmax_f32
 
 from ..moe_utils import (
     normalize_cute_dsl_moe_activation_type,
@@ -429,6 +430,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         situ_linear_beta: Optional[float] = None,
         gated: bool = True,
         use_a_per_token_scale: bool = False,
+        store_output_amax: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel with
         gather operation and FC1 activation fusion.
@@ -492,6 +494,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         self.sf_vec_size = sf_vec_size
         self.enable_pdl = enable_pdl
         self.use_a_per_token_scale = use_a_per_token_scale
+        self.store_output_amax = store_output_amax
         self.topk = topk
         self.gated = gated
         self.out_n_factor = 2 if gated else 1
@@ -810,6 +813,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         num_non_exiting_tiles: cute.Tensor,
         alpha: cute.Tensor,
         a_per_token_scale: Optional[cute.Tensor],
+        output_amax: Optional[cute.Tensor],
         max_active_clusters: cutlass.Constexpr,
         stream: cuda.CUstream,
         epilogue_op: cutlass.Constexpr = lambda x: x,
@@ -1173,6 +1177,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             num_non_exiting_tiles,
             alpha,
             a_per_token_scale,
+            output_amax,
             self.cluster_layout_vmnk,
             self.cluster_layout_sfb_vmnk,
             self.a_smem_layout_staged,
@@ -1260,6 +1265,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         num_non_exiting_tiles: cute.Tensor,
         alpha: cute.Tensor,
         a_per_token_scale: Optional[cute.Tensor],
+        output_amax: Optional[cute.Tensor],
         cluster_layout_vmnk: cute.Layout,
         cluster_layout_sfb_vmnk: cute.Layout,
         a_smem_layout_staged: cute.ComposedLayout,
@@ -2642,6 +2648,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
             num_prev_subtiles = cutlass.Int32(0)
             while is_valid_tile:
+                tile_amax = cutlass.Float32(0.0)
                 mma_tile_coord_mnl = (
                     tile_info[0] // cute.size(tiled_mma.thr_id.shape),
                     tile_info[1],
@@ -3208,6 +3215,15 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         acc_vec = tiled_copy_r2s.retile(tCompute).load()
                         acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
                         tRS_rC.store(acc_vec)
+                        if cutlass.const_expr(self.store_output_amax):
+                            # Match the standalone per-token quantizer exactly:
+                            # reduce values after the FP16/BF16 output rounding
+                            # that is visible in the materialized intermediate.
+                            for i in cutlass.range_constexpr(cute.size(acc_vec.shape)):
+                                tile_amax = fmax_f32(
+                                    tile_amax,
+                                    fabs_f32(cutlass.Float32(acc_vec[i])),
+                                )
 
                     #
                     # Store C to shared memory
@@ -3246,6 +3262,16 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 if cutlass.const_expr(not self.overlapping_accum):
                     acc_pipeline.consumer_release(acc_consumer_state)
                     acc_consumer_state.advance()
+
+                if cutlass.const_expr(self.store_output_amax):
+                    # One epilogue thread owns one logical output row.  Fold
+                    # all 64-column epilogue subtiles belonging to this GEMM
+                    # N tile, then publish one partial row maximum.  Use the
+                    # scheduler's logical coordinate because a persistent CTA
+                    # processes multiple tiles over its lifetime.
+                    output_row = tile_info[0] * self.cta_tile_shape_mnk_c[0] + epi_tidx
+                    if output_row < output_amax.shape[0]:
+                        output_amax[(output_row, tile_info[1])] = tile_amax
 
                 #
                 # Advance to next tile
@@ -4000,6 +4026,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
         num_non_exiting_tiles_ptr: cute.Pointer,
         global_sf_ptr: Optional[cute.Pointer],
         a_per_token_scale_ptr: Optional[cute.Pointer],
+        output_amax_ptr: Optional[cute.Pointer],
         orig_m: cutlass.Int64,
         m: cutlass.Int64,
         n: cutlass.Int64,
@@ -4057,6 +4084,22 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             if cutlass.const_expr(a_per_token_scale_ptr is not None)
             else None
         )
+        output_amax = (
+            cute.make_tensor(
+                output_amax_ptr,
+                layout=cute.make_ordered_layout(
+                    (
+                        m,
+                        cute.ceil_div(
+                            interm_size, self.mma_tiler[1] // self.out_n_factor
+                        ),
+                    ),
+                    order=(1, 0),
+                ),
+            )
+            if cutlass.const_expr(output_amax_ptr is not None)
+            else None
+        )
 
         tile_idx_to_group_idx = cute.make_tensor(
             tile_idx_to_group_idx_ptr, layout=cute.make_layout((num_tiles,))
@@ -4090,6 +4133,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
             num_non_exiting_tiles,
             alpha,
             a_per_token_scale,
+            output_amax,
             max_active_clusters=max_active_clusters,
             stream=stream,
             epilogue_op=epilogue_op,

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -50,8 +50,7 @@ from flashinfer.quantization.quantization_cute_dsl_utils import (
     float_to_ue8m0_fast,
     ue8m0_to_inv_scale_fast,
 )
-from flashinfer.cute_dsl.fp4_common import fabs_f32, fmax_f32
-
+from flashinfer.cute_dsl.fp4_common import bfloat2_max_abs, half2_max_abs
 from ..moe_utils import (
     normalize_cute_dsl_moe_activation_type,
     validate_cute_dsl_moe_situ_config,
@@ -2648,7 +2647,7 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
             num_prev_subtiles = cutlass.Int32(0)
             while is_valid_tile:
-                tile_amax = cutlass.Float32(0.0)
+                tile_amax_packed = cutlass.Uint32(0)
                 mma_tile_coord_mnl = (
                     tile_info[0] // cute.size(tiled_mma.thr_id.shape),
                     tile_info[1],
@@ -3215,15 +3214,6 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         acc_vec = tiled_copy_r2s.retile(tCompute).load()
                         acc_vec = epilogue_op(acc_vec.to(self.c_dtype))
                         tRS_rC.store(acc_vec)
-                        if cutlass.const_expr(self.store_output_amax):
-                            # Match the standalone per-token quantizer exactly:
-                            # reduce values after the FP16/BF16 output rounding
-                            # that is visible in the materialized intermediate.
-                            for i in cutlass.range_constexpr(cute.size(acc_vec.shape)):
-                                tile_amax = fmax_f32(
-                                    tile_amax,
-                                    fabs_f32(cutlass.Float32(acc_vec[i])),
-                                )
 
                     #
                     # Store C to shared memory
@@ -3254,6 +3244,79 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                         # Fence and barrier to make sure shared memory store is visible to TMA store
                         c_pipeline.producer_commit()
                         c_pipeline.producer_acquire()
+                    if cutlass.const_expr(self.store_output_amax):
+                        # Match the standalone per-token quantizer exactly by
+                        # reducing the rounded FP16/BF16 values visible in the
+                        # materialized intermediate.  Issue the shared/TMA
+                        # output store first, then use four independent packed
+                        # native-width maxNum trees while that asynchronous
+                        # store is in flight.  Keep one packed accumulator for
+                        # the whole GEMM N tile and defer lane folding and
+                        # widening until its final aux store.
+                        packed_acc = acc_vec.bitcast(cutlass.Uint32).to_vector(
+                            force_flatten=True
+                        )
+                        fragment_amax = cute.make_rmem_tensor(
+                            (cute.size(packed_acc.shape) // 8,), cutlass.Uint32
+                        )
+                        for packed_group in cutlass.range_constexpr(
+                            cute.size(fragment_amax)
+                        ):
+                            packed_idx = packed_group * 8
+                            if cutlass.const_expr(self.c_dtype is cutlass.BFloat16):
+                                max_01 = bfloat2_max_abs(
+                                    packed_acc[packed_idx], packed_acc[packed_idx + 1]
+                                )
+                                max_23 = bfloat2_max_abs(
+                                    packed_acc[packed_idx + 2],
+                                    packed_acc[packed_idx + 3],
+                                )
+                                max_45 = bfloat2_max_abs(
+                                    packed_acc[packed_idx + 4],
+                                    packed_acc[packed_idx + 5],
+                                )
+                                max_67 = bfloat2_max_abs(
+                                    packed_acc[packed_idx + 6],
+                                    packed_acc[packed_idx + 7],
+                                )
+                                max_0123 = bfloat2_max_abs(max_01, max_23)
+                                max_4567 = bfloat2_max_abs(max_45, max_67)
+                                fragment_amax[packed_group] = bfloat2_max_abs(
+                                    max_0123, max_4567
+                                )
+                            else:
+                                max_01 = half2_max_abs(
+                                    packed_acc[packed_idx], packed_acc[packed_idx + 1]
+                                )
+                                max_23 = half2_max_abs(
+                                    packed_acc[packed_idx + 2],
+                                    packed_acc[packed_idx + 3],
+                                )
+                                max_45 = half2_max_abs(
+                                    packed_acc[packed_idx + 4],
+                                    packed_acc[packed_idx + 5],
+                                )
+                                max_67 = half2_max_abs(
+                                    packed_acc[packed_idx + 6],
+                                    packed_acc[packed_idx + 7],
+                                )
+                                max_0123 = half2_max_abs(max_01, max_23)
+                                max_4567 = half2_max_abs(max_45, max_67)
+                                fragment_amax[packed_group] = half2_max_abs(
+                                    max_0123, max_4567
+                                )
+
+                        for packed_group in cutlass.range_constexpr(
+                            cute.size(fragment_amax)
+                        ):
+                            if cutlass.const_expr(self.c_dtype is cutlass.BFloat16):
+                                tile_amax_packed = bfloat2_max_abs(
+                                    tile_amax_packed, fragment_amax[packed_group]
+                                )
+                            else:
+                                tile_amax_packed = half2_max_abs(
+                                    tile_amax_packed, fragment_amax[packed_group]
+                                )
                     self.epilog_sync_barrier.arrive_and_wait()
 
                 #
@@ -3265,13 +3328,33 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
 
                 if cutlass.const_expr(self.store_output_amax):
                     # One epilogue thread owns one logical output row.  Fold
-                    # all 64-column epilogue subtiles belonging to this GEMM
-                    # N tile, then publish one partial row maximum.  Use the
-                    # scheduler's logical coordinate because a persistent CTA
-                    # processes multiple tiles over its lifetime.
+                    # the accumulator's two native-width lanes only once, then
+                    # clear the junk xor-sign before reinterpreting the low
+                    # lane in c_dtype for the final store.  Use the scheduler's
+                    # logical coordinate because a persistent CTA processes
+                    # multiple tiles over its lifetime.
+                    if cutlass.const_expr(self.c_dtype is cutlass.BFloat16):
+                        tile_amax_packed = bfloat2_max_abs(
+                            tile_amax_packed,
+                            tile_amax_packed >> cutlass.Uint32(16),
+                        )
+                    else:
+                        tile_amax_packed = half2_max_abs(
+                            tile_amax_packed,
+                            tile_amax_packed >> cutlass.Uint32(16),
+                        )
+                    tile_amax_bits = cute.make_rmem_tensor((1,), cutlass.Uint32)
+                    tile_amax_bits[0] = tile_amax_packed & cutlass.Uint32(0x7FFF)
+                    tile_amax = cute.recast_tensor(tile_amax_bits, self.c_dtype)[0]
                     output_row = tile_info[0] * self.cta_tile_shape_mnk_c[0] + epi_tidx
-                    if output_row < output_amax.shape[0]:
-                        output_amax[(output_row, tile_info[1])] = tile_amax
+                    if output_row < output_amax.shape[0] * 8:
+                        output_amax[
+                            (
+                                output_row // 8,
+                                tile_info[1],
+                                output_row % 8,
+                            )
+                        ] = tile_amax
 
                 #
                 # Advance to next tile
@@ -4040,6 +4123,8 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
     ):
         scale_k = k // scaling_vector_size
         interm_size = n // self.out_n_factor
+        output_tile_n = self.mma_tiler[1] // self.out_n_factor
+        num_output_n_tiles = interm_size // output_tile_n
         num_tiles = m // tile_size
         a = cute.make_tensor(
             a_ptr, layout=cute.make_ordered_layout((orig_m, k, 1), order=(1, 0, 2))
@@ -4089,12 +4174,11 @@ class BlockScaledContiguousGatherGroupedGemmKernel:
                 output_amax_ptr,
                 layout=cute.make_ordered_layout(
                     (
-                        m,
-                        cute.ceil_div(
-                            interm_size, self.mma_tiler[1] // self.out_n_factor
-                        ),
+                        m // 8,
+                        num_output_n_tiles,
+                        8,
                     ),
-                    order=(1, 0),
+                    order=(2, 1, 0),
                 ),
             )
             if cutlass.const_expr(output_amax_ptr is not None)

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -500,12 +500,13 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         a_per_token_scale: Optional per-token row scale for operand A,
             shape (seq_len,), float32. Indexed by the original token ID and
             applied before the fused activation.
-        out_amax: Optional float32 buffer for per-row, per-GEMM-N-tile output
-            absolute maxima. Its shape is ``(permuted_m, num_output_n_tiles)``.
-            Values are reduced after conversion to ``c_dtype`` so a downstream
-            per-token quantizer can recover the exact row maximum. Only rows
-            belonging to scheduled routing tiles are defined; the unused tail
-            of a maximum-sized routing buffer is left unchanged.
+        out_amax: Optional 4-byte-aligned ``c_dtype`` buffer for per-row,
+            per-GEMM-N-tile output absolute maxima. It uses the contiguous blocked-8 layout
+            ``(permuted_m // 8, num_output_n_tiles, 8)``. Values are reduced
+            after conversion to ``c_dtype`` so a downstream per-token quantizer
+            can recover the exact row maximum. Only rows belonging to scheduled
+            routing tiles are defined; the unused tail of a maximum-sized
+            routing buffer is left unchanged.
         topk: Number of experts per token. Default: 8
         a_dtype: Data type for the A matrix.
         b_dtype: Data type for the B matrix.
@@ -765,16 +766,33 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
                 "out_amax requires a materialized FP16 or BF16 GEMM1 output"
             )
         output_tile_n = mma_tiler_mn[1] // (2 if gated else 1)
+        if permuted_m % 8 != 0:
+            raise ValueError(
+                f"out_amax blocked-8 layout requires permuted_m={permuted_m} "
+                "to be divisible by 8"
+            )
+        if intermediate_size % output_tile_n != 0:
+            raise ValueError(
+                f"intermediate_size={intermediate_size} must be divisible by "
+                f"output_tile_n={output_tile_n}"
+            )
+        num_output_n_tiles = intermediate_size // output_tile_n
         expected_amax_shape = (
-            permuted_m,
-            (intermediate_size + output_tile_n - 1) // output_tile_n,
+            permuted_m // 8,
+            num_output_n_tiles,
+            8,
         )
         if out_amax.device != a.device:
             raise ValueError("out_amax must be on the same CUDA device as a")
-        if out_amax.dtype != torch.float32:
-            raise ValueError("out_amax must have dtype torch.float32")
+        expected_amax_dtype = cutlass_to_torch_dtype(c_dtype_cutlass)
+        if out_amax.dtype != expected_amax_dtype:
+            raise ValueError(
+                f"out_amax must have dtype {expected_amax_dtype} to match c_dtype"
+            )
         if not out_amax.is_contiguous():
             raise ValueError("out_amax must be contiguous")
+        if out_amax.data_ptr() % 4 != 0:
+            raise ValueError("out_amax must be 4-byte aligned")
         if tuple(out_amax.shape) != expected_amax_shape:
             raise ValueError(
                 f"out_amax must have shape {expected_amax_shape}, "
@@ -839,7 +857,7 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         a_per_token_scale_ptr = None
     output_amax_ptr = (
         make_ptr(
-            cutlass.Float32,
+            c_dtype_cutlass,
             out_amax.data_ptr(),
             cute.AddressSpace.gmem,
             assumed_align=4,

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -238,6 +238,7 @@ def _get_compiled_gather_kernel(
     num_tiles_ptr,
     norm_const_ptr,
     a_per_token_scale_ptr,
+    output_amax_ptr,
     max_active_clusters: int,
     stream,
     # Dtype parameters (compile-time - IN cache key)
@@ -269,6 +270,7 @@ def _get_compiled_gather_kernel(
     situ_linear_beta: Optional[float] = None,
     gated: bool = True,
     use_a_per_token_scale: bool = False,
+    store_output_amax: bool = False,
 ):
     """Get or compile the gather grouped GEMM with FC1 activation fusion.
 
@@ -317,6 +319,7 @@ def _get_compiled_gather_kernel(
         situ_linear_beta,
         gated,
         use_a_per_token_scale,
+        store_output_amax,
     )
 
     if cache_key not in _gather_kernel_cache:
@@ -374,18 +377,20 @@ def _get_compiled_gather_kernel(
                 situ_linear_beta=situ_linear_beta,
                 gated=gated,
                 use_a_per_token_scale=use_a_per_token_scale,
+                store_output_amax=store_output_amax,
             )
         wrapper_fn = gemm.wrapper
 
         # Compile with runtime parameters - they can vary across calls.
         # Order must match the wrapper signature, and the two wrappers have
         # DIFFERENT arities: the Blackwell wrapper takes a_per_token_scale_ptr
-        # (13 pointers), the Rubin SM107 wrapper does not (12 pointers).
-        # Passing 13 pointers to the SM107 wrapper shifts every argument one
+        # and output_amax_ptr; the Rubin SM107 wrapper takes neither.
+        # Passing the Blackwell-only pointers to the SM107 wrapper shifts arguments
         # slot and dies with "multiple values for argument 'tile_size'".
         # (a_ptr, b_ptr, a_sf_ptr, b_sf_ptr, c_ptr, c_sf_ptr, alpha_ptr,
         #  tile_idx_to_group_idx_ptr, tile_idx_to_mn_limit_ptr, token_id_mapping_ptr,
-        #  num_non_exiting_tiles_ptr, global_sf_ptr, [a_per_token_scale_ptr],
+        #  num_non_exiting_tiles_ptr, global_sf_ptr,
+        #  [a_per_token_scale_ptr, output_amax_ptr],
         #  orig_m, m, n, k, l, tile_size, scaling_vector_size,
         #  max_active_clusters, stream)
         compiled_gemm = cute.compile(
@@ -402,7 +407,7 @@ def _get_compiled_gather_kernel(
             token_id_ptr,
             num_tiles_ptr,
             norm_const_ptr,
-            *([] if is_rubin else [a_per_token_scale_ptr]),
+            *([] if is_rubin else [a_per_token_scale_ptr, output_amax_ptr]),
             orig_m,
             permuted_m,
             n,
@@ -434,6 +439,7 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
     global_scale: Optional[torch.Tensor] = None,
     *,
     a_per_token_scale: Optional[torch.Tensor] = None,
+    out_amax: Optional[torch.Tensor] = None,
     topk: int = 8,
     a_dtype: str = "float4_e2m1fn",
     b_dtype: str = "float4_e2m1fn",
@@ -494,6 +500,12 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         a_per_token_scale: Optional per-token row scale for operand A,
             shape (seq_len,), float32. Indexed by the original token ID and
             applied before the fused activation.
+        out_amax: Optional float32 buffer for per-row, per-GEMM-N-tile output
+            absolute maxima. Its shape is ``(permuted_m, num_output_n_tiles)``.
+            Values are reduced after conversion to ``c_dtype`` so a downstream
+            per-token quantizer can recover the exact row maximum. Only rows
+            belonging to scheduled routing tiles are defined; the unused tail
+            of a maximum-sized routing buffer is left unchanged.
         topk: Number of experts per token. Default: 8
         a_dtype: Data type for the A matrix.
         b_dtype: Data type for the B matrix.
@@ -606,6 +618,8 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
                 f"got {tuple(a_per_token_scale.shape)}"
             )
 
+    store_output_amax = out_amax is not None
+
     if n % 128 != 0:
         raise ValueError(f"GEMM1 output dim n={n} must be a multiple of 128.")
 
@@ -633,6 +647,10 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
     # Check compute capability
     major, minor = get_compute_capability(a.device)
     is_rubin = mma_tiler is not None and mma_inst_shape is not None
+    if store_output_amax and is_rubin:
+        raise NotImplementedError(
+            "out_amax is only supported by the SM100 GEMM1 kernel"
+        )
     if major != 10:
         raise ValueError(
             f"Blockscaled contiguous gather grouped GEMM requires SM10x family. "
@@ -741,6 +759,28 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
 
     tile_size = mma_tiler[0] if is_rubin else mma_tiler_mn[0]
 
+    if store_output_amax:
+        if generate_sfc or c_dtype not in {"float16", "bfloat16"}:
+            raise ValueError(
+                "out_amax requires a materialized FP16 or BF16 GEMM1 output"
+            )
+        output_tile_n = mma_tiler_mn[1] // (2 if gated else 1)
+        expected_amax_shape = (
+            permuted_m,
+            (intermediate_size + output_tile_n - 1) // output_tile_n,
+        )
+        if out_amax.device != a.device:
+            raise ValueError("out_amax must be on the same CUDA device as a")
+        if out_amax.dtype != torch.float32:
+            raise ValueError("out_amax must have dtype torch.float32")
+        if not out_amax.is_contiguous():
+            raise ValueError("out_amax must be contiguous")
+        if tuple(out_amax.shape) != expected_amax_shape:
+            raise ValueError(
+                f"out_amax must have shape {expected_amax_shape}, "
+                f"got {tuple(out_amax.shape)}"
+            )
+
     # Create raw pointers (TRT-LLM style) - allows same compiled kernel for different sizes
     a_ptr = make_ptr(
         a_dtype_cutlass, a.data_ptr(), cute.AddressSpace.gmem, assumed_align=32
@@ -797,6 +837,16 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         )
     else:
         a_per_token_scale_ptr = None
+    output_amax_ptr = (
+        make_ptr(
+            cutlass.Float32,
+            out_amax.data_ptr(),
+            cute.AddressSpace.gmem,
+            assumed_align=4,
+        )
+        if store_output_amax
+        else None
+    )
     tile_idx_ptr = make_ptr(
         cutlass.Int32, tile_idx_to_expert_idx.data_ptr(), cute.AddressSpace.gmem
     )
@@ -833,6 +883,7 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         num_tiles_ptr=num_tiles_ptr,
         norm_const_ptr=norm_const_ptr,
         a_per_token_scale_ptr=a_per_token_scale_ptr,
+        output_amax_ptr=output_amax_ptr,
         max_active_clusters=max_active_clusters,
         stream=stream,
         # Dtype parameters (compile-time, in cache key)
@@ -860,16 +911,17 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         situ_linear_beta=situ_linear_beta,
         gated=gated,
         use_a_per_token_scale=use_a_per_token_scale,
+        store_output_amax=store_output_amax,
     )
 
     # Execute kernel with runtime parameters.
     # Order must match the wrapper signature; the Rubin SM107 wrapper has no
-    # a_per_token_scale_ptr parameter (see the arity note at the compile site),
-    # so on Rubin the extra pointer must be omitted here too or every argument
+    # Blackwell-only optional pointer parameters (see the arity note at the
+    # compile site), so on Rubin the extra pointers must be omitted here or every argument
     # shifts one slot ("multiple values for argument 'stream'").
     # (a_ptr, b_ptr, a_sf_ptr, b_sf_ptr, c_ptr, c_sf_ptr, alpha_ptr,
     #  tile_idx_ptr, mn_limit_ptr, token_id_ptr, num_tiles_ptr, global_sf_ptr,
-    #  [a_per_token_scale_ptr], orig_m, m, n, k, l, stream)
+    #  [a_per_token_scale_ptr, output_amax_ptr], orig_m, m, n, k, l, stream)
     compiled_gemm(
         a_ptr,
         b_ptr,
@@ -883,7 +935,7 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
         token_id_ptr,
         num_tiles_ptr,
         norm_const_ptr,
-        *([] if is_rubin else [a_per_token_scale_ptr]),
+        *([] if is_rubin else [a_per_token_scale_ptr, output_amax_ptr]),
         seq_len,  # orig_m
         permuted_m,
         n,
@@ -910,6 +962,7 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
     global_scale: Optional[torch.Tensor] = None,
     *,
     a_per_token_scale: Optional[torch.Tensor] = None,
+    out_amax: Optional[torch.Tensor] = None,
     topk: int = 8,
     ab_dtype: str = "float4_e2m1fn",
     sf_dtype: str = "float8_e4m3fn",
@@ -953,6 +1006,7 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
         out_scale,
         global_scale,
         a_per_token_scale=a_per_token_scale,
+        out_amax=out_amax,
         topk=topk,
         a_dtype=ab_dtype,
         b_dtype=ab_dtype,

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -74,6 +74,7 @@ from ...quantization.kernels.nvfp4_quantize import (
     SF_LAYOUT_128x4,
     nvfp4_quantize_per_token_cute_dsl,
 )
+from ...quantization.nvfp4_quantization_utils import env_flag_enabled
 from ...utils import supported_compute_capability
 from .moe_utils import (
     moe_output_memset_inplace,
@@ -328,7 +329,24 @@ def _moe_core_impl(
             "c_dtype": "float4_e2m1fn",
         }
     )
+    # Temporary experiment gate.  This will be removed once the benchmark and
+    # layout arms have selected the production implementation.
+    use_intermediate_amax = use_per_token_activation and env_flag_enabled(
+        "FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX"
+    )
     intermediate_per_token_scale = None
+    intermediate_amax = None
+    if use_intermediate_amax:
+        intermediate_size = w1_weight.shape[1] // (2 if gated else 1)
+        output_tile_n = gemm1_mma_tiler_mn[1] // (2 if gated else 1)
+        intermediate_amax = torch.empty(
+            (
+                permuted_idx_to_expanded_idx.shape[0],
+                (intermediate_size + output_tile_n - 1) // output_tile_n,
+            ),
+            dtype=torch.float32,
+            device=x.device,
+        )
     intermediate, intermediate_sf = (
         blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
             a=x,
@@ -341,6 +359,7 @@ def _moe_core_impl(
             token_id_mapping=permuted_idx_to_expanded_idx,
             num_non_exiting_tiles=kernel_num_non_exiting_tiles,
             out=gemm1_out,
+            out_amax=intermediate_amax,
             **output_kwargs,
             topk=top_k,
             mma_tiler_mn=gemm1_mma_tiler_mn,
@@ -364,6 +383,7 @@ def _moe_core_impl(
                 fc2_input_scale,
                 sf_layout=SF_LAYOUT_128x4,
                 enable_pdl=enable_pdl,
+                input_amax=intermediate_amax,
             )
         )
         intermediate_sf = convert_sf_to_mma_layout(

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -100,6 +100,7 @@ from .tuner import (
 # =============================================================================
 
 _cuda_graph_resources: Dict[str, Any] = {}
+_PER_TOKEN_AUX_AMAX_MIN_TOKENS = 4
 
 
 def _intermediate_c_dtype(output_dtype: torch.dtype) -> str:
@@ -328,9 +329,15 @@ def _moe_core_impl(
             "c_dtype": "float4_e2m1fn",
         }
     )
+    # The aux handoff has fixed producer/consumer overhead at very small M.
+    # num_tokens is host-static, so CUDA graph capture specializes one path
+    # without a device-side branch or synchronization.
+    use_intermediate_amax = (
+        use_per_token_activation and num_tokens >= _PER_TOKEN_AUX_AMAX_MIN_TOKENS
+    )
     intermediate_per_token_scale = None
     intermediate_amax = None
-    if use_per_token_activation:
+    if use_intermediate_amax:
         intermediate_size = w1_weight.shape[1] // (2 if gated else 1)
         output_tile_n = gemm1_mma_tiler_mn[1] // (2 if gated else 1)
         num_output_tiles = (intermediate_size + output_tile_n - 1) // output_tile_n

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -74,7 +74,6 @@ from ...quantization.kernels.nvfp4_quantize import (
     SF_LAYOUT_128x4,
     nvfp4_quantize_per_token_cute_dsl,
 )
-from ...quantization.nvfp4_quantization_utils import env_flag_enabled
 from ...utils import supported_compute_capability
 from .moe_utils import (
     moe_output_memset_inplace,
@@ -329,14 +328,9 @@ def _moe_core_impl(
             "c_dtype": "float4_e2m1fn",
         }
     )
-    # Temporary experiment gate.  This will be removed once the benchmark and
-    # layout arms have selected the production implementation.
-    use_intermediate_amax = use_per_token_activation and env_flag_enabled(
-        "FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX"
-    )
     intermediate_per_token_scale = None
     intermediate_amax = None
-    if use_intermediate_amax:
+    if use_per_token_activation:
         intermediate_size = w1_weight.shape[1] // (2 if gated else 1)
         output_tile_n = gemm1_mma_tiler_mn[1] // (2 if gated else 1)
         num_output_tiles = (intermediate_size + output_tile_n - 1) // output_tile_n

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -339,12 +339,15 @@ def _moe_core_impl(
     if use_intermediate_amax:
         intermediate_size = w1_weight.shape[1] // (2 if gated else 1)
         output_tile_n = gemm1_mma_tiler_mn[1] // (2 if gated else 1)
+        num_output_tiles = (intermediate_size + output_tile_n - 1) // output_tile_n
+        num_permuted_rows = permuted_idx_to_expanded_idx.shape[0]
         intermediate_amax = torch.empty(
             (
-                permuted_idx_to_expanded_idx.shape[0],
-                (intermediate_size + output_tile_n - 1) // output_tile_n,
+                (num_permuted_rows + 7) // 8,
+                num_output_tiles,
+                8,
             ),
-            dtype=torch.float32,
+            dtype=output_dtype,
             device=x.device,
         )
     intermediate, intermediate_sf = (
@@ -384,6 +387,9 @@ def _moe_core_impl(
                 sf_layout=SF_LAYOUT_128x4,
                 enable_pdl=enable_pdl,
                 input_amax=intermediate_amax,
+                input_amax_valid_rows=(
+                    total_num_padded_tokens if intermediate_amax is not None else None
+                ),
             )
         )
         intermediate_sf = convert_sf_to_mma_layout(

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -61,6 +61,11 @@ from .moe_utils import (
 
 logger = logging.getLogger(__name__)
 
+# Bump this token whenever the SM100 per-token producer/consumer handoff changes
+# in a way that can affect GEMM tactic ranking.  Persisted autotune file keys do
+# not include the runner hash, so the pipeline contract belongs in ``extras``.
+_SM100_PER_TOKEN_PIPELINE_CACHE_SCHEMA = "aux_amax_blocked8_native_v1"
+
 
 # =============================================================================
 # Blackwell (SM100) Tactics
@@ -622,7 +627,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         )
 
     def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
-        return (
+        extras = (
             int(self.activation_type),
             self.swiglu_alpha,
             self.swiglu_beta,
@@ -630,6 +635,9 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
             self.situ_beta,
             self.situ_linear_beta,
         )
+        if self.use_per_token_activation:
+            extras += (_SM100_PER_TOKEN_PIPELINE_CACHE_SCHEMA,)
+        return extras
 
     def get_valid_tactics(  # type: ignore[override]
         self,

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -627,7 +627,7 @@ class CuteDslFusedMoENvfp4Runner(TunableRunner):
         )
 
     def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
-        extras = (
+        extras: tuple[Any, ...] = (
             int(self.activation_type),
             self.swiglu_alpha,
             self.swiglu_beta,

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -64,7 +64,7 @@ logger = logging.getLogger(__name__)
 # Bump this token whenever the SM100 per-token producer/consumer handoff changes
 # in a way that can affect GEMM tactic ranking.  Persisted autotune file keys do
 # not include the runner hash, so the pipeline contract belongs in ``extras``.
-_SM100_PER_TOKEN_PIPELINE_CACHE_SCHEMA = "aux_amax_blocked8_native_v1"
+_SM100_PER_TOKEN_PIPELINE_CACHE_SCHEMA = "aux_amax_blocked8_native_min_tokens_4_v2"
 
 
 # =============================================================================

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -39,16 +39,18 @@ import cutlass.cute.nvgpu.cpasync as cpasync
 import cutlass.pipeline as pipeline
 from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
 import torch
-from cutlass import Float32, Int32, Int64, Uint8
+from cutlass import Float32, Int32, Int64, Uint8, Uint32
 
 from ...api_logging import flashinfer_api
 from ...jit.cute_dsl_core import build_and_load_cute_dsl_kernel
 from ...cute_dsl.fp4_common import (
+    bfloat2_max_abs,
     block_reduce,
     fdiv_rn,
     fmax_f32,
     fmin_f32,
     get_ptr_as_int64,
+    half2_max_abs,
     ld_global_v4_u32,
     rcp_approx_ftz,
     st_global_u64,
@@ -694,13 +696,14 @@ class NVFP4QuantizeSwizzledKernel:
 
 _PER_TOKEN_THREADS = 128
 _PER_TOKEN_WARPS = _PER_TOKEN_THREADS // WARP_SIZE
+_PER_TOKEN_AUX_ROWS = 8
+_PER_TOKEN_AUX_ROWS_PER_WARP = _PER_TOKEN_AUX_ROWS // _PER_TOKEN_WARPS
 
 
 class NVFP4QuantizePerTokenKernel:
     """
-    One CTA per token row. The first pass reduces either the input row or a
-    precomputed row of tile amax values, then the second pass reuses the
-    regular NVFP4 block quantizer with that row's global encode scale.
+    Per-token quantization with either one CTA per row for the standalone
+    input scan or eight rows per CTA for the blocked auxiliary-amax path.
     """
 
     def __init__(
@@ -711,7 +714,6 @@ class NVFP4QuantizePerTokenKernel:
         enable_pdl: bool = False,
         disable_fp4_quant_fast_math: bool = False,
         nvfp4_4over6_config: NVFP44Over6Config | None = None,
-        has_input_amax: bool = False,
     ):
         self.dtype = dtype
         self.K = K
@@ -719,7 +721,6 @@ class NVFP4QuantizePerTokenKernel:
         self.enable_pdl = enable_pdl
         self.disable_fp4_quant_fast_math = disable_fp4_quant_fast_math
         self.nvfp4_4over6_config = nvfp4_4over6_config
-        self.has_input_amax = has_input_amax
         self.sf_layout = sf_layout
         self.sf_is_128x4 = sf_layout == SF_LAYOUT_128x4
         self.sf_is_8x4 = sf_layout == SF_LAYOUT_8x4
@@ -816,8 +817,8 @@ class NVFP4QuantizePerTokenKernel:
         input_amax_cols: Int32,
         stream,
     ):
-        """Launch the specialization that reduces precomputed tile amaxes."""
-        self.kernel(
+        """Launch the specialization that reduces blocked tile amaxes."""
+        self.kernel_with_input_amax(
             mInput,
             mOutput,
             mScales,
@@ -827,13 +828,233 @@ class NVFP4QuantizePerTokenKernel:
             mInputAmax,
             input_amax_cols,
         ).launch(
-            grid=[M, 1, 1],
+            grid=[cute.ceil_div(M, _PER_TOKEN_AUX_ROWS), 1, 1],
             block=[_PER_TOKEN_THREADS, 1, 1],
             max_number_threads=[_MAX_THREADS_PER_BLOCK, 1, 1],
             min_blocks_per_mp=_BLOCKS_PER_SM,
             stream=stream,
             use_pdl=self.enable_pdl,
         )
+
+    @cute.jit
+    def run_with_input_amax_valid_rows(
+        self,
+        mInput: cute.Tensor,
+        mOutput: cute.Tensor,
+        mScales: cute.Tensor,
+        mPerTokenScale: cute.Tensor,
+        M: Int32,
+        mGlobalScaleInv: cute.Tensor,
+        mInputAmax: cute.Tensor,
+        input_amax_cols: Int32,
+        mValidRows: cute.Tensor,
+        stream,
+    ):
+        """Launch blocked aux quantization bounded by a device row count."""
+        self.kernel_with_input_amax(
+            mInput,
+            mOutput,
+            mScales,
+            mPerTokenScale,
+            M,
+            mGlobalScaleInv,
+            mInputAmax,
+            input_amax_cols,
+            mValidRows,
+        ).launch(
+            grid=[cute.ceil_div(M, _PER_TOKEN_AUX_ROWS), 1, 1],
+            block=[_PER_TOKEN_THREADS, 1, 1],
+            max_number_threads=[_MAX_THREADS_PER_BLOCK, 1, 1],
+            min_blocks_per_mp=_BLOCKS_PER_SM,
+            stream=stream,
+            use_pdl=self.enable_pdl,
+        )
+
+    @cute.kernel
+    def kernel_with_input_amax(
+        self,
+        mInput: cute.Tensor,
+        mOutput: cute.Tensor,
+        mScales: cute.Tensor,
+        mPerTokenScale: cute.Tensor,
+        M: Int32,
+        mGlobalScaleInv: cute.Tensor,
+        mInputAmax: cute.Tensor,
+        input_amax_cols: Int32,
+        mValidRows: cute.Tensor | None = None,
+    ):
+        """Quantize eight rows per CTA from native-width blocked-8 amaxes."""
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+
+        if cutlass.const_expr(self.enable_pdl):
+            cute.arch.griddepcontrol_wait()
+
+        warp_idx = tidx // Int32(WARP_SIZE)
+        lane_idx = tidx % Int32(WARP_SIZE)
+        row_block_base = bidx * Int32(_PER_TOKEN_AUX_ROWS)
+        valid_rows = M
+        if cutlass.const_expr(mValidRows is not None):
+            valid_rows = Int32(mValidRows[Int32(0)])
+
+        # Warp 0 reduces all eight rows while keeping adjacent row maxima
+        # packed in native-width x2 words. Lanes with the same row-pair are
+        # four apart and collectively cover eight GEMM-N tiles at a time, so a
+        # warp load touches one contiguous 128-byte blocked-8 span.
+        smem = cutlass.utils.SmemAllocator()
+        row_amax_buffer = smem.allocate_tensor(
+            Float32,
+            cute.make_layout((_PER_TOKEN_AUX_ROWS,)),
+            byte_alignment=16,
+        )
+        if warp_idx == Int32(0):
+            row_pair = lane_idx % Int32(_PER_TOKEN_AUX_ROWS // 2)
+            tile_lane = lane_idx // Int32(_PER_TOKEN_AUX_ROWS // 2)
+            pair_first_row = row_block_base + row_pair * Int32(2)
+            packed_amax = Uint32(0)
+            if pair_first_row < M and pair_first_row < valid_rows:
+                tile_idx = tile_lane
+                while tile_idx < input_amax_cols:
+                    element_offset = (
+                        Int64(bidx)
+                        * Int64(input_amax_cols)
+                        * Int64(_PER_TOKEN_AUX_ROWS)
+                        + Int64(tile_idx) * Int64(_PER_TOKEN_AUX_ROWS)
+                        + Int64(row_pair) * Int64(2)
+                    )
+                    pair_addr = get_ptr_as_int64(
+                        mInputAmax, Int32(0)
+                    ) + element_offset * Int64(2)
+                    pair_tensor = cute.make_tensor(
+                        cute.make_ptr(
+                            Uint32,
+                            pair_addr,
+                            cute.AddressSpace.gmem,
+                            assumed_align=4,
+                        ),
+                        cute.make_layout((1,)),
+                    )
+                    if cutlass.const_expr(self.is_bfloat16):
+                        packed_amax = bfloat2_max_abs(packed_amax, pair_tensor[0])
+                    else:
+                        packed_amax = half2_max_abs(packed_amax, pair_tensor[0])
+                    tile_idx = tile_idx + Int32(8)
+
+            shuffled = cute.arch.shuffle_sync_bfly(packed_amax, offset=4)
+            if cutlass.const_expr(self.is_bfloat16):
+                packed_amax = bfloat2_max_abs(packed_amax, shuffled)
+            else:
+                packed_amax = half2_max_abs(packed_amax, shuffled)
+            shuffled = cute.arch.shuffle_sync_bfly(packed_amax, offset=8)
+            if cutlass.const_expr(self.is_bfloat16):
+                packed_amax = bfloat2_max_abs(packed_amax, shuffled)
+            else:
+                packed_amax = half2_max_abs(packed_amax, shuffled)
+            shuffled = cute.arch.shuffle_sync_bfly(packed_amax, offset=16)
+            if cutlass.const_expr(self.is_bfloat16):
+                packed_amax = bfloat2_max_abs(packed_amax, shuffled)
+            else:
+                packed_amax = half2_max_abs(packed_amax, shuffled)
+
+            if lane_idx < Int32(_PER_TOKEN_AUX_ROWS // 2):
+                value_bits = cute.make_rmem_tensor((1,), Uint32)
+                value_bits[0] = packed_amax & Uint32(0x7FFF)
+                low_value = cute.recast_tensor(value_bits, mInputAmax.element_type)[0]
+                value_bits[0] = (packed_amax >> Uint32(16)) & Uint32(0x7FFF)
+                high_value = cute.recast_tensor(value_bits, mInputAmax.element_type)[0]
+                row_amax_buffer[lane_idx * Int32(2)] = Float32(low_value)
+                row_amax_buffer[lane_idx * Int32(2) + Int32(1)] = Float32(high_value)
+        cute.arch.barrier()
+
+        # Four warps quantize two rows each. Fixed full-warp ownership avoids
+        # dynamic redux masks and gives each row 32-way block-scale parallelism
+        # while amortizing one CTA over eight rows.
+        for row_pass in cutlass.range_constexpr(_PER_TOKEN_AUX_ROWS_PER_WARP):
+            row_in_cta = warp_idx * Int32(_PER_TOKEN_AUX_ROWS_PER_WARP) + row_pass
+            row_idx = row_block_base + row_in_cta
+            if row_idx < M and row_idx < valid_rows:
+                # Build row views with 64-bit byte offsets. Production routing
+                # buffers can exceed the signed Int32 element-offset range.
+                input_row_addr = get_ptr_as_int64(mInput, Int32(0)) + Int64(
+                    row_idx
+                ) * Int64(self.K * (mInput.element_type.width // 8))
+                row_input = cute.make_tensor(
+                    cute.make_ptr(
+                        mInput.element_type,
+                        input_row_addr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=16,
+                    ),
+                    cute.make_layout((self.K,)),
+                )
+                output_row_addr = get_ptr_as_int64(mOutput, Int32(0)) + Int64(
+                    row_idx
+                ) * Int64(self.K // 2)
+                row_output = cute.make_tensor(
+                    cute.make_ptr(
+                        mOutput.element_type,
+                        output_row_addr,
+                        cute.AddressSpace.gmem,
+                        assumed_align=8,
+                    ),
+                    cute.make_layout((self.K // 2,)),
+                )
+
+                row_amax = row_amax_buffer[row_in_cta]
+                global_scale_inv = Float32(mGlobalScaleInv[Int32(0)])
+                global_encode_scale, per_token_scale = self._row_scales(
+                    row_amax, global_scale_inv
+                )
+                if lane_idx == Int32(0):
+                    mPerTokenScale[row_idx] = per_token_scale
+
+                num_sf_blocks_per_row = self.num_sf_blocks_per_row
+                padded_sf_cols = self.padded_sf_cols
+                sf_col_idx = lane_idx
+                while sf_col_idx < num_sf_blocks_per_row:
+                    elem_base = sf_col_idx * NVFP4_SF_VEC_SIZE
+                    if cutlass.const_expr(self.is_bfloat16):
+                        scale_fp8, packed64 = process_nvfp4_block_bfloat(
+                            row_input,
+                            elem_base,
+                            global_encode_scale,
+                            self.disable_fp4_quant_fast_math,
+                            self.nvfp4_4over6_config,
+                            row_amax,
+                        )
+                    else:
+                        scale_fp8, packed64 = process_nvfp4_block_half(
+                            row_input,
+                            elem_base,
+                            global_encode_scale,
+                            self.disable_fp4_quant_fast_math,
+                            self.nvfp4_4over6_config,
+                            row_amax,
+                        )
+
+                    sf_offset = self._compute_sf_offset(
+                        row_idx, sf_col_idx, padded_sf_cols
+                    )
+                    mScales[sf_offset] = scale_fp8
+
+                    out_base = sf_col_idx * Int32(NVFP4_SF_VEC_SIZE // 2)
+                    out_ptr = get_ptr_as_int64(row_output, out_base)
+                    st_global_u64(out_ptr, packed64)
+                    sf_col_idx = sf_col_idx + Int32(WARP_SIZE)
+
+                if cutlass.const_expr(self.sf_layout != SF_LAYOUT_LINEAR):
+                    sf_col_idx = num_sf_blocks_per_row + lane_idx
+                    while sf_col_idx < padded_sf_cols:
+                        sf_offset = self._compute_sf_offset(
+                            row_idx, sf_col_idx, padded_sf_cols
+                        )
+                        mScales[sf_offset] = Uint8(0)
+                        sf_col_idx = sf_col_idx + Int32(WARP_SIZE)
+
+        # Every CTA must reach the PDL signal, including row blocks beyond the
+        # device-side active routing extent.
+        if cutlass.const_expr(self.enable_pdl):
+            cute.arch.griddepcontrol_launch_dependents()
 
     @cute.kernel
     def kernel(
@@ -844,8 +1065,6 @@ class NVFP4QuantizePerTokenKernel:
         mPerTokenScale: cute.Tensor,
         M: Int32,
         mGlobalScaleInv: cute.Tensor,
-        mInputAmax: cute.Tensor | None = None,
-        input_amax_cols: Int32 | None = None,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
@@ -894,41 +1113,21 @@ class NVFP4QuantizePerTokenKernel:
         )
 
         local_amax = Float32(0.0)
-        if cutlass.const_expr(self.has_input_amax):
-            # Keep row addressing 64-bit like the input/output paths above so
-            # larger future aux shapes do not inherit an Int32 offset limit.
-            input_amax_row_addr = get_ptr_as_int64(mInputAmax, Int32(0)) + Int64(
-                row_idx
-            ) * Int64(input_amax_cols) * Int64(4)
-            row_input_amax = cute.make_tensor(
-                cute.make_ptr(
-                    Float32,
-                    input_amax_row_addr,
-                    cute.AddressSpace.gmem,
-                    assumed_align=4,
-                ),
-                cute.make_layout((input_amax_cols,)),
-            )
-            amax_col_idx = tidx
-            while amax_col_idx < input_amax_cols:
-                local_amax = fmax_f32(local_amax, Float32(row_input_amax[amax_col_idx]))
-                amax_col_idx = amax_col_idx + Int32(_PER_TOKEN_THREADS)
-        else:
-            sf_col_idx = tidx
-            while sf_col_idx < num_sf_blocks_per_row:
-                elem_base = sf_col_idx * NVFP4_SF_VEC_SIZE
-                ptr0 = get_ptr_as_int64(row_input, elem_base)
-                ptr1 = get_ptr_as_int64(row_input, elem_base + Int32(8))
-                h0, h1, h2, h3 = ld_global_v4_u32(ptr0)
-                h4, h5, h6, h7 = ld_global_v4_u32(ptr1)
-                if cutlass.const_expr(self.is_bfloat16):
-                    block_max_h2 = bfloat2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
-                    block_max = bfloat2_hmax_reduce_to_f32(block_max_h2)
-                else:
-                    block_max_h2 = half2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
-                    block_max = hmax_reduce_to_f32(block_max_h2)
-                local_amax = fmax_f32(local_amax, block_max)
-                sf_col_idx = sf_col_idx + Int32(_PER_TOKEN_THREADS)
+        sf_col_idx = tidx
+        while sf_col_idx < num_sf_blocks_per_row:
+            elem_base = sf_col_idx * NVFP4_SF_VEC_SIZE
+            ptr0 = get_ptr_as_int64(row_input, elem_base)
+            ptr1 = get_ptr_as_int64(row_input, elem_base + Int32(8))
+            h0, h1, h2, h3 = ld_global_v4_u32(ptr0)
+            h4, h5, h6, h7 = ld_global_v4_u32(ptr1)
+            if cutlass.const_expr(self.is_bfloat16):
+                block_max_h2 = bfloat2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
+                block_max = bfloat2_hmax_reduce_to_f32(block_max_h2)
+            else:
+                block_max_h2 = half2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
+                block_max = hmax_reduce_to_f32(block_max_h2)
+            local_amax = fmax_f32(local_amax, block_max)
+            sf_col_idx = sf_col_idx + Int32(_PER_TOKEN_THREADS)
 
         warp_amax = warp_reduce(local_amax, fmax_f32)
         row_amax = block_reduce(warp_amax, fmax_f32, reduction_buffer, Float32(0.0))
@@ -1717,7 +1916,9 @@ def _get_compiled_kernel_nvfp4_per_token(
     disable_fp4_quant_fast_math: bool = False,
     nvfp4_4over6_config: NVFP44Over6Config | None = None,
     has_input_amax: bool = False,
+    has_input_amax_valid_rows: bool = False,
 ) -> Callable:
+    assert not has_input_amax_valid_rows or has_input_amax
     _dtype_map = {
         "float16": cutlass.Float16,
         "bfloat16": cutlass.BFloat16,
@@ -1751,7 +1952,6 @@ def _get_compiled_kernel_nvfp4_per_token(
         enable_pdl=enable_pdl,
         disable_fp4_quant_fast_math=disable_fp4_quant_fast_math,
         nvfp4_4over6_config=nvfp4_4over6_config,
-        has_input_amax=has_input_amax,
     )
 
     kernel_name = _nvfp4_kernel_name(
@@ -1766,28 +1966,52 @@ def _get_compiled_kernel_nvfp4_per_token(
     )
     if has_input_amax:
         kernel_name += "_input_amax"
+        sym_input_amax_row_blocks = cute.sym_int()
         sym_input_amax_cols = cute.sym_int()
         input_amax_fake = cute.runtime.make_fake_compact_tensor(
-            cutlass.Float32,
-            (sym_m, sym_input_amax_cols),
-            stride_order=(1, 0),
+            cutlass_dtype,
+            (sym_input_amax_row_blocks, sym_input_amax_cols, _PER_TOKEN_AUX_ROWS),
+            stride_order=(2, 1, 0),
             assumed_align=4,
         )
-
-        def compile_fn():
-            return cute.compile(
-                kernel_obj.run_with_input_amax,
-                input_fake,
-                output_fake,
-                scales_fake,
-                per_token_scale_fake,
-                Int32(1),
-                global_scale_inv_fake,
-                input_amax_fake,
-                Int32(1),
-                stream_fake,
-                options="--enable-tvm-ffi",
+        if has_input_amax_valid_rows:
+            kernel_name += "_valid_rows"
+            valid_rows_fake = cute.runtime.make_fake_compact_tensor(
+                cutlass.Int32, (1,), assumed_align=4
             )
+
+            def compile_fn():
+                return cute.compile(
+                    kernel_obj.run_with_input_amax_valid_rows,
+                    input_fake,
+                    output_fake,
+                    scales_fake,
+                    per_token_scale_fake,
+                    Int32(1),
+                    global_scale_inv_fake,
+                    input_amax_fake,
+                    Int32(1),  # Dummy GEMM-N tile count
+                    valid_rows_fake,
+                    stream_fake,
+                    options="--enable-tvm-ffi",
+                )
+
+        else:
+
+            def compile_fn():
+                return cute.compile(
+                    kernel_obj.run_with_input_amax,
+                    input_fake,
+                    output_fake,
+                    scales_fake,
+                    per_token_scale_fake,
+                    Int32(1),
+                    global_scale_inv_fake,
+                    input_amax_fake,
+                    Int32(1),  # Dummy GEMM-N tile count
+                    stream_fake,
+                    options="--enable-tvm-ffi",
+                )
 
     else:
 
@@ -2408,6 +2632,7 @@ def nvfp4_quantize_per_token_cute_dsl(
     sf_layout: int = SF_LAYOUT_128x4,
     enable_pdl: bool | None = None,
     input_amax: torch.Tensor | None = None,
+    input_amax_valid_rows: torch.Tensor | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     r"""Per-token NVFP4 activation quantization using the CuTe-DSL kernel.
 
@@ -2423,9 +2648,9 @@ def nvfp4_quantize_per_token_cute_dsl(
     - Supports 128x4, 8x4, and linear scale-factor layouts
 
     The kernel is specialized by K, dtype, scale-factor layout, PDL, fast-math
-    and 4-over-6 settings, and whether ``input_amax`` is present. It handles
-    varying M (number of tokens) and aux widths at runtime without
-    recompilation.
+    and 4-over-6 settings, whether ``input_amax`` is present, and whether its
+    device-side valid-row bound is present. It handles varying M (number of
+    tokens) and aux widths at runtime without recompilation.
 
     Parameters
     ----------
@@ -2443,15 +2668,26 @@ def nvfp4_quantize_per_token_cute_dsl(
         device capability (SM >= 9.0) when ``None``; pass ``False`` to force it
         off.
     input_amax : torch.Tensor, optional
-        Contiguous 2-D CUDA ``float32`` tensor of shape ``[M, num_tiles]`` on
-        the same device as ``input``, with ``num_tiles > 0``. Each entry must
-        be the exact maximum absolute value, computed after conversion to
-        ``input.dtype``, for a subset of the corresponding input row; the
-        subsets must cover the row so that reducing this tensor's second
-        dimension produces the same row amax as reducing ``input`` directly.
-        When supplied, the kernel trusts this contract and skips its full-input
+        Contiguous, 4-byte-aligned CUDA tensor with the same dtype and device
+        as ``input`` in blocked-8 layout ``[ceil(M/8), num_tiles, 8]``, where
+        ``num_tiles`` is positive. Logical entry ``[row, tile]`` is stored at
+        ``[row//8, tile, row%8]``. Each entry must be the exact
+        maximum absolute value, computed after conversion to ``input.dtype``,
+        for a subset of the corresponding input row; the subsets must cover
+        the row so that reducing all tile entries produces the same row amax
+        as reducing ``input`` directly. Because a maximum of rounded FP16 or
+        BF16 values is itself exactly representable in that dtype, the blocked
+        native-width storage does not change the quantization scale. When
+        supplied, the kernel trusts this contract and skips its full-input
         row-amax pass. Quantization and per-token-scale math are otherwise
         unchanged.
+    input_amax_valid_rows : torch.Tensor, optional
+        Contiguous one-element CUDA ``int32`` tensor on the same device as
+        ``input``. This CUDA-graph-compatible bound may be supplied only with
+        ``input_amax`` and must contain a multiple-of-8 value in ``[0, M]``.
+        Row blocks starting at or above the bound are not read or written, so
+        their returned values are undefined. The fused MoE path naturally
+        satisfies this contract because its routing extent is GEMM-tile padded.
 
     Returns
     -------
@@ -2491,25 +2727,57 @@ def nvfp4_quantize_per_token_cute_dsl(
         assert isinstance(input_amax, torch.Tensor), (
             "input_amax must be a torch.Tensor when provided"
         )
-        assert input_amax.dtype == torch.float32, (
-            f"input_amax must have dtype torch.float32, got {input_amax.dtype}"
+        assert input_amax.dtype == input.dtype, (
+            f"input_amax must have the same dtype as input ({input.dtype}), "
+            f"got {input_amax.dtype}"
         )
         assert input_amax.is_cuda, "input_amax must be on a CUDA device"
         assert input_amax.device == input.device, (
             f"input_amax must be on the same device as input ({input.device}), "
             f"got {input_amax.device}"
         )
-        assert input_amax.dim() == 2, (
-            f"input_amax must be 2-D, got {input_amax.dim()} dimensions"
+        assert input_amax.dim() == 3, (
+            f"input_amax must be 3-D blocked-8, got {input_amax.dim()} dimensions"
         )
-        assert input_amax.shape[0] == m, (
-            f"input_amax must have one row per input row ({m}), "
-            f"got {input_amax.shape[0]}"
+        expected_row_blocks = (m + _PER_TOKEN_AUX_ROWS - 1) // _PER_TOKEN_AUX_ROWS
+        assert input_amax.shape[0] == expected_row_blocks, (
+            "input_amax blocked-8 row-block dimension must equal "
+            f"ceil(M/8)={expected_row_blocks}, got {input_amax.shape[0]}"
         )
-        assert input_amax.shape[1] > 0 and input_amax.numel() > 0, (
-            "input_amax must be nonempty and have at least one tile per row"
+        assert input_amax.shape[1] > 0, "input_amax must have at least one tile"
+        assert input_amax.shape[2] == _PER_TOKEN_AUX_ROWS, (
+            "input_amax blocked-8 trailing dimension must be 8, got "
+            f"{input_amax.shape[2]}"
         )
         assert input_amax.is_contiguous(), "input_amax must be contiguous"
+        assert input_amax.data_ptr() % 4 == 0, (
+            "input_amax must be 4-byte aligned for packed row-pair loads"
+        )
+
+    if input_amax_valid_rows is not None:
+        assert input_amax is not None, (
+            "input_amax_valid_rows may be supplied only with input_amax"
+        )
+        assert isinstance(input_amax_valid_rows, torch.Tensor), (
+            "input_amax_valid_rows must be a torch.Tensor when provided"
+        )
+        assert input_amax_valid_rows.dtype == torch.int32, (
+            "input_amax_valid_rows must have dtype torch.int32"
+        )
+        assert input_amax_valid_rows.is_cuda, (
+            "input_amax_valid_rows must be on a CUDA device"
+        )
+        assert input_amax_valid_rows.device == input.device, (
+            "input_amax_valid_rows must be on the same device as input "
+            f"({input.device}), got {input_amax_valid_rows.device}"
+        )
+        assert input_amax_valid_rows.shape == (1,), (
+            "input_amax_valid_rows must have shape (1,), got "
+            f"{tuple(input_amax_valid_rows.shape)}"
+        )
+        assert input_amax_valid_rows.is_contiguous(), (
+            "input_amax_valid_rows must be contiguous"
+        )
 
     _torch_to_dtype_key = {
         torch.float16: "float16",
@@ -2550,6 +2818,7 @@ def nvfp4_quantize_per_token_cute_dsl(
         disable_fp4_quant_fast_math,
         nvfp4_4over6_config,
         input_amax is not None,
+        input_amax_valid_rows is not None,
     )
 
     fp4_output = torch.empty(m, k // 2, dtype=torch.uint8, device=input.device)
@@ -2568,7 +2837,7 @@ def nvfp4_quantize_per_token_cute_dsl(
             global_scale_inv_tensor,
         )
     else:
-        kernel_fn(
+        args = (
             input,
             fp4_output,
             scale_output,
@@ -2578,6 +2847,10 @@ def nvfp4_quantize_per_token_cute_dsl(
             input_amax,
             input_amax.shape[1],
         )
+        if input_amax_valid_rows is None:
+            kernel_fn(*args)
+        else:
+            kernel_fn(*args, input_amax_valid_rows)
 
     scale_output = scale_output.reshape(-1, padded_sf_cols)
     return fp4_output, scale_output, per_token_scale

--- a/flashinfer/quantization/kernels/nvfp4_quantize.py
+++ b/flashinfer/quantization/kernels/nvfp4_quantize.py
@@ -698,9 +698,9 @@ _PER_TOKEN_WARPS = _PER_TOKEN_THREADS // WARP_SIZE
 
 class NVFP4QuantizePerTokenKernel:
     """
-    One CTA per token row. The first pass reduces the row amax, then the
-    second pass reuses the regular NVFP4 block quantizer with that row's
-    global encode scale.
+    One CTA per token row. The first pass reduces either the input row or a
+    precomputed row of tile amax values, then the second pass reuses the
+    regular NVFP4 block quantizer with that row's global encode scale.
     """
 
     def __init__(
@@ -711,6 +711,7 @@ class NVFP4QuantizePerTokenKernel:
         enable_pdl: bool = False,
         disable_fp4_quant_fast_math: bool = False,
         nvfp4_4over6_config: NVFP44Over6Config | None = None,
+        has_input_amax: bool = False,
     ):
         self.dtype = dtype
         self.K = K
@@ -718,6 +719,7 @@ class NVFP4QuantizePerTokenKernel:
         self.enable_pdl = enable_pdl
         self.disable_fp4_quant_fast_math = disable_fp4_quant_fast_math
         self.nvfp4_4over6_config = nvfp4_4over6_config
+        self.has_input_amax = has_input_amax
         self.sf_layout = sf_layout
         self.sf_is_128x4 = sf_layout == SF_LAYOUT_128x4
         self.sf_is_8x4 = sf_layout == SF_LAYOUT_8x4
@@ -801,6 +803,38 @@ class NVFP4QuantizePerTokenKernel:
             use_pdl=self.enable_pdl,
         )
 
+    @cute.jit
+    def run_with_input_amax(
+        self,
+        mInput: cute.Tensor,
+        mOutput: cute.Tensor,
+        mScales: cute.Tensor,
+        mPerTokenScale: cute.Tensor,
+        M: Int32,
+        mGlobalScaleInv: cute.Tensor,
+        mInputAmax: cute.Tensor,
+        input_amax_cols: Int32,
+        stream,
+    ):
+        """Launch the specialization that reduces precomputed tile amaxes."""
+        self.kernel(
+            mInput,
+            mOutput,
+            mScales,
+            mPerTokenScale,
+            M,
+            mGlobalScaleInv,
+            mInputAmax,
+            input_amax_cols,
+        ).launch(
+            grid=[M, 1, 1],
+            block=[_PER_TOKEN_THREADS, 1, 1],
+            max_number_threads=[_MAX_THREADS_PER_BLOCK, 1, 1],
+            min_blocks_per_mp=_BLOCKS_PER_SM,
+            stream=stream,
+            use_pdl=self.enable_pdl,
+        )
+
     @cute.kernel
     def kernel(
         self,
@@ -810,6 +844,8 @@ class NVFP4QuantizePerTokenKernel:
         mPerTokenScale: cute.Tensor,
         M: Int32,
         mGlobalScaleInv: cute.Tensor,
+        mInputAmax: cute.Tensor | None = None,
+        input_amax_cols: Int32 | None = None,
     ):
         tidx, _, _ = cute.arch.thread_idx()
         bidx, _, _ = cute.arch.block_idx()
@@ -858,21 +894,41 @@ class NVFP4QuantizePerTokenKernel:
         )
 
         local_amax = Float32(0.0)
-        sf_col_idx = tidx
-        while sf_col_idx < num_sf_blocks_per_row:
-            elem_base = sf_col_idx * NVFP4_SF_VEC_SIZE
-            ptr0 = get_ptr_as_int64(row_input, elem_base)
-            ptr1 = get_ptr_as_int64(row_input, elem_base + Int32(8))
-            h0, h1, h2, h3 = ld_global_v4_u32(ptr0)
-            h4, h5, h6, h7 = ld_global_v4_u32(ptr1)
-            if cutlass.const_expr(self.is_bfloat16):
-                block_max_h2 = bfloat2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
-                block_max = bfloat2_hmax_reduce_to_f32(block_max_h2)
-            else:
-                block_max_h2 = half2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
-                block_max = hmax_reduce_to_f32(block_max_h2)
-            local_amax = fmax_f32(local_amax, block_max)
-            sf_col_idx = sf_col_idx + Int32(_PER_TOKEN_THREADS)
+        if cutlass.const_expr(self.has_input_amax):
+            # Keep row addressing 64-bit like the input/output paths above so
+            # larger future aux shapes do not inherit an Int32 offset limit.
+            input_amax_row_addr = get_ptr_as_int64(mInputAmax, Int32(0)) + Int64(
+                row_idx
+            ) * Int64(input_amax_cols) * Int64(4)
+            row_input_amax = cute.make_tensor(
+                cute.make_ptr(
+                    Float32,
+                    input_amax_row_addr,
+                    cute.AddressSpace.gmem,
+                    assumed_align=4,
+                ),
+                cute.make_layout((input_amax_cols,)),
+            )
+            amax_col_idx = tidx
+            while amax_col_idx < input_amax_cols:
+                local_amax = fmax_f32(local_amax, Float32(row_input_amax[amax_col_idx]))
+                amax_col_idx = amax_col_idx + Int32(_PER_TOKEN_THREADS)
+        else:
+            sf_col_idx = tidx
+            while sf_col_idx < num_sf_blocks_per_row:
+                elem_base = sf_col_idx * NVFP4_SF_VEC_SIZE
+                ptr0 = get_ptr_as_int64(row_input, elem_base)
+                ptr1 = get_ptr_as_int64(row_input, elem_base + Int32(8))
+                h0, h1, h2, h3 = ld_global_v4_u32(ptr0)
+                h4, h5, h6, h7 = ld_global_v4_u32(ptr1)
+                if cutlass.const_expr(self.is_bfloat16):
+                    block_max_h2 = bfloat2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
+                    block_max = bfloat2_hmax_reduce_to_f32(block_max_h2)
+                else:
+                    block_max_h2 = half2_max_abs_8_fn(h0, h1, h2, h3, h4, h5, h6, h7)
+                    block_max = hmax_reduce_to_f32(block_max_h2)
+                local_amax = fmax_f32(local_amax, block_max)
+                sf_col_idx = sf_col_idx + Int32(_PER_TOKEN_THREADS)
 
         warp_amax = warp_reduce(local_amax, fmax_f32)
         row_amax = block_reduce(warp_amax, fmax_f32, reduction_buffer, Float32(0.0))
@@ -1660,6 +1716,7 @@ def _get_compiled_kernel_nvfp4_per_token(
     enable_pdl: bool = False,
     disable_fp4_quant_fast_math: bool = False,
     nvfp4_4over6_config: NVFP44Over6Config | None = None,
+    has_input_amax: bool = False,
 ) -> Callable:
     _dtype_map = {
         "float16": cutlass.Float16,
@@ -1694,31 +1751,63 @@ def _get_compiled_kernel_nvfp4_per_token(
         enable_pdl=enable_pdl,
         disable_fp4_quant_fast_math=disable_fp4_quant_fast_math,
         nvfp4_4over6_config=nvfp4_4over6_config,
+        has_input_amax=has_input_amax,
     )
+
+    kernel_name = _nvfp4_kernel_name(
+        "per_token",
+        dtype_key,
+        K,
+        sf_layout,
+        enable_pdl,
+        disable_fp4_quant_fast_math,
+        silu_and_mul=False,
+        nvfp4_4over6_config=nvfp4_4over6_config,
+    )
+    if has_input_amax:
+        kernel_name += "_input_amax"
+        sym_input_amax_cols = cute.sym_int()
+        input_amax_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Float32,
+            (sym_m, sym_input_amax_cols),
+            stride_order=(1, 0),
+            assumed_align=4,
+        )
+
+        def compile_fn():
+            return cute.compile(
+                kernel_obj.run_with_input_amax,
+                input_fake,
+                output_fake,
+                scales_fake,
+                per_token_scale_fake,
+                Int32(1),
+                global_scale_inv_fake,
+                input_amax_fake,
+                Int32(1),
+                stream_fake,
+                options="--enable-tvm-ffi",
+            )
+
+    else:
+
+        def compile_fn():
+            return cute.compile(
+                kernel_obj,
+                input_fake,
+                output_fake,
+                scales_fake,
+                per_token_scale_fake,
+                Int32(1),
+                global_scale_inv_fake,
+                stream_fake,
+                options="--enable-tvm-ffi",
+            )
 
     return build_and_load_cute_dsl_kernel(
         _CUTE_DSL_MODULE,
-        _nvfp4_kernel_name(
-            "per_token",
-            dtype_key,
-            K,
-            sf_layout,
-            enable_pdl,
-            disable_fp4_quant_fast_math,
-            silu_and_mul=False,
-            nvfp4_4over6_config=nvfp4_4over6_config,
-        ),
-        lambda: cute.compile(
-            kernel_obj,
-            input_fake,
-            output_fake,
-            scales_fake,
-            per_token_scale_fake,
-            Int32(1),
-            global_scale_inv_fake,
-            stream_fake,
-            options="--enable-tvm-ffi",
-        ),
+        kernel_name,
+        compile_fn,
         extra_key_files=_kernel_source_files(),
     )
 
@@ -2318,6 +2407,7 @@ def nvfp4_quantize_per_token_cute_dsl(
     global_scale_inv: torch.Tensor,
     sf_layout: int = SF_LAYOUT_128x4,
     enable_pdl: bool | None = None,
+    input_amax: torch.Tensor | None = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     r"""Per-token NVFP4 activation quantization using the CuTe-DSL kernel.
 
@@ -2332,8 +2422,10 @@ def nvfp4_quantize_per_token_cute_dsl(
     - E2M1 output format (4-bit, 2 values per byte)
     - Supports 128x4, 8x4, and linear scale-factor layouts
 
-    The kernel is compiled once per ``(K, dtype, sf_layout, pdl)`` tuple and
-    handles varying ``M`` (number of tokens) at runtime without recompilation.
+    The kernel is specialized by K, dtype, scale-factor layout, PDL, fast-math
+    and 4-over-6 settings, and whether ``input_amax`` is present. It handles
+    varying M (number of tokens) and aux widths at runtime without
+    recompilation.
 
     Parameters
     ----------
@@ -2350,6 +2442,16 @@ def nvfp4_quantize_per_token_cute_dsl(
         Whether to enable Programmatic Dependent Launch. Auto-detected from
         device capability (SM >= 9.0) when ``None``; pass ``False`` to force it
         off.
+    input_amax : torch.Tensor, optional
+        Contiguous 2-D CUDA ``float32`` tensor of shape ``[M, num_tiles]`` on
+        the same device as ``input``, with ``num_tiles > 0``. Each entry must
+        be the exact maximum absolute value, computed after conversion to
+        ``input.dtype``, for a subset of the corresponding input row; the
+        subsets must cover the row so that reducing this tensor's second
+        dimension produces the same row amax as reducing ``input`` directly.
+        When supplied, the kernel trusts this contract and skips its full-input
+        row-amax pass. Quantization and per-token-scale math are otherwise
+        unchanged.
 
     Returns
     -------
@@ -2384,6 +2486,30 @@ def nvfp4_quantize_per_token_cute_dsl(
     assert k % NVFP4_SF_VEC_SIZE == 0, (
         f"K ({k}) must be divisible by NVFP4_SF_VEC_SIZE={NVFP4_SF_VEC_SIZE}"
     )
+
+    if input_amax is not None:
+        assert isinstance(input_amax, torch.Tensor), (
+            "input_amax must be a torch.Tensor when provided"
+        )
+        assert input_amax.dtype == torch.float32, (
+            f"input_amax must have dtype torch.float32, got {input_amax.dtype}"
+        )
+        assert input_amax.is_cuda, "input_amax must be on a CUDA device"
+        assert input_amax.device == input.device, (
+            f"input_amax must be on the same device as input ({input.device}), "
+            f"got {input_amax.device}"
+        )
+        assert input_amax.dim() == 2, (
+            f"input_amax must be 2-D, got {input_amax.dim()} dimensions"
+        )
+        assert input_amax.shape[0] == m, (
+            f"input_amax must have one row per input row ({m}), "
+            f"got {input_amax.shape[0]}"
+        )
+        assert input_amax.shape[1] > 0 and input_amax.numel() > 0, (
+            "input_amax must be nonempty and have at least one tile per row"
+        )
+        assert input_amax.is_contiguous(), "input_amax must be contiguous"
 
     _torch_to_dtype_key = {
         torch.float16: "float16",
@@ -2423,6 +2549,7 @@ def nvfp4_quantize_per_token_cute_dsl(
         enable_pdl,
         disable_fp4_quant_fast_math,
         nvfp4_4over6_config,
+        input_amax is not None,
     )
 
     fp4_output = torch.empty(m, k // 2, dtype=torch.uint8, device=input.device)
@@ -2431,14 +2558,26 @@ def nvfp4_quantize_per_token_cute_dsl(
     )
     per_token_scale = torch.empty(m, dtype=torch.float32, device=input.device)
 
-    kernel_fn(
-        input,
-        fp4_output,
-        scale_output,
-        per_token_scale,
-        m,
-        global_scale_inv_tensor,
-    )
+    if input_amax is None:
+        kernel_fn(
+            input,
+            fp4_output,
+            scale_output,
+            per_token_scale,
+            m,
+            global_scale_inv_tensor,
+        )
+    else:
+        kernel_fn(
+            input,
+            fp4_output,
+            scale_output,
+            per_token_scale,
+            m,
+            global_scale_inv_tensor,
+            input_amax,
+            input_amax.shape[1],
+        )
 
     scale_output = scale_output.reshape(-1, padded_sf_cols)
     return fp4_output, scale_output, per_token_scale

--- a/tests/moe/test_cute_dsl_per_token_aux_amax.py
+++ b/tests/moe/test_cute_dsl_per_token_aux_amax.py
@@ -1,0 +1,192 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.cute_dsl.utils import is_cute_dsl_arch_supported
+from flashinfer.tllm_enums import ActivationType
+
+from .utils import create_moe_tensors
+
+
+def _is_sm100_family() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability() in ((10, 0), (10, 3))
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _is_sm100_family(), reason="requires the SM100/SM103 GEMM1 kernel"
+    ),
+    pytest.mark.skipif(not is_cute_dsl_available(), reason="CuTe DSL unavailable"),
+    pytest.mark.skipif(
+        torch.cuda.is_available()
+        and not is_cute_dsl_arch_supported(
+            *torch.cuda.get_device_capability(), native_only=True
+        ),
+        reason="installed CuTe DSL cannot target the current GPU",
+    ),
+]
+
+
+def _set_quant_mode(monkeypatch: pytest.MonkeyPatch, deterministic: bool) -> None:
+    values = {
+        "FLASHINFER_NVFP4_4OVER6": "1" if deterministic else "0",
+        "FLASHINFER_NVFP4_4OVER6_E4M3_USE_256": "1" if deterministic else "0",
+        "FLASHINFER_NVFP4_4OVER6_ERR_MODE": "MSE",
+        "FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH": "1" if deterministic else "0",
+        "FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH": "1" if deterministic else "0",
+    }
+    for name, value in values.items():
+        monkeypatch.setenv(name, value)
+
+
+@pytest.mark.parametrize("deterministic_quant", [False, True])
+@pytest.mark.parametrize(
+    ("tile_size", "gemm1_n", "activation_type", "gated"),
+    [
+        pytest.param(128, 128, ActivationType.Swiglu, True, id="m128-n128-swiglu"),
+        pytest.param(128, 256, ActivationType.Swiglu, True, id="m128-n256-swiglu"),
+        pytest.param(256, 128, ActivationType.Relu2, False, id="m256-n128-relu2"),
+        pytest.param(256, 256, ActivationType.Relu2, False, id="m256-n256-relu2"),
+    ],
+)
+def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
+    monkeypatch: pytest.MonkeyPatch,
+    tile_size: int,
+    gemm1_n: int,
+    activation_type: ActivationType,
+    gated: bool,
+    deterministic_quant: bool,
+):
+    """Check producer values and the exact legacy/accelerated MoE boundary."""
+    import flashinfer.fused_moe.cute_dsl.fused_moe as fused_moe_module
+
+    _set_quant_mode(monkeypatch, deterministic_quant)
+
+    num_tokens, top_k, num_experts = 8, 2, 16
+    hidden_size, intermediate_size = 256, 512
+    tensors = create_moe_tensors(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        top_k=top_k,
+        gated=gated,
+        use_per_token_activation=True,
+    )
+
+    # Give every expert exactly one routed row. The actual and maximum tile
+    # counts are then identical, so every materialized row and every aux cell
+    # is written and can be checked without consulting internal sort metadata.
+    tensors["token_selected_experts"].copy_(
+        torch.arange(
+            num_tokens * top_k,
+            device="cuda",
+            dtype=torch.int32,
+        ).reshape(num_tokens, top_k)
+    )
+    tensors["token_final_scales"].copy_(
+        torch.tensor([0.375, 0.625], device="cuda", dtype=torch.float32).repeat(
+            num_tokens, 1
+        )
+    )
+
+    kwargs = {
+        "x": tensors["x"],
+        "x_sf": tensors["x_sf"],
+        "token_selected_experts": tensors["token_selected_experts"],
+        "token_final_scales": tensors["token_final_scales"],
+        "w1_weight": tensors["w1_weight"],
+        "w1_weight_sf": tensors["w1_weight_sf"],
+        "w1_alpha": tensors["w1_alpha"],
+        "fc2_input_scale": tensors["fc2_input_scale"],
+        "w2_weight": tensors["w2_weight"],
+        "w2_weight_sf": tensors["w2_weight_sf"],
+        "w2_alpha": tensors["w2_alpha"],
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "num_local_experts": num_experts,
+        "tile_size": tile_size,
+        "gemm1_mma_tiler_mn": (tile_size, gemm1_n),
+        "gemm1_cluster_shape_mn": (tile_size // 128, 1),
+        "gemm2_mma_tiler_mn": (tile_size, 128),
+        "gemm2_cluster_shape_mn": (tile_size // 128, 1),
+        "use_async_memset": False,
+        "use_fused_finalize": False,
+        "enable_pdl": True,
+        "activation_type": activation_type.value,
+        "per_token_scale": tensors["x_per_token_scale"],
+    }
+
+    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "0")
+    legacy_output = fused_moe_module._moe_core_impl(**kwargs)
+
+    original_quantize = fused_moe_module.nvfp4_quantize_per_token_cute_dsl
+    calls_checked = 0
+
+    def checked_quantize(
+        input: torch.Tensor,
+        global_scale_inv: torch.Tensor,
+        sf_layout: int,
+        enable_pdl: bool,
+        input_amax: torch.Tensor | None = None,
+    ):
+        nonlocal calls_checked
+        assert input_amax is not None
+        output_tile_n = gemm1_n // (2 if gated else 1)
+        expected_amax = (
+            input.float()
+            .abs()
+            .reshape(input.shape[0], input.shape[1] // output_tile_n, output_tile_n)
+            .amax(dim=2)
+        )
+        assert torch.equal(input_amax, expected_amax)
+
+        legacy_quantized = original_quantize(
+            input,
+            global_scale_inv,
+            sf_layout=sf_layout,
+            enable_pdl=False,
+        )
+        accelerated_quantized = original_quantize(
+            input,
+            global_scale_inv,
+            sf_layout=sf_layout,
+            enable_pdl=enable_pdl,
+            input_amax=input_amax,
+        )
+        for accelerated, legacy in zip(
+            accelerated_quantized, legacy_quantized, strict=True
+        ):
+            assert torch.equal(accelerated, legacy)
+        calls_checked += 1
+        return accelerated_quantized
+
+    monkeypatch.setattr(
+        fused_moe_module,
+        "nvfp4_quantize_per_token_cute_dsl",
+        checked_quantize,
+    )
+    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "1")
+    accelerated_output = fused_moe_module._moe_core_impl(**kwargs)
+
+    assert calls_checked == 1
+    assert torch.equal(accelerated_output, legacy_output)

--- a/tests/moe/test_cute_dsl_per_token_aux_amax.py
+++ b/tests/moe/test_cute_dsl_per_token_aux_amax.py
@@ -73,7 +73,6 @@ def _make_gemm1_output(
     num_local_experts: int,
     tile_size: int,
     intermediate_size: int,
-    output_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
     from flashinfer.fused_moe.cute_dsl.moe_utils import (
         get_max_num_permuted_tokens,
@@ -90,7 +89,7 @@ def _make_gemm1_output(
     return torch.full(
         (max_num_permuted_tokens, intermediate_size),
         17.0,
-        dtype=output_dtype,
+        dtype=torch.bfloat16,
         device="cuda",
     )
 
@@ -107,7 +106,6 @@ def _make_core_kwargs(
     tile_size: int,
     gemm1_n: int,
     activation_type: ActivationType,
-    output_dtype: torch.dtype = torch.bfloat16,
 ) -> dict:
     return {
         "x": tensors["x"],
@@ -134,7 +132,6 @@ def _make_core_kwargs(
         "use_fused_finalize": False,
         "enable_pdl": True,
         "activation_type": activation_type.value,
-        "output_dtype": output_dtype,
         "per_token_scale": tensors["x_per_token_scale"],
         "gemm1_out": _make_gemm1_output(
             num_tokens=num_tokens,
@@ -142,7 +139,6 @@ def _make_core_kwargs(
             num_local_experts=num_local_experts,
             tile_size=tile_size,
             intermediate_size=intermediate_size,
-            output_dtype=output_dtype,
         ),
     }
 
@@ -315,50 +311,223 @@ def _assert_legacy_and_aux_paths_are_bitwise_equal(
     assert torch.equal(accelerated_output, legacy_output)
 
 
+@pytest.mark.parametrize(
+    ("num_tokens", "expect_aux"),
+    [
+        pytest.param(2, False, id="tokens2-legacy"),
+        pytest.param(4, True, id="tokens4-aux"),
+    ],
+)
+def test_per_token_aux_amax_dispatch_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    num_tokens: int,
+    expect_aux: bool,
+):
+    """The host-static token threshold selects the intended exact path."""
+    import flashinfer.fused_moe.cute_dsl.fused_moe as fused_moe_module
+
+    _set_quant_mode(monkeypatch, deterministic=False)
+
+    top_k, num_experts = 2, 16
+    hidden_size, intermediate_size = 256, 512
+    tile_size, gemm1_n = 128, 128
+    tensors = create_moe_tensors(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        top_k=top_k,
+        gated=True,
+        use_per_token_activation=True,
+    )
+    kwargs = _make_core_kwargs(
+        tensors,
+        num_tokens=num_tokens,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+        num_local_experts=num_experts,
+        local_expert_offset=0,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        activation_type=ActivationType.Swiglu,
+    )
+
+    original_gemm1 = (
+        fused_moe_module.blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4
+    )
+    original_quantize = fused_moe_module.nvfp4_quantize_per_token_cute_dsl
+    producer_uses_aux = []
+    quantizer_aux_args = []
+
+    def checked_gemm1(*args, **call_kwargs):
+        producer_uses_aux.append(call_kwargs.get("out_amax") is not None)
+        return original_gemm1(*args, **call_kwargs)
+
+    def checked_quantize(*args, **call_kwargs):
+        quantizer_aux_args.append(
+            (
+                call_kwargs.get("input_amax") is not None,
+                call_kwargs.get("input_amax_valid_rows") is not None,
+            )
+        )
+        return original_quantize(*args, **call_kwargs)
+
+    monkeypatch.setattr(
+        fused_moe_module,
+        "blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4",
+        checked_gemm1,
+    )
+    monkeypatch.setattr(
+        fused_moe_module,
+        "nvfp4_quantize_per_token_cute_dsl",
+        checked_quantize,
+    )
+
+    output = fused_moe_module._moe_core_impl(**kwargs)
+    torch.cuda.synchronize()
+
+    assert output.shape == (num_tokens, hidden_size)
+    assert producer_uses_aux == [expect_aux]
+    assert quantizer_aux_args == [(expect_aux, expect_aux)]
+
+
+def test_fp16_gemm1_aux_amax_handoff_is_bitwise_equal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Exercise the real FP16 producer/consumer boundary without GEMM2."""
+    from flashinfer.fused_moe.cute_dsl.blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
+        blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4,
+    )
+    from flashinfer.fused_moe.cute_dsl.moe_utils import moe_sort
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        SF_LAYOUT_128x4,
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    _set_quant_mode(monkeypatch, deterministic=False)
+
+    num_tokens = 128
+    hidden_size, intermediate_size = 256, 512
+    tile_size, gemm1_n = 128, 256
+    tensors = create_moe_tensors(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=1,
+        num_local_experts=1,
+        top_k=1,
+        gated=True,
+        use_per_token_activation=True,
+    )
+
+    (
+        tile_idx_to_expert_idx,
+        tile_idx_to_mn_limit,
+        _,
+        permuted_idx_to_expanded_idx,
+        total_num_padded_tokens,
+        num_non_exiting_tiles,
+    ) = moe_sort(
+        tensors["token_selected_experts"],
+        tensors["token_final_scales"],
+        num_experts=1,
+        top_k=1,
+        num_local_experts=1,
+        tile_tokens_dim=tile_size,
+        enable_pdl=True,
+    )
+
+    num_permuted_rows = permuted_idx_to_expanded_idx.shape[0]
+    output_tile_n = gemm1_n // 2
+    num_output_tiles = intermediate_size // output_tile_n
+    intermediate = torch.empty(
+        (num_permuted_rows, intermediate_size),
+        dtype=torch.float16,
+        device="cuda",
+    )
+    intermediate_amax = torch.empty(
+        (num_permuted_rows // 8, num_output_tiles, 8),
+        dtype=torch.float16,
+        device="cuda",
+    )
+
+    produced_intermediate, produced_sf = (
+        blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4(
+            a=tensors["x"],
+            b=tensors["w1_weight"],
+            a_scale=tensors["x_sf"],
+            b_scale=tensors["w1_weight_sf"],
+            alpha=tensors["w1_alpha"],
+            tile_idx_to_expert_idx=tile_idx_to_expert_idx,
+            tile_idx_to_mn_limit=tile_idx_to_mn_limit,
+            token_id_mapping=permuted_idx_to_expanded_idx,
+            num_non_exiting_tiles=num_non_exiting_tiles,
+            out=intermediate,
+            a_per_token_scale=tensors["x_per_token_scale"],
+            out_amax=intermediate_amax,
+            topk=1,
+            c_dtype="float16",
+            mma_tiler_mn=(tile_size, gemm1_n),
+            cluster_shape_mn=(1, 1),
+            enable_pdl=True,
+            activation_type=ActivationType.Swiglu.value,
+            gated=True,
+        )
+    )
+    assert produced_intermediate is intermediate
+    assert produced_sf is None
+
+    # Keep this launch immediately after GEMM1 so the test exercises the real
+    # producer-to-consumer PDL chain without a host synchronization in between.
+    accelerated_quantized = nvfp4_quantize_per_token_cute_dsl(
+        intermediate,
+        tensors["fc2_input_scale"],
+        sf_layout=SF_LAYOUT_128x4,
+        enable_pdl=True,
+        input_amax=intermediate_amax,
+        input_amax_valid_rows=total_num_padded_tokens,
+    )
+    legacy_quantized = nvfp4_quantize_per_token_cute_dsl(
+        intermediate,
+        tensors["fc2_input_scale"],
+        sf_layout=SF_LAYOUT_128x4,
+        enable_pdl=False,
+    )
+
+    assert int(total_num_padded_tokens.item()) == num_tokens
+    assert int(num_non_exiting_tiles.item()) == 1
+    assert intermediate.dtype == intermediate_amax.dtype == torch.float16
+    expected_amax = (
+        intermediate.float()
+        .abs()
+        .reshape(num_tokens, num_output_tiles, output_tile_n)
+        .amax(dim=2)
+        .to(torch.float16)
+    )
+    assert torch.equal(_unpack_blocked8(intermediate_amax), expected_amax)
+    for accelerated, legacy in zip(
+        accelerated_quantized, legacy_quantized, strict=True
+    ):
+        assert torch.equal(accelerated, legacy)
+
+
 @pytest.mark.parametrize("deterministic_quant", [False, True])
 @pytest.mark.parametrize(
-    ("tile_size", "gemm1_n", "activation_type", "gated", "output_dtype"),
+    ("tile_size", "gemm1_n", "activation_type", "gated"),
     [
-        pytest.param(
-            128,
-            128,
-            ActivationType.Swiglu,
-            True,
-            torch.bfloat16,
-            id="m128-n128-swiglu",
-        ),
-        pytest.param(
-            128,
-            256,
-            ActivationType.Swiglu,
-            True,
-            torch.float16,
-            id="m128-n256-swiglu-fp16",
-        ),
+        pytest.param(128, 128, ActivationType.Swiglu, True, id="m128-n128-swiglu"),
+        pytest.param(128, 256, ActivationType.Swiglu, True, id="m128-n256-swiglu"),
         pytest.param(
             256,
             256,
             ActivationType.Swiglu,
             True,
-            torch.bfloat16,
             id="m256-2cta-n256-swiglu",
         ),
-        pytest.param(
-            256,
-            128,
-            ActivationType.Relu2,
-            False,
-            torch.bfloat16,
-            id="m256-n128-relu2",
-        ),
-        pytest.param(
-            256,
-            256,
-            ActivationType.Relu2,
-            False,
-            torch.bfloat16,
-            id="m256-n256-relu2",
-        ),
+        pytest.param(256, 128, ActivationType.Relu2, False, id="m256-n128-relu2"),
+        pytest.param(256, 256, ActivationType.Relu2, False, id="m256-n256-relu2"),
     ],
 )
 def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
@@ -367,7 +536,6 @@ def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
     gemm1_n: int,
     activation_type: ActivationType,
     gated: bool,
-    output_dtype: torch.dtype,
     deterministic_quant: bool,
 ):
     """Check producer values and the exact legacy/accelerated MoE boundary."""
@@ -413,7 +581,6 @@ def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
         tile_size=tile_size,
         gemm1_n=gemm1_n,
         activation_type=activation_type,
-        output_dtype=output_dtype,
     )
 
     _assert_legacy_and_aux_paths_are_bitwise_equal(

--- a/tests/moe/test_cute_dsl_per_token_aux_amax.py
+++ b/tests/moe/test_cute_dsl_per_token_aux_amax.py
@@ -166,10 +166,46 @@ def _assert_legacy_and_aux_paths_are_bitwise_equal(
         return result
 
     monkeypatch.setattr(fused_moe_module, "moe_sort", checked_sort)
-    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "0")
-    legacy_output = fused_moe_module._moe_core_impl(**kwargs)
-
+    original_gemm1 = (
+        fused_moe_module.blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4
+    )
     original_quantize = fused_moe_module.nvfp4_quantize_per_token_cute_dsl
+    legacy_gemm1_calls = 0
+    legacy_quantize_calls = 0
+
+    def legacy_gemm1(*args, **call_kwargs):
+        nonlocal legacy_gemm1_calls
+        assert call_kwargs.get("out_amax") is not None
+        call_kwargs = dict(call_kwargs)
+        call_kwargs["out_amax"] = None
+        legacy_gemm1_calls += 1
+        return original_gemm1(*args, **call_kwargs)
+
+    def legacy_quantize(*args, **call_kwargs):
+        nonlocal legacy_quantize_calls
+        assert call_kwargs.get("input_amax") is not None
+        assert call_kwargs.get("input_amax_valid_rows") is not None
+        call_kwargs = dict(call_kwargs)
+        call_kwargs.pop("input_amax")
+        call_kwargs.pop("input_amax_valid_rows")
+        legacy_quantize_calls += 1
+        return original_quantize(*args, **call_kwargs)
+
+    with monkeypatch.context() as legacy_patch:
+        legacy_patch.setattr(
+            fused_moe_module,
+            "blockscaled_contiguous_gather_grouped_gemm_act_fusion_nvfp4",
+            legacy_gemm1,
+        )
+        legacy_patch.setattr(
+            fused_moe_module,
+            "nvfp4_quantize_per_token_cute_dsl",
+            legacy_quantize,
+        )
+        legacy_output = fused_moe_module._moe_core_impl(**kwargs)
+
+    assert legacy_gemm1_calls == 1
+    assert legacy_quantize_calls == 1
     calls_checked = 0
 
     def checked_quantize(
@@ -242,7 +278,6 @@ def _assert_legacy_and_aux_paths_are_bitwise_equal(
         "nvfp4_quantize_per_token_cute_dsl",
         checked_quantize,
     )
-    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "1")
     accelerated_output = fused_moe_module._moe_core_impl(**kwargs)
 
     assert calls_checked == 1

--- a/tests/moe/test_cute_dsl_per_token_aux_amax.py
+++ b/tests/moe/test_cute_dsl_per_token_aux_amax.py
@@ -57,12 +57,238 @@ def _set_quant_mode(monkeypatch: pytest.MonkeyPatch, deterministic: bool) -> Non
         monkeypatch.setenv(name, value)
 
 
+def _unpack_blocked8(input_amax: torch.Tensor) -> torch.Tensor:
+    """Return the logical [row, GEMM-N-tile] view of the aux buffer."""
+    return (
+        input_amax.permute(0, 2, 1)
+        .reshape(input_amax.shape[0] * 8, input_amax.shape[1])
+        .contiguous()
+    )
+
+
+def _make_gemm1_output(
+    *,
+    num_tokens: int,
+    top_k: int,
+    num_local_experts: int,
+    tile_size: int,
+    intermediate_size: int,
+) -> torch.Tensor:
+    from flashinfer.fused_moe.cute_dsl.moe_utils import (
+        get_max_num_permuted_tokens,
+    )
+
+    max_num_permuted_tokens = get_max_num_permuted_tokens(
+        num_tokens,
+        top_k,
+        num_local_experts,
+        tile_size,
+    )
+    # A finite sentinel makes the deliberately unused routing-buffer tail
+    # deterministic. GEMM1 must not touch it and GEMM2 must not consume it.
+    return torch.full(
+        (max_num_permuted_tokens, intermediate_size),
+        17.0,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+
+def _make_core_kwargs(
+    tensors: dict,
+    *,
+    num_tokens: int,
+    intermediate_size: int,
+    num_experts: int,
+    top_k: int,
+    num_local_experts: int,
+    local_expert_offset: int,
+    tile_size: int,
+    gemm1_n: int,
+    activation_type: ActivationType,
+) -> dict:
+    return {
+        "x": tensors["x"],
+        "x_sf": tensors["x_sf"],
+        "token_selected_experts": tensors["token_selected_experts"],
+        "token_final_scales": tensors["token_final_scales"],
+        "w1_weight": tensors["w1_weight"],
+        "w1_weight_sf": tensors["w1_weight_sf"],
+        "w1_alpha": tensors["w1_alpha"],
+        "fc2_input_scale": tensors["fc2_input_scale"],
+        "w2_weight": tensors["w2_weight"],
+        "w2_weight_sf": tensors["w2_weight_sf"],
+        "w2_alpha": tensors["w2_alpha"],
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "num_local_experts": num_local_experts,
+        "local_expert_offset": local_expert_offset,
+        "tile_size": tile_size,
+        "gemm1_mma_tiler_mn": (tile_size, gemm1_n),
+        "gemm1_cluster_shape_mn": (tile_size // 128, 1),
+        "gemm2_mma_tiler_mn": (tile_size, 128),
+        "gemm2_cluster_shape_mn": (tile_size // 128, 1),
+        "use_async_memset": False,
+        "use_fused_finalize": False,
+        "enable_pdl": True,
+        "activation_type": activation_type.value,
+        "per_token_scale": tensors["x_per_token_scale"],
+        "gemm1_out": _make_gemm1_output(
+            num_tokens=num_tokens,
+            top_k=top_k,
+            num_local_experts=num_local_experts,
+            tile_size=tile_size,
+            intermediate_size=intermediate_size,
+        ),
+    }
+
+
+def _assert_legacy_and_aux_paths_are_bitwise_equal(
+    monkeypatch: pytest.MonkeyPatch,
+    kwargs: dict,
+    *,
+    tile_size: int,
+    gemm1_n: int,
+    gated: bool,
+    expect_unused_rows: bool,
+    expect_masked_routes: bool = False,
+    expect_padded_rows: bool = False,
+) -> None:
+    """Compare every defined intermediate row and the final MoE output."""
+    import flashinfer.fused_moe.cute_dsl.fused_moe as fused_moe_module
+
+    original_sort = fused_moe_module.moe_sort
+    sort_results = []
+
+    def checked_sort(*args, **sort_kwargs):
+        result = original_sort(*args, **sort_kwargs)
+        sort_results.append(result)
+        return result
+
+    monkeypatch.setattr(fused_moe_module, "moe_sort", checked_sort)
+    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "0")
+    legacy_output = fused_moe_module._moe_core_impl(**kwargs)
+
+    original_quantize = fused_moe_module.nvfp4_quantize_per_token_cute_dsl
+    calls_checked = 0
+
+    def checked_quantize(
+        input: torch.Tensor,
+        global_scale_inv: torch.Tensor,
+        sf_layout: int,
+        enable_pdl: bool,
+        input_amax: torch.Tensor | None = None,
+        input_amax_valid_rows: torch.Tensor | None = None,
+    ):
+        nonlocal calls_checked
+        assert input_amax is not None
+
+        sort_result = sort_results[-1]
+        permuted_idx_to_expanded_idx = sort_result[3]
+        num_non_exiting_tiles = int(sort_result[5].item())
+        active_rows = num_non_exiting_tiles * tile_size
+        assert input.shape[0] == permuted_idx_to_expanded_idx.shape[0]
+        assert active_rows <= input.shape[0]
+        assert input_amax_valid_rows is not None
+        assert input_amax_valid_rows.dtype == torch.int32
+        assert input_amax_valid_rows.shape == (1,)
+        assert int(input_amax_valid_rows.item()) == active_rows
+
+        output_tile_n = gemm1_n // (2 if gated else 1)
+        expected_amax = (
+            input[:active_rows]
+            .float()
+            .abs()
+            .reshape(
+                active_rows,
+                input.shape[1] // output_tile_n,
+                output_tile_n,
+            )
+            .amax(dim=2)
+            .to(input.dtype)
+        )
+        # Only scheduled epilogue rows are defined. Rows in the allocation
+        # tail are deliberately not synchronized or initialized.
+        logical_input_amax = _unpack_blocked8(input_amax)
+        assert input_amax.dtype == input.dtype
+        assert torch.equal(logical_input_amax[:active_rows], expected_amax)
+
+        legacy_quantized = original_quantize(
+            input,
+            global_scale_inv,
+            sf_layout=sf_layout,
+            enable_pdl=False,
+        )
+        accelerated_quantized = original_quantize(
+            input,
+            global_scale_inv,
+            sf_layout=sf_layout,
+            enable_pdl=enable_pdl,
+            input_amax=input_amax,
+            input_amax_valid_rows=input_amax_valid_rows,
+        )
+        # FP4 codes, swizzled block scales, and per-token scales are compared
+        # bitwise for every row GEMM1 actually produced. active_rows is a
+        # multiple of 128, so it also covers whole 128x4 scale-layout tiles.
+        for accelerated, legacy in zip(
+            accelerated_quantized, legacy_quantized, strict=True
+        ):
+            assert torch.equal(accelerated[:active_rows], legacy[:active_rows])
+        calls_checked += 1
+        return accelerated_quantized
+
+    monkeypatch.setattr(
+        fused_moe_module,
+        "nvfp4_quantize_per_token_cute_dsl",
+        checked_quantize,
+    )
+    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "1")
+    accelerated_output = fused_moe_module._moe_core_impl(**kwargs)
+
+    assert calls_checked == 1
+    assert len(sort_results) == 2
+    # Within-expert permutation order is not part of moe_sort's contract, but
+    # both launches must agree on the padded and scheduled extents.
+    assert torch.equal(sort_results[0][4], sort_results[1][4])
+    assert torch.equal(sort_results[0][5], sort_results[1][5])
+
+    active_rows = int(sort_results[1][5].item()) * tile_size
+    expanded_idx_to_permuted_idx = sort_results[1][2]
+    gemm1_out = kwargs["gemm1_out"]
+    if expect_unused_rows:
+        assert active_rows < gemm1_out.shape[0]
+        assert torch.equal(
+            gemm1_out[active_rows:],
+            torch.full_like(gemm1_out[active_rows:], 17.0),
+        )
+    else:
+        assert active_rows == gemm1_out.shape[0]
+    if expect_masked_routes:
+        assert (expanded_idx_to_permuted_idx < 0).any()
+        assert (expanded_idx_to_permuted_idx >= 0).any()
+    if expect_padded_rows:
+        # The sort kernel does not promise a sentinel value in its padded
+        # inverse-map entries. Prove that padding exists from the number of
+        # valid local routes instead of reading those deliberately undefined
+        # entries.
+        num_valid_local_routes = int((expanded_idx_to_permuted_idx >= 0).sum().item())
+        assert num_valid_local_routes < active_rows
+    assert torch.equal(accelerated_output, legacy_output)
+
+
 @pytest.mark.parametrize("deterministic_quant", [False, True])
 @pytest.mark.parametrize(
     ("tile_size", "gemm1_n", "activation_type", "gated"),
     [
         pytest.param(128, 128, ActivationType.Swiglu, True, id="m128-n128-swiglu"),
         pytest.param(128, 256, ActivationType.Swiglu, True, id="m128-n256-swiglu"),
+        pytest.param(
+            256,
+            256,
+            ActivationType.Swiglu,
+            True,
+            id="m256-2cta-n256-swiglu",
+        ),
         pytest.param(256, 128, ActivationType.Relu2, False, id="m256-n128-relu2"),
         pytest.param(256, 256, ActivationType.Relu2, False, id="m256-n256-relu2"),
     ],
@@ -76,8 +302,6 @@ def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
     deterministic_quant: bool,
 ):
     """Check producer values and the exact legacy/accelerated MoE boundary."""
-    import flashinfer.fused_moe.cute_dsl.fused_moe as fused_moe_module
-
     _set_quant_mode(monkeypatch, deterministic_quant)
 
     num_tokens, top_k, num_experts = 8, 2, 16
@@ -109,84 +333,152 @@ def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
         )
     )
 
-    kwargs = {
-        "x": tensors["x"],
-        "x_sf": tensors["x_sf"],
-        "token_selected_experts": tensors["token_selected_experts"],
-        "token_final_scales": tensors["token_final_scales"],
-        "w1_weight": tensors["w1_weight"],
-        "w1_weight_sf": tensors["w1_weight_sf"],
-        "w1_alpha": tensors["w1_alpha"],
-        "fc2_input_scale": tensors["fc2_input_scale"],
-        "w2_weight": tensors["w2_weight"],
-        "w2_weight_sf": tensors["w2_weight_sf"],
-        "w2_alpha": tensors["w2_alpha"],
-        "num_experts": num_experts,
-        "top_k": top_k,
-        "num_local_experts": num_experts,
-        "tile_size": tile_size,
-        "gemm1_mma_tiler_mn": (tile_size, gemm1_n),
-        "gemm1_cluster_shape_mn": (tile_size // 128, 1),
-        "gemm2_mma_tiler_mn": (tile_size, 128),
-        "gemm2_cluster_shape_mn": (tile_size // 128, 1),
-        "use_async_memset": False,
-        "use_fused_finalize": False,
-        "enable_pdl": True,
-        "activation_type": activation_type.value,
-        "per_token_scale": tensors["x_per_token_scale"],
-    }
-
-    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "0")
-    legacy_output = fused_moe_module._moe_core_impl(**kwargs)
-
-    original_quantize = fused_moe_module.nvfp4_quantize_per_token_cute_dsl
-    calls_checked = 0
-
-    def checked_quantize(
-        input: torch.Tensor,
-        global_scale_inv: torch.Tensor,
-        sf_layout: int,
-        enable_pdl: bool,
-        input_amax: torch.Tensor | None = None,
-    ):
-        nonlocal calls_checked
-        assert input_amax is not None
-        output_tile_n = gemm1_n // (2 if gated else 1)
-        expected_amax = (
-            input.float()
-            .abs()
-            .reshape(input.shape[0], input.shape[1] // output_tile_n, output_tile_n)
-            .amax(dim=2)
-        )
-        assert torch.equal(input_amax, expected_amax)
-
-        legacy_quantized = original_quantize(
-            input,
-            global_scale_inv,
-            sf_layout=sf_layout,
-            enable_pdl=False,
-        )
-        accelerated_quantized = original_quantize(
-            input,
-            global_scale_inv,
-            sf_layout=sf_layout,
-            enable_pdl=enable_pdl,
-            input_amax=input_amax,
-        )
-        for accelerated, legacy in zip(
-            accelerated_quantized, legacy_quantized, strict=True
-        ):
-            assert torch.equal(accelerated, legacy)
-        calls_checked += 1
-        return accelerated_quantized
-
-    monkeypatch.setattr(
-        fused_moe_module,
-        "nvfp4_quantize_per_token_cute_dsl",
-        checked_quantize,
+    kwargs = _make_core_kwargs(
+        tensors,
+        num_tokens=num_tokens,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+        num_local_experts=num_experts,
+        local_expert_offset=0,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        activation_type=activation_type,
     )
-    monkeypatch.setenv("FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX", "1")
-    accelerated_output = fused_moe_module._moe_core_impl(**kwargs)
 
-    assert calls_checked == 1
-    assert torch.equal(accelerated_output, legacy_output)
+    _assert_legacy_and_aux_paths_are_bitwise_equal(
+        monkeypatch,
+        kwargs,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        gated=gated,
+        expect_unused_rows=False,
+    )
+
+
+@pytest.mark.parametrize("deterministic_quant", [False, True])
+def test_local_routing_with_padded_unused_rows_is_bitwise_equal(
+    monkeypatch: pytest.MonkeyPatch,
+    deterministic_quant: bool,
+):
+    """EP-local routes ignore both in-tile padding and allocation-tail rows."""
+    _set_quant_mode(monkeypatch, deterministic_quant)
+
+    num_tokens, top_k, num_experts = 9, 2, 16
+    num_local_experts, local_expert_offset = 4, 4
+    hidden_size, intermediate_size = 256, 512
+    tile_size, gemm1_n = 128, 128
+    tensors = create_moe_tensors(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        num_local_experts=num_local_experts,
+        top_k=top_k,
+        gated=True,
+        use_per_token_activation=True,
+    )
+
+    # Experts [4, 8) are local. Only experts 4 and 5 receive local routes, so
+    # moe_sort emits two heavily padded tiles into a four-tile allocation.
+    tensors["token_selected_experts"].copy_(
+        torch.tensor(
+            [
+                [4, 0],
+                [5, 15],
+                [4, 1],
+                [5, 14],
+                [4, 2],
+                [5, 13],
+                [4, 3],
+                [5, 12],
+                [4, 8],
+            ],
+            device="cuda",
+            dtype=torch.int32,
+        )
+    )
+    tensors["token_final_scales"].copy_(
+        torch.tensor([0.75, 0.25], device="cuda", dtype=torch.float32).repeat(
+            num_tokens, 1
+        )
+    )
+
+    kwargs = _make_core_kwargs(
+        tensors,
+        num_tokens=num_tokens,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+        num_local_experts=num_local_experts,
+        local_expert_offset=local_expert_offset,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        activation_type=ActivationType.Swiglu,
+    )
+    _assert_legacy_and_aux_paths_are_bitwise_equal(
+        monkeypatch,
+        kwargs,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        gated=True,
+        expect_unused_rows=True,
+        expect_masked_routes=True,
+        expect_padded_rows=True,
+    )
+
+
+@pytest.mark.parametrize("deterministic_quant", [False, True])
+def test_large_token_moe_aux_path_is_bitwise_equal(
+    monkeypatch: pytest.MonkeyPatch,
+    deterministic_quant: bool,
+):
+    """Exercise a 1K-token benchmark shape without adding a new kernel tactic."""
+    _set_quant_mode(monkeypatch, deterministic_quant)
+
+    num_tokens, top_k, num_experts = 1024, 2, 16
+    hidden_size, intermediate_size = 256, 512
+    tile_size, gemm1_n = 128, 128
+    tensors = create_moe_tensors(
+        num_tokens=num_tokens,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        num_local_experts=num_experts,
+        top_k=top_k,
+        gated=True,
+        use_per_token_activation=True,
+    )
+
+    # Two dense experts produce 16 scheduled M tiles. The tight worst-case
+    # allocation has 31 tiles, which simultaneously exercises a long unused
+    # tail while keeping the weight and compilation footprint small.
+    tensors["token_selected_experts"].copy_(
+        torch.tensor([0, 1], device="cuda", dtype=torch.int32).repeat(num_tokens, 1)
+    )
+    tensors["token_final_scales"].copy_(
+        torch.tensor([0.375, 0.625], device="cuda", dtype=torch.float32).repeat(
+            num_tokens, 1
+        )
+    )
+
+    kwargs = _make_core_kwargs(
+        tensors,
+        num_tokens=num_tokens,
+        intermediate_size=intermediate_size,
+        num_experts=num_experts,
+        top_k=top_k,
+        num_local_experts=num_experts,
+        local_expert_offset=0,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        activation_type=ActivationType.Swiglu,
+    )
+    _assert_legacy_and_aux_paths_are_bitwise_equal(
+        monkeypatch,
+        kwargs,
+        tile_size=tile_size,
+        gemm1_n=gemm1_n,
+        gated=True,
+        expect_unused_rows=True,
+    )

--- a/tests/moe/test_cute_dsl_per_token_aux_amax.py
+++ b/tests/moe/test_cute_dsl_per_token_aux_amax.py
@@ -73,6 +73,7 @@ def _make_gemm1_output(
     num_local_experts: int,
     tile_size: int,
     intermediate_size: int,
+    output_dtype: torch.dtype = torch.bfloat16,
 ) -> torch.Tensor:
     from flashinfer.fused_moe.cute_dsl.moe_utils import (
         get_max_num_permuted_tokens,
@@ -89,7 +90,7 @@ def _make_gemm1_output(
     return torch.full(
         (max_num_permuted_tokens, intermediate_size),
         17.0,
-        dtype=torch.bfloat16,
+        dtype=output_dtype,
         device="cuda",
     )
 
@@ -106,6 +107,7 @@ def _make_core_kwargs(
     tile_size: int,
     gemm1_n: int,
     activation_type: ActivationType,
+    output_dtype: torch.dtype = torch.bfloat16,
 ) -> dict:
     return {
         "x": tensors["x"],
@@ -132,6 +134,7 @@ def _make_core_kwargs(
         "use_fused_finalize": False,
         "enable_pdl": True,
         "activation_type": activation_type.value,
+        "output_dtype": output_dtype,
         "per_token_scale": tensors["x_per_token_scale"],
         "gemm1_out": _make_gemm1_output(
             num_tokens=num_tokens,
@@ -139,6 +142,7 @@ def _make_core_kwargs(
             num_local_experts=num_local_experts,
             tile_size=tile_size,
             intermediate_size=intermediate_size,
+            output_dtype=output_dtype,
         ),
     }
 
@@ -313,19 +317,48 @@ def _assert_legacy_and_aux_paths_are_bitwise_equal(
 
 @pytest.mark.parametrize("deterministic_quant", [False, True])
 @pytest.mark.parametrize(
-    ("tile_size", "gemm1_n", "activation_type", "gated"),
+    ("tile_size", "gemm1_n", "activation_type", "gated", "output_dtype"),
     [
-        pytest.param(128, 128, ActivationType.Swiglu, True, id="m128-n128-swiglu"),
-        pytest.param(128, 256, ActivationType.Swiglu, True, id="m128-n256-swiglu"),
+        pytest.param(
+            128,
+            128,
+            ActivationType.Swiglu,
+            True,
+            torch.bfloat16,
+            id="m128-n128-swiglu",
+        ),
+        pytest.param(
+            128,
+            256,
+            ActivationType.Swiglu,
+            True,
+            torch.float16,
+            id="m128-n256-swiglu-fp16",
+        ),
         pytest.param(
             256,
             256,
             ActivationType.Swiglu,
             True,
+            torch.bfloat16,
             id="m256-2cta-n256-swiglu",
         ),
-        pytest.param(256, 128, ActivationType.Relu2, False, id="m256-n128-relu2"),
-        pytest.param(256, 256, ActivationType.Relu2, False, id="m256-n256-relu2"),
+        pytest.param(
+            256,
+            128,
+            ActivationType.Relu2,
+            False,
+            torch.bfloat16,
+            id="m256-n128-relu2",
+        ),
+        pytest.param(
+            256,
+            256,
+            ActivationType.Relu2,
+            False,
+            torch.bfloat16,
+            id="m256-n256-relu2",
+        ),
     ],
 )
 def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
@@ -334,6 +367,7 @@ def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
     gemm1_n: int,
     activation_type: ActivationType,
     gated: bool,
+    output_dtype: torch.dtype,
     deterministic_quant: bool,
 ):
     """Check producer values and the exact legacy/accelerated MoE boundary."""
@@ -379,6 +413,7 @@ def test_gemm1_aux_amax_and_per_token_output_are_bitwise_equal(
         tile_size=tile_size,
         gemm1_n=gemm1_n,
         activation_type=activation_type,
+        output_dtype=output_dtype,
     )
 
     _assert_legacy_and_aux_paths_are_bitwise_equal(

--- a/tests/utils/test_nvfp4_per_token_input_amax.py
+++ b/tests/utils/test_nvfp4_per_token_input_amax.py
@@ -46,11 +46,33 @@ pytestmark = [
 
 
 def _exact_tile_amax(input: torch.Tensor, num_tiles: int) -> torch.Tensor:
-    """Build exact per-tile maxima from values already rounded to input.dtype."""
-    return torch.stack(
-        [chunk.abs().float().amax(dim=1) for chunk in input.tensor_split(num_tiles, 1)],
+    """Build native-width PTX maxNum tile maxima in blocked-8 layout."""
+    assert num_tiles > 0
+    row_major = torch.stack(
+        [
+            torch.where(torch.isnan(chunk), torch.zeros_like(chunk), chunk.abs())
+            .float()
+            .amax(dim=1)
+            for chunk in input.tensor_split(num_tiles, 1)
+        ],
         dim=1,
-    ).contiguous()
+    ).to(input.dtype)
+    padded = torch.zeros(
+        ((input.shape[0] + 7) // 8 * 8, num_tiles),
+        dtype=input.dtype,
+        device=input.device,
+    )
+    padded[: input.shape[0]].copy_(row_major)
+    return padded.reshape(-1, 8, num_tiles).permute(0, 2, 1).contiguous()
+
+
+def _unpack_blocked8(input_amax: torch.Tensor, rows: int) -> torch.Tensor:
+    """Return the logical [row, tile] view of a blocked-8 aux tensor."""
+    return (
+        input_amax.permute(0, 2, 1)
+        .reshape(input_amax.shape[0] * 8, input_amax.shape[1])[:rows]
+        .contiguous()
+    )
 
 
 @pytest.mark.parametrize("deterministic_quant", [False, True])
@@ -95,8 +117,8 @@ def test_nvfp4_per_token_input_amax_is_bitwise_equal(
     )
 
     # Both widths use the same presence-specialized compiled kernel. The second
-    # width also exercises the grid-stride aux reduction past 128 CTA threads.
-    for num_tiles in (7, 129):
+    # width also exercises the half-warp's grid-stride aux reduction.
+    for num_tiles in (7, 33):
         input_amax = _exact_tile_amax(input, num_tiles)
         actual = nvfp4_quantize_per_token_cute_dsl(
             input,
@@ -109,30 +131,146 @@ def test_nvfp4_per_token_input_amax_is_bitwise_equal(
             assert torch.equal(actual_tensor, expected_tensor)
 
 
+@pytest.mark.parametrize("deterministic_quant", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_nvfp4_per_token_input_amax_preserves_maxnum_edge_cases(
+    monkeypatch, dtype, deterministic_quant
+):
+    """The aux reduction must retain the legacy scan's maximumNumber contract."""
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6", "1" if deterministic_quant else "0")
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6_E4M3_USE_256", "1")
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6_ERR_MODE", "MSE")
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH", "1")
+    monkeypatch.setenv(
+        "FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH",
+        "1" if deterministic_quant else "0",
+    )
+
+    input = torch.zeros((6, 256), device="cuda", dtype=dtype)
+    nan = torch.tensor(float("nan"), device="cuda", dtype=dtype)
+    inf = torch.tensor(float("inf"), device="cuda", dtype=dtype)
+    tiny = torch.tensor(
+        torch.finfo(dtype).smallest_normal / 2,
+        device="cuda",
+        dtype=dtype,
+    )
+    input[0, :2] = torch.stack((nan, inf))
+    input[1, :2] = torch.stack((nan, -inf))
+    input[2].fill_(nan)
+    input[3, :2] = torch.tensor([-0.0, 0.0], device="cuda", dtype=dtype)
+    input[4, :3] = torch.stack((nan, tiny, -tiny))
+    input[5, :3] = torch.tensor([float("nan"), 3.0, -4.0], device="cuda", dtype=dtype)
+
+    input_amax = _exact_tile_amax(input, num_tiles=4)
+    row_amax = _unpack_blocked8(input_amax, input.shape[0]).float().amax(dim=1)
+    assert torch.equal(
+        row_amax,
+        torch.stack(
+            (
+                inf,
+                inf,
+                input.new_zeros(()),
+                input.new_zeros(()),
+                tiny,
+                input.new_tensor(4.0),
+            )
+        ).float(),
+    )
+    assert row_amax[2].view(torch.int32).item() == 0
+    assert row_amax[3].view(torch.int32).item() == 0
+
+    global_scale_inv = torch.tensor([1.0 / 6.0], device="cuda", dtype=torch.float32)
+    legacy = nvfp4_quantize_per_token_cute_dsl(
+        input,
+        global_scale_inv,
+        sf_layout=2,
+        enable_pdl=False,
+    )
+    accelerated = nvfp4_quantize_per_token_cute_dsl(
+        input,
+        global_scale_inv,
+        sf_layout=2,
+        enable_pdl=False,
+        input_amax=input_amax,
+    )
+    for accelerated_tensor, legacy_tensor in zip(accelerated, legacy, strict=True):
+        assert torch.equal(
+            accelerated_tensor.view(torch.uint8), legacy_tensor.view(torch.uint8)
+        )
+
+
+@pytest.mark.parametrize("enable_pdl", [False, True])
+def test_nvfp4_per_token_input_amax_respects_device_valid_rows(enable_pdl):
+    """An unwritten aux tail is neither read nor materialized by the consumer."""
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    torch.manual_seed(1)
+    input = torch.randn(17, 256, device="cuda", dtype=torch.bfloat16)
+    input_amax = _exact_tile_amax(input, num_tiles=5)
+    valid_rows = torch.tensor([8], device="cuda", dtype=torch.int32)
+    global_scale_inv = torch.tensor([1.0 / 6.0], device="cuda", dtype=torch.float32)
+
+    legacy = nvfp4_quantize_per_token_cute_dsl(
+        input,
+        global_scale_inv,
+        sf_layout=2,
+        enable_pdl=enable_pdl,
+    )
+    accelerated = nvfp4_quantize_per_token_cute_dsl(
+        input,
+        global_scale_inv,
+        sf_layout=2,
+        enable_pdl=enable_pdl,
+        input_amax=input_amax,
+        input_amax_valid_rows=valid_rows,
+    )
+    for accelerated_tensor, legacy_tensor in zip(accelerated, legacy, strict=True):
+        assert torch.equal(accelerated_tensor[:8], legacy_tensor[:8])
+
+
 @pytest.mark.parametrize(
     ("make_input_amax", "match"),
     [
         (lambda: [1.0], "torch.Tensor"),
         (
-            lambda: torch.ones((4, 2), device="cuda", dtype=torch.float16),
-            "torch.float32",
-        ),
-        (lambda: torch.ones((4, 2), dtype=torch.float32), "CUDA device"),
-        (
-            lambda: torch.ones((8,), device="cuda", dtype=torch.float32),
-            "must be 2-D",
+            lambda: torch.ones((1, 1, 8), device="cuda", dtype=torch.float16),
+            "same dtype as input",
         ),
         (
-            lambda: torch.ones((3, 2), device="cuda", dtype=torch.float32),
-            "one row per input row",
+            lambda: torch.ones((1, 1, 8), dtype=torch.bfloat16),
+            "CUDA device",
         ),
         (
-            lambda: torch.empty((4, 0), device="cuda", dtype=torch.float32),
-            "must be nonempty",
+            lambda: torch.ones((4, 2), device="cuda", dtype=torch.bfloat16),
+            "must be 3-D blocked-8",
         ),
         (
-            lambda: torch.ones((2, 4), device="cuda", dtype=torch.float32).T,
+            lambda: torch.ones((2, 1, 8), device="cuda", dtype=torch.bfloat16),
+            "row-block dimension",
+        ),
+        (
+            lambda: torch.empty((1, 0, 8), device="cuda", dtype=torch.bfloat16),
+            "at least one tile",
+        ),
+        (
+            lambda: torch.ones((1, 1, 4), device="cuda", dtype=torch.bfloat16),
+            "trailing dimension",
+        ),
+        (
+            lambda: torch.ones(
+                (1, 8, 4), device="cuda", dtype=torch.bfloat16
+            ).transpose(1, 2),
             "must be contiguous",
+        ),
+        (
+            lambda: torch.ones((1, 1, 9), device="cuda", dtype=torch.bfloat16)[..., 1:],
+            "4-byte aligned",
         ),
     ],
 )
@@ -153,6 +291,48 @@ def test_nvfp4_per_token_input_amax_validation(make_input_amax, match):
         )
 
 
+@pytest.mark.parametrize(
+    ("make_valid_rows", "with_input_amax", "match"),
+    [
+        (lambda: torch.tensor([4], device="cuda", dtype=torch.int32), False, "only"),
+        (lambda: [4], True, "torch.Tensor"),
+        (
+            lambda: torch.tensor([4], device="cuda", dtype=torch.int64),
+            True,
+            "torch.int32",
+        ),
+        (lambda: torch.tensor([4], dtype=torch.int32), True, "CUDA device"),
+        (
+            lambda: torch.tensor([[4]], device="cuda", dtype=torch.int32),
+            True,
+            r"shape \(1,\)",
+        ),
+    ],
+)
+def test_nvfp4_per_token_input_amax_valid_rows_validation(
+    make_valid_rows, with_input_amax, match
+):
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    input = torch.ones((4, 32), device="cuda", dtype=torch.bfloat16)
+    global_scale_inv = torch.ones((1,), device="cuda", dtype=torch.float32)
+    input_amax = (
+        torch.ones((1, 1, 8), device="cuda", dtype=torch.bfloat16)
+        if with_input_amax
+        else None
+    )
+    with pytest.raises(AssertionError, match=match):
+        nvfp4_quantize_per_token_cute_dsl(
+            input,
+            global_scale_inv,
+            enable_pdl=False,
+            input_amax=input_amax,
+            input_amax_valid_rows=make_valid_rows(),
+        )
+
+
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
 def test_nvfp4_per_token_input_amax_requires_same_device():
     from flashinfer.quantization.kernels.nvfp4_quantize import (
@@ -161,7 +341,7 @@ def test_nvfp4_per_token_input_amax_requires_same_device():
 
     input = torch.ones((4, 32), device="cuda:0", dtype=torch.bfloat16)
     global_scale_inv = torch.ones((1,), device="cuda:0", dtype=torch.float32)
-    input_amax = torch.ones((4, 2), device="cuda:1", dtype=torch.float32)
+    input_amax = torch.ones((1, 1, 8), device="cuda:1", dtype=torch.bfloat16)
 
     with pytest.raises(AssertionError, match="same device"):
         nvfp4_quantize_per_token_cute_dsl(

--- a/tests/utils/test_nvfp4_per_token_input_amax.py
+++ b/tests/utils/test_nvfp4_per_token_input_amax.py
@@ -1,0 +1,172 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+from flashinfer.cute_dsl import is_cute_dsl_available
+from flashinfer.utils import (
+    is_sm100a_supported,
+    is_sm110a_supported,
+    is_sm12x_supported,
+)
+
+
+def _is_nvfp4_supported() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    device = torch.device("cuda")
+    return (
+        is_sm100a_supported(device)
+        or is_sm110a_supported(device)
+        or is_sm12x_supported(device)
+    )
+
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _is_nvfp4_supported(),
+        reason="per-token NVFP4 CuTe-DSL quantizer requires Blackwell",
+    ),
+    pytest.mark.skipif(not is_cute_dsl_available(), reason="CuteDSL not available"),
+]
+
+
+def _exact_tile_amax(input: torch.Tensor, num_tiles: int) -> torch.Tensor:
+    """Build exact per-tile maxima from values already rounded to input.dtype."""
+    return torch.stack(
+        [chunk.abs().float().amax(dim=1) for chunk in input.tensor_split(num_tiles, 1)],
+        dim=1,
+    ).contiguous()
+
+
+@pytest.mark.parametrize("deterministic_quant", [False, True])
+@pytest.mark.parametrize("enable_pdl", [False, True])
+@pytest.mark.parametrize(
+    "sf_layout",
+    [
+        pytest.param(0, id="128x4"),
+        pytest.param(1, id="8x4"),
+        pytest.param(2, id="linear"),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_nvfp4_per_token_input_amax_is_bitwise_equal(
+    monkeypatch, dtype, sf_layout, enable_pdl, deterministic_quant
+):
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6", "1" if deterministic_quant else "0")
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6_E4M3_USE_256", "1")
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6_ERR_MODE", "MSE")
+    monkeypatch.setenv("FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH", "1")
+    monkeypatch.setenv(
+        "FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH",
+        "1" if deterministic_quant else "0",
+    )
+
+    torch.manual_seed(0)
+    input = torch.randn(17, 256, device="cuda", dtype=torch.float32).to(dtype)
+    input[0].zero_()
+    input[1, 0] = 31.0
+    input[2, -1] = -29.0
+    global_scale_inv = torch.tensor([1.0 / 6.0], device="cuda", dtype=torch.float32)
+
+    expected = nvfp4_quantize_per_token_cute_dsl(
+        input,
+        global_scale_inv,
+        sf_layout=sf_layout,
+        enable_pdl=enable_pdl,
+    )
+
+    # Both widths use the same presence-specialized compiled kernel. The second
+    # width also exercises the grid-stride aux reduction past 128 CTA threads.
+    for num_tiles in (7, 129):
+        input_amax = _exact_tile_amax(input, num_tiles)
+        actual = nvfp4_quantize_per_token_cute_dsl(
+            input,
+            global_scale_inv,
+            sf_layout=sf_layout,
+            enable_pdl=enable_pdl,
+            input_amax=input_amax,
+        )
+        for actual_tensor, expected_tensor in zip(actual, expected, strict=True):
+            assert torch.equal(actual_tensor, expected_tensor)
+
+
+@pytest.mark.parametrize(
+    ("make_input_amax", "match"),
+    [
+        (lambda: [1.0], "torch.Tensor"),
+        (
+            lambda: torch.ones((4, 2), device="cuda", dtype=torch.float16),
+            "torch.float32",
+        ),
+        (lambda: torch.ones((4, 2), dtype=torch.float32), "CUDA device"),
+        (
+            lambda: torch.ones((8,), device="cuda", dtype=torch.float32),
+            "must be 2-D",
+        ),
+        (
+            lambda: torch.ones((3, 2), device="cuda", dtype=torch.float32),
+            "one row per input row",
+        ),
+        (
+            lambda: torch.empty((4, 0), device="cuda", dtype=torch.float32),
+            "must be nonempty",
+        ),
+        (
+            lambda: torch.ones((2, 4), device="cuda", dtype=torch.float32).T,
+            "must be contiguous",
+        ),
+    ],
+)
+def test_nvfp4_per_token_input_amax_validation(make_input_amax, match):
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    input = torch.ones((4, 32), device="cuda", dtype=torch.bfloat16)
+    global_scale_inv = torch.ones((1,), device="cuda", dtype=torch.float32)
+
+    with pytest.raises(AssertionError, match=match):
+        nvfp4_quantize_per_token_cute_dsl(
+            input,
+            global_scale_inv,
+            enable_pdl=False,
+            input_amax=make_input_amax(),
+        )
+
+
+@pytest.mark.skipif(torch.cuda.device_count() < 2, reason="requires two CUDA devices")
+def test_nvfp4_per_token_input_amax_requires_same_device():
+    from flashinfer.quantization.kernels.nvfp4_quantize import (
+        nvfp4_quantize_per_token_cute_dsl,
+    )
+
+    input = torch.ones((4, 32), device="cuda:0", dtype=torch.bfloat16)
+    global_scale_inv = torch.ones((1,), device="cuda:0", dtype=torch.float32)
+    input_amax = torch.ones((4, 2), device="cuda:1", dtype=torch.float32)
+
+    with pytest.raises(AssertionError, match="same device"):
+        nvfp4_quantize_per_token_cute_dsl(
+            input,
+            global_scale_inv,
+            enable_pdl=False,
+            input_amax=input_amax,
+        )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

@humansand

This PR accelerates the SM100-family CuTe DSL NVFP4 W4A4 MoE per-token path by
reusing exact row-local maxima produced by the fused GEMM1 activation epilogue.
The intermediate per-token quantizer no longer rescans every GEMM1 output
element solely to rediscover each row's `amax`.

- **Producer:** each GEMM1 epilogue output tile reduces its own rows after the
  fused activation and after conversion to the materialized FP16/BF16 output
  dtype. It writes one exact local maximum per output row and GEMM-N tile.
- **Sync-free handoff:** every epilogue tile owns distinct
  `(row, GEMM-N tile)` entries, so producers need neither atomics nor inter-CTA
  synchronization. The native-width blocked-8 layout is
  `[permuted_m / 8, num_output_n_tiles, 8]`, with logical `(row, tile)` stored at
  `[row // 8, tile, row % 8]`.
- **Consumer:** `nvfp4_quantize_per_token_cute_dsl` accepts optional
  `input_amax` and `input_amax_valid_rows` tensors. One 128-thread CTA handles
  up to eight rows, reduces the tile-local maxima, and retains the existing
  scale-selection and FP4-quantization math. With PDL enabled, the consumer
  keeps the existing grid-dependency wait before reading the intermediate or
  auxiliary maxima.
- **Production policy:** token shapes below 4 retain the legacy full-row scan;
  shapes at or above 4 use the aux handoff. `num_tokens` is host-static, so each
  CUDA-graph capture specializes one path without a device-side branch or host
  readback.
- **Numerical contract:** aux values use the same dtype as the materialized
  intermediate. Reducing maxima after FP16/BF16 conversion is exactly
  equivalent to reducing the stored intermediate, including the existing
  maxNum behavior for NaN, infinity, signed zero, and subnormals. Packed E2M1
  values, E4M3 scale bytes, FP32 per-token scales, and final MoE outputs remain
  bitwise equal; no tolerance is relaxed.
- **CUDA-graph tail contract:** the optional one-element CUDA `int32`
  `input_amax_valid_rows` bound prevents the consumer from reading or writing
  unused rows in a maximum-sized routing buffer. It remains device-resident.
- **Autotuning:** the SM100 per-token pipeline adds an explicit cache-schema
  token to the tuner key because the handoff and its token threshold can change
  GEMM tactic ranking.

The GEMM's logical work remains two-dimensional in route-M and GEMM-N. The
static persistent scheduler flattens those logical clusters into a 1-D work
sequence, while the physical launch uses
`grid=(cluster_m, cluster_n, persistent_clusters)` and
`cluster=(cluster_m, cluster_n, 1)`. FC1 tactics currently require
`cluster_n=1`, so a `(1, 1)` tactic is physically 1-D and `(2, 1)` is physically
2-D. The x/y launch dimensions are cooperating CTAs within a cluster, not
expert axes; the expert is selected indirectly from the route-M tile mapping.
This ownership makes the aux writes synchronization-free.

### API and validation rules

`input_amax` is optional; calls that omit it retain the legacy specialization.
When supplied, it must be:

- a contiguous, 4-byte-aligned CUDA tensor on the input device;
- the same FP16/BF16 dtype as the input;
- shaped `[ceil(M / 8), num_tiles, 8]`, with `num_tiles > 0`; and
- populated with exact maxima over subsets that together cover each row.

`input_amax_valid_rows`, when supplied, must be a contiguous one-element CUDA
`int32` tensor on the same device. It is accepted only with `input_amax` and
must contain a multiple-of-eight value in `[0, M]`; row blocks starting at or
beyond the bound are neither read nor written, and their returned values are
undefined. The fused MoE producer has the stronger shape
`[permuted_m / 8, num_output_n_tiles, 8]` because its routing extent is padded
to eight rows and its intermediate width is tiled exactly. Its optional
`out_amax` is supported only by the SM100 GEMM1 path with a materialized
FP16/BF16 output and must match that output's dtype/device, blocked-8 shape,
contiguity, and 4-byte alignment.

### Scope and non-goals

- The handoff is used only for SM100-family CuTe DSL W4A4 MoE with per-token
  intermediate activation quantization.
- W4A16, globally scaled W4A4, GEMM2/finalize, routing, and SM107/Rubin kernels
  are unchanged.
- The producer is implemented in the existing Python CuTe DSL kernel; this PR
  adds no C++ or CUDA source files.
- The aux buffer is internal temporary storage, not a persistent user-managed
  MoE workspace.
- The consumer trusts the documented optional-input contract; it does not
  recompute the full-row maximum to validate caller-provided values.

### Final implementation state

- Upstream base: `231f70828dfe93f5bbba7f0360a64435a7a846be`
- Final publication head: `b6e4cdaddcfb716bf757f343c5cad5823c6dd362`
- GPU-tested head: `b6e4cdaddcfb716bf757f343c5cad5823c6dd362`
- Commits:
  - `a76ea9b9` (`feat(moe): reuse GEMM1 tile amax for per-token NVFP4`)
  - `32f7b6d0` (`perf(moe): coalesce per-token aux maxima`)
  - `26d2e099` (`perf(moe): enable per-token aux amax by default`)
  - `81caf642` (`test(moe): cover FP16 aux amax handoff`)
  - `0aeed372` (`perf(moe): bypass aux amax for tiny token batches`)
  - `b6e4cdad` (`chore(moe): type per-token tuner cache extras`)
- The final commit is a type annotation only. Exact GPU tests and selected-file
  pre-commit, including mypy, passed at `b6e4cdad`.
- The temporary `FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX` A/B switch exists
  only in the sealed benchmark/profile revision. The final head exposes no
  experiment gate and selects legacy for `<4` tokens and aux for `>=4` tokens.

## 🔍 Related Issues

- Builds on the CuTe DSL per-token NVFP4 path introduced in #3645.
- Uses the inference and deterministic-RL configurations from #4048.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

The targeted suites below pass; the repository-wide suite was not run.

### Environment

- Hardware: one C2 node with 8x NVIDIA B300 SXM6 AC; validation and
  measurements used visible GPU 0 (SM103 / native `sm103a`).
- Container: `nvcr.io/nvidia/pytorch:26.05-py3`
- amd64 image digest:
  `sha256:ca73b4795f0d3ae27e9cd81b1b1f1b7fc6c0a129f7d51a359d2326e95af48a3d`
- Driver: `590.48.01`
- CUDA toolkit: `13.2.78`; PyTorch CUDA: `13.2`
- PyTorch: `2.12.0a0+5aff3928d8.nv26.05`
- FlashInfer package version: `0.6.18`, imported from the recorded checkout
- `nvidia-cutlass-dsl`: `4.8.0.dev0`; Python: `3.12.3`
- CUPTI: `cuda-cupti-13-2=13.2.75-1`, `cupti-python=13.2.0`, and
  `/usr/local/cuda/targets/x86_64-linux/lib/libcupti.so.13`
- Nsight Compute: `2026.1.1.0`

### Exact numerical validation at the final head

```bash
CUDA_VISIBLE_DEVICES=0 pytest -q tests/utils/test_nvfp4_per_token_input_amax.py
# 44 passed, 1 skipped, 13 warnings in 0.90s

CUDA_VISIBLE_DEVICES=0 pytest -q tests/moe/test_cute_dsl_per_token_aux_amax.py
# 17 passed, 629 warnings in 15.38s
```

Coverage includes FP16/BF16, all scale-factor layouts, PDL on/off, ordinary and
deterministic 4-over-6 quantization, maxNum edge cases, device-side valid-row
tails, the `<4`/`>=4` dispatch boundary, a real FP16 GEMM1-to-aux-quantizer PDL
handoff, EP/unused routing rows, large token counts, and multiple GEMM tactics.
Assertions compare aux maxima, packed FP4 bytes, scale bytes, per-token scales,
and final MoE outputs exactly. The one expected skip is a two-GPU same-device
negative test while only GPU 0 is visible.

### Static validation

At `b6e4cdaddcfb716bf757f343c5cad5823c6dd362`:

```bash
files=(
  flashinfer/cute_dsl/fp4_common.py
  flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
  flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
  flashinfer/fused_moe/cute_dsl/fused_moe.py
  flashinfer/fused_moe/cute_dsl/tuner.py
  flashinfer/quantization/kernels/nvfp4_quantize.py
  tests/moe/test_cute_dsl_per_token_aux_amax.py
  tests/utils/test_nvfp4_per_token_input_amax.py
)
ruff format --check "${files[@]}"
ruff check "${files[@]}"
python3 -m py_compile "${files[@]}"
git diff --check 231f70828dfe93f5bbba7f0360a64435a7a846be...HEAD
```

Raw output:

```text
8 files already formatted
All checks passed!
# py_compile: exit 0, no output
# git diff --check: exit 0, no output
```

Selected-file pre-commit passed every configured hook, including mypy. The test
rerun used warm JIT caches whose source hashes were validated against the exact
head. The complete exact-head GPU/static validation archive has SHA-256
`3bc2a299cbf0156ca5c59544a4896034bc72e3d927118ab2fb95915f17d2e160`;
its `SHA256SUMS` manifest has SHA-256
`1d7b7f3729ee902d801472ebafb2b33da7c50ca13c42ad78d2287b823f43c7d6`.

### Performance methodology

The sealed benchmark used `benchmarks/bench_moe_deepseek.py` at revision
`32f7b6d001182a0a55b453a512bf737ed93b547a`: DeepSeek-V3, 256 experts,
EP=8, TP=1, per-token NVFP4 activations, logits routing, CUDA graphs, CUPTI
timing, cold-L2 flushing, 20 warmups, and 200 measured iterations. It covered
`1,2,4,8,16,32,64,128,256,512,1024,2048,4096` tokens with five adjacent,
parity-alternated pairs per cell.

- `inference`: fused finalize and ordinary per-token quantization.
- `deterministic-rl`: `--no-fused-finalize` plus the #4048 4-over-6 MSE
  settings.
- `activation-inclusive`: includes initial input activation quantization.
- `moe-only`: starts from quantized input but includes the targeted GEMM1-to-
  GEMM2 intermediate quantization.
- `fixed`: tune aux-off once and byte-copy one cache to both arms; this is the
  primary kernel-change attribution.
- `native`: tune each arm independently; this measures each implementation
  with its preferred tactics.

The common command shape was:

```bash
CUDA_VISIBLE_DEVICES=0 \
FLASHINFER_CUTEDSL_MOE_PER_TOKEN_AUX_AMAX=<0-or-1> \
python3 benchmarks/bench_moe_deepseek.py \
  --num-tokens 1,2,4,8,16,32,64,128,256,512,1024,2048,4096 \
  --num-experts 256 --ep 8 --tp 1 \
  --use-per-token-activation \
  --routing-input-mode logits --routing-bias-scale 0.01 \
  --backends cutedsl --no-autotune --warmup 20 --iters 200 \
  --cache <arm-cache.json>
```

Deterministic-RL additionally set:

```bash
export FLASHINFER_NVFP4_4OVER6=1
export FLASHINFER_NVFP4_4OVER6_E4M3_USE_256=1
export FLASHINFER_NVFP4_4OVER6_ERR_MODE=MSE
export FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH=1
export FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH=1
# Add --no-fused-finalize.
```

Inference inserted a TRTLLM process between each CuTe DSL pair. TRTLLM is not
reported as a deterministic-RL control because `--no-fused-finalize` changes
only the CuTe DSL arm. Speedups are geometric means of adjacent-pair latency
ratios. Confidence intervals use a deterministic paired bootstrap with 10,000
draws and seed 42.

### Production-policy performance results

These tables are a **deterministic derivation from the sealed same-source A/B
rows**, not a fresh timing run of the final head. The helper substitutes the
legacy row for token shapes 1 and 2, the measured aux row for shapes at or above
4, and recomputes the paired aggregate/bootstrap. Commits after `32f7b6d0`
change only Python policy/cache-schema, tests, and typing; the measured kernel
specializations are unchanged.

All-token aggregate (13 shapes, five adjacent pairs per shape; W4A16 is the
observed same-process off/on drift control):

| policy | config | scope | production W4A4 speedup | 95% CI | latency reduction | W4A16 control |
|---|---|---|---:|---:|---:|---:|
| fixed | inference | activation-inclusive | 1.0248x | [1.0245, 1.0251] | 2.42% | 1.0004x |
| fixed | inference | moe-only | 1.0285x | [1.0283, 1.0287] | 2.77% | 1.0002x |
| fixed | deterministic-RL | activation-inclusive | 1.0240x | [1.0236, 1.0245] | 2.34% | 1.0008x |
| fixed | deterministic-RL | moe-only | 1.0265x | [1.0262, 1.0268] | 2.59% | 1.0000x |
| native | inference | activation-inclusive | 1.0250x | [1.0246, 1.0252] | 2.44% | 1.0002x |
| native | inference | moe-only | 1.0278x | [1.0270, 1.0283] | 2.70% | 1.0005x |
| native | deterministic-RL | activation-inclusive | 1.0239x | [1.0236, 1.0241] | 2.34% | 1.0063x |
| native | deterministic-RL | moe-only | 1.0278x | [1.0277, 1.0281] | 2.71% | 1.0079x |

Inference gap versus TRTLLM under the same production policy:

| policy | scope | legacy slowdown | production slowdown | gap closed | fraction closed | 95% CI |
|---|---|---:|---:|---:|---:|---:|
| fixed | activation-inclusive | 7.46% | 4.86% | 2.60 pp | 34.89% | [2.57, 2.63] pp |
| fixed | moe-only | 7.28% | 4.30% | 2.97 pp | 40.87% | [2.95, 2.99] pp |
| native | activation-inclusive | 7.45% | 4.83% | 2.62 pp | 35.14% | [2.58, 2.64] pp |
| native | moe-only | 7.26% | 4.36% | 2.90 pp | 39.94% | [2.82, 2.96] pp |

Complete per-token production results follow. Each cell is `speedup
(latency reduction)`; `legacy` rows are exactly `1.0x` by production-policy
construction.

| tokens | path | fixed inference incl. | fixed inference MoE-only | fixed deterministic-RL incl. | fixed deterministic-RL MoE-only |
|---:|---|---:|---:|---:|---:|
| 1 | legacy | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) |
| 2 | legacy | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) |
| 4 | aux | 1.0224x (+2.19%) | 1.0296x (+2.88%) | 1.0216x (+2.11%) | 1.0271x (+2.64%) |
| 8 | aux | 1.0065x (+0.65%) | 1.0132x (+1.30%) | 1.0058x (+0.57%) | 1.0078x (+0.77%) |
| 16 | aux | 0.9926x (-0.74%) | 0.9926x (-0.75%) | 0.9925x (-0.75%) | 0.9907x (-0.94%) |
| 32 | aux | 1.0023x (+0.23%) | 1.0036x (+0.36%) | 1.0009x (+0.09%) | 1.0009x (+0.09%) |
| 64 | aux | 1.0017x (+0.17%) | 1.0035x (+0.35%) | 0.9985x (-0.15%) | 0.9996x (-0.04%) |
| 128 | aux | 1.0056x (+0.55%) | 1.0066x (+0.65%) | 0.9968x (-0.32%) | 0.9965x (-0.35%) |
| 256 | aux | 1.0093x (+0.92%) | 1.0102x (+1.01%) | 1.0038x (+0.37%) | 1.0040x (+0.39%) |
| 512 | aux | 1.0223x (+2.18%) | 1.0241x (+2.36%) | 1.0158x (+1.56%) | 1.0169x (+1.66%) |
| 1024 | aux | 1.0498x (+4.74%) | 1.0563x (+5.33%) | 1.0444x (+4.25%) | 1.0435x (+4.17%) |
| 2048 | aux | 1.0792x (+7.34%) | 1.0858x (+7.90%) | 1.0828x (+7.65%) | 1.0932x (+8.52%) |
| 4096 | aux | 1.1412x (+12.37%) | 1.1572x (+13.58%) | 1.1621x (+13.95%) | 1.1808x (+15.31%) |

| tokens | path | native inference incl. | native inference MoE-only | native deterministic-RL incl. | native deterministic-RL MoE-only |
|---:|---|---:|---:|---:|---:|
| 1 | legacy | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) |
| 2 | legacy | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) | 1.0000x (+0.00%) |
| 4 | aux | 1.0222x (+2.18%) | 1.0303x (+2.94%) | 1.0255x (+2.49%) | 1.0313x (+3.03%) |
| 8 | aux | 1.0070x (+0.69%) | 1.0105x (+1.04%) | 1.0035x (+0.35%) | 1.0088x (+0.87%) |
| 16 | aux | 0.9936x (-0.65%) | 0.9935x (-0.65%) | 0.9885x (-1.16%) | 0.9910x (-0.91%) |
| 32 | aux | 1.0025x (+0.25%) | 1.0027x (+0.27%) | 1.0009x (+0.09%) | 1.0026x (+0.26%) |
| 64 | aux | 1.0027x (+0.27%) | 1.0032x (+0.31%) | 0.9976x (-0.24%) | 0.9996x (-0.04%) |
| 128 | aux | 1.0059x (+0.58%) | 1.0063x (+0.63%) | 0.9979x (-0.21%) | 0.9997x (-0.03%) |
| 256 | aux | 1.0089x (+0.89%) | 1.0101x (+1.00%) | 1.0022x (+0.22%) | 1.0023x (+0.23%) |
| 512 | aux | 1.0214x (+2.09%) | 1.0228x (+2.23%) | 1.0171x (+1.68%) | 1.0184x (+1.80%) |
| 1024 | aux | 1.0503x (+4.79%) | 1.0563x (+5.33%) | 1.0434x (+4.16%) | 1.0463x (+4.43%) |
| 2048 | aux | 1.0780x (+7.24%) | 1.0836x (+7.71%) | 1.0841x (+7.76%) | 1.0941x (+8.60%) |
| 4096 | aux | 1.1420x (+12.44%) | 1.1534x (+13.30%) | 1.1635x (+14.05%) | 1.1841x (+15.55%) |

The aux path has a small, repeatable 16-token regression: 0.74-0.94% under the
fixed policy and 0.65-1.16% under native tuning. It is included in every
aggregate above. Also, the gate sees the host-static tensor shape captured by
the CUDA graph. A caller that pads logical work into a larger static bucket
selects from that bucket shape; this PR does not add a device-side active-token
dispatch. The benchmark captured each listed token shape directly.

### Benchmark provenance

- Benchmark revision: `32f7b6d001182a0a55b453a512bf737ed93b547a`
- Benchmark script SHA-256:
  `795d4af322214faed5f7442894fe133083b07f9a6853f40bc283400cecd4de4c`
- Matrix runner SHA-256:
  `cfb00b7bafbf8eab748cfda45bcc4aa10bc862098e705389f4224c1fe01b7433`
- Run contract SHA-256:
  `0d011fd3540e2dc97b34bca3b6e5edf3ac6f7744fbc0bfd6f0b01e61893615ea`
- Source-state digest:
  `d99f84bdcccd3c6b9cc16619de2cc9dbd5364c5419707618b747877c73291e25`
- Sealed parser SHA-256 recorded by the run:
  `31e63f857abb48ecf94e62d0e8db22ae3036abda109126b20d27340493a92554`
- Raw checksum entries verified: 730; raw `SHA256SUMS` SHA-256:
  `385fec39707c0b5791773222ca1dcf4d436f23bde18ababa8a51123790b0dc9d`
- Raw archive SHA-256:
  `0daacf5dd237c202d1d9ae63add4962896f62de3bc016b7fb27a61701a45dbd2`
- Parsed `process-medians.csv` SHA-256:
  `9fab11bd36868c417b20b1894e20785f04911b361dbf8f07f4e8b9097d974c29`
- Threshold-4 derivation helper SHA-256:
  `fd6098bb8576d32ff2360c54b3157d4a09351b5b59f46065bb9845f2abbe893b`
- Production CSV SHA-256, aggregate/TRT/per-token:
  `83425e01f55fe47a06857af54658b91a89fea8b82e845c2f25dd5fb2db646d9a` /
  `9f7b3e7da4b285956be076d913406a6ab3cabbd6816afcfa8c193ba2e41fe715` /
  `3b49ea255cb524af2e80d19088d84957eb21148024b37a7b460e24eebd076413`
- Production output `SHA256SUMS` SHA-256:
  `297941867600ef8c3a88519a407ca51f7074fd54f9d566db122f004e05dbaf85`

The project-local parser was hardened after capture and has publication hash
`34380b47a2c6695b0cfd547af044782b5ab48ba5d1c51c3b7fba4978931c4c67`;
the sealed run contract retains the exact parser identity above. The production
helper revalidates all raw checksums and all 2,340 process-median keys, then
reproduces the sealed 104 W4A4, 104 W4A16, 8 aggregate, and 56 TRT rows before
applying the threshold.

### Nsight Compute mechanism evidence

Paired `--set full` reports were captured at `32f7b6d0` for the 4096-token,
EP8/TP1, MoE-only point with fresh JIT roots and byte-identical fixed tactic
caches. CUDA graphs and CUPTI benchmark timing were disabled for this isolated
one-forward kernel replay; all-cache flushing and base clocks were enabled.

| config | arm/action | grid / block | duration | instructions | regs/thread | achieved occupancy | local spill requests / bytes | L/S sectors |
|---|---|---|---:|---:|---:|---:|---:|---:|
| inference | off/GEMM1 | `(2,1,74)` / 384 | 139.744 us | 20,969,356 | 168 | 18.19% | 0 / 0 B | 13,413,844 / 0 |
| inference | off/quant | `(40704,1,1)` / 128 | 82.976 us | 31,423,488 | 26 | 89.21% | 0 / 0 B | 20,985,356 / 2,645,760 |
| inference | on/GEMM1 | `(2,1,74)` / 384 | 140.128 us | 21,247,300 | 168 | 18.27% | 24,576 / 24,576 B | 13,413,860 / 16,384 |
| inference | on/quant | `(5088,1,1)` / 128 | 21.024 us | 4,357,952 | 31 | 44.84% | 0 / 0 B | 2,129,411 / 532,480 |
| deterministic-RL | off/GEMM1 | `(2,1,74)` / 384 | 142.560 us | 20,969,030 | 168 | 18.25% | 0 / 0 B | 13,413,876 / 0 |
| deterministic-RL | off/quant | `(40704,1,1)` / 128 | 217.248 us | 110,021,983 | 51 | 51.93% | 0 / 0 B | 21,003,264 / 2,645,760 |
| deterministic-RL | on/GEMM1 | `(2,1,74)` / 384 | 138.688 us | 21,247,344 | 168 | 18.28% | 24,576 / 24,576 B | 13,413,796 / 16,384 |
| deterministic-RL | on/quant | `(5088,1,1)` / 128 | 29.120 us | 7,757,934 | 60 | 39.34% | 0 / 0 B | 2,133,888 / 532,480 |

| config | GEMM1 delta | quant speedup | serialized GEMM1 + quant speedup |
|---|---:|---:|---:|
| inference | +0.384 us (+0.27%) | 3.9467x (74.66% lower) | 1.3820x (27.64% lower) |
| deterministic-RL | -3.872 us (-2.72%) | 7.4604x (86.60% lower) | 2.1442x (53.36% lower) |

`L/S sectors` are L1TEX global sectors (32 bytes each), not logical payload or
DRAM bytes. Aux-on GEMM1 reported 24,576 local-spilling requests, 24,576 bytes,
and 24,576 local-load instructions with no local-store instructions in each
profile; all quant actions and both aux-off GEMM1 actions reported zero. The
serialized sums are mechanism diagnostics, not CUDA-graph critical-path or
end-to-end claims when kernels overlap; those claims come only from the paired
benchmark matrix.

NCU raw identities:

- fixed-cache SHA-256, inference/deterministic-RL:
  `123d82a557f73a7ecefe146166ae8b2ebcd6ab4785d8f1b9d984e11c9019b04f` /
  `05f82bcc57d788e29274b4d9ec93eb5c2bd026c131dd7ece636b9808d408d707`
- `.ncu-rep` SHA-256, inference off/on:
  `a32eb47477c7ad9388c69d3458bc72b889f898a527e21c500100ec2bdea9c87b` /
  `716cf93add609ee440ca75837e7ba18d0cfa20d0fef9c6f1a31fb7e2a926c618`
- `.ncu-rep` SHA-256, deterministic-RL off/on:
  `1113b1c66c216f6b064b1ad64a947091d28192710378ace14e3e7d0dbe751660` /
  `e293f397c9f7b189a5ebb484f7d3b85977154901dc36d71f47b4e4b451dbda46`
- complete NCU raw/derived archive SHA-256:
  `ec448e62985194a2ca6d07fae33d6cbec9316e6305ae72691262ee2f356d9fd2`

The first inference parse failed closed because NCU auto-scaled one spill metric
to `Kbyte`; the saved reports were re-exported in base units and passed the same
strict raw/details identity checks without rerunning a kernel.

## Reviewer Notes

- Please focus on whether the optional aux-maxima ABI is narrow and explicit,
  whether the post-conversion maxNum reduction exactly matches the legacy
  full-row reduction, and whether the device valid-row bound is sufficient for
  graph-replayed maximum routing buffers.
- The producer intentionally stores per-row maxima for each epilogue output-N
  tile rather than one scalar for an entire `(M tile, N tile)`. This avoids
  producer synchronization while letting the consumer finish the row reduction.
- Performance evidence is exact-shape EP8/TP1 on one B300. Other topologies and
  caller-specific CUDA-graph bucketing were not measured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional per-token output-maximum tracking for grouped GEMM and NVFP4 quantization.
  - Added accelerated NVFP4 quantization using precomputed blocked-8 input maxima.
  - Added support for FP16 and BF16 maximum-magnitude calculations, including special-value handling.
  - Added validation for auxiliary maximum tensors, layouts, data types, devices, and alignment.
  - Existing behavior remains unchanged when auxiliary maxima are not provided.

- **Tests**
  - Added coverage for dispatch thresholds, quantization modes, layouts, padding, masking, special values, and legacy-path equivalence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->