### PR TITLE
fix: honor per-request seed/offset in sampling kernels

### DIFF
--- a/csrc/sampling.cu
+++ b/csrc/sampling.cu
@@ -22,10 +22,14 @@ using namespace flashinfer;
 
 using tvm::ffi::Optional;
 
-// Helper function to validate seed/offset tensors for sampling operations
-inline void validate_seed_offset_tensors(const Optional<TensorView>& maybe_seed_arr,
+// Helper function to validate seed/offset tensors for sampling operations.
+// Returns whether the seed/offset tensors broadcast to the whole batch, i.e. whether they hold a
+// single entry rather than one per request. The kernels index them by blockIdx.x otherwise, so a
+// wrong length here would be an out-of-bounds read.
+inline bool validate_seed_offset_tensors(const Optional<TensorView>& maybe_seed_arr,
                                          const Optional<TensorView>& maybe_offset_arr,
-                                         const TensorView& reference_tensor) {
+                                         const TensorView& reference_tensor, int64_t batch_size) {
+  bool broadcast_seed_offset = true;
   if (maybe_seed_arr.has_value()) {
     CHECK_INPUT(maybe_seed_arr.value());
     CHECK_DIM(1, maybe_seed_arr.value());
@@ -33,6 +37,10 @@ inline void validate_seed_offset_tensors(const Optional<TensorView>& maybe_seed_
                    maybe_seed_arr.value().dtype() == dl_uint64)
         << "seed tensor must be int64 or uint64";
     CHECK_DEVICE(maybe_seed_arr.value(), reference_tensor);
+    const int64_t seed_size = maybe_seed_arr.value().size(0);
+    TVM_FFI_ICHECK(seed_size == 1 || seed_size == batch_size)
+        << "seed tensor length must be 1 or " << batch_size << ", got " << seed_size;
+    broadcast_seed_offset = seed_size == 1;
   }
   if (maybe_offset_arr.has_value()) {
     CHECK_INPUT(maybe_offset_arr.value());
@@ -41,7 +49,15 @@ inline void validate_seed_offset_tensors(const Optional<TensorView>& maybe_seed_
                    maybe_offset_arr.value().dtype() == dl_uint64)
         << "offset tensor must be int64 or uint64";
     CHECK_DEVICE(maybe_offset_arr.value(), reference_tensor);
+    const int64_t offset_size = maybe_offset_arr.value().size(0);
+    TVM_FFI_ICHECK(offset_size == 1 || offset_size == batch_size)
+        << "offset tensor length must be 1 or " << batch_size << ", got " << offset_size;
+    // seed and offset are supplied together, so they must agree on the layout.
+    TVM_FFI_ICHECK(!maybe_seed_arr.has_value() || offset_size == maybe_seed_arr.value().size(0))
+        << "seed and offset tensors must have the same length";
+    broadcast_seed_offset = offset_size == 1;
   }
+  return broadcast_seed_offset;
 }
 
 void softmax(TensorView workspace_buffer, TensorView logits, TensorView output,
@@ -75,10 +91,11 @@ void sampling_from_logits(TensorView logits, TensorView output, Optional<TensorV
   CHECK_DIM(2, logits);  // logits: (batch_size, vocab_size)
   CHECK_MAYBE_INPUT_TYPES(maybe_indices, dl_int32, dl_int64);
   CHECK_MAYBE_SAME_DTYPE(maybe_indices, output);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, logits);
-
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = logits.size(1);
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, logits, batch_size);
 
   ffi::CUDADeviceGuard device_guard(logits.device().device_id);
   auto stream = get_stream(logits.device());
@@ -94,7 +111,7 @@ void sampling_from_logits(TensorView logits, TensorView output, Optional<TensorV
         seed_val,
         maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                      : nullptr,
-        offset_val, stream);
+        offset_val, broadcast_seed_offset, stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "SamplingFromLogits failed with error code " << cudaGetErrorString(status);
     return true;
@@ -112,10 +129,11 @@ void sampling_from_probs(TensorView probs, TensorView output, TensorView valid,
   CHECK_DEVICE(valid, probs);
   CHECK_MAYBE_INPUT_TYPES(maybe_indices, dl_int32, dl_int64);
   CHECK_MAYBE_SAME_DTYPE(maybe_indices, output);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs);
-
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = probs.size(1);
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs, batch_size);
 
   ffi::CUDADeviceGuard device_guard(probs.device().device_id);
   auto stream = get_stream(probs.device());
@@ -132,7 +150,7 @@ void sampling_from_probs(TensorView probs, TensorView output, TensorView valid,
         seed_val,
         maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                      : nullptr,
-        offset_val, stream);
+        offset_val, broadcast_seed_offset, stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "SamplingFromProbs failed with error code " << cudaGetErrorString(status);
     return true;
@@ -152,10 +170,11 @@ void top_p_sampling_from_probs(TensorView probs, TensorView output, TensorView v
   CHECK_DEVICE(valid, probs);
   CHECK_MAYBE_INPUT_TYPES(maybe_indices, dl_int32, dl_int64);
   CHECK_MAYBE_SAME_DTYPE(maybe_indices, output);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs);
