### PR TITLE
feat(attention): opt-in LDTM.STAT for PrimTS context row_max

### DIFF
--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -35,6 +35,7 @@ register trace templates.
 
 from dataclasses import dataclass
 import functools
+import importlib.metadata
 import itertools
 import math
 import numbers
@@ -62,6 +63,8 @@ _SUPPORTED_DTYPES = (
     torch.float8_e4m3fn,
 )
 _SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3), (10, 7))
+# tcgen05.ld.red.max (LDTM.STAT) is available on B300 (SM103) and Rubin
+# (SM107), not B200 (SM100).
 _INT32_MAX = 2**31 - 1
 _CUDA_GRID_YZ_MAX = 65_535
 _CONTEXT_KV_TILE_N = 128
@@ -215,6 +218,7 @@ def _make_context_kernel(
     has_q_offset: bool,
     causal_single_kv_tile: bool,
     scheduler: _ContextScheduler,
+    uses_ldtm_stat: bool,
     page_size: int | None = None,
     max_num_pages_per_seq_kv: int | None = None,
 ):
@@ -260,6 +264,7 @@ def _make_context_kernel(
         window_size_left=window_left if window_left > 0 else 0,
         h_r=num_qo_heads // num_kv_heads,
         enable_skip_correction=True,
+        uses_ldtm_stat=uses_ldtm_stat,
         causal_single_kv_tile=(causal_single_kv_tile and not use_paged_kv),
         **paged_kwargs,
     )
@@ -348,6 +353,29 @@ def _validate_device(device: torch.device) -> int:
 
         require_cute_dsl_arch(device_index)
     return device_index
+
+
+@functools.cache
+def _dsl_supports_ldtm_stat() -> bool:
+    """True if nvidia-cutlass-dsl >= 4.8.0."""
+    try:
+        dsl_version = importlib.metadata.version("nvidia-cutlass-dsl")
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    from packaging import version as pkg_version
+
+    try:
+        # Use .release so 4.8.0.dev* counts as >= 4.8.0.
+        return pkg_version.Version(dsl_version).release >= (4, 8, 0)
+    except pkg_version.InvalidVersion:
+        return False
+
+
+def _default_uses_ldtm_stat(device_index: int) -> bool:
+    """Enable LDTM.STAT on SM103/SM107 when nvidia-cutlass-dsl >= 4.8.0."""
+    if not _dsl_supports_ldtm_stat():
+        return False
+    return torch.cuda.get_device_capability(device_index) in ((10, 3), (10, 7))
 
 
 def _validate_mask(mask_type: str) -> None:
@@ -1158,6 +1186,7 @@ def _make_context_scheduler_probe(
         has_q_offset=geometry.has_q_offset,
         causal_single_kv_tile=causal_single_kv_tile,
         scheduler="static_persistent",
+        uses_ldtm_stat=_default_uses_ldtm_stat(geometry.device_index),
         page_size=page_size,
         max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
     )
@@ -1336,6 +1365,7 @@ def _get_compiled_context(
         has_q_offset=has_q_offset,
         causal_single_kv_tile=causal_single_kv_tile,
         scheduler=scheduler,
+        uses_ldtm_stat=_default_uses_ldtm_stat(device_index),
     )
     fmha.cfg.has_varlen = packed
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths
@@ -1548,6 +1578,7 @@ def _get_compiled_paged_context(
         has_q_offset=has_q_offset,
         causal_single_kv_tile=False,
         scheduler=scheduler,
+        uses_ldtm_stat=_default_uses_ldtm_stat(device_index),
         page_size=page_size,
         max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
     )

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -63,8 +63,6 @@ _SUPPORTED_DTYPES = (
     torch.float8_e4m3fn,
 )
 _SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3), (10, 7))
-# tcgen05.ld.red.max (LDTM.STAT) is available on B300 (SM103) and Rubin
-# (SM107), not B200 (SM100).
 _INT32_MAX = 2**31 - 1
 _CUDA_GRID_YZ_MAX = 65_535
 _CONTEXT_KV_TILE_N = 128
