### PR TITLE
perf(cute-dsl): skip inactive pages in windowed decode

### DIFF
--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -967,16 +967,15 @@ class GroupedQueryAttentionDecodePaged:
         # handle the boundary, while rebasing both KV indices and seqlen keeps
         # causal/window coordinates unchanged for multi-token decode.
         full_seqlen = seqlen
-        if cutlass.const_expr(
-            isinstance(mask_config, SlidingWindowMask)
-            and mask_config.window_left is not None
-        ):
-            first_active_token = cutlass.max(
-                0, seqlen - prediction - mask_config.window_left
-            )
-            skipped_pages = first_active_token // page_size
-            table_offset += skipped_pages
-            seqlen -= skipped_pages * page_size
+        if cutlass.const_expr(isinstance(mask_config, SlidingWindowMask)):
+            sliding_window = cast(SlidingWindowMask, mask_config)
+            window_left = sliding_window.window_left
+            if cutlass.const_expr(window_left is not None):
+                assert window_left is not None
+                first_active_token = cutlass.max(0, seqlen - prediction - window_left)
+                skipped_pages = first_active_token // page_size
+                table_offset += skipped_pages
+                seqlen -= skipped_pages * page_size
 
         page_count = cute.ceil_div(seqlen, page_size)
         tiles_s = cute.ceil_div(seqlen, blk_tile_s)

--- a/flashinfer/cute_dsl/attention/gqa_decode_paged.py
+++ b/flashinfer/cute_dsl/attention/gqa_decode_paged.py
@@ -956,12 +956,29 @@ class GroupedQueryAttentionDecodePaged:
         # Runtime control flow
         if cutlass.const_expr(is_varlen):
             seqlen = seqlen_smem[0]
-            page_count = cute.ceil_div(seqlen, page_size)
             table_offset = table_offset_smem[0]
         else:
             seqlen = seqlens_iter
-            page_count = cute.ceil_div(seqlen, page_size)
-            table_offset = coord_b * page_count
+            full_page_count = cute.ceil_div(seqlen, page_size)
+            table_offset = coord_b * full_page_count
+
+        # Drop only complete pages that precede every query's left-window
+        # bound.  Keeping the leading partial page lets the existing mask
+        # handle the boundary, while rebasing both KV indices and seqlen keeps
+        # causal/window coordinates unchanged for multi-token decode.
+        full_seqlen = seqlen
+        if cutlass.const_expr(
+            isinstance(mask_config, SlidingWindowMask)
+            and mask_config.window_left is not None
+        ):
+            first_active_token = cutlass.max(
+                0, seqlen - prediction - mask_config.window_left
+            )
+            skipped_pages = first_active_token // page_size
+            table_offset += skipped_pages
+            seqlen -= skipped_pages * page_size
+
+        page_count = cute.ceil_div(seqlen, page_size)
         tiles_s = cute.ceil_div(seqlen, blk_tile_s)
         iters_s = cute.ceil_div(tiles_s - kv_split_idx, kv_splits)
         exit_early = kv_split_idx >= tiles_s
@@ -1476,7 +1493,7 @@ class GroupedQueryAttentionDecodePaged:
                 # Per-batch BLASST threshold, matching trtllm:
                 # effective threshold_p = scale_factor / seqlen
                 log2_threshold_p = log2_threshold_scale_factor - cute.math.log2(
-                    Float32(seqlen)
+                    Float32(full_seqlen)
                 )
 
             # Masking phase loop over all sequence tiles

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -1098,21 +1098,41 @@ def test_cute_dsl_decode_paged_sliding_window_blasst_normalization():
     """Page rebasing must not change BLASST's full-length normalization."""
     dtype = torch.bfloat16
     page_size, window_left = 16, 511