-
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = probs.size(1);
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs, batch_size);
   check_tensor_param(maybe_top_p_arr, probs);
   bool has_top_p_arr = maybe_top_p_arr.has_value();
 
@@ -175,7 +194,7 @@ void top_p_sampling_from_probs(TensorView probs, TensorView output, TensorView v
         seed_val,
         maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                      : nullptr,
-        offset_val, stream);
+        offset_val, broadcast_seed_offset, stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "TopPSamplingFromProbs failed with error code " << cudaGetErrorString(status);
     return true;
@@ -198,10 +217,11 @@ void top_k_sampling_from_probs(TensorView probs, TensorView output, TensorView v
   CHECK_DEVICE(valid, probs);
   CHECK_MAYBE_INPUT_TYPES(maybe_indices, dl_int32, dl_int64);
   CHECK_MAYBE_SAME_DTYPE(maybe_indices, output);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs);
-
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = probs.size(1);
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs, batch_size);
   check_tensor_param(maybe_top_k_arr, probs);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
 
@@ -221,7 +241,7 @@ void top_k_sampling_from_probs(TensorView probs, TensorView output, TensorView v
         seed_val,
         maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                      : nullptr,
-        offset_val, stream);
+        offset_val, broadcast_seed_offset, stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "TopKSamplingFromProbs failed with error code " << cudaGetErrorString(status);
     return true;
@@ -244,10 +264,11 @@ void min_p_sampling_from_probs(TensorView probs, TensorView output, TensorView v
   CHECK_DEVICE(valid, probs);
   CHECK_MAYBE_INPUT_TYPES(maybe_indices, dl_int32, dl_int64);
   CHECK_MAYBE_SAME_DTYPE(maybe_indices, output);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs);
-
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = probs.size(1);
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs, batch_size);
   check_tensor_param(maybe_min_p_arr, probs);
   bool has_min_p_arr = maybe_min_p_arr.has_value();
 
@@ -267,7 +288,7 @@ void min_p_sampling_from_probs(TensorView probs, TensorView output, TensorView v
         seed_val,
         maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                      : nullptr,
-        offset_val, stream);
+        offset_val, broadcast_seed_offset, stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "MinPSamplingFromProb failed with error code " << cudaGetErrorString(status);
     return true;
@@ -291,10 +312,11 @@ void top_k_top_p_sampling_from_probs(TensorView probs, TensorView output, Tensor
   CHECK_DEVICE(valid, probs);
   CHECK_MAYBE_INPUT_TYPES(maybe_indices, dl_int32, dl_int64);
   CHECK_MAYBE_SAME_DTYPE(maybe_indices, output);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs);
-
   unsigned int batch_size = output.size(0);
   unsigned int vocab_size = probs.size(1);
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, probs, batch_size);
   check_tensor_param(maybe_top_k_arr, probs);
   check_tensor_param(maybe_top_p_arr, probs);
   bool has_top_k_arr = maybe_top_k_arr.has_value();
@@ -317,7 +339,7 @@ void top_k_top_p_sampling_from_probs(TensorView probs, TensorView output, Tensor
         seed_val,
         maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                      : nullptr,
-        offset_val, stream);
+        offset_val, broadcast_seed_offset, stream);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "TopKTopPSamplingFromProbs failed with error code " << cudaGetErrorString(status);
     return true;
@@ -335,8 +357,6 @@ void chain_speculative_sampling(TensorView draft_probs, TensorView draft_token_i
   CHECK_INPUT(target_probs);
   CHECK_DEVICE(draft_token_ids, draft_probs);
   CHECK_DEVICE(target_probs, draft_probs);
-  validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, draft_probs);
-
   CHECK_DIM(3, draft_probs);      // draft_probs: (batch_size, num_speculate_tokens, vocab_size)
   CHECK_DIM(2, draft_token_ids);  // draft_token_ids: (batch_size, num_speculate_tokens)
   CHECK_DIM(3, target_probs);  // target_probs: (batch_size, num_speculate_tokens + 1, vocab_size)