@@ -375,6 +373,8 @@ def _default_uses_ldtm_stat(device_index: int) -> bool:
     """Enable LDTM.STAT on SM103/SM107 when nvidia-cutlass-dsl >= 4.8.0."""
     if not _dsl_supports_ldtm_stat():
         return False
+    # tcgen05.ld.red.max (LDTM.STAT) is available on B300 (SM103) and Rubin
+    # (SM107), not B200 (SM100).
     return torch.cuda.get_device_capability(device_index) in ((10, 3), (10, 7))
 
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -2366,6 +2366,10 @@ class FmhaTs:
         grouped-query attention with an even repeat count.
     enable_skip_correction : bool, optional
         Enable skip-correction for softmax rescaling (default: True).
+    uses_ldtm_stat : bool, optional
+        Use ``tcgen05.ld.red.max`` (LDTM.STAT) to fuse the per-chunk row_max
+        into the TMEM S load on the non-masked path (default: False). Requires
+        SM103+/SM110+.
     causal_single_kv_tile : bool, optional
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V
@@ -2389,6 +2393,7 @@ class FmhaTs:
         has_variable_window: bool = False,
         h_r: int = 1,
         enable_skip_correction: bool = True,
+        uses_ldtm_stat: bool = False,
         use_paged_kv: bool = False,
         num_tokens_per_page: int = 32,
         max_num_pages_per_seq_kv: int = 1,
@@ -2470,6 +2475,7 @@ class FmhaTs:
             cfg.num_regs_correction = 88
             cfg.num_regs_other = 56
         cfg.enable_skip_correction = enable_skip_correction
+        cfg.uses_ldtm_stat = uses_ldtm_stat
         cfg.qk_acc_dtype = qk_acc_dtype or cutlass.Float32
         cfg.pv_acc_dtype = pv_acc_dtype or cutlass.Float32
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -2368,8 +2368,9 @@ class FmhaTs:
         Enable skip-correction for softmax rescaling (default: True).
     uses_ldtm_stat : bool, optional
         Use ``tcgen05.ld.red.max`` (LDTM.STAT) to fuse the per-chunk row_max
-        into the TMEM S load on the non-masked path (default: False). Requires
-        SM103+/SM110+.
+        into the TMEM S load on the non-masked path (default: False). The
+        context runner enables this by default on SM103 (B300) and SM107
+        (Rubin).
     causal_single_kv_tile : bool, optional
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -91,6 +91,7 @@ from .helpers import (
     variable_window_cta_min_start,
 )
 from cutlass.experimental import primitives as prims
+from cutlass._mlir.dialects import arith as arith_dialect
 
 SmemDescOffsets: TypeAlias = tuple[int, int]
 TmemAddr: TypeAlias = int | Int32
@@ -331,6 +332,11 @@ class FmhaConfig:
 
     seq_tile_n: int = 128
     tmem_x_load_s: int = 32
+    # Opt-in to `tcgen05.ld.red.max` (LDTM.STAT) for the non-masked
+    # `compute_row_max` path: fuses the per-chunk max into the TMEM load.
+    # Requires SM103+/SM110+ with tcgen05.ld.red support; the primitive is
+    # emitted with the 32dp x 32bit x 32rep shape only.
+    uses_ldtm_stat: bool = False
     # Causal S_q < S_kv shifts Q rows right by q_offset = S_kv - S_q.
     # This flag selects the shifted causal mask; there is no second causal mode.
     has_q_offset: bool = False
@@ -2530,6 +2536,53 @@ class TmemSPResource(MemoryResource):
         return old_row_max, row_max_safe
 
     @cute.jit
