### PR TITLE
feat(prims_ts): support no-padding MLA query rows

### DIFF
--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -140,6 +140,131 @@ class _PagedContextMetadata:
     dense_page_indices: tuple[int, ...]
 
 
+_ContextScheduler = Literal[
+    "nonpersistent",
+    "static_persistent",
+    "clc_dynamic_persistent",
+]
+
+
+@dataclass(frozen=True)
+class _ContextSchedulerProbe:
+    """Static kernel traits and device capacity used by scheduler policy."""
+
+    single_qkv_instance: bool
+    logical_work_tiles: int
+    max_active_clusters: int
+
+
+@dataclass(frozen=True)
+class _ContextCompileSpec:
+    """Batch-independent identity for one contiguous context compile."""
+
+    device_index: int
+    max_seq_len_q: int
+    max_seq_len_k: int
+    num_qo_heads: int
+    num_kv_heads: int
+    head_dim: int
+    q_dtype_key: str
+    output_dtype_key: str
+    mask_type: str
+    window_left: int
+    packed: bool
+    head_paired: bool
+    uniform_packed_lengths: bool
+    has_q_offset: bool
+    causal_single_kv_tile: bool
+    packed_dense_k_mask: bool
+    scheduler: _ContextScheduler
+
+
+@dataclass(frozen=True)
+class _PagedContextCompileSpec:
+    """Batch-independent identity for one paged context compile."""
+
+    device_index: int
+    max_seq_len_q: int
+    max_seq_len_k: int
+    page_size: int
+    max_num_pages_per_seq_kv: int
+    num_qo_heads: int
+    num_kv_heads: int
+    head_dim: int
+    q_dtype_key: str
+    output_dtype_key: str
+    mask_type: str
+    window_left: int
+    head_paired: bool
+    uniform_packed_lengths: bool
+    has_q_offset: bool
+    packed_dense_k_mask: bool
+    scheduler: _ContextScheduler
+
+
+def _make_context_kernel(
+    *,
+    input_dtype,
+    output_dtype,
+    head_dim: int,
+    mask_type: str,
+    window_left: int,
+    head_paired: bool,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    has_q_offset: bool,
+    causal_single_kv_tile: bool,
+    scheduler: _ContextScheduler,
+    page_size: int | None = None,
+    max_num_pages_per_seq_kv: int | None = None,
+):
+    """Build one context kernel from its batch-independent static topology."""
+
+    import cutlass
+
+    from .kernels.fmha_context.fmha_kernel import FmhaTs
+
+    use_paged_kv = page_size is not None
+    if use_paged_kv != (max_num_pages_per_seq_kv is not None):
+        raise ValueError("paged context requires both page geometry values")
+    is_persistent = scheduler != "nonpersistent"
+    is_clc_dynamic = scheduler == "clc_dynamic_persistent"
+    paged_kwargs = (
+        {
+            "use_paged_kv": True,
+            "num_tokens_per_page": page_size,
+            "max_num_pages_per_seq_kv": max_num_pages_per_seq_kv,
+        }
+        if use_paged_kv
+        else {}
+    )
+    return FmhaTs(
+        qk_acc_dtype=cutlass.Float32,
+        pv_acc_dtype=cutlass.Float32,
+        in_dtype=input_dtype,
+        out_dtype=output_dtype,
+        d=head_dim,
+        is_persistent=is_persistent,
+        is_causal=mask_type == "causal",
+        has_variable_window=mask_type == "variable_window",
+        balance_causal_workload=(
+            scheduler == "static_persistent"
+            and _uses_heavy_first_static_causal_raster(
+                mask_type=mask_type,
+                window_left=window_left,
+                has_q_offset=has_q_offset,
+            )
+        ),
+        is_clc_dynamic=is_clc_dynamic,
+        head_paired=head_paired,
+        window_size_left=window_left if window_left > 0 else 0,
+        h_r=num_qo_heads // num_kv_heads,
+        enable_skip_correction=True,
+        causal_single_kv_tile=(causal_single_kv_tile and not use_paged_kv),
+        **paged_kwargs,
+    )
+
+
 def _validate_tensor(tensor: torch.Tensor, name: str) -> None:
     if not isinstance(tensor, torch.Tensor):
         raise TypeError(f"{name} must be a torch.Tensor")
@@ -661,7 +786,7 @@ def _resolve_geometry(
     window_left: int,
     output_dtype: torch.dtype,
 ) -> _ContextGeometry:
-    """Validate a plan and derive its semantic compile key.
+    """Validate a plan and derive its semantic and storage geometry.
 
     Packed cumulative offsets are copied to the host only here.  A successful
     plan owns their tensor storage and never synchronizes on the run path.
@@ -997,80 +1122,190 @@ def _resolve_paged_geometry(
     return geometry, metadata
 
 
-def _semantic_key(geometry: _ContextGeometry) -> tuple[object, ...]:
-    return (
-        geometry.device_index,
-        geometry.batch_size,
-        geometry.max_seq_len_q,
-        geometry.max_seq_len_k,
-        geometry.num_qo_heads,
-        geometry.num_kv_heads,
-        geometry.head_dim,
-        _dtype_key(geometry.q_dtype),
-        _dtype_key(geometry.output_dtype),
-        geometry.mask_type,
-        geometry.window_left,
-        geometry.packed,
-        geometry.head_paired,
-        geometry.uniform_packed_lengths,
-        geometry.has_q_offset,
-        geometry.causal_single_kv_tile,
-        geometry.packed_dense_k_mask,
+def _make_context_scheduler_probe(
+    geometry: _ContextGeometry | _PagedContextGeometry,
+    *,
+    causal_single_kv_tile: bool,
+    page_size: int | None = None,
+    max_num_pages_per_seq_kv: int | None = None,
+) -> _ContextSchedulerProbe:
+    """Build the common static probe and logical work count for policy."""
+
+    import cutlass
+    import cutlass.utils as utils
+
+    dtype_map = {
+        torch.float16: cutlass.Float16,
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float8_e4m3fn: cutlass.Float8E4M3FN,
+    }
+    probe = _make_context_kernel(
+        input_dtype=dtype_map[geometry.q_dtype],
+        output_dtype=dtype_map[geometry.output_dtype],
+        head_dim=geometry.head_dim,
+        mask_type=geometry.mask_type,
+        window_left=geometry.window_left,
+        head_paired=geometry.head_paired,
+        num_qo_heads=geometry.num_qo_heads,
+        num_kv_heads=geometry.num_kv_heads,
+        has_q_offset=geometry.has_q_offset,
+        causal_single_kv_tile=causal_single_kv_tile,
+        scheduler="static_persistent",
+        page_size=page_size,
+        max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
+    )
+    with torch.cuda.device(geometry.device_index):
+        max_active_clusters = int(utils.HardwareInfo().get_max_active_clusters(1))
+    num_seq_tiles = (
+        geometry.max_seq_len_q + probe.cfg.cta_tiler[0] - 1
+    ) // probe.cfg.cta_tiler[0]
+    num_head_tiles = geometry.num_qo_heads // probe.cfg.work_tile_q_heads
+    logical_work_tiles = geometry.batch_size * num_seq_tiles * num_head_tiles
+    return _ContextSchedulerProbe(
+        single_qkv_instance=bool(probe.cfg.single_qkv_instance),
+        logical_work_tiles=int(logical_work_tiles),
+        max_active_clusters=max_active_clusters,
     )
 
 
-def _paged_semantic_key(
+def _resolve_context_scheduler(geometry: _ContextGeometry) -> _ContextScheduler:
+    """Select a scheduler from plan-time work while keeping batch out of JIT."""
+
+    probe = _make_context_scheduler_probe(
+        geometry,
+        causal_single_kv_tile=geometry.causal_single_kv_tile,
+    )
+    is_persistent = _contiguous_context_uses_persistent_scheduler(
+        single_qkv_instance=probe.single_qkv_instance,
+        head_paired=geometry.head_paired,
+        packed=geometry.packed,
+        uniform_packed_lengths=geometry.uniform_packed_lengths,
+        logical_work_tiles=probe.logical_work_tiles,
+        max_active_clusters=probe.max_active_clusters,
+        batch_size=geometry.batch_size,
+        num_qo_heads=geometry.num_qo_heads,
+        is_causal=geometry.mask_type == "causal",
+        has_q_offset=geometry.has_q_offset,
+    )
+    if not is_persistent:
+        return "nonpersistent"
+    if _contiguous_context_uses_clc_scheduler(
+        single_qkv_instance=probe.single_qkv_instance,
+        head_paired=geometry.head_paired,
+        packed=geometry.packed,
+        uniform_packed_lengths=geometry.uniform_packed_lengths,
+        is_causal=geometry.mask_type == "causal",
+        has_q_offset=geometry.has_q_offset,
+    ):
+        return "clc_dynamic_persistent"
+    return "static_persistent"
+
+
+def _resolve_paged_context_scheduler(
     geometry: _PagedContextGeometry,
-) -> tuple[object, ...]:
-    return (
-        geometry.device_index,
-        geometry.batch_size,
-        geometry.max_seq_len_q,
-        geometry.max_seq_len_k,
-        geometry.page_size,
-        geometry.max_num_pages_per_seq_kv,
-        geometry.num_qo_heads,
-        geometry.num_kv_heads,
-        geometry.head_dim,
-        _dtype_key(geometry.q_dtype),
-        _dtype_key(geometry.output_dtype),
-        geometry.mask_type,
-        geometry.window_left,
-        geometry.head_paired,
-        geometry.uniform_packed_lengths,
-        geometry.has_q_offset,
-        geometry.packed_dense_k_mask,
+) -> _ContextScheduler:
+    """Select paged-context scheduling from plan work, not JIT identity."""
+
+    probe = _make_context_scheduler_probe(
+        geometry,
+        causal_single_kv_tile=False,
+        page_size=geometry.page_size,
+        max_num_pages_per_seq_kv=geometry.max_num_pages_per_seq_kv,
+    )
+    is_persistent = _paged_context_uses_persistent_scheduler(
+        mask_type=geometry.mask_type,
+        head_paired=geometry.head_paired,
+        logical_work_tiles=probe.logical_work_tiles,
+        max_active_clusters=probe.max_active_clusters,
+        batch_size=geometry.batch_size,
+        num_qo_heads=geometry.num_qo_heads,
+    )
+    if not is_persistent:
+        return "nonpersistent"
+    if _paged_context_uses_clc_scheduler(
+        is_persistent=True,
+        single_qkv_instance=probe.single_qkv_instance,
+        is_causal=geometry.mask_type == "causal",
+        uniform_packed_lengths=geometry.uniform_packed_lengths,
+    ):
+        return "clc_dynamic_persistent"
+    return "static_persistent"
+
+
+def _context_compile_spec(geometry: _ContextGeometry) -> _ContextCompileSpec:
+    return _ContextCompileSpec(
+        device_index=geometry.device_index,
+        max_seq_len_q=geometry.max_seq_len_q,
+        max_seq_len_k=geometry.max_seq_len_k,
+        num_qo_heads=geometry.num_qo_heads,
+        num_kv_heads=geometry.num_kv_heads,
+        head_dim=geometry.head_dim,
+        q_dtype_key=_dtype_key(geometry.q_dtype),
+        output_dtype_key=_dtype_key(geometry.output_dtype),
+        mask_type=geometry.mask_type,
+        window_left=geometry.window_left,
+        packed=geometry.packed,
+        head_paired=geometry.head_paired,
+        uniform_packed_lengths=geometry.uniform_packed_lengths,
+        has_q_offset=geometry.has_q_offset,
+        causal_single_kv_tile=geometry.causal_single_kv_tile,
+        packed_dense_k_mask=geometry.packed_dense_k_mask,
+        scheduler=_resolve_context_scheduler(geometry),
+    )
+
+
+def _paged_context_compile_spec(
+    geometry: _PagedContextGeometry,
+) -> _PagedContextCompileSpec:
+    return _PagedContextCompileSpec(
+        device_index=geometry.device_index,
+        max_seq_len_q=geometry.max_seq_len_q,
+        max_seq_len_k=geometry.max_seq_len_k,
+        page_size=geometry.page_size,
+        max_num_pages_per_seq_kv=geometry.max_num_pages_per_seq_kv,
+        num_qo_heads=geometry.num_qo_heads,
+        num_kv_heads=geometry.num_kv_heads,
+        head_dim=geometry.head_dim,
+        q_dtype_key=_dtype_key(geometry.q_dtype),
+        output_dtype_key=_dtype_key(geometry.output_dtype),
+        mask_type=geometry.mask_type,
+        window_left=geometry.window_left,
+        head_paired=geometry.head_paired,
+        uniform_packed_lengths=geometry.uniform_packed_lengths,
+        has_q_offset=geometry.has_q_offset,
+        packed_dense_k_mask=geometry.packed_dense_k_mask,
+        scheduler=_resolve_paged_context_scheduler(geometry),
     )
 
 
 @functools.cache
 def _get_compiled_context(
-    device_index: int,
-    batch_size: int,
-    max_seq_len_q: int,
-    max_seq_len_k: int,
-    num_qo_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
-    q_dtype_key: str,
-    output_dtype_key: str,
-    mask_type: str,
-    window_left: int,
-    packed: bool,
-    head_paired: bool,
-    uniform_packed_lengths: bool,
-    has_q_offset: bool,
-    causal_single_kv_tile: bool,
-    packed_dense_k_mask: bool,
+    compile_spec: _ContextCompileSpec,
 ):
-    """Compile and cache one exact semantic context-attention specialization."""
+    """Compile one batch-dynamic context specialization and cache by topology."""
+
+    device_index = compile_spec.device_index
+    max_seq_len_q = compile_spec.max_seq_len_q
+    max_seq_len_k = compile_spec.max_seq_len_k
+    num_qo_heads = compile_spec.num_qo_heads
+    num_kv_heads = compile_spec.num_kv_heads
+    head_dim = compile_spec.head_dim
+    q_dtype_key = compile_spec.q_dtype_key
+    output_dtype_key = compile_spec.output_dtype_key
+    mask_type = compile_spec.mask_type
+    window_left = compile_spec.window_left
+    packed = compile_spec.packed
+    head_paired = compile_spec.head_paired
+    uniform_packed_lengths = compile_spec.uniform_packed_lengths
+    has_q_offset = compile_spec.has_q_offset
+    causal_single_kv_tile = compile_spec.causal_single_kv_tile
+    packed_dense_k_mask = compile_spec.packed_dense_k_mask
+    scheduler = compile_spec.scheduler
 
     import cutlass
     import cutlass.cute as cute
     from cuda.bindings import driver as cuda_drv
     import cutlass.utils as utils
-
-    from .kernels.fmha_context.fmha_kernel import FmhaTs
 
     dtype_map = {
         "float16": cutlass.Float16,
@@ -1079,91 +1314,22 @@ def _get_compiled_context(
     }
     input_dtype = dtype_map[q_dtype_key]
     output_dtype = dtype_map[output_dtype_key]
-    is_causal = mask_type == "causal"
     has_variable_window = mask_type == "variable_window"
-    # Construct the scheduler-independent topology first. Immutable
-    # single-instance domains can use the lower-overhead static persistent
-    # queue; paired or live-ragged domains are reconstructed with CLC.
-    fmha = FmhaTs(
-        qk_acc_dtype=cutlass.Float32,
-        pv_acc_dtype=cutlass.Float32,
-        in_dtype=input_dtype,
-        out_dtype=output_dtype,
-        d=head_dim,
-        is_persistent=True,
-        is_causal=is_causal,
-        has_variable_window=has_variable_window,
-        balance_causal_workload=_uses_heavy_first_static_causal_raster(
-            mask_type=mask_type,
-            window_left=window_left,
-            has_q_offset=has_q_offset,
-        ),
-        is_clc_dynamic=False,
-        head_paired=head_paired,
-        window_size_left=window_left if window_left > 0 else 0,
-        h_r=num_qo_heads // num_kv_heads,
-        enable_skip_correction=True,
-        causal_single_kv_tile=causal_single_kv_tile,
-    )
     with torch.cuda.device(device_index):
         max_active_clusters = int(utils.HardwareInfo().get_max_active_clusters(1))
-    num_seq_tiles = (max_seq_len_q + fmha.cfg.cta_tiler[0] - 1) // fmha.cfg.cta_tiler[0]
-    num_head_tiles = num_qo_heads // fmha.cfg.work_tile_q_heads
-    logical_work_tiles = batch_size * num_seq_tiles * num_head_tiles
-    is_persistent = _contiguous_context_uses_persistent_scheduler(
-        single_qkv_instance=fmha.cfg.single_qkv_instance,
+    fmha = _make_context_kernel(
+        input_dtype=input_dtype,
+        output_dtype=output_dtype,
+        head_dim=head_dim,
+        mask_type=mask_type,
+        window_left=window_left,
         head_paired=head_paired,
-        packed=packed,
-        uniform_packed_lengths=uniform_packed_lengths,
-        logical_work_tiles=logical_work_tiles,
-        max_active_clusters=max_active_clusters,
-        batch_size=batch_size,
         num_qo_heads=num_qo_heads,
-        is_causal=is_causal,
+        num_kv_heads=num_kv_heads,
         has_q_offset=has_q_offset,
+        causal_single_kv_tile=causal_single_kv_tile,
+        scheduler=scheduler,
     )
-    uses_clc = is_persistent and _contiguous_context_uses_clc_scheduler(
-        single_qkv_instance=fmha.cfg.single_qkv_instance,
-        head_paired=head_paired,
-        packed=packed,
-        uniform_packed_lengths=uniform_packed_lengths,
-        is_causal=is_causal,
-        has_q_offset=has_q_offset,
-    )
-    if uses_clc:
-        fmha = FmhaTs(
-            qk_acc_dtype=cutlass.Float32,
-            pv_acc_dtype=cutlass.Float32,
-            in_dtype=input_dtype,
-            out_dtype=output_dtype,
-            d=head_dim,
-            is_persistent=True,
-            is_causal=is_causal,
-            has_variable_window=has_variable_window,
-            is_clc_dynamic=True,
-            head_paired=head_paired,
-            window_size_left=window_left if window_left > 0 else 0,
-            h_r=num_qo_heads // num_kv_heads,
-            enable_skip_correction=True,
-            causal_single_kv_tile=causal_single_kv_tile,
-        )
-    elif not is_persistent:
-        fmha = FmhaTs(
-            qk_acc_dtype=cutlass.Float32,
-            pv_acc_dtype=cutlass.Float32,
-            in_dtype=input_dtype,
-            out_dtype=output_dtype,
-            d=head_dim,
-            is_persistent=False,
-            is_causal=is_causal,
-            has_variable_window=has_variable_window,
-            is_clc_dynamic=False,
-            head_paired=head_paired,
-            window_size_left=window_left if window_left > 0 else 0,
-            h_r=num_qo_heads // num_kv_heads,
-            enable_skip_correction=True,
-            causal_single_kv_tile=causal_single_kv_tile,
-        )
     fmha.cfg.has_varlen = packed
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths
     if uniform_packed_lengths:
@@ -1177,7 +1343,7 @@ def _get_compiled_context(
         )
     _validate_query_work_tile_span(fmha.cfg)
     fmha.cfg.packed_dense_k_mask = packed_dense_k_mask
-    if not is_causal and not packed:
+    if mask_type != "causal" and not packed:
         fmha.cfg.fixed_dense_k_tail = max_seq_len_k % fmha.cfg.kv_tile_n
 
     @cute.jit
@@ -1248,38 +1414,45 @@ def _get_compiled_context(
     if packed:
         runtime_total_q = cute.sym_int()
         runtime_total_k = cute.sym_int()
+        runtime_num_q_offsets = cute.sym_int()
+        runtime_num_k_offsets = cute.sym_int()
         q_shape = (runtime_total_q, num_qo_heads, head_dim)
         kv_shape = (runtime_total_k, num_kv_heads, head_dim)
         out_shape = (runtime_total_q, num_qo_heads, head_dim)
-        indptr_shape = (batch_size + 1,)
+        qo_indptr_shape = (runtime_num_q_offsets,)
+        kv_indptr_shape = (runtime_num_k_offsets,)
     else:
+        batch_size = cute.sym_int()
         q_shape = (batch_size, max_seq_len_q, num_qo_heads, head_dim)
         kv_shape = (batch_size, max_seq_len_k, num_kv_heads, head_dim)
         out_shape = q_shape
-        indptr_shape = (1,)
+        qo_indptr_shape = (1,)
+        kv_indptr_shape = (1,)
     q_fake = fake_compact(input_dtype, q_shape, 16)
     k_fake = fake_compact(input_dtype, kv_shape, 16)
     v_fake = fake_compact(input_dtype, kv_shape, 16)
     out_fake = fake_compact(output_dtype, out_shape, 16)
     scale_fake = fake_compact(cutlass.Float32, (1,), 4)
     output_scale_fake = fake_compact(cutlass.Float32, (1,), 4)
-    qo_indptr_fake = fake_compact(cutlass.Int32, indptr_shape, 4)
-    kv_indptr_fake = fake_compact(cutlass.Int32, indptr_shape, 4)
-    variable_window_shape = (
-        (batch_size * max_seq_len_q,) if has_variable_window else (1,)
-    )
+    qo_indptr_fake = fake_compact(cutlass.Int32, qo_indptr_shape, 4)
+    kv_indptr_fake = fake_compact(cutlass.Int32, kv_indptr_shape, 4)
+    if has_variable_window:
+        if packed:
+            raise RuntimeError("variable-window context requires fixed tensors")
+        variable_window_shape = (batch_size * max_seq_len_q,)
+        variable_window_tile_size_q = (
+            _CONTEXT_MAX_Q_ROWS_PER_WORK_TILE
+            if head_dim == _CONTEXT_TILE_SIZE_Q
+            else _CONTEXT_TILE_SIZE_Q
+        )
+        variable_window_cta_shape = (
+            batch_size * cute.ceil_div(max_seq_len_q, variable_window_tile_size_q),
+        )
+    else:
+        variable_window_shape = (1,)
+        variable_window_cta_shape = (1,)
     variable_window_starts_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
     variable_window_ends_fake = fake_compact(cutlass.Int32, variable_window_shape, 4)
-    variable_window_tile_size_q = (
-        _CONTEXT_MAX_Q_ROWS_PER_WORK_TILE
-        if head_dim == _CONTEXT_TILE_SIZE_Q
-        else _CONTEXT_TILE_SIZE_Q
-    )
-    variable_window_cta_shape = (
-        (batch_size * cute.ceil_div(max_seq_len_q, variable_window_tile_size_q),)
-        if has_variable_window
-        else (1,)
-    )
     variable_window_cta_starts_fake = fake_compact(
         cutlass.Int32, variable_window_cta_shape, 4
     )
@@ -1309,10 +1482,7 @@ def _get_compiled_context(
             options=_COMPILE_OPTIONS,
         )
     policy = (
-        (
-            "scheduler",
-            ("clc_dynamic_persistent" if fmha.is_clc_dynamic else "static_persistent"),
-        ),
+        ("scheduler", scheduler),
         ("pairing", "head" if head_paired else "query"),
         ("uniform_packed_lengths", uniform_packed_lengths),
         ("causal_single_kv_tile", causal_single_kv_tile),
@@ -1323,32 +1493,32 @@ def _get_compiled_context(
 
 @functools.cache
 def _get_compiled_paged_context(
-    device_index: int,
-    batch_size: int,
-    max_seq_len_q: int,
-    max_seq_len_k: int,
-    page_size: int,
-    max_num_pages_per_seq_kv: int,
-    num_qo_heads: int,
-    num_kv_heads: int,
-    head_dim: int,
-    q_dtype_key: str,
-    output_dtype_key: str,
-    mask_type: str,
-    window_left: int,
-    head_paired: bool,
-    uniform_packed_lengths: bool,
-    has_q_offset: bool,
-    packed_dense_k_mask: bool,
+    compile_spec: _PagedContextCompileSpec,
 ):
-    """Compile one packed-Q, paged-K/V context specialization."""
+    """Compile one batch-dynamic packed-Q, paged-K/V specialization."""
+
+    device_index = compile_spec.device_index
+    max_seq_len_q = compile_spec.max_seq_len_q
+    max_seq_len_k = compile_spec.max_seq_len_k
+    page_size = compile_spec.page_size
+    max_num_pages_per_seq_kv = compile_spec.max_num_pages_per_seq_kv
+    num_qo_heads = compile_spec.num_qo_heads
+    num_kv_heads = compile_spec.num_kv_heads
+    head_dim = compile_spec.head_dim
+    q_dtype_key = compile_spec.q_dtype_key
+    output_dtype_key = compile_spec.output_dtype_key
+    mask_type = compile_spec.mask_type
+    window_left = compile_spec.window_left
+    head_paired = compile_spec.head_paired
+    uniform_packed_lengths = compile_spec.uniform_packed_lengths
+    has_q_offset = compile_spec.has_q_offset
+    packed_dense_k_mask = compile_spec.packed_dense_k_mask
+    scheduler = compile_spec.scheduler
 
     import cutlass
     import cutlass.cute as cute
     from cuda.bindings import driver as cuda_drv
     import cutlass.utils as utils
-
-    from .kernels.fmha_context.fmha_kernel import FmhaTs
 
     dtype_map = {
         "float16": cutlass.Float16,
@@ -1357,102 +1527,23 @@ def _get_compiled_paged_context(
     }
     input_dtype = dtype_map[q_dtype_key]
     output_dtype = dtype_map[output_dtype_key]
-    is_causal = mask_type == "causal"
     with torch.cuda.device(device_index):
         max_active_clusters = int(utils.HardwareInfo().get_max_active_clusters(1))
-
-    # Build the persistent topology first to obtain its actual work-tile shape.
-    # Scheduler selection then follows the logical CTA wave count rather than a
-    # head-dimension or sequence-length performance threshold.  The tiler is
-    # scheduler-independent; reconstruct only the one-wave nonpersistent case.
-    fmha = FmhaTs(
-        qk_acc_dtype=cutlass.Float32,
-        pv_acc_dtype=cutlass.Float32,
-        in_dtype=input_dtype,
-        out_dtype=output_dtype,
-        d=head_dim,
-        is_persistent=True,
-        is_causal=is_causal,
-        # This topology probe is scheduler-independent. Persistent paired
-        # plans are reconstructed below with CLC after their logical wave
-        # count is known; single-instance plans retain the staged page-offset
-        # producer and static scheduling.
-        balance_causal_workload=_uses_heavy_first_static_causal_raster(
-            mask_type=mask_type,
-            window_left=window_left,
-            has_q_offset=has_q_offset,
-        ),
-        is_clc_dynamic=False,
-        head_paired=head_paired,
-        window_size_left=window_left if window_left > 0 else 0,
-        h_r=num_qo_heads // num_kv_heads,
-        enable_skip_correction=True,
-        use_paged_kv=True,
-        num_tokens_per_page=page_size,
-        max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
-        # The fixed one-tile shortcut assumes contiguous fixed-shape K/V and
-        # is intentionally disabled for the page-table path.
-        causal_single_kv_tile=False,
-    )
-    num_seq_tiles = (max_seq_len_q + fmha.cfg.cta_tiler[0] - 1) // fmha.cfg.cta_tiler[0]
-    num_head_tiles = num_qo_heads // fmha.cfg.work_tile_q_heads
-    logical_work_tiles = batch_size * num_seq_tiles * num_head_tiles
-    paged_is_persistent = _paged_context_uses_persistent_scheduler(
+    fmha = _make_context_kernel(
+        input_dtype=input_dtype,
+        output_dtype=output_dtype,
+        head_dim=head_dim,
         mask_type=mask_type,
+        window_left=window_left,
         head_paired=head_paired,
-        logical_work_tiles=logical_work_tiles,
-        max_active_clusters=max_active_clusters,
-        batch_size=batch_size,
         num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        has_q_offset=has_q_offset,
+        causal_single_kv_tile=False,
+        scheduler=scheduler,
+        page_size=page_size,
+        max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
     )
-    # A fixed/uniform causal plan has an immutable task domain. Its static
-    # queue avoids CLC response overhead; causal live-ragged plans retain CLC
-    # so request-local work changes are redistributed at runtime. Dense work
-    # does not have the causal request-dependent K-tile domain and stays static.
-    paged_uses_clc = _paged_context_uses_clc_scheduler(
-        is_persistent=paged_is_persistent,
-        single_qkv_instance=fmha.cfg.single_qkv_instance,
-        is_causal=is_causal,
-        uniform_packed_lengths=uniform_packed_lengths,
-    )
-    if paged_uses_clc:
-        fmha = FmhaTs(
-            qk_acc_dtype=cutlass.Float32,
-            pv_acc_dtype=cutlass.Float32,
-            in_dtype=input_dtype,
-            out_dtype=output_dtype,
-            d=head_dim,
-            is_persistent=True,
-            is_causal=is_causal,
-            is_clc_dynamic=True,
-            head_paired=head_paired,
-            window_size_left=window_left if window_left > 0 else 0,
-            h_r=num_qo_heads // num_kv_heads,
-            enable_skip_correction=True,
-            use_paged_kv=True,
-            num_tokens_per_page=page_size,
-            max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
-            causal_single_kv_tile=False,
-        )
-    elif not paged_is_persistent:
-        fmha = FmhaTs(
-            qk_acc_dtype=cutlass.Float32,
-            pv_acc_dtype=cutlass.Float32,
-            in_dtype=input_dtype,
-            out_dtype=output_dtype,
-            d=head_dim,
-            is_persistent=False,
-            is_causal=is_causal,
-            is_clc_dynamic=False,
-            head_paired=head_paired,
-            window_size_left=window_left if window_left > 0 else 0,
-            h_r=num_qo_heads // num_kv_heads,
-            enable_skip_correction=True,
-            use_paged_kv=True,
-            num_tokens_per_page=page_size,
-            max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
-            causal_single_kv_tile=False,
-        )
     fmha.cfg.has_varlen = True
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths
     if uniform_packed_lengths:
@@ -1511,6 +1602,9 @@ def _get_compiled_paged_context(
 
     runtime_total_q = cute.sym_int()
     runtime_num_pages = cute.sym_int()
+    batch_size = cute.sym_int()
+    runtime_num_q_offsets = cute.sym_int()
+    runtime_num_k_offsets = cute.sym_int()
     q_fake = fake_compact(input_dtype, (runtime_total_q, num_qo_heads, head_dim), 16)
     kv_shape = (
         runtime_num_pages,
@@ -1523,8 +1617,8 @@ def _get_compiled_paged_context(
     out_fake = fake_compact(output_dtype, (runtime_total_q, num_qo_heads, head_dim), 16)
     scale_fake = fake_compact(cutlass.Float32, (1,), 4)
     output_scale_fake = fake_compact(cutlass.Float32, (1,), 4)
-    qo_indptr_fake = fake_compact(cutlass.Int32, (batch_size + 1,), 4)
-    kv_indptr_fake = fake_compact(cutlass.Int32, (batch_size + 1,), 4)
+    qo_indptr_fake = fake_compact(cutlass.Int32, (runtime_num_q_offsets,), 4)
+    kv_indptr_fake = fake_compact(cutlass.Int32, (runtime_num_k_offsets,), 4)
     page_idx_fake = fake_compact(
         cutlass.Int32,
         (batch_size, 2, max_num_pages_per_seq_kv),
@@ -1553,16 +1647,7 @@ def _get_compiled_paged_context(
             options=_COMPILE_OPTIONS,
         )
     policy = (
-        (
-            "scheduler",
-            (
-                "clc_dynamic_persistent"
-                if paged_uses_clc
-                else "static_persistent"
-                if paged_is_persistent
-                else "nonpersistent"
-            ),
-        ),
+        ("scheduler", scheduler),
         ("pairing", "head" if head_paired else "query"),
         ("kv_layout", "paged_hnd"),
         ("page_size", page_size),
@@ -1799,7 +1884,7 @@ class BatchPrefillTSWrapper:
         # making plan publication atomic, this lets compute-sanitizer patch the
         # generated attention kernel without interleaving later PyTorch setup
         # launches with the DSL compiler/runtime callbacks.
-        compiled, policy = _get_compiled_context(*_semantic_key(geometry))
+        compiled, policy = _get_compiled_context(_context_compile_spec(geometry))
 
         # Publish only after validation, compilation, and allocation succeed.
         self._geometry = geometry
@@ -2007,7 +2092,9 @@ class BatchPrefillPagedTSWrapper:
 
         # Keep all runtime tensor allocation ahead of CUTLASS JIT, matching
         # BatchPrefillTSWrapper.plan and its compute-sanitizer ordering.
-        compiled, policy = _get_compiled_paged_context(*_paged_semantic_key(geometry))
+        compiled, policy = _get_compiled_paged_context(
+            _paged_context_compile_spec(geometry)
+        )
 
         # Publish only after validation, compilation, and allocation succeed.
         self._geometry = geometry

--- a/flashinfer/attention/prims_ts/decode.py
+++ b/flashinfer/attention/prims_ts/decode.py
@@ -96,12 +96,32 @@ class _DecodeWorkspaceViews:
 
 @dataclass(frozen=True)
 class _DecodeLaunchSpec:
-    """Automatic policy and scratch geometry for one semantic compile key."""
+    """Automatic policy and scratch geometry for one planned shape."""
 
     config: "FmhaDecodeConfig"
     max_active_clusters: int
     policy: tuple[tuple[str, object], ...]
     scratch_shapes: tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]
+
+
+@dataclass(frozen=True)
+class _DecodeCompileSpec:
+    """Batch-independent static identity for one compiled decode callable."""
+
+    device_index: int
+    config_items: tuple[tuple[str, object], ...]
+    num_qo_heads: int
+    num_kv_heads: int
+    head_dim: int
+    page_size: int
+    max_kv_len: int
+    seq_len_q: int
+    q_dtype_key: str
+    output_dtype_key: str
+    use_packed_q: bool
+    max_active_clusters: int
+    kv_prefix_mode: Literal["dynamic", "planned_full"]
+    kv_lengths_mode: Literal["dynamic", "planned_uniform_max"]
 
 
 @dataclass(frozen=True)
@@ -1026,6 +1046,49 @@ def _validate_out(
     _validate_16byte_alignment(out, "out")
 
 
+def _decode_scratch_shapes(
+    cfg: "FmhaDecodeConfig",
+    *,
+    batch_size,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    seq_len_q: int,
+):
+    """Return split-workspace shapes for a static config and batch extent."""
+
+    if not cfg.use_split_kv:
+        return (
+            (1, 1, 1, 1, 1),
+            (1, 1, 1, 1, 2),
+            (1, 1, 1),
+        )
+
+    from .kernels.fmha_decode.fmha_decode_config import make_q_tile_geometry
+
+    head_ratio = num_qo_heads // num_kv_heads
+    geometry = make_q_tile_geometry(
+        rows_per_cta=cfg.tile_size_q,
+        heads_q_per_kv=head_ratio,
+        groups_tokens_heads_q=cfg.groups_tokens_heads_q,
+    )
+    num_q_groups = max(int(geometry.num_q_ctas(seq_len_q)), 1)
+    partial_o_shape = (
+        batch_size,
+        num_kv_heads,
+        int(cfg.max_splits_kv),
+        head_ratio * seq_len_q,
+        head_dim,
+    )
+    partial_stats_shape = (
+        partial_o_shape[:-1]
+        if cfg.use_separate_reduction_kernel
+        else partial_o_shape[:-1] + (2,)
+    )
+    counter_shape = (batch_size, num_kv_heads, num_q_groups)
+    return partial_o_shape, partial_stats_shape, counter_shape
+
+
 def _decode_launch_spec_from_config(
     cfg: "FmhaDecodeConfig",
     *,
@@ -1038,41 +1101,20 @@ def _decode_launch_spec_from_config(
 ) -> _DecodeLaunchSpec:
     """Derive policy and scratch geometry from one finalized FMHA config."""
 
-    from .kernels.fmha_decode.fmha_decode_config import make_q_tile_geometry
-
-    head_ratio = num_qo_heads // num_kv_heads
-    geometry = make_q_tile_geometry(
-        rows_per_cta=cfg.tile_size_q,
-        heads_q_per_kv=head_ratio,
-        groups_tokens_heads_q=cfg.groups_tokens_heads_q,
+    scratch_shapes = _decode_scratch_shapes(
+        cfg,
+        batch_size=batch_size,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        seq_len_q=seq_len_q,
     )
-    num_q_groups = max(int(geometry.num_q_ctas(seq_len_q)), 1)
-    if cfg.use_split_kv:
-        q_output_rows = head_ratio * seq_len_q
-        partial_o_shape = (
-            batch_size,
-            num_kv_heads,
-            int(cfg.max_splits_kv),
-            q_output_rows,
-            head_dim,
-        )
-        partial_stats_shape = (
-            partial_o_shape[:-1]
-            if cfg.use_separate_reduction_kernel
-            else partial_o_shape[:-1] + (2,)
-        )
-        counter_shape = (batch_size, num_kv_heads, num_q_groups)
-    else:
-        # Uniform raw signatures keep minimal placeholders on direct paths.
-        partial_o_shape = (1, 1, 1, 1, 1)
-        partial_stats_shape = (1, 1, 1, 1, 2)
-        counter_shape = (1, 1, 1)
 
     return _DecodeLaunchSpec(
         config=cfg,
         max_active_clusters=int(max_active_clusters),
         policy=_decode_policy_from_config(cfg),
-        scratch_shapes=(partial_o_shape, partial_stats_shape, counter_shape),
+        scratch_shapes=scratch_shapes,
     )
 
 
@@ -1231,10 +1273,10 @@ def _resolve_decode_launch_spec(
     )
 
 
-@functools.cache
-def _get_compiled_decode(
+def _make_decode_compile_spec(
+    launch_spec: _DecodeLaunchSpec,
+    *,
     device_index: int,
-    batch_size: int,
     num_qo_heads: int,
     num_kv_heads: int,
     head_dim: int,
@@ -1242,16 +1284,50 @@ def _get_compiled_decode(
     max_kv_len: int,
     seq_len_q: int,
     q_dtype_key: str,
-    kv_dtype_key: str,
     output_dtype_key: str,
-    kv_layout: str,
-    mask_type: str,
     use_packed_q: bool,
-    window_left: int,
-    kv_prefix_mode: Literal["dynamic", "planned_full"] = "dynamic",
-    kv_lengths_mode: Literal["dynamic", "planned_uniform_max"] = "dynamic",
+    kv_prefix_mode: Literal["dynamic", "planned_full"],
+    kv_lengths_mode: Literal["dynamic", "planned_uniform_max"],
+) -> _DecodeCompileSpec:
+    """Freeze the resolved topology while leaving batch in runtime tensors."""
+
+    return _DecodeCompileSpec(
+        device_index=device_index,
+        config_items=launch_spec.config.compile_signature(),
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        max_kv_len=max_kv_len,
+        seq_len_q=seq_len_q,
+        q_dtype_key=q_dtype_key,
+        output_dtype_key=output_dtype_key,
+        use_packed_q=use_packed_q,
+        max_active_clusters=launch_spec.max_active_clusters,
+        kv_prefix_mode=kv_prefix_mode,
+        kv_lengths_mode=kv_lengths_mode,
+    )
+
+
+@functools.cache
+def _get_compiled_decode(
+    compile_spec: _DecodeCompileSpec,
 ):
-    """Compile and cache one exact semantic TS decode plan."""
+    """Compile and cache one batch-dynamic TS decode topology."""
+
+    device_index = compile_spec.device_index
+    num_qo_heads = compile_spec.num_qo_heads
+    num_kv_heads = compile_spec.num_kv_heads
+    head_dim = compile_spec.head_dim
+    page_size = compile_spec.page_size
+    max_kv_len = compile_spec.max_kv_len
+    seq_len_q = compile_spec.seq_len_q
+    q_dtype_key = compile_spec.q_dtype_key
+    output_dtype_key = compile_spec.output_dtype_key
+    use_packed_q = compile_spec.use_packed_q
+    max_active_clusters = compile_spec.max_active_clusters
+    kv_prefix_mode = compile_spec.kv_prefix_mode
+    kv_lengths_mode = compile_spec.kv_lengths_mode
 
     if kv_prefix_mode not in ("dynamic", "planned_full"):
         raise ValueError(f"unsupported KV-prefix compile mode {kv_prefix_mode!r}")
@@ -1274,33 +1350,14 @@ def _get_compiled_decode(
     }
     qkv_dtype = dtype_map[q_dtype_key]
     output_dtype = dtype_map[output_dtype_key]
-    spec = _resolve_decode_launch_spec(
-        device_index,
-        batch_size,
-        num_qo_heads,
-        num_kv_heads,
-        head_dim,
-        page_size,
-        max_kv_len,
-        seq_len_q,
-        q_dtype_key,
-        kv_dtype_key,
-        output_dtype_key,
-        kv_layout,
-        mask_type,
-        use_packed_q,
-        window_left,
-    )
-    cfg = spec.config
-    max_active_clusters = spec.max_active_clusters
-    partial_o_shape, partial_stats_shape, counter_shape = spec.scratch_shapes
+    cfg = FmhaDecodeConfig(**dict(compile_spec.config_items))
     partial_dtype = output_dtype
     if cfg.use_separate_reduction_kernel and output_dtype in (
         cutlass.BFloat16,
         cutlass.Float8E4M3FN,
     ):
         partial_dtype = cutlass.BFloat16
-    elif output_dtype == cutlass.Float8E4M3FN or partial_o_shape == (1, 1, 1, 1, 1):
+    elif output_dtype == cutlass.Float8E4M3FN or not cfg.use_split_kv:
         partial_dtype = cutlass.Float16
 
     Int32 = cutlass.Int32
@@ -1328,7 +1385,6 @@ def _get_compiled_decode(
         bmm2_scale: cutlass.Float32,
         stream: cuda_drv.CUstream,
         static_cfg: cutlass.Constexpr[FmhaDecodeConfig],
-        static_batch_size: cutlass.Constexpr[int],
         static_seq_len_q: cutlass.Constexpr[int],
         static_num_qo_heads: cutlass.Constexpr[int],
         static_num_kv_heads: cutlass.Constexpr[int],
@@ -1340,8 +1396,9 @@ def _get_compiled_decode(
     ) -> None:
         """Adapt TVM-FFI tensors to the raw native-CSR pointer launcher."""
 
+        batch_size = Int32(cute.size(seq_lens))
         q_offsets_iter = cu_seqlens_q.iterator
-        total_q_tokens = Int32(static_batch_size * static_seq_len_q)
+        total_q_tokens = batch_size * Int32(static_seq_len_q)
         if cutlass.const_expr(not static_cfg.use_variable_seqlens_q):
             # Fixed-Q is a distinct specialization. Keep a uniform TVM-FFI
             # wrapper signature, but pass a real null pointer to the kernel so
@@ -1352,7 +1409,7 @@ def _get_compiled_decode(
 
         fmha_decode_launch(
             (
-                Int32(static_batch_size),
+                batch_size,
                 Int32(static_num_qo_heads),
                 Int32(static_num_kv_heads),
                 Int32(static_max_kv_len),
@@ -1406,7 +1463,6 @@ def _get_compiled_decode(
             bmm2_scale: cutlass.Float32,
             stream: cuda_drv.CUstream,
             static_cfg: cutlass.Constexpr[FmhaDecodeConfig],
-            static_batch_size: cutlass.Constexpr[int],
             static_num_qo_heads: cutlass.Constexpr[int],
             static_num_kv_heads: cutlass.Constexpr[int],
             static_head_dim: cutlass.Constexpr[int],
@@ -1415,13 +1471,14 @@ def _get_compiled_decode(
         ) -> None:
             """Adapt TVM-FFI tensors to the raw standalone split reducer."""
 
+            batch_size = Int32(cute.size(seq_lens))
             q_offsets_iter = cu_seqlens_q.iterator
             if cutlass.const_expr(not static_cfg.use_variable_seqlens_q):
                 q_offsets_iter = cute.make_ptr(Int32, 0)
 
             fmha_decode_separate_reduction_launch(
                 (
-                    Int32(static_batch_size),
+                    batch_size,
                     Int32(static_num_qo_heads),
                     Int32(static_num_kv_heads),
                     Int32(static_max_kv_len),
@@ -1444,7 +1501,10 @@ def _get_compiled_decode(
     logical_pages = cute.sym_int()
     k_outer_stride = cute.sym_int64(divisibility=1)
     v_outer_stride = cute.sym_int64(divisibility=1)
+    batch_size = cute.sym_int()
     total_q_tokens = cute.sym_int()
+    runtime_num_q_offsets = cute.sym_int()
+    runtime_num_kv_offsets = cute.sym_int()
     q_shape = (
         (total_q_tokens, num_qo_heads, head_dim)
         if use_packed_q
@@ -1496,10 +1556,18 @@ def _get_compiled_decode(
 
     seq_lens_fake = fake_compact(Int32, (batch_size,), 4)
     cu_seqlens_q_fake = fake_compact(
-        Int32, (batch_size + 1,) if use_packed_q else (1,), 4
+        Int32, (runtime_num_q_offsets,) if use_packed_q else (1,), 4
     )
-    indptr_fake = fake_compact(Int32, (batch_size + 1,), 4)
+    indptr_fake = fake_compact(Int32, (runtime_num_kv_offsets,), 4)
     indices_fake = fake_compact(Int32, (logical_pages,), 4)
+    partial_o_shape, partial_stats_shape, counter_shape = _decode_scratch_shapes(
+        cfg,
+        batch_size=batch_size,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        seq_len_q=seq_len_q,
+    )
     partial_o_fake = fake_compact(partial_dtype, partial_o_shape, 16)
     partial_stats_fake = fake_compact(Float32, partial_stats_shape, 16)
     counter_fake = fake_compact(Int32, counter_shape, 4)
@@ -1528,7 +1596,6 @@ def _get_compiled_decode(
             Float32(1.0),
             stream_fake,
             cfg,
-            batch_size,
             seq_len_q,
             num_qo_heads,
             num_kv_heads,
@@ -1554,7 +1621,6 @@ def _get_compiled_decode(
                 Float32(1.0),
                 stream_fake,
                 cfg,
-                batch_size,
                 num_qo_heads,
                 num_kv_heads,
                 head_dim,
@@ -1563,11 +1629,7 @@ def _get_compiled_decode(
                 options=_COMPILE_OPTIONS,
             )
 
-    policy = spec.policy + (
-        ("kv_prefix_mode", kv_prefix_mode),
-        ("kv_lengths_mode", kv_lengths_mode),
-    )
-    return compiled_main, compiled_reducer, policy, spec.scratch_shapes
+    return compiled_main, compiled_reducer
 
 
 def get_prims_ts_batch_decode_workspace_size(
@@ -1591,13 +1653,13 @@ def get_prims_ts_batch_decode_workspace_size(
 ) -> int:
     """Return caller-workspace bytes for one automatic FMHA policy.
 
-    The arguments define the same semantic JIT key as
-    :func:`prims_ts_batch_decode_with_kv_cache`. The query resolves policy and
-    scratch layout but does not compile a kernel. Allocate at least the returned
-    number of bytes as a contiguous ``torch.int8`` or ``torch.uint8`` CUDA
-    tensor and zero it before its first FMHA launch. Re-zero a reused buffer
-    whenever an argument contributing to the semantic JIT key changes, because
-    the internal section offsets can change with that key. Fixed-Q launches use
+    The arguments resolve the same policy and scratch layout as
+    :func:`prims_ts_batch_decode_with_kv_cache`, without compiling a kernel.
+    Allocate at least the returned number of bytes as a contiguous
+    ``torch.int8`` or ``torch.uint8`` CUDA tensor and zero it before its first
+    FMHA launch. Re-zero a reused buffer whenever any workspace-layout input,
+    including ``batch_size``, changes because the internal section offsets can
+    move even when the compiled callable is reused. Fixed-Q launches use
     ``seq_len_q``. Packed-Q launches provide ``qo_indptr`` and the explicit
     static ``max_seq_len_q`` bound used for workspace geometry and JIT policy.
     ``max_seq_len`` must be no larger than ``2,147,483,392`` so the padded
@@ -1891,16 +1953,17 @@ def prims_ts_batch_decode_with_kv_cache(
     ``paged_kv_indices.numel()``; every live page ID must index ``kv_cache``.
 
     ``workspace_buffer`` must be zero-initialized before its first use and
-    re-zeroed whenever an argument contributing to the semantic JIT key changes,
-    because the internal section offsets can change with that key. It is exclusive
-    to one in-flight launch or captured graph and must not overlap query, K/V
+    re-zeroed whenever any workspace-layout input, including ``batch_size``,
+    changes because the internal section offsets can move even when the
+    compiled callable is reused. It is exclusive to one in-flight launch or
+    captured graph and must not overlap query, K/V
     cache, metadata, or output storage. Runtime sequence lengths must remain
     positive and no larger than ``max_seq_len``; this hot path
     deliberately does not read device metadata back to the host. Live CSR,
     length, page-ID, and packed-Q values may change between completed launches
     or graph replays only while all of their contracts remain valid. They must
     not be mutated concurrently with a launch or replay that reads them. Warm
-    the semantic key before CUDA graph capture and provide ``out`` to avoid an
+    the planned topology before CUDA graph capture and provide ``out`` to avoid an
     output allocation. Captured graphs must retain stable metadata storage;
     ``qo_indptr`` values may change only while the packed-offset contract
     remains valid, every delta stays within the compiled bound, and the final
@@ -1916,7 +1979,7 @@ def prims_ts_batch_decode_with_kv_cache(
     kv_cache : torch.Tensor or tuple[torch.Tensor, torch.Tensor]
         Combined or separate paged K/V storage.
     workspace_buffer : torch.Tensor
-        Zero-initialized caller-owned byte workspace for this semantic key.
+        Zero-initialized caller-owned byte workspace for this planned layout.
     paged_kv_indptr, paged_kv_indices : torch.Tensor
         Native CSR row offsets and physical page IDs.
     seq_lens : torch.Tensor
@@ -2001,7 +2064,7 @@ def prims_ts_batch_decode_with_kv_cache(
     _validate_dtype_pair(query.dtype, k_cache.dtype, output_dtype)
     device_index = _validate_runtime_device(query.device)
 
-    semantic_key = (
+    policy_args = (
         device_index,
         batch_size,
         num_qo_heads,
@@ -2018,7 +2081,7 @@ def prims_ts_batch_decode_with_kv_cache(
         use_packed_q,
         window_left,
     )
-    spec = _resolve_decode_launch_spec(*semantic_key)
+    spec = _resolve_decode_launch_spec(*policy_args)
     layout = _make_decode_workspace_layout(
         spec.scratch_shapes,
         output_dtype,
@@ -2070,11 +2133,22 @@ def prims_ts_batch_decode_with_kv_cache(
             paged_kv_last_page_len=None,
             workspace_buffer=workspace_buffer,
         )
-    compiled_main, compiled_reducer, _, scratch_shapes = _get_compiled_decode(
-        *semantic_key, "dynamic", "dynamic"
+    compile_spec = _make_decode_compile_spec(
+        spec,
+        device_index=device_index,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=head_dim,
+        page_size=page_size,
+        max_kv_len=max_seq_len,
+        seq_len_q=seq_len_q,
+        q_dtype_key=_dtype_key(query.dtype),
+        output_dtype_key=_dtype_key(output_dtype),
+        use_packed_q=use_packed_q,
+        kv_prefix_mode="dynamic",
+        kv_lengths_mode="dynamic",
     )
-    if scratch_shapes != spec.scratch_shapes:
-        raise RuntimeError("FMHA workspace policy changed during compilation")
+    compiled_main, compiled_reducer = _get_compiled_decode(compile_spec)
     workspace = _bind_decode_workspace(workspace_buffer, layout)
     return _launch_decode(
         runtime,
@@ -2278,7 +2352,7 @@ class BatchDecodePagedTSWrapper:
                 )
         exact_max_kv_len = _validate_max_kv_len(exact_max_kv_len, "max_kv_len")
 
-        semantic_key = (
+        policy_args = (
             device_index,
             batch_size,
             num_qo_heads,
@@ -2295,7 +2369,7 @@ class BatchDecodePagedTSWrapper:
             use_packed_q,
             window_left,
         )
-        spec = _resolve_decode_launch_spec(*semantic_key)
+        spec = _resolve_decode_launch_spec(*policy_args)
         static_full_split_prefix = _planned_full_split_prefix(
             spec.config,
             seq_lens_host,
@@ -2303,7 +2377,9 @@ class BatchDecodePagedTSWrapper:
             max_kv_len=exact_max_kv_len,
             mask_type=mask_type,
         )
-        kv_prefix_mode = "planned_full" if static_full_split_prefix else "dynamic"
+        kv_prefix_mode: Literal["dynamic", "planned_full"] = (
+            "planned_full" if static_full_split_prefix else "dynamic"
+        )
         # Keep native KV lengths explicit whenever the K domain ends in an
         # incomplete instruction group. The runtime validity predicate keeps
         # the inactive instance out of the softmax tail for both direct and
@@ -2332,11 +2408,28 @@ class BatchDecodePagedTSWrapper:
                 max_kv_len=exact_max_kv_len,
             )
         )
-        compiled_main, compiled_reducer, policy, scratch_shapes = _get_compiled_decode(
-            *semantic_key, kv_prefix_mode, kv_lengths_mode
+        compile_spec = _make_decode_compile_spec(
+            spec,
+            device_index=device_index,
+            num_qo_heads=num_qo_heads,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            page_size=page_size,
+            max_kv_len=exact_max_kv_len,
+            seq_len_q=seq_len_q,
+            q_dtype_key=_dtype_key(q_data_type),
+            output_dtype_key=_dtype_key(o_data_type),
+            use_packed_q=use_packed_q,
+            kv_prefix_mode=kv_prefix_mode,
+            kv_lengths_mode=kv_lengths_mode,
+        )
+        compiled_main, compiled_reducer = _get_compiled_decode(compile_spec)
+        policy = spec.policy + (
+            ("kv_prefix_mode", kv_prefix_mode),
+            ("kv_lengths_mode", kv_lengths_mode),
         )
         workspace_layout = _make_decode_workspace_layout(
-            scratch_shapes,
+            spec.scratch_shapes,
             o_data_type,
             use_separate_reduction_kernel=spec.config.use_separate_reduction_kernel,
         )

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
@@ -230,13 +230,14 @@ For the standalone workflow, call
 `get_prims_ts_batch_decode_workspace_size()` with the same shape, dtype, mask,
 window, and Q-layout arguments as the launch. Allocate at least that many
 bytes as a contiguous, 32-byte-aligned CUDA `torch.int8` or `torch.uint8`
-tensor. Zero it before first use and re-zero it whenever an argument that
-contributes to the semantic JIT key changes, because the internal workspace
-section offsets can change with that key. Do not share it between concurrent
-launches or captured graphs. It must not overlap Q, K/V cache, metadata, or
-output storage. The standalone hot path trusts CSR, `seq_lens`, and packed-Q
-values: keep lengths positive and within their static bounds, keep enough page
-entries in every CSR row for its live length, and keep all page IDs valid. CSR
+tensor. Zero it before first use and re-zero it whenever any workspace-layout
+input, including batch size, changes because the internal workspace section
+offsets can move even when the compiled callable is reused. Do not share it
+between concurrent launches or captured graphs. It must not overlap Q, K/V
+cache, metadata, or output storage. The standalone hot path trusts CSR,
+`seq_lens`, and packed-Q values: keep lengths positive and within their static
+bounds, keep enough page entries in every CSR row for its live length, and keep
+all page IDs valid. CSR
 offsets, sequence lengths, page IDs, and packed-Q offsets may change between
 completed launches or graph replays while preserving those contracts and
 stable captured storage. Do not mutate them concurrently with an execution

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -21,7 +21,7 @@ that should be set before kernel compilation.
 
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 
 import cutlass.utils as utils
 from cutlass import BFloat16, Float16, Float32, Float8E4M3FN
@@ -1317,6 +1317,20 @@ class FmhaDecodeConfig:
             or self.use_separate_reduction_kernel
         ):
             raise ValueError("block-sparse does not support split-KV reduction")
+
+    def compile_signature(self) -> tuple[tuple[str, object], ...]:
+        """Key and reconstruct the batch-dynamic callable in the decode cache.
+
+        The public planner can reuse one compiled topology across batch sizes.
+        Keeping the complete static config in the cache key prevents a callable
+        compiled for one scheduler, reduction, or tile layout from being reused
+        by another.
+        """
+
+        return tuple(
+            (config_field.name, getattr(self, config_field.name))
+            for config_field in fields(self)
+        )
 
     @property
     def uses_q_desc_ref(self) -> bool:

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/README.md
@@ -7,7 +7,7 @@ layout: every query/cache row contains a 512-element latent component followed
 by a 64-element RoPE component, while output contains the 512 latent values.
 
 FlashInfer selects the 1-CTA throughput/latency family or the 2-CTA throughput
-family automatically. Query grouping, persistent scheduling, split-KV, and
+family automatically. Flat-row tiling, persistent scheduling, split-KV, and
 local versus separate reduction are implementation decisions. Unsupported
 shape, dtype, or mask combinations raise an error rather than falling back to
 another backend.
@@ -39,9 +39,9 @@ carry the wrapper's plan-owned fixed-versus-packed query mode.
 | Output dimension | 512 |
 | Q/cache dtype | Matching `torch.bfloat16` or `torch.float8_e4m3fn` |
 | Output dtype | `torch.bfloat16` only |
-| Q length | Fixed or packed variable length; static maximum must be positive |
+| Q length | Fixed or packed variable length; packed requests may be empty, while the static maximum remains positive |
 | K/V length | Positive and at most `2**31 - 32768`; the reserve keeps the largest padded split-KV coordinate span in signed `int32` |
-| Q heads | Validated at 8, 16, 32, 64, and 128; other positive counts are accepted only when automatic selection reports an implementation |
+| Q heads | Validated at 6, 8, 12, 16, 24, 32, 48, 64, 96, and 128; other positive counts are accepted only when automatic selection reports an implementation |
 | K/V cache | Paged, one logical KV head; `[num_pages, page_size, 576]` or `[num_pages, 1, page_size, 576]` compact storage |
 | Metadata/cache index extents | Flattened query-head capacity, block-table elements, and physical page count must fit signed `int32` |
 | Page size | 16, 32, 64, or 128 tokens |
@@ -52,8 +52,8 @@ carry the wrapper's plan-owned fixed-versus-packed query mode.
 Current accuracy and performance signoff is on SM100a/B200. SM103a/B300 is
 admitted by the runtime architecture guard but remains to be qualified.
 
-Some head and Q-length combinations outside the validated power-of-two matrix
-do not have a generated implementation and are rejected.
+Some head and Q-length combinations outside the validated matrix do not have a
+generated implementation and are rejected.
 
 Query, cache, and output tensors must be compact, 16-byte-aligned CUDA tensors
 on the metadata device. `block_tables` and `seq_lens` are compact,
@@ -80,6 +80,21 @@ only. FP32 LSE is internal workspace and is not exposed as an output.
 - Runtime lengths: contiguous CUDA `int32[B]` `seq_lens`. Every length is
   positive and no larger than the static K/V bound.
 
+Internally, the query-token and query-head axes form one affine row space,
+`flat_row = query_idx * H + head_idx`. The 1-CTA profiles partition this space
+with physical M8/M16/M32/M64 tiles, while the 2-CTA family uses M128. Therefore
+the number of scheduled query tiles is `ceil(H * SQ / M)` and only the final
+physical tile can contain inactive rows. Public tensor shapes remain unchanged;
+valid physical rows map back to their logical `(query_idx, head_idx)` output
+coordinates.
+
+Split-KV workspaces intentionally retain rectangular physical geometry with
+`M * ceil(H * SQ / M)` rows. Producer stores and every reducer use the same
+mapping, and final-tile rows beyond `H * SQ` are predicated from public output.
+For packed Q, each request applies the same mapping to its runtime query length;
+rectangular tiles beyond a shorter request's active prefix retire scheduler
+bookkeeping without issuing Q/K/V or output accesses.
+
 For causal request `b`, query row `i` can attend through
 `seq_lens[b] - query_length[b] + i`. `bmm1_scale` and `bmm2_scale` default to
 1 and must be finite, positive Python scalars representable as positive
@@ -87,18 +102,20 @@ For causal request `b`, query row `i` can attend through
 
 Each `block_tables` row must contain at least
 `ceil(max_kv_len / page_size)` columns, and every page ID used by a runtime
-length must index the physical cache. Packed offsets start at zero, increase
-strictly, end at `total_q`, and have every per-request delta no greater than
-`max_seq_len_q`.
+length must index the physical cache. Packed offsets start at zero, are
+nondecreasing, end at `total_q`, and have every nonnegative per-request delta
+no greater than `max_seq_len_q`.
 
 The wrapper retains `block_tables`, `seq_lens`, and packed `qo_indptr` as live
 device inputs. Their storage must remain valid. Values may be changed in-place
 only while page IDs remain valid, K/V lengths stay positive and within the
-planned bound, packed-Q deltas stay positive and within their bound, and the
+planned bound, packed-Q deltas stay nonnegative and within their bound, and the
 final packed offset remains equal to the planned query/output extent. Causal
 metadata must also preserve `q_len[b] <= seq_lens[b]` for every request.
 For a packed wrapper plan, omitting `max_seq_len_q` makes `plan()` read the
-offsets once and use their largest delta as the bound. Every wrapper plan also
+offsets once and use their largest delta as the bound. An all-empty packed
+batch therefore requires an explicit positive `max_seq_len_q`; its launch
+returns an empty output without dispatching a GPU kernel. Every wrapper plan also
 reads `seq_lens` once, rejects nonpositive rows, and checks every row against
 the K/V bound. The standalone packed API requires an explicit bound and trusts
 the device-side values on each launch. Wrapper and standalone hot paths do not
@@ -123,8 +140,13 @@ and reduction topology automatically. CLC-persistent scheduling is used when
 the logical work benefits from reusing resident CTAs; callers do not select a
 scheduler or kernel family through the public wrappers.
 
+For a static split-KV 2-CTA launch, every reducer follows the same physical
+flat-row geometry. Padded M128 tails retain the compact logical-row reducer;
+fully populated layouts may use row-parallel or clustered reduction when their
+work and capacity bounds are satisfied.
+
 The BF16 2-CTA path enables CLC only when logical work exceeds one resident
-wave. Inactive Q groups, pruned split slots, and zero-visible-K tiles skip
+wave. Inactive physical Q tiles, pruned split slots, and zero-visible-K tiles skip
 their Q/K/V and TMEM data work and skip the active-tile throttle edge
 symmetrically. Every participating task still advances the work queue, so all
 tasks retire the same work-tile sequence. This matched progression is the
@@ -248,8 +270,9 @@ compact, 16-byte-aligned `out` tensor to avoid allocation.
 
 The public accuracy suite covers fixed and packed Q, `torch.bfloat16` and
 `torch.float8_e4m3fn` input, dense and causal masks, all four page sizes, both
-automatic kernel families, runtime K pruning, split-KV reduction,
-output/workspace contracts, and CUDA graphs:
+automatic kernel families, H6/H12/H24/H48/H96 flat-row cases, M128 tails,
+runtime K pruning, split-KV reduction, output/workspace contracts, and CUDA
+graphs:
 
 ```bash
 pytest -q tests/attention/test_attention_ts_mla_decode.py

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/helpers/constants.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/helpers/constants.py
@@ -92,6 +92,10 @@ CP_ASYNC_CACHE_CA = "ca"
 # outside the current kernel ABI.
 SUPPORTED_MLA_PAGE_SIZES = (16, 32, 64, 128)
 
+# Both MLA launch families and their standalone reducers share one fixed
+# workspace/scheduler split capacity.
+MAX_MLA_SPLITS_KV = 128
+
 # Throughput 2CTA epilogue maps 128 local threads onto two 64-row groups and
 # 128-column output halves for vectorized GMEM publication.
 EPILOGUE_THREAD_TILE_THREADS = 128

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/helpers/query.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/helpers/query.py
@@ -12,40 +12,63 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""groups_tokens_heads_q shape and row-mapping helpers for MLA decode."""
+"""Logical/physical query-row geometry helpers for MLA decode."""
+
+from dataclasses import dataclass
 
 import cutlass
 import cutlass.cute as cute
 from cutlass import Int32, Int64
 
 
-def groups_tokens_heads_q_capacity(logical_num_heads_q: int, tile_size_q: int) -> int:
-    """Return logical Q tokens grouped into one selected Q tile.
+@dataclass(frozen=True)
+class FlatQueryTileLayout:
+    """Host-side layout for consecutive ``(query, head)`` rows.
 
-    Capacity is a property of the selected tile and logical head count.  It is
-    intentionally independent of the runtime logical Q length so one compiled
-    layout has the same row geometry for short and long query sequences.
+    Query tokens and heads form one affine row space ordered as
+    ``flat_row = query_idx * logical_num_heads_q + head_idx``.  Physical MMA
+    tiles consume consecutive rows from that space, so only the final tile can
+    be partial.  ``tail_rows`` is in ``[1, tile_size_q]`` and equals
+    ``tile_size_q`` when the final tile is full.
+
+    Unlike the monolithic M128 helper, this generalized PrimTS layout permits
+    ``logical_num_heads_q > tile_size_q``.  That case is required by the M8,
+    M16, M32, and M64 1CTA profiles: a physical tile can cover part of one
+    token and the following tile continues at the next logical head row.
     """
 
-    if logical_num_heads_q <= 0:
-        raise ValueError("logical_num_heads_q must be positive")
-    if tile_size_q <= 0:
-        raise ValueError("tile_size_q must be positive")
-    return max(1, tile_size_q // logical_num_heads_q)
+    logical_num_heads_q: int
+    logical_seq_len_q: int
+    tile_size_q: int
+    total_rows: int
+    num_tiles: int
+    tail_rows: int
 
+    @classmethod
+    def for_tile(
+        cls,
+        logical_num_heads_q: int,
+        logical_seq_len_q: int,
+        tile_size_q: int,
+    ) -> "FlatQueryTileLayout":
+        if logical_num_heads_q <= 0:
+            raise ValueError("logical_num_heads_q must be positive")
+        if logical_seq_len_q <= 0:
+            raise ValueError("logical_seq_len_q must be positive")
+        if tile_size_q <= 0:
+            raise ValueError("tile_size_q must be positive")
 
-def groups_tokens_heads_q_group_count(
-    logical_seq_len_q: int, groups_tokens_heads_q_ratio: int
-) -> int:
-    """Return the ceil-divided number of effective query groups."""
-
-    if logical_seq_len_q <= 0:
-        raise ValueError("logical_seq_len_q must be positive")
-    if groups_tokens_heads_q_ratio <= 0:
-        raise ValueError("groups_tokens_heads_q_ratio must be positive")
-    return (
-        logical_seq_len_q + groups_tokens_heads_q_ratio - 1
-    ) // groups_tokens_heads_q_ratio
+        total_rows = logical_num_heads_q * logical_seq_len_q
+        num_tiles = (total_rows + tile_size_q - 1) // tile_size_q
+        tail_rows = total_rows - (num_tiles - 1) * tile_size_q
+        return cls(
+            logical_num_heads_q=logical_num_heads_q,
+            logical_seq_len_q=logical_seq_len_q,
+            tile_size_q=tile_size_q,
+            total_rows=total_rows,
+            num_tiles=num_tiles,
+            tail_rows=tail_rows,
+        )
 
 
 @cute.jit
@@ -69,39 +92,92 @@ def query_batch_bounds(
     return q_start, q_end - q_start
 
 
-def query_group_has_rows(
-    effective_seq_group_idx: int,
-    groups_tokens_heads_q_ratio: int,
-    logical_seq_len_q: int,
-) -> bool:
-    """Return whether an effective Q group contains a logical query row."""
-
-    if effective_seq_group_idx < 0:
-        raise ValueError("effective_seq_group_idx must be non-negative")
-    if groups_tokens_heads_q_ratio <= 0:
-        raise ValueError("groups_tokens_heads_q_ratio must be positive")
-    if logical_seq_len_q < 0:
-        raise ValueError("logical_seq_len_q must be non-negative")
-    return effective_seq_group_idx * groups_tokens_heads_q_ratio < logical_seq_len_q
-
-
 @cute.jit
-def runtime_query_group_has_rows(
-    effective_seq_group_idx,
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int],
+def runtime_flat_query_tile_valid_rows(
+    query_tile_idx,
+    tile_size_q: cutlass.Constexpr[int],
+    logical_num_heads_q: cutlass.Constexpr[int],
     logical_seq_len_q: cutlass.Constexpr[int],
     cu_seqlens_q=None,
     batch_idx=None,
 ):
-    """Return whether a runtime batch has data in an effective Q group."""
+    """Return the active row prefix of one physical flat-Q tile."""
 
     _, query_len = query_batch_bounds(
         cu_seqlens_q,
         batch_idx,
         logical_seq_len_q,
     )
+    remaining_rows = query_len * Int32(logical_num_heads_q) - Int32(
+        query_tile_idx
+    ) * Int32(tile_size_q)
+    return cute.math.max(
+        Int32(0),
+        cute.math.min(Int32(tile_size_q), remaining_rows),
+    )
+
+
+@cute.jit
+def runtime_flat_query_tile_has_rows(
+    query_tile_idx,
+    tile_size_q: cutlass.Constexpr[int],
+    logical_num_heads_q: cutlass.Constexpr[int],
+    logical_seq_len_q: cutlass.Constexpr[int],
+    cu_seqlens_q=None,
+    batch_idx=None,
+):
+    """Return whether one rectangular scheduler tile owns a logical Q row."""
+
+    return runtime_flat_query_tile_valid_rows(
+        query_tile_idx,
+        tile_size_q,
+        logical_num_heads_q,
+        logical_seq_len_q,
+        cu_seqlens_q,
+        batch_idx,
+    ) > Int32(0)
+
+
+@cute.jit
+def flat_query_row_state(
+    row_in_tile,
+    query_tile_idx,
+    tile_size_q: cutlass.Constexpr[int],
+    logical_num_heads_q: cutlass.Constexpr[int],
+    logical_seq_len_q: cutlass.Constexpr[int],
+    cu_seqlens_q=None,
+    batch_idx=None,
+):
+    """Map one physical flat-tile row to logical and public coordinates.
+
+    Returns ``(storage_flat_row, logical_head, safe_local_q, storage_q,
+    is_valid)``. Invalid final-tile rows receive safe control-flow coordinates
+    but remain predicated from every GMEM transaction by ``is_valid``.
+    """
+
+    local_flat_query_row = Int32(query_tile_idx) * Int32(tile_size_q) + Int32(
+        row_in_tile
+    )
+    logical_q_idx = local_flat_query_row // Int32(logical_num_heads_q)
+    logical_head_idx = local_flat_query_row - logical_q_idx * Int32(logical_num_heads_q)
+    q_start, q_len = query_batch_bounds(
+        cu_seqlens_q,
+        batch_idx,
+        logical_seq_len_q,
+    )
+    safe_q_len = cute.math.max(q_len, Int32(1))
+    safe_logical_q_idx = cute.math.min(logical_q_idx, safe_q_len - Int32(1))
+    storage_q_idx = q_start + safe_logical_q_idx
+    storage_flat_query_row = (
+        storage_q_idx * Int32(logical_num_heads_q) + logical_head_idx
+    )
+    is_valid = local_flat_query_row < q_len * Int32(logical_num_heads_q)
     return (
-        Int32(effective_seq_group_idx) * Int32(groups_tokens_heads_q_ratio) < query_len
+        storage_flat_query_row,
+        logical_head_idx,
+        safe_logical_q_idx,
+        storage_q_idx,
+        is_valid,
     )
 
 
@@ -130,34 +206,26 @@ def split_o_element_offset(
     split_idx,
     dim_idx,
 ):
-    """Return a partial-O offset without overflowing intermediate products.
+    """Return a batch-dynamic partial-O offset with 64-bit-safe products.
 
-    The workspace geometry is compile-time constant.  Keep the common, bounded
-    layouts in 32-bit arithmetic and widen the final element offset; use fully
-    widened arithmetic only when the flattened workspace can exceed ``Int32``.
+    Batch size is intentionally absent from the compile signature, so the
+    complete workspace extent cannot prove that every offset fits in Int32.
+    The within-batch layout is still compile-time constant, however. Keep that
+    common bounded part in 32-bit arithmetic and widen only the batch-stride
+    product. Use fully widened arithmetic when a profile's per-batch layout
+    alone exceeds Int32.
     """
 
-    if cutlass.const_expr(
-        cfg.batch_size
-        * cfg.seq_len_q
-        * cfg.num_heads_q
-        * cfg.num_ctas_per_seq_kv
-        * cfg.head_dim_v
-        <= (1 << 31) - 1
-    ):
-        return Int64(
-            batch_idx
-            * Int32(
-                cfg.seq_len_q
-                * cfg.num_heads_q
-                * cfg.num_ctas_per_seq_kv
-                * cfg.head_dim_v
-            )
-            + q_idx * Int32(cfg.num_heads_q * cfg.num_ctas_per_seq_kv * cfg.head_dim_v)
-            + head_idx * Int32(cfg.num_ctas_per_seq_kv * cfg.head_dim_v)
-            + split_idx * Int32(cfg.head_dim_v)
-            + dim_idx
-        )
+    elements_per_batch = (
+        cfg.seq_len_q * cfg.num_heads_q * cfg.num_ctas_per_seq_kv * cfg.head_dim_v
+    )
+    if cutlass.const_expr(elements_per_batch <= (1 << 31) - 1):
+        within_batch_offset = (
+            (Int32(q_idx) * Int32(cfg.num_heads_q) + Int32(head_idx))
+            * Int32(cfg.num_ctas_per_seq_kv)
+            + Int32(split_idx)
+        ) * Int32(cfg.head_dim_v) + Int32(dim_idx)
+        return Int64(batch_idx) * Int64(elements_per_batch) + Int64(within_batch_offset)
 
     return (
         (
@@ -168,57 +236,3 @@ def split_o_element_offset(
         * Int64(cfg.num_ctas_per_seq_kv)
         + Int64(split_idx)
     ) * Int64(cfg.head_dim_v) + Int64(dim_idx)
-
-
-@cute.jit
-def groups_tokens_heads_q_row_state(
-    effective_head_idx,
-    effective_seq_group_idx,
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int],
-    logical_num_heads_q: cutlass.Constexpr[int],
-    logical_seq_len_q: cutlass.Constexpr[int],
-    cu_seqlens_q=None,
-    batch_idx=None,
-):
-    """Map one effective groups_tokens_heads_q row to logical and storage coordinates.
-
-    Returns ``(storage_flat_row, logical_head, safe_local_q, storage_q,
-    is_valid)``.  In variable-length mode, storage coordinates include the
-    cumulative batch offset while causal coordinates stay batch-local.  The
-    local Q index is clamped to the final real query row so padded rows can
-    safely participate in K scheduling and synchronization.  ``is_valid``
-    predicates public and GMEM-partial output stores.  cluster-local staging may
-    retain padded rows so all participants synchronize uniformly.
-    """
-
-    effective_num_heads_q = Int32(logical_num_heads_q * groups_tokens_heads_q_ratio)
-    local_flat_query_row = Int32(
-        effective_seq_group_idx
-    ) * effective_num_heads_q + Int32(effective_head_idx)
-    logical_q_idx = local_flat_query_row // Int32(logical_num_heads_q)
-    logical_head_idx = local_flat_query_row - logical_q_idx * Int32(logical_num_heads_q)
-    q_start, q_len = query_batch_bounds(
-        cu_seqlens_q,
-        batch_idx,
-        logical_seq_len_q,
-    )
-    # Keep invalid padded rows on a valid local coordinate for control-flow
-    # and synchronization.  Their GMEM loads/stores are independently made
-    # OOB/predicated by the resource that owns the transaction.
-    safe_q_len = cute.math.max(q_len, Int32(1))
-    safe_logical_q_idx = cute.math.min(
-        logical_q_idx,
-        safe_q_len - Int32(1),
-    )
-    storage_q_idx = q_start + safe_logical_q_idx
-    storage_flat_query_row = (
-        storage_q_idx * Int32(logical_num_heads_q) + logical_head_idx
-    )
-    is_valid = logical_q_idx < q_len
-    return (
-        storage_flat_query_row,
-        logical_head_idx,
-        safe_logical_q_idx,
-        storage_q_idx,
-        is_valid,
-    )

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/helpers/tile.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/helpers/tile.py
@@ -23,9 +23,9 @@ from cutlass.experimental.task_scheduling.resources import StageInfo
 from .layout import _TASK_CACHE_SEQ_LEN_KV
 from .mask import MaskType, mask_visible_k_length
 from .query import (
-    groups_tokens_heads_q_row_state,
+    flat_query_row_state,
     query_batch_bounds,
-    runtime_query_group_has_rows,
+    runtime_flat_query_tile_has_rows,
 )
 from .stage import MlaStage
 from ..throughput_latency_1cta.config import MlaConfig
@@ -181,18 +181,18 @@ def runtime_seq_len_kv_for_q(
     cta_idx_q,
     cu_seqlens_q=None,
 ):
-    """Return the KV domain shared by groups_tokens_heads_q rows in a CTA.
+    """Return the KV domain shared by flat query rows in a CTA.
 
-    The last effective row has the largest causal domain. Grouped causal
-    softmax applies the remaining row-specific mask; all other modes can use
+    The last physical row has the largest causal domain. Row-causal softmax
+    applies the remaining row-specific mask; all other modes can use
     this CTA-visible length with the ordinary dense tail predicate.
     """
     if cutlass.const_expr(cfg.mask_type == MaskType.DENSE.value):
         return runtime_base_seq_len_kv(cfg, cache_seqs, batch_idx)
-    _, _, logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-        Int32(cfg.num_heads_q - 1),
+    _, _, logical_q_idx, _, _ = flat_query_row_state(
+        Int32(cfg.tile_size_q - 1),
         cta_idx_q,
-        cfg.groups_tokens_heads_q_ratio,
+        cfg.tile_size_q,
         cfg.logical_num_heads_q,
         cfg.logical_seq_len_q,
         cu_seqlens_q,
@@ -218,9 +218,10 @@ def runtime_query_tile_is_active(
 
     query_is_active = cutlass.Boolean(True)
     if cutlass.const_expr(cu_seqlens_q is not None):
-        query_is_active = runtime_query_group_has_rows(
+        query_is_active = runtime_flat_query_tile_has_rows(
             cta_idx_q,
-            cfg.groups_tokens_heads_q_ratio,
+            cfg.tile_size_q,
+            cfg.logical_num_heads_q,
             cfg.logical_seq_len_q,
             cu_seqlens_q,
             batch_idx,
@@ -300,19 +301,19 @@ def runtime_work_tile_is_active(
 
 
 @cute.jit
-def runtime_seq_len_kv_for_effective_head(
+def runtime_seq_len_kv_for_query_row(
     cfg: MlaConfig,
     cache_seqs,
     batch_idx,
     cta_idx_q,
-    effective_head_idx,
+    row_in_tile,
     cu_seqlens_q=None,
 ):
-    """Return the KV length visible to one groups_tokens_heads_q row."""
-    _, _, logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-        effective_head_idx,
+    """Return the KV length visible to one physical flat-query row."""
+    _, _, logical_q_idx, _, _ = flat_query_row_state(
+        row_in_tile,
         cta_idx_q,
-        cfg.groups_tokens_heads_q_ratio,
+        cfg.tile_size_q,
         cfg.logical_num_heads_q,
         cfg.logical_seq_len_q,
         cu_seqlens_q,
@@ -344,10 +345,10 @@ def runtime_seq_len_kv_from_task_cache(
         batch_idx,
         cfg.logical_seq_len_q,
     )
-    _, _, logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-        Int32(cfg.num_heads_q - 1),
+    _, _, logical_q_idx, _, _ = flat_query_row_state(
+        Int32(cfg.tile_size_q - 1),
         cta_idx_q,
-        cfg.groups_tokens_heads_q_ratio,
+        cfg.tile_size_q,
         cfg.logical_num_heads_q,
         cfg.logical_seq_len_q,
         cu_seqlens_q,

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/kernel_policy.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/kernel_policy.py
@@ -32,13 +32,12 @@ from ``make_throughput_latency_mla_config``.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, TypedDict, cast
-
-from typing_extensions import Unpack
+from typing import Literal, cast
 
 from .helpers.constants import SUPPORTED_MLA_PAGE_SIZES
 from .throughput_latency_1cta.config import (
     MlaConfig,
+    SUPPORTED_TILE_SIZE_Q,
     enumerate_throughput_latency_mla_profiles,
     make_throughput_latency_mla_config,
     tile_size_q_from_profile_name,
@@ -50,16 +49,6 @@ MlaKernelPolicy = Literal["throughput_2cta", "throughput_latency_1cta"]
 
 MlaKernelName = MlaKernelPolicy
 """Concrete TS MLA kernel family selected for a launch."""
-
-
-class _AutomaticMlaWork(TypedDict, total=False):
-    """Optional occupancy inputs accepted by automatic family selection."""
-
-    one_cta_work: int | None
-    one_cta_capacity: int | None
-    two_cta_cluster_work: int | None
-    two_cta_cluster_capacity: int | None
-    one_cta_is_extended_fp8_swaps: bool
 
 
 @dataclass(frozen=True)
@@ -101,59 +90,27 @@ def select_default_mla_kernel_policy(
     num_heads: int,
     seq_len_q: int,
     *,
-    one_cta_work: int | None = None,
-    one_cta_capacity: int | None = None,
-    two_cta_cluster_work: int | None = None,
-    two_cta_cluster_capacity: int | None = None,
-    one_cta_is_extended_fp8_swaps: bool = False,
+    one_cta_split_kv: int | None = None,
+    two_cta_split_kv: int | None = None,
 ) -> MlaKernelPolicy:
-    """Choose the default TS MLA family from work and resident capacity.
+    """Choose a native family, preferring direct output over split reduction.
 
-    Logical Q rows up to 64 retain the throughput-latency family.  Larger
-    shapes normally retain 2CTA, but an automatic caller may provide projected
-    work for both candidates.  The established probe requires the complete
-    2CTA launch to occupy at most one quarter of its resident cluster wave and
-    the 1CTA candidate to improve normalized occupancy.  A separately bounded
-    FP8 Q16 Swaps probe may use the whole 2CTA wave and accept equal normalized
-    occupancy: its caller has already proved a two-step local K bound, and the
-    1CTA schedule avoids 2CTA coordination at equal service-unit fill.  No
-    shape or device-name whitelist participates in either decision.
+    The M64 1CTA schedule owns one native tile of logical query rows. Within
+    that tile, 2CTA is selected only when it can write the final output directly
+    while 1CTA would require a split-K reduction. This compares task-graph
+    structure; it does not contain shape, dtype, or measured crossover tables.
     """
 
-    # Above 64 logical token-head rows, the 2CTA M128 schedule has enough Q work
-    # to amortize the extra CTA and reduction coordination.  Smaller rows prefer
-    # the 1CTA throughput-latency schedule.
-    if num_heads * seq_len_q <= 64:
-        return "throughput_latency_1cta"
+    if (one_cta_split_kv is None) != (two_cta_split_kv is None):
+        raise ValueError("automatic MLA split topology must be provided as a pair")
+    if one_cta_split_kv is not None:
+        if one_cta_split_kv <= 0 or two_cta_split_kv is None or two_cta_split_kv <= 0:
+            raise ValueError("automatic MLA split counts must be positive")
 
-    occupancy_inputs = (
-        one_cta_work,
-        one_cta_capacity,
-        two_cta_cluster_work,
-        two_cta_cluster_capacity,
-    )
-    if any(value is None for value in occupancy_inputs):
-        return "throughput_2cta"
-    if any(int(value) <= 0 for value in occupancy_inputs):
-        raise ValueError("automatic MLA family work and capacities must be positive")
-
-    assert one_cta_work is not None
-    assert one_cta_capacity is not None
-    assert two_cta_cluster_work is not None
-    assert two_cta_cluster_capacity is not None
-    if one_cta_is_extended_fp8_swaps:
-        two_cta_underfilled = two_cta_cluster_work <= two_cta_cluster_capacity
-        one_cta_has_more_occupancy = (
-            one_cta_work * two_cta_cluster_capacity
-            >= two_cta_cluster_work * one_cta_capacity
-        )
-    else:
-        two_cta_underfilled = two_cta_cluster_work * 4 <= two_cta_cluster_capacity
-        one_cta_has_more_occupancy = (
-            one_cta_work * two_cta_cluster_capacity
-            > two_cta_cluster_work * one_cta_capacity
-        )
-    if two_cta_underfilled and one_cta_has_more_occupancy:
+    if num_heads * seq_len_q <= max(SUPPORTED_TILE_SIZE_Q):
+        if one_cta_split_kv is not None:
+            if one_cta_split_kv > 1 and two_cta_split_kv == 1:
+                return "throughput_2cta"
         return "throughput_latency_1cta"
     return "throughput_2cta"
 
@@ -162,7 +119,9 @@ def resolve_mla_kernel_policy(
     policy: str | None,
     num_heads: int,
     seq_len_q: int,
-    **automatic_work: Unpack[_AutomaticMlaWork],
+    *,
+    one_cta_split_kv: int | None = None,
+    two_cta_split_kv: int | None = None,
 ) -> tuple[MlaKernelPolicy, str]:
     """Resolve an explicit or automatic TS MLA kernel policy."""
 
@@ -171,7 +130,8 @@ def resolve_mla_kernel_policy(
             select_default_mla_kernel_policy(
                 num_heads,
                 seq_len_q,
-                **automatic_work,
+                one_cta_split_kv=one_cta_split_kv,
+                two_cta_split_kv=two_cta_split_kv,
             ),
             "auto",
         )

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/parallel_reduction_topology.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/parallel_reduction_topology.py
@@ -18,8 +18,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .helpers.constants import MAX_MLA_SPLITS_KV
 
-_MAX_SPLITS_KV = 128
 _TARGET_SPLITS_PER_RANK = 8
 _PARALLEL_REDUCER_MIN_SPLITS_PER_RANK = 32
 _PARALLEL_REDUCER_MAX_CLUSTER_WAVES = 4
@@ -31,6 +31,43 @@ _OUTPUT_ELEMENTS_PER_WORK_UNIT = 1024
 _MAX_PARTIAL_O_WORKSPACE_ELEMENTS = 2**31 - 1
 
 
+def should_use_q128_g1_parallel_reducer(
+    *,
+    batch_size: int,
+    physical_rows_per_batch: int,
+    producer_ctas: int,
+    reference_rows_per_cta: int,
+    physical_sm_count: int,
+) -> bool:
+    """Prefer one-row G1 only for an underfilled reference launch.
+
+    The Q128 reference reducer coarsens several rows into one CTA.  That is
+    efficient once it fills the machine, but a sub-wave launch leaves most SMs
+    idle.  The one-row G1 reducer is useful only when the producer supplies at
+    least half a physical-SM wave of split work and its expanded row grid
+    remains within the same four-wave pressure bound used by the clustered
+    Q128 topology.  These occupancy bounds avoid a per-shape dispatch table.
+    """
+
+    _validate_positive_int(batch_size, "batch_size")
+    _validate_positive_int(physical_rows_per_batch, "physical_rows_per_batch")
+    _validate_positive_int(producer_ctas, "producer_ctas")
+    _validate_positive_int(reference_rows_per_cta, "reference_rows_per_cta")
+    _validate_positive_int(physical_sm_count, "physical_sm_count")
+
+    reference_ctas = (
+        batch_size
+        * (physical_rows_per_batch + reference_rows_per_cta - 1)
+        // reference_rows_per_cta
+    )
+    parallel_ctas = batch_size * physical_rows_per_batch
+    return (
+        reference_ctas < physical_sm_count
+        and producer_ctas >= (physical_sm_count + 1) // 2
+        and parallel_ctas <= physical_sm_count * _PARALLEL_REDUCER_MAX_CLUSTER_WAVES
+    )
+
+
 def _next_power_of_two(value: int) -> int:
     return 1 << (value - 1).bit_length()
 
@@ -38,8 +75,8 @@ def _next_power_of_two(value: int) -> int:
 def _validate_splits_kv(splits_kv: int) -> None:
     if isinstance(splits_kv, bool) or not isinstance(splits_kv, int):
         raise TypeError("splits_kv must be an integer")
-    if not 1 <= splits_kv <= _MAX_SPLITS_KV:
-        raise ValueError(f"splits_kv must be in [1, {_MAX_SPLITS_KV}]")
+    if not 1 <= splits_kv <= MAX_MLA_SPLITS_KV:
+        raise ValueError(f"splits_kv must be in [1, {MAX_MLA_SPLITS_KV}]")
 
 
 def _validate_positive_int(value: int, name: str) -> None:

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/config.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/config.py
@@ -14,24 +14,19 @@
 
 """Configuration for the throughput 2CTA MLA decode TS kernel.
 
-The throughput 2CTA policy uses a 2CTA M128 schedule. BF16 is the public
-throughput path; dtype traits are explicit so FP8 bring-up can share the same
-configuration structure once its 2CTA V/PV layout is complete.
+The throughput 2CTA policy uses a 2CTA M128 schedule. BF16 and FP8 inputs share
+the same explicit configuration structure and output-reduction contract.
 """
 
 from dataclasses import dataclass
 from typing import Tuple
 
-from ..helpers.constants import SUPPORTED_MLA_PAGE_SIZES
+from ..helpers.constants import MAX_MLA_SPLITS_KV, SUPPORTED_MLA_PAGE_SIZES
 from ..helpers.mask import MaskType, normalize_mask_type
 
 
 # Softmax converts natural-scale scores to exp2 with log2(e).
 LOG2_E = 1.4426950408889634074
-
-# Split-KV reduction allocates one LSE slot per possible split.  Match the
-# standalone reducer's qualified workspace and launch capacity.
-MAX_SPLITS = 128
 
 # The separate reducer follows the public MLA output contract: partial O is
 # stored as BF16 while LSE and the final accumulation remain FP32.  One
@@ -66,7 +61,7 @@ def ceil_div(a: int, b: int) -> int:
 def compute_split_kv(
     *,
     batch_size: int,
-    seq_len_q: int,
+    num_q_tiles: int,
     seq_len_kv: int,
     mma_qk_tiler_mn: Tuple[int, int] = (128, 128),
     max_active_blocks: int,
@@ -80,8 +75,8 @@ def compute_split_kv(
 
     if batch_size <= 0:
         raise ValueError(f"batch_size must be positive, got {batch_size}")
-    if seq_len_q <= 0:
-        raise ValueError(f"seq_len_q must be positive, got {seq_len_q}")
+    if num_q_tiles <= 0:
+        raise ValueError(f"num_q_tiles must be positive, got {num_q_tiles}")
     if seq_len_kv <= 0:
         raise ValueError(f"seq_len_kv must be positive, got {seq_len_kv}")
     if max_active_blocks <= 0:
@@ -92,30 +87,32 @@ def compute_split_kv(
         )
 
     max_splits = ceil_div(seq_len_kv, mma_qk_tiler_mn[1])
-    blocks_per_batch = max(1, max_active_blocks // batch_size // (seq_len_q * 2))
+    blocks_per_batch = max(1, max_active_blocks // batch_size // (num_q_tiles * 2))
     split_heur = min(max_splits, blocks_per_batch)
     k_waves = ceil_div(max_splits, split_heur)
     split_wave_aware = ceil_div(max_splits, k_waves)
-    # The 2CTA reduction workspace supports more split slots, but the automatic
-    # scheduler caps launch-time splits at 32 to avoid excessive reduction work.
-    return min(split_wave_aware, 32)
+    return min(split_wave_aware, MAX_MLA_SPLITS_KV)
 
 
 def compute_workspace_size(
     *,
-    num_heads: int,
-    seq_len_q: int,
+    tile_size_q: int,
+    num_q_tiles: int,
     latent_dim: int,
     batch_size: int,
     split_kv: int,
     partial_o_dtype,
     lse_dtype,
 ) -> int:
-    """Return mixed-dtype MLA split-KV workspace size in bytes."""
+    """Return the physical flat-tile split-KV workspace size in bytes."""
 
     if split_kv == 1:
         return 0
-    partial_rows = batch_size * num_heads * seq_len_q * split_kv
+    if tile_size_q <= 0:
+        raise ValueError(f"tile_size_q must be positive, got {tile_size_q}")
+    if num_q_tiles <= 0:
+        raise ValueError(f"num_q_tiles must be positive, got {num_q_tiles}")
+    partial_rows = batch_size * tile_size_q * num_q_tiles * split_kv
     return partial_rows * (
         latent_dim * partial_o_dtype.width // 8 + lse_dtype.width // 8
     )

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/kernel.py
@@ -51,21 +51,19 @@ from ...tensor_map import (
 
 from .config import (
     LOG2_E,
-    MAX_SPLITS,
     REDUCTION_ROWS_PER_CTA,
-    REDUCTION_THREADS_PER_CTA,
+    REDUCTION_THREADS_PER_ROW,
     V_TMA_LATENT_ELEMENTS,
     MlaDecodeConfig,
     make_mla_decode_config,
 )
-from ..helpers.constants import TMEM_DEALLOC_MBAR_THREADS
+from ..helpers.constants import MAX_MLA_SPLITS_KV, TMEM_DEALLOC_MBAR_THREADS
 from ..helpers.mask import MaskType, mask_visible_k_length, normalize_mask_type
 from ..helpers.query import (
-    groups_tokens_heads_q_capacity,
-    groups_tokens_heads_q_group_count,
-    groups_tokens_heads_q_row_state,
+    FlatQueryTileLayout,
+    flat_query_row_state,
     query_batch_bounds,
-    runtime_query_group_has_rows,
+    runtime_flat_query_tile_has_rows,
 )
 from .work_partition import (
     runtime_split_kv_cap,
@@ -89,6 +87,7 @@ from ..helpers.math import qkv_dtype
 from ..parallel_reduction_topology import (
     ParallelReductionTopology,
     make_q128_wave_limited_parallel_reduction_topology,
+    should_use_q128_g1_parallel_reducer,
     validate_parallel_reduction_workspace,
 )
 from .parallel_reduction import (
@@ -157,7 +156,6 @@ def build_mla_decode_task_manager(
     cache_seqs=None,
     cu_seqlens_q=None,
     split_kv=None,
-    groups_tokens_heads_ratio=1,
     logical_num_heads_q=128,
     logical_seq_len_q=1,
     tiled_mma_qk=None,
@@ -344,7 +342,6 @@ def build_mla_decode_task_manager(
         tma_desc_q_latent=tma_desc_q_latent,
         tma_desc_q_rope=tma_desc_q_rope,
         cu_seqlens_q=cu_seqlens_q,
-        groups_tokens_heads_q_ratio=groups_tokens_heads_ratio,
         logical_num_heads_q=logical_num_heads_q,
         logical_seq_len_q=logical_seq_len_q,
         cfg=cfg,
@@ -395,7 +392,6 @@ def build_mla_decode_task_manager(
         cache_seqs=cache_seqs,
         cu_seqlens_q=cu_seqlens_q,
         split_kv=split_kv,
-        groups_tokens_heads_q_ratio=groups_tokens_heads_ratio,
         logical_num_heads_q=logical_num_heads_q,
         logical_seq_len_q=logical_seq_len_q,
         tiled_mma_qk=tiled_mma_qk,
@@ -437,7 +433,6 @@ def build_mla_decode_task_manager(
         smem_exchange=None,  # set at runtime
         split_kv=None,  # set at runtime
         cu_seqlens_q=cu_seqlens_q,
-        groups_tokens_heads_q_ratio=groups_tokens_heads_ratio,
         logical_num_heads_q=logical_num_heads_q,
         logical_seq_len_q=logical_seq_len_q,
         name="gmem_o",
@@ -723,7 +718,6 @@ class MlaDecodeTs:
         qkv_dtype="bf16",
         out_dtype="bf16",
         rope_dim=64,
-        groups_tokens_heads=False,
         num_heads=128,
         seq_len_q=1,
         batch_size=1,
@@ -765,13 +759,10 @@ class MlaDecodeTs:
             Output dtype name.
         rope_dim : int, optional
             RoPE head dimension.
-        groups_tokens_heads : bool, optional
-            Accepted launch hint. Eligible speculative-decode shapes group
-            tokens and Q heads automatically from ``num_heads`` and the M tile.
         num_heads : int, optional
-            Logical query-head count used to derive groups_tokens_heads_q capacity.
+            Logical query-head count used to derive the flat-row tile count.
         seq_len_q : int, optional
-            Logical query length used to derive the effective grouped shape.
+            Logical query length used to derive the flat-row tile count.
         batch_size : int, optional
             Host-known batch size used to qualify the standalone reducer
             topology.
@@ -797,10 +788,10 @@ class MlaDecodeTs:
         self.is_var_split_kv = is_var_split_kv
         self.static_split_kv = static_split_kv
         self.reduction_split_capacity = (
-            static_split_kv if static_split_kv is not None else MAX_SPLITS
+            static_split_kv if static_split_kv is not None else MAX_MLA_SPLITS_KV
         )
-        if not 1 <= self.reduction_split_capacity <= MAX_SPLITS:
-            raise ValueError(f"static_split_kv must be in [1, {MAX_SPLITS}]")
+        if not 1 <= self.reduction_split_capacity <= MAX_MLA_SPLITS_KV:
+            raise ValueError(f"static_split_kv must be in [1, {MAX_MLA_SPLITS_KV}]")
         self.static_seq_len_k = static_seq_len_k
         self.qkv_dtype = qkv_dtype
         self.out_dtype = out_dtype
@@ -813,19 +804,17 @@ class MlaDecodeTs:
             raise ValueError("batch_size must be positive")
         self.batch_size = batch_size
         self.mask_type = normalize_mask_type(mask_type)
-        self.groups_tokens_heads_ratio = self.compute_groups_tokens_heads_ratio(
+        self.query_tile_layout = FlatQueryTileLayout.for_tile(
             num_heads, seq_len_q, mma_qk_tiler_mn[0]
         )
-        self.groups_tokens_heads = self.groups_tokens_heads_ratio > 1
+        self.num_q_tiles = self.query_tile_layout.num_tiles
+        self.tail_q_rows = self.query_tile_layout.tail_rows
         self.parallel_reduction_topology: ParallelReductionTopology | None = None
         self.use_parallel_reduction = False
         self._parallel_reduction_shape_is_eligible = (
             not is_var_split_kv
             and static_split_kv is not None
-            # Keep FlashInfer's qualified 512-thread/eight-row reducer for the
-            # normal S<=32 domain.  Split-parallel CTA clusters become useful
-            # only beyond that envelope and are selected automatically.
-            and 32 < static_split_kv <= 128
+            and 2 <= static_split_kv <= 128
             and mma_qk_tiler_mn[0] == 128
             and acc_dtype == _cutlass.Float32
             and lse_dtype == _cutlass.Float32
@@ -834,30 +823,54 @@ class MlaDecodeTs:
         self._configure_parallel_reduction_topology()
 
     def _effective_reduction_shape(self) -> tuple[int, int]:
-        """Return the grouped head and Q extents used by the workspace."""
+        """Return physical row/tile extents used by the split workspace."""
 
-        effective_num_heads = self.num_heads * self.groups_tokens_heads_ratio
-        effective_seq_len_q = groups_tokens_heads_q_group_count(
+        return self.mma_qk_tiler_mn[0], self.num_q_tiles
+
+    def compile_signature(self) -> tuple[object, ...]:
+        """Return the complete batch-independent JIT identity."""
+
+        return (
+            self.acc_dtype,
+            self.lse_dtype,
+            self.mma_qk_tiler_mn,
+            self.mma_pv_tiler_mn,
+            self.max_active_clusters,
+            self.page_size,
+            self.is_persistent,
+            self.is_var_seq,
+            self.is_var_split_kv,
+            self.static_split_kv,
+            self.static_seq_len_k,
+            self.qkv_dtype,
+            self.out_dtype,
+            self.rope_dim,
+            self.num_heads,
             self.seq_len_q,
-            self.groups_tokens_heads_ratio,
+            self.mask_type,
+            self.reduction_split_capacity,
+            self.query_tile_layout,
+            self.num_q_tiles,
+            self.tail_q_rows,
+            self._parallel_reduction_shape_is_eligible,
+            self.use_parallel_reduction,
+            self.parallel_reduction_topology,
         )
-        return effective_num_heads, effective_seq_len_q
 
     def _configure_parallel_reduction_topology(self) -> None:
         """Refresh reducer topology after any host-side launch-shape update."""
 
         self.parallel_reduction_topology = None
         self.use_parallel_reduction = False
-        effective_num_heads, effective_seq_len_q = self._effective_reduction_shape()
+        physical_tile_rows, num_query_tiles = self._effective_reduction_shape()
 
-        # The established reducer shares this normalized partial workspace.
-        # Validate its full configured capacity too, not only the clustered
-        # implementation selected for high split counts.
+        # Every reducer shares this normalized partial workspace. Validate its
+        # full configured capacity, not only high-split clustered launches.
         if self.reduction_split_capacity > 1:
             validate_parallel_reduction_workspace(
                 batch_size=self.batch_size,
-                num_heads_q=effective_num_heads,
-                seq_len_q=effective_seq_len_q,
+                num_heads_q=physical_tile_rows,
+                seq_len_q=num_query_tiles,
                 splits_kv=self.reduction_split_capacity,
                 head_dim=PARALLEL_REDUCTION_HEAD_DIM,
             )
@@ -867,143 +880,40 @@ class MlaDecodeTs:
         assert self.static_split_kv is not None
         topology = make_q128_wave_limited_parallel_reduction_topology(
             self.static_split_kv,
-            logical_rows=(effective_num_heads * effective_seq_len_q * self.batch_size),
+            logical_rows=(self.num_heads * self.seq_len_q * self.batch_size),
             physical_sm_count=self.max_active_clusters * 2,
             max_cluster_size=8,
         )
-        # G1 has no split-rank parallelism and is intentionally handled by the
-        # existing FlashInfer multi-row reducer.
-        if topology is not None and topology.cluster_size > 1:
+        parallel_g1_grid_has_no_padded_rows = (
+            self.query_tile_layout.total_rows == physical_tile_rows * num_query_tiles
+        )
+        # Small split counts use G1 only when row coarsening leaves a sub-wave
+        # grid and the producer generated enough work to amortize one CTA per
+        # physical row. Padded M128 tails and intermediate split counts retain
+        # the compact reference grid; high split counts may use clusters.
+        use_small_split_g1 = (
+            self.static_split_kv <= 16
+            and topology is not None
+            and topology.cluster_size == 1
+            and parallel_g1_grid_has_no_padded_rows
+            and should_use_q128_g1_parallel_reducer(
+                batch_size=self.batch_size,
+                physical_rows_per_batch=(physical_tile_rows * num_query_tiles),
+                producer_ctas=(
+                    self.batch_size * num_query_tiles * self.static_split_kv * 2
+                ),
+                reference_rows_per_cta=REDUCTION_ROWS_PER_CTA,
+                physical_sm_count=self.max_active_clusters * 2,
+            )
+        )
+        use_high_split_cluster = (
+            self.static_split_kv > 32
+            and topology is not None
+            and topology.cluster_size > 1
+        )
+        if use_small_split_g1 or use_high_split_cluster:
             self.parallel_reduction_topology = topology
             self.use_parallel_reduction = True
-
-    @staticmethod
-    def compute_groups_tokens_heads_ratio(
-        num_heads: int, seq_len_q: int, m_tile: int
-    ) -> int:
-        """Return the groups_tokens_heads_q capacity of one selected Q tile.
-
-        The capacity is deliberately independent of ``seq_len_q``.  A final
-        short group is represented by out-of-bounds Q rows and masked output
-        stores rather than by selecting a different compiled layout.
-        """
-
-        if num_heads <= 0 or seq_len_q <= 0 or m_tile <= 0:
-            return 1
-        return groups_tokens_heads_q_capacity(num_heads, m_tile)
-
-    @property
-    def groups_tokens_heads_q_ratio(self) -> int:
-        """Return the effective groups_tokens_heads_q capacity."""
-
-        return self.groups_tokens_heads_ratio
-
-    def validate_groups_tokens_heads_launch_shape(
-        self,
-        q_latent_shape,
-        q_rope_shape,
-        o_shape,
-        lse_shape,
-        cu_seqlens_q_shape=None,
-    ) -> None:
-        """Validate logical public tensor shapes and refresh groups_tokens_heads_q traits.
-
-        The JIT body cannot convert CuTe symbolic shape values back to Python
-        integers, so the host launch path refreshes grouping traits from the
-        concrete tensor shapes before compilation.
-        """
-
-        num_heads = int(q_latent_shape[0])
-        is_variable_q = len(q_latent_shape) == 3
-        if is_variable_q:
-            total_q = int(q_latent_shape[2])
-            groups_tokens_heads_q_ratio = self.compute_groups_tokens_heads_ratio(
-                num_heads, self.seq_len_q, self.mma_qk_tiler_mn[0]
-            )
-            for name, shape in (
-                ("q_latent", q_latent_shape),
-                ("q_rope", q_rope_shape),
-                ("o", o_shape),
-            ):
-                if len(shape) != 3:
-                    raise ValueError(
-                        f"{name} must be rank-3 for compact variable-length Q"
-                    )
-                if int(shape[0]) != num_heads or int(shape[2]) != total_q:
-                    raise ValueError(
-                        "compact variable-length Q tensors must agree on "
-                        f"num_heads/total_q for {name}"
-                    )
-            if len(lse_shape) != 2:
-                raise ValueError("lse must be rank-2 for compact variable-length Q")
-            if int(lse_shape[0]) != num_heads or int(lse_shape[1]) != total_q:
-                raise ValueError(
-                    "compact variable-length Q tensors must agree on "
-                    "num_heads/total_q for lse"
-                )
-            if cu_seqlens_q_shape is None:
-                raise ValueError(
-                    "cu_seqlens_q shape is required for compact variable-length Q"
-                )
-            if len(cu_seqlens_q_shape) != 1:
-                raise ValueError("cu_seqlens_q must be rank-1")
-            batch_size = int(cu_seqlens_q_shape[0]) - 1
-            if batch_size <= 0:
-                raise ValueError("cu_seqlens_q must contain at least two offsets")
-            self.num_heads = num_heads
-            self.batch_size = batch_size
-            self.groups_tokens_heads_ratio = groups_tokens_heads_q_ratio
-            self.groups_tokens_heads = groups_tokens_heads_q_ratio > 1
-            self._configure_parallel_reduction_topology()
-            return
-
-        if cu_seqlens_q_shape is not None:
-            raise ValueError("cu_seqlens_q requires rank-3 compact Q/O and rank-2 LSE")
-
-        if len(q_latent_shape) != 4:
-            raise ValueError("q_latent must be rank-4 for groups_tokens_heads_q launch")
-        seq_len_q = int(q_latent_shape[2])
-        batch_size = int(q_latent_shape[3])
-        groups_tokens_heads_q_ratio = self.compute_groups_tokens_heads_ratio(
-            num_heads, seq_len_q, self.mma_qk_tiler_mn[0]
-        )
-
-        def _check_4d(name, shape):
-            """Validate one logical 4D tensor against runtime H and SQ."""
-            if len(shape) != 4:
-                raise ValueError(
-                    f"{name} must be rank-4 for groups_tokens_heads_q launch"
-                )
-            if (
-                int(shape[0]) != num_heads
-                or int(shape[2]) != seq_len_q
-                or int(shape[3]) != batch_size
-            ):
-                raise ValueError(
-                    "groups_tokens_heads_q launch tensors must agree on "
-                    f"num_heads/seq_len_q/batch_size for {name}"
-                )
-
-        _check_4d("q_latent", q_latent_shape)
-        _check_4d("q_rope", q_rope_shape)
-        _check_4d("o", o_shape)
-        if len(lse_shape) != 3:
-            raise ValueError("lse must be rank-3 for groups_tokens_heads_q launch")
-        if (
-            int(lse_shape[0]) != num_heads
-            or int(lse_shape[1]) != seq_len_q
-            or int(lse_shape[2]) != batch_size
-        ):
-            raise ValueError(
-                "groups_tokens_heads_q launch tensors must agree on "
-                "num_heads/seq_len_q/batch_size for lse"
-            )
-        self.num_heads = num_heads
-        self.seq_len_q = seq_len_q
-        self.batch_size = batch_size
-        self.groups_tokens_heads_ratio = groups_tokens_heads_q_ratio
-        self.groups_tokens_heads = groups_tokens_heads_q_ratio > 1
-        self._configure_parallel_reduction_topology()
 
     @cute.jit
     def __call__(
@@ -1038,12 +948,11 @@ class MlaDecodeTs:
             is_var_split_kv=self.is_var_split_kv,
             mask_type=self.mask_type,
         )
-        group = self.groups_tokens_heads_q_ratio
-        effective_num_heads_q = self.num_heads * group
-        effective_seq_len_q = groups_tokens_heads_q_group_count(self.seq_len_q, group)
+        physical_tile_rows = self.mma_qk_tiler_mn[0]
+        num_query_tiles = self.num_q_tiles
         # Fixed public tensors retain [H,D,SQ,B]/[H,SQ,B]; variable-Q tensors
         # compact batches into [H,D,totalQ]/[H,totalQ]. The scheduler/workspace
-        # use effective groups_tokens_heads_q coordinates, while resources map
+        # use physical flat-query tile coordinates, while resources map
         # each valid row back to its logical fixed or ragged storage location.
         if cutlass.const_expr(cu_seqlens_q is not None):
             runtime_assert(
@@ -1053,6 +962,10 @@ class MlaDecodeTs:
             batch_size = cute.size(cu_seqlens_q) - Int32(1)
         else:
             batch_size = cute.size(o.shape[3])
+            runtime_assert(
+                batch_size == cute.size(cache_seqs),
+                "fixed output batch size must match cache_seqs",
+            )
 
         runtime_assert(
             q_latent.stride[2] == q_latent.shape[0] * q_latent.stride[0],
@@ -1114,8 +1027,8 @@ class MlaDecodeTs:
         # Create TMA descriptors (same as bare metal)
 
         # Keep the descriptor extent at the logical H*SQ row count.  The final
-        # groups_tokens_heads_q group still requests a full M tile; tensor-map OOB fill supplies
-        # zeros for its tail without changing the public Q tensor shape.
+        # physical query tile still requests a full M tile; tensor-map OOB fill
+        # supplies zeros for its tail without changing the public Q shape.
         q_latent_tma = _flatten_query_rows_for_tma(q_latent)
         if cutlass.const_expr(cu_seqlens_q is not None):
             tma_desc_q_latent = create_tensor_map_ragged_from_tensor(
@@ -1226,20 +1139,20 @@ class MlaDecodeTs:
         tile_sched_params = create_mla_static_tile_scheduler_params(
             self.is_persistent,
             batch_size,
-            Int32(effective_seq_len_q),
+            Int32(num_query_tiles),
             cfg.cluster_shape_mnk,
             kernel_split_kv,
         )
         use_clc_dynamic = self.is_persistent and not cfg.is_fp8_qkv()
         clc_tile_sched_params = None
         if cutlass.const_expr(use_clc_dynamic):
-            # Keep the logical query-group dimension in grid X and flatten
+            # Keep the physical query-tile dimension in grid X and flatten
             # only split/batch into grid Z.  Besides avoiding a hot-path
             # S/B decode for every stolen tile, this preserves the natural
             # 2CTA query-cluster raster used by the nonpersistent launch.
             clc_tile_sched_params = utils.ClcDynamicPersistentTileSchedulerParams(
                 (
-                    cfg.cluster_shape_mnk[0] * Int32(effective_seq_len_q),
+                    cfg.cluster_shape_mnk[0] * Int32(num_query_tiles),
                     1,
                     batch_size * kernel_split_kv,
                 ),
@@ -1253,18 +1166,18 @@ class MlaDecodeTs:
 
         # Initialize workspace for split_kv > 1
         acc_o, acc_lse = self.initialize_workspace(
-            Int32(effective_num_heads_q),  # grouped H
+            Int32(physical_tile_rows),
             cfg.latent_dim,  # D
-            Int32(effective_seq_len_q),  # grouped SQ groups
+            Int32(num_query_tiles),
             batch_size,
             kernel_split_kv,
             workspace,
         )
+        # A one-wave producer can publish its dependent reducer launch while
+        # retiring, hiding launch latency without admitting reducer CTAs into
+        # an actively grid-striding persistent producer.
+        use_one_wave_reducer_pdl = acc_o is not None and not self.is_persistent
 
-        # Keep the separate reducer ordered after the producer.  A dependent
-        # PDL launch can occupy the SMs left by a one-wave 2CTA grid while the
-        # producer is still streaming paged KV, increasing producer latency
-        # enough to outweigh reducer overlap.
         self.split_kv_kernel(
             tma_desc_q_latent,
             tma_desc_q_rope,
@@ -1292,17 +1205,12 @@ class MlaDecodeTs:
             cluster=cfg.cluster_shape_mnk,
             stream=stream,
             min_blocks_per_mp=1,
-            use_pdl=False,
+            use_pdl=use_one_wave_reducer_pdl,
         )
 
         # Reduction kernel: combine per-split results when split_kv > 1
         if cutlass.const_expr(acc_o is not None):
             if cutlass.const_expr(self.use_parallel_reduction):
-                runtime_assert(
-                    batch_size == Int32(self.batch_size),
-                    "parallel-reducer runtime batch size must match "
-                    "host-known batch_size",
-                )
                 topology = self.parallel_reduction_topology
                 self.parallel_reduction_kernel(
                     o,
@@ -1315,19 +1223,18 @@ class MlaDecodeTs:
                     block_split_kvs,
                 ).launch(
                     grid=(
-                        effective_num_heads_q * topology.cluster_size,
-                        effective_seq_len_q,
+                        physical_tile_rows * topology.cluster_size,
+                        num_query_tiles,
                         batch_size,
                     ),
                     block=[PARALLEL_REDUCTION_THREADS, 1, 1],
                     cluster=[topology.cluster_size, 1, 1],
-                    # The 2CTA producer intentionally has no PDL signal; same-
-                    # stream launch ordering keeps this reducer after stores.
                     stream=stream,
                     min_blocks_per_mp=1,
-                    use_pdl=False,
+                    use_pdl=use_one_wave_reducer_pdl,
                 )
             else:
+                logical_query_rows = self.num_heads * self.seq_len_q
                 self.reduction_kernel(
                     o,
                     lse,
@@ -1339,11 +1246,11 @@ class MlaDecodeTs:
                     block_split_kvs,
                 ).launch(
                     grid=(
-                        ceil_div(effective_num_heads_q, REDUCTION_ROWS_PER_CTA),
-                        effective_seq_len_q,
+                        ceil_div(logical_query_rows, REDUCTION_ROWS_PER_CTA),
+                        1,
                         batch_size,
                     ),
-                    block=[REDUCTION_THREADS_PER_CTA, 1, 1],
+                    block=[REDUCTION_ROWS_PER_CTA * REDUCTION_THREADS_PER_ROW, 1, 1],
                     smem=(
                         REDUCTION_ROWS_PER_CTA
                         * self.reduction_split_capacity
@@ -1351,11 +1258,8 @@ class MlaDecodeTs:
                         // 8
                     ),
                     stream=stream,
-                    # Match the reducer's 512-thread, eight-row resource model:
-                    # two resident CTAs keep register allocation from expanding
-                    # beyond what this bandwidth-oriented kernel can use.
                     min_blocks_per_mp=2,
-                    use_pdl=False,
+                    use_pdl=use_one_wave_reducer_pdl,
                 )
 
     @cute.kernel
@@ -1396,10 +1300,7 @@ class MlaDecodeTs:
             is_var_split_kv=self.is_var_split_kv,
             mask_type=self.mask_type,
         )
-        effective_seq_len_q = groups_tokens_heads_q_group_count(
-            self.seq_len_q,
-            self.groups_tokens_heads_q_ratio,
-        )
+        num_query_tiles = self.num_q_tiles
         use_clc_dynamic = self.is_persistent and not cfg.is_fp8_qkv()
         tiled_mma_qk = None
         if cutlass.const_expr(cfg.is_fp8_qkv()):
@@ -1518,7 +1419,7 @@ class MlaDecodeTs:
             cluster_idx = query_cluster_idx % Int32(cfg.cluster_shape_mnk[0])
             split_kv_idx, batch_idx = divmod_constexpr_power_of_two_or_fdd(
                 split_batch_idx,
-                self.batch_size,
+                None,
                 tile_sched_params.problem_shape_b_fdd,
             )
             blk_coord = (cluster_idx, seq_q_idx, batch_idx, split_kv_idx)
@@ -1530,12 +1431,12 @@ class MlaDecodeTs:
             cluster_idx = current_work_linear_idx % Int32(cfg.cluster_shape_mnk[0])
             current_work_after_seq_q, seq_q_idx = divmod_constexpr_power_of_two_or_fdd(
                 current_work_cluster_batch,
-                effective_seq_len_q,
+                num_query_tiles,
                 tile_sched_params.problem_shape_s_fdd,
             )
             current_work_after_batch, batch_idx = divmod_constexpr_power_of_two_or_fdd(
                 current_work_after_seq_q,
-                self.batch_size,
+                None,
                 tile_sched_params.problem_shape_b_fdd,
             )
             _, split_kv_idx = divmod(
@@ -1546,7 +1447,7 @@ class MlaDecodeTs:
             cluster_idx, seq_batch_idx, split_kv_idx = cute.arch.block_idx()
             seq_q_idx, batch_idx = divmod_constexpr_power_of_two_or_fdd(
                 seq_batch_idx,
-                self.batch_size,
+                None,
                 tile_sched_params.problem_shape_b_fdd,
             )
             blk_coord = (cluster_idx, seq_q_idx, batch_idx, split_kv_idx)
@@ -1561,6 +1462,16 @@ class MlaDecodeTs:
         )
         if cutlass.const_expr(fixed_nonempty_single_split):
             max_split_kv = Int32(1)
+            exit_early = False
+        elif cutlass.const_expr(not self.is_persistent):
+            # Every task already derives its graph-live K/Q domain through the
+            # work queue. Let a zero-domain task skip its data schedule instead
+            # of recomputing the same metadata in an all-warp CTA prologue.
+            max_split_kv = (
+                Int32(self.static_split_kv)
+                if cutlass.const_expr(self.static_split_kv is not None)
+                else split_kv
+            )
             exit_early = False
         else:
             # Compute the initial tile's active Q/split state for static early
@@ -1578,9 +1489,10 @@ class MlaDecodeTs:
                 tile_batch_idx,
                 self.seq_len_q,
             )
-            q_group_has_rows = runtime_query_group_has_rows(
+            query_tile_has_rows = runtime_flat_query_tile_has_rows(
                 tile_seq_q_idx,
-                self.groups_tokens_heads_q_ratio,
+                self.mma_qk_tiler_mn[0],
+                self.num_heads,
                 self.seq_len_q,
                 cu_seqlens_q,
                 tile_batch_idx,
@@ -1588,17 +1500,17 @@ class MlaDecodeTs:
             if cutlass.const_expr(
                 cfg.mask_type == MaskType.CAUSAL.value and self.seq_len_q > 1
             ):
-                _, _, logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-                    Int32(self.num_heads * self.groups_tokens_heads_q_ratio - 1),
+                _, _, logical_q_idx, _, _ = flat_query_row_state(
+                    Int32(self.mma_qk_tiler_mn[0] - 1),
                     tile_seq_q_idx,
-                    self.groups_tokens_heads_q_ratio,
+                    self.mma_qk_tiler_mn[0],
                     self.num_heads,
                     self.seq_len_q,
                     cu_seqlens_q,
                     tile_batch_idx,
                 )
                 K = mask_visible_k_length(cfg.mask_type, K, logical_q_idx, q_len)
-            K = K if q_group_has_rows else Int32(0)
+            K = K if query_tile_has_rows else Int32(0)
             # split_kv is the static launch/workspace capacity. Runtime K
             # contracts the optional per-batch cap to an active prefix.
             max_split_kv = (
@@ -1707,11 +1619,10 @@ class MlaDecodeTs:
                 static_split_kv=self.static_split_kv,
                 static_seq_len_k=self.static_seq_len_k,
                 cu_seqlens_q=cu_seqlens_q,
-                groups_tokens_heads_q_ratio=self.groups_tokens_heads_q_ratio,
                 logical_num_heads_q=self.num_heads,
                 logical_seq_len_q=self.seq_len_q,
-                static_problem_shape_b=self.batch_size,
-                static_problem_shape_s=effective_seq_len_q,
+                static_problem_shape_b=None,
+                static_problem_shape_s=num_query_tiles,
                 use_clc_dynamic=use_clc_dynamic,
                 tile_scheduler_config=work_queue_tile_scheduler_config,
                 pipeline_config=work_queue_pipeline_config,
@@ -1742,7 +1653,6 @@ class MlaDecodeTs:
                 cache_seqs=cache_seqs,
                 cu_seqlens_q=cu_seqlens_q,
                 split_kv=max_split_kv,
-                groups_tokens_heads_ratio=self.groups_tokens_heads_q_ratio,
                 logical_num_heads_q=self.num_heads,
                 logical_seq_len_q=self.seq_len_q,
                 tiled_mma_qk=tiled_mma_qk,
@@ -1833,6 +1743,11 @@ class MlaDecodeTs:
                 cfg.num_tmem_cols,
                 group="cta_2",
             )
+            # Each producer CTA publishes completion only after its paired
+            # TMEM lifetime and all scheduled output work have retired.
+            if cutlass.const_expr(acc_o is not None and not self.is_persistent):
+                if prims.elect_sync():
+                    prims.griddepcontrol(kind=prims.GridDepAction.LAUNCH_DEPENDENTS)
 
     @cute.jit
     def initialize_workspace(
@@ -1896,6 +1811,8 @@ class MlaDecodeTs:
             o_dtype=self.out_dtype,
             mask_type=self.mask_type,
         )
+        if cutlass.const_expr(not self.is_persistent):
+            prims.griddepcontrol(kind=prims.GridDepAction.WAIT)
         run_reduction_kernel(
             self,
             output,
@@ -1908,6 +1825,7 @@ class MlaDecodeTs:
             block_split_kvs,
             cfg,
             self.reduction_split_capacity,
+            REDUCTION_ROWS_PER_CTA,
         )
 
     @cute.kernel
@@ -1933,9 +1851,10 @@ class MlaDecodeTs:
             o_dtype=self.out_dtype,
             mask_type=self.mask_type,
         )
+        if cutlass.const_expr(not self.is_persistent):
+            prims.griddepcontrol(kind=prims.GridDepAction.WAIT)
         topology = self.parallel_reduction_topology
         run_parallel_reduction_kernel(
-            self.groups_tokens_heads_q_ratio,
             self.num_heads,
             self.seq_len_q,
             self.is_var_split_kv,

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/parallel_reduction.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/parallel_reduction.py
@@ -24,7 +24,7 @@ from ..helpers.constants import SPLIT_REDUCTION_SCALE_BARRIER_ID
 from ..helpers.mask import MaskType, mask_visible_k_length
 from ..helpers.math import ceil_div
 from ..helpers.ops import fmax_f32, warp_reduce_max_f32, warp_reduce_sum_f32
-from ..helpers.query import groups_tokens_heads_q_row_state, query_batch_bounds
+from ..helpers.query import flat_query_row_state, query_batch_bounds
 from .work_partition import (
     runtime_row_prefix_active_split_count,
     runtime_split_kv_cap,
@@ -43,7 +43,7 @@ PARALLEL_REDUCTION_HEAD_DIM = (
 
 @cute.jit
 def _parallel_reduction_row_state(
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int],
+    tile_size_q: cutlass.Constexpr[int],
     num_heads: cutlass.Constexpr[int],
     seq_len_q: cutlass.Constexpr[int],
     is_var_split_kv: cutlass.Constexpr[bool],
@@ -51,15 +51,15 @@ def _parallel_reduction_row_state(
     cu_seqlens_q,
     block_split_kvs,
     split_kv,
-    effective_head_idx,
-    seq_q_idx,
+    row_in_tile,
+    query_tile_idx,
     batch_idx,
     cfg,
 ):
     """Return logical row coordinates and its runtime active split count.
 
     Keep this arithmetic identical to the serial reducer below.  A causal row
-    can see fewer K tiles than the last row in its grouped producer tile, and a
+    can see fewer K tiles than the last row in its producer tile, and a
     variable-length batch can expose fewer real partitions than the compiled
     static split capacity.  The parallel reducer must ignore both kinds of
     empty workspace rows.
@@ -71,10 +71,10 @@ def _parallel_reduction_row_state(
         logical_q_idx,
         storage_q_idx,
         query_is_valid,
-    ) = groups_tokens_heads_q_row_state(
-        effective_head_idx,
-        seq_q_idx,
-        groups_tokens_heads_q_ratio,
+    ) = flat_query_row_state(
+        row_in_tile,
+        query_tile_idx,
+        tile_size_q,
         num_heads,
         seq_len_q,
         cu_seqlens_q,
@@ -88,27 +88,27 @@ def _parallel_reduction_row_state(
         block_split_kvs,
         batch_idx,
     )
-    group_k = cache_seqs[batch_idx]
-    row_k = group_k
+    tile_k = cache_seqs[batch_idx]
+    row_k = tile_k
     if cutlass.const_expr(cfg.mask_type == MaskType.CAUSAL.value and seq_len_q > 1):
         _, logical_seq_len_q = query_batch_bounds(
             cu_seqlens_q,
             batch_idx,
             seq_len_q,
         )
-        _, _, group_last_logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-            Int32(num_heads * groups_tokens_heads_q_ratio - 1),
-            seq_q_idx,
-            groups_tokens_heads_q_ratio,
+        _, _, tile_last_logical_q_idx, _, _ = flat_query_row_state(
+            Int32(tile_size_q - 1),
+            query_tile_idx,
+            tile_size_q,
             num_heads,
             seq_len_q,
             cu_seqlens_q,
             batch_idx,
         )
-        group_k = mask_visible_k_length(
+        tile_k = mask_visible_k_length(
             cfg.mask_type,
-            group_k,
-            group_last_logical_q_idx,
+            tile_k,
+            tile_last_logical_q_idx,
             logical_seq_len_q,
         )
         row_k = mask_visible_k_length(
@@ -117,11 +117,11 @@ def _parallel_reduction_row_state(
             logical_q_idx,
             logical_seq_len_q,
         )
-    group_k_tile_total = (group_k + cfg.mma_qk_tiler[1] - 1) // cfg.mma_qk_tiler[1]
+    tile_k_tile_total = (tile_k + cfg.mma_qk_tiler[1] - 1) // cfg.mma_qk_tiler[1]
     row_k_tile_total = (row_k + cfg.mma_qk_tiler[1] - 1) // cfg.mma_qk_tiler[1]
     active_split_kv = runtime_row_prefix_active_split_count(
         row_k_tile_total,
-        group_k_tile_total,
+        tile_k_tile_total,
         split_kv_cap,
     )
     return (
@@ -178,7 +178,6 @@ def _store_parallel_reduction_result(
 
 @cute.jit
 def run_parallel_reduction_kernel(
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int],
     num_heads: cutlass.Constexpr[int],
     seq_len_q: cutlass.Constexpr[int],
     is_var_split_kv: cutlass.Constexpr[bool],
@@ -203,16 +202,16 @@ def run_parallel_reduction_kernel(
     publishes a neutral-or-valid ``(FP32 LSE, BF16 O[512])`` state to DSMEM and
     rank zero performs the final merge. Arithmetic remains FP32.
 
-    The producer kernel does not emit a PDL signal, so this same-stream launch
-    intentionally contains no ``griddepcontrol`` wait.
+    For a one-wave producer, the caller waits for its post-TMEM dependent-launch
+    signal before entering this body.
     """
 
-    block_idx_x, seq_q_idx, batch_idx = cute.arch.block_idx()
+    block_idx_x, query_tile_idx, batch_idx = cute.arch.block_idx()
     tidx, _, _ = cute.arch.thread_idx()
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     lane_idx = tidx % Int32(cfg.threads_per_warp)
     cluster_rank = cute.arch.block_idx_in_cluster()
-    effective_head_idx = block_idx_x // Int32(cluster_size)
+    row_in_tile = block_idx_x // Int32(cluster_size)
     (
         logical_head_idx,
         logical_q_idx,
@@ -220,7 +219,7 @@ def run_parallel_reduction_kernel(
         query_is_valid,
         active_split_kv,
     ) = _parallel_reduction_row_state(
-        groups_tokens_heads_q_ratio,
+        cfg.mma_qk_tiler[0],
         num_heads,
         seq_len_q,
         is_var_split_kv,
@@ -228,8 +227,8 @@ def run_parallel_reduction_kernel(
         cu_seqlens_q,
         block_split_kvs,
         split_kv,
-        effective_head_idx,
-        seq_q_idx,
+        row_in_tile,
+        query_tile_idx,
         batch_idx,
         cfg,
     )
@@ -274,7 +273,7 @@ def run_parallel_reduction_kernel(
             # ranks must not form a load from the unpadded producer allocation.
             if active_slot:
                 lane_lse[lane_slot_i] = Float32(
-                    acc_lse[effective_head_idx, split_idx, seq_q_idx, batch_idx]
+                    acc_lse[row_in_tile, split_idx, query_tile_idx, batch_idx]
                 )
             local_lse_max = fmax_f32(
                 local_lse_max,
@@ -333,10 +332,10 @@ def run_parallel_reduction_kernel(
         if active_slot:
             split_scale = Float32(smem_local_scale[slot_i])
             partial_offset = Int64(
-                effective_head_idx * acc_output.stride[0]
+                row_in_tile * acc_output.stride[0]
                 + split_idx * acc_output.stride[1]
                 + element_idx * acc_output.stride[2]
-                + seq_q_idx * acc_output.stride[3]
+                + query_tile_idx * acc_output.stride[3]
                 + batch_idx * acc_output.stride[4]
             )
             partial_output = (

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/reduction.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/reduction.py
@@ -20,7 +20,6 @@ from cutlass import Float32, Int32, Int64
 from cutlass.experimental import primitives as prims
 
 from .config import (
-    REDUCTION_ROWS_PER_CTA,
     REDUCTION_THREADS_PER_ROW,
     REDUCTION_VALUES_PER_THREAD,
     REDUCTION_VECTOR_BYTES,
@@ -34,7 +33,7 @@ from ..helpers.ops import (
     warp_reduce_sum_f32,
     vector_from_scalars,
 )
-from ..helpers.query import groups_tokens_heads_q_row_state, query_batch_bounds
+from ..helpers.query import flat_query_row_state, query_batch_bounds
 from .work_partition import (
     runtime_row_prefix_active_split_count,
     runtime_split_kv_cap,
@@ -54,15 +53,19 @@ def run_reduction_kernel(
     block_split_kvs,
     cfg,
     max_splits: cutlass.Constexpr[int],
+    rows_per_cta: cutlass.Constexpr[int],
 ):
-    """Combine eight grouped-coordinate split rows per 512-thread CTA.
+    """Combine consecutive logical split rows in one reference-reducer CTA.
 
     Each 64-thread row group owns one D512 output row.  Its first warp computes
     FP32 LSE rescale factors, both warps consume one contiguous 16-byte BF16
-    fragment per thread, and the final accumulation remains FP32.  Padded rows
-    still participate in CTA synchronization but never publish public output.
+    fragment per thread, and the final accumulation remains FP32.  The launch
+    is flattened over logical query rows, then each row is decomposed back into
+    its physical M128 workspace tile and row.  Only the last CTA can contain
+    inactive row groups; those groups still synchronize but never access the
+    workspace or publish public output.
     """
-    effective_head_group_idx, seq_q_idx, batch_idx = cute.arch.block_idx()
+    reduction_group_idx, _, batch_idx = cute.arch.block_idx()
     tidx, _, _ = cute.arch.thread_idx()
     row_in_cta = tidx // Int32(REDUCTION_THREADS_PER_ROW)
     row_thread_idx = tidx - row_in_cta * Int32(REDUCTION_THREADS_PER_ROW)
@@ -71,33 +74,45 @@ def run_reduction_kernel(
     )
     lane_idx = row_thread_idx % Int32(cfg.threads_per_warp)
 
-    effective_num_heads_q = Int32(kernel.num_heads * kernel.groups_tokens_heads_q_ratio)
-    effective_head_idx = (
-        effective_head_group_idx * Int32(REDUCTION_ROWS_PER_CTA) + row_in_cta
+    physical_tile_rows = Int32(cfg.mma_qk_tiler[0])
+    logical_query_rows = Int32(kernel.num_heads * kernel.seq_len_q)
+    local_flat_query_row = reduction_group_idx * Int32(rows_per_cta) + row_in_cta
+    row_is_valid = local_flat_query_row < logical_query_rows
+    # Clamp the final CTA's inactive row groups before decomposing the physical
+    # workspace coordinate.  ``rows_per_cta`` divides M128, so every CTA
+    # containing valid rows belongs to exactly one producer query tile.
+    safe_local_flat_query_row = cute.math.min(
+        local_flat_query_row, logical_query_rows - Int32(1)
     )
-    head_is_valid = effective_head_idx < effective_num_heads_q
-    # The row helper performs control-flow and storage-coordinate arithmetic.
-    # Clamp a tail CTA's padding rows before calling it, then predicate every
-    # public/workspace access with ``head_is_valid``.
-    safe_effective_head_idx = cute.math.min(
-        effective_head_idx, effective_num_heads_q - Int32(1)
-    )
-    (
-        storage_flat_query_row,
-        _,
-        logical_q_idx,
-        _,
-        mapped_query_is_valid,
-    ) = groups_tokens_heads_q_row_state(
-        safe_effective_head_idx,
-        seq_q_idx,
-        kernel.groups_tokens_heads_q_ratio,
-        kernel.num_heads,
-        kernel.seq_len_q,
-        cu_seqlens_q,
-        batch_idx,
-    )
-    query_is_valid = head_is_valid and mapped_query_is_valid
+    if cutlass.const_expr(kernel.num_heads * kernel.seq_len_q <= cfg.mma_qk_tiler[0]):
+        query_tile_idx = Int32(0)
+        row_in_tile = safe_local_flat_query_row
+    else:
+        query_tile_idx = safe_local_flat_query_row // physical_tile_rows
+        row_in_tile = safe_local_flat_query_row - query_tile_idx * physical_tile_rows
+    if cutlass.const_expr(cu_seqlens_q is None):
+        # Fixed Q storage is already flat in the producer's logical row order;
+        # bypass packed-offset clamping on this latency-sensitive reducer path.
+        storage_flat_query_row = safe_local_flat_query_row
+        logical_q_idx = storage_flat_query_row // Int32(kernel.num_heads)
+        mapped_query_is_valid = True
+    else:
+        (
+            storage_flat_query_row,
+            _,
+            logical_q_idx,
+            _,
+            mapped_query_is_valid,
+        ) = flat_query_row_state(
+            row_in_tile,
+            query_tile_idx,
+            cfg.mma_qk_tiler[0],
+            kernel.num_heads,
+            kernel.seq_len_q,
+            cu_seqlens_q,
+            batch_idx,
+        )
+    query_is_valid = row_is_valid and mapped_query_is_valid
     public_flat_query_row = storage_flat_query_row
     if cutlass.const_expr(cu_seqlens_q is None):
         public_flat_query_row = public_flat_query_row + batch_idx * Int32(
@@ -119,8 +134,8 @@ def run_reduction_kernel(
         )
     # Producer splits are sized from the group's largest K domain, while each
     # logical row consumes only the prefix containing its visible K tiles.
-    group_k = cache_seqs[batch_idx]
-    row_k = group_k
+    tile_k = cache_seqs[batch_idx]
+    row_k = tile_k
     if cutlass.const_expr(
         cfg.mask_type == MaskType.CAUSAL.value and kernel.seq_len_q > 1
     ):
@@ -129,19 +144,19 @@ def run_reduction_kernel(
             batch_idx,
             kernel.seq_len_q,
         )
-        _, _, group_last_logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-            Int32(kernel.num_heads * kernel.groups_tokens_heads_q_ratio - 1),
-            seq_q_idx,
-            kernel.groups_tokens_heads_q_ratio,
+        _, _, tile_last_logical_q_idx, _, _ = flat_query_row_state(
+            Int32(cfg.mma_qk_tiler[0] - 1),
+            query_tile_idx,
+            cfg.mma_qk_tiler[0],
             kernel.num_heads,
             kernel.seq_len_q,
             cu_seqlens_q,
             batch_idx,
         )
-        group_k = mask_visible_k_length(
+        tile_k = mask_visible_k_length(
             cfg.mask_type,
-            group_k,
-            group_last_logical_q_idx,
+            tile_k,
+            tile_last_logical_q_idx,
             logical_seq_len_q,
         )
         row_k = mask_visible_k_length(
@@ -150,25 +165,25 @@ def run_reduction_kernel(
             logical_q_idx,
             logical_seq_len_q,
         )
-    group_k_tile_total = (group_k + cfg.mma_qk_tiler[1] - 1) // cfg.mma_qk_tiler[1]
+    tile_k_tile_total = (tile_k + cfg.mma_qk_tiler[1] - 1) // cfg.mma_qk_tiler[1]
     row_k_tile_total = (row_k + cfg.mma_qk_tiler[1] - 1) // cfg.mma_qk_tiler[1]
     # A causal row consumes the prefix of configured-span ranges intersecting
     # its visible K tiles. This must stay identical to the producer geometry.
     local_split_kv = runtime_row_prefix_active_split_count(
         row_k_tile_total,
-        group_k_tile_total,
+        tile_k_tile_total,
         split_kv_cap,
     )
 
     smem_lse_scale = cutlass.Array(
         kernel.lse_dtype,
-        REDUCTION_ROWS_PER_CTA * max_splits,
+        rows_per_cta * max_splits,
         space=cutlass.AddressSpace.smem,
         alignment=16,
     )
     row_scale_offset = row_in_cta * Int32(max_splits)
 
-    acc_lse_tile = acc_lse[safe_effective_head_idx, None, seq_q_idx, batch_idx]
+    acc_lse_tile = acc_lse[row_in_tile, None, query_tile_idx, batch_idx]
     if row_warp_idx == 0:
         # The first warp for each row owns its log-sum-exp merge.  It publishes
         # one rescale factor per active split for the row's second warp too.
@@ -211,7 +226,7 @@ def run_reduction_kernel(
                     else kernel.lse_dtype(0.0)
                 )
 
-    # Eight independent writer warps publish scales before any row consumes
+    # Independent writer warps publish scales before any row consumes
     # them.  Invalid/padded rows participate so this remains a full CTA barrier.
     prims.barrier_cta_sync(SPLIT_REDUCTION_SCALE_BARRIER_ID)
 
@@ -234,14 +249,14 @@ def run_reduction_kernel(
         partial_elem_offset_base = (
             Int64(batch_idx)
             * Int64(cute.size(acc_output.shape[3]))
-            * Int64(effective_num_heads_q)
+            * Int64(physical_tile_rows)
             * Int64(split_kv)
             * Int64(cfg.latent_dim)
-            + Int64(seq_q_idx)
-            * Int64(effective_num_heads_q)
+            + Int64(query_tile_idx)
+            * Int64(physical_tile_rows)
             * Int64(split_kv)
             * Int64(cfg.latent_dim)
-            + Int64(safe_effective_head_idx) * Int64(split_kv) * Int64(cfg.latent_dim)
+            + Int64(row_in_tile) * Int64(split_kv) * Int64(cfg.latent_dim)
             + Int64(element_idx)
         )
         partial_output_ptr = acc_output_ptr + partial_elem_offset_base

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/resources.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/resources.py
@@ -107,9 +107,9 @@ from ..helpers.ops import (
 )
 from ..helpers.mask import MaskType, mask_visible_k_length
 from ..helpers.query import (
-    groups_tokens_heads_q_row_state,
+    flat_query_row_state,
     query_batch_bounds,
-    runtime_query_group_has_rows,
+    runtime_flat_query_tile_has_rows,
 )
 from .work_partition import (
     runtime_split_kv_cap,
@@ -186,10 +186,10 @@ class MlaTsWorkTileInfo:
     ):
         """Initialize the staged tile coordinate and cached K-domain metadata."""
         cluster_idx, seq_q_idx, batch_idx, split_kv_idx = tile_idx
-        self._cluster_idx = cluster_idx
-        self._seq_q_idx = seq_q_idx
-        self._batch_idx = batch_idx
-        self._split_kv_idx = split_kv_idx
+        self._cluster_idx = Int32(cluster_idx)
+        self._seq_q_idx = Int32(seq_q_idx)
+        self._batch_idx = Int32(batch_idx)
+        self._split_kv_idx = Int32(split_kv_idx)
         self._is_valid = Boolean(is_valid)
         self._k_len = Int32(k_len)
         self._k_tile_count = Int32(k_tile_count)
@@ -215,7 +215,7 @@ class MlaTsWorkTileInfo:
     @property
     @cute.jit
     def k_len(self):
-        """Return the runtime K length associated with this tile."""
+        """Return the request's graph-live K length for this tile."""
         return self._k_len
 
     @property
@@ -294,7 +294,6 @@ class MlaWorkQueue(WorkQueue):
     static_split_kv: cutlass.Constexpr = None
     static_seq_len_k: cutlass.Constexpr = None
     cu_seqlens_q: Any = None
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int] = 1
     logical_num_heads_q: cutlass.Constexpr[int] = 128
     logical_seq_len_q: cutlass.Constexpr[int] = 1
     static_problem_shape_b: cutlass.Constexpr[int] = None
@@ -316,7 +315,6 @@ class MlaWorkQueue(WorkQueue):
         static_split_kv=None,
         static_seq_len_k=None,
         cu_seqlens_q=None,
-        groups_tokens_heads_q_ratio=1,
         logical_num_heads_q=128,
         logical_seq_len_q=1,
         static_problem_shape_b=None,
@@ -345,7 +343,6 @@ class MlaWorkQueue(WorkQueue):
         self.static_split_kv = static_split_kv
         self.static_seq_len_k = static_seq_len_k
         self.cu_seqlens_q = cu_seqlens_q
-        self.groups_tokens_heads_q_ratio = groups_tokens_heads_q_ratio
         self.logical_num_heads_q = logical_num_heads_q
         self.logical_seq_len_q = logical_seq_len_q
         self.static_problem_shape_b = static_problem_shape_b
@@ -444,19 +441,21 @@ class MlaWorkQueue(WorkQueue):
             K = Int32(self.static_seq_len_k)
         else:
             K = Int32(self.cache_seqs[safe_b_idx])
+        sequence_k_len = K
 
-        # The launch uses the largest grouped-Q count in the batch. Shorter
-        # variable-Q requests can therefore receive a whole group containing
-        # no real query rows. Give that group an empty K domain so every task
+        # The launch uses the largest flat-Q tile count in the batch. Shorter
+        # variable-Q requests can therefore receive a whole tile containing
+        # no real query rows. Give that tile an empty K domain so every task
         # skips it before any Q/K/V or partial-output access.
         _, q_len = query_batch_bounds(
             self.cu_seqlens_q,
             safe_b_idx,
             self.logical_seq_len_q,
         )
-        q_group_has_rows = runtime_query_group_has_rows(
+        query_tile_has_rows = runtime_flat_query_tile_has_rows(
             s_idx,
-            self.groups_tokens_heads_q_ratio,
+            cfg.mma_qk_tiler[0],
+            self.logical_num_heads_q,
             self.logical_seq_len_q,
             self.cu_seqlens_q,
             safe_b_idx,
@@ -464,20 +463,21 @@ class MlaWorkQueue(WorkQueue):
         if cutlass.const_expr(
             cfg.mask_type == MaskType.CAUSAL.value and self.logical_seq_len_q > 1
         ):
-            # Split partitioning owns the mask-visible CTA domain. The last
-            # groups_tokens_heads_q row provides the group maximum; grouped
-            # causal softmax narrows earlier rows without changing geometry.
-            _, _, logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-                Int32(self.logical_num_heads_q * self.groups_tokens_heads_q_ratio - 1),
+            # Split partitioning owns the mask-visible CTA domain. The final
+            # physical row resolves to the tile's latest valid Q
+            # token. Row-causal softmax narrows earlier rows without changing
+            # producer split geometry.
+            _, _, logical_q_idx, _, _ = flat_query_row_state(
+                Int32(cfg.mma_qk_tiler[0] - 1),
                 s_idx,
-                self.groups_tokens_heads_q_ratio,
+                cfg.mma_qk_tiler[0],
                 self.logical_num_heads_q,
                 self.logical_seq_len_q,
                 self.cu_seqlens_q,
                 safe_b_idx,
             )
             K = mask_visible_k_length(cfg.mask_type, K, logical_q_idx, q_len)
-        K = K if q_group_has_rows else Int32(0)
+        K = K if query_tile_has_rows else Int32(0)
         k_tile_total = (K + Int32(cfg.mma_qk_tiler[1] - 1)) // Int32(
             cfg.mma_qk_tiler[1]
         )
@@ -506,7 +506,13 @@ class MlaWorkQueue(WorkQueue):
                 split_kv_cap,
                 split_kv_idx,
             )
-        return MlaTsWorkTileInfo(tile_idx, is_valid, K, k_tile_count, k_index_base)
+        return MlaTsWorkTileInfo(
+            tile_idx,
+            is_valid,
+            sequence_k_len,
+            k_tile_count,
+            k_index_base,
+        )
 
     @cute.jit
     def k_tile_count_for_tile(self, tile_idx):
@@ -822,7 +828,6 @@ class SmemQResource(HighThroughputMlaResource):
     tma_desc_q_latent: Any = None
     tma_desc_q_rope: Any = None
     cu_seqlens_q: Any = None
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int] = 1
     logical_num_heads_q: cutlass.Constexpr[int] = 128
     logical_seq_len_q: cutlass.Constexpr[int] = 1
     cfg: cutlass.Constexpr = field(default_factory=MlaDecodeConfig)
@@ -866,10 +871,8 @@ class SmemQResource(HighThroughputMlaResource):
 
         cta_v = cute.arch.make_warp_uniform(cute.arch.block_idx_in_cluster())
         coord_m = cta_v * Int32(cfg.mma_qk_tiler[0] // cfg.num_mma_ctas)
-        effective_num_heads_q = Int32(
-            self.logical_num_heads_q * self.groups_tokens_heads_q_ratio
-        )
-        flat_query_row = Int32(blk_coord[1]) * effective_num_heads_q + coord_m
+        physical_tile_rows = Int32(cfg.mma_qk_tiler[0])
+        flat_query_row = Int32(blk_coord[1]) * physical_tile_rows + coord_m
         batch_idx = Int32(blk_coord[2])
         storage_flat_query_row = flat_query_row
         query_row_extent = Int32(cfg.mma_qk_tiler[0] // cfg.num_mma_ctas)
@@ -1639,7 +1642,6 @@ class TmemSResource(HighThroughputMlaResource):
     cache_seqs: Any = None  # per-batch valid K length
     cu_seqlens_q: Any = None  # cumulative compact-Q offsets, or None for fixed Q
     split_kv: Any = None  # per-work-tile split count
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int] = 1
     logical_num_heads_q: cutlass.Constexpr[int] = 128
     logical_seq_len_q: cutlass.Constexpr[int] = 1
     cfg: cutlass.Constexpr = field(default_factory=MlaDecodeConfig)
@@ -1993,17 +1995,35 @@ class TmemSResource(HighThroughputMlaResource):
         k_index = work_tile.k_index_base + Int32(stage_info.loop_offset)
         tile_offset_k = k_index * Int32(cfg.mma_qk_tiler[1])
         needs_row_causal_mask = cutlass.const_expr(
-            cfg.mask_type == MaskType.CAUSAL.value
-            and self.groups_tokens_heads_q_ratio > 1
+            cfg.mask_type == MaskType.CAUSAL.value and self.logical_seq_len_q > 1
         )
-        min_visible_k_len = K
         if cutlass.const_expr(needs_row_causal_mask):
-            min_visible_k_len = K - Int32(self.groups_tokens_heads_q_ratio - 1)
-        group_needs_mask = kv_tile_needs_right_mask(
-            tile_offset_k,
-            Int32(cfg.mma_qk_tiler[1]),
-            min_visible_k_len,
-        )
+            batch_idx = Int32(work_tile.tile_idx[2])
+            _, logical_seq_len_q = query_batch_bounds(
+                self.cu_seqlens_q,
+                batch_idx,
+                self.logical_seq_len_q,
+            )
+            first_flat_query_row = Int32(work_tile.tile_idx[1]) * Int32(
+                cfg.mma_qk_tiler[0]
+            )
+            # A row r sees key k iff H * (k - K + SQ) <= r.  Apply the
+            # equivalent boundary test to the first row in this physical tile
+            # so non-power-of-two H never needs a quotient on the softmax path.
+            first_mask_flat_row = Int32(self.logical_num_heads_q) * (
+                tile_offset_k
+                + Int32(cfg.mma_qk_tiler[1])
+                - K
+                + logical_seq_len_q
+                - Int32(1)
+            )
+            group_needs_mask = first_flat_query_row < first_mask_flat_row
+        else:
+            group_needs_mask = kv_tile_needs_right_mask(
+                tile_offset_k,
+                Int32(cfg.mma_qk_tiler[1]),
+                K,
+            )
 
         neg_inf = Float32(-Float32.inf)
         row_max_tile = row_max
@@ -2021,39 +2041,38 @@ class TmemSResource(HighThroughputMlaResource):
             qk_acc_regs.store(loaded, load_idx * TCGEN05_32B_REGS_PER_LOAD)
 
         if group_needs_mask:
-            row_k_len = K
             if cutlass.const_expr(needs_row_causal_mask):
-                # Recover this row's exact endpoint only on a group boundary.
-                batch_idx = Int32(work_tile.tile_idx[2])
-                _, logical_seq_len_q = query_batch_bounds(
-                    self.cu_seqlens_q,
-                    batch_idx,
-                    self.logical_seq_len_q,
-                )
-                effective_head_idx = self.cta_rank * Int32(
+                # Clamp padded physical tail rows to the request's last real
+                # row. Their Q/output accesses remain independently
+                # predicated, while this keeps the masking arithmetic safe.
+                row_in_tile = self.cta_rank * Int32(
                     cfg.mma_qk_tiler[0] // cfg.num_mma_ctas
                 ) + (local_tidx & Int32(EPILOGUE_ROW_MASK))
-                _, _, logical_q_idx, _, _ = groups_tokens_heads_q_row_state(
-                    effective_head_idx,
-                    work_tile.tile_idx[1],
-                    self.groups_tokens_heads_q_ratio,
-                    self.logical_num_heads_q,
-                    self.logical_seq_len_q,
-                    self.cu_seqlens_q,
-                    batch_idx,
+                flat_query_row = (
+                    Int32(work_tile.tile_idx[1]) * Int32(cfg.mma_qk_tiler[0])
+                    + row_in_tile
                 )
-                row_k_len = mask_visible_k_length(
-                    cfg.mask_type,
-                    self.cache_seqs[batch_idx],
-                    logical_q_idx,
-                    logical_seq_len_q,
+                last_flat_query_row = cute.math.max(
+                    logical_seq_len_q * Int32(self.logical_num_heads_q) - Int32(1),
+                    Int32(0),
+                )
+                flat_query_row = cute.math.min(
+                    flat_query_row,
+                    last_flat_query_row,
                 )
             tidx_col = (
                 local_tidx >> EPILOGUE_COLUMN_GROUP_SHIFT
             ) << EPILOGUE_COLUMN_GROUP_SHIFT
             for i in cutlass.range_constexpr(64):
                 token_idx = tile_offset_k + tidx_col + Int32(i)
-                qk_acc_regs[i] = qk_acc_regs[i] if token_idx < row_k_len else neg_inf
+                if cutlass.const_expr(needs_row_causal_mask):
+                    mask_flat_row = Int32(self.logical_num_heads_q) * (
+                        token_idx - K + logical_seq_len_q
+                    )
+                    token_is_visible = flat_query_row >= mask_flat_row
+                else:
+                    token_is_visible = token_idx < K
+                qk_acc_regs[i] = qk_acc_regs[i] if token_is_visible else neg_inf
 
         max0 = neg_inf
         max1 = neg_inf
@@ -3028,18 +3047,17 @@ class GmemOResource(HighThroughputMlaResource):
     smem_exchange: Any = None  # SMEM for row_sum exchange (as Int32 base addr)
     split_kv: Any = None
     cu_seqlens_q: Any = None
-    groups_tokens_heads_q_ratio: cutlass.Constexpr[int] = 1
     logical_num_heads_q: cutlass.Constexpr[int] = 128
     logical_seq_len_q: cutlass.Constexpr[int] = 1
     cfg: cutlass.Constexpr = field(default_factory=MlaDecodeConfig)
 
     @cute.jit
-    def _query_row_state(self, effective_head_idx, effective_seq_group_idx, batch_idx):
-        """Map one groups_tokens_heads_q epilogue row to public storage."""
-        return groups_tokens_heads_q_row_state(
-            effective_head_idx,
-            effective_seq_group_idx,
-            self.groups_tokens_heads_q_ratio,
+    def _query_row_state(self, row_in_tile, query_tile_idx, batch_idx):
+        """Map one physical flat-tile row to public storage."""
+        return flat_query_row_state(
+            row_in_tile,
+            query_tile_idx,
+            self.cfg.mma_qk_tiler[0],
             self.logical_num_heads_q,
             self.logical_seq_len_q,
             self.cu_seqlens_q,
@@ -3111,28 +3129,26 @@ class GmemOResource(HighThroughputMlaResource):
         g_j = (tidx_g >> EPILOGUE_COLUMN_GROUP_SHIFT) * EPILOGUE_THREAD_TILE_THREADS
 
         # Public O/LSE remain in logical coordinates. Split-KV partials retain
-        # the groups_tokens_heads_q scheduler/workspace coordinates until final reduction.
+        # physical flat-tile coordinates until final reduction.
         logical_num_heads_q = Int32(self.logical_num_heads_q)
-        effective_num_heads_q = Int32(
-            self.logical_num_heads_q * self.groups_tokens_heads_q_ratio
-        )
+        physical_tile_rows = Int32(cfg.mma_qk_tiler[0])
         D = cfg.latent_dim
         head_tile_idx = blk_coord[0]
         seq_q_idx = blk_coord[1]
         batch_idx = blk_coord[2]
         split_kv_idx = blk_coord[3]
-        effective_head_idx = head_tile_idx * tile_h + g_i
+        row_in_tile = head_tile_idx * tile_h + g_i
         (
             storage_flat_query_row,
             logical_head_idx,
             logical_q_idx,
             _,
             query_is_valid,
-        ) = self._query_row_state(effective_head_idx, seq_q_idx, batch_idx)
+        ) = self._query_row_state(row_in_tile, seq_q_idx, batch_idx)
 
-        # Fully masked split rows can occur when padded query rows have
-        # different causal K lengths.  Store zero O and -inf LSE for those
-        # rows so the split-KV reduction gives them zero weight.
+        # Fully masked split rows can occur when physical tail rows or earlier
+        # causal query rows have no visible K values in this split. Store zero
+        # O and -inf LSE so split-KV reduction gives those rows zero weight.
         row_has_values = row_sum > Float32(0)
         safe_row_sum = row_sum if row_has_values else Float32(1)
         norm_scale = self.output_scale * cute.math.rcp(safe_row_sum, approx=True)
@@ -3161,7 +3177,7 @@ class GmemOResource(HighThroughputMlaResource):
                 qk_acc_regs[i + 1] = scaled[1]
 
             # Store O to GMEM
-            if effective_head_idx < effective_num_heads_q and query_is_valid:
+            if row_in_tile < physical_tile_rows and query_is_valid:
                 if cutlass.const_expr(self.partial_output is not None):
                     # Split-KV partial O uses BF16 workspace storage.  LSE and
                     # the eventual cross-split accumulation remain FP32.
@@ -3172,14 +3188,14 @@ class GmemOResource(HighThroughputMlaResource):
                     )
                     o_base_ptr = (
                         self.partial_output.iterator.raw_ptr()
-                        + Int64(effective_head_idx) * Int64(self.split_kv) * Int64(D)
+                        + Int64(row_in_tile) * Int64(self.split_kv) * Int64(D)
                         + Int64(split_kv_idx) * Int64(D)
                         + Int64(seq_q_idx)
                         * Int64(self.split_kv)
-                        * Int64(effective_num_heads_q)
+                        * Int64(physical_tile_rows)
                         * Int64(D)
                         + Int64(batch_idx)
-                        * Int64(effective_num_heads_q)
+                        * Int64(physical_tile_rows)
                         * Int64(self.split_kv)
                         * Int64(S_q)
                         * Int64(D)
@@ -3291,15 +3307,15 @@ class GmemOResource(HighThroughputMlaResource):
         # indexing, not global tidx (which is 128..255 for correction warps).
         lse_tidx = local_tidx
         if lse_tidx < tile_h:
-            effective_lse_head_idx = head_tile_idx * tile_h + lse_tidx
+            lse_row_in_tile = head_tile_idx * tile_h + lse_tidx
             (
                 storage_flat_lse_row,
                 logical_lse_head_idx,
                 logical_lse_q_idx,
                 _,
                 lse_query_is_valid,
-            ) = self._query_row_state(effective_lse_head_idx, seq_q_idx, batch_idx)
-            if effective_lse_head_idx < effective_num_heads_q and lse_query_is_valid:
+            ) = self._query_row_state(lse_row_in_tile, seq_q_idx, batch_idx)
+            if lse_row_in_tile < physical_tile_rows and lse_query_is_valid:
                 if cutlass.const_expr(self.partial_lse is not None):
                     S_q = (
                         cutlass.Int32(self.partial_lse.shape[2])
@@ -3308,13 +3324,13 @@ class GmemOResource(HighThroughputMlaResource):
                     )
                     lse_base_ptr = (
                         self.partial_lse.iterator.raw_ptr()
-                        + Int64(effective_lse_head_idx) * Int64(self.split_kv)
+                        + Int64(lse_row_in_tile) * Int64(self.split_kv)
                         + Int64(split_kv_idx)
                         + Int64(seq_q_idx)
-                        * Int64(effective_num_heads_q)
+                        * Int64(physical_tile_rows)
                         * Int64(self.split_kv)
                         + Int64(batch_idx)
-                        * Int64(effective_num_heads_q)
+                        * Int64(physical_tile_rows)
                         * Int64(self.split_kv)
                         * Int64(S_q)
                     )
@@ -3396,24 +3412,22 @@ class GmemOResource(HighThroughputMlaResource):
         g_j = (tidx_g >> EPILOGUE_COLUMN_GROUP_SHIFT) * EPILOGUE_THREAD_TILE_THREADS
 
         logical_num_heads_q = Int32(self.logical_num_heads_q)
-        effective_num_heads_q = Int32(
-            self.logical_num_heads_q * self.groups_tokens_heads_q_ratio
-        )
+        physical_tile_rows = Int32(cfg.mma_qk_tiler[0])
         D = cfg.latent_dim
         head_tile_idx = blk_coord[0]
         seq_q_idx = blk_coord[1]
         batch_idx = blk_coord[2]
         split_kv_idx = blk_coord[3]
-        effective_head_idx = head_tile_idx * tile_h + g_i
+        row_in_tile = head_tile_idx * tile_h + g_i
         (
             storage_flat_query_row,
             logical_head_idx,
             logical_q_idx,
             _,
             query_is_valid,
-        ) = self._query_row_state(effective_head_idx, seq_q_idx, batch_idx)
+        ) = self._query_row_state(row_in_tile, seq_q_idx, batch_idx)
 
-        if effective_head_idx < effective_num_heads_q and query_is_valid:
+        if row_in_tile < physical_tile_rows and query_is_valid:
             if cutlass.const_expr(self.partial_output is not None):
                 S_q = (
                     cutlass.Int32(self.partial_output.shape[3])
@@ -3422,14 +3436,14 @@ class GmemOResource(HighThroughputMlaResource):
                 )
                 o_base_ptr = (
                     self.partial_output.iterator.raw_ptr()
-                    + Int64(effective_head_idx) * Int64(self.split_kv) * Int64(D)
+                    + Int64(row_in_tile) * Int64(self.split_kv) * Int64(D)
                     + Int64(split_kv_idx) * Int64(D)
                     + Int64(seq_q_idx)
                     * Int64(self.split_kv)
-                    * Int64(effective_num_heads_q)
+                    * Int64(physical_tile_rows)
                     * Int64(D)
                     + Int64(batch_idx)
-                    * Int64(effective_num_heads_q)
+                    * Int64(physical_tile_rows)
                     * Int64(self.split_kv)
                     * Int64(S_q)
                     * Int64(D)
@@ -3531,18 +3545,15 @@ class GmemOResource(HighThroughputMlaResource):
             )
             lse_tidx = local_tidx
             if lse_tidx < tile_h:
-                effective_lse_head_idx = head_tile_idx * tile_h + lse_tidx
+                lse_row_in_tile = head_tile_idx * tile_h + lse_tidx
                 (
                     storage_flat_lse_row,
                     logical_lse_head_idx,
                     logical_lse_q_idx,
                     _,
                     lse_query_is_valid,
-                ) = self._query_row_state(effective_lse_head_idx, seq_q_idx, batch_idx)
-                if (
-                    effective_lse_head_idx < effective_num_heads_q
-                    and lse_query_is_valid
-                ):
+                ) = self._query_row_state(lse_row_in_tile, seq_q_idx, batch_idx)
+                if lse_row_in_tile < physical_tile_rows and lse_query_is_valid:
                     if cutlass.const_expr(self.partial_lse is not None):
                         S_q = (
                             cutlass.Int32(self.partial_lse.shape[2])
@@ -3551,13 +3562,13 @@ class GmemOResource(HighThroughputMlaResource):
                         )
                         lse_base_ptr = (
                             self.partial_lse.iterator.raw_ptr()
-                            + Int64(effective_lse_head_idx) * Int64(self.split_kv)
+                            + Int64(lse_row_in_tile) * Int64(self.split_kv)
                             + Int64(split_kv_idx)
                             + Int64(seq_q_idx)
-                            * Int64(effective_num_heads_q)
+                            * Int64(physical_tile_rows)
                             * Int64(self.split_kv)
                             + Int64(batch_idx)
-                            * Int64(effective_num_heads_q)
+                            * Int64(physical_tile_rows)
                             * Int64(self.split_kv)
                             * Int64(S_q)
                         )

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_2cta/tasks.py
@@ -205,7 +205,11 @@ class MlaTask(Task):
             work_tile = self.work_queue._work_tile_from_block_idx(cute.arch.block_idx())
             self.work_queue._set_consumer_var_from_ts("work_tile", work_tile)
             self._run_pre_work_loop_entries(work_tile, context)
-            self._run_one_mla_work_tile(work_tile, context)
+            # Runtime K/Q metadata can make a statically launched split empty.
+            # Keep the CTA on the ordinary initialized-pipeline path, but skip
+            # its captured HEAD/LOOP/TAIL data work when the domain is zero.
+            if work_tile.k_tile_count > cutlass.Int32(0):
+                self._run_one_mla_work_tile(work_tile, context)
             self._run_post_work_loop_entries(work_tile, context)
             self._drain_mla_work_tile_tails()
             return

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/config.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/config.py
@@ -31,29 +31,15 @@ from math import ceil
 from typing import Any
 
 from ....split_kv_mode_policy import select_split_kv_modes
-from ..helpers.constants import SUPPORTED_MLA_PAGE_SIZES
+from ..helpers.constants import MAX_MLA_SPLITS_KV, SUPPORTED_MLA_PAGE_SIZES
 from ..helpers.mask import MaskType, normalize_mask_type
-from ..helpers.query import (
-    groups_tokens_heads_q_capacity,
-    groups_tokens_heads_q_group_count,
-)
+from ..helpers.query import FlatQueryTileLayout
 
 
 # 1CTA profiles are specialized for these Q/head tiles.  Tile sizes 8/16 use
 # the swaps-MMA-AB schedule; tile sizes 32/64 are supported for explicit or
 # keeps-MMA-AB profiles.
 SUPPORTED_TILE_SIZE_Q = (8, 16, 32, 64)
-
-# Automatic profile search without a groups_tokens_heads_q tile target considers only
-# the low-Q swaps-MMA-AB variants. groups_tokens_heads_q selection may supply a
-# q32 or q64 target before profile resolution.
-AUTO_SWAPS_TILE_SIZE_Q = (8, 16)
-
-# The swaps-MMA-AB generation heuristic partitions K in 256-token chunks.  TS
-# measurements place the q16/q64 crossover below the reference 1024-token
-# boundary: q64 wins once projected q16 work exceeds 768 KV tokens per CTA.
-SWAPS_MMA_AB_KV_STEP_TOKENS = 256
-SWAPS_MMA_AB_MAX_SEQ_LEN_PER_CTA_KV = 768
 
 # SM100A exposes 227 KiB of dynamic SMEM.  Keep a small TS metadata reservation
 # when deciding whether the automatic cluster-reduction scratch can fit.
@@ -109,9 +95,6 @@ class MlaConfig:
     seq_len_kv: int = 4096
     logical_num_heads_q: int = 16
     logical_seq_len_q: int = 4
-    # Public spelling retained from the existing groups_tokens_heads API;
-    # kernel code uses the semantic ``groups_tokens_heads_q_ratio`` property.
-    groups_tokens_heads_ratio: int = 1
     # Causal is bottom-right aligned for speculative decode. Dense keeps only
     # the ordinary per-batch KV-tail predicate.
     mask_type: str = MaskType.CAUSAL.value
@@ -129,7 +112,7 @@ class MlaConfig:
     use_bf16_output: int = 1
     use_fp8_output: int = 0
 
-    # Mainloop tile shape for groups_tokens_heads_q decode.  Each loop step consumes two
+    # Mainloop tile shape for flat query-row decode. Each loop step consumes two
     # 128-token KV tiles: K for the current score update and V for the delayed
     # PV update.
     tile_size_q: int = 16
@@ -209,12 +192,6 @@ class MlaConfig:
     use_attention_sinks: int = 0
     use_sliding_window_causal: int = 0
     attention_window_size: int = 0
-
-    @property
-    def groups_tokens_heads_q_ratio(self) -> int:
-        """Return logical Q positions grouped into one effective row."""
-
-        return self.groups_tokens_heads_ratio
 
     @property
     def softmax0_num_warps(self) -> int:
@@ -449,40 +426,34 @@ class MlaProfile:
 
 
 @dataclass(frozen=True)
-class GroupsTokensHeadsLaunchShape:
-    """Logical and effective groups_tokens_heads_q launch dimensions."""
+class FlatQueryLaunchShape:
+    """Logical query geometry and its normalized physical flat-row launch."""
 
-    enabled: bool
-    ratio: int
     logical_num_heads_q: int
     logical_seq_len_q: int
     num_heads_q: int
     seq_len_q: int
-    tile_size_q: int | None
+    tile_size_q: int
 
     @classmethod
     def for_tile(
         cls,
         logical_num_heads_q: int,
         logical_seq_len_q: int,
-        tile_size_q: int | None,
-    ) -> "GroupsTokensHeadsLaunchShape":
-        """Build effective dimensions from an optional selected Q tile."""
+        tile_size_q: int,
+    ) -> "FlatQueryLaunchShape":
+        """Build consecutive physical M-row tiles for one logical query."""
 
-        if logical_num_heads_q <= 0:
-            raise ValueError("logical_num_heads_q must be positive")
-        ratio = (
-            groups_tokens_heads_q_capacity(logical_num_heads_q, tile_size_q)
-            if tile_size_q is not None
-            else 1
+        layout = FlatQueryTileLayout.for_tile(
+            logical_num_heads_q,
+            logical_seq_len_q,
+            tile_size_q,
         )
         return cls(
-            enabled=ratio > 1,
-            ratio=ratio,
             logical_num_heads_q=logical_num_heads_q,
             logical_seq_len_q=logical_seq_len_q,
-            num_heads_q=logical_num_heads_q * ratio,
-            seq_len_q=groups_tokens_heads_q_group_count(logical_seq_len_q, ratio),
+            num_heads_q=layout.tile_size_q,
+            seq_len_q=layout.num_tiles,
             tile_size_q=tile_size_q,
         )
 
@@ -509,123 +480,6 @@ def tile_size_q_from_profile_name(profile: str | None) -> int | None:
     return None
 
 
-def resolve_groups_tokens_heads_q_tile_hint(
-    explicit_tile_size_q: int | None,
-    profile: str | None,
-) -> int | None:
-    """Resolve explicit tile precedence without treating zero as absent."""
-
-    if explicit_tile_size_q is not None:
-        return validate_tile_size_q(explicit_tile_size_q)
-    return tile_size_q_from_profile_name(profile)
-
-
-def should_auto_group_tokens_heads_q(num_heads_q: int, seq_len_q: int) -> bool:
-    """Return whether a no-hint 1CTA launch should group tokens and Q heads."""
-
-    if num_heads_q <= 0:
-        raise ValueError("num_heads_q must be positive")
-    if seq_len_q <= 0:
-        raise ValueError("seq_len_q must be positive")
-    return seq_len_q > 1 or num_heads_q < min(SUPPORTED_TILE_SIZE_Q)
-
-
-def tile_size_q_for_tokens_heads(num_tokens_heads_q: int) -> int:
-    """Return the groups_tokens_heads_q tile target from tokens times heads."""
-
-    if num_tokens_heads_q <= 0:
-        raise ValueError("num_tokens_heads_q must be positive")
-    if num_tokens_heads_q <= 8:
-        return 8
-    if num_tokens_heads_q <= 16:
-        return 16
-    if num_tokens_heads_q <= 32:
-        return 32
-    return 64
-
-
-def compute_mla_groups_tokens_heads_ratio_for_tile(
-    num_heads_q: int,
-    seq_len_q: int,
-    tile_size_q: int,
-) -> int:
-    """Return the groups_tokens_heads_q ratio for a selected Q tile."""
-
-    if seq_len_q <= 0:
-        raise ValueError("seq_len_q must be positive")
-    return groups_tokens_heads_q_capacity(num_heads_q, tile_size_q)
-
-
-def resolve_groups_tokens_heads_q_launch_shape(
-    *,
-    num_heads_q: int,
-    seq_len_q: int,
-    groups_tokens_heads: bool,
-    tile_size_q: int | None,
-    auto_groups_tokens_heads: bool = False,
-) -> GroupsTokensHeadsLaunchShape:
-    """Resolve logical and effective groups_tokens_heads_q dimensions."""
-
-    target_tile_size_q = tile_size_q
-    grouping_selected = (
-        groups_tokens_heads or auto_groups_tokens_heads or tile_size_q is not None
-    )
-    if grouping_selected and target_tile_size_q is None:
-        target_tile_size_q = tile_size_q_for_tokens_heads(num_heads_q * seq_len_q)
-
-    return GroupsTokensHeadsLaunchShape.for_tile(
-        num_heads_q,
-        seq_len_q,
-        target_tile_size_q if grouping_selected else None,
-    )
-
-
-def resolve_throughput_latency_groups_tokens_heads_q_shape(
-    *,
-    num_heads_q: int,
-    seq_len_q: int,
-    explicit_tile_size_q: int | None,
-    profile: str | None,
-    groups_tokens_heads: bool = False,
-    auto_groups_tokens_heads: bool = True,
-) -> GroupsTokensHeadsLaunchShape:
-    """Apply 1CTA tile precedence and automatic groups_tokens_heads_q policy once."""
-
-    tile_size_q = resolve_groups_tokens_heads_q_tile_hint(explicit_tile_size_q, profile)
-    return resolve_groups_tokens_heads_q_launch_shape(
-        num_heads_q=num_heads_q,
-        seq_len_q=seq_len_q,
-        groups_tokens_heads=groups_tokens_heads,
-        tile_size_q=tile_size_q,
-        auto_groups_tokens_heads=(
-            auto_groups_tokens_heads
-            and should_auto_group_tokens_heads_q(num_heads_q, seq_len_q)
-        ),
-    )
-
-
-def resolve_groups_tokens_heads_launch_shape(
-    *,
-    num_heads_q: int,
-    seq_len_q: int,
-    groups_tokens_heads: bool,
-    tile_size_q: int | None,
-    auto_groups_tokens_heads: bool = False,
-    m_tile: int = 128,
-) -> GroupsTokensHeadsLaunchShape:
-    """Resolve the public groups_tokens_heads launch shape."""
-
-    del m_tile
-    shape = resolve_groups_tokens_heads_q_launch_shape(
-        num_heads_q=num_heads_q,
-        seq_len_q=seq_len_q,
-        groups_tokens_heads=groups_tokens_heads,
-        tile_size_q=tile_size_q,
-        auto_groups_tokens_heads=auto_groups_tokens_heads,
-    )
-    return shape
-
-
 def validate_max_active_clusters(max_active_clusters: int) -> int:
     """Return the explicit hardware active-cluster capacity."""
 
@@ -637,174 +491,53 @@ def validate_max_active_clusters(max_active_clusters: int) -> int:
 
 
 def tile_size_q_for_heads(num_heads_q: int) -> int:
-    """Choose the automatic 1CTA Q tile from the effective grouped head count."""
+    """Choose the automatic 1CTA Q tile from the physical row extent."""
 
-    # H8 gets a q8 tile, H16/H32 use the q16 swaps-MMA-AB schedule, and wider
-    # effective head tiles use the q64 keeps-MMA-AB schedule.
-    if num_heads_q <= 8:
-        return 8
-    if num_heads_q <= 32:
-        return 16
-    return 64
-
-
-def use_swaps_mma_ab_mla_gen_kernel(
-    *,
-    batch_size: int,
-    num_heads_q: int,
-    seq_len_q: int,
-    seq_len_kv: int,
-    multi_processor_count: int,
-) -> bool:
-    """Return whether MLA generation should use swaps-MMA-AB.
-
-    Estimate the number of KV CTAs using a 256-token KV step, then use
-    swaps-MMA-AB while its projected per-CTA KV work stays within the
-    TS-measured crossover and the q16 head split fits within one SM wave.
-    """
-
-    num_ctas = batch_size * seq_len_q * ceil(num_heads_q / 16)
-    if num_ctas <= 0:
-        return False
-
-    max_num_ctas_per_seq_kv = ceil(seq_len_kv / SWAPS_MMA_AB_KV_STEP_TOKENS)
-    num_ctas_per_seq_kv = min(
-        max_num_ctas_per_seq_kv,
-        max(1, multi_processor_count // num_ctas),
-    )
-    seq_len_per_cta_kv = ceil(seq_len_kv / num_ctas_per_seq_kv)
-    return (
-        seq_len_per_cta_kv <= SWAPS_MMA_AB_MAX_SEQ_LEN_PER_CTA_KV
-        and num_ctas <= multi_processor_count
+    return auto_tile_size_q_for_mla_gen(
+        num_heads_q=num_heads_q,
+        seq_len_q=1,
     )
 
 
 def auto_tile_size_q_for_mla_gen(
     *,
-    batch_size: int,
     num_heads_q: int,
     seq_len_q: int,
-    seq_len_kv: int,
-    multi_processor_count: int,
 ) -> int:
-    """Select the default 1CTA MLA generation Q tile.
+    """Choose the smallest native M tile covering the flat query rows.
 
-    When the normal family choice is q16, prefer a full q32 tile if it is the
-    smallest tile that collapses the q16 work from multiple CTA waves to one
-    without leaving capacity for a split-KV replica.  This occupancy transition
-    refines swaps-MMA-AB only; it must not replace a q64 keeps-MMA-AB choice.
+    Shapes wider than the largest 1CTA tile use repeated M64 tiles. The choice
+    depends only on query geometry, so one compiled topology is reusable across
+    runtime batch extents and K/V lengths.
     """
 
-    if num_heads_q <= 32:
-        base_tile_size_q = 8 if num_heads_q <= 8 else 16
-    elif use_swaps_mma_ab_mla_gen_kernel(
-        batch_size=batch_size,
-        num_heads_q=num_heads_q,
-        seq_len_q=seq_len_q,
-        seq_len_kv=seq_len_kv,
-        multi_processor_count=multi_processor_count,
-    ):
-        base_tile_size_q = 16
-    else:
-        base_tile_size_q = 64
-
-    q16_work = q_tile_work_count(batch_size, num_heads_q, seq_len_q, 16)
-    q32_work = q_tile_work_count(batch_size, num_heads_q, seq_len_q, 32)
-    full_q32 = num_heads_q >= 32 and num_heads_q % 32 == 0
-    if (
-        base_tile_size_q == 16
-        and full_q32
-        and q16_work > multi_processor_count
-        and q32_work <= multi_processor_count
-        and multi_processor_count // q32_work == 1
-    ):
-        return 32
-    return base_tile_size_q
+    total_q_rows = num_heads_q * seq_len_q
+    for tile_size_q in SUPPORTED_TILE_SIZE_Q:
+        if total_q_rows <= tile_size_q:
+            return tile_size_q
+    return SUPPORTED_TILE_SIZE_Q[-1]
 
 
-def resolve_auto_mla_gen_groups_tokens_heads_q_shape(
+def resolve_auto_flat_query_launch_shape(
     *,
-    batch_size: int,
     num_heads_q: int,
     seq_len_q: int,
-    seq_len_kv: int,
-    qkv_dtype: str,
-    max_active_clusters: int,
-) -> GroupsTokensHeadsLaunchShape:
-    """Resolve the automatic grouped-Q shape used by the public MLA planner.
+) -> FlatQueryLaunchShape:
+    """Resolve the public 1CTA profile tile and flat-row launch extent.
 
-    The grouped FP8 q32 swaps-MMA-AB schedule is still a useful explicit
-    benchmark target, but grouping every query token into one q32 CTA removes
-    too much launch parallelism for a short-K launch whose per-token grid still
-    fits in one resident wave.  In that regime, retain the established
-    MLA-generation tile heuristic so the planner uses the smaller per-token
-    tile.  Long-K launches, multi-wave per-token grids, keeps-MMA-AB q64
-    grouping, and BF16 grouped schedules retain their existing choices.
+    Equivalent H/Q factorizations resolve to the same physical profile when
+    their runtime work is otherwise identical.
     """
-
-    launch_shape = resolve_throughput_latency_groups_tokens_heads_q_shape(
-        num_heads_q=num_heads_q,
-        seq_len_q=seq_len_q,
-        explicit_tile_size_q=None,
-        profile=None,
-        auto_groups_tokens_heads=True,
-    )
-    if not (
-        qkv_dtype == "e4m3"
-        and launch_shape.tile_size_q == 32
-        and launch_shape.ratio > 1
-    ):
-        return launch_shape
 
     tile_size_q = auto_tile_size_q_for_mla_gen(
-        batch_size=batch_size,
         num_heads_q=num_heads_q,
         seq_len_q=seq_len_q,
-        seq_len_kv=seq_len_kv,
-        multi_processor_count=max_active_clusters,
     )
-    per_token_work = q_tile_work_count(
-        batch_size,
+    return FlatQueryLaunchShape.for_tile(
         num_heads_q,
         seq_len_q,
         tile_size_q,
     )
-    steady_steps = ceil(seq_len_kv / (MlaConfig.tile_size_kv * MlaConfig.num_insts_kv))
-    if per_token_work > max_active_clusters or steady_steps > 8:
-        return launch_shape
-    return resolve_throughput_latency_groups_tokens_heads_q_shape(
-        num_heads_q=num_heads_q,
-        seq_len_q=seq_len_q,
-        explicit_tile_size_q=tile_size_q,
-        profile=None,
-        auto_groups_tokens_heads=True,
-    )
-
-
-def min_heuristic_tile_size_q(num_heads_q: int) -> int:
-    """Return the smallest Q tile considered after split-KV is exhausted."""
-
-    if num_heads_q <= 8:
-        return 8
-    return 16
-
-
-def smaller_tile_size_q_candidates(
-    num_heads_q: int, tile_size_q: int
-) -> tuple[int, ...]:
-    """Return smaller Q tiles considered after split-KV in heuristic order."""
-
-    min_tile_size_q = min_heuristic_tile_size_q(num_heads_q)
-    candidates = []
-    # Keep tile_size_q=32 available for explicit benchmarking, but do not
-    # select it automatically until the swaps-MMA-AB q32 profile is tuned.
-    for candidate in reversed(AUTO_SWAPS_TILE_SIZE_Q):
-        if candidate >= tile_size_q or candidate < min_tile_size_q:
-            continue
-        if num_heads_q > candidate and num_heads_q % candidate != 0:
-            continue
-        candidates.append(candidate)
-    return tuple(candidates)
 
 
 def profile_name(
@@ -823,33 +556,34 @@ def q_tile_work_count(
     """Return CTA work count before KV or V-head-dim decomposition."""
 
     tile_size_q = tile_size_q or tile_size_q_for_heads(num_heads_q)
-    return batch_size * seq_len_q * ceil(num_heads_q / tile_size_q)
+    return batch_size * ceil(num_heads_q * seq_len_q / tile_size_q)
 
 
-def automatic_split_kv_step_tokens(
-    *, qkv_dtype: str, tile_size_q: int, base_work: int
+def automatic_split_kv_step_tokens(tile_size_q: int) -> int:
+    """Return one steady-state K step for the selected task graph."""
+
+    num_kv_insts = 1 if tile_size_q >= 64 else MlaConfig.num_insts_kv
+    return MlaConfig.tile_size_kv * num_kv_insts
+
+
+def select_auto_split_kv(
+    *,
+    seq_len_kv: int,
+    tile_size_q: int,
+    base_work: int,
+    target_work: int,
 ) -> int:
-    """Return the target KV-token cadence limiting automatic split count.
+    """Choose the smallest split count preserving the target K-step depth."""
 
-    The base steady-state step consumes two 128-token KV tiles.  FP8 q8 keeps
-    two such steps per split, while FP8 q16 uses four once the Q grid already
-    exposes more than four CTAs. Those FP8 factors come from local measurements
-    rather than imported constants. For non-divisible K, the final balanced split
-    can own less than the target. BF16 q8 uses the common one-step cadence;
-    the tiny q16 grid keeps its existing two-step cadence.
-    """
-
-    steady_step_tokens = MlaConfig.tile_size_kv * MlaConfig.num_insts_kv
-    if qkv_dtype == "e4m3":
-        if tile_size_q <= 8 or (tile_size_q == 16 and base_work <= 4):
-            return steady_step_tokens * 2
-        if tile_size_q == 16:
-            return steady_step_tokens * 4
-        return steady_step_tokens
-
-    if tile_size_q == 16 and base_work == 2:
-        return steady_step_tokens * 2
-    return steady_step_tokens
+    split_kv_step_tokens = automatic_split_kv_step_tokens(tile_size_q)
+    max_split_kv = max(1, ceil(seq_len_kv / split_kv_step_tokens))
+    split_kv = min(
+        max_split_kv,
+        max(1, target_work // base_work),
+        MAX_MLA_SPLITS_KV,
+    )
+    local_k_steps = ceil(max_split_kv / split_kv)
+    return ceil(max_split_kv / local_k_steps)
 
 
 def is_power_of_two(value: int) -> bool:
@@ -949,6 +683,9 @@ def keeps_mma_ab_config_kwargs(profile: MlaProfile, qkv_dtype: str) -> dict[str,
         use_clc_dynamic_persistent_scheduler = 0
 
     return {
+        # Keeps-MMA-AB has one QK/PV pipe.  Raising this value would change the
+        # KV work partition without adding the second stream used by the swaps
+        # schedule, and would therefore skip every other KV tile.
         "num_insts_kv": 1,
         "kv_stages": kv_stages,
         "q_stages": q_stages,
@@ -1292,7 +1029,10 @@ def keeps_mma_ab_profiles(
     )
     base_work = q_tile_work_count(batch_size, num_heads_q, seq_len_q, 64)
     if base_work > max_active_clusters:
-        return clc, nonpersistent, split
+        # The Keeps-MMA-AB task graph supports one persistent work tile. A
+        # persistent launch would therefore omit the grid suffix once work
+        # exceeds the resident wave, so multi-wave shapes use the direct grid.
+        return nonpersistent, split
     return nonpersistent, clc, split
 
 
@@ -1430,10 +1170,8 @@ def auto_split_profile(
     latent_dim: int,
     max_active_clusters: int,
     tile_size_q: int | None = None,
-    allow_tile_size_q_adjustment: bool = False,
-    qkv_dtype: str = "bf16",
 ) -> MlaProfile | None:
-    """Choose split-KV, then smaller Q tiles, then V head-dim splitting."""
+    """Choose split-KV followed by V head-dimension decomposition."""
 
     max_active_clusters = validate_max_active_clusters(max_active_clusters)
     original_tile_size_q = tile_size_q or tile_size_q_for_heads(num_heads_q)
@@ -1442,42 +1180,20 @@ def auto_split_profile(
     if base_work <= 0 or base_work >= target_work:
         return None
 
-    # Limit split count with the measured target cadence for this TS schedule.
-    split_kv_step_tokens = automatic_split_kv_step_tokens(
-        qkv_dtype=qkv_dtype,
+    split_kv = select_auto_split_kv(
+        seq_len_kv=seq_len_kv,
         tile_size_q=original_tile_size_q,
         base_work=base_work,
+        target_work=target_work,
     )
-    max_split_kv = max(1, ceil(seq_len_kv / split_kv_step_tokens))
-    split_kv = min(max_split_kv, max(1, target_work // base_work))
     work_after_kv = base_work * split_kv
-    selected_tile_size_q = original_tile_size_q
-
-    if allow_tile_size_q_adjustment and work_after_kv < target_work:
-        for candidate_tile_size_q in smaller_tile_size_q_candidates(
-            num_heads_q, selected_tile_size_q
-        ):
-            candidate_work = (
-                q_tile_work_count(
-                    batch_size, num_heads_q, seq_len_q, candidate_tile_size_q
-                )
-                * split_kv
-            )
-            selected_tile_size_q = candidate_tile_size_q
-            work_after_kv = candidate_work
-            if work_after_kv >= target_work:
-                break
 
     head_dim_split = head_dim_split_for_work(
         work_after_kv=work_after_kv,
         target_work=target_work,
         latent_dim=latent_dim,
     )
-    if (
-        split_kv == 1
-        and head_dim_split == 1
-        and selected_tile_size_q == original_tile_size_q
-    ):
+    if split_kv == 1 and head_dim_split == 1:
         return None
 
     suffix = "baseline"
@@ -1488,7 +1204,7 @@ def auto_split_profile(
     if split_kv > 1 and head_dim_split > 1:
         suffix = f"{suffix}_hdim{latent_dim // head_dim_split}"
     return MlaProfile(
-        name=profile_name(suffix, num_heads_q, selected_tile_size_q),
+        name=profile_name(suffix, num_heads_q, original_tile_size_q),
         num_ctas_per_seq_kv=split_kv,
         num_ctas_per_head_dim=head_dim_split,
         use_persistent_scheduler=0,
@@ -1496,113 +1212,10 @@ def auto_split_profile(
         use_multi_ctas_kv=int_flag(split_kv > 1),
         use_cluster_reduction=int_flag(split_kv > 1),
         kernel_variant=(
-            "keeps_mma_ab" if selected_tile_size_q >= 64 else "swaps_mma_ab"
+            "keeps_mma_ab" if original_tile_size_q >= 64 else "swaps_mma_ab"
         ),
-        tile_size_q=selected_tile_size_q,
+        tile_size_q=original_tile_size_q,
     )
-
-
-def wave_fill_split_kv(
-    *,
-    batch_size: int,
-    num_heads_q: int,
-    seq_len_q: int,
-    seq_len_kv: int,
-    latent_dim: int,
-    max_active_clusters: int,
-    tile_size_q: int,
-) -> int:
-    """Choose a joint split-KV/V decomposition for a family-switch probe.
-
-    The probe may use every legal one-step KV split, then derives V sharding
-    with ``head_dim_split_for_work``.  It maximizes resident CTA work without
-    exceeding one 1CTA wave; equal-work candidates prefer fewer KV splits to
-    reduce reduction overhead.  This path is internal to automatic family
-    selection and does not alter explicit split requests.
-    """
-
-    max_active_clusters = validate_max_active_clusters(max_active_clusters)
-    base_work = q_tile_work_count(batch_size, num_heads_q, seq_len_q, tile_size_q)
-    if base_work <= 0:
-        raise ValueError("base work must be positive")
-
-    steady_step_tokens = MlaConfig.tile_size_kv * MlaConfig.num_insts_kv
-    max_split_kv = min(
-        max(1, ceil(seq_len_kv / steady_step_tokens)),
-        max(1, max_active_clusters // base_work),
-    )
-    best_split = 1
-    best_score = (-1, 0)
-    for split_kv in range(1, max_split_kv + 1):
-        work_after_kv = base_work * split_kv
-        head_dim_split = head_dim_split_for_work(
-            work_after_kv=work_after_kv,
-            target_work=max_active_clusters,
-            latent_dim=latent_dim,
-        )
-        total_work = work_after_kv * head_dim_split
-        if total_work > max_active_clusters:
-            continue
-        score = (total_work, -split_kv)
-        if score > best_score:
-            best_split = split_kv
-            best_score = score
-    return best_split
-
-
-def fp8_q16_extended_family_probe_split_kv(
-    *,
-    batch_size: int,
-    num_heads_q: int,
-    seq_len_q: int,
-    seq_len_kv: int,
-    max_active_clusters: int,
-) -> int | None:
-    """Return the bounded split count for an extended FP8 Q16 family probe.
-
-    The ordinary family probe is intentionally conservative and remains
-    unchanged.  This extended probe is considered only by the public planner
-    after a 2CTA launch fits in one resident cluster wave.  A Q16 Swaps CTA
-    consumes two KV128 instructions per steady-state step.  Give the candidate
-    enough splits to keep its local K span at no more than two such steps while
-    keeping the complete Q/K grid in one 1CTA wave.  If hardware capacity
-    cannot satisfy both constraints, return ``None`` instead of selecting a
-    K-rereading Q16 family with a long local mainloop.
-
-    V-head-dimension sharding is deliberately not part of this decision.  The
-    existing ``head_dim_split_for_work`` policy derives it after split-KV has
-    been fixed, preserving the launch-policy order of Q tile, K split, then V
-    decomposition.
-    """
-
-    max_active_clusters = validate_max_active_clusters(max_active_clusters)
-    if seq_len_kv <= 0:
-        raise ValueError("seq_len_kv must be positive")
-
-    tile_size_q = 16
-    base_work = q_tile_work_count(
-        batch_size,
-        num_heads_q,
-        seq_len_q,
-        tile_size_q,
-    )
-    if base_work <= 0:
-        raise ValueError("base work must be positive")
-    max_wave_splits = max_active_clusters // base_work
-    if max_wave_splits <= 0:
-        return None
-
-    steady_step_tokens = MlaConfig.tile_size_kv * MlaConfig.num_insts_kv
-    max_local_steps = 2
-    target_split_kv = max(
-        1,
-        ceil(seq_len_kv / (max_local_steps * steady_step_tokens)),
-    )
-    split_kv = min(target_split_kv, max_wave_splits)
-    local_steps = ceil(seq_len_kv / (split_kv * steady_step_tokens))
-    if local_steps > max_local_steps:
-        return None
-    return split_kv
 
 
 def is_throughput_latency_mla_supported_shape(
@@ -1660,13 +1273,9 @@ def enumerate_throughput_latency_mla_profiles(
     ):
         return ()
 
-    target_work = max_active_clusters
     selected_tile_size_q = tile_size_q or auto_tile_size_q_for_mla_gen(
-        batch_size=batch_size,
         num_heads_q=num_heads_q,
         seq_len_q=seq_len_q,
-        seq_len_kv=seq_len_kv,
-        multi_processor_count=target_work,
     )
     if explicit_split_kv is not None and explicit_split_kv > 0:
         if explicit_split_kv > 1 and explicit_persistent is True:
@@ -1734,8 +1343,6 @@ def enumerate_throughput_latency_mla_profiles(
         latent_dim=latent_dim,
         max_active_clusters=max_active_clusters,
         tile_size_q=selected_tile_size_q,
-        allow_tile_size_q_adjustment=False,
-        qkv_dtype=qkv_dtype,
     )
     if split_profile is not None:
         profiles.append(split_profile)
@@ -1837,24 +1444,12 @@ def make_throughput_latency_mla_config(
     reduction_mode: str | None = None,
     logical_num_heads_q: int | None = None,
     logical_seq_len_q: int | None = None,
-    groups_tokens_heads_ratio: int = 1,
     tile_size_q: int | None = None,
     explicit_split_kv: int | None = None,
     explicit_persistent: bool | None = None,
-    groups_tokens_heads_q_ratio: int | None = None,
     mask_type: MaskType | str = MaskType.CAUSAL,
 ) -> MlaConfig:
     """Return throughput-latency 1CTA MLA traits for a concrete profile."""
-
-    if groups_tokens_heads_q_ratio is None:
-        groups_tokens_heads_q_ratio = groups_tokens_heads_ratio
-    elif (
-        groups_tokens_heads_ratio != 1
-        and groups_tokens_heads_ratio != groups_tokens_heads_q_ratio
-    ):
-        raise ValueError(
-            "groups_tokens_heads_q_ratio conflicts with groups_tokens_heads_ratio"
-        )
 
     mask_type = normalize_mask_type(mask_type)
 
@@ -1880,19 +1475,6 @@ def make_throughput_latency_mla_config(
         raise ValueError("logical_seq_len_q must be positive")
     if seq_len_kv <= 0:
         raise ValueError("seq_len_kv must be positive")
-    if groups_tokens_heads_q_ratio <= 0:
-        raise ValueError("groups_tokens_heads_q_ratio must be positive")
-    if num_heads_q != logical_num_heads_q * groups_tokens_heads_q_ratio:
-        raise ValueError(
-            "effective num_heads_q must equal logical_num_heads_q * groups_tokens_heads_q_ratio"
-        )
-    if seq_len_q != groups_tokens_heads_q_group_count(
-        logical_seq_len_q, groups_tokens_heads_q_ratio
-    ):
-        raise ValueError(
-            "effective seq_len_q must equal ceil(logical_seq_len_q / "
-            "groups_tokens_heads_q_ratio)"
-        )
     if latent_dim <= 0:
         raise ValueError("latent_dim must be positive")
     if rope_dim < 0:
@@ -1949,6 +1531,19 @@ def make_throughput_latency_mla_config(
     tile_size_q = tile_size_q_for_profile(
         selected_profile, num_heads_q, seq_len_q, tile_size_q
     )
+    flat_layout = FlatQueryTileLayout.for_tile(
+        logical_num_heads_q,
+        logical_seq_len_q,
+        tile_size_q,
+    )
+    if num_heads_q != flat_layout.tile_size_q or seq_len_q != flat_layout.num_tiles:
+        raise ValueError(
+            "physical 1CTA launch shape must match the flat query-row layout: "
+            f"got num_heads_q={num_heads_q}, seq_len_q={seq_len_q}; expected "
+            f"num_heads_q={flat_layout.tile_size_q}, "
+            f"seq_len_q={flat_layout.num_tiles} for logical "
+            f"H={logical_num_heads_q}, SQ={logical_seq_len_q}"
+        )
     if selected_profile.kernel_variant == "keeps_mma_ab" and num_heads_q < tile_size_q:
         raise ValueError(
             "keeps_mma_ab profiles require an effective Q tile of at least "
@@ -1981,14 +1576,12 @@ def make_throughput_latency_mla_config(
         head_dim_per_cta_v=head_dim_per_cta_v,
         reduction_mode=reduction_mode,
     )
-    if use_cluster_reduction == 1 and (
-        num_heads_q < tile_size_q or num_heads_q % tile_size_q != 0
-    ):
+    if use_cluster_reduction == 1 and flat_layout.tail_rows != tile_size_q:
         if reduction_mode == "cluster":
             raise ValueError(
                 "cluster reduction requires every launched Q tile to contain a full "
                 "tile_size_q rows: "
-                f"num_heads_q={num_heads_q}, tile_size_q={tile_size_q}"
+                f"tail_rows={flat_layout.tail_rows}, tile_size_q={tile_size_q}"
             )
         use_cluster_reduction = 0
     num_ctas_per_seq_q = max(1, seq_len_q)
@@ -2000,7 +1593,6 @@ def make_throughput_latency_mla_config(
         seq_len_kv=seq_len_kv,
         logical_num_heads_q=logical_num_heads_q,
         logical_seq_len_q=logical_seq_len_q,
-        groups_tokens_heads_ratio=groups_tokens_heads_q_ratio,
         mask_type=mask_type,
         head_dim_qk=head_dim_qk,
         head_dim_v=latent_dim,

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/kernel.py
@@ -55,7 +55,6 @@ from cutlass.experimental.task_scheduling.task_manager import TaskManager
 from .config import (
     MlaConfig,
     make_throughput_latency_mla_config,
-    resolve_throughput_latency_groups_tokens_heads_q_shape,
 )
 from .resources import (
     SmemKvResource,
@@ -97,7 +96,6 @@ from .parallel_reduction import (
 from .reduction import gmem_reduction_launch_shape, run_gmem_reduction_kernel
 from ..helpers.constants import TMEM_LIFECYCLE_BARRIER_ID
 from ..helpers.mask import MaskType, normalize_mask_type
-from ..helpers.query import groups_tokens_heads_q_group_count
 from ..helpers.tile import (
     runtime_query_tile_is_active,
     runtime_split_pruning_is_profitable,
@@ -207,7 +205,7 @@ def _publish_neutral_standalone_partial(
 
 @cute.jit
 def _persistent_work_tile_is_inactive(cfg, cache_seqs, cu_seqlens_q, work_tile):
-    """Return whether a persistent Q tile is runtime padding."""
+    """Return whether a persistent physical Q tile has no runtime rows."""
 
     cta_idx_q, _, batch_head_idx = work_tile.tile_idx
     batch_idx = Int32(batch_head_idx) // Int32(cfg.num_ctas_for_all_heads)
@@ -226,6 +224,7 @@ class ThroughputLatencyMlaStaticWorkQueue(WorkQueue):
     """Static persistent scheduler for MLA tiles shaped as (cta_q, cta_head_dim, batch_head_tile)."""
 
     cfg: cutlass.Constexpr[MlaConfig] = None
+    batch_size: object = None
     cache_seqs: object = None
     cu_seqlens_q: object = None
     enable_runtime_skip: cutlass.Constexpr[bool] = False
@@ -234,6 +233,7 @@ class ThroughputLatencyMlaStaticWorkQueue(WorkQueue):
         self,
         tile_scheduler_config: TileSchedulerConfig,
         cfg: cutlass.Constexpr[MlaConfig] = None,
+        batch_size=None,
         cache_seqs=None,
         cu_seqlens_q=None,
         **kwargs,
@@ -244,13 +244,14 @@ class ThroughputLatencyMlaStaticWorkQueue(WorkQueue):
             **kwargs,
         )
         self.cfg = cfg
+        self.batch_size = batch_size
         self.cache_seqs = cache_seqs
         self.cu_seqlens_q = cu_seqlens_q
         self.enable_runtime_skip = cu_seqlens_q is not None
 
     @cute.jit
     def skip_work_tile_if(self, work_tile: WorkTileInfo):
-        """Skip packed-Q padding while retaining queue bookkeeping."""
+        """Skip inactive physical Q tiles while retaining queue bookkeeping."""
 
         return _persistent_work_tile_is_inactive(
             self.cfg,
@@ -271,7 +272,7 @@ class ThroughputLatencyMlaStaticWorkQueue(WorkQueue):
         cta_idx_q = in_batch_head_idx - cta_idx_head_dim * ctas_q
         total_tiles = (
             tiles_per_batch_head
-            * Int32(self.cfg.batch_size)
+            * Int32(self.batch_size)
             * Int32(self.cfg.num_ctas_for_all_heads)
         )
         return WorkTileInfo(
@@ -333,7 +334,7 @@ class ThroughputLatencyMlaClcWorkQueue(WorkQueue):
 
     @cute.jit
     def skip_work_tile_if(self, work_tile: WorkTileInfo):
-        """Skip packed-Q padding while retaining queue bookkeeping."""
+        """Skip inactive physical Q tiles while retaining queue bookkeeping."""
 
         return _persistent_work_tile_is_inactive(
             self.cfg,
@@ -377,6 +378,7 @@ def _make_static_work_queue(
             tile_scheduler_params=tile_sched_params,
         ),
         cfg=cfg,
+        batch_size=cute.size(cache_seqs),
         cache_seqs=cache_seqs,
         cu_seqlens_q=cu_seqlens_q,
         name=name,
@@ -1441,46 +1443,20 @@ class ThroughputLatencyMlaDecodeTs:
         profile: str | None = None,
         persistent_wave_sm_count: int | None = None,
         reduction_mode: str | None = None,
-        groups_tokens_heads: bool = False,
-        groups_tokens_heads_ratio: int = 1,
-        logical_num_heads: int | None = None,
-        logical_seq_len_q: int | None = None,
-        tile_size_q: int | None = None,
+        logical_num_heads: int,
+        logical_seq_len_q: int,
+        tile_size_q: int,
         explicit_split_kv: int | None = None,
         explicit_persistent: bool | None = None,
-        groups_tokens_heads_q_ratio: int | None = None,
         mask_type: MaskType | str = MaskType.CAUSAL,
     ):
-        """Initialize the wrapper, deriving groups_tokens_heads_q rows when unspecified."""
+        """Initialize one selected physical tile profile over logical flat Q rows."""
         import cutlass as _cutlass
 
         if acc_dtype is None:
             acc_dtype = _cutlass.Float32
         if lse_dtype is None:
             lse_dtype = _cutlass.Float32
-
-        has_explicit_groups_tokens_heads_q_shape = (
-            groups_tokens_heads_q_ratio is not None
-            or groups_tokens_heads
-            or groups_tokens_heads_ratio != 1
-            or logical_num_heads is not None
-            or logical_seq_len_q is not None
-        )
-        if not has_explicit_groups_tokens_heads_q_shape:
-            groups_tokens_heads_q_shape = (
-                resolve_throughput_latency_groups_tokens_heads_q_shape(
-                    num_heads_q=num_heads,
-                    seq_len_q=seq_len_q,
-                    explicit_tile_size_q=tile_size_q,
-                    profile=profile,
-                )
-            )
-            num_heads = groups_tokens_heads_q_shape.num_heads_q
-            seq_len_q = groups_tokens_heads_q_shape.seq_len_q
-            logical_num_heads = groups_tokens_heads_q_shape.logical_num_heads_q
-            logical_seq_len_q = groups_tokens_heads_q_shape.logical_seq_len_q
-            tile_size_q = groups_tokens_heads_q_shape.tile_size_q
-            groups_tokens_heads_q_ratio = groups_tokens_heads_q_shape.ratio
 
         self.batch_size = batch_size
         self.num_heads = num_heads
@@ -1495,27 +1471,6 @@ class ThroughputLatencyMlaDecodeTs:
         self.profile = profile
         self.persistent_wave_sm_count = persistent_wave_sm_count
         self.reduction_mode = reduction_mode
-        if groups_tokens_heads_q_ratio is None:
-            group = groups_tokens_heads_ratio if groups_tokens_heads else 1
-        else:
-            if groups_tokens_heads or groups_tokens_heads_ratio != 1:
-                raise ValueError(
-                    "groups_tokens_heads_q_ratio cannot be combined with explicit "
-                    "groups_tokens_heads arguments"
-                )
-            group = groups_tokens_heads_q_ratio
-        if group <= 0:
-            raise ValueError("groups_tokens_heads_q_ratio must be positive")
-        self.groups_tokens_heads_ratio = group
-        self.groups_tokens_heads = group > 1
-        if logical_num_heads is None:
-            logical_num_heads = num_heads // group
-        if logical_seq_len_q is None:
-            if group != 1:
-                raise ValueError(
-                    "logical_seq_len_q is required for groups_tokens_heads_q launches"
-                )
-            logical_seq_len_q = seq_len_q
         self.logical_num_heads = logical_num_heads
         self.logical_seq_len_q = logical_seq_len_q
         self.tile_size_q = tile_size_q
@@ -1524,11 +1479,9 @@ class ThroughputLatencyMlaDecodeTs:
         self.mask_type = normalize_mask_type(mask_type)
 
         cfg = self._make_config()
-        # The parallel standalone reducer is a production-derived choice, not
-        # a user knob.  It requires a fixed split profile and a static producer
-        # schedule so the reducer topology and workspace contract are compile-
-        # time invariant.  Every other supported profile keeps the established
-        # FlashInfer reducer as an automatic fallback.
+        # Parallel standalone reduction requires a fixed split profile and a
+        # static producer schedule so its topology and workspace contract are
+        # compile-time invariant. Other profiles use the general reducer.
         self.use_parallel_reduction = (
             supports_parallel_gmem_reduction(cfg)
             and lse_dtype == _cutlass.Float32
@@ -1542,9 +1495,8 @@ class ThroughputLatencyMlaDecodeTs:
             else PARALLEL_GMEM_REDUCTION_ELEMENTS_PER_SLICE
         )
         if cfg.use_multi_ctas_kv == 1 and cfg.use_cluster_reduction != 1:
-            # Both the retained reducer and the parallel implementation use
-            # the same normalized partial-O workspace. Qualify the configured
-            # separate-GMEM launch regardless of which reducer is selected.
+            # Both reducer implementations use the same normalized partial-O
+            # workspace. Validate every separate-GMEM launch against it.
             validate_parallel_reduction_workspace(
                 batch_size=cfg.batch_size,
                 num_heads_q=cfg.num_heads_q,
@@ -1572,21 +1524,50 @@ class ThroughputLatencyMlaDecodeTs:
                     cluster_size=cluster_size,
                 )
             )
-        if num_heads > cfg.tile_size_q and num_heads % cfg.tile_size_q != 0:
-            raise NotImplementedError(
-                "Throughput-latency 1CTA TS MLA runtime requires multi-tile num_heads to be "
-                f"divisible by tile_size_q: num_heads={num_heads}, "
-                f"tile_size_q={cfg.tile_size_q}."
-            )
-
         self.acc_dtype = acc_dtype
         self.lse_dtype = lse_dtype
 
-    @property
-    def groups_tokens_heads_q_ratio(self) -> int:
-        """Return the effective groups_tokens_heads_q capacity."""
+    def compile_topology_signature(self) -> tuple[object, ...]:
+        """Describe batch-derived reducer choices without retaining batch."""
 
-        return self.groups_tokens_heads_ratio
+        cfg = self._make_config()
+        if cfg.use_multi_ctas_kv != 1 or cfg.use_cluster_reduction == 1:
+            return ("no_separate_reducer",)
+        if self.use_parallel_reduction:
+            return (
+                "parallel",
+                self.parallel_reduction_topology,
+                self.parallel_reduction_elements_per_slice,
+            )
+        grid, smem, threads, reduction_ctas = gmem_reduction_launch_shape(
+            cfg,
+            cfg.seq_len_q,
+            cfg.batch_size,
+            self.lse_dtype.width,
+            self.max_active_clusters,
+        )
+        return (
+            "reference",
+            grid[0],
+            grid[1],
+            smem,
+            threads,
+            reduction_ctas,
+        )
+
+    def compile_signature(self) -> tuple[object, ...]:
+        """Return the complete batch-independent JIT identity."""
+
+        cfg = dataclass_replace(self._make_config(), batch_size=1)
+        return (
+            cfg,
+            self.acc_dtype,
+            self.lse_dtype,
+            self.use_parallel_reduction,
+            self.parallel_reduction_topology,
+            self.parallel_reduction_elements_per_slice,
+            self.compile_topology_signature(),
+        )
 
     def _make_config(self):
         """Create the static throughput-latency MLA config for this wrapper."""
@@ -1606,7 +1587,6 @@ class ThroughputLatencyMlaDecodeTs:
             reduction_mode=self.reduction_mode,
             logical_num_heads_q=self.logical_num_heads,
             logical_seq_len_q=self.logical_seq_len_q,
-            groups_tokens_heads_q_ratio=self.groups_tokens_heads_q_ratio,
             tile_size_q=self.tile_size_q,
             explicit_split_kv=self.explicit_split_kv,
             explicit_persistent=self.explicit_persistent,
@@ -1629,105 +1609,6 @@ class ThroughputLatencyMlaDecodeTs:
         if cfg.use_multi_ctas_kv == 1 and split_kv < cfg.num_ctas_per_seq_kv:
             raise ValueError(
                 "split_kv is smaller than the configured multi-CTA-KV split count"
-            )
-
-    def validate_groups_tokens_heads_launch_shape(
-        self,
-        q_latent_shape,
-        q_rope_shape,
-        o_shape,
-        lse_shape,
-        logical_num_heads: int,
-        logical_seq_len_q: int,
-        cu_seqlens_q_shape=None,
-    ) -> None:
-        """Validate logical public tensors against the groups_tokens_heads_q launch shape."""
-
-        is_ragged = len(q_latent_shape) == 3
-        if is_ragged:
-            if cu_seqlens_q_shape is None:
-                raise ValueError("rank-3 compact Q/O tensors require cu_seqlens_q")
-            if len(cu_seqlens_q_shape) != 1 or int(cu_seqlens_q_shape[0]) != (
-                self.batch_size + 1
-            ):
-                raise ValueError(
-                    "cu_seqlens_q must be rank-1 with batch_size + 1 offsets"
-                )
-            for name, shape in (
-                ("q_latent", q_latent_shape),
-                ("q_rope", q_rope_shape),
-                ("o", o_shape),
-            ):
-                if len(shape) != 3:
-                    raise ValueError(
-                        f"{name} must be rank-3 for a compact ragged-query launch"
-                    )
-                if int(shape[0]) != logical_num_heads:
-                    raise ValueError(
-                        "compact ragged-query launch tensors must agree on "
-                        f"logical num_heads for {name}"
-                    )
-            if len(lse_shape) != 2:
-                raise ValueError("lse must be rank-2 for a compact ragged-query launch")
-            if int(lse_shape[0]) != logical_num_heads:
-                raise ValueError(
-                    "compact ragged-query launch tensors must agree on "
-                    "logical num_heads for lse"
-                )
-            total_query_rows = int(q_latent_shape[2])
-            if (
-                int(q_rope_shape[2]) != total_query_rows
-                or int(o_shape[2]) != total_query_rows
-                or int(lse_shape[1]) != total_query_rows
-            ):
-                raise ValueError(
-                    "compact ragged-query launch tensors must agree on total Q rows"
-                )
-        else:
-            if cu_seqlens_q_shape is not None:
-                raise ValueError("cu_seqlens_q requires rank-3 compact Q/O tensors")
-            for name, shape in (
-                ("q_latent", q_latent_shape),
-                ("q_rope", q_rope_shape),
-                ("o", o_shape),
-            ):
-                if len(shape) != 4:
-                    raise ValueError(
-                        f"{name} must be rank-4 for groups_tokens_heads_q launch"
-                    )
-                if (
-                    int(shape[0]) != logical_num_heads
-                    or int(shape[2]) != logical_seq_len_q
-                ):
-                    raise ValueError(
-                        "groups_tokens_heads_q launch tensors must agree on "
-                        f"logical num_heads/seq_len_q for {name}"
-                    )
-            if len(lse_shape) != 3:
-                raise ValueError("lse must be rank-3 for groups_tokens_heads_q launch")
-            if (
-                int(lse_shape[0]) != logical_num_heads
-                or int(lse_shape[1]) != logical_seq_len_q
-            ):
-                raise ValueError(
-                    "groups_tokens_heads_q launch tensors must agree on "
-                    "logical num_heads/seq_len_q for lse"
-                )
-
-        group = self.groups_tokens_heads_q_ratio
-        if group <= 1:
-            return
-        if logical_num_heads * group != self.num_heads:
-            raise ValueError(
-                "groups_tokens_heads_q effective heads must match kernel num_heads"
-            )
-        if (
-            groups_tokens_heads_q_group_count(logical_seq_len_q, group)
-            != self.seq_len_q
-        ):
-            raise ValueError(
-                "groups_tokens_heads_q effective seq_len_q must be the ceil-divided "
-                "logical query length"
             )
 
     def initialize_workspace(
@@ -1791,8 +1672,8 @@ class ThroughputLatencyMlaDecodeTs:
 
         # Public fixed tensors use [H,D,SQ,B]/[H,SQ,B]; compact ragged tensors
         # use [H,D,totalQ]/[H,totalQ]. Both flatten H x Q for TMA because the
-        # scheduler operates on groups_tokens_heads_q rows. Resource-level
-        # predicates own the padded final group and map outputs back to storage.
+        # scheduler operates on consecutive physical row tiles. Resource-level
+        # predicates own the final partial tile and map outputs back to storage.
         tma_box0 = min(128 // cfg.qkv_dtype_bytes, cfg.head_dim_per_stage_kv)
         tma_page_tokens = cfg.num_tokens_per_page
         if cutlass.const_expr(q_latent.stride[1] != 1 or q_rope.stride[1] != 1):
@@ -1835,7 +1716,7 @@ class ThroughputLatencyMlaDecodeTs:
             )
         else:
             runtime_assert(
-                cute.size(cu_seqlens_q) == Int32(cfg.batch_size + 1),
+                cute.size(cu_seqlens_q) == cute.size(cache_seqs) + Int32(1),
                 "cu_seqlens_q must contain batch_size + 1 offsets",
             )
         if cutlass.const_expr(
@@ -1968,11 +1849,17 @@ class ThroughputLatencyMlaDecodeTs:
         use_gmem_reduction = cutlass.const_expr(
             cfg.use_multi_ctas_kv == 1 and cfg.use_cluster_reduction != 1
         )
+        batch_size = Int32(cute.size(cache_seqs))
+        if cutlass.const_expr(cu_seqlens_q is None):
+            runtime_assert(
+                cute.size(o.shape[3]) == batch_size,
+                "fixed output batch size must match cache_seqs",
+            )
         acc_o, acc_lse = self.initialize_workspace(
             cutlass.Int32(cfg.num_heads_q),
             cfg.head_dim_v,
             cutlass.Int32(cfg.seq_len_q),
-            cutlass.Int32(cfg.batch_size),
+            batch_size,
             workspace_split_kv,
             workspace if use_gmem_reduction else None,
         )
@@ -1990,7 +1877,7 @@ class ThroughputLatencyMlaDecodeTs:
                 (
                     cfg.num_ctas_per_seq_q,
                     cfg.num_ctas_per_head_dim,
-                    cfg.batch_size * cfg.num_ctas_for_all_heads,
+                    batch_size * Int32(cfg.num_ctas_for_all_heads),
                 ),
                 (1, 1, 1),
             )
@@ -2000,7 +1887,7 @@ class ThroughputLatencyMlaDecodeTs:
                 (
                     cfg.num_ctas_per_seq_q,
                     cfg.num_ctas_per_head_dim,
-                    cfg.batch_size * cfg.num_ctas_for_all_heads,
+                    batch_size * Int32(cfg.num_ctas_for_all_heads),
                 ),
                 (1, 1, 1),
             )
@@ -2014,7 +1901,7 @@ class ThroughputLatencyMlaDecodeTs:
                 * cfg.num_ctas_per_seq_q
                 * cfg.num_ctas_per_seq_kv,
                 cfg.num_ctas_per_head_dim,
-                cfg.batch_size,
+                batch_size,
             )
         cluster_shape = None
         if cutlass.const_expr(cfg.use_cluster_reduction == 1):
@@ -2053,6 +1940,11 @@ class ThroughputLatencyMlaDecodeTs:
                         topology,
                         self.parallel_reduction_elements_per_slice,
                     )
+                )
+                reduction_grid = (
+                    reduction_grid[0],
+                    reduction_grid[1],
+                    batch_size,
                 )
                 reduction_threads = parallel_gmem_reduction_threads(
                     self.parallel_reduction_elements_per_slice
@@ -2095,6 +1987,11 @@ class ThroughputLatencyMlaDecodeTs:
                 self.lse_dtype.width,
                 self.max_active_clusters,
             )
+            reduction_grid = (
+                reduction_grid[0],
+                reduction_grid[1],
+                batch_size,
+            )
             self.gmem_reduction_kernel(
                 o,
                 lse,
@@ -2132,11 +2029,11 @@ class ThroughputLatencyMlaDecodeTs:
         output_scale: cutlass.Float32,
         tile_sched_params: object,
     ):
-        """Execute one groups_tokens_heads_q, batch, KV-split, and V head-dimension tile."""
+        """Execute one flat-Q, batch, KV-split, and V head-dimension tile."""
         cfg = self._make_config()
 
-        # The grid is expressed in effective grouped-Q coordinates. Decode it
-        # once here; Q/O resources retain responsibility for logical row
+        # The grid is expressed in physical flat-Q tile coordinates. Decode it
+        # once here; Q/O resources retain responsibility for logical-row
         # mapping, compact-ragged offsets, and padded-tail publication.
         cta_idx_x, cta_idx_head_dim_v, batch_idx = cute.arch.block_idx()
         if cutlass.const_expr(cfg.use_cluster_reduction == 1):

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/parallel_reduction.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/parallel_reduction.py
@@ -27,7 +27,7 @@ from ..helpers.ops import (
     warp_reduce_max_f32,
     warp_reduce_sum_f32,
 )
-from ..helpers.query import groups_tokens_heads_q_row_state, public_query_flat_row
+from ..helpers.query import flat_query_row_state, public_query_flat_row
 from ..parallel_reduction_topology import ParallelReductionTopology
 from .config import MlaConfig
 
@@ -233,10 +233,10 @@ def _run_parallel_gmem_reduction_g1_shared_stats(
             _,
             _,
             valid_output_row,
-        ) = groups_tokens_heads_q_row_state(
+        ) = flat_query_row_state(
             head_idx,
             q_idx,
-            cfg.groups_tokens_heads_q_ratio,
+            cfg.tile_size_q,
             cfg.logical_num_heads_q,
             cfg.logical_seq_len_q,
             cu_seqlens_q=cu_seqlens_q,
@@ -310,10 +310,10 @@ def _run_parallel_gmem_reduction_g1_shared_stats(
         _,
         _,
         valid_output_row,
-    ) = groups_tokens_heads_q_row_state(
+    ) = flat_query_row_state(
         head_idx,
         q_idx,
-        cfg.groups_tokens_heads_q_ratio,
+        cfg.tile_size_q,
         cfg.logical_num_heads_q,
         cfg.logical_seq_len_q,
         cu_seqlens_q=cu_seqlens_q,
@@ -453,10 +453,10 @@ def _run_parallel_gmem_reduction_shared_stats(
             _,
             _,
             valid_stats_row,
-        ) = groups_tokens_heads_q_row_state(
+        ) = flat_query_row_state(
             stats_head_idx,
             q_idx,
-            cfg.groups_tokens_heads_q_ratio,
+            cfg.tile_size_q,
             cfg.logical_num_heads_q,
             cfg.logical_seq_len_q,
             cu_seqlens_q=cu_seqlens_q,
@@ -478,7 +478,7 @@ def _run_parallel_gmem_reduction_shared_stats(
             lane_lse[lane_slot_i] = neg_inf
         local_lse = neg_inf
         if valid_stats:
-            # Form the row view only after validating the grouped output row.
+            # Form the row view only after validating the flat output row.
             # Invalid/padded rows publish a neutral state without an acc_lse
             # address or load.
             row_lse = acc_lse[stats_head_idx, None, q_idx, batch_idx]
@@ -535,10 +535,10 @@ def _run_parallel_gmem_reduction_shared_stats(
         _,
         _,
         valid_output_row,
-    ) = groups_tokens_heads_q_row_state(
+    ) = flat_query_row_state(
         head_idx,
         q_idx,
-        cfg.groups_tokens_heads_q_ratio,
+        cfg.tile_size_q,
         cfg.logical_num_heads_q,
         cfg.logical_seq_len_q,
         cu_seqlens_q=cu_seqlens_q,
@@ -649,10 +649,10 @@ def _run_parallel_gmem_reduction_shared_stats(
                 _,
                 _,
                 valid_stats_row,
-            ) = groups_tokens_heads_q_row_state(
+            ) = flat_query_row_state(
                 stats_head_idx,
                 q_idx,
-                cfg.groups_tokens_heads_q_ratio,
+                cfg.tile_size_q,
                 cfg.logical_num_heads_q,
                 cfg.logical_seq_len_q,
                 cu_seqlens_q=cu_seqlens_q,

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/reduction.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/reduction.py
@@ -28,7 +28,7 @@ from ..helpers.ops import (
     vector_from_scalars,
 )
 from ..helpers.query import (
-    groups_tokens_heads_q_row_state,
+    flat_query_row_state,
     public_query_flat_row,
     split_o_element_offset,
 )
@@ -246,10 +246,10 @@ def run_gmem_reduction_kernel(
     neutral partials, so the reducer retains configured, compile-time split
     geometry without consuming stale workspace from an earlier graph replay.
 
-    The grid and workspace remain in effective groups_tokens_heads_q
-    coordinates. Every reducer variant maps those coordinates to
-    fixed or compact-ragged public storage; padded tail rows may synchronize
-    and consume workspace slots but never publish O or LSE.
+    The grid and workspace remain in physical flat-query tile coordinates.
+    Every reducer variant maps those coordinates to fixed or compact-ragged
+    public storage; inactive tail rows may synchronize and consume workspace
+    slots but never publish O or LSE.
     """
     # Pair with the dense kernel PDL signal before reading partials.
     prims.griddepcontrol(kind=prims.GridDepAction.WAIT)
@@ -291,10 +291,10 @@ def run_gmem_reduction_kernel(
                 _,
                 _,
                 valid_output_row,
-            ) = groups_tokens_heads_q_row_state(
+            ) = flat_query_row_state(
                 head_idx,
                 cta_idx_q,
-                cfg.groups_tokens_heads_q_ratio,
+                cfg.tile_size_q,
                 cfg.logical_num_heads_q,
                 cfg.logical_seq_len_q,
                 cu_seqlens_q=cu_seqlens_q,
@@ -427,10 +427,10 @@ def run_gmem_reduction_kernel(
                 _,
                 _,
                 valid_output_row,
-            ) = groups_tokens_heads_q_row_state(
+            ) = flat_query_row_state(
                 global_head_idx,
                 q_idx,
-                cfg.groups_tokens_heads_q_ratio,
+                cfg.tile_size_q,
                 cfg.logical_num_heads_q,
                 cfg.logical_seq_len_q,
                 cu_seqlens_q=cu_seqlens_q,
@@ -518,10 +518,10 @@ def run_gmem_reduction_kernel(
             _,
             _,
             valid_output_row,
-        ) = groups_tokens_heads_q_row_state(
+        ) = flat_query_row_state(
             global_head_idx,
             q_idx,
-            cfg.groups_tokens_heads_q_ratio,
+            cfg.tile_size_q,
             cfg.logical_num_heads_q,
             cfg.logical_seq_len_q,
             cu_seqlens_q=cu_seqlens_q,
@@ -603,10 +603,10 @@ def run_gmem_reduction_kernel(
                 _,
                 _,
                 valid_output_row,
-            ) = groups_tokens_heads_q_row_state(
+            ) = flat_query_row_state(
                 head_idx,
                 row_q_idx,
-                cfg.groups_tokens_heads_q_ratio,
+                cfg.tile_size_q,
                 cfg.logical_num_heads_q,
                 cfg.logical_seq_len_q,
                 cu_seqlens_q=cu_seqlens_q,
@@ -680,10 +680,10 @@ def run_gmem_reduction_kernel(
             _,
             _,
             valid_output_row,
-        ) = groups_tokens_heads_q_row_state(
+        ) = flat_query_row_state(
             head_idx,
             q_idx,
-            cfg.groups_tokens_heads_q_ratio,
+            cfg.tile_size_q,
             cfg.logical_num_heads_q,
             cfg.logical_seq_len_q,
             cu_seqlens_q=cu_seqlens_q,
@@ -742,7 +742,7 @@ def run_gmem_reduction_kernel(
             )
         return
 
-    # Scalar fallback: one reducer coordinate owns one grouped row and one
+    # Scalar fallback: one reducer coordinate owns one flat query row and one
     # head-dimension band, then publishes only after logical-row validation.
     reduction_dim_tiles = ceil_div(cfg.head_dim_v, GMEM_REDUCTION_SCALAR_DIM_TILE)
     head_idx = head_dim_tile_idx // Int32(reduction_dim_tiles)
@@ -753,10 +753,10 @@ def run_gmem_reduction_kernel(
         _,
         _,
         valid_output_row,
-    ) = groups_tokens_heads_q_row_state(
+    ) = flat_query_row_state(
         head_idx,
         q_idx,
-        cfg.groups_tokens_heads_q_ratio,
+        cfg.tile_size_q,
         cfg.logical_num_heads_q,
         cfg.logical_seq_len_q,
         cu_seqlens_q=cu_seqlens_q,

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/resources/tmem_corr.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/resources/tmem_corr.py
@@ -78,7 +78,7 @@ from ...helpers.ops import (
     vector_from_scalars,
 )
 from ...helpers.query import (
-    groups_tokens_heads_q_row_state,
+    flat_query_row_state,
     public_query_flat_row,
     split_o_element_offset,
 )
@@ -408,10 +408,10 @@ class TmemCorrResource(MlaResource):
                 cfg.num_heads_q
             ):
                 storage_flat_query_row, _, _, _, valid_output_row = (
-                    groups_tokens_heads_q_row_state(
+                    flat_query_row_state(
                         global_head_idx,
                         cta_idx_q,
-                        cfg.groups_tokens_heads_q_ratio,
+                        cfg.tile_size_q,
                         cfg.logical_num_heads_q,
                         cfg.logical_seq_len_q,
                         cu_seqlens_q=self.cu_seqlens_q,
@@ -508,10 +508,10 @@ class TmemCorrResource(MlaResource):
                 self.cfg.num_heads_q
             ):
                 storage_flat_query_row, _, _, _, valid_output_row = (
-                    groups_tokens_heads_q_row_state(
+                    flat_query_row_state(
                         head_idx,
                         cta_idx_q,
-                        self.cfg.groups_tokens_heads_q_ratio,
+                        self.cfg.tile_size_q,
                         self.cfg.logical_num_heads_q,
                         self.cfg.logical_seq_len_q,
                         cu_seqlens_q=self.cu_seqlens_q,
@@ -743,10 +743,10 @@ class TmemCorrResource(MlaResource):
                                 _,
                                 _,
                                 valid_output_row,
-                            ) = groups_tokens_heads_q_row_state(
+                            ) = flat_query_row_state(
                                 global_head_idx,
                                 cta_idx_q,
-                                cfg.groups_tokens_heads_q_ratio,
+                                cfg.tile_size_q,
                                 cfg.logical_num_heads_q,
                                 cfg.logical_seq_len_q,
                                 cu_seqlens_q=self.cu_seqlens_q,
@@ -1373,16 +1373,14 @@ class TmemCorrResource(MlaResource):
         # the row index; the upper lane bit selects the head-dim half.
         local_row_idx = warp_idx * Int32(16) + (lane_idx & Int32(0xF))
         global_head_idx = head_base_idx + local_row_idx
-        storage_flat_query_row, _, _, _, valid_output_row = (
-            groups_tokens_heads_q_row_state(
-                global_head_idx,
-                cta_idx_q,
-                cfg.groups_tokens_heads_q_ratio,
-                cfg.logical_num_heads_q,
-                cfg.logical_seq_len_q,
-                cu_seqlens_q=self.cu_seqlens_q,
-                batch_idx=batch_idx,
-            )
+        storage_flat_query_row, _, _, _, valid_output_row = flat_query_row_state(
+            global_head_idx,
+            cta_idx_q,
+            cfg.tile_size_q,
+            cfg.logical_num_heads_q,
+            cfg.logical_seq_len_q,
+            cu_seqlens_q=self.cu_seqlens_q,
+            batch_idx=batch_idx,
         )
         half_warp_col_offset = (lane_idx >> Int32(4)) * Int32(
             cfg.head_dim_per_stage_v // 2

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/resources/tmem_s.py
@@ -88,8 +88,7 @@ from ...helpers.tile import (
     cta_idx_kv_for_stage,
     cta_idx_q_for_stage,
     global_kv_tile_idx,
-    head_idx_for_stage,
-    runtime_seq_len_kv_for_effective_head,
+    runtime_seq_len_kv_for_query_row,
     runtime_seq_len_kv_from_task_cache,
     softmax_kv_tile_idx,
 )
@@ -393,7 +392,7 @@ class TmemSResource(MlaResource):
         s_arr,
         section: cutlass.Constexpr[MlaStage],
     ):
-        """Read S from TMEM and update the grouped-head softmax state."""
+        """Read S from TMEM and update the flat-query softmax state."""
         # Consumer work for TmemSResource: softmax waits for the QK MMA score
         # stage, loads S from TMEM, applies masks, and returns updated local
         # softmax state to the captured schedule.
@@ -498,33 +497,36 @@ class TmemSResource(MlaResource):
             (seq_len_kv % Int32(cfg.tile_size_kv)) != Int32(0)
         ) or (next_tile_offset_k > seq_len_kv)
         needs_row_causal_mask = cutlass.const_expr(
-            cfg.mask_type == MaskType.CAUSAL.value
-            and cfg.groups_tokens_heads_q_ratio > 1
+            cfg.mask_type == MaskType.CAUSAL.value and cfg.logical_seq_len_q > 1
         )
         if cutlass.const_expr(needs_row_causal_mask):
-            min_seq_len_kv = seq_len_kv - Int32(cfg.groups_tokens_heads_q_ratio - 1)
+            min_seq_len_kv = runtime_seq_len_kv_for_query_row(
+                cfg,
+                self.cache_seqs,
+                batch_idx,
+                cta_idx_q,
+                Int32(0),
+                self.cu_seqlens_q,
+            )
             should_apply_dense_mask = should_apply_dense_mask or (
                 next_tile_offset_k > min_seq_len_kv
             )
         if should_apply_dense_mask:
-            # The CTA domain already captures dense and non-grouped causal
-            # visibility. Only grouped causal rows need a narrower row limit.
+            # The CTA domain follows the latest logical query row in the flat
+            # tile. Earlier rows can have a narrower bottom-right causal limit.
             warp_idx = task_cache[_TASK_CACHE_WARP_IDX]
             lane_idx = task_cache[_TASK_CACHE_LANE_IDX]
             if cutlass.const_expr(cfg.kernel_variant == "keeps_mma_ab"):
                 local_col_base = (lane_idx >> Int32(4)) * Int32(cfg.tile_size_kv // 2)
                 local_row_idx = warp_idx * Int32(16) + (lane_idx & Int32(0xF))
-                effective_head_idx = (
-                    head_idx_for_stage(self.head_idx, cfg, stage_info) + local_row_idx
-                )
                 row_seq_len_kv = seq_len_kv
                 if cutlass.const_expr(needs_row_causal_mask):
-                    row_seq_len_kv = runtime_seq_len_kv_for_effective_head(
+                    row_seq_len_kv = runtime_seq_len_kv_for_query_row(
                         cfg,
                         self.cache_seqs,
                         batch_idx,
                         cta_idx_q,
-                        effective_head_idx,
+                        local_row_idx,
                         self.cu_seqlens_q,
                     )
                 for reg_idx in cutlass.range_constexpr(num_s_regs_per_thread(cfg)):
@@ -539,34 +541,31 @@ class TmemSResource(MlaResource):
                 # Score TMEM is read as two panels: each repeat contributes
                 # the first two 8-token groups, then the second panel carries
                 # the next two groups.
-                head_idx = head_idx_for_stage(self.head_idx, cfg, stage_info)
                 local_q_pair = (lane_idx & Int32(QUAD_LANE_MASK)) * Int32(
                     SCORE_ROWS_PER_Q_PAIR
                 )
                 for repeat_idx in cutlass.range_constexpr(q_repeats):
-                    effective_head_idx_0 = (
-                        head_idx
-                        + Int32(repeat_idx * SCORE_TOKENS_PER_QK_GROUP)
-                        + local_q_pair
+                    row_in_tile_0 = (
+                        Int32(repeat_idx * SCORE_TOKENS_PER_QK_GROUP) + local_q_pair
                     )
-                    effective_head_idx_1 = effective_head_idx_0 + Int32(1)
+                    row_in_tile_1 = row_in_tile_0 + Int32(1)
                     seq_len_kv_0 = seq_len_kv
                     seq_len_kv_1 = seq_len_kv
                     if cutlass.const_expr(needs_row_causal_mask):
-                        seq_len_kv_0 = runtime_seq_len_kv_for_effective_head(
+                        seq_len_kv_0 = runtime_seq_len_kv_for_query_row(
                             cfg,
                             self.cache_seqs,
                             batch_idx,
                             cta_idx_q,
-                            effective_head_idx_0,
+                            row_in_tile_0,
                             self.cu_seqlens_q,
                         )
-                        seq_len_kv_1 = runtime_seq_len_kv_for_effective_head(
+                        seq_len_kv_1 = runtime_seq_len_kv_for_query_row(
                             cfg,
                             self.cache_seqs,
                             batch_idx,
                             cta_idx_q,
-                            effective_head_idx_1,
+                            row_in_tile_1,
                             self.cu_seqlens_q,
                         )
                     s_base = repeat_idx * 4

--- a/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/mla_decode/throughput_latency_1cta/tasks.py
@@ -19,7 +19,11 @@ from cutlass import Int32
 from cutlass.experimental import primitives as prims
 
 from cutlass.experimental.task_scheduling.resources import WorkQueue
-from cutlass.experimental.task_scheduling.schedule_builder import domain_loop, schedule
+from cutlass.experimental.task_scheduling.schedule_builder import (
+    domain_loop,
+    schedule,
+    work_tile_loop,
+)
 from cutlass.experimental.task_scheduling.task import Task
 
 from ..helpers.constants import (
@@ -118,7 +122,7 @@ class MlaDecodeTask(Task):
 
         # Task-domain ownership must match K/V, softmax, and reduction: dense
         # uses the full runtime K length, while causal uses the largest
-        # logical-Q-visible length in this groups_tokens_heads_q CTA. Using the
+        # logical-Q-visible length in this physical flat-query tile. Using the
         # raw batch length for causal can move an all-masked tile into tail and
         # replace a real loop accumulator at a tile boundary.
         cta_idx_q = tile_coord[0]
@@ -1372,19 +1376,30 @@ def create_throughput_latency_scheduler_task(
 ) -> Task:
     """Create the CLC dynamic persistent scheduler task."""
 
+    work_tile_skip_if = runtime_work_tile_skip_if(work_queue)
+
     @schedule
     def scheduler_schedule(work_queue, schedule_token_throttle=None):
         """Fetch and publish the next dynamic persistent work tile."""
-        _work_tile, _ = work_queue.init_work_tile()
-        with domain_loop(0, 0, 1):
-            pass
-        schedule_token_throttle_tail(schedule_token_throttle)
-        work_queue.acquire()
-        work_queue.fetch_work_tile()
-        work_queue.commit()
-        work_queue.wait()
-        work_queue.get_and_advance_work_tile()
-        work_queue.release()
+
+        with work_tile_loop(work_queue, skip_if=work_tile_skip_if) as work_tiles:
+            if work_tile_skip_if is None:
+                with domain_loop(0, 0, 1):
+                    pass
+                schedule_token_throttle_tail(schedule_token_throttle)
+            else:
+                # Runtime-empty packed-Q tiles do not publish a load token, but
+                # the scheduler must still fetch and advance past them.
+                with work_tiles.skippable():
+                    with domain_loop(0, 0, 1):
+                        pass
+                    schedule_token_throttle_tail(schedule_token_throttle)
+            work_queue.acquire()
+            work_queue.fetch_work_tile()
+            work_queue.commit()
+            work_queue.wait()
+            work_queue.get_and_advance_work_tile()
+            work_queue.release()
 
     captured_schedule = (
         scheduler_schedule(work_queue)

--- a/flashinfer/attention/prims_ts/mla_decode.py
+++ b/flashinfer/attention/prims_ts/mla_decode.py
@@ -15,7 +15,7 @@
 """Task-scheduled paged MLA decode with a plan/run lifecycle."""
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import functools
 from typing import Any, Literal, Optional, cast
 
@@ -65,14 +65,31 @@ _MLA_MAX_KV_LEN = _INT32_MAX - (_MLA_MAX_KV_COORDINATE_SPAN - 1)
 
 @dataclass(frozen=True)
 class _MLADecodeLaunchSpec:
-    """Automatic MLA kernel selection and scratch for one semantic key."""
+    """Automatic MLA policy and scratch geometry for one plan."""
 
     kernel: Any
-    qkv_dtype: object
-    output_dtype: object
     policy: tuple[tuple[str, object], ...]
     kernel_workspace_bytes: int
     split_kv: int
+
+
+@dataclass(frozen=True)
+class _MLADecodeCompileSpec:
+    """Batch-independent identity and implementation for one MLA compile."""
+
+    device_index: int
+    kernel_signature: tuple[object, ...]
+    num_heads: int
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    page_size: int
+    q_dtype_key: str
+    output_dtype_key: str
+    max_seq_len_q: int
+    packed_query: bool
+    has_kernel_workspace: bool
+    split_kv: int
+    kernel: Any = field(compare=False, hash=False, repr=False)
 
 
 @dataclass(frozen=True)
@@ -164,6 +181,15 @@ def _validate_mla_int32_extent(value: int, name: str) -> int:
     return value
 
 
+def _validate_mla_nonnegative_int32_extent(value: int, name: str) -> int:
+    """Validate a possibly empty flattened extent used by Int32 coordinates."""
+    if value < 0:
+        raise ValueError(f"{name} must be nonnegative")
+    if value > _INT32_MAX:
+        raise NotImplementedError(f"{name} must fit in a signed int32")
+    return value
+
+
 def _validate_mla_query_head_extent(
     *,
     batch_size: int,
@@ -177,7 +203,7 @@ def _validate_mla_query_head_extent(
         "batch_size * max_seq_len_q * num_heads",
     )
     if total_q is not None:
-        _validate_mla_int32_extent(
+        _validate_mla_nonnegative_int32_extent(
             total_q * num_heads,
             "total_q * num_heads",
         )
@@ -298,7 +324,7 @@ def _derive_max_seq_len_q(
     *,
     batch_size: int,
 ) -> tuple[int, int, tuple[int, ...]]:
-    """Validate cumulative offsets and derive their maximum positive delta.
+    """Validate cumulative offsets and derive their maximum nonnegative delta.
 
     This helper intentionally synchronizes and is therefore used only by the
     wrapper planning path when the caller omits an explicit static bound.
@@ -312,8 +338,8 @@ def _derive_max_seq_len_q(
     q_lengths = tuple(
         end - start for start, end in zip(offsets[:-1], offsets[1:], strict=True)
     )
-    if any(length <= 0 for length in q_lengths):
-        raise ValueError("qo_indptr must be strictly increasing")
+    if any(length < 0 for length in q_lengths):
+        raise ValueError("qo_indptr must be nondecreasing")
     return max(q_lengths), offsets[-1], q_lengths
 
 
@@ -367,7 +393,10 @@ def _validate_query(
     if query.ndim != expected_rank:
         expected_shape = "[total_q, H, 576]" if packed_query else "[B, SQ, H, 576]"
         raise ValueError(f"query must have shape {expected_shape}")
-    if any(int(extent) <= 0 for extent in query.shape[:-1]):
+    if packed_query:
+        if int(query.shape[1]) <= 0:
+            raise ValueError("query head extent must be positive")
+    elif any(int(extent) <= 0 for extent in query.shape[:-1]):
         raise ValueError("query row and head extents must be positive")
     if query.shape[-1] != _MLA_QUERY_DIM:
         raise ValueError(
@@ -398,10 +427,10 @@ def _validate_query(
             if batch_size is None:
                 raise ValueError("batch_size is required to validate packed query")
             total_q = int(query.shape[0])
-            if total_q < batch_size or total_q > batch_size * max_seq_len_q:
+            if total_q > batch_size * max_seq_len_q:
                 raise ValueError(
                     "packed query total rows must be within "
-                    f"[{batch_size}, {batch_size * max_seq_len_q}], got {total_q}"
+                    f"[0, {batch_size * max_seq_len_q}], got {total_q}"
                 )
         elif query.shape[1] != max_seq_len_q:
             raise ValueError(
@@ -562,19 +591,18 @@ def _resolve_mla_decode_launch_spec(
         resolve_mla_kernel_policy,
         select_mla_ts_kernel,
     )
+    from .kernels.mla_decode.helpers.query import FlatQueryTileLayout
     from .kernels.mla_decode.throughput_2cta.config import (
         compute_split_kv,
         compute_workspace_size as compute_2cta_workspace_size,
     )
     from .kernels.mla_decode.throughput_2cta.kernel import MlaDecodeTs
     from .kernels.mla_decode.throughput_latency_1cta.config import (
-        GroupsTokensHeadsLaunchShape,
-        auto_tile_size_q_for_mla_gen,
         compute_workspace_size as compute_1cta_workspace_size,
-        fp8_q16_extended_family_probe_split_kv,
-        resolve_auto_mla_gen_groups_tokens_heads_q_shape,
+        q_tile_work_count,
+        resolve_auto_flat_query_launch_shape,
         resolve_runtime_cluster_reduction_mode,
-        wave_fill_split_kv,
+        select_auto_split_kv,
     )
     from .kernels.mla_decode.throughput_latency_1cta.kernel import (
         ThroughputLatencyMlaDecodeTs,
@@ -591,12 +619,6 @@ def _resolve_mla_decode_launch_spec(
     _validate_mla_dims(kv_lora_rank, qk_rope_head_dim)
     qkv_dtype_name = _kernel_dtype_name(q_dtype_key)
     output_dtype_name = _kernel_dtype_name(output_dtype_key)
-    dtype_map = {
-        "bf16": cutlass.BFloat16,
-        "e4m3": cutlass.Float8E4M3FN,
-    }
-    qkv_dtype = dtype_map[qkv_dtype_name]
-    output_dtype = dtype_map[output_dtype_name]
 
     with torch.cuda.device(device_index):
         plan_stream = cuda_drv.CUstream(
@@ -609,45 +631,48 @@ def _resolve_mla_decode_launch_spec(
         max_active_two_cta_clusters = hardware_info.get_max_active_clusters(
             2, plan_stream
         )
-
-        two_cta_launch_shape = GroupsTokensHeadsLaunchShape.for_tile(
-            num_heads, seq_len_q, 128
+        one_cta_launch_shape = resolve_auto_flat_query_launch_shape(
+            num_heads_q=num_heads,
+            seq_len_q=seq_len_q,
         )
+        one_cta_base_work = q_tile_work_count(
+            batch_size,
+            one_cta_launch_shape.num_heads_q,
+            one_cta_launch_shape.seq_len_q,
+            one_cta_launch_shape.tile_size_q,
+        )
+        one_cta_split_kv = select_auto_split_kv(
+            seq_len_kv=max_kv_len,
+            tile_size_q=one_cta_launch_shape.tile_size_q,
+            base_work=one_cta_base_work,
+            target_work=max_active_one_cta_clusters,
+        )
+        two_cta_launch_shape = FlatQueryTileLayout.for_tile(num_heads, seq_len_q, 128)
         two_cta_split_kv = compute_split_kv(
             batch_size=batch_size,
-            seq_len_q=two_cta_launch_shape.seq_len_q,
+            num_q_tiles=two_cta_launch_shape.num_tiles,
             seq_len_kv=max_kv_len,
             mma_qk_tiler_mn=(128, 128),
             max_active_blocks=max_active_two_cta_clusters * 2,
         )
-        two_cta_cluster_work = (
-            batch_size * two_cta_launch_shape.seq_len_q * max(two_cta_split_kv, 1)
+        requested_policy, policy_source = resolve_mla_kernel_policy(
+            None,
+            num_heads,
+            seq_len_q,
+            one_cta_split_kv=one_cta_split_kv,
+            two_cta_split_kv=two_cta_split_kv,
         )
+        use_throughput_latency = requested_policy == "throughput_latency_1cta"
 
-        one_cta_launch_shape = resolve_auto_mla_gen_groups_tokens_heads_q_shape(
-            batch_size=batch_size,
-            num_heads_q=num_heads,
-            seq_len_q=seq_len_q,
-            seq_len_kv=max_kv_len,
-            qkv_dtype=qkv_dtype_name,
-            max_active_clusters=max_active_one_cta_clusters,
-        )
-        family_probe_decision = None
-        family_probe_split_kv = None
-        family_probe_launch_shape = None
-        family_probe_is_extended_fp8_swaps = False
-        one_cta_work = None
-        use_established_family_probe = (
-            num_heads * seq_len_q > 64
-            and two_cta_cluster_work * 4 <= max_active_two_cta_clusters
-        )
-        if use_established_family_probe:
-            family_probe_launch_shape = one_cta_launch_shape
-            initial_probe = select_mla_ts_kernel(
-                requested_policy="throughput_latency_1cta",
+        kernel: Any
+        if use_throughput_latency:
+            max_active_clusters = max_active_one_cta_clusters
+            launch_shape = one_cta_launch_shape
+            decision = select_mla_ts_kernel(
+                requested_policy=requested_policy,
                 batch_size=batch_size,
-                num_heads=family_probe_launch_shape.num_heads_q,
-                seq_len_q=family_probe_launch_shape.seq_len_q,
+                num_heads=launch_shape.num_heads_q,
+                seq_len_q=launch_shape.seq_len_q,
                 seq_len_k=max_kv_len,
                 latent_dim=kv_lora_rank,
                 rope_dim=qk_rope_head_dim,
@@ -655,159 +680,11 @@ def _resolve_mla_decode_launch_spec(
                 dtype=qkv_dtype_name,
                 out_dtype=output_dtype_name,
                 throughput_latency_profile=None,
-                throughput_latency_tile_size_q=(family_probe_launch_shape.tile_size_q),
-                max_active_clusters=max_active_one_cta_clusters,
+                throughput_latency_tile_size_q=launch_shape.tile_size_q,
+                max_active_clusters=max_active_clusters,
                 throughput_latency_split_kv=None,
                 throughput_latency_persistent=None,
             )
-            if initial_probe.implementation_ready and initial_probe.config is not None:
-                family_probe_split_kv = wave_fill_split_kv(
-                    batch_size=batch_size,
-                    num_heads_q=family_probe_launch_shape.num_heads_q,
-                    seq_len_q=family_probe_launch_shape.seq_len_q,
-                    seq_len_kv=max_kv_len,
-                    latent_dim=kv_lora_rank,
-                    max_active_clusters=max_active_one_cta_clusters,
-                    tile_size_q=int(initial_probe.config.tile_size_q),
-                )
-                family_probe_decision = select_mla_ts_kernel(
-                    requested_policy="throughput_latency_1cta",
-                    batch_size=batch_size,
-                    num_heads=family_probe_launch_shape.num_heads_q,
-                    seq_len_q=family_probe_launch_shape.seq_len_q,
-                    seq_len_k=max_kv_len,
-                    latent_dim=kv_lora_rank,
-                    rope_dim=qk_rope_head_dim,
-                    page_size=page_size,
-                    dtype=qkv_dtype_name,
-                    out_dtype=output_dtype_name,
-                    throughput_latency_profile=None,
-                    throughput_latency_tile_size_q=(
-                        family_probe_launch_shape.tile_size_q
-                    ),
-                    max_active_clusters=max_active_one_cta_clusters,
-                    throughput_latency_split_kv=family_probe_split_kv,
-                    throughput_latency_persistent=None,
-                )
-                family_cfg = family_probe_decision.config
-                if family_cfg is not None:
-                    one_cta_work = (
-                        family_cfg.batch_size
-                        * family_cfg.num_ctas_per_seq_q
-                        * family_cfg.num_ctas_for_all_heads
-                        * family_cfg.num_ctas_per_seq_kv
-                        * family_cfg.num_ctas_per_head_dim
-                    )
-        elif (
-            num_heads * seq_len_q > 64
-            and qkv_dtype_name == "e4m3"
-            and two_cta_cluster_work <= max_active_two_cta_clusters
-        ):
-            # The established probe intentionally covers only a severely
-            # underfilled 2CTA grid.  A second FP8-only probe considers Q16
-            # Swaps when both candidates fit one wave and the Q16 local K span
-            # can be held to two steady-state steps.  This avoids switching
-            # saturated or long-local-K shapes that benefit from the grouped
-            # M128 2CTA schedule.
-            probe_tile_size_q = auto_tile_size_q_for_mla_gen(
-                batch_size=batch_size,
-                num_heads_q=num_heads,
-                seq_len_q=seq_len_q,
-                seq_len_kv=max_kv_len,
-                multi_processor_count=max_active_one_cta_clusters,
-            )
-            if probe_tile_size_q == 16:
-                extended_launch_shape = GroupsTokensHeadsLaunchShape.for_tile(
-                    num_heads,
-                    seq_len_q,
-                    probe_tile_size_q,
-                )
-                extended_split_kv = fp8_q16_extended_family_probe_split_kv(
-                    batch_size=batch_size,
-                    num_heads_q=extended_launch_shape.num_heads_q,
-                    seq_len_q=extended_launch_shape.seq_len_q,
-                    seq_len_kv=max_kv_len,
-                    max_active_clusters=max_active_one_cta_clusters,
-                )
-                if extended_split_kv is not None:
-                    extended_decision = select_mla_ts_kernel(
-                        requested_policy="throughput_latency_1cta",
-                        batch_size=batch_size,
-                        num_heads=extended_launch_shape.num_heads_q,
-                        seq_len_q=extended_launch_shape.seq_len_q,
-                        seq_len_k=max_kv_len,
-                        latent_dim=kv_lora_rank,
-                        rope_dim=qk_rope_head_dim,
-                        page_size=page_size,
-                        dtype=qkv_dtype_name,
-                        out_dtype=output_dtype_name,
-                        throughput_latency_profile=None,
-                        throughput_latency_tile_size_q=probe_tile_size_q,
-                        max_active_clusters=max_active_one_cta_clusters,
-                        throughput_latency_split_kv=extended_split_kv,
-                        throughput_latency_persistent=None,
-                    )
-                    extended_cfg = extended_decision.config
-                    if (
-                        extended_decision.implementation_ready
-                        and extended_cfg is not None
-                        and extended_cfg.kernel_variant == "swaps_mma_ab"
-                        and extended_cfg.tile_size_q == 16
-                    ):
-                        family_probe_decision = extended_decision
-                        family_probe_split_kv = extended_split_kv
-                        family_probe_launch_shape = extended_launch_shape
-                        family_probe_is_extended_fp8_swaps = True
-                        one_cta_work = (
-                            extended_cfg.batch_size
-                            * extended_cfg.num_ctas_per_seq_q
-                            * extended_cfg.num_ctas_for_all_heads
-                            * extended_cfg.num_ctas_per_seq_kv
-                            * extended_cfg.num_ctas_per_head_dim
-                        )
-
-        requested_policy, policy_source = resolve_mla_kernel_policy(
-            None,
-            num_heads,
-            seq_len_q,
-            one_cta_work=one_cta_work,
-            one_cta_capacity=(
-                max_active_one_cta_clusters if one_cta_work is not None else None
-            ),
-            two_cta_cluster_work=(
-                two_cta_cluster_work if one_cta_work is not None else None
-            ),
-            two_cta_cluster_capacity=(
-                max_active_two_cta_clusters if one_cta_work is not None else None
-            ),
-            one_cta_is_extended_fp8_swaps=(family_probe_is_extended_fp8_swaps),
-        )
-        use_throughput_latency = requested_policy == "throughput_latency_1cta"
-
-        kernel: Any
-        if use_throughput_latency:
-            max_active_clusters = max_active_one_cta_clusters
-            launch_shape = family_probe_launch_shape or one_cta_launch_shape
-            decision = family_probe_decision
-            if decision is None:
-                family_probe_split_kv = None
-                decision = select_mla_ts_kernel(
-                    requested_policy=requested_policy,
-                    batch_size=batch_size,
-                    num_heads=launch_shape.num_heads_q,
-                    seq_len_q=launch_shape.seq_len_q,
-                    seq_len_k=max_kv_len,
-                    latent_dim=kv_lora_rank,
-                    rope_dim=qk_rope_head_dim,
-                    page_size=page_size,
-                    dtype=qkv_dtype_name,
-                    out_dtype=output_dtype_name,
-                    throughput_latency_profile=None,
-                    throughput_latency_tile_size_q=launch_shape.tile_size_q,
-                    max_active_clusters=max_active_clusters,
-                    throughput_latency_split_kv=None,
-                    throughput_latency_persistent=None,
-                )
             if not decision.implementation_ready or decision.config is None:
                 raise NotImplementedError(decision.reason)
             reduction_mode = resolve_runtime_cluster_reduction_mode(
@@ -831,11 +708,10 @@ def _resolve_mla_decode_launch_spec(
                 out_dtype=output_dtype_name,
                 profile=decision.profile_name,
                 reduction_mode=reduction_mode,
-                groups_tokens_heads_q_ratio=launch_shape.ratio,
                 logical_num_heads=num_heads,
                 logical_seq_len_q=seq_len_q,
                 tile_size_q=launch_shape.tile_size_q,
-                explicit_split_kv=family_probe_split_kv,
+                explicit_split_kv=None,
                 explicit_persistent=None,
                 mask_type=mask_type,
             )
@@ -889,14 +765,14 @@ def _resolve_mla_decode_launch_spec(
                 out_dtype=output_dtype_name,
                 throughput_latency_profile=None,
                 throughput_latency_tile_size_q=None,
-                max_active_clusters=max_active_one_cta_clusters,
+                max_active_clusters=max_active_clusters,
                 throughput_latency_split_kv=None,
                 throughput_latency_persistent=None,
             )
             if not decision.implementation_ready:
                 raise NotImplementedError(decision.reason)
             split_kv = two_cta_split_kv
-            work_clusters = batch_size * launch_shape.seq_len_q * max(split_kv, 1)
+            work_clusters = batch_size * launch_shape.num_tiles * max(split_kv, 1)
             # Dynamic cluster stealing only helps once logical work exceeds a
             # resident wave.  Within one wave every cluster already launches,
             # so the CLC producer/response pipeline is pure overhead.
@@ -922,8 +798,8 @@ def _resolve_mla_decode_launch_spec(
                 mask_type=mask_type,
             )
             workspace_size = compute_2cta_workspace_size(
-                num_heads=int(launch_shape.num_heads_q),
-                seq_len_q=int(launch_shape.seq_len_q),
+                tile_size_q=int(launch_shape.tile_size_q),
+                num_q_tiles=int(launch_shape.num_tiles),
                 latent_dim=kv_lora_rank,
                 batch_size=batch_size,
                 split_kv=split_kv,
@@ -958,51 +834,87 @@ def _resolve_mla_decode_launch_spec(
 
     return _MLADecodeLaunchSpec(
         kernel=kernel,
-        qkv_dtype=qkv_dtype,
-        output_dtype=output_dtype,
         policy=policy,
         kernel_workspace_bytes=int(workspace_size),
         split_kv=int(split_kv),
     )
 
 
-@functools.cache
-def _get_compiled_mla_decode(
+def _mla_kernel_compile_signature(kernel: Any) -> tuple[object, ...]:
+    """Return all static kernel state except the batch extent."""
+
+    make_signature = getattr(kernel, "compile_signature", None)
+    if not callable(make_signature):
+        raise TypeError("MLA kernels must define compile_signature()")
+    signature = (
+        type(kernel).__module__,
+        type(kernel).__qualname__,
+        make_signature(),
+    )
+    try:
+        hash(signature)
+    except TypeError as error:
+        raise TypeError("MLA kernel compile state must be hashable") from error
+    return signature
+
+
+def _make_mla_decode_compile_spec(
+    launch_spec: _MLADecodeLaunchSpec,
+    *,
     device_index: int,
-    batch_size: int,
     num_heads: int,
     kv_lora_rank: int,
     qk_rope_head_dim: int,
     page_size: int,
-    max_kv_len: int,
     q_dtype_key: str,
-    kv_dtype_key: str,
     output_dtype_key: str,
-    mask_type: str,
-    max_seq_len_q: int = 1,
-    packed_query: bool = False,
+    max_seq_len_q: int,
+    packed_query: bool,
+) -> _MLADecodeCompileSpec:
+    """Keep policy resolution plan-specific and JIT identity batch-free."""
+
+    return _MLADecodeCompileSpec(
+        device_index=device_index,
+        kernel_signature=_mla_kernel_compile_signature(launch_spec.kernel),
+        num_heads=num_heads,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        page_size=page_size,
+        q_dtype_key=q_dtype_key,
+        output_dtype_key=output_dtype_key,
+        max_seq_len_q=max_seq_len_q,
+        packed_query=packed_query,
+        has_kernel_workspace=launch_spec.kernel_workspace_bytes > 0,
+        split_kv=launch_spec.split_kv,
+        kernel=launch_spec.kernel,
+    )
+
+
+@functools.cache
+def _get_compiled_mla_decode(
+    compile_spec: _MLADecodeCompileSpec,
 ):
-    """Compile and cache one exact semantic TS MLA decode plan."""
+    """Compile and cache one batch-dynamic TS MLA topology."""
 
     import cutlass
     import cutlass.cute as cute
 
-    spec = _resolve_mla_decode_launch_spec(
-        device_index,
-        batch_size,
-        num_heads,
-        kv_lora_rank,
-        qk_rope_head_dim,
-        page_size,
-        max_kv_len,
-        q_dtype_key,
-        kv_dtype_key,
-        output_dtype_key,
-        mask_type,
-        max_seq_len_q,
-    )
+    device_index = compile_spec.device_index
+    num_heads = compile_spec.num_heads
+    kv_lora_rank = compile_spec.kv_lora_rank
+    qk_rope_head_dim = compile_spec.qk_rope_head_dim
+    page_size = compile_spec.page_size
+    max_seq_len_q = compile_spec.max_seq_len_q
+    packed_query = compile_spec.packed_query
+    kernel = compile_spec.kernel
+    dtype_map = {
+        "bfloat16": cutlass.BFloat16,
+        "float8_e4m3fn": cutlass.Float8E4M3FN,
+    }
+    qkv_dtype = dtype_map[compile_spec.q_dtype_key]
+    output_dtype = dtype_map[compile_spec.output_dtype_key]
     physical_pages = cute.sym_int()
-    runtime_batch = cute.sym_int()
+    batch_size = cute.sym_int()
     runtime_total_q = cute.sym_int()
 
     # These fake tensors pin the compact public ABI while allowing runtime
@@ -1018,30 +930,30 @@ def _get_compiled_mla_decode(
         q_stride = (q_stride_h, 1, q_stride_q)
     else:
         q_stride_batch = max_seq_len_q * q_stride_q
-        q_latent_shape = (num_heads, kv_lora_rank, max_seq_len_q, runtime_batch)
+        q_latent_shape = (num_heads, kv_lora_rank, max_seq_len_q, batch_size)
         q_rope_shape = (
             num_heads,
             qk_rope_head_dim,
             max_seq_len_q,
-            runtime_batch,
+            batch_size,
         )
         q_stride = (q_stride_h, 1, q_stride_q, q_stride_batch)
     q_latent_fake = cute.runtime.make_fake_tensor(
-        spec.qkv_dtype, q_latent_shape, stride=q_stride, assumed_align=16
+        qkv_dtype, q_latent_shape, stride=q_stride, assumed_align=16
     )
     q_rope_fake = cute.runtime.make_fake_tensor(
-        spec.qkv_dtype, q_rope_shape, stride=q_stride, assumed_align=16
+        qkv_dtype, q_rope_shape, stride=q_stride, assumed_align=16
     )
     cache_token_stride = _MLA_QUERY_DIM
     cache_page_stride = page_size * _MLA_QUERY_DIM
     c_latent_fake = cute.runtime.make_fake_tensor(
-        spec.qkv_dtype,
+        qkv_dtype,
         (page_size, kv_lora_rank, physical_pages),
         stride=(cache_token_stride, 1, cache_page_stride),
         assumed_align=16,
     )
     c_rope_fake = cute.runtime.make_fake_tensor(
-        spec.qkv_dtype,
+        qkv_dtype,
         (page_size, qk_rope_head_dim, physical_pages),
         stride=(cache_token_stride, 1, cache_page_stride),
         assumed_align=16,
@@ -1049,7 +961,7 @@ def _get_compiled_mla_decode(
     runtime_page_columns = cute.sym_int()
     page_offsets_fake = cute.runtime.make_fake_tensor(
         cutlass.Int32,
-        (runtime_page_columns, runtime_batch),
+        (runtime_page_columns, batch_size),
         stride=(1, runtime_page_columns),
         assumed_align=16,
     )
@@ -1065,27 +977,28 @@ def _get_compiled_mla_decode(
         lse_stride = (1, num_heads)
     else:
         out_stride_batch = max_seq_len_q * out_stride_row
-        out_shape = (num_heads, kv_lora_rank, max_seq_len_q, runtime_batch)
+        out_shape = (num_heads, kv_lora_rank, max_seq_len_q, batch_size)
         out_stride = (kv_lora_rank, 1, out_stride_row, out_stride_batch)
-        lse_shape = (num_heads, max_seq_len_q, runtime_batch)
+        lse_shape = (num_heads, max_seq_len_q, batch_size)
         lse_stride = (1, num_heads, max_seq_len_q * num_heads)
     out_fake = cute.runtime.make_fake_tensor(
-        spec.output_dtype, out_shape, stride=out_stride, assumed_align=16
+        output_dtype, out_shape, stride=out_stride, assumed_align=16
     )
     lse_fake = cute.runtime.make_fake_tensor(
         cutlass.Float32, lse_shape, stride=lse_stride, assumed_align=16
     )
     workspace_fake = None
-    if spec.kernel_workspace_bytes > 0:
+    if compile_spec.has_kernel_workspace:
+        workspace_bytes = cute.sym_int()
         workspace_fake = cute.runtime.make_fake_compact_tensor(
             cutlass.Int8,
-            (spec.kernel_workspace_bytes,),
+            (workspace_bytes,),
             stride_order=(0,),
             assumed_align=32,
         )
     cache_seqs_fake = cute.runtime.make_fake_compact_tensor(
         cutlass.Int32,
-        (runtime_batch,),
+        (batch_size,),
         stride_order=(0,),
         assumed_align=16,
     )
@@ -1100,59 +1013,11 @@ def _get_compiled_mla_decode(
         )
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
-    # Refresh host-side grouping/reducer traits with a representative compact
-    # extent before lowering. Runtime Q lengths still come only from qo_indptr.
-    representative_total_q = batch_size * max_seq_len_q
-    validation_q_shape: tuple[int, ...]
-    validation_q_rope_shape: tuple[int, ...]
-    validation_out_shape: tuple[int, ...]
-    validation_lse_shape: tuple[int, ...]
-    validation_qo_shape: tuple[int, ...] | None
-    if packed_query:
-        validation_q_shape = (num_heads, kv_lora_rank, representative_total_q)
-        validation_q_rope_shape = (
-            num_heads,
-            qk_rope_head_dim,
-            representative_total_q,
-        )
-        validation_out_shape = (num_heads, kv_lora_rank, representative_total_q)
-        validation_lse_shape = (num_heads, representative_total_q)
-        validation_qo_shape = (batch_size + 1,)
-    else:
-        validation_q_shape = (num_heads, kv_lora_rank, max_seq_len_q, batch_size)
-        validation_q_rope_shape = (
-            num_heads,
-            qk_rope_head_dim,
-            max_seq_len_q,
-            batch_size,
-        )
-        validation_out_shape = (num_heads, kv_lora_rank, max_seq_len_q, batch_size)
-        validation_lse_shape = (num_heads, max_seq_len_q, batch_size)
-        validation_qo_shape = None
-    if dict(spec.policy)["kernel"] == "throughput_latency_1cta":
-        spec.kernel.validate_groups_tokens_heads_launch_shape(
-            validation_q_shape,
-            validation_q_rope_shape,
-            validation_out_shape,
-            validation_lse_shape,
-            num_heads,
-            max_seq_len_q,
-            validation_qo_shape,
-        )
-    else:
-        spec.kernel.validate_groups_tokens_heads_launch_shape(
-            validation_q_shape,
-            validation_q_rope_shape,
-            validation_out_shape,
-            validation_lse_shape,
-            validation_qo_shape,
-        )
-
     # Task objects carry loop-local state through generated control flow, so
     # select the public staged frontend for this compilation.
     with torch.cuda.device(device_index):
         compiled = cute.compile[cute.FrontendNext](
-            spec.kernel,
+            kernel,
             q_latent_fake,
             q_rope_fake,
             c_latent_fake,
@@ -1161,7 +1026,7 @@ def _get_compiled_mla_decode(
             out_fake,
             lse_fake,
             workspace_fake,
-            cutlass.Int32(spec.split_kv),
+            cutlass.Int32(compile_spec.split_kv),
             cache_seqs_fake,
             qo_indptr_fake,
             None,
@@ -1170,7 +1035,7 @@ def _get_compiled_mla_decode(
             stream_fake,
             options=_COMPILE_OPTIONS,
         )
-    return compiled, spec.policy, spec.kernel_workspace_bytes
+    return compiled
 
 
 def get_prims_ts_batch_decode_mla_workspace_size(
@@ -1191,9 +1056,9 @@ def get_prims_ts_batch_decode_mla_workspace_size(
 ) -> int:
     """Return caller-workspace bytes for one automatic MLA policy.
 
-    The arguments define the same semantic JIT key as
-    :func:`prims_ts_batch_decode_with_kv_cache_mla`. Policy and private scratch
-    layout are resolved without compiling a kernel. ``max_seq_len_q`` is the
+    The arguments resolve the same policy and private scratch layout as
+    :func:`prims_ts_batch_decode_with_kv_cache_mla`, without compiling a
+    kernel. ``max_seq_len_q`` is the
     static per-request Q bound for both fixed and packed-query launches;
     ``seq_len_q`` remains a backward-compatible fixed-Q alias. If neither is
     supplied, the bound is one. The returned byte count includes both split-KV
@@ -1356,6 +1221,8 @@ def _launch_mla_decode(
     """Form the dimension-first views and launch one compiled MLA kernel."""
 
     packed_query = qo_indptr is not None
+    if packed_query and int(runtime.query.shape[0]) == 0:
+        return runtime.out
     if packed_query:
         q_latent = runtime.query[..., :kv_lora_rank].permute(1, 2, 0)
         q_rope = runtime.query[..., kv_lora_rank:].permute(1, 2, 0)
@@ -1417,8 +1284,10 @@ def prims_ts_batch_decode_with_kv_cache_mla(
     ``qo_indptr`` contains the ``B + 1`` cumulative Q offsets. Runtime Q
     lengths are exclusively ``qo_indptr[b + 1] - qo_indptr[b]``;
     ``max_seq_len_q`` is only the static policy, JIT, and workspace bound and
-    is required for compact launches. The last query dimension concatenates
-    the 512 latent and 64 RoPE dimensions. ``kv_cache`` accepts compact rank-3
+    is required for compact launches. Individual packed requests may be empty,
+    and an all-empty launch returns its empty output without dispatching a GPU
+    kernel. The last query dimension concatenates the 512 latent and 64 RoPE
+    dimensions. ``kv_cache`` accepts compact rank-3
     ``[pages, page_size, 576]`` or rank-4 ``[pages, 1, page_size, 576]``
     storage. ``block_tables`` and ``seq_lens`` follow FlashInfer's native dense
     paged-cache ABI; ``max_seq_len`` is the exact static policy/JIT maximum.
@@ -1427,13 +1296,13 @@ def prims_ts_batch_decode_with_kv_cache_mla(
 
     The workspace is exclusive to one in-flight launch or captured graph and
     must not overlap query, K/V cache, metadata, or output storage.
-    Runtime lengths must remain positive and no larger than ``max_seq_len``;
+    Runtime K/V lengths must remain positive and no larger than ``max_seq_len``;
     this hot path deliberately performs no device-to-host metadata reads. For
     packed launches, callers must ensure that offsets start at zero, are
-    strictly increasing, end at ``query.shape[0]``, and have every delta no
+    nondecreasing, end at ``query.shape[0]``, and have every delta no
     larger than ``max_seq_len_q``. For causal masking, every fixed or packed
     per-request Q length must also be no greater than the corresponding live
-    ``seq_lens`` value. Warm the semantic key before CUDA graph
+    ``seq_lens`` value. Warm the planned topology before CUDA graph
     capture and provide ``out`` to avoid an output allocation. Captured graphs
     must retain stable ``qo_indptr`` storage; its values may change only while
     that packed-offset contract and the captured query/output extent remain
@@ -1446,7 +1315,7 @@ def prims_ts_batch_decode_with_kv_cache_mla(
     kv_cache : torch.Tensor
         Compact paged latent K/V cache.
     workspace_buffer : torch.Tensor
-        Caller-owned byte workspace for this semantic key.
+        Caller-owned byte workspace for this planned layout.
     kv_lora_rank, qk_rope_head_dim : int
         Latent and RoPE dimensions.
     block_tables : torch.Tensor
@@ -1575,11 +1444,19 @@ def prims_ts_batch_decode_with_kv_cache_mla(
             qo_indptr=qo_indptr,
             workspace_buffer=workspace_buffer,
         )
-    compiled, policy, kernel_workspace_bytes = _get_compiled_mla_decode(
-        *spec_key, packed_query
+    compile_spec = _make_mla_decode_compile_spec(
+        spec,
+        device_index=device_index,
+        num_heads=num_heads,
+        kv_lora_rank=kv_lora_rank,
+        qk_rope_head_dim=qk_rope_head_dim,
+        page_size=page_size,
+        q_dtype_key=_dtype_key(query.dtype),
+        output_dtype_key=_dtype_key(out_dtype),
+        max_seq_len_q=max_seq_len_q,
+        packed_query=packed_query,
     )
-    if kernel_workspace_bytes != spec.kernel_workspace_bytes or policy != spec.policy:
-        raise RuntimeError("MLA workspace policy changed during compilation")
+    compiled = _get_compiled_mla_decode(compile_spec)
     workspace = _bind_mla_workspace(workspace_buffer, layout)
     return _launch_mla_decode(
         runtime,
@@ -1626,13 +1503,14 @@ class BatchMLADecodePagedTSWrapper:
         offsets. Planning always validates those offsets and their final total
         with one device-to-host synchronization. If ``max_seq_len_q`` is
         omitted, their exact maximum delta becomes the plan bound; an explicit
-        bound may be larger. Planning also reads and validates every K/V length;
+        bound may be larger. An all-empty packed plan requires an explicit
+        positive bound. Planning also reads and validates every K/V length;
         an explicit KV bound is checked against all rows. With
         ``qo_indptr=None``, the Q bound is the exact fixed query length and
         defaults to one. ``seq_len_q`` remains a backward-compatible alias for
         the same static bound. CUDA graph use requires stable ``qo_indptr``
-        storage. Interior offsets may change only when they remain strictly
-        increasing, every delta stays within the plan bound, and the final
+        storage. Interior offsets may change only when they remain
+        nondecreasing, every delta stays within the plan bound, and the final
         offset continues to match the packed query/output extent fixed by the
         plan. ``seq_lens`` is also live. For a causal plan, every replay must
         preserve ``q_len[b] <= seq_lens[b]`` for each request. One wrapper
@@ -1688,6 +1566,10 @@ class BatchMLADecodePagedTSWrapper:
                 planned_q_lengths,
             ) = _derive_max_seq_len_q(qo_indptr, batch_size=batch_size)
             if resolved_q_bound is None:
+                if derived_q_bound == 0:
+                    raise ValueError(
+                        "max_seq_len_q is required for an all-empty packed query"
+                    )
                 max_seq_len_q = derived_q_bound
             else:
                 max_seq_len_q = resolved_q_bound
@@ -1745,7 +1627,7 @@ class BatchMLADecodePagedTSWrapper:
                 f"columns ({required_page_columns}), got {max_num_pages}"
             )
 
-        compiled, policy, workspace_size = _get_compiled_mla_decode(
+        spec = _resolve_mla_decode_launch_spec(
             device_index,
             batch_size,
             num_heads,
@@ -1758,8 +1640,22 @@ class BatchMLADecodePagedTSWrapper:
             _dtype_key(o_data_type),
             mask_type,
             max_seq_len_q,
-            packed_query,
         )
+        compile_spec = _make_mla_decode_compile_spec(
+            spec,
+            device_index=device_index,
+            num_heads=num_heads,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            page_size=page_size,
+            q_dtype_key=_dtype_key(q_data_type),
+            output_dtype_key=_dtype_key(o_data_type),
+            max_seq_len_q=max_seq_len_q,
+            packed_query=packed_query,
+        )
+        compiled = _get_compiled_mla_decode(compile_spec)
+        policy = spec.policy
+        workspace_size = spec.kernel_workspace_bytes
         workspace_layout = _make_mla_workspace_layout(
             workspace_size, batch_size, num_heads, max_seq_len_q
         )
@@ -1938,9 +1834,12 @@ def batch_decode_mla_with_paged_kv_cache(
         )
         num_heads = int(query.shape[1])
         if max_seq_len_q is None:
-            _validate_mla_int32_extent(
-                int(query.shape[0]) * num_heads,
-                "total_q * num_heads",
+            if int(query.shape[0]) == 0:
+                raise ValueError(
+                    "max_seq_len_q is required for an all-empty packed query"
+                )
+            _validate_mla_nonnegative_int32_extent(
+                int(query.shape[0]) * num_heads, "total_q * num_heads"
             )
         else:
             max_seq_len_q = _validate_positive_int(max_seq_len_q, "max_seq_len_q")

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -1448,7 +1448,7 @@ def test_attention_ts_context_plan_rejects_causal_q_longer_than_kv(paged: bool):
 
 @pytest.mark.arch_blackwell
 @_REQUIRES_CONTEXT_GPU
-def test_attention_ts_context_paged_uniform_geometry_has_distinct_semantic_key():
+def test_attention_ts_context_paged_uniform_geometry_has_distinct_compile_spec():
     """Only max-filled Q and uniform snapshotted K select uniform offsets."""
 
     uniform_case = _make_paged_context_case(
@@ -1501,10 +1501,12 @@ def test_attention_ts_context_paged_uniform_geometry_has_distinct_semantic_key()
     assert redistributable_metadata.seq_lens == uniform_metadata.seq_lens
     assert redistributable_geometry.uniform_packed_lengths is False
 
-    uniform_key = context_module._paged_semantic_key(uniform_geometry)
-    redistributable_key = context_module._paged_semantic_key(redistributable_geometry)
-    assert uniform_key != redistributable_key
-    assert uniform_key == context_module._paged_semantic_key(
+    uniform_spec = context_module._paged_context_compile_spec(uniform_geometry)
+    redistributable_spec = context_module._paged_context_compile_spec(
+        redistributable_geometry
+    )
+    assert uniform_spec != redistributable_spec
+    assert uniform_spec == context_module._paged_context_compile_spec(
         replace(redistributable_geometry, uniform_packed_lengths=True)
     )
 
@@ -1989,6 +1991,77 @@ def test_attention_ts_context_variable_window_clamps_padded_q_rows(head_dim: int
 
 @pytest.mark.arch_blackwell
 @_REQUIRES_CONTEXT_GPU
+@pytest.mark.parametrize("packed", (False, True), ids=("fixed", "packed"))
+def test_attention_ts_context_reuses_compiled_topology_across_batch_sizes(
+    packed: bool,
+):
+    """One resolved context topology accepts different batch extents."""
+
+    wrappers = []
+    for batch_size in (3, 4):
+        case = _make_context_case(
+            q_lengths=(33,) * batch_size,
+            k_lengths=(65,) * batch_size,
+            num_qo_heads=4,
+            num_kv_heads=4,
+            qkv_dtype=torch.float16,
+            packed=packed,
+            mask_type="dense",
+            output_dtype=torch.float16,
+            device="cuda",
+            seed=2026071420 + batch_size,
+        )
+        wrapper = BatchPrefillTSWrapper()
+        _plan_wrapper(wrapper, case)
+        actual = wrapper.run(case.q, case.k, case.v)
+        _assert_context_correct(actual, case)
+        wrappers.append(wrapper)
+
+    assert wrappers[0]._compiled is wrappers[1]._compiled
+
+
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_paged_context_reuses_compiled_topology_across_batch_sizes():
+    """One paged-context topology accepts different batch extents."""
+
+    wrappers = []
+    for batch_size in (3, 4):
+        case = _make_paged_context_case(
+            q_lengths=(33,) * batch_size,
+            k_lengths=(65,) * batch_size,
+            num_qo_heads=4,
+            num_kv_heads=4,
+            head_dim=128,
+            qkv_dtype=torch.float16,
+            mask_type="dense",
+            output_dtype=torch.float16,
+            seed=2026071430 + batch_size,
+        )
+        wrapper = BatchPrefillPagedTSWrapper()
+        wrapper.plan(
+            case.reference.q,
+            case.k_cache,
+            case.v_cache,
+            case.qo_indptr,
+            case.paged_kv_indptr,
+            case.paged_kv_indices,
+            case.paged_kv_last_page_len,
+            page_size=case.page_size,
+            mask_type=case.reference.mask_type,
+            sm_scale=case.reference.sm_scale,
+            output_scale=case.reference.output_scale,
+            out_dtype=case.reference.output_dtype,
+        )
+        actual = wrapper.run(case.reference.q, case.k_cache, case.v_cache)
+        _assert_context_correct(actual, case.reference)
+        wrappers.append(wrapper)
+
+    assert wrappers[0]._compiled is wrappers[1]._compiled
+
+
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
 def test_attention_ts_context_fixed_dense_k_tail_excludes_tma_padding():
     # With zero Q/K, every real key has score zero. A missing right-edge mask
     # therefore dilutes the output by 65/128 because TMA zero-fills the rest
@@ -2324,11 +2397,9 @@ def test_attention_ts_context_d256_fixed_head_paired_window_runtime():
 
 @pytest.mark.arch_blackwell
 @_REQUIRES_CONTEXT_GPU
-def test_attention_ts_context_d256_bf16_fixed_dense_static_runtime():
-    # Dense query pairing carries S/P state between work tiles and publishes
-    # correction stats through SMEM.  BF16 is the largest input footprint and
-    # therefore guards the B200 dynamic-SMEM launch limit for the static
-    # persistent single-instance schedule.
+def test_attention_ts_context_d256_bf16_fixed_dense_runtime():
+    # BF16 D256 is the largest fixed-input footprint and therefore guards the
+    # B200 dynamic-SMEM launch limit independently of automatic scheduling.
     case = _make_context_case(
         q_lengths=(129,),
         k_lengths=(257,),
@@ -2344,7 +2415,6 @@ def test_attention_ts_context_d256_bf16_fixed_dense_static_runtime():
     )
     wrapper = BatchPrefillTSWrapper()
     _plan_wrapper(wrapper, case)
-    assert dict(wrapper._policy)["scheduler"] == "static_persistent"
 
     for _ in range(2):
         output = wrapper.run(case.q, case.k, case.v)

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -4284,6 +4284,47 @@ def test_attention_ts_decode_q64_kv256_boundaries(
         assert policy["use_split_kv"] is False
 
 
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+@pytest.mark.parametrize("packed_query", (False, True), ids=("fixed", "packed"))
+def test_attention_ts_decode_reuses_compiled_topology_across_batch_sizes(
+    packed_query: bool,
+):
+    """One resolved paged-decode topology accepts different batch extents."""
+
+    wrappers = []
+    for batch_size in (2, 3):
+        case = _make_decode_case(
+            kv_lens=(2049,) * batch_size,
+            num_qo_heads=16,
+            num_kv_heads=2,
+            head_dim=128,
+            seq_len_q=2 if packed_query else 1,
+            page_size=32,
+            qkv_dtype=torch.bfloat16,
+            output_dtype=torch.bfloat16,
+            cache_form="combined",
+            mask_type="dense",
+            device="cuda",
+            seed=32900 + batch_size,
+        )
+        qo_indptr = None
+        if packed_query:
+            case, qo_indptr = _pack_decode_case(case, (1,) * batch_size)
+        wrapper = _plan_case(
+            case,
+            max_kv_len=2049,
+            qo_indptr=qo_indptr,
+            max_seq_len_q=1 if packed_query else None,
+        )
+        output = _run_case(wrapper, case)
+        _assert_case_correct(output, case)
+        wrappers.append(wrapper)
+
+    assert wrappers[0]._compiled_main is wrappers[1]._compiled_main
+    assert wrappers[0]._compiled_reducer is wrappers[1]._compiled_reducer
+
+
 @pytest.mark.parametrize("head_dim", (64, 128, 256), ids=lambda value: f"d{value}")
 @pytest.mark.parametrize(
     "num_qo_heads_per_kv",

--- a/tests/attention/test_attention_ts_mla_decode.py
+++ b/tests/attention/test_attention_ts_mla_decode.py
@@ -45,11 +45,9 @@ from flashinfer.attention.prims_ts import (
     batch_decode_mla_with_paged_kv_cache,
 )
 from flashinfer.attention.prims_ts.kernels.mla_decode.throughput_2cta.config import (
-    MAX_SPLITS,
     make_mla_decode_config,
 )
 from flashinfer.attention.prims_ts.kernels.mla_decode.throughput_2cta.kernel import (
-    MlaDecodeTs,
     build_mla_decode_task_manager,
 )
 from flashinfer.attention.prims_ts.kernels.mla_decode.throughput_2cta.resources import (
@@ -57,6 +55,12 @@ from flashinfer.attention.prims_ts.kernels.mla_decode.throughput_2cta.resources 
 )
 from flashinfer.attention.prims_ts.kernels.mla_decode.kernel_policy import (
     select_mla_ts_kernel,
+)
+from flashinfer.attention.prims_ts.kernels.mla_decode.helpers.query import (
+    FlatQueryTileLayout,
+)
+from flashinfer.attention.prims_ts.kernels.mla_decode.throughput_latency_1cta.config import (
+    make_throughput_latency_mla_config,
 )
 from flashinfer.mla import (
     get_prims_ts_batch_decode_mla_workspace_size,
@@ -78,6 +82,10 @@ _ROPE_DIM = 64
 _QK_DIM = _LATENT_DIM + _ROPE_DIM
 _DEFAULT_PAGE_SIZE = 32
 _FP8_PROBABILITY_SCALE = 448.0
+# CUTLASS DSL CUDA graphs retain raw pointers into their wrapper and input
+# allocations. Keep only graph-parity anchor owners alive until module teardown
+# so later parametrized cases cannot reuse those allocations prematurely.
+_CUDA_GRAPH_ANCHOR_OWNERS: list[tuple[object, ...]] = []
 _MLA_INTERNAL_TUNING_PARAMETERS = frozenset(
     {
         "autotuner",
@@ -123,6 +131,39 @@ _INTERNAL_TUNING_TOKEN_SEQUENCES = (
     ("single", "kv"),
     ("tensor", "cores"),
 )
+
+
+@pytest.mark.parametrize(
+    "num_heads,seq_len_q,tile_size_q,expected",
+    (
+        (128, 3, 128, (384, 3, 128)),
+        (96, 3, 128, (288, 3, 32)),
+        (12, 11, 128, (132, 2, 4)),
+        (12, 2, 8, (24, 3, 8)),
+        (96, 2, 64, (192, 3, 64)),
+        (12, 4, 16, (48, 3, 16)),
+        (48, 4, 64, (192, 3, 64)),
+    ),
+)
+def test_attention_ts_mla_flat_query_tile_layout(
+    num_heads, seq_len_q, tile_size_q, expected
+):
+    layout = FlatQueryTileLayout.for_tile(num_heads, seq_len_q, tile_size_q)
+    assert (layout.total_rows, layout.num_tiles, layout.tail_rows) == expected
+    assert layout.logical_num_heads_q == num_heads
+    assert layout.logical_seq_len_q == seq_len_q
+    assert layout.tile_size_q == tile_size_q
+
+
+@pytest.mark.parametrize(
+    "num_heads,seq_len_q,tile_size_q",
+    ((0, 1, 128), (64, 0, 128), (64, 1, 0), (-1, 1, 8)),
+)
+def test_attention_ts_mla_flat_query_tile_layout_rejects_invalid_extent(
+    num_heads, seq_len_q, tile_size_q
+):
+    with pytest.raises(ValueError):
+        FlatQueryTileLayout.for_tile(num_heads, seq_len_q, tile_size_q)
 
 
 @dataclass(frozen=True)
@@ -255,8 +296,8 @@ def _pack_mla_case(
 
     if case.query.ndim != 4 or len(q_lens) != case.query.shape[0]:
         raise ValueError("packed-Q source must be [B, SQ, H, 576] with B lengths")
-    if min(q_lens) <= 0 or max(q_lens) > case.query.shape[1]:
-        raise ValueError("packed Q lengths must be positive and within source SQ")
+    if min(q_lens) < 0 or max(q_lens) > case.query.shape[1]:
+        raise ValueError("packed Q lengths must be nonnegative and within source SQ")
     offsets = [0]
     for q_len in q_lens:
         offsets.append(offsets[-1] + q_len)
@@ -433,7 +474,16 @@ def _mla_reference(
                     probabilities @ visible_cache[:, :_LATENT_DIM] * case.bmm2_scale
                 )
             request_outputs.append(output)
-        outputs.append(torch.stack(request_outputs))
+        if request_outputs:
+            outputs.append(torch.stack(request_outputs))
+        else:
+            outputs.append(
+                torch.empty(
+                    (0, request_queries.shape[1], _LATENT_DIM),
+                    dtype=torch.float32,
+                    device=request_queries.device,
+                )
+            )
     return torch.cat(outputs) if qo_indptr is not None else torch.stack(outputs)
 
 
@@ -464,32 +514,6 @@ def _case(
     }
 
 
-def _policy(
-    kernel: str,
-    tile_size_q: int,
-    split_kv: int,
-    head_dim_per_cta_v: int,
-    *,
-    cluster: bool,
-    persistent: bool = False,
-    clc: bool = False,
-    schedulers: bool = True,
-) -> dict[str, object]:
-    expected = {
-        "kernel": kernel,
-        "tile_size_q": tile_size_q,
-        "split_kv": split_kv,
-        "head_dim_per_cta_v": head_dim_per_cta_v,
-        "use_cluster_reduction": cluster,
-    }
-    if schedulers:
-        expected.update(
-            use_persistent_scheduler=persistent,
-            use_clc_dynamic_persistent_scheduler=clc,
-        )
-    return expected
-
-
 def _param(
     case_kwargs: dict[str, object],
     expected_policy: dict[str, object],
@@ -512,39 +536,48 @@ def _param(
 _MLA_CASES = (
     _param(
         _case(2, 8, 2048, torch.bfloat16, 32001),
-        _policy("throughput_latency_1cta", 8, 8, 128, cluster=True),
+        {
+            "kernel": "throughput_latency_1cta",
+            "use_cluster_reduction": True,
+        },
         "identity",
         False,
         exercise_all_paths=True,
-        id="M1-bf16-q8-v128-s8-cluster",
+        id="bf16-1cta-cluster-reduction",
     ),
     _param(
         _case(4, 16, 4097, torch.float8_e4m3fn, 32002),
-        _policy("throughput_latency_1cta", 16, 9, 128, cluster=False),
+        {
+            "kernel": "throughput_latency_1cta",
+            "separate_reducer_impl": "parallel",
+        },
         "mixed",
         True,
-        id="M2-fp8-q16-v128-s9-separate",
+        id="fp8-1cta-parallel-reduction",
     ),
     _param(
         _case(128, 32, 2048, torch.bfloat16, 32003),
-        _policy("throughput_latency_1cta", 32, 1, 512, cluster=False),
+        {"kernel": "throughput_latency_1cta", "split_kv": 1},
         None,
         False,
-        id="M3-bf16-q32-v512-direct-one-wave",
+        id="bf16-1cta-direct",
     ),
     _param(
         _case(128, 64, 2048, torch.float8_e4m3fn, 32004),
-        _policy("throughput_latency_1cta", 64, 1, 512, cluster=False),
+        {"kernel": "throughput_latency_1cta", "split_kv": 1},
         "identity",
         False,
-        id="M4-fp8-q64-keeps-direct-static",
+        id="fp8-1cta-direct",
     ),
     _param(
         _case(8, 128, 2048, torch.float8_e4m3fn, 32005),
-        _policy("throughput_2cta", 128, 8, 256, cluster=False),
+        {
+            "kernel": "throughput_2cta",
+            "separate_reducer_impl": "reference",
+        },
         "mixed",
         False,
-        id="M5-fp8-2cta-q128-v256-s8-separate",
+        id="fp8-2cta-reference-reduction",
     ),
     _param(
         _case(
@@ -555,18 +588,24 @@ _MLA_CASES = (
             32006,
             seq_len_q=4,
         ),
-        _policy("throughput_latency_1cta", 64, 17, 256, cluster=False),
+        {
+            "kernel": "throughput_latency_1cta",
+            "separate_reducer_impl": "parallel",
+        },
         "mixed",
         False,
-        id="M6-fp8-sq4-grouped-q64-v256-s17",
+        id="fp8-multi-q-1cta-parallel-reduction",
     ),
     _param(
         _case(4, 16, 4097, torch.bfloat16, 32007, seq_len_q=8),
-        _policy("throughput_2cta", 128, 17, 256, cluster=False),
+        {
+            "kernel": "throughput_2cta",
+            "separate_reducer_impl": "reference",
+        },
         "identity",
         False,
         exercise_all_paths=True,
-        id="M7-bf16-sq8-grouped-2cta-q128-v256-s17",
+        id="bf16-multi-q-2cta-reference-reduction",
     ),
     _param(
         _case(
@@ -578,40 +617,45 @@ _MLA_CASES = (
             seq_len_q=4,
             mask_type="dense",
         ),
-        _policy("throughput_latency_1cta", 64, 9, 128, cluster=False, schedulers=False),
+        {
+            "kernel": "throughput_latency_1cta",
+            "separate_reducer_impl": "parallel",
+        },
         "tail",
         False,
-        id="M8-spec-dense-tail-visible",
+        id="speculative-dense-tail",
     ),
     _param(
         _case(2, 16, 2049, torch.bfloat16, 32008, seq_len_q=4),
-        _policy("throughput_latency_1cta", 64, 9, 128, cluster=False, schedulers=False),
+        {
+            "kernel": "throughput_latency_1cta",
+            "separate_reducer_impl": "parallel",
+        },
         "tail",
         False,
-        id="M9-spec-causal-tail-progressive",
+        id="speculative-causal-tail",
     ),
     _param(
         _case(128, 128, 2048, torch.bfloat16, 32009),
-        _policy(
-            "throughput_2cta",
-            128,
-            1,
-            256,
-            cluster=False,
-            persistent=True,
-            clc=True,
-        ),
+        {
+            "kernel": "throughput_2cta",
+            "split_kv": 1,
+            "use_persistent_scheduler": True,
+            "use_clc_dynamic_persistent_scheduler": True,
+        },
         None,
         False,
-        id="M10-bf16-2cta-q128-direct-clc",
+        id="bf16-2cta-persistent-direct",
     ),
     _param(
         _case(5, 65, 256, torch.bfloat16, 32010, seq_len_q=2),
-        _policy("throughput_2cta", 128, 2, 256, cluster=False)
-        | {"separate_reducer_impl": "reference"},
+        {
+            "kernel": "throughput_2cta",
+            "separate_reducer_impl": "reference",
+        },
         None,
         False,
-        id="M11-bf16-2cta-q128-s2-reducer-tail",
+        id="bf16-2cta-reference-reducer-tail",
     ),
     _param(
         _case(
@@ -622,18 +666,15 @@ _MLA_CASES = (
             32011,
             page_size=128,
         ),
-        _policy(
-            "throughput_2cta",
-            128,
-            1,
-            256,
-            cluster=False,
-            persistent=True,
-            clc=True,
-        ),
+        {
+            "kernel": "throughput_2cta",
+            "split_kv": 1,
+            "use_persistent_scheduler": True,
+            "use_clc_dynamic_persistent_scheduler": True,
+        },
         None,
         False,
-        id="M12-bf16-b128-h128-k4097-page128-direct-clc",
+        id="bf16-page128-2cta-persistent-direct",
     ),
 )
 
@@ -765,14 +806,15 @@ def _assert_auto_policy(
     *,
     device: torch.device,
 ) -> None:
-    """Contract exact B200 coverage and portable Blackwell legality."""
+    """Contract requested feature coverage and portable Blackwell legality."""
 
     assert policy["source"] == "auto"
     assert policy["kernel"] in ("throughput_latency_1cta", "throughput_2cta")
     assert policy["tile_size_q"] in (8, 16, 32, 64, 128)
     assert policy["tile_size_kv"] == 128
     assert int(policy["num_insts_kv"]) in (1, 2)
-    assert int(policy["split_kv"]) >= 1
+    split_kv = int(policy["split_kv"])
+    assert split_kv >= 1
     head_dim_per_cta_v = int(policy["head_dim_per_cta_v"])
     num_ctas_per_head_dim = int(policy["num_ctas_per_head_dim"])
     assert head_dim_per_cta_v in (128, 256, 512)
@@ -781,9 +823,16 @@ def _assert_auto_policy(
     use_cluster = bool(policy["use_cluster_reduction"])
     persistent = bool(policy["use_persistent_scheduler"])
     use_clc = bool(policy["use_clc_dynamic_persistent_scheduler"])
+    separate_reducer = policy["separate_reducer_impl"]
+    assert separate_reducer in ("none", "reference", "parallel")
     if use_cluster:
-        assert int(policy["split_kv"]) > 1
+        assert split_kv > 1
         assert policy["kernel"] == "throughput_latency_1cta"
+        assert separate_reducer == "none"
+    if separate_reducer != "none":
+        assert split_kv > 1
+    if split_kv == 1:
+        assert separate_reducer == "none"
     if use_clc:
         assert persistent
     if policy["kernel"] == "throughput_2cta":
@@ -830,6 +879,8 @@ def _assert_case_correct(output, case, policy, *, qo_indptr=None):
     )
     rtol, atol = _mla_tolerances(case.query.dtype)
     torch.testing.assert_close(actual, expected, rtol=rtol, atol=atol)
+    if expected.numel() == 0:
+        return
     relative_l2 = torch.linalg.vector_norm(
         actual - expected
     ) / torch.linalg.vector_norm(expected)
@@ -872,6 +923,7 @@ def _exercise_public_paths(
     torch.cuda.synchronize()
     _assert_case_correct(graph_out, case, policy, qo_indptr=qo_indptr)
     torch.testing.assert_close(graph_out, eager, rtol=0, atol=0)
+    _CUDA_GRAPH_ANCHOR_OWNERS.append((graph, graph_out, wrapper, case))
     return eager
 
 
@@ -989,7 +1041,6 @@ def _make_clc_work_queue(cfg) -> MlaWorkQueue:
         cfg=cfg,
         static_split_kv=1,
         static_seq_len_k=128,
-        groups_tokens_heads_q_ratio=1,
         logical_num_heads_q=128,
         logical_seq_len_q=1,
         static_problem_shape_b=1,
@@ -1222,6 +1273,33 @@ def test_attention_ts_mla_explicit_split_preserves_explicit_profile():
         )
 
 
+def test_attention_ts_mla_partial_tail_rejects_cluster_reduction():
+    """Keep partial flat-row tails on the predicated standalone reducer."""
+
+    config_kwargs = {
+        "batch_size": 1,
+        "num_heads_q": 8,
+        "seq_len_q": 1,
+        "seq_len_kv": 4096,
+        "logical_num_heads_q": 5,
+        "logical_seq_len_q": 1,
+        "tile_size_q": 8,
+        "explicit_split_kv": 2,
+        "max_active_clusters": 148,
+    }
+    automatic = make_throughput_latency_mla_config(**config_kwargs)
+    assert automatic.use_cluster_reduction == 0
+
+    with pytest.raises(
+        ValueError,
+        match=r"cluster reduction requires every launched Q tile.*tail_rows=5",
+    ):
+        make_throughput_latency_mla_config(
+            **config_kwargs,
+            reduction_mode="cluster",
+        )
+
+
 def test_attention_ts_mla_int32_kv_coordinate_bound():
     """The public K/V bound reserves the largest padded split-KV span."""
 
@@ -1252,6 +1330,12 @@ def test_attention_ts_mla_int32_kv_coordinate_bound():
         batch_size=1,
         num_heads=1,
         max_seq_len_q=2**31 - 1,
+    )
+    mla_decode_module._validate_mla_query_head_extent(
+        batch_size=1,
+        num_heads=1,
+        max_seq_len_q=1,
+        total_q=0,
     )
     with pytest.raises(
         NotImplementedError,
@@ -1285,16 +1369,25 @@ def test_attention_ts_mla_int32_kv_coordinate_bound():
         )
 
 
-def test_attention_ts_mla_2cta_reduction_capacity_bound():
-    """The producer and standalone reducer expose the same split capacity."""
-
-    assert MAX_SPLITS == 128
-    assert MlaDecodeTs().reduction_split_capacity == MAX_SPLITS
+@pytest.mark.parametrize(
+    ("offsets", "expected"),
+    (
+        pytest.param((0, 8, 8, 9, 12), (8, 12, (8, 0, 1, 3)), id="mixed"),
+        pytest.param((0, 0, 0), (0, 0, (0, 0)), id="all-empty"),
+    ),
+)
+def test_attention_ts_mla_packed_q_offsets_allow_zero_lengths(offsets, expected):
+    qo_indptr = torch.tensor(offsets, dtype=torch.int32)
     assert (
-        MlaDecodeTs(static_split_kv=MAX_SPLITS).reduction_split_capacity == MAX_SPLITS
+        mla_decode_module._derive_max_seq_len_q(qo_indptr, batch_size=len(offsets) - 1)
+        == expected
     )
-    with pytest.raises(ValueError, match=r"static_split_kv must be in \[1, 128\]"):
-        MlaDecodeTs(static_split_kv=MAX_SPLITS + 1)
+
+
+def test_attention_ts_mla_packed_q_offsets_reject_decrease():
+    qo_indptr = torch.tensor((0, 2, 1), dtype=torch.int32)
+    with pytest.raises(ValueError, match="qo_indptr must be nondecreasing"):
+        mla_decode_module._derive_max_seq_len_q(qo_indptr, batch_size=2)
 
 
 def test_attention_ts_mla_workspace_rejects_unsafe_int32_kv_bound():
@@ -1497,23 +1590,12 @@ def test_attention_ts_mla_fp8_reference_uses_p448():
                 "qkv_dtype": torch.float8_e4m3fn,
                 "seed": 20260808,
             },
-            _policy("throughput_latency_1cta", 16, 3, 128, cluster=True),
+            {
+                "kernel": "throughput_latency_1cta",
+                "use_cluster_reduction": True,
+            },
             0,
             id="smem-p-cluster",
-        ),
-        pytest.param(
-            {
-                "batch_size": 64,
-                "num_qo_heads": 64,
-                "max_seq_len": 257,
-                "kv_seq_lens": (257,) + (1,) * 63,
-                "qkv_dtype": torch.float8_e4m3fn,
-                "seed": 20260809,
-            },
-            _policy("throughput_latency_1cta", 64, 2, 512, cluster=False)
-            | {"separate_reducer_impl": "parallel"},
-            8_421_376,
-            id="tmem-p-separate",
         ),
     ),
 )
@@ -1559,9 +1641,9 @@ def test_attention_ts_mla_speculative_mask_oracle_distinguishes_tail_visibility(
 @pytest.mark.arch_blackwell
 @_REQUIRES_PRIMTS_GPU
 def test_attention_ts_mla_decode_packed_q_public_parity():
-    """Define variable runtime Q lengths exclusively with cumulative offsets."""
+    """Define variable and empty runtime Q lengths with cumulative offsets."""
 
-    q_lens = (1, 3, 8)
+    q_lens = (1, 0, 8)
     max_seq_len_q = max(q_lens)
     case = _make_mla_case(
         batch_size=len(q_lens),
@@ -1633,10 +1715,10 @@ def test_attention_ts_mla_decode_packed_q_public_parity():
 
 @pytest.mark.arch_blackwell
 @_REQUIRES_PRIMTS_GPU
-def test_attention_ts_mla_decode_packed_q_clc_empty_group_progress():
-    """Advance CLC bookkeeping when a packed request has no row in a Q group."""
+def test_attention_ts_mla_decode_packed_q_clc_empty_tile_progress():
+    """Advance CLC bookkeeping when a packed request has no row in a Q tile."""
 
-    q_lens = tuple(1 if batch_idx % 2 == 0 else 2 for batch_idx in range(64))
+    q_lens = tuple(0 if batch_idx % 2 == 0 else 2 for batch_idx in range(64))
     max_seq_len_q = max(q_lens)
     case = _make_mla_case(
         batch_size=len(q_lens),
@@ -1784,7 +1866,7 @@ def test_attention_ts_mla_2cta_graph_reloads_remapped_page_window():
 def test_attention_ts_mla_decode_graph_reloads_all_live_metadata():
     """One replay reloads packed Q offsets, K lengths, and every page-table row."""
 
-    q_lens = tuple(1 if batch_idx % 2 == 0 else 2 for batch_idx in range(64))
+    q_lens = tuple(0 if batch_idx % 2 == 0 else 2 for batch_idx in range(64))
     replay_q_lens = tuple(reversed(q_lens))
     max_seq_len_q = max(q_lens)
     case = _make_mla_case(
@@ -1961,6 +2043,210 @@ def test_attention_ts_mla_decode_head_dtype_product(
     _exercise_auto_mla_case(case)
 
 
+@pytest.mark.parametrize("num_qo_heads", (12, 96), ids=("h12", "h96"))
+@pytest.mark.parametrize("packed_query", (False, True), ids=("fixed", "packed"))
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_reuses_compiled_topology_across_batch_sizes(
+    num_qo_heads: int,
+    packed_query: bool,
+):
+    """One resolved topology accepts different batch extents."""
+
+    wrappers = []
+    for batch_size in (3, 4):
+        case = _make_mla_case(
+            batch_size=batch_size,
+            num_qo_heads=num_qo_heads,
+            max_seq_len=1024,
+            qkv_dtype=torch.bfloat16,
+            device="cuda",
+            seed=39000 + num_qo_heads + batch_size,
+        )
+        qo_indptr = None
+        if packed_query:
+            case, qo_indptr = _pack_mla_case(case, (1,) * batch_size)
+        wrapper = _plan_case(
+            case,
+            qo_indptr=qo_indptr,
+            max_seq_len_q=1 if packed_query else None,
+        )
+        policy = _policy_dict(wrapper)
+        output = _run_case(wrapper, case)
+        _assert_case_correct(output, case, policy, qo_indptr=qo_indptr)
+        wrappers.append(wrapper)
+
+    assert wrappers[0]._compiled is wrappers[1]._compiled
+
+
+@pytest.mark.parametrize(
+    "num_qo_heads,seq_len_q",
+    (
+        pytest.param(6, 8, id="h6-sq8"),
+        pytest.param(12, 4, id="h12-sq4"),
+        pytest.param(24, 2, id="h24-sq2"),
+        pytest.param(48, 1, id="h48-sq1"),
+    ),
+)
+@pytest.mark.parametrize(
+    "qkv_dtype",
+    (torch.bfloat16, torch.float8_e4m3fn),
+    ids=("bf16", "fp8"),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_non_power_of_two_heads_1cta_auto(
+    num_qo_heads: int,
+    seq_len_q: int,
+    qkv_dtype: torch.dtype,
+):
+    """Decode equivalent 48-row non-power head shapes with public auto dispatch."""
+
+    case = _make_mla_case(
+        batch_size=4,
+        num_qo_heads=num_qo_heads,
+        max_seq_len=257,
+        seq_len_q=seq_len_q,
+        qkv_dtype=qkv_dtype,
+        device="cuda",
+        seed=40000 + num_qo_heads + (1 if qkv_dtype == _FP8 else 0),
+    )
+    _exercise_auto_mla_case(
+        case,
+        expected_b200={"kernel": "throughput_latency_1cta"},
+    )
+
+
+@pytest.mark.parametrize(
+    "qkv_dtype",
+    (torch.bfloat16, torch.float8_e4m3fn),
+    ids=("bf16", "fp8"),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_non_power_heads_1cta_split_reduction(
+    qkv_dtype: torch.dtype,
+):
+    """Validate split reduction for non-power query heads in the 1CTA family."""
+
+    case = _make_mla_case(
+        batch_size=4,
+        num_qo_heads=12,
+        max_seq_len=32769,
+        seq_len_q=1,
+        qkv_dtype=qkv_dtype,
+        device="cuda",
+        seed=40112 + (1 if qkv_dtype == _FP8 else 0),
+    )
+    policy = _exercise_auto_mla_case(
+        case,
+        expected_b200={"kernel": "throughput_latency_1cta"},
+    )
+    assert int(policy["split_kv"]) > 1
+
+
+@pytest.mark.parametrize(
+    "batch_size,num_qo_heads,seq_len_q,seed",
+    (
+        pytest.param(160, 6, 8, 40564, id="direct-grid"),
+        pytest.param(320, 8, 1, 40508, id="persistent-grid"),
+    ),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_one_cta_multiwave_progress(
+    batch_size: int,
+    num_qo_heads: int,
+    seq_len_q: int,
+    seed: int,
+):
+    """Execute every request when 1CTA work exceeds one resident wave."""
+
+    case = _make_mla_case(
+        batch_size=batch_size,
+        num_qo_heads=num_qo_heads,
+        max_seq_len=129,
+        seq_len_q=seq_len_q,
+        qkv_dtype=torch.bfloat16,
+        device="cuda",
+        seed=seed,
+    )
+    _exercise_auto_mla_case(
+        case,
+        expected_b200={"kernel": "throughput_latency_1cta"},
+    )
+
+
+@pytest.mark.parametrize(
+    "num_qo_heads,seq_len_q",
+    (
+        pytest.param(96, 4, id="h96-sq4"),
+        pytest.param(48, 8, id="h48-sq8"),
+        pytest.param(24, 16, id="h24-sq16"),
+        pytest.param(12, 32, id="h12-sq32"),
+    ),
+)
+@pytest.mark.parametrize(
+    "qkv_dtype",
+    (torch.bfloat16, torch.float8_e4m3fn),
+    ids=("bf16", "fp8"),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_non_power_of_two_heads_2cta_matched_rows(
+    num_qo_heads: int,
+    seq_len_q: int,
+    qkv_dtype: torch.dtype,
+):
+    """Decode equal-row non-power head shapes through public 2CTA dispatch."""
+
+    case = _make_mla_case(
+        batch_size=16,
+        num_qo_heads=num_qo_heads,
+        max_seq_len=1024,
+        seq_len_q=seq_len_q,
+        qkv_dtype=qkv_dtype,
+        device="cuda",
+        seed=41000 + num_qo_heads + (1 if qkv_dtype == _FP8 else 0),
+    )
+    wrapper = _plan_case(case)
+    policy = _policy_dict(wrapper)
+    _assert_auto_policy(
+        policy,
+        {"kernel": "throughput_2cta"},
+        device=case.query.device,
+    )
+    _exercise_public_paths(wrapper, case, policy, exercise_all_paths=False)
+
+
+@pytest.mark.parametrize(
+    "qkv_dtype",
+    (torch.bfloat16, torch.float8_e4m3fn),
+    ids=("bf16", "fp8"),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_non_power_heads_2cta_split_reduction(
+    qkv_dtype: torch.dtype,
+):
+    """Validate split reduction for a partial M128 query tile."""
+
+    case = _make_mla_case(
+        batch_size=1,
+        num_qo_heads=96,
+        max_seq_len=32769,
+        seq_len_q=1,
+        qkv_dtype=qkv_dtype,
+        device="cuda",
+        seed=41596 + (1 if qkv_dtype == _FP8 else 0),
+    )
+    policy = _exercise_auto_mla_case(
+        case,
+        expected_b200={"kernel": "throughput_2cta"},
+    )
+    assert int(policy["split_kv"]) > 1
+
+
 @pytest.mark.parametrize("num_qo_heads", (8, 16, 32, 64), ids=lambda value: f"h{value}")
 @pytest.mark.parametrize(
     "qkv_dtype",
@@ -1975,7 +2261,7 @@ def test_attention_ts_mla_decode_sq2_head_dtype_mask_product(
     qkv_dtype: torch.dtype,
     mask_type: str,
 ):
-    """Cross SQ2 grouped heads with dtype and speculative mask semantics."""
+    """Cross SQ2 flat query rows with dtype and speculative mask semantics."""
 
     case = _make_mla_case(
         batch_size=3,
@@ -2030,6 +2316,172 @@ def test_attention_ts_mla_decode_packed_dtype_mask_page_product(
         max_seq_len_q=max_seq_len_q,
     )
     assert policy["source"] == "auto"
+
+
+@pytest.mark.parametrize(
+    "num_qo_heads,expected_kernel",
+    (
+        pytest.param(6, "throughput_latency_1cta", id="h6-1cta"),
+        pytest.param(96, "throughput_2cta", id="h96-2cta"),
+    ),
+)
+@pytest.mark.parametrize(
+    "qkv_dtype",
+    (torch.bfloat16, torch.float8_e4m3fn),
+    ids=("bf16", "fp8"),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_packed_non_power_of_two_heads(
+    num_qo_heads: int,
+    expected_kernel: str | None,
+    qkv_dtype: torch.dtype,
+):
+    """Mixed empty packed requests predicate flat tiles in both families."""
+
+    q_lens = (8, 1, 0, 3)
+    max_seq_len_q = max(q_lens)
+    case = _make_mla_case(
+        batch_size=len(q_lens),
+        num_qo_heads=num_qo_heads,
+        max_seq_len=1024,
+        seq_len_q=max_seq_len_q,
+        qkv_dtype=qkv_dtype,
+        mask_type="causal",
+        page_size=64,
+        device="cuda",
+        seed=43000 + num_qo_heads + (1 if qkv_dtype == _FP8 else 0),
+    )
+    case = _apply_mla_tail_markers(case)
+    case, qo_indptr = _pack_mla_case(case, q_lens)
+    wrapper = _plan_case(
+        case,
+        qo_indptr=qo_indptr,
+        max_seq_len_q=max_seq_len_q,
+    )
+    policy = _policy_dict(wrapper)
+    _assert_auto_policy(
+        policy,
+        {"kernel": expected_kernel} if expected_kernel is not None else {},
+        device=case.query.device,
+    )
+    assert policy["kernel"] in ("throughput_latency_1cta", "throughput_2cta")
+    eager = _exercise_public_paths(
+        wrapper,
+        case,
+        policy,
+        exercise_all_paths=True,
+        qo_indptr=qo_indptr,
+        max_seq_len_q=max_seq_len_q,
+    )
+    one_shot = batch_decode_mla_with_paged_kv_cache(
+        case.query,
+        case.kv_cache,
+        case.block_tables,
+        case.seq_lens,
+        qo_indptr=qo_indptr,
+        max_seq_len_q=max_seq_len_q,
+        mask_type=case.mask_type,
+        max_kv_len=case.max_seq_len,
+        bmm1_scale=case.bmm1_scale,
+        bmm2_scale=case.bmm2_scale,
+        out_dtype=case.output_dtype,
+    )
+    _assert_case_correct(one_shot, case, policy, qo_indptr=qo_indptr)
+    torch.testing.assert_close(one_shot, eager, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "num_qo_heads,expected_kernel",
+    (
+        pytest.param(6, "throughput_latency_1cta", id="h6-1cta"),
+        pytest.param(96, "throughput_2cta", id="h96-2cta"),
+    ),
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_mla_decode_all_empty_packed_query_noop(
+    num_qo_heads: int,
+    expected_kernel: str,
+):
+    """An explicitly bounded all-empty batch returns empty public outputs."""
+
+    q_lens = (0, 0, 0, 0)
+    max_seq_len_q = 8
+    case = _make_mla_case(
+        batch_size=len(q_lens),
+        num_qo_heads=num_qo_heads,
+        max_seq_len=257,
+        seq_len_q=max_seq_len_q,
+        qkv_dtype=torch.bfloat16,
+        mask_type="causal",
+        page_size=64,
+        device="cuda",
+        seed=44000 + num_qo_heads,
+    )
+    case, qo_indptr = _pack_mla_case(case, q_lens)
+
+    with pytest.raises(
+        ValueError, match="max_seq_len_q is required for an all-empty packed query"
+    ):
+        _plan_case(case, qo_indptr=qo_indptr)
+    with pytest.raises(
+        ValueError, match="max_seq_len_q is required for an all-empty packed query"
+    ):
+        batch_decode_mla_with_paged_kv_cache(
+            case.query,
+            case.kv_cache,
+            case.block_tables,
+            case.seq_lens,
+            qo_indptr=qo_indptr,
+            max_kv_len=case.max_seq_len,
+        )
+
+    wrapper = _plan_case(
+        case,
+        qo_indptr=qo_indptr,
+        max_seq_len_q=max_seq_len_q,
+    )
+    policy = _policy_dict(wrapper)
+    _assert_auto_policy(
+        policy,
+        {"kernel": expected_kernel},
+        device=case.query.device,
+    )
+
+    eager_out = torch.empty(
+        (0, num_qo_heads, _LATENT_DIM),
+        dtype=case.output_dtype,
+        device=case.query.device,
+    )
+    eager = _run_case(wrapper, case, out=eager_out)
+    assert eager is eager_out
+    _assert_case_correct(eager, case, policy, qo_indptr=qo_indptr)
+
+    standalone = _run_standalone(
+        case,
+        qo_indptr=qo_indptr,
+        max_seq_len_q=max_seq_len_q,
+    )
+    _assert_case_correct(standalone, case, policy, qo_indptr=qo_indptr)
+
+    one_shot_out = torch.empty_like(eager)
+    one_shot = batch_decode_mla_with_paged_kv_cache(
+        case.query,
+        case.kv_cache,
+        case.block_tables,
+        case.seq_lens,
+        qo_indptr=qo_indptr,
+        max_seq_len_q=max_seq_len_q,
+        mask_type=case.mask_type,
+        max_kv_len=case.max_seq_len,
+        bmm1_scale=case.bmm1_scale,
+        bmm2_scale=case.bmm2_scale,
+        out=one_shot_out,
+        out_dtype=case.output_dtype,
+    )
+    assert one_shot is one_shot_out
+    _assert_case_correct(one_shot, case, policy, qo_indptr=qo_indptr)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Port the no-padding grouped query-row work to PrimTS attention and MLA decode, covering both throughput-latency 1CTA and throughput 2CTA kernels.

## Features

- Flatten `(query token, query head)` into physical query rows without padding.
- Support fixed and packed Q layouts, including empty packed requests.
- Support non-power-of-two query-head counts such as H6, H12, H24, H48, and H96.
- Make context, FMHA decode, and MLA compiled callables batch-dynamic while keeping workspace sizing plan-specific.
- Reuse compiled topologies across batch sizes when their static scheduler/reducer topology is unchanged.

## Dispatch policy

- Select the 1CTA query tile from flat query geometry only.
- Derive split-KV from K-step work, resident capacity, and the shared 128-split implementation limit.
- Use 2CTA above the native M64 1CTA row boundary.
- Within M64, select 2CTA only when 1CTA requires split reduction and 2CTA can produce direct output.
- Remove dtype-, shape-, and measurement-specific crossover tables, power-of-two split rounding, and candidate scoring.

A few structural performance outliers are intentionally retained rather than adding case-specific dispatch exceptions.

## Correctness fixes

- Predicate partial flat-query tails and empty runtime tiles.
- Apply causal masking using logical query rows.
- Preserve scheduler progress for multiwave and empty-tile launches.
- Correct split-workspace addressing and runtime-K pruning.
- Keep producer and standalone-reducer topology/capacity consistent.
- Use the fixed qualified reference-reducer launch geometry.

## Validation

| Validation | Result |
|---|---|
| Repository-wide pre-commit | Passed |
| Affected host suites | 178 passed, 286 skipped |
| CUDA 13.4 / B200 PrimTS MLA suite | 144 passed |
| Issue #4390 backend matrix | 72/72 refchecks |
| PrimTS wins in issue #4390 matrix | 24/24 |
| CuTe DSL / PrimTS geometric mean | 1.4288 |
| CuTe DSL / PrimTS minimum | 1.0832 |
| Representative 28-cell policy A/B geometric mean | 1.0851 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for empty and partially empty packed-query requests, including safe no-op handling for all-empty batches.
  * Expanded MLA decode support for additional query-head counts and non-power-of-two configurations.
  * Improved compiled-kernel reuse across batch sizes and runtime metadata sizes.
  * Added automatic scheduler and split-KV topology selection.

* **Bug Fixes**
  * Improved causal masking, variable-length query handling, split-KV reduction, and padded-row processing.
  * Prevented unnecessary work for empty attention tiles.

* **Documentation**
  * Clarified workspace reinitialization requirements, including after batch-size changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->