### PR TITLE
feat(gemm): enable tinygemm2_sm100 on SM107 (Rubin)

### DIFF
--- a/csrc/tinygemm2_sm100.cu
+++ b/csrc/tinygemm2_sm100.cu
@@ -2038,9 +2038,9 @@ inline void CheckSm100Family(int device_id) {
             "cudaDeviceGetAttribute(compute capability major)");
   CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
             "cudaDeviceGetAttribute(compute capability minor)");
-  TVM_FFI_ICHECK(major == 10 && (minor == 0 || minor == 3))
-      << "tinygemm2_sm100 requires an SM100/SM103 (B200/B300 class) device, got sm_" << major
-      << minor;
+  TVM_FFI_ICHECK(major == 10 && (minor == 0 || minor == 3 || minor == 7))
+      << "tinygemm2_sm100 requires an SM100/SM103/SM107 (B200/B300/Rubin class) device, got sm_"
+      << major << minor;
   {
     std::lock_guard<std::mutex> lock(fam_mu);
     fam_ok.push_back(device_id);

--- a/csrc/tinygemm2_sm100.cu
+++ b/csrc/tinygemm2_sm100.cu
@@ -2038,10 +2038,6 @@ inline void CheckSm100Family(int device_id) {
             "cudaDeviceGetAttribute(compute capability major)");
   CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
             "cudaDeviceGetAttribute(compute capability minor)");
-  // SM107 is only accepted when this file was compiled by a toolkit that can emit
-  // compute_107a (CUDA 13.4+). gen_tinygemm2_sm100_module gates the gencode the same
-  // way, so on older toolkits there is no sm_107a image here and admitting the device
-  // would trade this message for an opaque load failure.
 #if defined(__CUDACC_VER_MAJOR__) && \
     (__CUDACC_VER_MAJOR__ > 13 || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ >= 4))
   constexpr bool kSupportsSm107 = true;

--- a/csrc/tinygemm2_sm100.cu
+++ b/csrc/tinygemm2_sm100.cu
@@ -2038,9 +2038,19 @@ inline void CheckSm100Family(int device_id) {
             "cudaDeviceGetAttribute(compute capability major)");
   CheckCuda(cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, device_id),
             "cudaDeviceGetAttribute(compute capability minor)");
-  TVM_FFI_ICHECK(major == 10 && (minor == 0 || minor == 3 || minor == 7))
-      << "tinygemm2_sm100 requires an SM100/SM103/SM107 (B200/B300/Rubin class) device, got sm_"
-      << major << minor;
+  // SM107 is only accepted when this file was compiled by a toolkit that can emit
+  // compute_107a (CUDA 13.4+). gen_tinygemm2_sm100_module gates the gencode the same
+  // way, so on older toolkits there is no sm_107a image here and admitting the device
+  // would trade this message for an opaque load failure.
+#if defined(__CUDACC_VER_MAJOR__) && \
+    (__CUDACC_VER_MAJOR__ > 13 || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ >= 4))
+  constexpr bool kSupportsSm107 = true;
+#else
+  constexpr bool kSupportsSm107 = false;
+#endif
+  TVM_FFI_ICHECK(major == 10 && (minor == 0 || minor == 3 || (minor == 7 && kSupportsSm107)))
+      << "tinygemm2_sm100 requires an SM100/SM103 (B200/B300) device, or an SM107 (Rubin) "
+      << "device with a CUDA 13.4+ toolkit, got sm_" << major << minor;
   {
     std::lock_guard<std::mutex> lock(fam_mu);
     fam_ok.push_back(device_id);

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -492,29 +492,19 @@ def get_tinygemm2_sm100_module():
 
 
 # The generated kernels are validated on SM100 (B200), SM103 (B300/GB300) and
-# SM107 (Rubin) exactly -- the bitwise-parity suite in
-# tests/model_optimizations/test_tinygemm2_sm100.py passes on each. Any other
-# 10.x device passes is_sm100a_supported's major==10 predicate but has not been
-# validated, so it must keep using the reference kernel; hence an explicit
-# allowlist rather than a major-version check.
+# SM107 (Rubin) exactly; other 10.x devices pass is_sm100a_supported's
+# major==10 predicate but must keep using the reference kernel.
 _TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3), (10, 7))
 
 
 def _use_tinygemm2_sm100(device: torch.device) -> bool:
-    """Whether the generated tinygemm2_sm100 variants may serve ``device``."""
     if os.environ.get("FLASHINFER_DISABLE_TINYGEMM2_SM100", "0") == "1":
         return False
     compute_capability = get_compute_capability(device)
     if compute_capability not in _TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES:
         return False
     if compute_capability == (10, 7) and not is_cuda_version_at_least("13.4"):