+    def _load_s_chunks_and_reduce_row_max(
+        self,
+        stage_info: StageInfo,
+        row_max: SoftmaxScalar,
+    ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
+        """LDTM.STAT: fuse S load and per-chunk row_max via tcgen05.ld.red.max.
+
+        Instead of loading each S chunk with ``tcgen05.ld`` and then folding
+        a per-lane max in registers, use ``tcgen05.ld.red.max`` so the
+        reduction happens as part of the TMEM load.  Only valid on the
+        non-masked path (masked variants must observe raw S values before
+        applying the mask).
+        """
+        tmem_s_addr = self.tmem_s_addr_cached + self._stage_col_offset(stage_info)
+        tmem_x = self.cfg.tmem_x_load_s
+        num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
+        old_row_max = row_max
+        s_data: SoftmaxChunks = [None] * num_chunks
+        for chunk_idx in cutlass.range_constexpr(num_chunks):
+            loaded_words, red_word = prims.tcgen05_ld_red(
+                prims.Tcgen05LdStShape.SHAPE_32X32B,
+                prims.make_tmem_ptr(
+                    tmem_s_addr + chunk_idx * tmem_x, self.cfg.qk_acc_dtype
+                ),
+                prims.ReductionKind.MAX,
+                num=tmem_x,
+            )
+            s_data[chunk_idx] = cutlass.Vector.from_elements(
+                tuple(
+                    loaded_words[i].bitcast(self.cfg.qk_acc_dtype)
+                    for i in range(tmem_x)
+                ),
+                dtype=self.cfg.qk_acc_dtype,
+            )
+            chunk_max = self.cfg.qk_acc_dtype(
+                arith_dialect.bitcast(
+                    self.cfg.qk_acc_dtype.mlir_type, red_word.ir_value()
+                )
+            )
+            row_max = cute.math.max(row_max, chunk_max)
+        _tmem_sp_sdata[id(self)] = s_data
+        row_max_safe = row_max
+        if row_max == -Float32.inf:
+            row_max_safe = Float32(0.0)
+        return old_row_max, row_max_safe
+
+    @cute.jit
     def _exp2_p_store(
         self,
         stage_col_offset: TmemAddr,
@@ -2970,6 +3023,8 @@ class TmemSPResource(MemoryResource):
         row_max: SoftmaxScalar,
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
         """Main K-loop stage: load S from TMEM and compute unmasked row_max."""
+        if cutlass.const_expr(self.cfg.uses_ldtm_stat):
+            return self._load_s_chunks_and_reduce_row_max(stage_info, row_max)
         s_data = self._load_s_chunks(stage_info)
         return self._reduce_row_max(s_data, row_max)
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -2576,6 +2576,7 @@ class TmemSPResource(MemoryResource):
                 )
             )
             row_max = cute.math.max(row_max, chunk_max)
