### PR TITLE
feat(attention): add skip-softmax to SM120 PRIMS

### DIFF
--- a/flashinfer/attention/cute_dsl/sm120_fmha.py
+++ b/flashinfer/attention/cute_dsl/sm120_fmha.py
@@ -41,7 +41,7 @@ import math
 import os
 from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 from cutlass.cute.typing import Float32, Int32
@@ -167,6 +167,47 @@ def _validate_lse(q: torch.Tensor, lse: Optional[torch.Tensor]) -> None:
         raise ValueError("lse must be contiguous")
 
 
+def _prepare_skip_softmax_threshold(
+    skip_softmax_threshold: Optional[Union[float, torch.Tensor]],
+    q: torch.Tensor,
+    batch_size: int,
+) -> Optional[torch.Tensor]:
+    """Validate or expand the per-request e-based skip threshold."""
+    if skip_softmax_threshold is None:
+        return None
+    if isinstance(skip_softmax_threshold, torch.Tensor):
+        if skip_softmax_threshold.dtype != torch.float32:
+            raise ValueError(
+                "skip_softmax_threshold must have dtype torch.float32, got "
+                f"{skip_softmax_threshold.dtype}"
+            )
+        if not skip_softmax_threshold.is_cuda:
+            raise ValueError("skip_softmax_threshold must be a CUDA tensor")
+        if skip_softmax_threshold.device != q.device:
+            raise ValueError("skip_softmax_threshold and q must be on the same device")
+        expected_shape = (batch_size,)
+        if tuple(skip_softmax_threshold.shape) != expected_shape:
+            raise ValueError(
+                f"skip_softmax_threshold must have shape {expected_shape}, got "
+                f"{tuple(skip_softmax_threshold.shape)}"
+            )
+        if not skip_softmax_threshold.is_contiguous():
+            raise ValueError("skip_softmax_threshold must be contiguous")
+        return skip_softmax_threshold
+
+    try:
+        value = float(skip_softmax_threshold)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            "skip_softmax_threshold must be None, a Python float, or a torch.Tensor"
+        ) from exc
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(
+            f"skip_softmax_threshold must be finite and >= 0; got {value!r}"
+        )
+    return torch.full((batch_size,), value, dtype=torch.float32, device=q.device)
+
+
 def _validate_hnd_paged_pool(name: str, pool: torch.Tensor) -> None:
     """Validate the HND inner layout while allowing combined-cache views."""
     if pool.ndim != 4:
@@ -203,6 +244,7 @@ def sm120_fmha_fp8_ragged_prefill(
     lse: Optional[torch.Tensor] = None,
     v_scale: Optional[float] = None,
     enable_pdl: bool = False,
+    skip_softmax_threshold: Optional[Union[float, torch.Tensor]] = None,
 ) -> None:
     """Run SM120 FP8 FMHA on packed contiguous ragged Q/K/V.
 
@@ -237,6 +279,19 @@ def sm120_fmha_fp8_ragged_prefill(
         Scalar multiplier folded into the normalized output. Defaults to 1.
     enable_pdl : bool
         Whether to enable Programmatic Dependent Launch.
+    skip_softmax_threshold : float or torch.Tensor, optional
+        Skip a K/V tile when all rows owned by a compute warp satisfy
+        ``exp((tile_max - running_max) * sm_scale) < threshold``. A Python
+        float applies one static threshold to the whole batch. During CUDA
+        Graph capture its value is fixed in the captured graph. A tensor is
+        the dynamic form: it must be a contiguous CUDA float32 tensor on the
+        same device as ``q`` with shape ``(batch_size,)``. The caller owns its
+        allocation and lifetime, must keep its address stable, and may update
+        values in place between graph replays. Tensor values are required to
+        be finite and non-negative; this content contract is not checked to
+        avoid a device-to-host synchronization. ``None`` selects the dense
+        specialization; every supplied value, including zero, selects the
+        skip-enabled specialization.
     Raises
     ------
     RuntimeError
@@ -254,6 +309,9 @@ def sm120_fmha_fp8_ragged_prefill(
 
     _check_sm120(q.device)
     _validate_lse(q, lse)
+
+    batch_size = cu_seqlens_q.numel() - 1
+    threshold = _prepare_skip_softmax_threshold(skip_softmax_threshold, q, batch_size)
 
     _, Hq, D = q.shape
     _, Hkv, D_k = k.shape
@@ -302,6 +360,7 @@ def sm120_fmha_fp8_ragged_prefill(
         device=q.device,
         with_lse=lse is not None,
         balanced_scheduler=_use_balanced_scheduler(is_causal),
+        enable_skip_softmax=threshold is not None,
     )
 
     if sm_scale is None:
@@ -317,6 +376,7 @@ def sm120_fmha_fp8_ragged_prefill(
         lse,
         scale_log2,
         output_scale,
+        threshold,
         None,
         cu_seqlens_q_i32,
         None,
@@ -347,6 +407,7 @@ def sm120_fmha_fp8_paged_prefill(
     lse: Optional[torch.Tensor] = None,
     v_scale: Optional[float] = None,
     enable_pdl: bool = False,
+    skip_softmax_threshold: Optional[Union[float, torch.Tensor]] = None,
 ) -> None:
     """Run SM120 FP8 FMHA prefill with paged K/V cache.
 
@@ -396,6 +457,19 @@ def sm120_fmha_fp8_paged_prefill(
         Scalar multiplier folded into the normalized output. Defaults to 1.
     enable_pdl : bool
         Whether to enable Programmatic Dependent Launch.
+    skip_softmax_threshold : float or torch.Tensor, optional
+        Skip a K/V tile when all rows owned by a compute warp satisfy
+        ``exp((tile_max - running_max) * sm_scale) < threshold``. A Python
+        float applies one static threshold to the whole batch. During CUDA
+        Graph capture its value is fixed in the captured graph. A tensor is
+        the dynamic form: it must be a contiguous CUDA float32 tensor on the
+        same device as ``q`` with shape ``(batch_size,)``. The caller owns its
+        allocation and lifetime, must keep its address stable, and may update
+        values in place between graph replays. Tensor values are required to
+        be finite and non-negative; this content contract is not checked to
+        avoid a device-to-host synchronization. ``None`` selects the dense
+        specialization; every supplied value, including zero, selects the
+        skip-enabled specialization.
     Raises
     ------
     RuntimeError
@@ -434,6 +508,7 @@ def sm120_fmha_fp8_paged_prefill(
         f"block_tables must be (B, max_pages), got {block_tables.shape}"
     )
     B = block_tables.shape[0]
+    threshold = _prepare_skip_softmax_threshold(skip_softmax_threshold, q, B)
 
     in_ct = _cutlass_dtype(q.dtype)
     out_ct = _cutlass_dtype(o.dtype)
@@ -475,6 +550,7 @@ def sm120_fmha_fp8_paged_prefill(
         device=q.device,
         with_lse=lse is not None,
         balanced_scheduler=_use_balanced_scheduler(is_causal),
+        enable_skip_softmax=threshold is not None,
     )
 
     if sm_scale is None:
@@ -495,6 +571,7 @@ def sm120_fmha_fp8_paged_prefill(
         lse,
         scale_log2,
         output_scale,
+        threshold,
         seqlens_kv_i32,
         cu_seqlens_q_i32,
         block_tables,

--- a/flashinfer/attention/cute_dsl/sm120_fmha.py
+++ b/flashinfer/attention/cute_dsl/sm120_fmha.py
@@ -710,6 +710,7 @@ class SM120PrimsBatchPrefillBackend:
             device=self.device,
             with_lse=False,
             balanced_scheduler=_use_balanced_scheduler(causal),
+            enable_skip_softmax=False,
         )
         self._compiled_lse_variants = {False}
 
@@ -783,6 +784,7 @@ class SM120PrimsBatchPrefillBackend:
             device=self.device,
             with_lse=False,
             balanced_scheduler=_use_balanced_scheduler(causal),
+            enable_skip_softmax=False,
         )
         self._compiled_lse_variants = {False}
 
@@ -834,30 +836,36 @@ class SM120PrimsBatchPrefillBackend:
             compile_sm120_fmha_fp8_ragged_kernel,
         )
 
-        common = (
-            self._q_dtype,
-            self._o_dtype,
-            self._num_qo_heads,
-            self._num_kv_heads,
-            self._head_dim,
-            self._causal,
-            128,
-            128,
-        )
         if self._mode == "ragged":
             compile_sm120_fmha_fp8_ragged_kernel(
-                *common,
-                self.device,
-                with_lse,
-                _use_balanced_scheduler(self._causal),
+                in_dtype=self._q_dtype,
+                out_dtype=self._o_dtype,
+                num_qo_heads=self._num_qo_heads,
+                num_kv_heads=self._num_kv_heads,
+                head_dim=self._head_dim,
+                is_causal=self._causal,
+                kv_tile=128,
+                q_tile=128,
+                device=self.device,
+                with_lse=with_lse,
+                balanced_scheduler=_use_balanced_scheduler(self._causal),
+                enable_skip_softmax=False,
             )
         else:
             compile_sm120_fmha_fp8_paged_kernel(
-                *common,
-                self._page_size,
-                self.device,
-                with_lse,
-                _use_balanced_scheduler(self._causal),
+                in_dtype=self._q_dtype,
+                out_dtype=self._o_dtype,
+                num_qo_heads=self._num_qo_heads,
+                num_kv_heads=self._num_kv_heads,
+                head_dim=self._head_dim,
+                is_causal=self._causal,
+                kv_tile=128,
+                q_tile=128,
+                num_tokens_per_page=self._page_size,
+                device=self.device,
+                with_lse=with_lse,
+                balanced_scheduler=_use_balanced_scheduler(self._causal),
+                enable_skip_softmax=False,
             )
         self._compiled_lse_variants.add(with_lse)
 

