### PR TITLE
feat(attention): support LDTM.STAT for PrimTS fmha context kernel

### DIFF
--- a/ci/cuda-versions.json
+++ b/ci/cuda-versions.json
@@ -3,7 +3,7 @@
     "nvidia-cutlass-dsl": {
       "provider_build_specifier": ">=4.6.2a0",
       "cuda_extra_specifier": ">=4.7.0a0",
-      "ci_image_specifier": "==4.7.0",
+      "ci_image_specifier": "==4.8.0.dev0",
       "cuda_major_extras": {
         "13": ["cu13"]
       }

--- a/ci/validate_cuda_versions.py
+++ b/ci/validate_cuda_versions.py
@@ -19,10 +19,13 @@ CUDNN_PATTERN = re.compile(r"^[0-9]+(?:\.[0-9]+){3}$")
 ARCH_LIST_PATTERN = re.compile(r"^[0-9]+\.[0-9]+[a-z]?(?: [0-9]+\.[0-9]+[a-z]?)*$")
 DEPENDENCY_PACKAGE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 DEPENDENCY_VERSION_PATTERN = re.compile(
-    r"^(?P<release>[0-9]+(?:\.[0-9]+)*)(?:(?P<phase>a|b|rc)(?P<serial>[0-9]+))?$"
+    r"^(?P<release>[0-9]+(?:\.[0-9]+)*)"
+    r"(?:(?P<phase>a|b|rc)(?P<serial>[0-9]+))?"
+    r"(?:\.dev(?P<dev>[0-9]+))?$"
 )
 DEPENDENCY_SPECIFIER_PATTERN = re.compile(
-    r"^(?P<operator>==|>=)(?P<version>[0-9]+(?:\.[0-9]+)*(?:(?:a|b|rc)[0-9]+)?)$"
+    r"^(?P<operator>==|>=)"
+    r"(?P<version>[0-9]+(?:\.[0-9]+)*(?:(?:a|b|rc)[0-9]+)?(?:\.dev[0-9]+)?)$"
 )
 DEPENDENCY_EXTRA_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 CUDA_MAJOR_PATTERN = re.compile(r"^[0-9]+$")
@@ -63,9 +66,23 @@ def _version_key(version: str) -> tuple[int, ...]:
     release = tuple(int(part) for part in match.group("release").split("."))
     release = (*release, *(0 for _ in range(4 - len(release))))
     phase = match.group("phase")
-    phase_rank = {"a": 0, "b": 1, "rc": 2, None: 3}[phase]
+    dev = match.group("dev")
+    # PEP 440 ordering within one release, lowest to highest:
+    #   X.devN  <  XaN  <  XbN  <  XrcN  <  X (final)
+    # A dev release with no pre-release phase precedes every pre-release, so it
+    # ranks below alpha; a final release (no phase, no dev) ranks above them.
+    if phase is not None:
+        phase_rank = {"a": 0, "b": 1, "rc": 2}[phase]
+    elif dev is not None:
+        phase_rank = -1
+    else:
+        phase_rank = 3
     serial = int(match.group("serial") or 0)
-    return (*release, phase_rank, serial)
+    # Within the same (release, phase, serial) a dev release precedes its
+    # non-dev counterpart, e.g. 4.8.0a1.dev2 < 4.8.0a1: (0, dev) sorts before
+    # (1, 0).
+    dev_key = (0, int(dev)) if dev is not None else (1, 0)
+    return (*release, phase_rank, serial, *dev_key)
 
 
 def _toml_string_arrays(path: Path, section: str) -> dict[str, list[str]]:

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -2366,6 +2366,13 @@ class FmhaTs:
         grouped-query attention with an even repeat count.
     enable_skip_correction : bool, optional
         Enable skip-correction for softmax rescaling (default: True).
+    uses_ldtm_stat : bool, optional
+        Use ``tcgen05.ld.red.max`` (LDTM.STAT) to fuse the per-chunk row_max
+        into the TMEM S load on the non-masked path (default: False). Requires
+        SM103+/SM110+. Also switches the correction O-rescale loop to a
+        software-pipelined form (``ld[i]`` alongside ``st[i-1]``) so the shared
+        tcgen05 issue pipe can overlap loads and stores while LDTM.STAT is in
+        flight, closing the causal-balanced regression.
     causal_single_kv_tile : bool, optional
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V
@@ -2389,6 +2396,7 @@ class FmhaTs:
         has_variable_window: bool = False,
         h_r: int = 1,
         enable_skip_correction: bool = True,
+        uses_ldtm_stat: bool = False,
         use_paged_kv: bool = False,
         num_tokens_per_page: int = 32,
         max_num_pages_per_seq_kv: int = 1,
@@ -2470,6 +2478,7 @@ class FmhaTs:
             cfg.num_regs_correction = 88
             cfg.num_regs_other = 56
         cfg.enable_skip_correction = enable_skip_correction
+        cfg.uses_ldtm_stat = uses_ldtm_stat
         cfg.qk_acc_dtype = qk_acc_dtype or cutlass.Float32
         cfg.pv_acc_dtype = pv_acc_dtype or cutlass.Float32
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -91,6 +91,7 @@ from .helpers import (
     variable_window_cta_min_start,
 )
 from cutlass.experimental import primitives as prims
+from cutlass._mlir.dialects import arith as arith_dialect
 
 SmemDescOffsets: TypeAlias = tuple[int, int]
 TmemAddr: TypeAlias = int | Int32
@@ -331,6 +332,14 @@ class FmhaConfig:
 
     seq_tile_n: int = 128
     tmem_x_load_s: int = 32
+    # Opt-in to `tcgen05.ld.red.max` (LDTM.STAT) for the non-masked
+    # `compute_row_max` path: fuses the per-chunk max into the TMEM load.
+    # Requires SM103+/SM110+ with tcgen05.ld.red support; the primitive is
+    # emitted with the 32dp x 32bit x 32rep shape only.
+    # Also switches the correction O-rescale loop to a software-pipelined
+    # form (ld[i] issued alongside st[i-1]) so the shared tcgen05 issue pipe
+    # can overlap loads and stores while softmax LDTM.STAT is in flight.
+    uses_ldtm_stat: bool = False
     # Causal S_q < S_kv shifts Q rows right by q_offset = S_kv - S_q.
     # This flag selects the shifted causal mask; there is no second causal mode.
     has_q_offset: bool = False
@@ -2530,6 +2539,53 @@ class TmemSPResource(MemoryResource):
         return old_row_max, row_max_safe
 
     @cute.jit
+    def _load_s_chunks_and_reduce_row_max(
+        self,
+        stage_info: StageInfo,
+        row_max: SoftmaxScalar,
+    ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
+        """LDTM.STAT: fuse S load and per-chunk row_max via tcgen05.ld.red.max.
+
+        Instead of loading each S chunk with ``tcgen05.ld`` and then folding
+        a per-lane max in registers, use ``tcgen05.ld.red.max`` so the
+        reduction happens as part of the TMEM load.  Only valid on the
+        non-masked path (masked variants must observe raw S values before
+        applying the mask).
+        """
+        tmem_s_addr = self.tmem_s_addr_cached + self._stage_col_offset(stage_info)
+        tmem_x = self.cfg.tmem_x_load_s
+        num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
+        old_row_max = row_max
+        s_data: SoftmaxChunks = [None] * num_chunks
+        for chunk_idx in cutlass.range_constexpr(num_chunks):
+            loaded_words, red_word = prims.tcgen05_ld_red(
+                prims.Tcgen05LdStShape.SHAPE_32X32B,
+                prims.make_tmem_ptr(
+                    tmem_s_addr + chunk_idx * tmem_x, self.cfg.qk_acc_dtype
+                ),
+                prims.ReductionKind.MAX,
+                num=tmem_x,
+            )
+            s_data[chunk_idx] = cutlass.Vector.from_elements(
+                tuple(
+                    loaded_words[i].bitcast(self.cfg.qk_acc_dtype)
+                    for i in range(tmem_x)
+                ),
+                dtype=self.cfg.qk_acc_dtype,
+            )
+            chunk_max = self.cfg.qk_acc_dtype(
+                arith_dialect.bitcast(
+                    self.cfg.qk_acc_dtype.mlir_type, red_word.ir_value()
+                )
+            )
+            row_max = cute.math.max(row_max, chunk_max)
+        _tmem_sp_sdata[id(self)] = s_data
+        row_max_safe = row_max
+        if row_max == -Float32.inf:
+            row_max_safe = Float32(0.0)
+        return old_row_max, row_max_safe
+
+    @cute.jit
     def _exp2_p_store(
         self,
         stage_col_offset: TmemAddr,
@@ -2970,6 +3026,8 @@ class TmemSPResource(MemoryResource):
         row_max: SoftmaxScalar,
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
         """Main K-loop stage: load S from TMEM and compute unmasked row_max."""
+        if cutlass.const_expr(self.cfg.uses_ldtm_stat):
+            return self._load_s_chunks_and_reduce_row_max(stage_info, row_max)
         s_data = self._load_s_chunks(stage_info)
         return self._reduce_row_max(s_data, row_max)
 
@@ -4342,20 +4400,43 @@ class TmemOResource(MemoryResource):
             tmem_x = 16
 
             num_iters = self.cfg.cta_tiler[2] // tmem_x
-            for i in cutlass.range_constexpr(num_iters):
-                tmem_tile_addr = tmem_o_addr + i * tmem_x
-                tmem_ptr = cutlass.inttoptr(
-                    tmem_tile_addr,
+
+            def _tmem_ptr(i: int):
+                return cutlass.inttoptr(
+                    tmem_o_addr + i * tmem_x,
                     mem_space=6,
                     dtype=self.cfg.pv_acc_dtype,
                 )
 
-                # Load from TMEM as vector, scale, store back
-                o_vec = prims.tcgen05_ld(tmem_shape, tmem_ptr, num=tmem_x)
+            if cutlass.const_expr(self.cfg.uses_ldtm_stat):
+                # Software-pipeline: ld[i] issued alongside st[i-1] each
+                # iteration, breaking the ld->st chain so the tcgen05 issue
+                # pipe can overlap loads and stores. Prologue issues ld[0];
+                # steady-state issues ld[i]+st[i-1]; epilogue drains st[N-1].
+                ptr0 = _tmem_ptr(0)
+                v_prev = prims.tcgen05_ld(tmem_shape, ptr0, num=tmem_x)
                 cute.arch.fence_view_async_tmem_load()
-                scale_vec = cutlass.vector.full_like(o_vec, scale)
-                o_scaled = o_vec * scale_vec
-                prims.tcgen05_st(tmem_shape, tmem_ptr, o_scaled)
+                scale_vec = cutlass.vector.full_like(v_prev, scale)
+                s_prev = v_prev * scale_vec
+                ptr_prev = ptr0
+
+                for i in cutlass.range_constexpr(1, num_iters):
+                    ptr_i = _tmem_ptr(i)
+                    v_i = prims.tcgen05_ld(tmem_shape, ptr_i, num=tmem_x)
+                    cute.arch.fence_view_async_tmem_load()
+                    prims.tcgen05_st(tmem_shape, ptr_prev, s_prev)
+                    s_prev = v_i * scale_vec
+                    ptr_prev = ptr_i
+
+                prims.tcgen05_st(tmem_shape, ptr_prev, s_prev)
+            else:
+                for i in cutlass.range_constexpr(num_iters):
+                    tmem_ptr = _tmem_ptr(i)
+                    o_vec = prims.tcgen05_ld(tmem_shape, tmem_ptr, num=tmem_x)
+                    cute.arch.fence_view_async_tmem_load()
+                    scale_vec = cutlass.vector.full_like(o_vec, scale)
+                    o_scaled = o_vec * scale_vec
+                    prims.tcgen05_st(tmem_shape, tmem_ptr, o_scaled)
 
             cute.arch.fence_view_async_tmem_store()
         # else: skip TMEM rescale entirely when scale=1.0

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1078,6 +1078,18 @@ def create_softmax_task(
             src = _src_resources(tmem_sp, work_queue=work_queue)
             dst = [tmem_vec, tmem_p]
 
+            # Software-pipeline the vec-mbarrier acquire past the LDTM.STAT
+            # issue so the mbarrier try_wait overlaps with the in-flight
+            # tcgen05.ld.red.max latency.  Restricted to the schedule shape
+            # where it was measured to help (LDTM.STAT + causal-balanced);
+            # dense LDTM.STAT regresses under this reordering, so fall back
+            # to the original schedule for all other configs.
+            use_sw_pipeline = (
+                tmem_sp.cfg.uses_ldtm_stat
+                and tmem_sp.cfg.is_causal
+                and tmem_sp.cfg.balance_causal_workload
+            )
+
             @schedule
             def softmax_schedule(
                 sp: TmemSPResource,
@@ -1101,7 +1113,9 @@ def create_softmax_task(
                     window_end = Int32(0)
                     if tmem_sp.uses_variable_window:
                         window_start, window_end = sp.cache_variable_window_bounds()
-                    vec.acquire()
+                    if not use_sw_pipeline:
+                        # Reserve the first stats slot up-front.
+                        vec.acquire()
                     with domain_loop(loop_start, loop_end, loop_step):
                         # Softmax(i): wait for QK(Q,Ki) -> S(i).
                         sp.wait()
@@ -1140,6 +1154,12 @@ def create_softmax_task(
                         else:
                             old_row_max, row_max = sp.compute_row_max(row_max=row_max)
                         # Stats(i): S(i) -> row max/sum for correction.
+                        if use_sw_pipeline:
+                            # Acquire this iter's stats slot after LDTM.STAT
+                            # has been issued so the mbarrier try_wait
+                            # overlaps with the in-flight tcgen05.ld.red.max
+                            # latency.
+                            vec.acquire()
                         vec.store_vec(
                             old_row_max=old_row_max,
                             row_max=row_max,
@@ -1165,7 +1185,9 @@ def create_softmax_task(
                             p_chunk=p_chunk,
                             scale_softmax_log2=scale_softmax_log2,
                         )
-                        vec.acquire()
+                        if not use_sw_pipeline:
+                            # Reserve next iter / tail's stats slot.
+                            vec.acquire()
 
                     if tmem_sp.uses_head_paired_causal_tail_mask:
                         # Tail S: consume and mask the final head-paired score tile.
@@ -1175,6 +1197,8 @@ def create_softmax_task(
                             q_offset=q_offset,
                             section=FmhaStage.Tail,
                         )
+                        if use_sw_pipeline:
+                            vec.acquire()
                         vec.store_vec(
                             old_row_max=old_row_max,
                             row_max=row_max,
@@ -1196,13 +1220,17 @@ def create_softmax_task(
                             p_chunk=p_chunk,
                             scale_softmax_log2=scale_softmax_log2,
                         )
-                        vec.acquire()
+                        if not use_sw_pipeline:
+                            # Reserve the identity-drain stats slot.
+                            vec.acquire()
                         # Drain the final SP/P-ready slots and publish identity stats.
                         sp.wait()
                         sp.release()
                         tp.acquire()
                         tp.commit()
                         old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                        if use_sw_pipeline:
+                            vec.acquire()
                         vec.store_vec(
                             old_row_max=old_row_max,
                             row_max=row_max,
@@ -1217,6 +1245,8 @@ def create_softmax_task(
                             row_max=row_max,
                             q_offset=q_offset,
                         )
+                        if use_sw_pipeline:
+                            vec.acquire()
                         vec.store_vec(
                             old_row_max=old_row_max,
                             row_max=row_max,
@@ -1272,6 +1302,8 @@ def create_softmax_task(
                             row_max=row_max,
                             q_offset=q_offset,
                         )
+                        if use_sw_pipeline:
+                            vec.acquire()
                         vec.store_vec(
                             old_row_max=old_row_max,
                             row_max=row_max,
@@ -1314,6 +1346,8 @@ def create_softmax_task(
                         tp.acquire()
                         tp.commit()
                         old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                        if use_sw_pipeline:
+                            vec.acquire()
                         vec.store_vec(
                             old_row_max=old_row_max,
                             row_max=row_max,
@@ -1354,6 +1388,13 @@ def create_softmax_task(
         src = _src_resources(tmem_sp, work_queue=work_queue)
         dst = [tmem_vec]
 
+        # See variant above for the gating rationale.
+        use_sw_pipeline = (
+            tmem_sp.cfg.uses_ldtm_stat
+            and tmem_sp.cfg.is_causal
+            and tmem_sp.cfg.balance_causal_workload
+        )
+
         @schedule
         def softmax_schedule(
             sp: TmemSPResource,
@@ -1383,7 +1424,8 @@ def create_softmax_task(
                 window_end = Int32(0)
                 if tmem_sp.uses_variable_window:
                     window_start, window_end = sp.cache_variable_window_bounds()
-                vec.acquire()
+                if not use_sw_pipeline:
+                    vec.acquire()
                 with domain_loop(loop_start, loop_end, loop_step):
                     sp.wait()
                     if tmem_sp.uses_variable_window:
@@ -1420,6 +1462,11 @@ def create_softmax_task(
                         )
                     else:
                         old_row_max, row_max = sp.row_max(row_max)
+                    if use_sw_pipeline:
+                        # Acquire this iter's stats slot after LDTM.STAT has
+                        # been issued so the mbarrier try_wait overlaps with
+                        # the in-flight tcgen05.ld.red.max latency.
+                        vec.acquire()
                     vec.store_vec(
                         old_row_max,
                         row_max,
@@ -1431,7 +1478,8 @@ def create_softmax_task(
                     row_sum = sp.softmax_post_release_reduce(
                         old_row_max, row_max, row_sum, p_chunk
                     )
-                    vec.acquire()
+                    if not use_sw_pipeline:
+                        vec.acquire()
 
                 if tmem_sp.uses_head_paired_causal_tail_mask:
                     sp.wait()
@@ -1440,6 +1488,8 @@ def create_softmax_task(
                         q_offset=q_offset,
                         section=FmhaStage.Tail,
                     )
+                    if use_sw_pipeline:
+                        vec.acquire()
                     vec.store_vec(
                         old_row_max,
                         row_max,
@@ -1451,10 +1501,13 @@ def create_softmax_task(
                     row_sum = sp.softmax_post_release_reduce(
                         old_row_max, row_max, row_sum, p_chunk
                     )
-                    vec.acquire()
+                    if not use_sw_pipeline:
+                        vec.acquire()
                     sp.wait()
                     sp.release()
                     old_row_max = sp.softmax_post_release_identity(row_max)
+                    if use_sw_pipeline:
+                        vec.acquire()
                     vec.store_vec(
                         old_row_max,
                         row_max,
@@ -1468,6 +1521,8 @@ def create_softmax_task(
                         row_max=row_max,
                         q_offset=q_offset,
                     )
+                    if use_sw_pipeline:
+                        vec.acquire()
                     vec.store_vec(old_row_max, row_max, row_sum)
                     vec.commit()
                     p_chunk = sp.masked_exp2_p(
@@ -1502,6 +1557,8 @@ def create_softmax_task(
                         row_max=row_max,
                         q_offset=q_offset,
                     )
+                    if use_sw_pipeline:
+                        vec.acquire()
                     vec.store_vec(old_row_max, row_max, row_sum)
                     vec.commit()
                     p_chunk = sp.masked_exp2_p(
@@ -1526,6 +1583,8 @@ def create_softmax_task(
                     sp.wait()
                     sp.release()
                     old_row_max = sp.softmax_post_release_identity(row_max)
+                    if use_sw_pipeline:
+                        vec.acquire()
                     vec.store_vec(old_row_max, row_max, row_sum)
                     vec.commit()
 
@@ -1552,6 +1611,17 @@ def create_softmax_task(
     dst = [tmem_vec]
     if s0s1_seq is not None and index == 0:
         dst.append(s0s1_seq)
+
+    # Software-pipeline the vec-mbarrier acquire past the LDTM.STAT issue so the
+    # mbarrier try_wait overlaps with the in-flight tcgen05.ld.red.max latency.
+    # Restricted to the schedule shape where it was measured to help (LDTM.STAT
+    # + causal-balanced); dense LDTM.STAT regresses under this reordering, so
+    # fall back to the original schedule for all other configs.
+    use_sw_pipeline = (
+        tmem_sp.cfg.uses_ldtm_stat
+        and tmem_sp.cfg.is_causal
+        and tmem_sp.cfg.balance_causal_workload
+    )
 
     @schedule
     def softmax_schedule(
@@ -1581,8 +1651,9 @@ def create_softmax_task(
             window_end = Int32(0)
             if tmem_sp.uses_variable_window:
                 window_start, window_end = sp.cache_variable_window_bounds()
-            # Reserve a stats slot before the first softmax result is published.
-            vec.acquire()
+            if not use_sw_pipeline:
+                # Reserve the first stats slot up-front.
+                vec.acquire()
             with domain_loop(loop_start, loop_end, loop_step):
                 sp.wait()
                 # Compute row max and publish vec.
@@ -1620,6 +1691,11 @@ def create_softmax_task(
                     )
                 else:
                     old_row_max, row_max = sp.compute_row_max(row_max=row_max)
+                if use_sw_pipeline:
+                    # Acquire this iter's stats slot after LDTM.STAT has been
+                    # issued so the mbarrier try_wait overlaps with the
+                    # in-flight tcgen05.ld.red.max latency.
+                    vec.acquire()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1654,8 +1730,9 @@ def create_softmax_task(
                     p_chunk=p_chunk,
                     scale_softmax_log2=scale_softmax_log2,
                 )
-                # Acquire vec for next iter.
-                vec.acquire()
+                if not use_sw_pipeline:
+                    # Reserve next iter / tail's stats slot.
+                    vec.acquire()
 
             if tmem_sp.uses_head_paired_causal_tail_mask:
                 # Head-paired maps Q0/Q1 to adjacent Hq slices at the same S
@@ -1667,6 +1744,8 @@ def create_softmax_task(
                     q_offset=q_offset,
                     section=FmhaStage.Tail,
                 )
+                if use_sw_pipeline:
+                    vec.acquire()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1697,10 +1776,14 @@ def create_softmax_task(
                     p_chunk=p_chunk,
                     scale_softmax_log2=scale_softmax_log2,
                 )
-                vec.acquire()
+                if not use_sw_pipeline:
+                    # Reserve the identity-drain stats slot.
+                    vec.acquire()
                 sp.wait()
                 sp.release()
                 old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                if use_sw_pipeline:
+                    vec.acquire()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1717,6 +1800,8 @@ def create_softmax_task(
                     row_max=row_max,
                     q_offset=q_offset,
                 )
+                if use_sw_pipeline:
+                    vec.acquire()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1773,6 +1858,8 @@ def create_softmax_task(
                     row_max=row_max,
                     q_offset=q_offset,
                 )
+                if use_sw_pipeline:
+                    vec.acquire()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,
@@ -1812,6 +1899,8 @@ def create_softmax_task(
                 sp.wait()
                 sp.release()
                 old_row_max = sp.softmax_aux_identity(row_max=row_max)
+                if use_sw_pipeline:
+                    vec.acquire()
                 vec.store_vec(
                     old_row_max=old_row_max,
                     row_max=row_max,

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/cute_dsl_utils.py
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/cute_dsl_utils.py
@@ -28,7 +28,8 @@ from cutlass.cute.runtime import from_dlpack
 _STATIC_TYPES = (cutlass.Constexpr, NumericMeta, int, bool, str, float, type(None))
 
 
-_EXPECTED_CUTLASS_DSL_VERSION = "4.7.0"  # keep in sync with requirements.txt
+# Keep in sync with ci/cuda-versions.json (ci_image_specifier).
+_EXPECTED_CUTLASS_DSL_VERSION = "4.8.0.dev0"
 
 # Serializes the save/patch/restore sequence below so overlapping
 # cute.compile(..., "--enable-tvm-ffi") calls from different threads can't

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/dispatch_helpers.py
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/dispatch_helpers.py
@@ -781,8 +781,8 @@ def combine_blk64_kv_bucketed_partials(
 def workaround_cutlass_hash_import_bug():
     """Avoid optional generated dialect imports that are broken in this environment.
 
-    The alias loop below is verified against the pinned nvidia-cutlass-dsl==4.7.0
-    (see requirements.txt): ``cutlass._mlir_helpers.<suffix>`` is the real
+    The alias loop below is verified against the pinned nvidia-cutlass-dsl==4.8.0.dev0
+    (see ci/cuda-versions.json): ``cutlass._mlir_helpers.<suffix>`` is the real
     module and ``cutlass.base_dsl._mlir_helpers.<suffix>`` is the (missing)
     alias some generated code expects, so the loop builds that alias. This
     direction is version-sensitive -- it was reversed on nvidia-cutlass-dsl

--- a/flashinfer/gdn_kernels/experimental/README.md
+++ b/flashinfer/gdn_kernels/experimental/README.md
@@ -435,7 +435,7 @@ the composable path.
    A CuTe-DSL impl must also stay inside the DSL surface its *deployed*
    version offers, not the newest one installed while developing.  **The
    runtime floor for this package is nvidia-cutlass-dsl 4.5**, which is
-   deliberately lower than the `==4.7.0` FlashInfer itself pins in
+   deliberately lower than the `==4.8.0.dev0` FlashInfer itself pins in
    `requirements.txt` and the `cu12`/`cu13` extras.  The two answer different
    questions: the pin says which DSL a FlashInfer install brings along, the
    floor says which DSL the shipped kernel must still compile under — and

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -30,8 +30,8 @@ import torch
 
 pytest.importorskip(
     "cutlass",
-    minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl>=4.7.0",
+    minversion="4.8.0.dev0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl>=4.8.0.dev0",
 )
 
 import flashinfer.attention.prims_ts as prims_ts

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -32,7 +32,7 @@ pytest.importorskip(
     reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
 )
 
-from cutlass import BFloat16, Float16, Float8E4M3FN
+from cutlass import BFloat16, Float16, Float32, Float8E4M3FN
 from cutlass.experimental.task_scheduling.enums import TileSchedulerType
 
 import flashinfer.attention.prims_ts.context as context_module
@@ -909,6 +909,57 @@ def test_attention_ts_context_heavy_first_static_raster_policy(
         )
         is expected
     )
+
+
+def test_attention_ts_context_uses_ldtm_stat_default_is_off():
+    """The LDTM.STAT (tcgen05.ld.red.max) row_max path is opt-in.
+
+    Existing callers must not see a behavior change: FmhaConfig defaults the
+    flag to False, and FmhaTs must forward the kwarg to cfg.uses_ldtm_stat so
+    callers can flip the routing without reaching into resource internals.
+    """
+    from flashinfer.attention.prims_ts.kernels.fmha_context.fmha_resources import (
+        FmhaConfig,
+    )
+
+    assert FmhaConfig().uses_ldtm_stat is False
+
+    default_fmha = FmhaTs(
+        qk_acc_dtype=Float32,
+        pv_acc_dtype=Float32,
+        d=128,
+        is_persistent=True,
+    )
+    assert default_fmha.cfg.uses_ldtm_stat is False
+
+    enabled_fmha = FmhaTs(
+        qk_acc_dtype=Float32,
+        pv_acc_dtype=Float32,
+        d=128,
+        is_persistent=True,
+        uses_ldtm_stat=True,
+    )
+    assert enabled_fmha.cfg.uses_ldtm_stat is True
+
+
+def test_attention_ts_context_uses_ldtm_stat_schedule_builds():
+    """The LDTM.STAT flag flows through the non-masked schedule without
+    changing schedule shape (routing is inside compute_row_max, not the
+    task graph)."""
+    kernel = FmhaTs(
+        qk_acc_dtype=Float32,
+        pv_acc_dtype=Float32,
+        d=128,
+        is_persistent=True,
+        is_causal=False,
+        is_clc_dynamic=False,
+        uses_ldtm_stat=True,
+    )
+    assert kernel.cfg.uses_ldtm_stat is True
+    # Building the task manager exercises the full task graph construction,
+    # which is where any schedule-shape divergence would surface. The routing
+    # itself lives inside compute_row_max on TmemSPResource.
+    build_fmha_task_manager(kernel.cfg)
 
 
 @pytest.mark.parametrize(

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -28,8 +28,8 @@ import torch
 
 pytest.importorskip(
     "cutlass",
-    minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    minversion="4.8.0.dev0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.8.0.dev0",
 )
 
 from cutlass import BFloat16, Float16, Float32, Float8E4M3FN

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -27,8 +27,8 @@ import torch
 
 pytest.importorskip(
     "cutlass",
-    minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    minversion="4.8.0.dev0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.8.0.dev0",
 )
 
 import cutlass

--- a/tests/attention/test_attention_ts_mask.py
+++ b/tests/attention/test_attention_ts_mask.py
@@ -18,8 +18,8 @@ import pytest
 
 pytest.importorskip(
     "cutlass",
-    minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    minversion="4.8.0.dev0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.8.0.dev0",
 )
 
 from flashinfer.attention.prims_ts.kernels.mask import (

--- a/tests/attention/test_attention_ts_mla_decode.py
+++ b/tests/attention/test_attention_ts_mla_decode.py
@@ -26,8 +26,8 @@ import torch
 
 pytest.importorskip(
     "cutlass",
-    minversion="4.7.0",
-    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
+    minversion="4.8.0.dev0",
+    reason="PrimTS attention tests require nvidia-cutlass-dsl==4.8.0.dev0",
 )
 
 import cutlass.pipeline as pipeline

--- a/tests/attention/test_prims_ts_decode_backend.py
+++ b/tests/attention/test_prims_ts_decode_backend.py
@@ -25,8 +25,8 @@ import torch
 
 pytest.importorskip(
     "cutlass",
-    minversion="4.7.0",
-    reason="prims-ts decode requires nvidia-cutlass-dsl==4.7.0",
+    minversion="4.8.0.dev0",
+    reason="prims-ts decode requires nvidia-cutlass-dsl==4.8.0.dev0",
 )
 
 import flashinfer  # noqa: E402


### PR DESCRIPTION
## Summary

Two changes to the PrimTS (CuTe-DSL) attention stack, plus the dependency pin they were developed against.

### 1. Opt-in `LDTM.STAT` for PrimTS context `row_max` (`7b5676e2`)

Adds `FmhaConfig.uses_ldtm_stat` (default **False**), exposed as a kwarg on `FmhaTs`, that switches the non-masked `compute_row_max` path to `tcgen05.ld.red.max` (LDTM.STAT). The primitive fuses the per-chunk `row_max` into the TMEM `S` load instead of folding a per-lane max in registers. Masked variants (causal tail, sliding-window, dense-k, …) keep the register-reduce path since they must observe raw `S` values before applying the mask.

Two coupled schedule-level tweaks activate together with the flag to avoid stalling the shared tcgen05 issue pipe:

- The correction O-rescale loop in `TmemOResource` runs software-pipelined (`ld[i]` issued alongside `st[i-1]`) so loads and stores overlap on tcgen05 while LDTM.STAT is in flight.
- The softmax `vec.acquire()` is moved past the LDTM.STAT issue so the mbarrier `try_wait` overlaps the in-flight `tcgen05.ld.red.max` latency. Gated on `(uses_ldtm_stat AND is_causal AND balance_causal_workload)` where the reorder was measured to help; dense LDTM.STAT regresses under it and falls back to the original schedule. Applied to all three softmax variants.

Requires **SM103+/SM110+** (`tcgen05.ld.red` is unavailable on sm_100). Adds two unit tests: one pinning the default-off invariant and the `FmhaTs`→`cfg.uses_ldtm_stat` forwarding, one building the task manager with the flag on to validate end-to-end wiring.

Ported from GitLab MR `perkzz/flashinfer!5` (7 commits), 3-way merged onto current `main`.

### 2. Pin `nvidia-cutlass-dsl` to `4.8.0.dev0` (`39c5ede1`)

Bumps the **exact** version FlashInfer builds and tests against (4.7.0 → 4.8.0.dev0): `ci_image_specifier` in `ci/cuda-versions.json` (which drives the CI image and the exact-version assertion in `docker/test_ci_image.py`), plus the constants, comments, and PrimTS attention test guards (`minversion` + skip reasons) that track that pin.

Install **floors are deliberately left unchanged** — `requirements.txt` (`>=4.6.2a0`) and the pyproject cu12/cu13 extras (`>=4.7.0a0`) stay low so serving stacks that resolve their own DSL (e.g. vLLM downgrading to 4.5.2) still satisfy FlashInfer's declared requirement, as documented in `tests/gdn/test_fused_decode.py`.

`ci/validate_cuda_versions.py` previously accepted only release + `a|b|rc` pre-release segments, so a literal `.dev0` would fail its checks (and thus pre-commit/CI). It is extended to accept an optional `.devN` suffix, with `_version_key` taught PEP 440 ordering: a dev release sorts before `a`/`b`/`rc` pre-releases, and a dev of a pre-release sorts before that pre-release (`X.devN < XaN < XbN < XrcN < X`).

## Test plan

- `python ci/validate_cuda_versions.py` passes ("Validated CUDA configuration").
- New PrimTS context tests: `test_attention_ts_context_uses_ldtm_stat_default_is_off`, `test_attention_ts_context_uses_ldtm_stat_schedule_builds`.
- LDTM.STAT numerics require SM103+/SM110+ hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in optimization for supported GPUs that combines row-maximum reduction with data loading during attention processing.
  * Improved scheduling to overlap operations, potentially increasing performance for selected causal workloads.
* **Compatibility**
  * Added support for development-release version ordering in CUDA environment validation.
  * Updated the supported CuTe-DSL baseline to the latest development release.
* **Tests**
  * Added coverage confirming the new attention optimization is disabled by default and integrates correctly when enabled.
* **Documentation**
  * Updated runtime requirements and version references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->