### PR TITLE
test: skip external-suite sharding tests when the temp dir is inside the repository

### DIFF
--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -32,6 +32,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 RUNNER = REPO_ROOT / "scripts" / "unit_test_runner.py"
 
 
+def _require_external_tmp(tmp_path: Path) -> None:
+    """Skip when the pytest temp directory resolves inside the repository.
+
+    ``runner._pytest_root`` anchors in-repository test paths at the repository
+    root, so a temporary suite that physically lives inside the checkout
+    collects with repository-relative node IDs instead of the suite-relative
+    ones these tests assert. That happens on hosts whose system temp directory
+    falls back into the checkout (see issue #4498).
+    """
+    if tmp_path.resolve().is_relative_to(REPO_ROOT):
+        pytest.skip("system temp directory is inside the repository")
+
+
 def _queue_test_unit(identifier: str) -> Unit:
     return Unit(
         id=identifier,
@@ -372,6 +385,7 @@ def test_cli_summary_ignores_unscoped_start_time_environment(tmp_path: Path) -> 
 
 
 def test_optional_timing_files_use_first_matching_rows(tmp_path: Path) -> None:
+    _require_external_tmp(tmp_path)
     suite = tmp_path / "suite"
     suite.mkdir()
     source = suite / "test_sample.py"
@@ -508,6 +522,7 @@ def test_slow_collection_reports_a_live_heartbeat(
 
 
 def test_collection_isolates_sm90_pull_multirank_modules(tmp_path: Path) -> None:
+    _require_external_tmp(tmp_path)
     suite = tmp_path / "suite"
     suite.mkdir()
     sm100 = suite / "sm100"
@@ -568,6 +583,7 @@ def test_sm90():
 def test_pytest_root_is_stable_for_repository_and_external_scopes(
     tmp_path: Path,
 ) -> None:
+    _require_external_tmp(tmp_path)
     suite = tmp_path / "suite"
     suite.mkdir()
     test_file = suite / "test_sample.py"
@@ -579,6 +595,7 @@ def test_pytest_root_is_stable_for_repository_and_external_scopes(
 
 
 def test_collection_preserves_external_pytest_config(tmp_path: Path) -> None:
+    _require_external_tmp(tmp_path)
     suite = tmp_path / "suite"
     suite.mkdir()
     (suite / "pytest.ini").write_text(
@@ -1041,6 +1058,7 @@ def test_plan_run_and_completed_reuse_publish_resumable_artifacts(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _require_external_tmp(tmp_path)
     # Pytest 9 may otherwise inherit the repository root for this external
     # temporary suite, which used to leak pytest-of-*/... prefixes into node IDs.
     monkeypatch.setenv("PYTEST_ADDOPTS", f"--rootdir={REPO_ROOT}")
@@ -1566,6 +1584,7 @@ def test_terminal_timeout_policies_synthesize_junit(
 def test_timeout_policy_resume_starts_a_new_attempt_without_fake_results(
     tmp_path: Path,
 ) -> None:
+    _require_external_tmp(tmp_path)
     suite = tmp_path / "suite"
     suite.mkdir()
     (suite / "test_slow.py").write_text(
@@ -1779,6 +1798,7 @@ def test_missing_test_path_fails_closed(tmp_path: Path) -> None:
 
 
 def test_collect_nodes_unions_multiple_directories(tmp_path: Path) -> None:
+    _require_external_tmp(tmp_path)
     first = tmp_path / "a"
     second = tmp_path / "b"
     first.mkdir()


### PR DESCRIPTION
Fixes #4498.

## Root cause

`test_collection_isolates_sm90_pull_multirank_modules` builds a scratch suite under pytest's `tmp_path` and asserts `runner._collect_nodes()` returns suite-relative node IDs. That silently assumes the pytest temp directory lies outside the checkout. `scripts/test_sharding/runner.py::_pytest_root` intentionally anchors any in-repository path at the repository root (the contract pinned by `test_pytest_root_is_stable_for_repository_and_external_scopes`), keeping node IDs stable across collection, execution, junit, and duration-estimate keys.

On the failing Spark runner the container had no usable system temp directory and no resolvable user: `getpass` fell back to `unknown` and `tempfile.gettempdir()` fell back to the working directory — the repository root. The scratch suite therefore physically sat inside the checkout, `_pytest_root` returned the repo root, and collection produced exactly the ID in the CI report: `pytest-of-unknown/pytest-1/test_collection_isolates_sm90_0/suite/test_aaa_sm100.py::test_sm100`. The runner itself stays self-consistent in that environment; only the tests' external-suite premise breaks. Seven tests in the file share that premise.

## Fix

Add `_require_external_tmp(tmp_path)` — skips with an actionable reason when `tmp_path` resolves inside the repository — and call it first in those seven tests. An external suite genuinely cannot be constructed in that environment (nothing outside the checkout is guaranteed writable), so a skip naming the temp-directory problem is the honest treatment; coverage is unchanged on healthy hosts. Same family as the file's existing pytest-9 rootdir note in `test_plan_run_and_completed_reuse_publish_resumable_artifacts`.

## Verification

The sharding runner and its tests are pure Python (no GPU involved). Run on WSL2 Ubuntu, Python 3.12, pytest 9.1.1, driving the file with `--noconftest` + `PYTHONPATH=<repo>`:

- Healthy env: 61 passed before the fix, 61 passed after — coverage unchanged.
- Degraded env (TMPDIR inside the checkout, reproducing Spark): before — 7 failed, 54 passed, with the isolates test failing on `tmpci/pytest-of-hacker/pytest-0/.../test_aaa_sm100.py::test_sm100`, the same shape as CI; after — 7 skipped ("system temp directory is inside the repository"), 54 passed.
- ruff 0.12.8 `check` + `format --check` (the repo's pinned hooks) pass on the changed file.

Not run (disclosed): the repo's full CI, and the actual Spark container — the diagnosis rests on the exact match between the CI assertion string and the deterministic local reproduction of the same mechanism.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for temporary test suites created outside the project directory.
  * Added safeguards to skip environment-incompatible scenarios when temporary directories are located within the repository.
  * Strengthened coverage for test collection, configuration handling, resumable artifacts, timeout recovery, and multi-directory node discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->