### PR TITLE
perf(gdn): avoid initializing MTP placeholder tensor

### DIFF
--- a/flashinfer/gdn_decode.py
+++ b/flashinfer/gdn_decode.py
@@ -861,7 +861,7 @@ def gated_delta_rule_mtp(
         )
     else:
         cache_steps = T
-        intermediate_states = torch.zeros(1, 1, 1, dtype=torch.float32, device=q.device)
+        intermediate_states = torch.empty(1, 1, 1, dtype=torch.float32, device=q.device)
 
     # FLA-style per-token pool scatter. When provided, the kernel writes each
     # h_{t+1} directly to initial_state[ssm_state_indices[i, t]] instead of


### PR DESCRIPTION
## 📌 Description

Replace the unused `[1, 1, 1]` MTP intermediate-state placeholder allocation from `torch.zeros` to `torch.empty` when intermediate-state caching is disabled.

The placeholder contents are never observed: `run_mtp_decode` replaces it with the cached, correctly shaped `[1, V, K]` dummy tensor before TVM-FFI validation and kernel launch. This avoids unnecessary zero initialization while preserving the existing public function signature and behavior.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [ ] `pre-commit run --all-files` was not run.
- [x] `ruff check` passed for the modified file.
- [x] `ruff format --check` passed for the modified file.

## 🧪 Tests

- [x] `python3 -m py_compile flashinfer/gdn_decode.py flashinfer/gdn_kernels/gdn_decode_mtp.py`

## Reviewer Notes

This is intentionally limited to the one-line `torch.zeros` to `torch.empty` change; `run_mtp_decode` retains its original public positional signature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary initialization overhead when intermediate state caching is disabled.
* **Bug Fixes**
  * Preserved existing behavior while using a more efficient placeholder for non-caching decode operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->