--- a/flashinfer/cute_dsl/attention/fmha/sm120/compile.py
+++ b/flashinfer/cute_dsl/attention/fmha/sm120/compile.py
@@ -54,6 +54,7 @@ def _compile_sm120_fmha_fp8_ragged_kernel(
     device: torch.device,
     with_lse: bool = False,
     balanced_scheduler: bool = False,
+    enable_skip_softmax: bool = False,
 ):
     """Compile one sequence-length-independent packed ragged kernel."""
 
@@ -78,6 +79,7 @@ def _compile_sm120_fmha_fp8_ragged_kernel(
     sym_total_q = cute.sym_int()
     sym_total_k = cute.sym_int()
     sym_cu = cute.sym_int()
+    sym_b = cute.sym_int()
     fake_q = make_fake_compact_tensor(
         in_ct,
         (sym_total_q, num_qo_heads, head_dim),
@@ -114,6 +116,11 @@ def _compile_sm120_fmha_fp8_ragged_kernel(
     )
     fake_cu_seqlens_q = make_fake_compact_tensor(Int32, (sym_cu,), assumed_align=4)
     fake_cu_seqlens_k = make_fake_compact_tensor(Int32, (sym_cu,), assumed_align=4)
+    fake_skip_softmax_threshold = (
+        make_fake_compact_tensor(cutlass.Float32, (sym_b,), assumed_align=4)
+        if enable_skip_softmax
+        else None
+    )
     stream_fake = make_fake_stream(use_tvm_ffi_env_stream=True)
 
     return cute.compile(
@@ -125,6 +132,7 @@ def _compile_sm120_fmha_fp8_ragged_kernel(
         fake_lse,
         cutlass.Float32(1.0),  # softmax_scale_log2 placeholder
         cutlass.Float32(1.0),  # output_scale placeholder
+        fake_skip_softmax_threshold,
         stream_fake,
         None,  # seqlens_kv
         fake_cu_seqlens_q,
@@ -149,6 +157,7 @@ def _compile_sm120_fmha_fp8_paged_kernel(
     device: torch.device,
     with_lse: bool = False,
     balanced_scheduler: bool = False,
+    enable_skip_softmax: bool = False,
 ):
     """Compile one sequence-length-independent packed-Q paged kernel."""
     _validate_balanced_scheduler(is_causal, balanced_scheduler)
@@ -228,6 +237,11 @@ def _compile_sm120_fmha_fp8_paged_kernel(
 
     fake_seqlens_kv = make_fake_compact_tensor(Int32, (sym_seqlens,), assumed_align=4)
     fake_cu_seqlens_q = make_fake_compact_tensor(Int32, (sym_cu_q,), assumed_align=4)
+    fake_skip_softmax_threshold = (
+        make_fake_compact_tensor(cutlass.Float32, (sym_b,), assumed_align=4)
+        if enable_skip_softmax
+        else None
+    )
     # Both dimensions are dynamic: M is a runtime row stride, not a
     # sequence-capacity specialization.
     fake_block_tables = make_fake_compact_tensor(
@@ -248,6 +262,7 @@ def _compile_sm120_fmha_fp8_paged_kernel(
         fake_lse,
         cutlass.Float32(1.0),  # softmax_scale_log2 placeholder
         cutlass.Float32(1.0),  # output_scale placeholder
+        fake_skip_softmax_threshold,
         stream_fake,
         fake_seqlens_kv,
         fake_cu_seqlens_q,
@@ -284,6 +299,7 @@ def compile_sm120_fmha_fp8_ragged_kernel(
     device: torch.device,
     with_lse: bool = False,
     balanced_scheduler: bool = False,
+    enable_skip_softmax: bool = False,
 ):
     _validate_balanced_scheduler(is_causal, balanced_scheduler)
 
@@ -297,6 +313,7 @@ def compile_sm120_fmha_fp8_ragged_kernel(
         f"_hq{num_qo_heads}_hkv{num_kv_heads}_d{head_dim}"
         f"_causal{int(is_causal)}_kt{kv_tile}_qt{q_tile}"
         f"_lse{int(with_lse)}_balanced{int(balanced_scheduler)}"
+        f"_skip{int(enable_skip_softmax)}"
     )
     return build_and_load_cute_dsl_kernel(
         "sm120_prims_fmha_fp8",
@@ -313,6 +330,7 @@ def compile_sm120_fmha_fp8_ragged_kernel(
             device,
             with_lse,
             balanced_scheduler,
+            enable_skip_softmax,
         ),
         extra_key_files=_cache_key_files(),
     )
@@ -332,6 +350,7 @@ def compile_sm120_fmha_fp8_paged_kernel(
     device: torch.device,
     with_lse: bool = False,
     balanced_scheduler: bool = False,
+    enable_skip_softmax: bool = False,
 ):
     _validate_balanced_scheduler(is_causal, balanced_scheduler)
 
@@ -346,6 +365,7 @@ def compile_sm120_fmha_fp8_paged_kernel(
         f"_causal{int(is_causal)}_kt{kv_tile}_qt{q_tile}"
         f"_page{num_tokens_per_page}_lse{int(with_lse)}"
         f"_balanced{int(balanced_scheduler)}"
+        f"_skip{int(enable_skip_softmax)}"
     )
     return build_and_load_cute_dsl_kernel(
         "sm120_prims_fmha_fp8",
@@ -363,6 +383,7 @@ def compile_sm120_fmha_fp8_paged_kernel(
             device,
             with_lse,
             balanced_scheduler,
+            enable_skip_softmax,
         ),
         extra_key_files=_cache_key_files(),
     )

--- a/flashinfer/cute_dsl/attention/fmha/sm120/fmha_prefill_fp8_tma.py
+++ b/flashinfer/cute_dsl/attention/fmha/sm120/fmha_prefill_fp8_tma.py
@@ -2245,12 +2245,6 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             q_tile_idx = block_x
             q_head_idx = block_y
         batch_idx = block_z
-        skip_softmax_threshold_log2 = None
-        if cutlass.const_expr(skip_softmax_threshold is not None):
-            skip_softmax_threshold_log2 = cute.math.log2(
-                cutlass.Float32(skip_softmax_threshold[batch_idx]),
-                fastmath=True,
-            )
         q_seq_idx = q_tile_idx * self.q_tile
 
         warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -2266,6 +2260,15 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         causal_q_offset = cutlass.Int32(0)
 
         cute.arch.griddepcontrol_wait()
+        # A dynamic threshold can be produced or updated by an earlier kernel.
+        # Keep its load after the PDL dependency wait so a dependent launch
+        # never observes the predecessor's stale value.
+        skip_softmax_threshold_log2 = None
+        if cutlass.const_expr(skip_softmax_threshold is not None):
+            skip_softmax_threshold_log2 = cute.math.log2(
+                cutlass.Float32(skip_softmax_threshold[batch_idx]),
+                fastmath=True,
+            )
         q_token_base = cutlass.Int32(cu_seqlens_q[batch_idx])
         seqlen_q = cutlass.Int32(cu_seqlens_q[batch_idx + 1]) - q_token_base
         num_heads_q = q.shape[1]

--- a/flashinfer/cute_dsl/attention/fmha/sm120/fmha_prefill_fp8_tma.py
+++ b/flashinfer/cute_dsl/attention/fmha/sm120/fmha_prefill_fp8_tma.py
@@ -335,8 +335,9 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
     # Barrier 0 is the CTA-wide initialization barrier; barrier 1 synchronizes
     # compute warps before the K/V storage is aliased for the output epilogue.
     COMPUTE_BARRIER_ID = 1
-    # K and V operands share a three-slot circular TMA pipeline. D256 uses
-    # 96 KiB for these slots, which fits the SM120 shared-memory capacity.
+    # K and V operands share a three-slot circular TMA pipeline for the
+    # Q128/KV128 fast paths. D128 and D256 use 48 KiB and 96 KiB respectively,
+    # both within the SM120 shared-memory capacity.
     KV_PIPELINE_STAGES = 3
 
     def __init__(
@@ -390,7 +391,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         self.q_tile = q_tile
         self.kv_tile = kv_tile
         self.kv_pipeline_stages = (
-            3 if head_tile == 256 and q_tile == 128 and kv_tile == 128 else 2
+            3 if head_tile in (128, 256) and q_tile == 128 and kv_tile == 128 else 2
         )
         if self.use_paged_kv:
             if num_tokens_per_page not in self.SUPPORTED_PAGE_SIZES:
@@ -558,7 +559,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             return False
 
         kv_pipeline_stages = (
-            3 if head_dim == 256 and q_tile == 128 and kv_tile == 128 else 2
+            3 if head_dim in (128, 256) and q_tile == 128 and kv_tile == 128 else 2
         )
         kv_smem_bytes = kv_pipeline_stages * kv_tile * head_dim * in_dtype.bytes
         output_bytes = q_tile * head_dim * out_dtype.bytes
@@ -944,13 +945,17 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
     def mma_qk_single_buffer(
         self,
         basic_params: SimpleNamespace,
-        mma_params: SimpleNamespace,
         q_regs: cutlass.Array,
-    ) -> cutlass.Array:
-        """Original fixed-K QK path for the two-buffer specialization."""
+        sK: cutlass.Pointer,
+        tracks_tile_row_max: cutlass.Constexpr[bool],
+    ) -> tuple:
+        """Direct-row-state QK path, optionally folding in the row-max scan."""
         s_regs = cutlass.Array(cutlass.Float32, self.qk_k_frags * 4, alignment=16)
         for i in cutlass.range_constexpr(self.qk_k_frags * 4):
             s_regs[i] = cutlass.Float32(0.0)
+        tile_row_max = cutlass.Array(cutlass.Float32, 2, alignment=16)
+        for row_half in cutlass.range_constexpr(2):
+            tile_row_max[row_half] = -cutlass.Float32.inf
 
         k_row_in_frag_pair = (basic_params.lane_div8 // 2) * 8 + basic_params.lane_mod8
         k_col_in_frag_pair = (basic_params.lane_div8 % 2) * 16
@@ -964,7 +969,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             k_chunk = k_col // self.tma_copy_head_per_iter
             k_col_in_chunk = k_col % self.tma_copy_head_per_iter
             sK_ptr = (
-                mma_params.sK.data_ptr()
+                sK
                 + k_chunk * self.tma_copy_elems_per_iter
                 + k_row * self.tma_copy_head_per_iter
                 + self._get_swizzled_col(k_row, k_col_in_chunk)
@@ -1000,6 +1005,28 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                         s_regs[s_off + 3],
                         self.in_dtype,
                     )
+                # On the final head-dimension fragment, reduce the preceding
+                # score block while this block's independent MMA results are
+                # still in flight. This overlaps the skip predicate's scalar
+                # work with QK instead of scanning every score afterward.
+                if cutlass.const_expr(
+                    tracks_tile_row_max
+                    and d_frag + 1 == self.qk_d_frags
+                    and k_block > 0
+                ):
+                    previous_k_block = k_block - 1
+                    for previous_k_in_block in cutlass.range_constexpr(4):
+                        previous_k_frag = previous_k_block * 4 + previous_k_in_block
+                        previous_s_off = previous_k_frag * 4
+                        for row_half in cutlass.range_constexpr(2):
+                            tile_row_max[row_half] = cute.arch.fmax(
+                                tile_row_max[row_half],
+                                s_regs[previous_s_off + row_half * 2],
+                            )
+                            tile_row_max[row_half] = cute.arch.fmax(
+                                tile_row_max[row_half],
+                                s_regs[previous_s_off + row_half * 2 + 1],
+                            )
                 if cutlass.const_expr(
                     d_frag == 0 and k_block + 1 < self.qk_k_frags // 4
                 ):
@@ -1015,9 +1042,25 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                         d_next,
                         k_pair,
                     )
+            if cutlass.const_expr(
+                tracks_tile_row_max and d_frag + 1 == self.qk_d_frags
+            ):
+                last_k_block = self.qk_k_frags // 4 - 1
+                for last_k_in_block in cutlass.range_constexpr(4):
+                    last_k_frag = last_k_block * 4 + last_k_in_block
+                    last_s_off = last_k_frag * 4
+                    for row_half in cutlass.range_constexpr(2):
+                        tile_row_max[row_half] = cute.arch.fmax(
+                            tile_row_max[row_half],
+                            s_regs[last_s_off + row_half * 2],
+                        )
+                        tile_row_max[row_half] = cute.arch.fmax(
+                            tile_row_max[row_half],
+                            s_regs[last_s_off + row_half * 2 + 1],
+                        )
             k_cur = k_next
 
-        return s_regs
+        return s_regs, tile_row_max
 
     @cute.jit
     def online_softmax(
@@ -1252,12 +1295,15 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         basic_params: SimpleNamespace,
         mma_params: SimpleNamespace,
         softmax_params: SimpleNamespace,
+        sV: cutlass.Pointer,
         s_regs: cutlass.Array,
+        tile_row_max: cutlass.Array,
         kv_seq_idx: cutlass.Int32,
         is_masked_frontier_tile: cutlass.Constexpr[bool],
         uses_softmax_init_path: cutlass.Constexpr[bool],
+        uses_precomputed_tile_row_max: cutlass.Constexpr[bool],
     ) -> tuple:
-        """Original direct row-state softmax for the two-buffer path."""
+        """Direct-row-state softmax with an explicit V-stage pointer."""
         o_regs = mma_params.o_regs
         row_max = softmax_params.row_max
         row_sum = softmax_params.row_sum
@@ -1291,32 +1337,35 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                     )
                     has_valid_cols = kv_seq_idx < valid_cols
 
-            cur_max0 = -cutlass.Float32.inf
-            cur_max1 = -cutlass.Float32.inf
-            for k_frag in cutlass.range_constexpr(self.qk_k_frags):
-                s_off = k_frag * 4
-                s0 = s_regs[s_off + s_reg_idx_lo]
-                s1 = s_regs[s_off + s_reg_idx_hi]
-                if cutlass.const_expr(is_masked_frontier_tile):
-                    k_col0 = kv_seq_idx + k_frag * 8 + 2 * basic_params.lane_mod4
-                    k_col1 = k_col0 + 1
-                    if cutlass.const_expr(self.is_causal):
-                        valid0 = k_col0 < valid_cols if has_valid_cols else False
-                        valid1 = k_col1 < valid_cols if has_valid_cols else False
-                    else:
-                        valid0 = k_col0 < valid_cols
-                        valid1 = k_col1 < valid_cols
-                    if not valid0:
-                        s0 = -cutlass.Float32.inf
-                    if not valid1:
-                        s1 = -cutlass.Float32.inf
-                s_regs[s_off + s_reg_idx_lo] = s0
-                s_regs[s_off + s_reg_idx_hi] = s1
-                cur_max0 = cute.arch.fmax(cur_max0, s0)
-                cur_max1 = cute.arch.fmax(cur_max1, s1)
+            if cutlass.const_expr(uses_precomputed_tile_row_max):
+                cur_max = nvvm_threadquad_reduction_max(tile_row_max[row_half])
+            else:
+                cur_max0 = -cutlass.Float32.inf
+                cur_max1 = -cutlass.Float32.inf
+                for k_frag in cutlass.range_constexpr(self.qk_k_frags):
+                    s_off = k_frag * 4
+                    s0 = s_regs[s_off + s_reg_idx_lo]
+                    s1 = s_regs[s_off + s_reg_idx_hi]
+                    if cutlass.const_expr(is_masked_frontier_tile):
+                        k_col0 = kv_seq_idx + k_frag * 8 + 2 * basic_params.lane_mod4
+                        k_col1 = k_col0 + 1
+                        if cutlass.const_expr(self.is_causal):
+                            valid0 = k_col0 < valid_cols if has_valid_cols else False
+                            valid1 = k_col1 < valid_cols if has_valid_cols else False
+                        else:
+                            valid0 = k_col0 < valid_cols
+                            valid1 = k_col1 < valid_cols
+                        if not valid0:
+                            s0 = -cutlass.Float32.inf
+                        if not valid1:
+                            s1 = -cutlass.Float32.inf
+                    s_regs[s_off + s_reg_idx_lo] = s0
+                    s_regs[s_off + s_reg_idx_hi] = s1
+                    cur_max0 = cute.arch.fmax(cur_max0, s0)
+                    cur_max1 = cute.arch.fmax(cur_max1, s1)
 
-            cur_max = cute.arch.fmax(cur_max0, cur_max1)
-            cur_max = nvvm_threadquad_reduction_max(cur_max)
+                cur_max = cute.arch.fmax(cur_max0, cur_max1)
+                cur_max = nvvm_threadquad_reduction_max(cur_max)
 
             old_scale = cutlass.Float32(1.0)
             if cutlass.const_expr(uses_softmax_init_path):
@@ -1397,7 +1446,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                 # scalar softmax work available to hide the shared-memory load.
                 v_initial = self.load_v_initial_fragments_single_buffer(
                     basic_params,
-                    mma_params,
+                    sV,
                 )
 
         return p_regs, v_initial
@@ -1566,9 +1615,9 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
     def load_v_initial_fragments_single_buffer(
         self,
         basic_params: SimpleNamespace,
-        mma_params: SimpleNamespace,
+        sV: cutlass.Pointer,
     ) -> cutlass.Array:
-        """Load the first BMM2 V fragment set before online softmax."""
+        """Load the first BMM2 V fragment set from the selected pipeline stage."""
         v_regs = cutlass.Array(cutlass.Int32, self.pv_d_frags * 2, alignment=16)
         v_lane = basic_params.lane
         uses_direct_p_pack = cutlass.const_expr(
@@ -1600,7 +1649,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             v_chunk = v_col // self.tma_copy_head_per_iter
             v_col_in_chunk = v_col % self.tma_copy_head_per_iter
             sV_ptr = (
-                mma_params.sV.data_ptr()
+                sV
                 + v_chunk * self.tma_copy_elems_per_iter
                 + v_row * self.tma_copy_head_per_iter
                 + self._get_swizzled_col(v_row, v_col_in_chunk)
@@ -1624,6 +1673,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         self,
         basic_params: SimpleNamespace,
         mma_params: SimpleNamespace,
+        sV: cutlass.Pointer,
         p_regs: cutlass.Array,
         v_initial: cutlass.Array,
     ) -> None:
@@ -1659,7 +1709,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             v_chunk = v_col // self.tma_copy_head_per_iter
             v_col_in_chunk = v_col % self.tma_copy_head_per_iter
             sV_ptr = (
-                mma_params.sV.data_ptr()
+                sV
                 + v_chunk * self.tma_copy_elems_per_iter
                 + v_row * self.tma_copy_head_per_iter
                 + self._get_swizzled_col(v_row, v_col_in_chunk)
@@ -1783,6 +1833,131 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             pass
 
     @cute.jit
+    def should_skip_softmax(
+        self,
+        basic_params: SimpleNamespace,
+        softmax_params: SimpleNamespace,
+        s_regs: cutlass.Array,
+        row_state: cutlass.Float32,
+        kv_seq_idx: cutlass.Int32,
+        is_masked_frontier_tile: cutlass.Constexpr[bool],
+    ) -> cutlass.Boolean:
+        """Return a warp-uniform decision to skip this K/V tile.
+
+        Each compute warp owns 16 complete query rows.  A tile may be skipped
+        only when every valid row owned by the warp is below the configured
+        threshold.  Keeping the decision warp-uniform lets the caller omit
+        both online-softmax state updates and the PV MMA without introducing
+        divergent MMA execution.
+        """
+        uses_distributed_row_state = cutlass.const_expr(
+            self.head_tile == 256 and self.q_tile == 128 and self.kv_tile == 128
+        )
+        if cutlass.const_expr(not uses_distributed_row_state):
+            row_max = softmax_params.row_max
+
+        thread_wants_skip = cutlass.Boolean(True)
+        for row_half in cutlass.range_constexpr(2):
+            q_row_in_cta = (
+                basic_params.q_warp_row0 + basic_params.lane_div4 + row_half * 8
+            )
+            q_row_is_valid = (
+                basic_params.q_seq_idx + q_row_in_cta < basic_params.seqlen_q
+            )
+
+            valid_cols = basic_params.seqlen_k
+            has_valid_cols = True
+            if cutlass.const_expr(is_masked_frontier_tile):
+                if cutlass.const_expr(self.is_causal):
+                    valid_cols = cute.math.min(
+                        basic_params.q_seq_idx
+                        + q_row_in_cta
+                        + basic_params.causal_q_offset
+                        + 1,
+                        basic_params.seqlen_k,
+                    )
+                    has_valid_cols = kv_seq_idx < valid_cols
+
+            tile_row_max = -cutlass.Float32.inf
+            for k_frag in cutlass.range_constexpr(self.qk_k_frags):
+                s_off = k_frag * 4
+                s0 = s_regs[s_off + row_half * 2]
+                s1 = s_regs[s_off + row_half * 2 + 1]
+                if cutlass.const_expr(is_masked_frontier_tile):
+                    k_col0 = kv_seq_idx + k_frag * 8 + 2 * basic_params.lane_mod4
+                    k_col1 = k_col0 + 1
+                    if cutlass.const_expr(self.is_causal):
+                        valid0 = k_col0 < valid_cols if has_valid_cols else False
+                        valid1 = k_col1 < valid_cols if has_valid_cols else False
+                    else:
+                        valid0 = k_col0 < valid_cols
+                        valid1 = k_col1 < valid_cols
+                    if not valid0:
+                        s0 = -cutlass.Float32.inf
+                    if not valid1:
+                        s1 = -cutlass.Float32.inf
+                tile_row_max = cute.arch.fmax(tile_row_max, s0)
+                tile_row_max = cute.arch.fmax(tile_row_max, s1)
+
+            if cutlass.const_expr(uses_distributed_row_state):
+                tile_row_max = nvvm_threadquad_reduction_max(tile_row_max)
+                previous_row_max = prims.shfl_sync(
+                    thread_mask=0xFFFFFFFF,
+                    val=row_state,
+                    offset=row_half,
+                    mask_and_clamp=0x1C03,
+                    kind=prims.Shfl.IDX,
+                )
+            else:
+                tile_row_max = nvvm_threadquad_reduction_max_full(tile_row_max)
+                previous_row_max = row_max[row_half]
+
+            row_wants_skip = cutlass.Boolean(False)
+            if not q_row_is_valid or tile_row_max == -cutlass.Float32.inf:
+                row_wants_skip = cutlass.Boolean(True)
+            elif previous_row_max != -cutlass.Float32.inf:
+                row_wants_skip = (
+                    (tile_row_max - previous_row_max)
+                    * softmax_params.softmax_scale_log2
+                    < softmax_params.skip_softmax_threshold_log2
+                )
+            thread_wants_skip = thread_wants_skip and row_wants_skip
+
+        return cute.arch.vote_all_sync(thread_wants_skip)
+
+    @cute.jit
+    def should_skip_softmax_from_tile_row_max(
+        self,
+        basic_params: SimpleNamespace,
+        softmax_params: SimpleNamespace,
+        tile_row_max: cutlass.Array,
+    ) -> cutlass.Boolean:
+        """Evaluate the hot-loop skip predicate from QK-folded row maxima."""
+        thread_wants_skip = cutlass.Boolean(True)
+        for row_half in cutlass.range_constexpr(2):
+            q_row_in_cta = (
+                basic_params.q_warp_row0 + basic_params.lane_div4 + row_half * 8
+            )
+            q_row_is_valid = (
+                basic_params.q_seq_idx + q_row_in_cta < basic_params.seqlen_q
+            )
+            reduced_tile_row_max = nvvm_threadquad_reduction_max_full(
+                tile_row_max[row_half]
+            )
+            row_wants_skip = cutlass.Boolean(False)
+            if not q_row_is_valid or reduced_tile_row_max == -cutlass.Float32.inf:
+                row_wants_skip = cutlass.Boolean(True)
+            elif softmax_params.row_max[row_half] != -cutlass.Float32.inf:
+                row_wants_skip = (
+                    (reduced_tile_row_max - softmax_params.row_max[row_half])
+                    * softmax_params.softmax_scale_log2
+                    < softmax_params.skip_softmax_threshold_log2
+                )
+            thread_wants_skip = thread_wants_skip and row_wants_skip
+
+        return cute.arch.vote_all_sync(thread_wants_skip)
+
+    @cute.jit
     def compute_one_kv_tile(
         self,
         basic_params: SimpleNamespace,
@@ -1839,23 +2014,51 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             )
 
         kv_seq_idx = kv_tile_idx * self.kv_tile
-        p_regs, row_state = self.online_softmax(
-            basic_params,
-            mma_params,
-            softmax_params,
-            s_regs,
-            row_state,
-            kv_seq_idx,
-            is_masked_frontier_tile,
-            uses_softmax_init_path,
-        )
-        # Softmax has no V dependency. Delay the arrival wait until the first
-        # V consumer so its scalar work can hide the outstanding TMA transfer.
+        enable_skip_softmax = softmax_params.skip_softmax_threshold_log2 is not None
+        skip_softmax = cutlass.Boolean(False)
+        if cutlass.const_expr(enable_skip_softmax and not uses_softmax_init_path):
+            skip_softmax = self.should_skip_softmax(
+                basic_params,
+                softmax_params,
+                s_regs,
+                row_state,
+                kv_seq_idx,
+                is_masked_frontier_tile,
+            )
         v_arrived = self.get_mbar_stage_ptr(basic_params.mbar_arrived, v_stage)
-        self.wait_pipeline_barrier(v_arrived, v_phase)
-
         sV = self.get_kv_stage_ptr(mma_params.sKV, v_stage)
-        self.mma_pv(basic_params, mma_params, p_regs, sV)
+        if cutlass.const_expr(enable_skip_softmax):
+            if not skip_softmax:
+                p_regs, row_state = self.online_softmax(
+                    basic_params,
+                    mma_params,
+                    softmax_params,
+                    s_regs,
+                    row_state,
+                    kv_seq_idx,
+                    is_masked_frontier_tile,
+                    uses_softmax_init_path,
+                )
+                # Softmax has no V dependency. Delay the arrival wait until
+                # the first V consumer so scalar work hides the TMA transfer.
+                self.wait_pipeline_barrier(v_arrived, v_phase)
+                self.mma_pv(basic_params, mma_params, p_regs, sV)
+            else:
+                # Even a skipped tile must consume its V pipeline slot.
+                self.wait_pipeline_barrier(v_arrived, v_phase)
+        else:
+            p_regs, row_state = self.online_softmax(
+                basic_params,
+                mma_params,
+                softmax_params,
+                s_regs,
+                row_state,
+                kv_seq_idx,
+                is_masked_frontier_tile,
+                uses_softmax_init_path,
+            )
+            self.wait_pipeline_barrier(v_arrived, v_phase)
+            self.mma_pv(basic_params, mma_params, p_regs, sV)
         if prims.elect_sync():
             v_consumed = self.get_mbar_stage_ptr(basic_params.mbar_consumed, v_stage)
             prims.mbarrier_arrive(
@@ -1865,7 +2068,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         return row_state
 
     @cute.jit
-    def compute_one_kv_tile_single_buffer(
+    def compute_one_kv_tile_direct_state(
         self,
         basic_params: SimpleNamespace,
         mma_params: SimpleNamespace,
@@ -1873,48 +2076,120 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         q_regs: cutlass.Array,
         num_kv_tiles: cutlass.Int32,
         kv_tile_idx: cutlass.Int32,
+        k_stage: cutlass.Int32,
+        uses_kv_ring: cutlass.Constexpr[bool],
         is_masked_frontier_tile: cutlass.Constexpr[bool],
         uses_softmax_init_path: cutlass.Constexpr[bool],
     ) -> None:
-        """Original independent fixed-buffer K/V compute iteration."""
-        tma_phase = (num_kv_tiles - 1 - kv_tile_idx) & cutlass.Int32(1)
-        while not prims.mbarrier_try_wait_parity(
-            basic_params.mbar_k_arrived, tma_phase, time_limit=10_000_000
-        ):
-            pass
+        """One direct-row-state QK/skip/softmax/PV iteration."""
+        if cutlass.const_expr(uses_kv_ring):
+            k_phase = k_stage & cutlass.Int32(1)
+            v_stage = k_stage + cutlass.Int32(1)
+            if v_stage == self.kv_pipeline_stages:
+                v_stage = cutlass.Int32(0)
+            v_phase = (k_stage + cutlass.Int32(1)) // cutlass.Int32(2)
+            sK = self.get_kv_stage_ptr(mma_params.sKV, k_stage)
+            k_arrived = self.get_mbar_stage_ptr(basic_params.mbar_arrived, k_stage)
+            k_consumed = self.get_mbar_stage_ptr(basic_params.mbar_consumed, k_stage)
+            sV = self.get_kv_stage_ptr(mma_params.sKV, v_stage)
+            v_arrived = self.get_mbar_stage_ptr(basic_params.mbar_arrived, v_stage)
+            v_consumed = self.get_mbar_stage_ptr(basic_params.mbar_consumed, v_stage)
+        else:
+            tma_phase = (num_kv_tiles - 1 - kv_tile_idx) & cutlass.Int32(1)
+            k_phase = tma_phase
+            v_phase = tma_phase
+            sK = mma_params.sK.data_ptr()
+            k_arrived = basic_params.mbar_k_arrived
+            k_consumed = basic_params.mbar_k_consumed
+            sV = mma_params.sV.data_ptr()
+            v_arrived = basic_params.mbar_v_arrived
+            v_consumed = basic_params.mbar_v_consumed
 
-        s_regs = self.mma_qk_single_buffer(basic_params, mma_params, q_regs)
+        self.wait_pipeline_barrier(k_arrived, k_phase)
+
+        enable_skip_softmax = softmax_params.skip_softmax_threshold_log2 is not None
+        tracks_tile_row_max = cutlass.const_expr(
+            enable_skip_softmax
+            and not uses_softmax_init_path
+            and not is_masked_frontier_tile
+        )
+        s_regs, tile_row_max = self.mma_qk_single_buffer(
+            basic_params,
+            q_regs,
+            sK,
+            tracks_tile_row_max,
+        )
         if prims.elect_sync():
             prims.mbarrier_arrive(
-                basic_params.mbar_k_consumed,
+                k_consumed,
                 count=cute.arch.WARP_SIZE,
             )
 
-        while not prims.mbarrier_try_wait_parity(
-            basic_params.mbar_v_arrived, tma_phase, time_limit=10_000_000
-        ):
-            pass
-
         kv_seq_idx = kv_tile_idx * self.kv_tile
-        p_regs, v_initial = self.online_softmax_single_buffer(
-            basic_params,
-            mma_params,
-            softmax_params,
-            s_regs,
-            kv_seq_idx,
-            is_masked_frontier_tile,
-            uses_softmax_init_path,
-        )
+        skip_softmax = cutlass.Boolean(False)
+        if cutlass.const_expr(enable_skip_softmax and not uses_softmax_init_path):
+            if cutlass.const_expr(tracks_tile_row_max):
+                skip_softmax = self.should_skip_softmax_from_tile_row_max(
+                    basic_params,
+                    softmax_params,
+                    tile_row_max,
+                )
+            else:
+                skip_softmax = self.should_skip_softmax(
+                    basic_params,
+                    softmax_params,
+                    s_regs,
+                    cutlass.Float32(0.0),
+                    kv_seq_idx,
+                    is_masked_frontier_tile,
+                )
 
-        self.mma_pv_single_buffer_preloaded(
-            basic_params,
-            mma_params,
-            p_regs,
-            v_initial,
-        )
+        self.wait_pipeline_barrier(v_arrived, v_phase)
+
+        if cutlass.const_expr(enable_skip_softmax):
+            if not skip_softmax:
+                p_regs, v_initial = self.online_softmax_single_buffer(
+                    basic_params,
+                    mma_params,
+                    softmax_params,
+                    sV,
+                    s_regs,
+                    tile_row_max,
+                    kv_seq_idx,
+                    is_masked_frontier_tile,
+                    uses_softmax_init_path,
+                    tracks_tile_row_max,
+                )
+                self.mma_pv_single_buffer_preloaded(
+                    basic_params,
+                    mma_params,
+                    sV,
+                    p_regs,
+                    v_initial,
+                )
+        else:
+            p_regs, v_initial = self.online_softmax_single_buffer(
+                basic_params,
+                mma_params,
+                softmax_params,
+                sV,
+                s_regs,
+                tile_row_max,
+                kv_seq_idx,
+                is_masked_frontier_tile,
+                uses_softmax_init_path,
+                tracks_tile_row_max,
+            )
+            self.mma_pv_single_buffer_preloaded(
+                basic_params,
+                mma_params,
+                sV,
+                p_regs,
+                v_initial,
+            )
         if prims.elect_sync():
             prims.mbarrier_arrive(
-                basic_params.mbar_v_consumed,
+                v_consumed,
                 count=cute.arch.WARP_SIZE,
             )
 
@@ -1930,6 +2205,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         tma_v_desc: cutlass.GridConstant[cuda.TensorMap],
         softmax_scale_log2: cutlass.Float32,
         output_scale: cutlass.Float32,
+        skip_softmax_threshold: cute.Tensor | None,
         seqlens_kv: cute.Tensor | None = None,
         cu_seqlens_q: cute.Tensor | None = None,
         block_tables: cute.Tensor | None = None,
@@ -1947,6 +2223,8 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         :param softmax_scale_log2: ``softmax_scale * log2(e)``, pre-folded host-side.
         :param output_scale: Scalar V dequantization scale folded into the
             final normalization.
+        :param skip_softmax_threshold: Optional e-based skip threshold for
+            each request, shape ``[batch_size]``.
         :param seqlens_kv: Optional runtime K/V length for each request.
         :param cu_seqlens_q: Optional cumulative offsets for packed Q/O.
         :param block_tables: Shared K/V page indices with shape ``[B,max_pages]``.
@@ -1967,6 +2245,12 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             q_tile_idx = block_x
             q_head_idx = block_y
         batch_idx = block_z
+        skip_softmax_threshold_log2 = None
+        if cutlass.const_expr(skip_softmax_threshold is not None):
+            skip_softmax_threshold_log2 = cute.math.log2(
+                cutlass.Float32(skip_softmax_threshold[batch_idx]),
+                fastmath=True,
+            )
         q_seq_idx = q_tile_idx * self.q_tile
 
         warp = cute.arch.make_warp_uniform(cute.arch.warp_idx())
@@ -2067,7 +2351,9 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             prims.setmaxregister(24, prims.SetMaxRegisterAction.DECREASE)
 
             uses_three_stage_pipeline = cutlass.const_expr(
-                self.head_tile == 256 and self.q_tile == 128 and self.kv_tile == 128
+                self.head_tile in (128, 256)
+                and self.q_tile == 128
+                and self.kv_tile == 128
             )
             uses_kv_l2_policy = cutlass.const_expr(
                 self.head_tile in (128, 256)
@@ -2289,7 +2575,12 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             uses_distributed_row_state = cutlass.const_expr(
                 self.head_tile == 256 and self.q_tile == 128 and self.kv_tile == 128
             )
-            uses_unified_kv_ring = uses_distributed_row_state
+            uses_direct_state_ring = cutlass.const_expr(
+                self.head_tile == 128 and self.q_tile == 128 and self.kv_tile == 128
+            )
+            uses_unified_kv_ring = cutlass.const_expr(
+                uses_distributed_row_state or uses_direct_state_ring
+            )
             if cutlass.const_expr(uses_distributed_row_state):
                 # D256/Q128/KV128 crosses the register cliff with four state
                 # scalars. Distribute them across each threadquad: lanes 0/1
@@ -2343,13 +2634,10 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                 mbar_k_consumed=mbar_consumed,
                 mbar_v_consumed=mbar_consumed.subview(1),
             )
-            if cutlass.const_expr(uses_distributed_row_state):
+            if cutlass.const_expr(uses_distributed_row_state or uses_direct_state_ring):
                 mma_params = SimpleNamespace(
                     sKV=sKV,
                     o_regs=o_regs,
-                )
-                softmax_params = SimpleNamespace(
-                    softmax_scale_log2=softmax_scale_log2,
                 )
             else:
                 mma_params = SimpleNamespace(
@@ -2358,10 +2646,18 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                     sV=sKV.subview(self.kv_tile_elems),
                     o_regs=o_regs,
                 )
+
+            if cutlass.const_expr(uses_distributed_row_state):
+                softmax_params = SimpleNamespace(
+                    softmax_scale_log2=softmax_scale_log2,
+                    skip_softmax_threshold_log2=skip_softmax_threshold_log2,
+                )
+            else:
                 softmax_params = SimpleNamespace(
                     row_max=row_max,
                     row_sum=row_sum,
                     softmax_scale_log2=softmax_scale_log2,
+                    skip_softmax_threshold_log2=skip_softmax_threshold_log2,
                 )
 
             # Load Q into registers.
@@ -2396,19 +2692,34 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
                             is_masked_frontier_tile=True,
                             uses_softmax_init_path=(step == 0),
                         )
-                    else:
-                        self.compute_one_kv_tile_single_buffer(
+                    elif cutlass.const_expr(uses_direct_state_ring):
+                        self.compute_one_kv_tile_direct_state(
                             basic_params,
                             mma_params,
                             softmax_params,
                             q_regs,
                             num_kv_tiles,
                             kv_tile_idx,
+                            pipeline_k_stage,
+                            uses_kv_ring=True,
+                            is_masked_frontier_tile=True,
+                            uses_softmax_init_path=(step == 0),
+                        )
+                    else:
+                        self.compute_one_kv_tile_direct_state(
+                            basic_params,
+                            mma_params,
+                            softmax_params,
+                            q_regs,
+                            num_kv_tiles,
+                            kv_tile_idx,
+                            pipeline_k_stage,
+                            uses_kv_ring=False,
                             is_masked_frontier_tile=True,
                             uses_softmax_init_path=(step == 0),
                         )
                 kv_tile_idx -= 1
-                if cutlass.const_expr(uses_distributed_row_state):
+                if cutlass.const_expr(uses_unified_kv_ring):
                     if pipeline_k_stage == 0:
                         pipeline_k_stage = cutlass.Int32(2)
                     else:
@@ -2417,25 +2728,41 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             # Phase 2: remaining tiles outside the explicit mask frontier.
             while kv_tile_idx >= 0:
                 if cutlass.const_expr(uses_unified_kv_ring):
-                    row_state = self.compute_one_kv_tile(
-                        basic_params,
-                        mma_params,
-                        softmax_params,
-                        q_regs,
-                        row_state,
-                        kv_tile_idx,
-                        pipeline_k_stage,
-                        is_masked_frontier_tile=False,
-                        uses_softmax_init_path=False,
-                    )
+                    if cutlass.const_expr(uses_distributed_row_state):
+                        row_state = self.compute_one_kv_tile(
+                            basic_params,
+                            mma_params,
+                            softmax_params,
+                            q_regs,
+                            row_state,
+                            kv_tile_idx,
+                            pipeline_k_stage,
+                            is_masked_frontier_tile=False,
+                            uses_softmax_init_path=False,
+                        )
+                    else:
+                        self.compute_one_kv_tile_direct_state(
+                            basic_params,
+                            mma_params,
+                            softmax_params,
+                            q_regs,
+                            num_kv_tiles,
+                            kv_tile_idx,
+                            pipeline_k_stage,
+                            uses_kv_ring=True,
+                            is_masked_frontier_tile=False,
+                            uses_softmax_init_path=False,
+                        )
                 else:
-                    self.compute_one_kv_tile_single_buffer(
+                    self.compute_one_kv_tile_direct_state(
                         basic_params,
                         mma_params,
                         softmax_params,
                         q_regs,
                         num_kv_tiles,
                         kv_tile_idx,
+                        pipeline_k_stage,
+                        uses_kv_ring=False,
                         is_masked_frontier_tile=False,
                         uses_softmax_init_path=False,
                     )
@@ -2637,6 +2964,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         lse: cute.Tensor | None,
         softmax_scale_log2: cutlass.Float32,
         output_scale: cutlass.Float32,
+        skip_softmax_threshold: cute.Tensor | None,
         stream: cuda_driver.CUstream,
         seqlens_kv: cute.Tensor | None = None,
         cu_seqlens_q: cute.Tensor | None = None,
@@ -2657,6 +2985,9 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
         :param lse: Optional packed float32 log2 LSE ``(total_q,Hq)``.
         :param softmax_scale_log2: ``softmax_scale * log2(e)``.
         :param output_scale: Scalar multiplier applied to normalized output.
+        :param skip_softmax_threshold: E-based threshold for omitting tiles
+            whose contribution is negligible, one float32 value per request.
+            ``None`` selects the dense specialization.
         :param stream: CUDA stream used for the launch.
         :param seqlens_kv: Runtime K/V lengths, one Int32 per request.
         :param cu_seqlens_q: Packed-Q cumulative Int32 offsets.
@@ -2755,6 +3086,7 @@ class SM120FusedMultiHeadAttentionFP8ForwardTMA:
             tma_v_desc,
             softmax_scale_log2,
             output_scale,
+            skip_softmax_threshold,
             seqlens_kv,
             cu_seqlens_q,
             block_tables,

--- a/tests/attention/test_sm120_fmha.py
+++ b/tests/attention/test_sm120_fmha.py
@@ -358,6 +358,7 @@ def test_sm120_ragged_tensor_threshold_updates_between_graph_replays():
         cu_k,
         max_seqlen_q=Sq,
         skip_softmax_threshold=threshold,
+        enable_pdl=True,
     )
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
@@ -370,6 +371,7 @@ def test_sm120_ragged_tensor_threshold_updates_between_graph_replays():
             cu_k,
             max_seqlen_q=Sq,
             skip_softmax_threshold=threshold,
+            enable_pdl=True,
         )
 
     threshold.copy_(torch.tensor([2.0, 0.0], device="cuda"))

--- a/tests/attention/test_sm120_fmha.py
+++ b/tests/attention/test_sm120_fmha.py
@@ -275,9 +275,157 @@ def test_sm120_ragged_empty_kv_return_lse():
     assert torch.isneginf(lse).all()
 
 
+@pytest.mark.parametrize(
+    "D",
+    [
+        pytest.param(64, id="d64-fixed-buffer"),
+        pytest.param(128, id="d128-direct-state-ring"),
+        pytest.param(256, id="d256-distributed-state-ring"),
+    ],
+)
+def test_sm120_ragged_skip_softmax_omits_negligible_tiles(D):
+    """A threshold above one skips one equal-score tile from output and LSE."""
+    H, Sq, Skv = 2, 128, 256
+    q = torch.zeros(Sq, H, D, device="cuda", dtype=torch.float8_e4m3fn)
+    k = torch.zeros(Skv, H, D, device="cuda", dtype=torch.float8_e4m3fn)
+    v = torch.empty_like(k)
+    v[:128] = -1
+    v[128:] = 1
+    cu_q = torch.tensor([0, Sq], device="cuda", dtype=torch.int32)
+    cu_k = torch.tensor([0, Skv], device="cuda", dtype=torch.int32)
+    dense = torch.empty(Sq, H, D, device="cuda", dtype=torch.float16)
+    skipped = torch.empty_like(dense)
+    dense_lse = torch.empty(Sq, H, device="cuda", dtype=torch.float32)
+    skipped_lse = torch.empty_like(dense_lse)
+
+    sm120_fmha_fp8_ragged_prefill(
+        q,
+        k,
+        v,
+        dense,
+        cu_q,
+        cu_k,
+        q_tile=128,
+        kv_tile=128,
+        lse=dense_lse,
+    )
+    sm120_fmha_fp8_ragged_prefill(
+        q,
+        k,
+        v,
+        skipped,
+        cu_q,
+        cu_k,
+        q_tile=128,
+        kv_tile=128,
+        lse=skipped_lse,
+        # The equal-score left tile contributes exp(0) = 1, so 2 skips it.
+        skip_softmax_threshold=2.0,
+    )
+
+    torch.testing.assert_close(dense, torch.zeros_like(dense), atol=1e-3, rtol=0)
+    torch.testing.assert_close(skipped, torch.ones_like(skipped), atol=1e-3, rtol=0)
+    torch.testing.assert_close(
+        dense_lse, torch.full_like(dense_lse, 8.0), atol=2e-3, rtol=0
+    )
+    torch.testing.assert_close(
+        skipped_lse, torch.full_like(skipped_lse, 7.0), atol=2e-3, rtol=0
+    )
+
+
+def test_sm120_ragged_tensor_threshold_updates_between_graph_replays():
+    """A stable per-request tensor can be updated between graph replays."""
+    batch_size, H, D, Sq, Skv = 2, 2, 64, 128, 256
+    q = torch.zeros(batch_size * Sq, H, D, device="cuda", dtype=torch.float8_e4m3fn)
+    k = torch.zeros(batch_size * Skv, H, D, device="cuda", dtype=torch.float8_e4m3fn)
+    v = torch.empty_like(k)
+    for batch_idx in range(batch_size):
+        start = batch_idx * Skv
+        v[start : start + 128] = -1
+        v[start + 128 : start + Skv] = 1
+    cu_q = torch.tensor([0, Sq, 2 * Sq], device="cuda", dtype=torch.int32)
+    cu_k = torch.tensor([0, Skv, 2 * Skv], device="cuda", dtype=torch.int32)
+    threshold = torch.zeros(batch_size, device="cuda", dtype=torch.float32)
+    out = torch.empty_like(q, dtype=torch.float16)
+
+    # Compile the one skip-enabled specialization before capture.
+    sm120_fmha_fp8_ragged_prefill(
+        q,
+        k,
+        v,
+        out,
+        cu_q,
+        cu_k,
+        max_seqlen_q=Sq,
+        skip_softmax_threshold=threshold,
+    )
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        sm120_fmha_fp8_ragged_prefill(
+            q,
+            k,
+            v,
+            out,
+            cu_q,
+            cu_k,
+            max_seqlen_q=Sq,
+            skip_softmax_threshold=threshold,
+        )
+
+    threshold.copy_(torch.tensor([2.0, 0.0], device="cuda"))
+    graph.replay()
+    torch.cuda.synchronize()
+    expected = torch.cat((torch.ones_like(out[:Sq]), torch.zeros_like(out[Sq:])), dim=0)
+    torch.testing.assert_close(out, expected, atol=1e-3, rtol=0)
+
+    threshold.copy_(torch.tensor([0.0, 2.0], device="cuda"))
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, 1 - expected, atol=1e-3, rtol=0)
+
+
 # ---------------------------------------------------------------------------
 # Paged prefill shared block-table contract
 # ---------------------------------------------------------------------------
+
+
+def test_sm120_paged_tensor_threshold_omits_negligible_tile():
+    H, D, Sq, Skv, page_size = 2, 64, 128, 256, 128
+    q = torch.zeros(Sq, H, D, device="cuda", dtype=torch.float8_e4m3fn)
+    k_pool = torch.zeros(2, H, page_size, D, device="cuda", dtype=torch.float8_e4m3fn)
+    v_pool = torch.empty_like(k_pool)
+    v_pool[0].fill_(-1)
+    v_pool[1].fill_(1)
+    block_tables = torch.tensor([[0, 1]], device="cuda", dtype=torch.int32)
+    seqlens_kv = torch.tensor([Skv], device="cuda", dtype=torch.int32)
+    cu_q = torch.tensor([0, Sq], device="cuda", dtype=torch.int32)
+    dense = torch.empty(Sq, H, D, device="cuda", dtype=torch.float16)
+    skipped = torch.empty_like(dense)
+
+    sm120_fmha_fp8_paged_prefill(
+        q,
+        k_pool,
+        v_pool,
+        dense,
+        block_tables,
+        seqlens_kv,
+        cu_q,
+        max_seqlen_q=Sq,
+    )
+    sm120_fmha_fp8_paged_prefill(
+        q,
+        k_pool,
+        v_pool,
+        skipped,
+        block_tables,
+        seqlens_kv,
+        cu_q,
+        max_seqlen_q=Sq,
+        skip_softmax_threshold=torch.tensor([2.0], device="cuda"),
+    )
+
+    torch.testing.assert_close(dense, torch.zeros_like(dense), atol=1e-3, rtol=0)
+    torch.testing.assert_close(skipped, torch.ones_like(skipped), atol=1e-3, rtol=0)
 
 
 def _run_paged_case(

--- a/tests/attention/test_sm120_fmha_api.py
+++ b/tests/attention/test_sm120_fmha_api.py
@@ -116,3 +116,14 @@ def test_skip_softmax_has_a_distinct_jit_specialization(monkeypatch):
     assert observed_names[0][1].endswith("_skip0")
     assert observed_names[1][1].endswith("_skip1")
     compile_sm120_fmha_fp8_ragged_kernel.cache_clear()
+
+
+def test_skip_softmax_threshold_load_follows_pdl_dependency_wait():
+    from flashinfer.cute_dsl.attention.fmha.sm120 import (
+        SM120FusedMultiHeadAttentionFP8ForwardTMA,
+    )
+
+    kernel_source = inspect.getsource(SM120FusedMultiHeadAttentionFP8ForwardTMA.kernel)
+    wait = kernel_source.index("cute.arch.griddepcontrol_wait()")
+    threshold_load = kernel_source.index("skip_softmax_threshold[batch_idx]")
+    assert wait < threshold_load

--- a/tests/attention/test_sm120_fmha_api.py
+++ b/tests/attention/test_sm120_fmha_api.py
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Host-side tests for the SM120 PRIMS FMHA API and JIT specialization."""
+
+import inspect
+import pytest
+import torch
+
+from flashinfer.attention.cute_dsl.sm120_fmha import (
+    _prepare_skip_softmax_threshold,
+    sm120_fmha_fp8_paged_prefill,
+    sm120_fmha_fp8_ragged_prefill,
+)
+
+
+def test_skip_softmax_threshold_float_expansion_and_validation():
+    q = torch.empty(1)
+    assert _prepare_skip_softmax_threshold(None, q, 3) is None
+    zero = _prepare_skip_softmax_threshold(0.0, q, 3)
+    assert zero is not None
+    assert zero.shape == (3,)
+    assert zero.dtype == torch.float32
+    assert torch.equal(zero, torch.zeros(3))
+    threshold = _prepare_skip_softmax_threshold(2.0, q, 3)
+    assert torch.equal(threshold, torch.full((3,), 2.0))
+    with pytest.raises(ValueError, match="finite and >= 0"):
+        _prepare_skip_softmax_threshold(-1.0, q, 3)
+    with pytest.raises(ValueError, match="finite and >= 0"):
+        _prepare_skip_softmax_threshold(float("nan"), q, 3)
+    with pytest.raises(TypeError, match="None, a Python float, or a torch.Tensor"):
+        _prepare_skip_softmax_threshold(object(), q, 3)
+
+
+def test_skip_softmax_threshold_rejects_cpu_tensor():
+    q = torch.empty(1)
+    with pytest.raises(ValueError, match="must be a CUDA tensor"):
+        _prepare_skip_softmax_threshold(torch.zeros(2), q, 2)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_skip_softmax_threshold_tensor_metadata_validation():
+    q = torch.empty(1, device="cuda")
+    threshold = torch.zeros(2, device="cuda", dtype=torch.float32)
+    assert _prepare_skip_softmax_threshold(threshold, q, 2) is threshold
+    with pytest.raises(ValueError, match="dtype torch.float32"):
+        _prepare_skip_softmax_threshold(threshold.half(), q, 2)
+    with pytest.raises(ValueError, match=r"shape \(2,\)"):
+        _prepare_skip_softmax_threshold(threshold[:1], q, 2)
+    noncontiguous = torch.zeros(4, device="cuda", dtype=torch.float32)[::2]
+    with pytest.raises(ValueError, match="must be contiguous"):
+        _prepare_skip_softmax_threshold(noncontiguous, q, 2)
+
+
+def test_skip_softmax_is_exposed_only_by_direct_sm120_apis():
+    from flashinfer.prefill import (
+        BatchPrefillWithPagedKVCacheWrapper,
+        BatchPrefillWithRaggedKVCacheWrapper,
+    )
+
+    ragged = inspect.signature(sm120_fmha_fp8_ragged_prefill).parameters
+    paged = inspect.signature(sm120_fmha_fp8_paged_prefill).parameters
+    assert "skip_softmax_threshold" in ragged
+    assert "skip_softmax_threshold" in paged
+    assert "max_seqlen_k" not in ragged
+    assert "max_seqlen_kv" not in paged
+    assert "skip_softmax_threshold_scale_factor" not in ragged
+    assert "skip_softmax_threshold_scale_factor" not in paged
+
+    ragged_wrapper = inspect.signature(
+        BatchPrefillWithRaggedKVCacheWrapper.run
+    ).parameters
+    paged_wrapper = inspect.signature(
+        BatchPrefillWithPagedKVCacheWrapper.run
+    ).parameters
+    assert "skip_softmax_threshold_scale_factor" not in ragged_wrapper
+    assert "skip_softmax_threshold_scale_factor" in paged_wrapper
+
+
+def test_skip_softmax_has_a_distinct_jit_specialization(monkeypatch):
+    pytest.importorskip("cutlass.experimental")
+
+    from flashinfer.cute_dsl.attention.fmha.sm120.compile import (
+        compile_sm120_fmha_fp8_ragged_kernel,
+    )
+    from flashinfer.jit import cute_dsl_core
+
+    observed_names = []
+
+    def fake_build_and_load(module_name, kernel_name, compile_fn, **kwargs):
+        observed_names.append((module_name, kernel_name))
+        return kernel_name
+
+    compile_sm120_fmha_fp8_ragged_kernel.cache_clear()
+    monkeypatch.setattr(
+        torch.cuda, "get_device_capability", lambda device=None: (12, 0)
+    )
+    monkeypatch.setattr(
+        cute_dsl_core, "build_and_load_cute_dsl_kernel", fake_build_and_load
+    )
+
+    common = dict(
+        in_dtype=torch.float8_e4m3fn,
+        out_dtype=torch.bfloat16,
+        num_qo_heads=8,
+        num_kv_heads=8,
+        head_dim=128,
+        is_causal=False,
+        kv_tile=128,
+        q_tile=128,
+        device=torch.device("cuda"),
+    )
+    dense = compile_sm120_fmha_fp8_ragged_kernel(**common)
+    sparse = compile_sm120_fmha_fp8_ragged_kernel(**common, enable_skip_softmax=True)
+
+    assert dense != sparse
+    assert observed_names[0][1].endswith("_skip0")
+    assert observed_names[1][1].endswith("_skip1")
+    compile_sm120_fmha_fp8_ragged_kernel.cache_clear()

--- a/tests/attention/test_sm120_prims_prefill_backend.py
+++ b/tests/attention/test_sm120_prims_prefill_backend.py
@@ -315,6 +315,10 @@ def test_prims_fail_fast_for_unsupported_options():
     sinks = torch.zeros(hq, dtype=torch.float32, device="cuda")
     with pytest.raises(NotImplementedError, match="does not support attention sinks"):
         paged_wrapper.run(q, cache, sinks=sinks)
+    with pytest.raises(
+        NotImplementedError, match="skip_softmax_threshold_scale_factor"
+    ):
+        paged_wrapper.run(q, cache, skip_softmax_threshold_scale_factor=2.0)
 
     ragged_wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
         workspace, "NHD", backend="cute-dsl-prims"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Add opt-in skip-softmax to the SM120 CuTe DSL PRIMS FP8 ragged and paged prefill APIs, building on the merged #4714.

- The direct APIs accept `skip_softmax_threshold: Optional[Union[float, torch.Tensor]]`. A float supplies the final e-based threshold for every request; a contiguous CUDA float32 tensor of shape `[batch_size]` supplies one final threshold per request. There is no sequence-length normalization.
- A compute warp skips a K/V tile only when every valid row satisfies `exp((tile_max - running_max) * sm_scale) < threshold`. Skipping omits both online-softmax updates and PV MMA. The first visited tile always runs the initialization path.
- `None` selects the dense specialization. Any supplied threshold, including zero, selects the skip-enabled specialization; zero preserves dense behavior. Dynamic threshold loads follow the PDL dependency wait. Caller-owned threshold tensors can be updated in place between CUDA Graph replays.
- The D128 Q128/KV128 path uses a three-stage unified K/V TMA ring. V tiles are still transported and their pipeline barriers consumed when PV is skipped.
- Shared batch-prefill wrappers retain their existing APIs; skip-softmax through those wrappers remains unsupported for `cute-dsl-prims`.

The implementation is scoped to FP8 Q/K/V, with FP16/BF16 output. Tests cover API validation, JIT specialization, CUDA Graph/PDL, ragged/paged storage, and real skipping with output and log2 LSE checks for D64/D128/D256.

### D128 TMA pipeline optimization

One dedicated load warp prefetches the K/V tensor-map descriptors, initializes the arrived/consumed mbarriers, reduces its register allocation to 24, and issues asynchronous TMA copies into shared memory. TMA hardware transfers the tile payload; the load warp controls the copies and pipeline state. The compute warps receive 240 registers and consume the shared-memory stages.

Before this optimization, D128 used two type-fixed slots (`sK`, `sV`). After QK consumed `K0`, the producer could reload `K1` into the K slot while `V0` was still live, but startup held only `K0,V0`, `V1` remained blocked until `V0` was fully consumed, and every iteration serialized the producer through separate K-then-V consumed waits.

The optimized path treats K and V as one ordered three-slot ring. Its initial contents are logically `K0, V0, K1`; afterwards the producer waits only when it wraps around and reuses a consumed slot. For FP8 D128, one 128x128 operand tile is 16 KiB, so the ring uses 3x16 KiB = 48 KiB of shared memory. This adds K lookahead and overlaps TMA transport with QK/softmax/PV work without changing attention math.

The optimization does not yet suppress V transport for skipped tiles: tensor work and memory traffic measurements below remain effectively unchanged. The gain comes from overlap and reduced producer/consumer serialization.

### RTX PRO 5000 performance

Synthetic controlled-skip microbenchmark, not an end-to-end model claim:

| Realized tile skip fraction | Dense | Skip specialization | Speedup vs dense | max abs | relative L2 |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 0.000000 | 235.425 ms | 245.553 ms | 0.9588x | 0 | 0 |
| 0.248996 | 237.767 ms | 214.058 ms | 1.1108x | 0 | 0 |
| 0.500000 | 237.781 ms | 180.761 ms | 1.3154x | 0.00012207 | 0.000340933 |
| 0.748996 | 237.200 ms | 147.742 ms | 1.6055x | 0.000244141 | 0.00058125 |
| 0.899598 | 236.882 ms | 128.137 ms | 1.8487x | 0.000244141 | 0.000673415 |
| 0.989960 | 236.825 ms | 116.889 ms | 2.0261x | 0.000976562 | 0.00265553 |
| 0.997992 | 236.632 ms | 115.881 ms | 2.0420x | 0.00390625 | 0.00593319 |

At zero skipped tiles the specialization costs 4.1%; the measured crossover is below 25% skipped tiles. The feature remains explicitly opt-in through its threshold argument.

Configuration: SM120 RTX PRO 5000, GPU 6, driver 580.95.05, CUDA 13.0, torch 2.11.0+cu130, nvidia-cutlass-dsl 4.7.1, batch 1, ragged non-causal attention, q_len=kv_len=63744, 56 Q/KV heads, head_dim=128, Q/KV tile 128x128, FP8 E4M3 Q/K/V, BF16 output, legacy threshold scale factor 1.0 (equivalent to final `skip_softmax_threshold=1/63744` with the current API), 5 warmups, 30 repeats, warm L2, CUDA-event timing because CUPTI Python timing was unavailable.

#### Same-GPU schedule A/B

| Mode | Two-stage baseline | Three-stage | Three-stage improvement |
| --- | ---: | ---: | ---: |
| Dense | 261.852 ms | 232.138 ms | 1.128x |
| Skip specialization, no tiles skipped | 269.336 ms | 239.996 ms | 1.122x |
| Skip specialization, 99.8% tiles skipped | 176.888 ms | 115.325 ms | 1.534x |
| Active-skip speedup vs its own dense | 1.480x | 2.013x | +0.533x |

The three-stage schedule reduces active-skip latency by 34.8% relative to the two-stage implementation. The following Nsight Compute metrics are for active skip on the same GPU and shape:

| NCU metric | Two-stage | Three-stage |
| --- | ---: | ---: |
| Duration | 176.888 ms | 115.325 ms |
| SM throughput | 56.13% | 86.34% |
| Issue active | 12.99% | 22.94% |
| Eligible warps | 0.18 | 0.29 |
| Long-scoreboard stall | 5.71% | 3.87% |
| Wait stall | 22.77% | 34.71% |
| Math-pipe throttle | 28.89% | 32.91% |
| MIO throttle | 6.33% | 0.04% |
| Barrier stall | 0.01% | 0.05% |
| Tensor work ratio vs dense | 0.501 | 0.501 |
| L2 traffic | 425.148 GiB | 425.150 GiB |
| DRAM read | 1.291 GiB | 1.292 GiB |

The key changes are higher SM utilization and issue activity, more eligible warps, lower long-scoreboard stalls, and the near-elimination of MIO throttling. The higher wait-stall percentage is a share of a much shorter kernel and is not an increase in absolute runtime. Stable tensor work and traffic show that the result is a scheduling improvement, not less input data or a changed skip decision.

Measured kernel commit: `9965a38b483847f0d770bbbe72ff50bc8fc9e3b6`; fraction-sweep runner commit: `b68dd3b45d8b23ca5213579c6fd94e54e123217f`. These are historical pipeline measurements taken before the direct-threshold API and PDL updates. The current revision has been correctness-tested as described below; these performance measurements were not rerun for the test-only follow-up.

Result roots:

- three-stage benchmark: `/lustre/raplab/client/sylarl/sm120-d128-three-stage-results/20260901T043127Z`;
- three-stage NCU: `/lustre/raplab/client/sylarl/sm120-d128-three-stage-ncu/20260901T043326Z`;
- two-stage baseline NCU: `/lustre/raplab/client/sylarl/sm120-d128-two-stage-baseline-ncu/20260901T043500Z`;
- skip-fraction sweep: `/lustre/raplab/client/sylarl/sm120-d128-three-stage-fraction-sweep`.

## 🔍 Related Issues

- Builds on #4714 (merged).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually on changed files and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.). Full upstream GPU CI still requires authorization.

Local validation on 2026-09-17: SM120 GPU (reported as NVIDIA Graphics Device, compute capability 12.0), driver 580.95.05, CUDA 13.0, PyTorch 2.13.0+cu130, nvidia-cutlass-dsl 4.7.1.

```bash
python -m pytest tests/attention/test_sm120_fmha.py \
  tests/attention/test_sm120_fmha_api.py \
  tests/attention/test_sm120_prims_prefill_backend.py -v
```

- **56 passed** across the three files; the targeted paged/causal skip selection passed all 9 cases.
- Paged real-skip tests cover D64/D128/D256, non-identity page tables, and both output and log2 LSE.
- Causal real-skip tests cover ragged and paged storage at D64/D128/D256, GQA, Q128/KV128, rectangular Q/K lengths (129/449), partial Q/K tails, and a non-initial masked-frontier skip.
- `pre-commit run --files tests/attention/test_sm120_fmha.py` and `git diff --check`: passed.

The previous upstream Test Results Summary failed because CI was skipped pending authorization, before any GPU test ran. An authorized maintainer must start public CI for the new head.

## Reviewer Notes

Please focus on the warp-uniform skip predicate, D128/D256 ring stage and phase progression, and V-barrier consumption on skipped tiles.

The new causal fixture has a bottom-right offset of 320. In its first Q CTA, rows 0–63 see an entirely masked first K tile and must initialize on the second frontier tile; rows 64–127 initialize on the first tile and skip the second while `is_masked_frontier_tile=True` and `uses_softmax_init_path=False`. Tile-specific V values and analytic retained-token LSE make real skipping observable. The extra Q row and partially populated last page cover tail masking.
