### PR TITLE
fix(gemm,moe): restore bmm_fp8 auto fallback and drop an over-strict SM107 tactic guard

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -647,10 +647,6 @@ def _blockscaled_contiguous_gather_grouped_gemm_act_fusion(
             f"mma_tiler/mma_inst_shape select the Rubin (SM107) kernel, but "
             f"the device is SM{major}{minor}."
         )
-    if not is_rubin and minor == 7:
-        raise ValueError(
-            "SM107 requires the Rubin tactic parameters mma_tiler and mma_inst_shape."
-        )
 
     # Validate configuration
     a_dtype_cutlass = get_cutlass_dtype(a_dtype)

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -509,10 +509,6 @@ def _blockscaled_contiguous_grouped_gemm_finalize_fusion(
             f"mma_tiler/mma_inst_shape select the Rubin (SM107) finalize "
             f"kernel, but the device is SM{major}{minor}."
         )
-    if not is_rubin and minor == 7:
-        raise ValueError(
-            "SM107 requires the Rubin tactic parameters mma_tiler and mma_inst_shape."
-        )
 
     # Validate configuration
     a_dtype_cutlass = get_cutlass_dtype(a_dtype)

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1956,8 +1956,6 @@ def fp8_gemm_sm100(
     tuner = AutoTuner.get()
 
     runners = []
-    if "cute-dsl_sm107" in runner_names:
-        runners.append(_cute_dsl_fp8_gemm_runner_sm107())
     if "cutlass_sm10x" in runner_names:
         runners.append(get_gemm_sm100_module_cutlass_fp8().cutlass_fp8_gemm_runner())
     if "cutlass_sm12x" in runner_names:
@@ -1966,6 +1964,8 @@ def fp8_gemm_sm100(
         runners.append(get_gemm_module().cublas_fp8_gemm_runner())
     if "cudnn" in runner_names:
         runners.append(_cudnn_gemm_fp8_runner())
+    if "cute-dsl_sm107" in runner_names:
+        runners.append(_cute_dsl_fp8_gemm_runner_sm107())
     assert runners, "No suitable runners found"
 
     inputs = [a, b, scale_a, scale_b, out, workspace_buffer]


### PR DESCRIPTION
## 📌 Description

Port of #4645 to `main`. That PR was merged into `release-v0.6.18` only, so both
defects are still present on `main` today — verified against `main` before
opening: all eight lines this PR removes are still there.

Two Rubin (SM107) fixes, both originally measured on VR200.

### 1. Keep the experimental cute-dsl `bmm_fp8` runner last

`_heuristic_func_bmm_fp8` documents the intended ordering — *"preserve order of
[cutlass, cublas, cudnn, cute-dsl] … cute-dsl is placed last as it's still
experimental"* (still present on `main` at `gemm_base.py:7478-7479`) — but
`fp8_gemm_sm100` built the runner list in the opposite order, appending
`cute-dsl_sm107` **first**.

The AutoTuner uses `runners[0]` as its no-profile fallback, so on SM107 every
**untuned** `backend="auto"` call went straight to the experimental CuTe DSL
runner. For any shape the SM107 tactic space cannot serve (`m < 256` or
`n < 128`, since every `SM107_AUTOTUNE_CONFIGS` entry is 2-CTA with
`mma_tiler M=256`) `bmm_fp8` then raised

```
ValueError: No valid cute-dsl SM107 bmm_fp8 config for problem (...)
```

instead of falling back to cutlass/cublas/cudnn. Autotuned calls were
unaffected, since profiling walks the whole runner list.

### 2. Drop the "SM107 requires the Rubin tactic parameters" guard

Both MoE entry points rejected calls that supplied Blackwell-style tactic
parameters (`mma_tiler_mn`) on an SM107 device. That guard assumed SM100 tactics
cannot run on Rubin — an assumption drawn from such calls failing with
`cudaErrorInvalidValue`. That failure has since been traced to the CuTe DSL 4.8
cu12/cu13 runtime-selection bug, not to the tactics, so the premise no longer
holds; the design comment in the finalize dispatcher says the SM100 kernel runs
on Rubin via the `sm_100f` family target.

The converse check (Rubin tactics on a non-Rubin device) is kept.

## 🧪 Tests

Validation below was performed on the `release-v0.6.18` version of this change;
the diff ported here is identical.

**Fix 1 — A/B on VR200, same test path, one commit apart:**

| | passed | failed |
|---|---|---|
| `release-v0.6.18` | 1,750 | **9** |
| with this change | **1,759** | **0** |

The 9 were all `backend="auto"` cases in `tests/gemm/test_unified_gemm_fuzz.py`
(`n=16`/`n=32` shapes plus `test_convention_conformance` at `m=128, n=256`).

**Fix 2 — on GR100** with the cu13 runtime pinned and the guard absent,
`tests/moe/test_cute_dsl_mxfp8_mxfp4_grouped_gemm.py::TestMxfp8Mxfp4TwoStageMoe::test_gemm2_finalize_tile_n_variants`
passes **5/5**. With the guard, it contributes to 13 VR200 failures across
`test_gemm2_finalize_tile_n_variants`, `test_gemm1_quantize_then_gemm2_finalize`,
`test_wrapper_with_poisoned_moe_sort_buffers` and
`test_functional_and_wrapper_agree`.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🔍 Related

* Original release-branch PR: #4645
* The `cudaErrorInvalidValue` failures referenced above are the CuTe DSL 4.8
  cu12/cu13 support-runtime selection bug (`[cu13]` installs cu12 as well, and
  auto-discovery returns the cu12 DSO on `sm_107a`), worked around in CI by
  pinning `CUTE_DSL_LIBS` to the cu13 runtime.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 grouped GEMM compatibility on SM107 devices when Rubin-specific parameters are unavailable.
  * Updated execution selection to prioritize established CUTLASS, cuBLAS, and cuDNN paths before the SM107 specialized runner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->