-        # gen_tinygemm2_sm100_module only emits compute_107a on CUDA >= 13.4, so on
-        # older toolkits the module contains no image for this device and dispatching
-        # here would fail at module load rather than fall back to the reference
-        # kernel. Ask the same question the build asks -- is_cuda_version_at_least
-        # reads the *toolkit* (nvcc) version, whereas torch.version.cuda below
-        # describes the torch build; the two can disagree, and it is the toolkit that
-        # decides whether the sm_107a image exists.
+        # gen_tinygemm2_sm100_module only emits compute_107a on CUDA >= 13.4.
         return False
     return version_at_least(torch.version.cuda, "12.8")
 

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -4,6 +4,7 @@ from ..trace.templates.gemm import (
     mm_M1_16_K7168_N256_trace,
     tinygemm_bf16_trace,
 )
+from flashinfer.jit.cpp_ext import is_cuda_version_at_least
 from flashinfer.jit import (
     gen_dsv3_router_gemm_module,
     gen_tinygemm2_module,
@@ -500,13 +501,22 @@ _TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3), (10, 7))
 
 
 def _use_tinygemm2_sm100(device: torch.device) -> bool:
+    """Whether the generated tinygemm2_sm100 variants may serve ``device``."""
     if os.environ.get("FLASHINFER_DISABLE_TINYGEMM2_SM100", "0") == "1":
         return False
-    return get_compute_capability(
-        device
-    ) in _TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES and version_at_least(
-        torch.version.cuda, "12.8"
-    )
+    compute_capability = get_compute_capability(device)
+    if compute_capability not in _TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES:
+        return False
+    if compute_capability == (10, 7) and not is_cuda_version_at_least("13.4"):
+        # gen_tinygemm2_sm100_module only emits compute_107a on CUDA >= 13.4, so on
+        # older toolkits the module contains no image for this device and dispatching
+        # here would fail at module load rather than fall back to the reference
+        # kernel. Ask the same question the build asks -- is_cuda_version_at_least
+        # reads the *toolkit* (nvcc) version, whereas torch.version.cuda below
+        # describes the torch build; the two can disagree, and it is the toolkit that
+        # decides whether the sm_107a image exists.
+        return False
+    return version_at_least(torch.version.cuda, "12.8")
 
 
 @backend_requirement({}, common_check=_tinygemm_bf16_shape_checks)

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -504,7 +504,6 @@ def _use_tinygemm2_sm100(device: torch.device) -> bool:
     if compute_capability not in _TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES:
         return False
     if compute_capability == (10, 7) and not is_cuda_version_at_least("13.4"):
-        # gen_tinygemm2_sm100_module only emits compute_107a on CUDA >= 13.4.
         return False
     return version_at_least(torch.version.cuda, "12.8")
 

--- a/flashinfer/gemm/routergemm.py
+++ b/flashinfer/gemm/routergemm.py
@@ -490,10 +490,13 @@ def get_tinygemm2_sm100_module():
     return SimpleNamespace(tinygemm2_sm100_op=tinygemm2_sm100_op_impl)
 
 
-# The generated kernels are validated on SM100 (B200) and SM103 (B300/GB300)
-# exactly; other 10.x devices (e.g. SM107) pass is_sm100a_supported's
-# major==10 predicate but must keep using the reference kernel.
-_TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3))
+# The generated kernels are validated on SM100 (B200), SM103 (B300/GB300) and
+# SM107 (Rubin) exactly -- the bitwise-parity suite in
+# tests/model_optimizations/test_tinygemm2_sm100.py passes on each. Any other
+# 10.x device passes is_sm100a_supported's major==10 predicate but has not been
+# validated, so it must keep using the reference kernel; hence an explicit
+# allowlist rather than a major-version check.
+_TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3), (10, 7))
 
 
 def _use_tinygemm2_sm100(device: torch.device) -> bool:

--- a/flashinfer/jit/tinygemm2.py
+++ b/flashinfer/jit/tinygemm2.py
@@ -16,10 +16,7 @@ def gen_tinygemm2_module() -> JitSpec:
 
 
 def gen_tinygemm2_sm100_module() -> JitSpec:
