### PR TITLE
fix(moe): use conservative per-token NVFP4 configs for the untuned trtllm-gen MoE fallback

### DIFF
--- a/csrc/trtllm_batched_gemm_runner.cu
+++ b/csrc/trtllm_batched_gemm_runner.cu
@@ -549,6 +549,29 @@ int64_t TrtllmGenBatchedGemmRunner::getDefaultValidConfigIndex(
   auto const validConfigIndices =
       getValidConfigIndices(m, n, k, batchedTokens, numTokens, numBatches, maxNumCtasInBatchDim);
 
+  if (mOptions.usePerTokenScaling) {
+    // The sort order produced by getValidConfigIndices is a pure performance
+    // heuristic; its first entry can be an exported per-token NVFP4 cubin that
+    // returns non-finite outputs in the large-batch routed-MoE regime on
+    // SM100f/SM103 (#4588, same kernel family as #4486). The untuned fallback
+    // must be conservative rather than fast: for the routed FC1 prefer kernels
+    // that gather activations with TMA over the LDGSTS scale-factor-gather
+    // variants, and for the unrouted FC2 prefer single-CTA-cluster kernels over
+    // multi-CTA-cluster ones. Both preferred variants sort immediately behind
+    // the heuristic default, so this only ever swaps in an equally-ranked
+    // sibling config. The autotuner tactic space is unchanged.
+    auto const configs = BatchedGemmInterface().getBatchedGemmConfigs();
+    for (auto const configIndex : validConfigIndices) {
+      auto const& options = configs[configIndex].mOptions;
+      if (mOptions.routeAct) {
+        if (!doesRouteImplUseTma(options.mRouteImpl)) continue;
+      } else if (options.mClusterDimX * options.mClusterDimY * options.mClusterDimZ > 1) {
+        continue;
+      }
+      return configIndex;
+    }
+  }
+
   return validConfigIndices[0];
 }
 

--- a/tests/moe/test_trtllm_gen_per_token_moe.py
+++ b/tests/moe/test_trtllm_gen_per_token_moe.py
@@ -327,3 +327,17 @@ def test_routed_fused_moe(
     torch.cuda.synchronize()
 
     check_accuracy(reference, result, atol=0.1, rtol=0.85, percent=0.9)
+
+
+def test_routed_fused_moe_fallback_large_batch():
+    """The untuned fallback tactic must stay finite and accurate with
+    per-token NVFP4 at large num_tokens (#4588)."""
+    test_routed_fused_moe(
+        num_tokens=8064,
+        hidden_size=6144,
+        intermediate_size=768,
+        num_experts=256,
+        top_k=6,
+        use_4over6=False,
+        weights_use_4over6=False,
+    )


### PR DESCRIPTION
Fixes #4588. With `per_token_scale` and no autotune cache entry, the fallback tactic sort (`getDefaultValidConfigIndex`) lands on exported per-token NVFP4 cubins (LDGSTS SF-gather FC1, 2-CTA-cluster FC2) that return non-finite outputs in the ≥6k-token routed regime on SM100f/SM103 (same kernel family as #4486). For the untuned fallback only, prefer the equally-ranked conservative siblings (TMA-routed FC1, single-CTA FC2); the autotuner tactic space is unchanged. Adds a fallback-path regression test at the issue shape.
