### PR TITLE
fix: skip SM107 low-latency GEMM cubins on Blackwell (#4773)

### DIFF
--- a/csrc/trtllm_low_latency_gemm_runner.cu
+++ b/csrc/trtllm_low_latency_gemm_runner.cu
@@ -19,6 +19,7 @@
 #include <tvm/ffi/error.h>
 #include <tvm_ffi_utils.h>
 
+#include <algorithm>
 #include <vector>
 
 #include "flashinfer/exception.h"
@@ -36,6 +37,29 @@ namespace flashinfer {
 
 using tvm::ffi::Array;
 using tvm::ffi::Optional;
+
+namespace {
+
+bool isArchCompatible(int smVersion, gemm::trtllm::gen::CudaArch cubinArch) {
+  using CudaArch = gemm::trtllm::gen::CudaArch;
+  switch (cubinArch) {
+    case CudaArch::Sm100a:
+      return smVersion == 100;
+    case CudaArch::Sm100f:
+      // Low-latency heuristic kernels are named `_sm100f` and also run on sm107.
+      return smVersion == 100 || smVersion == 103 || smVersion == 107;
+    case CudaArch::Sm103a:
+      return smVersion == 103;
+#ifdef TLLM_RUBIN_FEATURES
+    case CudaArch::Sm107a:
+      return smVersion == 107;
+#endif
+    default:
+      return false;
+  }
+}
+
+}  // namespace
 
 struct TrtllmLowLatencyGemmRunnerOptions {
   gemm::trtllm::gen::Dtype eltType;
@@ -137,6 +161,7 @@ class TrtllmLowLatencyGemmRunner {
     auto const configs = gemm.getGemmConfigs();
 
     mPassingConfigIndices.clear();
+    int const sv = getSMVersion();
 
     for (size_t i = 0; i < gemm.getNumGemmConfigs(); ++i) {
       auto const configOptions = configs[i].mOptions;
@@ -146,6 +171,7 @@ class TrtllmLowLatencyGemmRunner {
           configOptions.mTransposeMmaOutput == true &&
           configOptions.mLayoutA == gemm::gemm::MatrixLayout::BlockMajorK &&
           configOptions.mUseShuffledMatrix) {
+        if (!isArchCompatible(sv, configs[i].mSm)) continue;
         mPassingConfigIndices.push_back(i);
       }
     }
@@ -155,11 +181,20 @@ class TrtllmLowLatencyGemmRunner {
         "No valid low latency TRTLLM-GEN GEMM kernel was found for the given data types.");
   }
 
+  void checkPassingConfigIndex(int64_t tactic) const {
+    auto it = std::find(mPassingConfigIndices.begin(), mPassingConfigIndices.end(), tactic);
+    TVM_FFI_ICHECK(it != mPassingConfigIndices.end())
+        << "Tactic " << tactic
+        << " is not in this runner's compatible config set (device architecture or GEMM options "
+           "mismatch)";
+  }
+
   void run(int64_t m, int64_t n, int64_t k, void const* a, void const* b, void* c, void* cScale,
            void* workspace, CUstream stream, int32_t device_index, int64_t tactic) {
     auto gemm = gemm::gemm::GemmInterface();
     auto const configs = gemm.getGemmConfigs();
     TVM_FFI_ICHECK(tactic >= 0 && tactic < gemm.getNumGemmConfigs()) << "Invalid tactic id in run";
+    checkPassingConfigIndex(tactic);
     auto const& config = configs[tactic];
 
     gemm::gemm::GemmData gemmData = createGemmData(m, n, k);


### PR DESCRIPTION
## 📌 Description

Port of #4786 (plus the #4792 `Sm100f`/sm107 allowance) onto `main`. After #4648 the trtllm-gen GEMM pack is a single multi-arch artifact, so `getValidTactics()` on the low-latency runner returned SM107 cubins on Blackwell. Autotune then handed those indices to `cuModuleLoadData`.

`trtllm_low_latency_gemm_runner.cu` was the one trtllm-gen runner still missing the `isArchCompatible` / `checkPassingConfigIndex` filter that #4280 added to `trtllm_gemm_runner.cu` and `trtllm_batched_gemm_runner.cu`.

Do not cherry-pick #4786 verbatim: that filter treated `Sm100f` as sm100/sm103 only, and `select_kernel()` still names `_sm100f` heuristics, which #4792 showed fails every `mm_fp8` case on Rubin. This PR uses the combined `release-v0.6.18` rule (`Sm100f` on 100/103/107).

On B200 (SM100) unpatched `getValidTactics(4, 2560, 8192)` returned 16 indices (`0,2,3,4,5,7,10,11` + `93,95,96,97,101,102,104,109`). Forced tactic `93` failed inside `gemm.run`. After the filter: 8 sm100f tactics; tactic `93` raises `Tactic 93 is not in this runner's compatible config set`.

## 🔍 Related Issues

- Closes #4773
- Cherry-pick / port of #4786 onto `main` (not a verbatim cherry-pick; includes the #4792 `Sm100f` sm107 allowance)

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Local B200 (SM100, CUDA 13.0, torch 2.13.0+cu130), worktree at `upstream/main` + this commit:

- `pytest tests/gemm/test_mm_fp8.py tests/utils/test_logging_replay.py::test_mm_fp8_replay` → 31 passed
- Tactic dump and forced-sm107a FFI path as above

Not verified here: SM103 (B300) or SM107 (Rubin). Those were covered on `release-v0.6.18` by #4786 / #4792.

## Reviewer Notes

Sibling runners on `main` still map `Sm100f` to `100 || 103` only. They were left alone: they already have an arch filter, their heuristics have dedicated `_sm107a` names, and #4792 called that follow-up out of scope for the low-latency crash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved low-latency matrix multiplication compatibility across supported GPU architectures.
  * Prevented execution with unsupported kernel configurations, reducing the risk of invalid tactics and runtime failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->