@@ -349,6 +369,9 @@ void chain_speculative_sampling(TensorView draft_probs, TensorView draft_token_i
   TVM_FFI_ICHECK_EQ(vocab_size, target_probs.size(2));
   TVM_FFI_ICHECK_EQ(batch_size, output_accepted_token_num.size(0));
   TVM_FFI_ICHECK_EQ(batch_size, output_emitted_draft_token_num.size(0));
+
+  const bool broadcast_seed_offset =
+      validate_seed_offset_tensors(maybe_seed_arr, maybe_offset_arr, draft_probs, batch_size);
 
   ffi::CUDADeviceGuard device_guard(draft_probs.device().device_id);
   auto stream = get_stream(draft_probs.device());
@@ -363,7 +386,7 @@ void chain_speculative_sampling(TensorView draft_probs, TensorView draft_token_i
       seed_val,
       maybe_offset_arr.has_value() ? static_cast<uint64_t*>(maybe_offset_arr.value().data_ptr())
                                    : nullptr,
-      offset_val, stream);
+      offset_val, broadcast_seed_offset, stream);
 
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "ChainSpeculativeSampling failed with error code " << cudaGetErrorString(status);

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -730,6 +730,15 @@ def _validate_and_convert_seed_offset(
         if maybe_offset_arr.size(0) not in [1, batch_size]:
             raise ValueError(f"offset tensor length must be 1 or {batch_size}")
 
+    # Both are indexed by the same row index in the kernel, so a length-1 seed paired with a
+    # per-row offset (or vice versa) would silently mean two different things per row.
+    if maybe_seed_arr is not None and maybe_offset_arr is not None:
+        if maybe_seed_arr.size(0) != maybe_offset_arr.size(0):
+            raise ValueError(
+                "seed and offset tensors must have the same length, got "
+                f"{maybe_seed_arr.size(0)} and {maybe_offset_arr.size(0)}"
+            )
+
     return maybe_seed_arr, seed_val, maybe_offset_arr, offset_val
 
 
@@ -827,6 +836,8 @@ def sampling_from_logits(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -836,6 +847,8 @@ def sampling_from_logits(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -907,6 +920,8 @@ def sampling_from_probs(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -916,6 +931,8 @@ def sampling_from_probs(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1018,6 +1035,8 @@ def top_p_sampling_from_probs(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1027,6 +1046,8 @@ def top_p_sampling_from_probs(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1138,6 +1159,8 @@ def top_k_sampling_from_probs(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1147,6 +1170,8 @@ def top_k_sampling_from_probs(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1259,6 +1284,8 @@ def min_p_sampling_from_probs(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1268,6 +1295,8 @@ def min_p_sampling_from_probs(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1473,6 +1502,8 @@ def top_k_top_p_sampling_from_logits(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1482,6 +1513,8 @@ def top_k_top_p_sampling_from_logits(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1632,6 +1665,8 @@ def top_k_top_p_sampling_from_probs(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -1641,6 +1676,8 @@ def top_k_top_p_sampling_from_probs(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -2025,6 +2062,8 @@ def chain_speculative_sampling(
     seed: Optional[Union[int, torch.Tensor]]
         Random seed value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating
@@ -2034,6 +2073,8 @@ def chain_speculative_sampling(
     offset: Optional[Union[int, torch.Tensor]]
         Random offset value for the sampling operation. Can be either an integer or a torch.Tensor.
         When provided as a torch.Tensor, it must be int64 or uint64 dtype, 1D, and length 1 or batch_size.
+        A length-``batch_size`` tensor gives each request its own value; a length-1 tensor is
+        broadcast to the whole batch. seed and offset must have the same length.
         Using torch.Tensor is required for CUDA graph compatibility.
 
         Warning: If you provide seed and offset explicitly, you are responsible for updating

--- a/include/flashinfer/sampling.cuh
+++ b/include/flashinfer/sampling.cuh
@@ -676,6 +676,21 @@ struct DataAndIndex {
   }
 };
 
+// Resolve the Philox seed/offset for one batch row. Per-request tensors carry one entry per
+// row and are indexed by blockIdx.x, matching the convention used by the other per-request
+// arrays here (e.g. top_k_arr). A length-1 tensor broadcasts to every row, which the Python
+// layer permits as the tensor spelling of a scalar seed; broadcast is resolved here rather
+// than by materializing an expanded tensor so the caller stays CUDA-graph friendly.
+__device__ __forceinline__ void ResolvePhiloxSeedOffset(uint64_t* seed_arr, uint64_t seed_val,
+                                                        uint64_t* offset_arr, uint64_t offset_val,
+                                                        bool broadcast_seed_offset, uint32_t bx,
+                                                        uint64_t* philox_seed,
+                                                        uint64_t* philox_offset) {
+  const uint32_t idx = broadcast_seed_offset ? 0 : bx;
+  *philox_seed = seed_arr ? seed_arr[idx] : seed_val;
+  *philox_offset = offset_arr ? offset_arr[idx] : offset_val;
+}
+
 template <typename DType, uint32_t VEC_SIZE>
 __device__ __forceinline__ vec_t<DType, VEC_SIZE> GenerateGumbelNoise(uint64_t philox_seed,
                                                                       uint64_t philox_offset,
@@ -735,12 +750,13 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           typename DType, typename IdType>
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void SamplingFromLogitsKernel(
     DType* logits, IdType* output, IdType* indices, uint32_t d, uint64_t* seed_arr,
-    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val, bool broadcast_seed_offset) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
   using SharedMem = typename BlockReduce<DataAndIndex<DType, IdType>, BLOCK_THREADS,
@@ -784,13 +800,14 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           typename DType, typename IdType>
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void SamplingFromProbKernel(
     DType* probs, IdType* output, bool* valid, IdType* indices, uint32_t d, uint64_t* seed_arr,
-    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val, bool broadcast_seed_offset) {
   curandStatePhilox4_32_10_t state;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   curand_init(philox_seed, bx, philox_offset, &state);
   const uint32_t row_idx = indices == nullptr ? bx : indices[bx];
@@ -849,13 +866,14 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKSamplingFromProbKernel(
     DType* probs, IdType* output, bool* valid, IdType* indices, IdType* top_k_arr,
     uint32_t top_k_val, uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
-    uint64_t offset_val) {
+    uint64_t offset_val, bool broadcast_seed_offset) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   curandStatePhilox4_32_10_t state;
   curand_init(philox_seed, bx, philox_offset, &state);
@@ -981,13 +999,15 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           typename DType, typename IdType>
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopPSamplingFromProbKernel(
     DType* probs, IdType* output, bool* valid, IdType* indices, float* top_p_arr, float top_p_val,
-    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val,
+    bool broadcast_seed_offset) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   curandStatePhilox4_32_10_t state;
   curand_init(philox_seed, bx, philox_offset, &state);
@@ -1107,12 +1127,14 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
           typename DType, typename IdType>
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void MinPSamplingFromProbKernel(
     DType* probs, float* min_p_arr, IdType* output, bool* valid, IdType* indices, float min_p_val,
-    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val) {
+    uint32_t d, uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val,
+    bool broadcast_seed_offset) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   float p = (min_p_arr == nullptr) ? min_p_val : min_p_arr[bx];
   curandStatePhilox4_32_10_t state;
@@ -1202,13 +1224,14 @@ template <uint32_t BLOCK_THREADS, BlockScanAlgorithm SCAN_ALGORITHM,
 __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void TopKTopPSamplingFromProbKernel(
     DType* probs, IdType* top_k_arr, float* top_p_arr, IdType* output, bool* valid, IdType* indices,
     IdType top_k_val, float top_p_val, uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-    uint64_t* offset_arr, uint64_t offset_val) {
+    uint64_t* offset_arr, uint64_t offset_val, bool broadcast_seed_offset) {
   const uint32_t batch_size = gridDim.x;
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   curandStatePhilox4_32_10_t state;
   curand_init(philox_seed, bx, philox_offset, &state);
@@ -1476,14 +1499,16 @@ template <typename T, typename IdType>
 cudaError_t SamplingFromLogits(T* logits, IdType* output, IdType* indices, uint32_t batch_size,
                                uint32_t d, bool deterministic, uint64_t* seed_arr,
                                uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val,
-                               cudaStream_t stream = 0) {
+                               bool broadcast_seed_offset, cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
   DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&logits, &output, &indices, &d, &seed_arr, &seed_val, &offset_arr, &offset_val};
+    void* args[] = {&logits,     &output,     &indices,
+                    &d,          &seed_arr,   &seed_val,
+                    &offset_arr, &offset_val, &broadcast_seed_offset};
     const uint32_t smem_size = sizeof(
         typename BlockReduce<DataAndIndex<T, IdType>, BLOCK_THREADS, REDUCE_ALGO>::TempStorage);
 
@@ -1502,15 +1527,16 @@ template <typename T, typename IdType>
 cudaError_t SamplingFromProb(T* probs, IdType* output, bool* valid, IdType* indices,
                              uint32_t batch_size, uint32_t d, bool deterministic,
                              uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
-                             uint64_t offset_val, cudaStream_t stream = 0) {
+                             uint64_t offset_val, bool broadcast_seed_offset,
+                             cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
   DISPATCH_COMPUTE_CAP_NUM_THREADS(compute_capacity, BLOCK_THREADS, {
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs,    &output,   &valid,      &indices,   &d,
-                    &seed_arr, &seed_val, &offset_arr, &offset_val};
+    void* args[] = {&probs,    &output,   &valid,      &indices,    &d,
+                    &seed_arr, &seed_val, &offset_arr, &offset_val, &broadcast_seed_offset};
     const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
 
     DISPATCH_ALIGNED_VEC_SIZE(
@@ -1529,7 +1555,7 @@ cudaError_t TopKSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* 
                                  T* top_k_arr, uint32_t batch_size, uint32_t top_k_val, uint32_t d,
                                  bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
                                  uint64_t* offset_arr, uint64_t offset_val,
-                                 cudaStream_t stream = 0) {
+                                 bool broadcast_seed_offset, cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
@@ -1537,8 +1563,8 @@ cudaError_t TopKSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* 
     const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &output,   &valid,    &indices,    &top_k_arr, &top_k_val,
-                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val};
+    void* args[] = {&probs, &output,   &valid,    &indices,    &top_k_arr,  &top_k_val,
+                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val, &broadcast_seed_offset};
 
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -1558,7 +1584,7 @@ cudaError_t TopPSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* 
                                  T* top_p_arr, uint32_t batch_size, T top_p_val, uint32_t d,
                                  bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
                                  uint64_t* offset_arr, uint64_t offset_val,
-                                 cudaStream_t stream = 0) {
+                                 bool broadcast_seed_offset, cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
@@ -1566,8 +1592,8 @@ cudaError_t TopPSamplingFromProb(T* probs, IdType* output, bool* valid, IdType* 
     const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &output,   &valid,    &indices,    &top_p_arr, &top_p_val,
-                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val};
+    void* args[] = {&probs, &output,   &valid,    &indices,    &top_p_arr,  &top_p_val,
+                    &d,     &seed_arr, &seed_val, &offset_arr, &offset_val, &broadcast_seed_offset};
 
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -1587,7 +1613,7 @@ cudaError_t MinPSamplingFromProb(T* probs, T* min_p_arr, IdType* output, bool* v
                                  IdType* indices, uint32_t batch_size, float min_p_val, uint32_t d,
                                  bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
                                  uint64_t* offset_arr, uint64_t offset_val,
-                                 cudaStream_t stream = 0) {
+                                 bool broadcast_seed_offset, cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
@@ -1595,8 +1621,9 @@ cudaError_t MinPSamplingFromProb(T* probs, T* min_p_arr, IdType* output, bool* v
     const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs, &min_p_arr, &output,   &valid,      &indices,   &min_p_val,
-                    &d,     &seed_arr,  &seed_val, &offset_arr, &offset_val};
+    void* args[] = {&probs,    &min_p_arr,  &output,     &valid,
+                    &indices,  &min_p_val,  &d,          &seed_arr,
+                    &seed_val, &offset_arr, &offset_val, &broadcast_seed_offset};
 
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -1616,7 +1643,8 @@ cudaError_t TopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, 
                                      bool* valid, IdType* indices, uint32_t batch_size,
                                      IdType top_k_val, T top_p_val, uint32_t d, bool deterministic,
                                      uint64_t* seed_arr, uint64_t seed_val, uint64_t* offset_arr,
-                                     uint64_t offset_val, cudaStream_t stream = 0) {
+                                     uint64_t offset_val, bool broadcast_seed_offset,
+                                     cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(T), d);
 
   auto compute_capacity = GetCudaComputeCapability();
@@ -1624,9 +1652,13 @@ cudaError_t TopKTopPSamplingFromProb(T* probs, IdType* top_k_arr, T* top_p_arr, 
     const uint32_t smem_size = sizeof(SamplingTempStorage<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO>);
     dim3 nblks(batch_size);
     dim3 nthrs(BLOCK_THREADS);
-    void* args[] = {&probs,    &top_k_arr,  &top_p_arr, &output, &valid,
-                    &indices,  &top_k_val,  &top_p_val, &d,      &seed_arr,
-                    &seed_val, &offset_arr, &offset_val};
+    void* args[] = {&probs,      &top_k_arr,
+                    &top_p_arr,  &output,
+                    &valid,      &indices,
+                    &top_k_val,  &top_p_val,
+                    &d,          &seed_arr,
+                    &seed_val,   &offset_arr,
+                    &offset_val, &broadcast_seed_offset};
 
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
@@ -1870,13 +1902,14 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void ChainSpeculativ
     DType* draft_probs, IdType* draft_token_ids, DType* target_probs, IdType* output_token_ids,
     IdType* output_accepted_token_num, IdType* output_emitted_draft_token_num,
     uint32_t num_speculative_tokens, uint32_t d, uint64_t* seed_arr, uint64_t seed_val,
-    uint64_t* offset_arr, uint64_t offset_val) {
+    uint64_t* offset_arr, uint64_t offset_val, bool broadcast_seed_offset) {
   const uint32_t bx = blockIdx.x, tx = threadIdx.x;
   const uint32_t row_idx = bx;
 
   // Resolve seed/offset from tensor or scalar
-  uint64_t philox_seed = seed_arr ? seed_arr[0] : seed_val;
-  uint64_t philox_offset = offset_arr ? offset_arr[0] : offset_val;
+  uint64_t philox_seed, philox_offset;
+  ResolvePhiloxSeedOffset(seed_arr, seed_val, offset_arr, offset_val, broadcast_seed_offset, bx,
+                          &philox_seed, &philox_offset);
 
   curandStatePhilox4_32_10_t curand_state;
   curand_init(philox_seed, bx, philox_offset, &curand_state);
@@ -2004,11 +2037,14 @@ __global__ FLASHINFER_SAMPLING_LAUNCH_BOUNDS(BLOCK_THREADS) void ChainSpeculativ
 }
 
 template <typename DType, typename IdType>
-cudaError_t ChainSpeculativeSampling(
-    DType* draft_probs, IdType* draft_token_ids, DType* target_probs, IdType* output_token_ids,
-    IdType* output_accepted_token_num, IdType* output_emitted_draft_token_num, uint32_t batch_size,
-    uint32_t num_speculative_tokens, uint32_t d, bool deterministic, uint64_t* seed_arr,
-    uint64_t seed_val, uint64_t* offset_arr, uint64_t offset_val, cudaStream_t stream = 0) {
+cudaError_t ChainSpeculativeSampling(DType* draft_probs, IdType* draft_token_ids,
+                                     DType* target_probs, IdType* output_token_ids,
+                                     IdType* output_accepted_token_num,
+                                     IdType* output_emitted_draft_token_num, uint32_t batch_size,
+                                     uint32_t num_speculative_tokens, uint32_t d,
+                                     bool deterministic, uint64_t* seed_arr, uint64_t seed_val,
+                                     uint64_t* offset_arr, uint64_t offset_val,
+                                     bool broadcast_seed_offset, cudaStream_t stream = 0) {
   const uint32_t vec_size = std::gcd(16 / sizeof(DType), d);
 
   auto compute_capacity = GetCudaComputeCapability();
@@ -2027,7 +2063,8 @@ cudaError_t ChainSpeculativeSampling(
                     &seed_arr,
                     &seed_val,
                     &offset_arr,
-                    &offset_val};
+                    &offset_val,
+                    &broadcast_seed_offset};
     DISPATCH_ALIGNED_VEC_SIZE(
         vec_size, VEC_SIZE, {DISPATCH_DETERMINISTIC(deterministic, DETERMINISTIC, {
           auto kernel = ChainSpeculativeSampling<BLOCK_THREADS, SCAN_ALGO, REDUCE_ALGO, VEC_SIZE,

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -1197,6 +1197,221 @@ def test_sampling_nan_input(batch_size, vocab_size):
     check_result(result, valid)
 
 
+_PER_REQUEST_SAMPLERS = [
+    "from_probs",
+    "from_logits",
+    "top_p",
+    "top_k",
+    "min_p",
+    "top_k_top_p",
+]
+
+
+def _sample_with_seed(sampling_type, probs, logits, seed, offset):
+    """Dispatch one sampler with explicit seed/offset (scalars or per-row tensors)."""
+    k = min(100, probs.size(-1))
+    if sampling_type == "from_probs":
+        return flashinfer.sampling.sampling_from_probs(probs, seed=seed, offset=offset)
+    if sampling_type == "from_logits":
+        return flashinfer.sampling.sampling_from_logits(
+            logits, seed=seed, offset=offset
+        )
+    if sampling_type == "top_p":
+        return flashinfer.sampling.top_p_sampling_from_probs(
+            probs, 0.9, seed=seed, offset=offset
+        )
+    if sampling_type == "top_k":
+        return flashinfer.sampling.top_k_sampling_from_probs(
+            probs, k, seed=seed, offset=offset
+        )
+    if sampling_type == "min_p":
+        return flashinfer.sampling.min_p_sampling_from_probs(
+            probs, 0.1, seed=seed, offset=offset
+        )
+    if sampling_type == "top_k_top_p":
+        return flashinfer.sampling.top_k_top_p_sampling_from_probs(
+            probs, k, 0.9, filter_apply_order="joint", seed=seed, offset=offset
+        )
+    raise ValueError(sampling_type)
+
+
+@pytest.mark.parametrize("sampling_type", _PER_REQUEST_SAMPLERS)
+@pytest.mark.parametrize("vocab_size", [111, 32000])
+def test_per_request_seed_selects_that_rows_stream(sampling_type, vocab_size):
+    """Each row must use the seed its caller gave for that row, not row 0's.
+
+    Note the kernels already vary the Philox *subsequence* by row, so two rows sharing a seed
+    still differ; that is by design and not what is under test here. What must hold is that a
+    row's sample depends on its own seed entry: running with a mixed seed tensor must equal
+    running each half separately with the corresponding scalar seed. Before per-row indexing
+    every row used seed_arr[0], so the second half matched the wrong scalar run.
+    """
+    torch.manual_seed(42)
+    batch_size = 64
+    logits = torch.randn(batch_size, vocab_size, device="cuda:0")
+    probs = torch.softmax(logits, dim=-1)
+
+    seed_a, seed_b = 12345, 67890
+    all_a = _sample_with_seed(sampling_type, probs, logits, seed_a, 0)
+    all_b = _sample_with_seed(sampling_type, probs, logits, seed_b, 0)
+
+    half = batch_size // 2
+    seed = torch.tensor(
+        [seed_a] * half + [seed_b] * (batch_size - half),
+        dtype=torch.int64,
+        device="cuda:0",
+    )
+    offset = torch.zeros(batch_size, dtype=torch.int64, device="cuda:0")
+    mixed = _sample_with_seed(sampling_type, probs, logits, seed, offset)
+
+    expected = torch.cat([all_a[:half], all_b[half:]])
+    assert torch.all(mixed == expected), (
+        "each row must sample from the stream selected by its own seed entry"
+    )
+
+
+@pytest.mark.parametrize("sampling_type", _PER_REQUEST_SAMPLERS)
+@pytest.mark.parametrize("vocab_size", [111, 32000])
+def test_per_request_offset_selects_that_rows_stream(sampling_type, vocab_size):
+    """Same as above for offset: a row must advance by its own offset entry."""
+    torch.manual_seed(42)
+    batch_size = 64
+    logits = torch.randn(batch_size, vocab_size, device="cuda:0")
+    probs = torch.softmax(logits, dim=-1)
+
+    offset_a, offset_b = 0, 8192
+    all_a = _sample_with_seed(sampling_type, probs, logits, 12345, offset_a)
+    all_b = _sample_with_seed(sampling_type, probs, logits, 12345, offset_b)
+
+    half = batch_size // 2
+    seed = torch.full((batch_size,), 12345, dtype=torch.int64, device="cuda:0")
+    offset = torch.tensor(
+        [offset_a] * half + [offset_b] * (batch_size - half),
+        dtype=torch.int64,
+        device="cuda:0",
+    )
+    mixed = _sample_with_seed(sampling_type, probs, logits, seed, offset)
+
+    expected = torch.cat([all_a[:half], all_b[half:]])
+    assert torch.all(mixed == expected), (
+        "each row must sample from the stream selected by its own offset entry"
+    )
+
+
+@pytest.mark.parametrize("sampling_type", _PER_REQUEST_SAMPLERS)
+@pytest.mark.parametrize("batch_size", [1, 19, 99])
+@pytest.mark.parametrize("vocab_size", [111, 32000])
+def test_length_one_seed_tensor_matches_scalar(sampling_type, batch_size, vocab_size):
+    """A length-1 seed/offset tensor is the tensor spelling of a scalar seed.
+
+    It must broadcast to every row and reproduce the scalar path exactly, which is what keeps
+    existing length-1 callers unaffected by per-row indexing.
+    """
+    torch.manual_seed(42)
+    logits = torch.randn(batch_size, vocab_size, device="cuda:0")
+    probs = torch.softmax(logits, dim=-1)
+
+    scalar = _sample_with_seed(sampling_type, probs, logits, 12345, 0)
+    tensor = _sample_with_seed(
+        sampling_type,
+        probs,
+        logits,
+        torch.tensor([12345], dtype=torch.int64, device="cuda:0"),
+        torch.tensor([0], dtype=torch.int64, device="cuda:0"),
+    )
+
+    assert torch.all(scalar == tensor), (
+        "length-1 seed/offset tensors must broadcast and match the scalar path"
+    )
+
+
+@pytest.mark.parametrize("sampling_type", _PER_REQUEST_SAMPLERS)
+@pytest.mark.parametrize("vocab_size", [111, 32000])
+def test_per_request_seed_reproducibility(sampling_type, vocab_size):
+    """Per-row seed/offset tensors must be reproducible across calls."""
+    torch.manual_seed(42)
+    batch_size = 37
+    logits = torch.randn(batch_size, vocab_size, device="cuda:0")
+    probs = torch.softmax(logits, dim=-1)
+
+    seed = torch.arange(batch_size, dtype=torch.int64, device="cuda:0") + 12345
+    offset = torch.arange(batch_size, dtype=torch.int64, device="cuda:0") * 32
+
+    first = _sample_with_seed(sampling_type, probs, logits, seed, offset)
+    second = _sample_with_seed(sampling_type, probs, logits, seed, offset)
+
+    assert torch.all(first == second)
+
+
+@pytest.mark.parametrize("batch_size", [4, 19])
+def test_seed_offset_tensor_length_validation(batch_size):
+    """Lengths other than 1 or batch_size are rejected rather than read out of bounds."""
+    torch.manual_seed(42)
+    vocab_size = 111
+    probs = torch.softmax(torch.randn(batch_size, vocab_size, device="cuda:0"), dim=-1)
+
+    wrong_len = torch.zeros(batch_size + 1, dtype=torch.int64, device="cuda:0")
+    per_row = torch.zeros(batch_size, dtype=torch.int64, device="cuda:0")
+    broadcast = torch.zeros(1, dtype=torch.int64, device="cuda:0")
+
+    with pytest.raises(ValueError, match="length must be 1"):
+        flashinfer.sampling.sampling_from_probs(probs, seed=wrong_len, offset=wrong_len)
+
+    # seed and offset must agree on layout, otherwise one of them is indexed wrongly
+    with pytest.raises(ValueError, match="same length"):
+        flashinfer.sampling.sampling_from_probs(probs, seed=broadcast, offset=per_row)
+
+
+def test_chain_speculative_sampling_per_request_seed():
+    """Per-row seeds must reach the rejection-sampling kernel too.
+
+    Same construction as the sampling tests: a mixed seed tensor must reproduce, row by row,
+    what the corresponding scalar seed produces for that half of the batch.
+    """
+    torch.manual_seed(42)
+    batch_size, num_speculate_tokens, vocab_size = 64, 4, 512
+
+    draft_probs = torch.softmax(
+        torch.randn(batch_size, num_speculate_tokens, vocab_size, device="cuda:0"),
+        dim=-1,
+    )
+    target_probs = torch.softmax(
+        torch.randn(batch_size, num_speculate_tokens + 1, vocab_size, device="cuda:0"),
+        dim=-1,
+    )
+    draft_token_ids = torch.randint(
+        0,
+        vocab_size,
+        (batch_size, num_speculate_tokens),
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+
+    def run(seed, offset):
+        tokens, _, _ = flashinfer.sampling.chain_speculative_sampling(
+            draft_probs, draft_token_ids, target_probs, seed=seed, offset=offset
+        )
+        return tokens
+
+    seed_a, seed_b = 12345, 67890
+    all_a = run(seed_a, 0)
+    all_b = run(seed_b, 0)
+
+    half = batch_size // 2
+    seed = torch.tensor(
+        [seed_a] * half + [seed_b] * (batch_size - half),
+        dtype=torch.int64,
+        device="cuda:0",
+    )
+    offset = torch.zeros(batch_size, dtype=torch.int64, device="cuda:0")
+    mixed = run(seed, offset)
+
+    expected = torch.cat([all_a[:half], all_b[half:]])
+    assert torch.all(mixed == expected), (
+        "per-row seeds must reach ChainSpeculativeSampling"
+    )
+
+
 if __name__ == "__main__":
     # test_sampling_freq(128256, gumbel_distribution(0.1), 0.5)
     test_sampling_from_logits_freq(128256, gumbel_distribution(0.1))


### PR DESCRIPTION
## 📌 Description

The sampling kernels accept `seed`/`offset` as per-request tensors, and the Python layer validates them as length 1 or `batch_size`, but every kernel read only `seed_arr[0]` / `offset_arr[0]` and applied that single value to the entire batch. Rows were separated solely by the Philox subsequence (`blockIdx.x`).

So rows did draw from distinct streams, but no row except the first used the seed its caller asked for. A user-specified per-request seed was unreproducible whenever `batch_size > 1`, and a request's tokens depended on where it happened to land in the batch. Concretely, seeds `[1111, 2222, 3333, 4444]` produced the same output as `[1111, 1111, 1111, 1111]`.

This PR indexes the arrays by `blockIdx.x`, matching the convention already used by the other per-request arrays in the same kernels (e.g. `top_k_arr[bx]`). Seven kernels are affected: `SamplingFromLogitsKernel`, `SamplingFromProbKernel`, `TopKSamplingFromProbKernel`, `TopPSamplingFromProbKernel`, `MinPSamplingFromProbKernel`, `TopKTopPSamplingFromProbKernel` and `ChainSpeculativeSampling`.

A length-1 tensor still broadcasts to every row, so existing callers that pass the tensor spelling of a scalar seed are unaffected. The broadcast is resolved in-kernel via a flag rather than by materializing an expanded tensor, since expanding would allocate on every call and break CUDA graph capture — which is precisely the case per-request seeds are needed for.

The length that makes the indexing safe was previously only checked in Python, so a direct FFI caller could read out of bounds. `validate_seed_offset_tensors` now checks it too (and derives the broadcast flag), and seed/offset tensors of differing lengths are rejected in both layers.

**Scope:** this is deliberately limited to making per-request seed/offset take effect. It does not include the in-kernel atomic offset update / round-based offset tracking from #2345; those are separable and can follow if wanted.

## 🔍 Related Issues

- Closes #1104
- Supersedes #2345 — opened as a new PR at @yzh119's suggestion, since he does not currently have bandwidth to carry that one forward. Credit for the original design and the C++/Python plumbing goes to him; this PR reuses that surface and fixes the kernel-side indexing. Downstream, TensorRT-LLM already plumbs per-row Philox `(seed, offset)` end-to-end and is blocked on this behavior.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added to `tests/utils/test_sampling.py`, covering all 6 sampling entry points × 2 vocab sizes plus chain-speculative sampling:

- `test_per_request_seed_selects_that_rows_stream` / `test_per_request_offset_selects_that_rows_stream` — running with a mixed seed (offset) tensor must equal, row for row, running each half separately with the corresponding scalar value.
- `test_length_one_seed_tensor_matches_scalar` — a length-1 tensor must broadcast and match the scalar path exactly.
- `test_per_request_seed_reproducibility` — per-row tensors are reproducible across calls.
- `test_seed_offset_tensor_length_validation` — bad lengths and mismatched seed/offset lengths raise instead of reading out of bounds.
- `test_chain_speculative_sampling_per_request_seed` — same guarantee for the rejection-sampling kernel.

Note the kernels intentionally vary the Philox *subsequence* by row, so two rows sharing a seed still differ; the tests assert the property that actually matters — that a row's sample follows its own seed entry — rather than asserting rows with equal seeds are identical.

Verified on B200 (CUDA 13, PyTorch 2.12):

- With the fix: **84 passed**.
- Reverting just the per-row indexing to `idx = 0` to emulate the old behavior: **25 failed**, covering all seven kernels — confirming the tests actually catch the bug rather than passing vacuously.
- Full `tests/utils/test_sampling.py`: **1860 passed, 120 skipped**. Six `test_top_k_top_p_sampling_from_probs_logits_alignment[...128256...]` failures also reproduce on an unmodified `main` at `5a8e62ac`, so they are pre-existing and unrelated to this change.

## Reviewer Notes

The kernel diff is mechanical and identical across all seven kernels — the three-line seed/offset resolution is now a shared `ResolvePhiloxSeedOffset` helper, so the per-kernel change is one call.

Worth a look: `bx` is used as the seed index rather than `row_idx`. Seed/offset are validated against `batch_size` (== `indices.size(0)` when `indices` is given), so `bx` is the batch row and is the correct index, consistent with `top_k_arr[bx]` in the same kernels; `row_idx` is the row of the probs/logits tensor and would be wrong here.

AI-assisted with Claude Code; I've reviewed the change and can walk through the rationale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sampling now supports per-request random seeds and offsets.
  * Length-1 seed and offset tensors are broadcast across the batch.
  * Batch-sized seed and offset tensors allow independent reproducible sampling for each request.
* **Bug Fixes**
  * Invalid seed/offset lengths and mismatched tensor lengths now raise clear validation errors.
* **Tests**
  * Added coverage for broadcasting, per-request reproducibility, validation errors, and speculative sampling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->