### PR TITLE
feat(moe): enable tile_size=256 for Rubin MoE autotuning

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -188,20 +188,16 @@ def get_rubin_gemm1_valid_tactics(tile_size: int) -> List[Tuple]:
 
     # (mma_tiler_m, mma_inst_m) candidates — B-reuse when tiler_m = 2 * inst_m
     #
-    # NOTE: while tile_size is restricted to 128 (see get_rubin_moe_valid_tactics),
-    # the mma_tiler_m == tile_size and cluster_shape_m * mma_tiler_m <= tile_size
-    # constraints below force mma_tiler_m = 128 and cluster_shape_m = 1.  Every
-    # 2CTA and B-reuse entry here is therefore currently unreachable, and only
-    # the two 1CTA (128, 128) tactics are actually tuned.  The entries are kept
-    # because they become reachable again once tile_size=256 is re-enabled.
+    # The mma_tiler_m == tile_size and cluster_shape_m * mma_tiler_m <= tile_size
+    # constraints below decide which of these are reachable at a given tile_size;
+    # entries unreachable at one tile_size are reachable at another.
     mma_m_candidates = [
         (128, 128),  # no B-reuse, 1CTA
-        (256, 256),  # no B-reuse, 2CTA   (unreachable at tile_size=128)
-        (256, 128),  # B-reuse, 1CTA      (unreachable at tile_size=128)
-        (512, 256),  # B-reuse, 2CTA      (unreachable at tile_size=128)
+        (256, 256),  # no B-reuse, 2CTA
+        (256, 128),  # B-reuse, 1CTA
+        (512, 256),  # B-reuse, 2CTA
     ]
     mma_n_candidates = [128, 256]
-    # (2, 1) is unreachable at tile_size=128 for the same reason.
     cluster_shape_mn_candidates = [(1, 1), (2, 1)]
     raster_along_m_candidates = [False]
 
@@ -245,13 +241,13 @@ def get_rubin_gemm2_valid_tactics(tile_size: int) -> List[Tuple]:
     mma_inst_k = 128
 
     # As in get_rubin_gemm1_valid_tactics, the mma_tiler_m == tile_size and
-    # cluster_shape_m * mma_tiler_m <= tile_size constraints below make every
-    # 2CTA and B-reuse entry unreachable while tile_size is restricted to 128.
+    # cluster_shape_m * mma_tiler_m <= tile_size constraints below decide which
+    # of these are reachable at a given tile_size.
     mma_m_candidates = [
         (128, 128),
-        (256, 256),  # unreachable at tile_size=128
-        (256, 128),  # unreachable at tile_size=128
-        (512, 256),  # unreachable at tile_size=128
+        (256, 256),
+        (256, 128),
+        (512, 256),
     ]
     mma_n_candidates = [128, 256]
     # cluster_shape_n is pinned to 1: the Rubin finalize kernel triggers
@@ -297,11 +293,11 @@ def get_rubin_moe_valid_tactics() -> List[Tuple]:
     Returns: List of (tile_size, gemm1_tactic, gemm2_tactic)
     """
     tactics = []
-    # Only tile_size=128 is enabled. tile_size=256 with B-reuse causes
-    # illegal memory accesses for certain GEMM2 tactic configurations and
-    # is disabled until the kernel bug is fixed (mirrors the Blackwell
-    # restriction in get_blackwell_moe_valid_tactics).
-    for tile_size in [128]:
+    # tile_size=256 is enabled, mirroring get_blackwell_moe_valid_tactics: the
+    # gemm1(2CTA)/gemm2(1CTA) layout mismatch that motivated the restriction
+    # (#3067) was fixed by parameterizing the gemm2 candidates on tile_size
+    # (#3171), which get_rubin_gemm2_valid_tactics already does.
+    for tile_size in VALID_TILE_SIZES:
         gemm1_tactics = get_rubin_gemm1_valid_tactics(tile_size)
         gemm2_tactics = get_rubin_gemm2_valid_tactics(tile_size)
         for gemm1_tactic, gemm2_tactic in itertools.product(


### PR DESCRIPTION
## 📌 Description

`get_rubin_moe_valid_tactics` restricted the autotuner to `tile_size=128`, citing illegal memory accesses at `tile_size=256` with B-reuse and pointing at the equivalent restriction in `get_blackwell_moe_valid_tactics`.

**That Blackwell restriction no longer exists.** It was the gemm1(2CTA)/gemm2(1CTA) layout mismatch of #3067, fixed in #3171 by parameterizing the gemm2 candidate list on `tile_size`. `get_rubin_gemm2_valid_tactics` is already parameterized the same way, so the Rubin path carries that fix too — the restriction was mirroring a constraint that had since been lifted.

This iterates over `VALID_TILE_SIZES`, matching the Blackwell path.

The candidate lists are **unchanged**. The existing `mma_tiler_m == tile_size` and `cluster_shape_m * mma_tiler_m <= tile_size` constraints already decide what is reachable at each tile size, and the 2CTA / B-reuse entries were deliberately left in place for this — the note on them read *"kept because they become reachable again once tile_size=256 is re-enabled."* Those notes, which described the entries as unreachable, are corrected.

Net effect is a deletion: 16 insertions, 20 deletions, no new data tables or special cases.

## 🔍 Related Issues

Follows #3067 / #3171, which fixed and then re-enabled the same restriction on the Blackwell path.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Verified on an SM107 device by autotuning `cute_dsl_fused_moe_nvfp4`, with the autotuner's per-tactic profiling traced at debug level:

- The tactic list grows from **4 to 8** entries, split `{128: 4, 256: 4}`.
- All 8 candidates profile on device and **none are skipped**, so every newly reachable tactic compiles, launches and completes.
- A sweep of **10 shapes** — 1 to 4096 tokens, 8 to 128 experts, `top_k` 2 to 8, hidden/intermediate 1024 and 2048 — completes with **no illegal memory access** (the process exits cleanly; an IMA is not catchable and would abort it).
- Output matches the non-autotuned reference in every case, cosine similarity **>= 0.999993**.

The routing-varying dimensions were chosen deliberately, since the restriction described the IMAs as routing-dependent.

No new test file: `get_rubin_moe_valid_tactics` is only reachable on `cc == (10, 7)` via `_get_arch_tactics()`, so a tile-256 assertion would skip everywhere in CI today. The existing `TestTacticEnumeration` invariants continue to pass.

## Reviewer Notes

**This is not a performance claim.** It removes a restriction that no longer applies and lets the autotuner consider tactics it could not previously reach; it asserts nothing about their speed. The autotuner continues to select whichever candidate it measures as best.

An earlier revision of this PR added four tile-256 tactics as a hand-written allowlist. That approach is dropped: those entries had `cluster_shape_m * mma_tiler_m = 512 > tile_size = 256` and so were **rejected by the generator's own validity rule** — they sat outside the constraints the module asserts. Removing the stale gate reaches the intended configurations through the existing rules instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for W4A8 quantization alongside W4A4 in the fused MoE tuner.
  * Added expanded Blackwell and Rubin tactic selection, including 256-sized tile options.
  * Added validation and default tactic handling for W4A8 configurations.

* **Compatibility**
  * Preserved access to the previous runner name with a deprecation warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->