-    """Generate the JIT spec for the generated tinygemm2 variants.
-
-    Targets SM100/SM103, and additionally SM107 (Rubin) when the toolkit is CUDA
-    13.4 or newer -- earlier toolkits reject ``compute_107a``.
+    """Generate the JIT spec for the SM100/SM103 generated tinygemm2 variants.
 
     ``csrc/tinygemm2_sm100.cu`` is a single translation unit
     holding all four frozen generated variants (deep/shallow pipeline ring x

--- a/flashinfer/jit/tinygemm2.py
+++ b/flashinfer/jit/tinygemm2.py
@@ -16,7 +16,10 @@ def gen_tinygemm2_module() -> JitSpec:
 
 
 def gen_tinygemm2_sm100_module() -> JitSpec:
-    """Generate the JIT spec for the SM100/SM103 generated tinygemm2 variants.
+    """Generate the JIT spec for the generated tinygemm2 variants.
+
+    Targets SM100/SM103, and additionally SM107 (Rubin) when the toolkit is CUDA
+    13.4 or newer -- earlier toolkits reject ``compute_107a``.
 
     ``csrc/tinygemm2_sm100.cu`` is a single translation unit
     holding all four frozen generated variants (deep/shallow pipeline ring x

--- a/flashinfer/jit/tinygemm2.py
+++ b/flashinfer/jit/tinygemm2.py
@@ -1,4 +1,5 @@
 from .core import JitSpec, gen_jit_spec, current_compilation_context, sm100a_nvcc_flags
+from .cpp_ext import is_cuda_version_at_least
 from . import env as jit_env
 
 
@@ -28,6 +29,12 @@ def gen_tinygemm2_sm100_module() -> JitSpec:
         "tinygemm2_sm100",
         [jit_env.FLASHINFER_CSRC_DIR / "tinygemm2_sm100.cu"],
         extra_cuda_cflags=sm100a_nvcc_flags
-        + ["-gencode=arch=compute_103a,code=sm_103a"],
+        + ["-gencode=arch=compute_103a,code=sm_103a"]
+        # SM107 (Rubin) needs CUDA 13.4; older toolkits reject compute_107a.
+        + (
+            ["-gencode=arch=compute_107a,code=sm_107a"]
+            if is_cuda_version_at_least("13.4")
+            else []
+        ),
         extra_include_paths=[jit_env.FLASHINFER_CSRC_DIR],
     )

--- a/flashinfer/jit/tinygemm2.py
+++ b/flashinfer/jit/tinygemm2.py
@@ -30,7 +30,6 @@ def gen_tinygemm2_sm100_module() -> JitSpec:
         [jit_env.FLASHINFER_CSRC_DIR / "tinygemm2_sm100.cu"],
         extra_cuda_cflags=sm100a_nvcc_flags
         + ["-gencode=arch=compute_103a,code=sm_103a"]
-        # SM107 (Rubin) needs CUDA 13.4; older toolkits reject compute_107a.
         + (
             ["-gencode=arch=compute_107a,code=sm_107a"]
             if is_cuda_version_at_least("13.4")


### PR DESCRIPTION
## 📌 Description

The generated SM100 `tinygemm2` variants run correctly on SM107, but three separate gates kept them off that architecture:

1. `CheckSm100Family` (`csrc/tinygemm2_sm100.cu`) hard-rejected any minor other than 0 or 3, so the kernel aborted at dispatch on `sm_107`.
2. `gen_tinygemm2_sm100_module` emitted only `compute_100a`/`compute_103a` gencode, so no `sm_107a` cubin was produced even once the check passed.
3. `_TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES` excluded `(10, 7)`, so the router GEMM kept falling back to the reference kernel regardless.

All three are needed. Fixing only the first two leaves the kernel unreachable in production — the dispatch gate silently sends every call to the reference path.

The existing comment reserved SM107 for the reference kernel *until the generated variants were validated there*, so that is what this change rests on (see Tests).

The allowlist stays explicit rather than becoming a `major == 10` check: other 10.x devices remain unvalidated. The gencode is gated on CUDA >= 13.4 because earlier toolkits reject `compute_107a`; on those toolkits the module builds exactly as before.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/model_optimizations/test_tinygemm2_sm100.py` on an SM107 device:

| | Result |
|---|---|
| Before this change | **29 failed** |
| With this change | **29 passed** |

That includes all 20 `test_tinygemm2_sm100_bitwise_parity` cases, which assert `torch.equal` against the reference kernel rather than a tolerance — the bit-identical contract the generated variants are held to on SM100/SM103.

No new test file is added: the existing suite already targets SM107 (its skip helper uses `is_sm100a_supported`, a `major == 10` predicate), so it was running and failing there rather than skipping.

Behaviour on SM100/SM103 is unchanged, and on toolkits older than CUDA 13.4 the built module is byte-for-byte what it was.

## Reviewer Notes

Point 3 is the easy one to miss — `_TINYGEMM2_SM100_SUPPORTED_COMPUTE_CAPABILITIES` lives in `flashinfer/gemm/routergemm.py`, some distance from the other two, and without it the first two changes are dead code. `test_tinygemm2_sm100_dispatch_and_escape_hatch` is the test that catches it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TinyGEMM support for SM107 (Rubin-class) GPUs when using CUDA 13.4 or newer.
  * Enabled SM107 kernel generation with CUDA 13.4 or newer.

* **Compatibility**
  * Existing SM100 and SM103 support remains unchanged.
  * On older CUDA toolkits, SM107 operations automatically fall back to the reference kernel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