+        cute.arch.fence_view_async_tmem_load()
         _tmem_sp_sdata[id(self)] = s_data
         row_max_safe = row_max
         if row_max == -Float32.inf:

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -295,13 +295,11 @@ install_and_verify() {
         # version skew between libs-base and libs-cu13.  requirements.txt
         # cannot add the extra conditionally, hence the separate install.
         #
-        # Keep this a floor, not an exact pin: an exact ==4.7.0 downgrades a
-        # newer CuTe DSL that the test image may ship (the Rubin image ships
-        # 4.8.0a0), which removes cutlass.utils.rubin_helpers and the sm_107a
-        # Arch member and so disables every SM107 path for the whole run.
-        # The a0 suffix is required for pip to consider pre-releases at all.
+        # Test-only floor for LDTM.STAT (tcgen05.ld.red.max, DSL >= 4.8.0).
+        # Do not raise requirements.txt: runtime stays co-installable with 4.6.x.
+        # Use .dev0, not a0: 4.8.0.dev0 (e.g. Rubin images) sorts below 4.8.0a0.
         if [[ "${CUDA_VERSION}" == *"cu13"* || "${CUDA_VERSION}" == 13.* ]]; then
-            _dependency_args+=("nvidia-cutlass-dsl[cu13]>=4.7.0a0")
+            _dependency_args+=("nvidia-cutlass-dsl[cu13]>=4.8.0.dev0")
         fi
         pip install --no-deps "${_dependency_args[@]}"
         unset _dependency_args

--- a/scripts/test_utils.sh
+++ b/scripts/test_utils.sh
@@ -295,11 +295,13 @@ install_and_verify() {
         # version skew between libs-base and libs-cu13.  requirements.txt
         # cannot add the extra conditionally, hence the separate install.
         #
-        # Test-only floor for LDTM.STAT (tcgen05.ld.red.max, DSL >= 4.8.0).
-        # Do not raise requirements.txt: runtime stays co-installable with 4.6.x.
-        # Use .dev0, not a0: 4.8.0.dev0 (e.g. Rubin images) sorts below 4.8.0a0.
+        # Keep this a floor, not an exact pin: an exact ==4.7.0 downgrades a
+        # newer CuTe DSL that the test image may ship (the Rubin image ships
+        # 4.8.0a0), which removes cutlass.utils.rubin_helpers and the sm_107a
+        # Arch member and so disables every SM107 path for the whole run.
+        # The a0 suffix is required for pip to consider pre-releases at all.
         if [[ "${CUDA_VERSION}" == *"cu13"* || "${CUDA_VERSION}" == 13.* ]]; then
-            _dependency_args+=("nvidia-cutlass-dsl[cu13]>=4.8.0.dev0")
+            _dependency_args+=("nvidia-cutlass-dsl[cu13]>=4.7.0a0")
         fi
         pip install --no-deps "${_dependency_args[@]}"
         unset _dependency_args

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -912,7 +912,7 @@ def test_attention_ts_context_heavy_first_static_raster_policy(
 
 
 def test_attention_ts_context_uses_ldtm_stat_default_is_off():
-    """LDTM.STAT row_max is off unless FmhaTs(uses_ldtm_stat=True) is passed."""
+    """FmhaTs stays off unless requested; the runner enables it on SM103/SM107."""
     from flashinfer.attention.prims_ts.kernels.fmha_context.fmha_resources import (
         FmhaConfig,
     )
@@ -935,6 +935,15 @@ def test_attention_ts_context_uses_ldtm_stat_default_is_off():
         uses_ldtm_stat=True,
     )
     assert enabled_fmha.cfg.uses_ldtm_stat is True
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_attention_ts_context_uses_ldtm_stat_default_follows_gpu():
+    """Context attention enables LDTM.STAT on B300 (SM103) and Rubin (SM107)."""
+    expected = torch.cuda.get_device_capability() in ((10, 3), (10, 7))
+    assert (
+        context_module._default_uses_ldtm_stat(torch.cuda.current_device()) is expected
+    )
 
 
 def test_attention_ts_context_uses_ldtm_stat_schedule_builds():

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -58,6 +58,12 @@ _REQUIRES_CONTEXT_GPU = pytest.mark.skipif(
     reason="PrimTS context attention requires SM100 or SM103",
 )
 
+_REQUIRES_LDTM_STAT = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or not context_module._default_uses_ldtm_stat(torch.cuda.current_device()),
+    reason="requires _default_uses_ldtm_stat",
+)
+
 _HEAD_DIM = 128
 _FP8 = torch.float8_e4m3fn
 
@@ -946,6 +952,7 @@ def test_attention_ts_context_uses_ldtm_stat_default_follows_gpu():
     )
 
 
+@_REQUIRES_LDTM_STAT
 def test_attention_ts_context_uses_ldtm_stat_schedule_builds():
     """uses_ldtm_stat=True still builds the non-masked FMHA task graph."""
     kernel = FmhaTs(
@@ -958,7 +965,28 @@ def test_attention_ts_context_uses_ldtm_stat_schedule_builds():
         uses_ldtm_stat=True,
     )
     assert kernel.cfg.uses_ldtm_stat is True