-    seq_lens_host = [1025, 2051]
-    batch_size = len(seq_lens_host)
-    torch.manual_seed(0)
-    # Zero Q/K makes every active-window probability exactly 1 / 512.
-    # A scale factor of 1.5 yields a lower threshold with the full lengths
-    # (1.5 / 1025 and 1.5 / 2051), but a higher threshold with the rebased
-    # lengths (about 1.5 / 514). Thus this case detects which denominator the
-    # BLASST path uses instead of merely checking that the path launches.
-    q = torch.zeros(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    seq_lens_host = [1025]
+    q = torch.zeros(1, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    q[..., 0] = 1
     kv, kv_indptr, kv_indices, _last_page_len, seq_lens = _make_paged_kv_varlen(
         seq_lens_host, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
     )
     k_cache, v_cache = kv.unbind(dim=1)
     k_cache.zero_()
+    v_cache.zero_()
     sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    # The BLASST specialization uses 128-token sequence tiles and always keeps
+    # its first two tiles. Give the third retained tile a maximum-score drop
+    # that the full-length threshold accepts but a rebased-length threshold
+    # rejects, and make it the only tile with nonzero values.
+    threshold_scale_factor = 1.5
+    full_seqlen = seq_lens_host[0]
+    first_active_token = full_seqlen - 1 - window_left
+    skipped_tokens = (first_active_token // page_size) * page_size
+    rebased_seqlen = full_seqlen - skipped_tokens
+    score_delta_log2 = -9.0
+    full_threshold_log2 = math.log2(threshold_scale_factor / full_seqlen)
+    rebased_threshold_log2 = math.log2(threshold_scale_factor / rebased_seqlen)
+    assert full_threshold_log2 < score_delta_log2 < rebased_threshold_log2
+
+    blasst_tile_size = 128
+    later_tile_start = skipped_tokens + 2 * blasst_tile_size
+    later_tile_end = later_tile_start + blasst_tile_size
+    assert later_tile_start % page_size == later_tile_end % page_size == 0
+    later_page_start = later_tile_start // page_size
+    later_page_end = later_tile_end // page_size
+    key_component = score_delta_log2 / (sm_scale * math.log2(math.e))
+    k_cache[later_page_start:later_page_end, :, :, 0] = key_component
+    v_cache[later_page_start:later_page_end] = 32
+
     wrapper = BatchDecodePagedCuteDSLWrapper(
         torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
     )
@@ -1126,18 +1146,26 @@ def test_cute_dsl_decode_paged_sliding_window_blasst_normalization():
         page_size=page_size,
         q_data_type=dtype,
         sm_scale=sm_scale,
-        kv_splits=3,
+        kv_splits=1,
         reduction="kernel",
         window_left=window_left,
         window_right=0,
         max_kv_len=max(seq_lens_host),
     )
     out_std = wrapper.run(q, k_cache, v_cache)
-    out_blasst = wrapper.run(
+    out_full_threshold = wrapper.run(
         q,
         k_cache,
         v_cache,
-        skip_softmax_threshold_scale_factor=1.5,
+        skip_softmax_threshold_scale_factor=threshold_scale_factor,
+    )
+    out_rebased_threshold = wrapper.run(
+        q,
+        k_cache,
+        v_cache,
+        skip_softmax_threshold_scale_factor=(
+            threshold_scale_factor * full_seqlen / rebased_seqlen
+        ),
     )
     ref = _decode_reference_paged_window(
         q,
@@ -1150,7 +1178,14 @@ def test_cute_dsl_decode_paged_sliding_window_blasst_normalization():
         window_left,
     )[:, 0]
     torch.testing.assert_close(out_std, ref, rtol=5e-3, atol=5e-3)
-    torch.testing.assert_close(out_blasst, out_std, rtol=5e-3, atol=5e-3)
+    torch.testing.assert_close(out_full_threshold, out_std, rtol=5e-3, atol=5e-3)
+    assert out_full_threshold.abs().min() > 1e-2
+    torch.testing.assert_close(
+        out_rebased_threshold,
+        torch.zeros_like(out_rebased_threshold),
+        rtol=0,
+        atol=1e-4,
+    )
 
 
 @pytest.mark.parametrize("batch_size", [4])

--- a/tests/attention/test_cute_dsl_decode.py
+++ b/tests/attention/test_cute_dsl_decode.py
@@ -132,6 +132,42 @@ def _decode_reference_paged_non_causal(
     return out.to(q.dtype)
 
 
+def _decode_reference_paged_window(
+    q,
+    k_cache,
+    v_cache,
+    kv_indptr,
+    kv_indices,
+    seq_lens,
+    sm_scale,
+    window_left,
+    window_right=0,
+):
+    """Bottom-right aligned sliding-window reference for paged GQA decode."""
+    if q.ndim == 3:
+        q = q[:, None]
+    batch_size, q_len, num_qo_heads, head_dim = q.shape
+    num_kv_heads = k_cache.shape[2]
+    group = num_qo_heads // num_kv_heads
+    out = torch.empty_like(q, dtype=torch.float32)
+    for b in range(batch_size):
+        length = int(seq_lens[b].item())
+        pages_b = kv_indices[kv_indptr[b] : kv_indptr[b + 1]]
+        keys = k_cache[pages_b].float().reshape(-1, num_kv_heads, head_dim)
+        values = v_cache[pages_b].float().reshape(-1, num_kv_heads, head_dim)
+        keys = keys[:length].repeat_interleave(group, dim=1)
+        values = values[:length].repeat_interleave(group, dim=1)
+        logits = torch.einsum("qhd,nhd->hqn", q[b].float(), keys) * sm_scale
+        query_positions = torch.arange(length - q_len, length, device=q.device)[:, None]
+        key_positions = torch.arange(length, device=q.device)[None, :]
+        keep = key_positions >= query_positions - window_left
+        if window_right is not None:
+            keep &= key_positions <= query_positions + window_right
+        logits.masked_fill_(~keep[None], float("-inf"))
+        out[b] = torch.einsum("hqn,nhd->qhd", torch.softmax(logits, dim=-1), values)
+    return out.to(q.dtype)
+
+
 def _decode_reference_contiguous(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -923,6 +959,198 @@ def test_batch_decode_wrapper_cute_dsl_sliding_window(dtype):
     out = cd.run(q, kv)
     ref = ref_wrapper.run(q, kv)
     torch.testing.assert_close(out, ref, rtol=5e-3, atol=5e-3)
+
+
+@pytest.mark.parametrize("page_size", [8, 16, 32, 64])
+@pytest.mark.parametrize("q_len_per_req", [1, 4])
+def test_cute_dsl_decode_paged_sliding_window_skips_full_pages(
+    page_size, q_len_per_req
+):
+    """Sliding-window page rebasing preserves ragged split-K numerics."""
+    dtype = torch.bfloat16
+    seq_lens_host = [257, 1025, 2051]
+    window_left = 511
+    batch_size = len(seq_lens_host)
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size,
+        q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        device=DEVICE,
+        dtype=dtype,
+    )
+    kv, kv_indptr, kv_indices, _last_page_len, seq_lens = _make_paged_kv_varlen(
+        seq_lens_host, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+        kv_splits=3,
+        reduction="kernel",
+        q_len_per_req=q_len_per_req,
+        window_left=window_left,
+        window_right=0,
+        max_kv_len=max(seq_lens_host),
+    )
+    out = wrapper.run(
+        q.reshape(batch_size * q_len_per_req, NUM_QO_HEADS, HEAD_DIM),
+        k_cache,
+        v_cache,
+    )
+    ref = _decode_reference_paged_window(
+        q,
+        k_cache,
+        v_cache,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        sm_scale,
+        window_left,
+    )
+    torch.testing.assert_close(out.reshape_as(ref), ref, rtol=5e-3, atol=5e-3)
+
+
+def test_cute_dsl_decode_paged_sliding_window_cuda_graph_runtime_lengths():
+    """Graph replay must observe changed lengths without changing page tables."""
+    dtype = torch.bfloat16
+    page_size, q_len_per_req, window_left = 16, 4, 511
+    capacity_lens_host = [1025, 2051]
+    initial_lens_host = [769, 1537]
+    batch_size = len(capacity_lens_host)
+    torch.manual_seed(0)
+    q = torch.randn(
+        batch_size,
+        q_len_per_req,
+        NUM_QO_HEADS,
+        HEAD_DIM,
+        device=DEVICE,
+        dtype=dtype,
+    )
+    kv, kv_indptr, kv_indices, _last_page_len, seq_lens = _make_paged_kv_varlen(
+        capacity_lens_host, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    seq_lens.copy_(torch.tensor(initial_lens_host, device=DEVICE, dtype=torch.int32))
+    k_cache, v_cache = kv.unbind(dim=1)
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE),
+        use_cuda_graph=True,
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+        kv_splits=3,
+        reduction="kernel",
+        q_len_per_req=q_len_per_req,
+        window_left=window_left,
+        window_right=0,
+        max_kv_len=max(capacity_lens_host),
+    )
+    q_flat = q.reshape(batch_size * q_len_per_req, NUM_QO_HEADS, HEAD_DIM)
+    out = torch.empty_like(q_flat)
+    wrapper.run(q_flat, k_cache, v_cache, out=out)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = wrapper.run(q_flat, k_cache, v_cache, out=out)
+    replay_lens = torch.tensor(capacity_lens_host, device=DEVICE, dtype=torch.int32)
+    seq_lens.copy_(replay_lens)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    ref = _decode_reference_paged_window(
+        q,
+        k_cache,
+        v_cache,
+        kv_indptr,
+        kv_indices,
+        replay_lens,
+        sm_scale,
+        window_left,
+    )
+    assert graph_out.data_ptr() == out.data_ptr()
+    torch.testing.assert_close(graph_out.reshape_as(ref), ref, rtol=5e-3, atol=5e-3)
+
+
+def test_cute_dsl_decode_paged_sliding_window_blasst_normalization():
+    """Page rebasing must not change BLASST's full-length normalization."""
+    dtype = torch.bfloat16
+    page_size, window_left = 16, 511
+    seq_lens_host = [1025, 2051]
+    batch_size = len(seq_lens_host)
+    torch.manual_seed(0)
+    # Zero Q/K makes every active-window probability exactly 1 / 512.
+    # A scale factor of 1.5 yields a lower threshold with the full lengths
+    # (1.5 / 1025 and 1.5 / 2051), but a higher threshold with the rebased
+    # lengths (about 1.5 / 514). Thus this case detects which denominator the
+    # BLASST path uses instead of merely checking that the path launches.
+    q = torch.zeros(batch_size, NUM_QO_HEADS, HEAD_DIM, device=DEVICE, dtype=dtype)
+    kv, kv_indptr, kv_indices, _last_page_len, seq_lens = _make_paged_kv_varlen(
+        seq_lens_host, page_size, NUM_KV_HEADS, HEAD_DIM, dtype, DEVICE
+    )
+    k_cache, v_cache = kv.unbind(dim=1)
+    k_cache.zero_()
+    sm_scale = 1.0 / math.sqrt(HEAD_DIM)
+    wrapper = BatchDecodePagedCuteDSLWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        num_qo_heads=NUM_QO_HEADS,
+        num_kv_heads=NUM_KV_HEADS,
+        head_dim=HEAD_DIM,
+        page_size=page_size,
+        q_data_type=dtype,
+        sm_scale=sm_scale,
+        kv_splits=3,
+        reduction="kernel",
+        window_left=window_left,
+        window_right=0,
+        max_kv_len=max(seq_lens_host),
+    )
+    out_std = wrapper.run(q, k_cache, v_cache)
+    out_blasst = wrapper.run(
+        q,
+        k_cache,
+        v_cache,
+        skip_softmax_threshold_scale_factor=1.5,
+    )
+    ref = _decode_reference_paged_window(
+        q,
+        k_cache,
+        v_cache,
+        kv_indptr,
+        kv_indices,
+        seq_lens,
+        sm_scale,
+        window_left,
+    )[:, 0]
+    torch.testing.assert_close(out_std, ref, rtol=5e-3, atol=5e-3)
+    torch.testing.assert_close(out_blasst, out_std, rtol=5e-3, atol=5e-3)
 
 
 @pytest.mark.parametrize("batch_size", [4])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Skip whole paged-KV pages that are entirely before a sliding-window decode
request's earliest active key. The kernel advances the page-table origin and
rebases the effective sequence length before constructing page and sequence
tile counts; the existing mask still handles the retained leading partial
page.

The rebase preserves three invariants:

1. key and query coordinates shift by the same whole-page token count, so
   causal and sliding-window mask decisions are unchanged, including
   multi-token decode;
2. the sequence-length remainder modulo page size is unchanged, so partial
   last-page handling is unchanged;
3. skipped pages plus retained pages equals the original page count, so fixed
   and ragged page-table segments remain in bounds.

BLASST threshold normalization intentionally continues to use the original
full sequence length. Dense and causal-without-left-window paths do not enter
the new branch.

### Performance

Fresh same-GPU results compare parent `231f708` with exact candidate
`117518a` on one NVIDIA B300 SM103. The workload is BF16
B16/Q1/Hq32/Hkv16/D256 with `window_left=1023`. Compilation, allocation, and
graph capture are outside timing. Each measurement uses 50 warmups and 300
CUDA Graph iterations; cells run A/B/A for three cycles. The parent median is
over six samples and the candidate median over three.

| Page | K | Parent median (us) | Candidate median (us) | Latency reduction |
|---:|---:|---:|---:|---:|
| 16 | 1024 | 42.185 | 42.237 | -0.12% |
| 16 | 4096 | 152.694 | 42.585 | 72.11% |
| 16 | 8192 | 304.258 | 42.872 | 85.91% |
| 32 | 1024 | 41.880 | 41.714 | 0.40% |
| 32 | 4096 | 152.613 | 41.899 | 72.55% |
| 32 | 8192 | 305.401 | 42.022 | 86.24% |
| 64 | 1024 | 41.927 | 41.814 | 0.27% |
| 64 | 4096 | 153.293 | 41.639 | 72.84% |
| 64 | 8192 | 306.466 | 41.854 | 86.34% |

K1024 is the no-skip control because the requested window already covers the
entire sequence; it remains flat. At longer K the candidate remains near the
cost of the retained window while the parent scans the full sequence.

CLI-equivalent command used by each arm (with `$P` and `$K` expanded per row):

```bash
python flashinfer/cute_dsl/attention/gqa_decode_paged.py \
  --b 16 --p 1 --s "$K" --pg "$P" --h_q 32 --h_k 16 --d 256 \
  --kv_splits 0 --reduction auto --window_left 1023 --window_right 0 \
  --warmups 50 --iterations 300 --skip_ref_check --quiet
```

The CLI's derived throughput labels use the original full K and are not
reported here after page skipping; only measured latency is compared.

## 🔍 Related Issues

None yet.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used my preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Local source checks completed:

- `uvx pre-commit run --all-files`
- `uvx ruff check flashinfer/cute_dsl/attention/gqa_decode_paged.py tests/attention/test_cute_dsl_decode.py`
- `uvx ruff format --check flashinfer/cute_dsl/attention/gqa_decode_paged.py tests/attention/test_cute_dsl_decode.py`
- `python3 -m py_compile flashinfer/cute_dsl/attention/gqa_decode_paged.py tests/attention/test_cute_dsl_decode.py`
- `git diff --check`

B300 checks completed for exact candidate `117518a`:

- 10 focused tests passed: Q1/Q4, page sizes 8/16/32/64, ragged split-K,
  split early-exit, CUDA Graph replay with growing lengths, and the BLASST
  full-length-normalization discriminator;
- the direct fixed-length B2/Q4/K2051/page16/split-K3 CLI path passed its
  numerical reference;
- the exact D256 benchmark geometry passed numerical reference checks at page
  sizes 16, 32, and 64;
- Compute Sanitizer 2025.3.1 memcheck reported zero errors for a ragged
  page16/split-K3 early-exit cell;
- the reproducible parent/candidate latency matrix above completed.

Follow-up review fix `eebdefb` strengthens the BLASST test with a third-tile
score delta that lies between the full-length and rebased-length thresholds and
distinct nonzero values on that tile. On the same B300, the exact follow-up head
passed the full focused matrix: `10 passed, 178 deselected`. The source-side
change in that commit only makes the existing sliding-window subtype narrowing
explicit for mypy; the page-rebase calculation is unchanged. The performance
table remains the A/B/A measurement of `117518a` reported above.

## Reviewer Notes

Please focus on the page-table-origin/sequence-coordinate invariant and the
choice to retain full-sequence BLASST normalization. The change was
independently reviewed by Kimi K3 Max; its initial test-strength finding was
addressed before commit. AI assistance was used to review and prepare this
change; the human submitter has reviewed the final diff and is responsible for
the design and results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paged sliding-window decoding to preserve partially active pages and ensure correct attention results at window boundaries.
  * Fixed sequence-length handling when runtime lengths change, including CUDA Graph replay scenarios.
  * Corrected threshold normalization to consistently use the full sequence length.
  * Improved numerical correctness for split-K decoding and kernel-based reduction paths across supported configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->