### PR TITLE
chore: update TRTLLM-Gen GEMM cubins

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -142,7 +142,7 @@ class ArtifactPath:
         "8ec29a98612c3670f9f28825d1ed19f09496073b/batched_gemm-fa419f4-31ee4e5/"
     )
     TRTLLM_GEN_GEMM: str = (
-        "2d6a5a029eefcc388ec0ceb87efb55d8bcce5c3c/gemm-fa419f4-25754e6/"
+        "7b1fc253cd6237950e76310873f4acf4d97a3904/gemm-b738138-25754e6/"
     )
     CUDNN_SDPA: str = "a72d85b019dc125b9f711300cb989430f762f5a6/fmha/cudnn/"
     # For DEEPGEMM, we also need to update KernelMap.KERNEL_MAP_HASH in flashinfer/deep_gemm.py
@@ -171,7 +171,7 @@ class CheckSumHash:
     )
     DEEPGEMM: str = "09e961d4e3852a6cf81b3482d0604c09dcb1f69c1b7936f535c9ee2f53335184"
     TRTLLM_GEN_GEMM: str = (
-        "d0783b41d2be41a0f7583668faa1edd6b4f5b48f70e2d58b7a9dfe475f87cc5a"
+        "ca9d4f956f3fb63bff3066db88fa7ccf08b00f4b0b2751cc14ba72454fd01638"
     )
     # SHA256 of the checksums.txt manifest file per cpu-arch/sm-arch,
     # NOT hashes of individual kernel .so files.


### PR DESCRIPTION
## 📌 Description

Update the TRTLLM-Gen dense GEMM artifact pin to the newly published multi-architecture package:

- artifact: `7b1fc253cd6237950e76310873f4acf4d97a3904/gemm-b738138-25754e6/`
- manifest SHA-256: `ca9d4f956f3fb63bff3066db88fa7ccf08b00f4b0b2751cc14ba72454fd01638`
- kernels: 186 cubins (`93 sm100f + 93 sm107a`)

This brings in the TRTLLM-Gen dense GEMM fixes from revision `b738138` while retaining the existing GEMM config hash `25754e6`.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Commit-time pre-commit hooks passed.
- [ ] `pre-commit run --all-files` was not run for this pin-only change.

## 🧪 Tests

- [x] The public artifact and manifest URLs return HTTP 200.
- [x] The downloaded `checksums.txt` SHA-256 matches the new pin and contains 201 entries.
- [ ] Full local test suite was not run.

## Reviewer Notes

The artifact was published from cubin-publishing main pipeline `65421116`, job `418937481`; public publish job `418937489` completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the TensorRT-LLM generated GEMM artifact reference.
  * Updated its verification checksum to ensure the correct artifact is retrieved and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->