-    build_fmha_task_manager(kernel.cfg)
+    cfg = kernel.cfg
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        task_manager, *_ = build_fmha_task_manager(
+            cfg,
+            tile_sched_params=None,
+            tma_q_desc=None,
+            tma_k_desc=None,
+            tma_v_desc=None,
+            tma_o_desc=None,
+            cum_seqlen_q=None,
+            cum_seqlen_k=None,
+            num_kv_tiles=2,
+            q_offset=0,
+            g_page_idx_kv=None,
+            g_seq_lens_kv=None,
+            max_seq_len_kv=256,
+            is_persistent=True,
+            is_clc_dynamic=False,
+            exhaustive_deadlock_race_check=True,
+        )
+    assert task_manager is not None
 
 
 @pytest.mark.parametrize(

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -32,7 +32,7 @@ pytest.importorskip(
     reason="PrimTS attention tests require nvidia-cutlass-dsl==4.7.0",
 )
 
-from cutlass import BFloat16, Float16, Float8E4M3FN
+from cutlass import BFloat16, Float16, Float32, Float8E4M3FN
 from cutlass.experimental.task_scheduling.enums import TileSchedulerType
 
 import flashinfer.attention.prims_ts.context as context_module
@@ -909,6 +909,47 @@ def test_attention_ts_context_heavy_first_static_raster_policy(
         )
         is expected
     )
+
+
+def test_attention_ts_context_uses_ldtm_stat_default_is_off():
+    """LDTM.STAT row_max is off unless FmhaTs(uses_ldtm_stat=True) is passed."""
+    from flashinfer.attention.prims_ts.kernels.fmha_context.fmha_resources import (
+        FmhaConfig,
+    )
+
+    assert FmhaConfig().uses_ldtm_stat is False
+
+    default_fmha = FmhaTs(
+        qk_acc_dtype=Float32,
+        pv_acc_dtype=Float32,
+        d=128,
+        is_persistent=True,
+    )
+    assert default_fmha.cfg.uses_ldtm_stat is False
+
+    enabled_fmha = FmhaTs(
+        qk_acc_dtype=Float32,
+        pv_acc_dtype=Float32,
+        d=128,
+        is_persistent=True,
+        uses_ldtm_stat=True,
+    )
+    assert enabled_fmha.cfg.uses_ldtm_stat is True
+
+
+def test_attention_ts_context_uses_ldtm_stat_schedule_builds():
+    """uses_ldtm_stat=True still builds the non-masked FMHA task graph."""
+    kernel = FmhaTs(
+        qk_acc_dtype=Float32,
+        pv_acc_dtype=Float32,
+        d=128,
+        is_persistent=True,
+        is_causal=False,
+        is_clc_dynamic=False,
+        uses_ldtm_stat=True,
+    )
+    assert kernel.cfg.uses_ldtm_stat is True
+    build_fmha_task_manager(kernel.cfg)
 
 
 @pytest.mark.parametrize(

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -946,7 +946,10 @@ def test_attention_ts_context_uses_ldtm_stat_default_is_off():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
 def test_attention_ts_context_uses_ldtm_stat_default_follows_gpu():
     """Context attention enables LDTM.STAT on B300 (SM103) and Rubin (SM107)."""
-    expected = torch.cuda.get_device_capability() in ((10, 3), (10, 7))
+    expected = (
+        context_module._dsl_supports_ldtm_stat()
+        and torch.cuda.get_device_capability() in ((10, 3), (10, 7))
+    )
     assert (
         context_module._default_uses_ldtm_stat(torch.cuda.current_device()) is expected
     )


### PR DESCRIPTION
## Summary

Adds the `LDTM.STAT` (`tcgen05.ld.red.max`) row-max primitive to the PrimTS
context FMHA softmax, exposed as the `FmhaConfig.uses_ldtm_stat` flag and
**enabled by default on B300 (SM103) and Rubin (SM107)** via the context runner,
plus the CI DSL version bump needed to build and test it. On B200 (SM100) the
instruction is unavailable, so the default stays off and the shipped kernel is
**byte-identical to `main`** there.

## What's in this PR

**Feature — LDTM.STAT row_max** (`uses_ldtm_stat`)

- `fmha_resources.py`: adds the `FmhaConfig.uses_ldtm_stat` flag (kernel-level
  default `False`) and, in `TmemSPResource`, switches the non-masked
  `compute_row_max` path to `tcgen05.ld.red.max` — fusing the per-chunk row_max
  into the TMEM S load instead of a register-side lane max. Masked variants
  (causal tail, sliding-window, dense-k) keep the register-reduce path; they
  must observe raw S before masking.
- `fmha_kernel.py`: exposes `uses_ldtm_stat` as an `FmhaTs` kwarg.
- `context.py`: the context runner derives the flag per device via
  `_default_uses_ldtm_stat()` — **on by default on B300 (SM103) and Rubin
  (SM107)**, off on B200 (SM100) where `tcgen05.ld.red` is unavailable — and
  threads it through both the ragged and paged build paths.
- `tests/attention/test_attention_ts_context.py`: adds wiring + invariant unit
  tests (kernel default-off, schedule builds, and the per-device default tracks
  `(10, 3)` / `(10, 7)`).

**Dependency — nvidia-cutlass-dsl 4.7.0 → 4.8.0.dev0** (required for the
`tcgen05.ld.red.max` codegen)

- Pins the CI build/test DSL in `ci/cuda-versions.json`; raises the install
  floor in `requirements.txt` and the `cu12`/`cu13` pyproject extras.
- `ci/validate_cuda_versions.py`: accepts and correctly orders a PEP 440
  `.devN` suffix (dev sorts before `a`/`b`/`rc`).
- Updates the DSL version strings referenced in the PrimTS/GDN test skip-guards,
  the `sm100_blk64` DSL helpers, and the GDN experimental README.

## Safety

`uses_ldtm_stat` is a trace-time constant, so the CuTe-DSL tracer emits only the
selected branch. On B200 (SM100) the runner leaves it `False` and the shipped
kernel is **byte-identical to `main`** there. On B300 (SM103) and Rubin (SM107)
the runner turns it on by default — the intended behavior change — and only the
non-masked `compute_row_max` path differs: `TmemOResource` and the net
`fmha_tasks.py` diff are unchanged from `main`, and all masked paths are
untouched.

A couple of scheduling tweaks prototyped alongside the feature measured no
benefit on B300 and were removed within the branch, so they net to zero in the
diff.

## Validation (B300 / SM103)

Benchmarked on an **exclusive** B300 (SM103) node (whole node reserved, no
co-tenant), **batch size 16**, GQA H=64 / Hkv=8, D=128, with `uses_ldtm_stat`
forced OFF vs ON in separate processes (the context runner's per-device default
is pinned so the OFF process never silently runs the ON path). The sweep covers
**both storage layouts** — packed THD and paged HND with a non-identity page
table — × dense/causal × S ∈ {2048, 4096, 8192, 16384}: 16 cases per dtype, 32
total. 100 timed iters/case with cold L2, medians reported. Timing is via CUDA
events (the CI container ships no CUPTI, so `bench_gpu_time` falls back
automatically — identically for OFF and ON). The OFF baseline was reproduced
against a separate, non-exclusive run on the same node and matched to within
run-to-run noise (14 of 16 cases within ±0.6%, worst 1.1%), so the deltas below
are not an artifact of node sharing.

- **Correctness**: validated with the repo's own context-attention checker
  (`tests/attention/test_attention_ts_context.py::_assert_context_correct` — a
  dtype-branched `torch.testing.assert_close` plus a global relative-L2 gate,
  the same bar the unit tests enforce). All 32 cases pass in **both** bf16 and
  fp8 (`float8_e4m3fn` in → bf16 out), for both layouts. LDTM.STAT-on is
  **bit-identical** to LDTM.STAT-off — the per-case relative-L2 matches to every
  reported digit in all 32 cases — because `tcgen05.ld.red.max` returns the same
  row-max as the manual reduction it replaces, so the fusion changes throughput,
  not results. Relative-L2 ≈ 0.021–0.024 for fp8 (gate 0.1; the E4M3
  probability-quantization floor) and ≈ 0.0019–0.0021 for bf16 (gate 0.02).
- **Perf**: LDTM.STAT-on is faster in every case measured. Mean speedup by
  layout and dtype:

  | dtype | packed | paged |
  |-------|-------:|------:|
  | bf16  | +2.72% | +2.20% |
  | fp8   | +5.52% | +4.93% |

  Fusing the per-chunk row_max into the TMEM S-load pays off more in fp8, where
  the matmuls are cheaper and softmax is a larger share of the kernel, and more
  on dense than causal (the fused row-max lives in the non-masked path, so
  causal — which masks part of it — sees less).

**bf16** (H=64 / Hkv=8, D=128, batch=16), median GPU ms:

| case | off_ms | on_ms | speedup |
|------|-------:|------:|--------:|
| packed dense 2048 | 2.8252 | 2.7218 | +3.66% |
| packed dense 4096 | 10.8150 | 10.4725 | +3.17% |
| packed dense 8192 | 43.3981 | 41.7961 | +3.69% |
| packed dense 16384 | 172.3961 | 166.3278 | +3.52% |
| packed causal 2048 | 1.7254 | 1.6948 | +1.77% |
| packed causal 4096 | 6.0836 | 5.9710 | +1.85% |
| packed causal 8192 | 23.1711 | 22.7205 | +1.94% |
| packed causal 16384 | 90.5610 | 88.5955 | +2.17% |
| paged dense 2048 | 2.8683 | 2.7822 | +3.00% |
| paged dense 4096 | 10.9589 | 10.6609 | +2.72% |
| paged dense 8192 | 43.7944 | 42.3752 | +3.24% |
| paged dense 16384 | 174.7451 | 168.7577 | +3.43% |
| paged causal 2048 | 1.8893 | 1.8708 | +0.98% |
| paged causal 4096 | 6.5137 | 6.4256 | +1.35% |
| paged causal 8192 | 24.3318 | 23.9939 | +1.39% |
| paged causal 16384 | 94.0002 | 92.6024 | +1.49% |

**fp8** (`float8_e4m3fn` in → bf16 out, H=64 / Hkv=8, D=128, batch=16), median GPU ms:

| case | off_ms | on_ms | speedup |
|------|-------:|------:|--------:|
| packed dense 2048 | 2.3045 | 2.2006 | +4.51% |
| packed dense 4096 | 8.9436 | 8.4695 | +5.30% |
| packed dense 8192 | 35.7765 | 34.3255 | +4.06% |
| packed dense 16384 | 142.3252 | 133.9633 | +5.88% |
| packed causal 2048 | 1.4551 | 1.3650 | +6.19% |
| packed causal 4096 | 5.1071 | 4.8046 | +5.92% |
| packed causal 8192 | 19.3607 | 18.1105 | +6.46% |
| packed causal 16384 | 75.7499 | 71.3134 | +5.86% |
| paged dense 2048 | 2.3317 | 2.2272 | +4.48% |
| paged dense 4096 | 9.0434 | 8.5688 | +5.25% |
| paged dense 8192 | 36.1381 | 34.4387 | +4.70% |
| paged dense 16384 | 143.1347 | 135.6068 | +5.26% |
| paged causal 2048 | 1.4449 | 1.3752 | +4.82% |
| paged causal 4096 | 5.0580 | 4.8189 | +4.73% |
| paged causal 8192 | 19.2594 | 18.3464 | +4.74% |
| paged causal 16384 | 75.5303 | 71.4147 | +5.45% |

Rubin (SM107) enables the same path because it exposes `tcgen05.ld.red.max` and
compiles through the `sm_100f` family target (handled by `_validate_device`); it
has not yet been perf/correctness-validated on Rubin silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in attention execution mode using fused row-maximum reduction for supported unmasked workloads.
  * Added configuration support for selecting this mode.

* **Compatibility**
  * Updated CuTe-DSL requirements and validation to support the 4.8.0 development release and development-version ordering.

* **Tests**
  * Added coverage for the new attention option and updated version compatibility checks.

* **Documentation**
  * Updated CuTe-DSL version references, requirements, and related guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
