### PR TITLE
feat(attention): add Gemma-style VariableWindow to FA3 Hopper batch prefill

### DIFF
--- a/csrc/batch_prefill_fp8_paged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_fp8_paged_sm90_kernel_inst.jinja
@@ -8,6 +8,7 @@ template cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched
     <{{ head_dim_qk }},
      {{ mask_mode }},
      /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }},
+     /*USE_VARIABLE_WINDOW=*/{{ use_variable_window }},
      /*SAME_SCHEDULER_FOR_ALL_HEADS=*/{{ same_scheduler_for_all_heads }},
      {{ variant_name }}, PagedParams>(PagedParams& params, bool enable_pdl, cudaStream_t stream);
 {% endfor %}

--- a/csrc/batch_prefill_fp8_ragged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_fp8_ragged_sm90_kernel_inst.jinja
@@ -8,6 +8,7 @@ template cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched
     <{{ head_dim_qk }},
      {{ mask_mode }},
      /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }},
+     /*USE_VARIABLE_WINDOW=*/{{ use_variable_window }},
      /*SAME_SCHEDULER_FOR_ALL_HEADS=*/{{ same_scheduler_for_all_heads }},
      {{ variant_name }}, RaggedParams>(RaggedParams& params, bool enable_pdl, cudaStream_t stream);
 {% endfor %}

--- a/csrc/batch_prefill_fp8_sm90.cu
+++ b/csrc/batch_prefill_fp8_sm90.cu
@@ -25,12 +25,14 @@
 namespace flashinfer {
 
 template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, bool enable_pdl,
                                                       cudaStream_t stream);
 
 template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched(Params& params, bool enable_pdl,
                                                        cudaStream_t stream);
 
@@ -159,11 +161,9 @@ void BatchPrefillWithRaggedKVCacheSM90Run(ffi::TensorView float_workspace_buffer
 
         bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
         DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
-          cudaError_t status =
-              BatchFP8PrefillWithRaggedKVCacheDispatched<HEAD_DIM_QK, MASK_MODE, USE_SLIDING_WINDOW,
-                                                         SAME_SCHEDULER_FOR_ALL_HEADS,
-                                                         AttentionVariant>(params, enable_pdl,
-                                                                           stream);
+          cudaError_t status = BatchFP8PrefillWithRaggedKVCacheDispatched<
+              HEAD_DIM_QK, MASK_MODE, USE_SLIDING_WINDOW, USE_VARIABLE_WINDOW,
+              SAME_SCHEDULER_FOR_ALL_HEADS, AttentionVariant>(params, enable_pdl, stream);
 
           TVM_FFI_ICHECK(status == cudaSuccess)
               << "BatchPrefillWithRaggedKVCacheSM90Run failed with error: "
@@ -271,11 +271,9 @@ void BatchPrefillWithPagedKVCacheSM90Run(
 
         bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
         DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
-          cudaError_t status =
-              BatchFP8PrefillWithPagedKVCacheDispatched<HEAD_DIM_QK, MASK_MODE, USE_SLIDING_WINDOW,
-                                                        SAME_SCHEDULER_FOR_ALL_HEADS,
-                                                        AttentionVariant>(params, enable_pdl,
-                                                                          stream);
+          cudaError_t status = BatchFP8PrefillWithPagedKVCacheDispatched<
+              HEAD_DIM_QK, MASK_MODE, USE_SLIDING_WINDOW, USE_VARIABLE_WINDOW,
+              SAME_SCHEDULER_FOR_ALL_HEADS, AttentionVariant>(params, enable_pdl, stream);
 
           TVM_FFI_ICHECK(status == cudaSuccess)
               << "BatchPrefillWithPagedKVCacheSM90Run failed with error: "

--- a/csrc/batch_prefill_paged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_paged_sm90_kernel_inst.jinja
@@ -9,6 +9,7 @@ template cudaError_t BatchPrefillWithPagedKVCacheDispatched
      {{ head_dim_vo }},
      {{ mask_mode }},
      /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }},
+     /*USE_VARIABLE_WINDOW=*/{{ use_variable_window }},
      /*SAME_SCHEDULER_FOR_ALL_HEADS=*/{{ same_scheduler_for_all_heads }},
      {{ variant_name }}, PagedParams>(PagedParams& params, bool enable_pdl, cudaStream_t stream);
 {% endfor %}

--- a/csrc/batch_prefill_ragged_sm90_kernel_inst.jinja
+++ b/csrc/batch_prefill_ragged_sm90_kernel_inst.jinja
@@ -9,6 +9,7 @@ template cudaError_t BatchPrefillWithRaggedKVCacheDispatched
      {{ head_dim_vo }},
      {{ mask_mode }},
      /*USE_SLIDING_WINDOW=*/{{ use_sliding_window }},
+     /*USE_VARIABLE_WINDOW=*/{{ use_variable_window }},
      /*SAME_SCHEDULER_FOR_ALL_HEADS=*/{{ same_scheduler_for_all_heads }},
      {{ variant_name }}>(RaggedParams& params, bool enable_pdl, cudaStream_t stream);
 {% endfor %}

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -26,12 +26,14 @@
 namespace flashinfer {
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_pdl,
                                                     cudaStream_t stream);
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_pdl,
                                                    cudaStream_t stream);
 
@@ -152,8 +154,8 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
         bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
         DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
           cudaError_t status = BatchPrefillWithRaggedKVCacheDispatched<
-              HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE, USE_SLIDING_WINDOW, SAME_SCHEDULER_FOR_ALL_HEADS,
-              AttentionVariant>(params, enable_pdl, stream);
+              HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE, USE_SLIDING_WINDOW, USE_VARIABLE_WINDOW,
+              SAME_SCHEDULER_FOR_ALL_HEADS, AttentionVariant>(params, enable_pdl, stream);
 
           TVM_FFI_ICHECK(status == cudaSuccess)
               << "BatchPrefillWithRaggedKVCacheSM90Run failed with error: "
@@ -262,8 +264,8 @@ void BatchPrefillWithPagedKVCacheSM90Run(
         bool same_schedule_for_all_heads = plan_info.same_schedule_for_all_heads;
         DISPATCH_BOOL(same_schedule_for_all_heads, SAME_SCHEDULER_FOR_ALL_HEADS, [&] {
           cudaError_t status = BatchPrefillWithPagedKVCacheDispatched<
-              HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE, USE_SLIDING_WINDOW, SAME_SCHEDULER_FOR_ALL_HEADS,
-              AttentionVariant>(params, enable_pdl, stream);
+              HEAD_DIM_QK, HEAD_DIM_VO, MASK_MODE, USE_SLIDING_WINDOW, USE_VARIABLE_WINDOW,
+              SAME_SCHEDULER_FOR_ALL_HEADS, AttentionVariant>(params, enable_pdl, stream);
 
           TVM_FFI_ICHECK(status == cudaSuccess)
               << "BatchPrefillWithPagedKVCacheSM90Run failed with error: "

--- a/csrc/batch_prefill_sm90_customize_config.jinja
+++ b/csrc/batch_prefill_sm90_customize_config.jinja
@@ -22,6 +22,9 @@ constexpr int HEAD_DIM_QK = {{ head_dim_qk }};
 constexpr int HEAD_DIM_VO = {{ head_dim_vo }};
 constexpr auto USE_LOGITS_SOFT_CAP = {{ use_logits_soft_cap }};
 constexpr auto USE_SLIDING_WINDOW = {{ use_sliding_window }};
+constexpr auto USE_VARIABLE_WINDOW = {{ use_variable_window }};
+static_assert(!(USE_SLIDING_WINDOW && USE_VARIABLE_WINDOW),
+              "VariableWindow cannot be combined with sliding window");
 
 struct RaggedParams {
   using DTypeQ = DTypeQ;

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -197,6 +197,7 @@ def gen_fa2(
         head_dim_vo=head_dim_vo,
         pos_encoding_mode=0,
         use_sliding_window=use_sliding_window,
+        use_variable_window=False,
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=False,
     )
@@ -244,6 +245,7 @@ def gen_fa3(
         head_dim_vo=head_dim_vo,
         pos_encoding_mode=0,
         use_sliding_window=use_sliding_window,
+        use_variable_window=False,
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=False,
     )

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1235,8 +1235,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     head_dim,
                     PosEncodingMode[pos_encoding_mode].value,
                     window_left != -1,
+                    False,  # use_variable_window
                     logits_soft_cap > 0,
-                    False,
+                    False,  # use_fp16_qk_reduction
                 )
             qo_indptr_host = _get_range_buf(batch_size + 1, "cpu")
             # Multi-token requests are causal within each request's block;
@@ -1787,6 +1788,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     head_dim,  # head_dim_vo
                     PosEncodingMode[pos_encoding_mode].value,
                     window_left != -1,  # use_sliding_window
+                    False,  # use_variable_window
                     logits_soft_cap > 0,  # use_logits_soft_cap
                     False,  # use_fp16_qk_reduction
                 )
@@ -3036,8 +3038,32 @@ class TrtllmGenDecodeModule:
 
 
 @functools.cache
-def get_trtllm_gen_decode_module(*args):
-    uri = get_batch_prefill_uri("trtllm-gen", *args)
+def get_trtllm_gen_decode_module(
+    dtype_q,
+    dtype_kv,
+    dtype_o,
+    dtype_idx,
+    head_dim_qk,
+    head_dim_vo,
+    pos_encoding_mode,
+    use_sliding_window,
+    use_logits_soft_cap,
+    use_fp16_qk_reduction,
+):
+    uri = get_batch_prefill_uri(
+        "trtllm-gen",
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        dtype_idx,
+        head_dim_qk,
+        head_dim_vo,
+        pos_encoding_mode,
+        use_sliding_window,
+        use_variable_window=False,
+        use_logits_soft_cap=use_logits_soft_cap,
+        use_fp16_qk_reduction=use_fp16_qk_reduction,
+    )
     module = TrtllmGenDecodeModule()
 
     @register_custom_op(

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -445,8 +445,9 @@ def get_batch_prefill_uri(
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
+    use_variable_window: bool = False,
 ) -> str:
-    return (
+    uri = (
         f"batch_prefill_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
         f"dtype_kv_{filename_safe_dtype_map_kv(dtype_kv)}_"
         f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
@@ -458,6 +459,9 @@ def get_batch_prefill_uri(
         f"use_logits_cap_{use_logits_soft_cap}_"
         f"f16qk_{use_fp16_qk_reduction}" + ("_sm90" if backend == "fa3" else "")
     )
+    if use_variable_window:
+        uri += "_use_vw_True"
+    return uri
 
 
 def get_batch_prefill_attention_sink_uri(
@@ -1034,6 +1038,7 @@ def gen_batch_prefill_module(
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
+    use_variable_window: bool = False,
 ) -> JitSpec:
     uri = get_batch_prefill_uri(
         backend,
@@ -1047,6 +1052,7 @@ def gen_batch_prefill_module(
         use_sliding_window,
         use_logits_soft_cap,
         use_fp16_qk_reduction,
+        use_variable_window,
     )
 
     # use `fp8_enabled` flag to use separate kernel template
@@ -1060,6 +1066,11 @@ def gen_batch_prefill_module(
     assert dtype_o not in [torch.float8_e4m3fn, torch.float8_e5m2], (
         "FP8 output is not supported in fa2/fa3 backends yet"
     )
+    if use_variable_window:
+        if backend != "fa3":
+            raise ValueError("variable_window is only supported for the fa3 backend")
+        if use_sliding_window:
+            raise ValueError("variable_window cannot be combined with sliding window")
 
     if backend == "fa2":
         assert not fp8_enabled, "fp8 tensor core is not supported in fa2 backend"
@@ -1127,6 +1138,15 @@ def gen_batch_prefill_module(
             additional_scalar_dtypes = ["double", "double", "double", "double"]
             variant_name = "DefaultFP8Attention"
             variant_decl = "#include<flashinfer/attention/hopper/variants.cuh>"
+        if use_variable_window:
+            additional_tensor_names = additional_tensor_names + [
+                "maybe_variable_window_token_starts",
+                "maybe_variable_window_token_ends",
+            ]
+            additional_tensor_dtypes = additional_tensor_dtypes + [
+                "int32_t",
+                "int32_t",
+            ]
 
     return gen_customize_batch_prefill_module(
         backend,
@@ -1148,6 +1168,7 @@ def gen_batch_prefill_module(
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=use_fp16_qk_reduction,
         fp8_enabled=fp8_enabled,
+        use_variable_window=use_variable_window,
     )
 
 
@@ -1679,6 +1700,7 @@ def gen_customize_batch_prefill_module(
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
     fp8_enabled: bool = False,
+    use_variable_window: bool = False,
 ) -> JitSpec:
     require_fp4_kv_cache = dtype_map_kv[dtype_kv] == "__nv_fp4x2_e2m1"
     if require_fp4_kv_cache:
@@ -1708,6 +1730,7 @@ def gen_customize_batch_prefill_module(
         "use_sliding_window": str(use_sliding_window).lower(),
         "use_logits_soft_cap": str(use_logits_soft_cap).lower(),
         "use_fp16_qk_reduction": str(use_fp16_qk_reduction).lower(),
+        "use_variable_window": str(use_variable_window).lower(),
     }
     if backend == "auto":
         raise ValueError("backend should not be auto when jit_args is provided")

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -443,9 +443,9 @@ def get_batch_prefill_uri(
     head_dim_vo: int,
     pos_encoding_mode: int,
     use_sliding_window: bool,
+    use_variable_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
-    use_variable_window: bool = False,
 ) -> str:
     return (
         f"batch_prefill_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
@@ -1035,9 +1035,9 @@ def gen_batch_prefill_module(
     head_dim_vo: int,
     pos_encoding_mode: int,
     use_sliding_window: bool,
+    use_variable_window: bool,
     use_logits_soft_cap: bool,
     use_fp16_qk_reduction: bool,
-    use_variable_window: bool = False,
 ) -> JitSpec:
     uri = get_batch_prefill_uri(
         backend,
@@ -1049,9 +1049,9 @@ def gen_batch_prefill_module(
         head_dim_vo,
         pos_encoding_mode,
         use_sliding_window,
+        use_variable_window,
         use_logits_soft_cap,
         use_fp16_qk_reduction,
-        use_variable_window,
     )
 
     # use `fp8_enabled` flag to use separate kernel template
@@ -1164,10 +1164,10 @@ def gen_batch_prefill_module(
         variant_decl,
         pos_encoding_mode=pos_encoding_mode,
         use_sliding_window=use_sliding_window,
+        use_variable_window=use_variable_window,
         use_logits_soft_cap=use_logits_soft_cap,
         use_fp16_qk_reduction=use_fp16_qk_reduction,
         fp8_enabled=fp8_enabled,
-        use_variable_window=use_variable_window,
     )
 
 
@@ -1696,10 +1696,10 @@ def gen_customize_batch_prefill_module(
     variant_decl: str,
     pos_encoding_mode: int = 0,
     use_sliding_window: bool = False,
+    use_variable_window: bool = False,
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
     fp8_enabled: bool = False,
-    use_variable_window: bool = False,
 ) -> JitSpec:
     require_fp4_kv_cache = dtype_map_kv[dtype_kv] == "__nv_fp4x2_e2m1"
     if require_fp4_kv_cache:
@@ -1727,9 +1727,9 @@ def gen_customize_batch_prefill_module(
         "head_dim_vo": head_dim_vo,
         "pos_encoding_mode": pos_encoding_mode_literal[pos_encoding_mode],
         "use_sliding_window": str(use_sliding_window).lower(),
+        "use_variable_window": str(use_variable_window).lower(),
         "use_logits_soft_cap": str(use_logits_soft_cap).lower(),
         "use_fp16_qk_reduction": str(use_fp16_qk_reduction).lower(),
-        "use_variable_window": str(use_variable_window).lower(),
     }
     if backend == "auto":
         raise ValueError("backend should not be auto when jit_args is provided")

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -447,7 +447,7 @@ def get_batch_prefill_uri(
     use_fp16_qk_reduction: bool,
     use_variable_window: bool = False,
 ) -> str:
-    uri = (
+    return (
         f"batch_prefill_with_kv_cache_dtype_q_{filename_safe_dtype_map[dtype_q]}_"
         f"dtype_kv_{filename_safe_dtype_map_kv(dtype_kv)}_"
         f"dtype_o_{filename_safe_dtype_map[dtype_o]}_"
@@ -457,11 +457,10 @@ def get_batch_prefill_uri(
         f"posenc_{pos_encoding_mode}_"
         f"use_swa_{use_sliding_window}_"
         f"use_logits_cap_{use_logits_soft_cap}_"
-        f"f16qk_{use_fp16_qk_reduction}" + ("_sm90" if backend == "fa3" else "")
+        f"f16qk_{use_fp16_qk_reduction}"
+        + ("_sm90" if backend == "fa3" else "")
+        + ("_use_vw_True" if use_variable_window else "")
     )
-    if use_variable_window:
-        uri += "_use_vw_True"
-    return uri
 
 
 def get_batch_prefill_attention_sink_uri(

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -412,6 +412,7 @@ class PODWithPagedKVCacheWrapper:
                 head_dim,  # head_dim_vo
                 PosEncodingMode[pos_encoding_mode].value,
                 window_left != -1,  # use_sliding_window
+                False,  # use_variable_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 False,  # use_fp16_qk_reduction
             )
@@ -1042,6 +1043,7 @@ class BatchPODWithPagedKVCacheWrapper:
                 head_dim,  # head_dim_vo
                 PosEncodingMode[pos_encoding_mode].value,
                 window_left != -1,  # use_sliding_window
+                False,  # use_variable_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 False,  # use_fp16_qk_reduction
             )

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -108,6 +108,84 @@ def _split_scale_param(scale):
         return None, float(scale)
 
 
+def _clone_variable_window_bounds(
+    variable_window_token_starts,
+    variable_window_token_ends,
+    *,
+    nnz_qo: int,
+    device: torch.device,
+    window_left: int,
+    causal: bool,
+    custom_mask,
+    packed_custom_mask,
+    prefix_len_ptr,
+    backend: str,
+    head_dim_qk: int,
+    head_dim_vo: int,
+):
+    """Validate packed [nnz_qo] VariableWindow bounds and clone them at plan time."""
+    has_starts = variable_window_token_starts is not None
+    has_ends = variable_window_token_ends is not None
+    if has_starts != has_ends:
+        raise ValueError(
+            "variable_window_token_starts and variable_window_token_ends must both "
+            "be provided or both omitted"
+        )
+    if not has_starts:
+        return False, None, None
+    if window_left >= 0:
+        raise ValueError("variable_window cannot be combined with window_left >= 0")
+    if custom_mask is not None or packed_custom_mask is not None:
+        raise ValueError("variable_window cannot be combined with custom_mask")
+    if prefix_len_ptr is not None:
+        raise ValueError(
+            "variable_window cannot be combined with prefix_len_ptr (multi-item scoring)"
+        )
+    if causal:
+        raise ValueError(
+            "variable_window requires causal=False; bake causal into the start/end arrays"
+        )
+    if backend not in ("auto", "fa3"):
+        raise ValueError(
+            "variable_window is only supported for the fa3 backend "
+            f"(got backend={backend!r})"
+        )
+    if head_dim_qk != head_dim_vo:
+        raise ValueError(
+            "variable_window requires equal QK and VO head dimensions "
+            f"(got head_dim_qk={head_dim_qk}, head_dim_vo={head_dim_vo})"
+        )
+    if head_dim_qk not in (64, 128, 256):
+        raise ValueError(
+            "variable_window requires head_dim in {64, 128, 256} "
+            f"(got head_dim_qk={head_dim_qk})"
+        )
+    starts = variable_window_token_starts
+    ends = variable_window_token_ends
+    if starts.dtype != torch.int32 or ends.dtype != torch.int32:
+        raise ValueError(
+            "variable_window_token_starts/ends must have dtype torch.int32"
+        )
+    if not starts.is_cuda or not ends.is_cuda:
+        raise ValueError("variable_window_token_starts/ends must be CUDA tensors")
+    if starts.device != device or ends.device != device:
+        raise ValueError(
+            "variable_window_token_starts/ends must be on the same device as the wrapper"
+        )
+    if not starts.is_contiguous() or not ends.is_contiguous():
+        raise ValueError("variable_window_token_starts/ends must be contiguous")
+    if starts.dim() != 1 or ends.dim() != 1:
+        raise ValueError(
+            "variable_window_token_starts/ends must be 1-D tensors of shape [nnz_qo]"
+        )
+    if starts.numel() != nnz_qo or ends.numel() != nnz_qo:
+        raise ValueError(
+            f"variable_window_token_starts/ends must have shape [{nnz_qo}] "
+            f"(got {tuple(starts.shape)} and {tuple(ends.shape)})"
+        )
+    return True, starts.clone(), ends.clone()
+
+
 @functools.cache
 def get_fmha_module(
     dtype_q: torch.dtype,
@@ -456,6 +534,7 @@ def get_single_prefill_module(backend, *args):
 
 @functools.cache
 def get_batch_prefill_module(backend, *args):
+    use_variable_window = bool(args[10]) if len(args) > 10 else False
     if backend == "trtllm-gen":
         uri = "trtllm_gen_context"
         module = get_trtllm_gen_prefill_module()
@@ -513,6 +592,8 @@ def get_batch_prefill_module(backend, *args):
         scale_q: Optional[torch.Tensor] = None,
         scale_k: Optional[torch.Tensor] = None,
         scale_v: Optional[torch.Tensor] = None,
+        maybe_variable_window_token_starts: Optional[torch.Tensor] = None,
+        maybe_variable_window_token_ends: Optional[torch.Tensor] = None,
     ) -> None:
         # Check if FP8 by presence of scale tensors
         is_fp8 = scale_q is not None
@@ -548,10 +629,16 @@ def get_batch_prefill_module(backend, *args):
                 token_pos_in_items_len,
             )
         elif is_fp8:
-            # FA3 FP8: scale_q, scale_k, scale_v, sm_scale, scale_q_scalar, scale_k_scalar, scale_v_scalar
+            # FA3 FP8: scale_q, scale_k, scale_v, [vw starts/ends], sm_scale, scale_*_scalar
             scale_q_tensor, scale_q_scalar = _split_scale_param(scale_q)
             scale_k_tensor, scale_k_scalar = _split_scale_param(scale_k)
             scale_v_tensor, scale_v_scalar = _split_scale_param(scale_v)
+            extra_vw = []
+            if use_variable_window:
+                extra_vw = [
+                    maybe_variable_window_token_starts,
+                    maybe_variable_window_token_ends,
+                ]
             ragged_run_func(
                 float_workspace_buffer,
                 int_workspace_buffer,
@@ -570,6 +657,7 @@ def get_batch_prefill_module(backend, *args):
                 scale_q_tensor,
                 scale_k_tensor,
                 scale_v_tensor,
+                *extra_vw,
                 sm_scale,
                 scale_q_scalar,
                 scale_k_scalar,
@@ -577,8 +665,15 @@ def get_batch_prefill_module(backend, *args):
             )
         else:
             # FA3 FP16: maybe_prefix_len_ptr, maybe_token_pos_in_items_ptr,
-            # maybe_max_item_len_ptr, scale_v, logits_soft_cap, sm_scale, scale_v_scalar, token_pos_in_items_len
+            # maybe_max_item_len_ptr, scale_v, [vw starts/ends],
+            # logits_soft_cap, sm_scale, scale_v_scalar, token_pos_in_items_len
             scale_v_tensor, scale_v_scalar = _split_scale_param(scale_v)
+            extra_vw = []
+            if use_variable_window:
+                extra_vw = [
+                    maybe_variable_window_token_starts,
+                    maybe_variable_window_token_ends,
+                ]
             ragged_run_func(
                 float_workspace_buffer,
                 int_workspace_buffer,
@@ -598,6 +693,7 @@ def get_batch_prefill_module(backend, *args):
                 maybe_token_pos_in_items_ptr,
                 maybe_max_item_len_ptr,
                 scale_v_tensor,
+                *extra_vw,
                 logits_soft_cap,
                 sm_scale,
                 scale_v_scalar,
@@ -702,6 +798,8 @@ def get_batch_prefill_module(backend, *args):
         use_fp16_softmax: Optional[bool] = None,
         uses_spcompress: Optional[bool] = None,
         multi_ctas_kv_counter_buffer: Optional[torch.Tensor] = None,
+        maybe_variable_window_token_starts: Optional[torch.Tensor] = None,
+        maybe_variable_window_token_ends: Optional[torch.Tensor] = None,
     ) -> None:
         if backend == "trtllm-gen":
             assert num_qo_heads is not None
@@ -780,6 +878,12 @@ def get_batch_prefill_module(backend, *args):
             )
         else:
             scale_v_tensor, scale_v_scalar = _split_scale_param(scale_v)
+            extra_vw = []
+            if use_variable_window:
+                extra_vw = [
+                    maybe_variable_window_token_starts,
+                    maybe_variable_window_token_ends,
+                ]
             if not is_float8(q):
                 paged_run_func(
                     float_workspace_buffer,
@@ -802,6 +906,7 @@ def get_batch_prefill_module(backend, *args):
                     maybe_token_pos_in_items_ptr,
                     maybe_max_item_len_ptr,
                     scale_v_tensor,
+                    *extra_vw,
                     logits_soft_cap,
                     sm_scale,
                     scale_v_scalar,
@@ -830,6 +935,7 @@ def get_batch_prefill_module(backend, *args):
                     scale_q_tensor,
                     scale_k_tensor,
                     scale_v_tensor,
+                    *extra_vw,
                     sm_scale,
                     scale_q_scalar,
                     scale_k_scalar,
@@ -1844,6 +1950,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._seq_lens_kv = None
         self._seq_lens_q = None
         self._block_tables = None
+        self._use_variable_window = False
+        self._variable_window_token_starts = None
+        self._variable_window_token_ends = None
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
@@ -2182,6 +2291,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         max_sequence_kv: Optional[int] = None,
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
+        variable_window_token_starts: Optional[torch.Tensor] = None,
+        variable_window_token_ends: Optional[torch.Tensor] = None,
     ) -> None:
         r"""Plan batch prefill/append attention on Paged KV-Cache for given problem specification.
 
@@ -2292,6 +2403,13 @@ class BatchPrefillWithPagedKVCacheWrapper:
             and lead to a varied number of launched CTAs.
         disable_split_kv : bool,
             Whether to disable the split-kv for determinism in CUDA Graph, defaults to ``False``.
+        variable_window_token_starts : Optional[torch.Tensor]
+            Packed int32 ``[nnz_qo]`` inclusive KV start index per query token (ragged
+            ``qo_indptr`` order). Must be paired with ``variable_window_token_ends``.
+            FA3 only; mutually exclusive with sliding window, custom mask, causal, and
+            multi-item scoring. Cloned at ``plan()`` and reused at ``run()``.
+        variable_window_token_ends : Optional[torch.Tensor]
+            Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -2363,6 +2481,24 @@ class BatchPrefillWithPagedKVCacheWrapper:
         qo_indptr_host = qo_indptr.to("cpu")
         self._qo_indptr_last = int(qo_indptr_host[-1])
         total_num_rows = self._qo_indptr_last
+        (
+            self._use_variable_window,
+            self._variable_window_token_starts,
+            self._variable_window_token_ends,
+        ) = _clone_variable_window_bounds(
+            variable_window_token_starts,
+            variable_window_token_ends,
+            nnz_qo=total_num_rows,
+            device=self.device,
+            window_left=window_left,
+            causal=causal,
+            custom_mask=custom_mask,
+            packed_custom_mask=packed_custom_mask,
+            prefix_len_ptr=prefix_len_ptr,
+            backend=self._backend,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+        )
         if max_token_per_sequence is not None:
             self._max_q_len = max_token_per_sequence
         else:
@@ -2548,6 +2684,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     head_dim_qk=head_dim_qk,
                     head_dim_vo=head_dim_vo,
                 )
+            if self._use_variable_window and self._backend != "fa3":
+                raise ValueError(
+                    "variable_window requires the fa3 backend on SM90 "
+                    f"(resolved backend={self._backend!r})"
+                )
             if self._backend != "cudnn":
                 get_module_args = (
                     q_data_type,
@@ -2560,6 +2701,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     window_left >= 0,  # use_sliding_window
                     logits_soft_cap > 0,  # use_logits_soft_cap
                     use_fp16_qk_reduction,
+                    self._use_variable_window,
                 )
 
                 self._cached_module = get_batch_prefill_module(
@@ -3004,7 +3146,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 key_block_scales = key_block_scales.transpose(-3, -2).contiguous()
                 value_block_scales = value_block_scales.transpose(-3, -2).contiguous()
 
-        if self._custom_mask_buf is not None or self._variant_owns_mask:
+        if self._use_variable_window:
+            mask_mode = MaskMode.NON_CAUSAL.value
+        elif self._custom_mask_buf is not None or self._variant_owns_mask:
             mask_mode = MaskMode.CUSTOM.value
         else:
             if self._causal:
@@ -3166,7 +3310,15 @@ class BatchPrefillWithPagedKVCacheWrapper:
             if self._backend == "trtllm-gen":
                 assert self._trtllm_gen_multi_ctas_kv_counter_buffer is not None
             assert self._cached_module is not None, "cached module is not initialized"
-            self._cached_module.paged_run(*run_args)
+            vw_kwargs = {}
+            if self._use_variable_window:
+                vw_kwargs["maybe_variable_window_token_starts"] = (
+                    self._variable_window_token_starts
+                )
+                vw_kwargs["maybe_variable_window_token_ends"] = (
+                    self._variable_window_token_ends
+                )
+            self._cached_module.paged_run(*run_args, **vw_kwargs)
 
             is_float_one = isinstance(v_scale, float) and v_scale == 1.0
             if v_scale is not None and not is_float_one:
@@ -3473,6 +3625,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._max_total_num_rows: Optional[int] = None
         self._backend = backend
         self._cached_module = None
+        self._use_variable_window = False
+        self._variable_window_token_starts = None
+        self._variable_window_token_ends = None
 
     @property
     def is_cuda_graph_enabled(self) -> bool:
@@ -3537,6 +3692,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         max_sequence_kv: Optional[int] = None,
         v_indptr: Optional[torch.Tensor] = None,
         o_indptr: Optional[torch.Tensor] = None,
+        variable_window_token_starts: Optional[torch.Tensor] = None,
+        variable_window_token_ends: Optional[torch.Tensor] = None,
     ) -> None:
         r"""Plan batch prefill/append attention on Ragged KV-Cache for given problem specification.
 
@@ -3644,6 +3801,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             Required for cudnn backend. This is the indptr of the value tensor.
         o_indptr: Optional[torch.Tensor]
             Required for cudnn backend. This is the indptr of the output tensor.
+        variable_window_token_starts : Optional[torch.Tensor]
+            Packed int32 ``[nnz_qo]`` inclusive KV start index per query token (ragged
+            ``qo_indptr`` order). Must be paired with ``variable_window_token_ends``.
+            FA3 only; mutually exclusive with sliding window, custom mask, causal, and
+            multi-item scoring. Cloned at ``plan()`` and reused at ``run()``.
+        variable_window_token_ends : Optional[torch.Tensor]
+            Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note
         ----
         The :meth:`plan` method should be called before any :meth:`run` or
@@ -3695,6 +3859,24 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         self._qo_indptr_last = int(qo_indptr_host[-1])
         total_num_rows = self._qo_indptr_last
+        (
+            self._use_variable_window,
+            self._variable_window_token_starts,
+            self._variable_window_token_ends,
+        ) = _clone_variable_window_bounds(
+            variable_window_token_starts,
+            variable_window_token_ends,
+            nnz_qo=total_num_rows,
+            device=self.device,
+            window_left=window_left,
+            causal=causal,
+            custom_mask=custom_mask,
+            packed_custom_mask=packed_custom_mask,
+            prefix_len_ptr=prefix_len_ptr,
+            backend=self._backend,
+            head_dim_qk=head_dim_qk,
+            head_dim_vo=head_dim_vo,
+        )
 
         if self.is_cuda_graph_enabled:
             if self._max_total_num_rows is None:
@@ -3917,6 +4099,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     and prefix_len_ptr is None
                     and token_pos_in_items_ptr is None
                     and max_item_len_ptr is None
+                    and not self._use_variable_window
                     and _should_use_fmha_v2_sm120(
                         self.device,
                         PosEncodingMode[pos_encoding_mode].value,
@@ -3926,6 +4109,12 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     )
                 ):
                     self._backend = "fmha_v2"
+
+            if self._use_variable_window and self._backend != "fa3":
+                raise ValueError(
+                    "variable_window requires the fa3 backend on SM90 "
+                    f"(resolved backend={self._backend!r})"
+                )
 
             get_module_args = (
                 q_data_type,
@@ -3938,6 +4127,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 window_left >= 0,  # use_sliding_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
+                self._use_variable_window,
             )
             if self._backend == "fmha_v2":
                 # Cache plan data for run() — avoid GPU-CPU sync in hot path
@@ -4405,7 +4595,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             k = k.to(torch.float16)
             v = v.to(torch.float16)
 
-        if self._custom_mask_buf is not None or self._variant_owns_mask:
+        if self._use_variable_window:
+            mask_mode = MaskMode.NON_CAUSAL.value
+        elif self._custom_mask_buf is not None or self._variant_owns_mask:
             mask_mode = MaskMode.CUSTOM.value
         else:
             if self._causal:
@@ -4464,7 +4656,15 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 run_args.extend(list(args))  # scale_q, scale_k, scale_v
 
         assert self._cached_module is not None, "cached module is not initialized"
-        self._cached_module.ragged_run(*run_args)
+        vw_kwargs = {}
+        if self._use_variable_window:
+            vw_kwargs["maybe_variable_window_token_starts"] = (
+                self._variable_window_token_starts
+            )
+            vw_kwargs["maybe_variable_window_token_ends"] = (
+                self._variable_window_token_ends
+            )
+        self._cached_module.ragged_run(*run_args, **vw_kwargs)
 
         # Apply V scaling for NVFP4 ragged KV if v_scale is provided and not equal to 1.0
         is_float_one = isinstance(v_scale, float) and v_scale == 1.0

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -272,6 +272,7 @@ def get_customize_batch_prefill_module(
     variant_decl: str,
     pos_encoding_mode: int = 0,
     use_sliding_window: bool = False,
+    use_variable_window: bool = False,
     use_logits_soft_cap: bool = False,
     use_fp16_qk_reduction: bool = False,
     fp8_enabled: bool = False,
@@ -291,11 +292,12 @@ def get_customize_batch_prefill_module(
         additional_scalar_dtypes,
         variant_name,
         variant_decl,
-        pos_encoding_mode,
-        use_sliding_window,
-        use_logits_soft_cap,
-        use_fp16_qk_reduction,
-        fp8_enabled,
+        pos_encoding_mode=pos_encoding_mode,
+        use_sliding_window=use_sliding_window,
+        use_variable_window=use_variable_window,
+        use_logits_soft_cap=use_logits_soft_cap,
+        use_fp16_qk_reduction=use_fp16_qk_reduction,
+        fp8_enabled=fp8_enabled,
     ).build_and_load()
 
 
@@ -535,18 +537,44 @@ def get_single_prefill_module(backend, *args):
 
 
 @functools.cache
-def get_batch_prefill_module(backend, *args):
-    use_variable_window = bool(args[10]) if len(args) > 10 else False
+def get_batch_prefill_module(
+    backend: str,
+    dtype_q: torch.dtype,
+    dtype_kv: torch.dtype,
+    dtype_o: torch.dtype,
+    dtype_idx: torch.dtype,
+    head_dim_qk: int,
+    head_dim_vo: int,
+    pos_encoding_mode: int,
+    use_sliding_window: bool,
+    use_variable_window: bool,
+    use_logits_soft_cap: bool,
+    use_fp16_qk_reduction: bool,
+):
     if backend == "trtllm-gen":
         uri = "trtllm_gen_context"
+        use_variable_window = False
         module = get_trtllm_gen_prefill_module()
         plan_func = module.plan
         workspace_size_func = None
         ragged_run_func = module.ragged_run
         paged_run_func = module.paged_run
     else:
-        uri = get_batch_prefill_uri(backend, *args)
-        module = gen_batch_prefill_module(backend, *args).build_and_load()
+        module_args = (
+            dtype_q,
+            dtype_kv,
+            dtype_o,
+            dtype_idx,
+            head_dim_qk,
+            head_dim_vo,
+            pos_encoding_mode,
+            use_sliding_window,
+            use_variable_window,
+            use_logits_soft_cap,
+            use_fp16_qk_reduction,
+        )
+        uri = get_batch_prefill_uri(backend, *module_args)
+        module = gen_batch_prefill_module(backend, *module_args).build_and_load()
         plan_func = module.plan
         workspace_size_func = getattr(module, "workspace_size", None)
         ragged_run_func = module.ragged_run
@@ -2024,6 +2052,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         max_sequence_kv: Optional[int] = None,
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
+        variable_window_token_starts: Optional[torch.Tensor] = None,
+        variable_window_token_ends: Optional[torch.Tensor] = None,
     ) -> Tuple[int, int]:
         r"""Return the caller-owned workspace size required by :meth:`plan`.
 
@@ -2033,6 +2063,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
         way as :meth:`plan`.  The wrapper's float workspace buffer is only used
         as the device/stream selector for the underlying module query.  This
         method does not allocate buffers and does not mutate cached plan state.
+
+        Sizing is currently implemented for the ``fa2`` backend.  ``fa3``
+        (including ``backend="auto"`` when it resolves to FA3) and
+        ``cudnn`` raise :class:`NotImplementedError` without compiling a
+        module.  ``variable_window`` requires FA3, so it is rejected the same
+        way.
 
         Parameters
         ----------
@@ -2113,6 +2149,11 @@ class BatchPrefillWithPagedKVCacheWrapper:
             The fixed split size for split-kv prefill, in pages.
         disable_split_kv : bool
             Whether to disable the split-kv. Defaults to ``False``.
+        variable_window_token_starts, variable_window_token_ends : Optional[torch.Tensor]
+            Packed ``[nnz_qo]`` bounds as in :meth:`plan`. Not supported here:
+            ``variable_window`` requires the fa3 backend, which does not export
+            ``workspace_size``. Providing either tensor raises
+            :class:`NotImplementedError`.
 
         Returns
         -------
@@ -2131,6 +2172,18 @@ class BatchPrefillWithPagedKVCacheWrapper:
         _check_workspace_buffer_alignment(
             self._float_workspace_buffer, "float_workspace_buffer"
         )
+        if (
+            variable_window_token_starts is not None
+            or variable_window_token_ends is not None
+        ):
+            raise NotImplementedError(
+                "workspace_size is not available for variable_window; "
+                "the fa3 backend does not export workspace_size"
+            )
+        if self._backend in ("fa3", "cudnn"):
+            raise NotImplementedError(
+                f"workspace_size is not available for prefill backend {self._backend!r}"
+            )
         del (
             block_tables,
             max_item_len_ptr,
@@ -2207,10 +2260,12 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     use_custom_mask,
                     q_data_type,
                     kv_data_type,
+                    head_dim_qk=head_dim_qk,
+                    head_dim_vo=head_dim_vo,
                 )
-            if backend == "cudnn":
+            if backend in ("fa3", "cudnn"):
                 raise NotImplementedError(
-                    "workspace_size is not available for cudnn prefill backend"
+                    f"workspace_size is not available for prefill backend {backend!r}"
                 )
             module = get_batch_prefill_module(
                 backend,
@@ -2222,6 +2277,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 head_dim_vo,
                 PosEncodingMode[pos_encoding_mode].value,
                 window_left >= 0,
+                False,  # use_variable_window
                 logits_soft_cap > 0,
                 use_fp16_qk_reduction,
             )
@@ -2703,11 +2759,10 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     head_dim_vo,
                     PosEncodingMode[pos_encoding_mode].value,
                     window_left >= 0,  # use_sliding_window
+                    self._use_variable_window,
                     logits_soft_cap > 0,  # use_logits_soft_cap
                     use_fp16_qk_reduction,
-                    self._use_variable_window,
                 )
-
                 self._cached_module = get_batch_prefill_module(
                     self._backend, *get_module_args
                 )
@@ -4122,19 +4177,6 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     f"(resolved backend={self._backend!r})"
                 )
 
-            get_module_args = (
-                q_data_type,
-                kv_data_type,
-                o_data_type,
-                kv_indptr.dtype,
-                head_dim_qk,
-                head_dim_vo,
-                PosEncodingMode[pos_encoding_mode].value,
-                window_left >= 0,  # use_sliding_window
-                logits_soft_cap > 0,  # use_logits_soft_cap
-                use_fp16_qk_reduction,
-                self._use_variable_window,
-            )
             if self._backend == "fmha_v2":
                 # Cache plan data for run() — avoid GPU-CPU sync in hot path
                 self._fmha_v2_seq_lens = kv_len_arr.to(torch.int32).to(
@@ -4146,14 +4188,33 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._fmha_v2_qo_indptr = self._qo_indptr_buf.to(torch.int32)
                 self._fmha_v2_kv_indptr = self._kv_indptr_buf.to(torch.int32)
             elif self._backend == "cutlass":
-                # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
-                new_get_module_args = (
-                    get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]
+                self._cached_module = get_fmha_module(
+                    q_data_type,
+                    kv_data_type,
+                    o_data_type,
+                    kv_indptr.dtype,
+                    head_dim_qk,
+                    head_dim_vo,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    window_left >= 0,  # use_sliding_window
+                    logits_soft_cap > 0,  # use_logits_soft_cap
+                    qo_indptr.device,
+                    use_fp16_qk_reduction,
                 )
-                self._cached_module = get_fmha_module(*new_get_module_args)
             elif self._backend != "cudnn":
                 self._cached_module = get_batch_prefill_module(
-                    self._backend, *get_module_args
+                    self._backend,
+                    q_data_type,
+                    kv_data_type,
+                    o_data_type,
+                    kv_indptr.dtype,
+                    head_dim_qk,
+                    head_dim_vo,
+                    PosEncodingMode[pos_encoding_mode].value,
+                    window_left >= 0,
+                    self._use_variable_window,
+                    logits_soft_cap > 0,
+                    use_fp16_qk_reduction,
                 )
 
         if self._backend == "cutlass":
@@ -4827,6 +4888,7 @@ def fmha_varlen(
         False,  # use_sliding_window
         False,  # use_logits_soft_cap
         q.device,
+        False,  # use_fp16_qk_reduction
     )
 
     nnz_qo, num_qo_heads, head_dim_qk = q.shape

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -75,6 +75,7 @@ from .utils import (
     get_alibi_slopes,
     get_compute_capability,
     get_device_sm_count,
+    is_fa3_prefill_head_dim_supported,
     is_float8,
     is_sm12x_supported,
     is_sm100a_supported,
@@ -127,6 +128,7 @@ def _validate_variable_window_bounds(
 
     Returns the caller tensors by reference (same contract as ``prefix_len_ptr``).
     They must stay alive and unchanged from ``plan()`` through ``run()``.
+    Checks are host metadata only (no copy, no device sync on the arrays).
     """
     has_starts = variable_window_token_starts is not None
     has_ends = variable_window_token_ends is not None
@@ -154,15 +156,11 @@ def _validate_variable_window_bounds(
             "variable_window is only supported for the fa3 backend "
             f"(got backend={backend!r})"
         )
-    if head_dim_qk != head_dim_vo:
+    if not is_fa3_prefill_head_dim_supported(head_dim_qk, head_dim_vo):
         raise ValueError(
-            "variable_window requires equal QK and VO head dimensions "
+            "variable_window requires an FA3-supported head-dim pair: equal "
+            "{64, 128, 256} or (head_dim_qk, head_dim_vo)=(192, 128) "
             f"(got head_dim_qk={head_dim_qk}, head_dim_vo={head_dim_vo})"
-        )
-    if head_dim_qk not in (64, 128, 256):
-        raise ValueError(
-            "variable_window requires head_dim in {64, 128, 256} "
-            f"(got head_dim_qk={head_dim_qk})"
         )
     starts = variable_window_token_starts
     ends = variable_window_token_ends
@@ -2411,8 +2409,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
             Packed int32 ``[nnz_qo]`` inclusive KV start index per query token (ragged
             ``qo_indptr`` order). Must be paired with ``variable_window_token_ends``.
             FA3 only; mutually exclusive with sliding window, custom mask, causal, and
-            multi-item scoring. Held by reference like ``prefix_len_ptr`` and reused
-            at ``run()``; keep the tensors alive and unchanged until then.
+            multi-item scoring. Bake causal / SWA into the arrays. Held by reference
+            like ``prefix_len_ptr`` and reused at ``run()``; keep the tensors alive
+            and unchanged until then.
         variable_window_token_ends : Optional[torch.Tensor]
             Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note
@@ -3810,8 +3809,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             Packed int32 ``[nnz_qo]`` inclusive KV start index per query token (ragged
             ``qo_indptr`` order). Must be paired with ``variable_window_token_ends``.
             FA3 only; mutually exclusive with sliding window, custom mask, causal, and
-            multi-item scoring. Held by reference like ``prefix_len_ptr`` and reused
-            at ``run()``; keep the tensors alive and unchanged until then.
+            multi-item scoring. Bake causal / SWA into the arrays. Held by reference
+            like ``prefix_len_ptr`` and reused at ``run()``; keep the tensors alive
+            and unchanged until then.
         variable_window_token_ends : Optional[torch.Tensor]
             Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -108,7 +108,7 @@ def _split_scale_param(scale):
         return None, float(scale)
 
 
-def _clone_variable_window_bounds(
+def _validate_variable_window_bounds(
     variable_window_token_starts,
     variable_window_token_ends,
     *,
@@ -123,7 +123,11 @@ def _clone_variable_window_bounds(
     head_dim_qk: int,
     head_dim_vo: int,
 ):
-    """Validate packed [nnz_qo] VariableWindow bounds and clone them at plan time."""
+    """Validate packed [nnz_qo] VariableWindow bounds.
+
+    Returns the caller tensors by reference (same contract as ``prefix_len_ptr``).
+    They must stay alive and unchanged from ``plan()`` through ``run()``.
+    """
     has_starts = variable_window_token_starts is not None
     has_ends = variable_window_token_ends is not None
     if has_starts != has_ends:
@@ -183,7 +187,7 @@ def _clone_variable_window_bounds(
             f"variable_window_token_starts/ends must have shape [{nnz_qo}] "
             f"(got {tuple(starts.shape)} and {tuple(ends.shape)})"
         )
-    return True, starts.clone(), ends.clone()
+    return True, starts, ends
 
 
 @functools.cache
@@ -2407,7 +2411,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
             Packed int32 ``[nnz_qo]`` inclusive KV start index per query token (ragged
             ``qo_indptr`` order). Must be paired with ``variable_window_token_ends``.
             FA3 only; mutually exclusive with sliding window, custom mask, causal, and
-            multi-item scoring. Cloned at ``plan()`` and reused at ``run()``.
+            multi-item scoring. Held by reference like ``prefix_len_ptr`` and reused
+            at ``run()``; keep the tensors alive and unchanged until then.
         variable_window_token_ends : Optional[torch.Tensor]
             Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note
@@ -2485,7 +2490,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
             self._use_variable_window,
             self._variable_window_token_starts,
             self._variable_window_token_ends,
-        ) = _clone_variable_window_bounds(
+        ) = _validate_variable_window_bounds(
             variable_window_token_starts,
             variable_window_token_ends,
             nnz_qo=total_num_rows,
@@ -3805,7 +3810,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             Packed int32 ``[nnz_qo]`` inclusive KV start index per query token (ragged
             ``qo_indptr`` order). Must be paired with ``variable_window_token_ends``.
             FA3 only; mutually exclusive with sliding window, custom mask, causal, and
-            multi-item scoring. Cloned at ``plan()`` and reused at ``run()``.
+            multi-item scoring. Held by reference like ``prefix_len_ptr`` and reused
+            at ``run()``; keep the tensors alive and unchanged until then.
         variable_window_token_ends : Optional[torch.Tensor]
             Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note
@@ -3863,7 +3869,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             self._use_variable_window,
             self._variable_window_token_starts,
             self._variable_window_token_ends,
-        ) = _clone_variable_window_bounds(
+        ) = _validate_variable_window_bounds(
             variable_window_token_starts,
             variable_window_token_ends,
             nnz_qo=total_num_rows,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -129,6 +129,12 @@ def _validate_variable_window_bounds(
     Returns the caller tensors by reference (same contract as ``prefix_len_ptr``).
     They must stay alive and unchanged from ``plan()`` through ``run()``.
     Checks are host metadata only (no copy, no device sync on the arrays).
+
+    Starts and ends must be nondecreasing within each request (same contract as
+    trtllm-gen VariableWindow). The kernel uses the first/last Q rows of each
+    CTA for KV-tile loads (union) and skips per-row masking on tiles inside the
+    intersection, so a later row with a *smaller* start than an earlier row in
+    the same tile is unsupported.
     """
     has_starts = variable_window_token_starts is not None
     has_ends = variable_window_token_ends is not None
@@ -2467,7 +2473,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
             FA3 only; mutually exclusive with sliding window, custom mask, causal, and
             multi-item scoring. Bake causal / SWA into the arrays. Held by reference
             like ``prefix_len_ptr`` and reused at ``run()``; keep the tensors alive
-            and unchanged until then.
+            and unchanged until then. Within each request, ``starts`` and ``ends``
+            must be nondecreasing so the kernel can skip masking on fully-interior
+            KV tiles (trtllm-gen VariableWindow / causal fast path).
         variable_window_token_ends : Optional[torch.Tensor]
             Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note
@@ -3866,7 +3874,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             FA3 only; mutually exclusive with sliding window, custom mask, causal, and
             multi-item scoring. Bake causal / SWA into the arrays. Held by reference
             like ``prefix_len_ptr`` and reused at ``run()``; keep the tensors alive
-            and unchanged until then.
+            and unchanged until then. Within each request, ``starts`` and ``ends``
+            must be nondecreasing so the kernel can skip masking on fully-interior
+            KV tiles (trtllm-gen VariableWindow / causal fast path).
         variable_window_token_ends : Optional[torch.Tensor]
             Packed int32 ``[nnz_qo]`` inclusive KV end index per query token.
         Note

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -1144,6 +1144,7 @@ class BlockSparseAttentionWrapper:
                 head_dim,  # head_dim_vo
                 PosEncodingMode[pos_encoding_mode].value,
                 False,  # use_sliding_window
+                False,  # use_variable_window
                 logits_soft_cap > 0,  # use_logits_soft_cap
                 use_fp16_qk_reduction,
             )
@@ -1784,6 +1785,7 @@ class VariableBlockSparseAttentionWrapper:
             head_dim,  # head_dim_vo
             PosEncodingMode[pos_encoding_mode].value,
             False,  # use_sliding_window
+            False,  # use_variable_window
             logits_soft_cap > 0,  # use_logits_soft_cap
             use_fp16_qk_reduction,
         )

--- a/include/flashinfer/attention/hopper/mainloop.cuh
+++ b/include/flashinfer/attention/hopper/mainloop.cuh
@@ -151,8 +151,8 @@ struct CollectiveMainloop {
     return num_kv_tiles;
   }
 
-  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
-            typename SharedStorage>
+  template <bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW = false, typename BlockCoord,
+            typename Scheduler, typename SharedStorage>
   CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
                            MainloopPipeline pipeline_v, PipelineState& smem_pipe_write_k,
                            PipelineState& smem_pipe_write_v, SharedStorage& shared_storage,
@@ -193,10 +193,8 @@ struct CollectiveMainloop {
     int num_kv_tiles = get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
     int kv_tile_idx = num_kv_tiles - 1;
     int swa_begin_kv_tile_idx = 0;
-    if constexpr (LEFT_SLIDING_WINDOW) {
-      swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
-                                                                       q_tile_idx, qo_len, kv_len);
-    }
+    apply_window_kv_tile_skip<CTA_Q, CTA_KV, LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
+        mainloop_params, qo_indptr, q_tile_idx, qo_len, kv_len, kv_tile_idx, swa_begin_kv_tile_idx);
 
     int lane_predicate = cute::elect_one_sync();
     if (lane_predicate) {

--- a/include/flashinfer/attention/hopper/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/mainloop_mma.cuh
@@ -12,14 +12,15 @@
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
 
+#include "utils.cuh"
 #include "variants.cuh"
 
 namespace flashinfer {
 
 template <typename Ktraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL, bool MULTIITEMSCORING,
-          typename WarpScheduler, typename AttentionVariant, typename Params,
-          typename MainloopPipeline, typename PipelineState, typename SharedStorage,
-          typename FrgTensorO, typename AttentionUpdater>
+          bool LEFT_VARIABLE_WINDOW, typename WarpScheduler, typename AttentionVariant,
+          typename Params, typename MainloopPipeline, typename PipelineState,
+          typename SharedStorage, typename FrgTensorO, typename AttentionUpdater>
 CUTLASS_DEVICE void mma_f16(
     const Params& mainloop_params, AttentionVariant& variant, MainloopPipeline pipeline_k,
     MainloopPipeline pipeline_v, PipelineState& smem_pipe_read_k, PipelineState& smem_pipe_read_v,
@@ -28,7 +29,7 @@ CUTLASS_DEVICE void mma_f16(
     int q_tile_idx, SharedStorage& shared_storage, const int32_t qo_len, const int32_t kv_len,
     const int32_t qo_head_idx, const int32_t kv_head_idx, const uint32_t prefix_len,
     uint16_t* token_pos_in_items, const int num_kv_tiles_outside_items_window = 0,
-    const int num_kv_tiles_prefix = 0) {
+    const int num_kv_tiles_prefix = 0, const int packed_qo_offset = 0) {
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
   using IdType = typename Ktraits::IdType;
@@ -94,6 +95,11 @@ CUTLASS_DEVICE void mma_f16(
   auto col_limit_right = [&](int qo_idx) { return qo_idx + 1 + kv_len - qo_len; };
   auto col_limit_left = [&](int qo_idx) {
     return qo_idx + kv_len - qo_len - mainloop_params.window_left;
+  };
+  auto apply_variable_window_mask = [&](auto& score, int qo_idx, int kv_idx) {
+    apply_variable_window_score_mask<LEFT_VARIABLE_WINDOW>(mainloop_params, packed_qo_offset,
+                                                           qo_idx, qo_len, kv_idx, kv_len, score,
+                                                           AttentionUpdater::fill_value);
   };
   auto mask_multi_item_scoring = [&](decltype(tSrS)& tSrS, int i, int qo_idx, int kv_idx) {
     const uint32_t idx_in_original_seq = qo_idx + kv_len - qo_len;
@@ -168,6 +174,7 @@ CUTLASS_DEVICE void mma_f16(
           tSrS(i) = AttentionUpdater::fill_value;
         }
       }
+      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
   }
 
@@ -216,6 +223,7 @@ CUTLASS_DEVICE void mma_f16(
           tSrS(i) = AttentionUpdater::fill_value;
         }
       }
+      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
     attention_updater.update</*init=*/false>(tSrS);
     warpgroup_wait<0>();
@@ -250,6 +258,7 @@ CUTLASS_DEVICE void mma_f16(
       int kv_idx = get<1>(tScS(i)) + kv_tile_idx_decrement(kv_tile_idx) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                         qo_head_idx, kv_head_idx);
+      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
     if constexpr (MULTIITEMSCORING) {
       // auto nums_tiles_outside_causal_diagonal = kv_tile_idx_count - cute::ceil_div(CTA_Q,
@@ -273,7 +282,7 @@ CUTLASS_DEVICE void mma_f16(
                tOrP);
   }
 
-  if constexpr (LEFT_SLIDING_WINDOW) {
+  if constexpr (LEFT_SLIDING_WINDOW || LEFT_VARIABLE_WINDOW) {
 #pragma unroll 1
     for (; kv_tile_idx > swa_begin_kv_tile_idx; --kv_tile_idx) {
       Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_QKD{}));
@@ -296,9 +305,12 @@ CUTLASS_DEVICE void mma_f16(
         int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
         tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                           qo_head_idx, kv_head_idx);
-        if (kv_idx < col_limit_left(qo_idx)) {
-          tSrS(i) = AttentionUpdater::fill_value;
+        if constexpr (LEFT_SLIDING_WINDOW) {
+          if (kv_idx < col_limit_left(qo_idx)) {
+            tSrS(i) = AttentionUpdater::fill_value;
+          }
         }
+        apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
       }
       attention_updater.update</*init=*/false>(tSrS);
       warpgroup_wait<0>();

--- a/include/flashinfer/attention/hopper/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/mainloop_mma.cuh
@@ -182,8 +182,23 @@ CUTLASS_DEVICE void mma_f16(
   Tensor tOrP = make_tensor(convert_type<DTypeKV>(tSrS).data(),
                             convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout()));
 
-  constexpr int n_masking_steps = MULTIITEMSCORING ? (cute::ceil_div(CTA_Q, CTA_KV) + 1)
-                                                   : (CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0);
+  int n_masking_steps;
+  if constexpr (LEFT_VARIABLE_WINDOW) {
+    n_masking_steps = 0;
+    using AdditionalParamsT = decltype(mainloop_params.additional_params);
+    if constexpr (has_maybe_variable_window_token_starts_v<AdditionalParamsT> &&
+                  has_maybe_variable_window_token_ends_v<AdditionalParamsT>) {
+      auto vw_bounds = get_variable_window_kv_tile_bounds<CTA_Q, CTA_KV>(
+          mainloop_params.additional_params.maybe_variable_window_token_starts,
+          mainloop_params.additional_params.maybe_variable_window_token_ends, packed_qo_offset,
+          q_tile_idx, qo_len, kv_len);
+      n_masking_steps = std::max(0, vw_bounds.end - vw_bounds.unmask_end - 1);
+    }
+  } else if constexpr (MULTIITEMSCORING) {
+    n_masking_steps = cute::ceil_div(CTA_Q, CTA_KV) + 1;
+  } else {
+    n_masking_steps = CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0;
+  }
   // masking loops
   // ziangl@nvidia.com: for multi item scoring, we use this loop only to mask along the diagonal
 #pragma unroll
@@ -213,7 +228,7 @@ CUTLASS_DEVICE void mma_f16(
                                         qo_head_idx, kv_head_idx);
       if (MULTIITEMSCORING) {
         mask_multi_item_scoring(tSrS, i, qo_idx, kv_idx);
-      } else {
+      } else if constexpr (CAUSAL) {
         if (kv_idx >= col_limit_right(qo_idx)) {
           tSrS(i) = AttentionUpdater::fill_value;
         }
@@ -258,7 +273,6 @@ CUTLASS_DEVICE void mma_f16(
       int kv_idx = get<1>(tScS(i)) + kv_tile_idx_decrement(kv_tile_idx) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/0, qo_idx, kv_idx,
                                         qo_head_idx, kv_head_idx);
-      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
     if constexpr (MULTIITEMSCORING) {
       // auto nums_tiles_outside_causal_diagonal = kv_tile_idx_count - cute::ceil_div(CTA_Q,

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -42,7 +42,7 @@ DEFINE_HAS_MEMBER(maybe_max_item_len_ptr)
 
 template <typename CollectiveMainloop, typename CollectiveEpilogue, typename Ktraits,
           bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename TileScheduler,
-          bool MULTIITEMSCORING = false>
+          bool MULTIITEMSCORING = false, bool LEFT_VARIABLE_WINDOW = false>
 __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp, 1)
     PrefillWithKVCacheKernel(CUTE_GRID_CONSTANT
                              typename CollectiveMainloop::Params const mainloop_params,
@@ -189,12 +189,12 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
         }
         if constexpr (MULTIITEMSCORING) {
-          collective_mainloop.load<LEFT_SLIDING_WINDOW>(
+          collective_mainloop.load<LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
               mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
               shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx,
               num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
         } else {
-          collective_mainloop.template load<LEFT_SLIDING_WINDOW>(
+          collective_mainloop.template load<LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
               mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
               shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx);
         }
@@ -250,12 +250,9 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
 
       int swa_begin_kv_tile_idx = 0;
       int swa_end_kv_tile_idx = -1;
-      if constexpr (LEFT_SLIDING_WINDOW) {
-        swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(
-            mainloop_params.window_left, q_tile_idx, qo_len, kv_len);
-        swa_end_kv_tile_idx = get_swa_end_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
-                                                                     q_tile_idx, qo_len, kv_len);
-      }
+      apply_window_kv_tile_skip_consumer<CTA_Q, CTA_KV, LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
+          mainloop_params, qo_indptr, q_tile_idx, qo_len, kv_len, num_kv_tiles,
+          swa_begin_kv_tile_idx, swa_end_kv_tile_idx);
 
       uint32_t prefix_len = 0;
       uint16_t* token_pos_in_items = nullptr;
@@ -274,12 +271,12 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
         num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
       }
       mma_f16<Ktraits, /*LEFT_SLIDING_WINDOW=*/LEFT_SLIDING_WINDOW, CAUSAL, MULTIITEMSCORING,
-              CollectiveMainloop::WarpScheduler>(
+              /*LEFT_VARIABLE_WINDOW=*/LEFT_VARIABLE_WINDOW, CollectiveMainloop::WarpScheduler>(
           mainloop_params, variant, pipeline_k, pipeline_v, smem_pipe_read_k, smem_pipe_read_v,
           tOrO, attention_updater, num_kv_tiles, swa_begin_kv_tile_idx, swa_end_kv_tile_idx,
           threadIdx.x - NUM_COPY_THREADS, work_idx, q_tile_idx, shared_storage, qo_len, kv_len,
           qo_head_idx, kv_head_idx, prefix_len, token_pos_in_items,
-          num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
+          num_kv_tiles_outside_items_window, num_kv_tiles_prefix, qo_indptr);
       collective_epilogue.store(epilogue_params, tOrO, attention_updater.get_lse(), shared_storage,
                                 tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord);
 
@@ -352,7 +349,8 @@ cudaError_t SinglePrefillWithKVCacheKernelTraitsDispatched(Params& params, cudaS
 }
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool MULTIITEMSCORING = false>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool MULTIITEMSCORING = false,
+          bool LEFT_VARIABLE_WINDOW = false>
 cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
                                                                cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -407,9 +405,9 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
 
   // Get the ptr to kernel function.
-  auto kernel =
-      (void*)PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
-                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler, MULTIITEMSCORING>;
+  auto kernel = (void*)PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue,
+                                                KernelTraits, LEFT_SLIDING_WINDOW, CAUSAL,
+                                                Scheduler, MULTIITEMSCORING, LEFT_VARIABLE_WINDOW>;
   int smem_size = sizeof(typename KernelTraits::SharedStorage);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -429,7 +427,7 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
 }
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool LEFT_VARIABLE_WINDOW = false>
 cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
                                                                 cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -484,7 +482,8 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
   // Get the ptr to kernel function.
   auto kernel =
       (void*)PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
-                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler>;
+                                      LEFT_SLIDING_WINDOW, CAUSAL, Scheduler,
+                                      /*MULTIITEMSCORING=*/false, LEFT_VARIABLE_WINDOW>;
   int smem_size = sizeof(typename KernelTraits::SharedStorage);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -545,7 +544,8 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params& params, cudaStream_t stre
 }
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_pdl,
                                                     cudaStream_t stream) {
   static_assert(HEAD_DIM_VO == 64 || HEAD_DIM_VO == 128 || HEAD_DIM_VO == 256);
@@ -560,13 +560,15 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_
                             /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
                             /*NUM_STAGES_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
                             typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
-      LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+      LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+      params, stream);
   cudaError_t status = cudaGetLastError();
   return status;
 }
 
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_pdl,
                                                    cudaStream_t stream) {
   static_assert(HEAD_DIM_VO == 64 || HEAD_DIM_VO == 128 || HEAD_DIM_VO == 256);
@@ -585,8 +587,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
-          params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING,
+          LEFT_VARIABLE_WINDOW>(params, stream);
     } else if constexpr (HEAD_DIM_VO == 128) {
       BatchPrefillWithPagedKVCacheKernelTraitsDispatched<
           AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK, HEAD_DIM_VO,
@@ -595,8 +597,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
-          params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING,
+          LEFT_VARIABLE_WINDOW>(params, stream);
     } else {
       // HEAD_DIM == 256;
       // NOTE(Zihao): CTA_KV not tuned for HEAD_DIM == 256, need to optimize later
@@ -607,8 +609,8 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
                                 /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                 typename Params::DTypeKV, typename Params::DTypeO,
                                 typename Params::IdType, AttentionVariant>,
-          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
-          params, stream);
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING,
+          LEFT_VARIABLE_WINDOW>(params, stream);
     }
   } else {
     return cudaErrorNotSupported;

--- a/include/flashinfer/attention/hopper/quantization/mainloop_load.cuh
+++ b/include/flashinfer/attention/hopper/quantization/mainloop_load.cuh
@@ -150,8 +150,8 @@ struct FP8CollectiveMainloop {
     return num_kv_tiles;
   }
 
-  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
-            typename SharedStorage>
+  template <bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW = false, typename BlockCoord,
+            typename Scheduler, typename SharedStorage>
   CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
                            MainloopPipeline pipeline_v, MainloopPipelineVt pipeline_vt,
                            PipelineState& smem_pipe_write, PipelineState& smem_pipe_read,
@@ -203,10 +203,8 @@ struct FP8CollectiveMainloop {
     int num_kv_tiles = get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
     int kv_tile_idx = num_kv_tiles - 1;
     int swa_begin_kv_tile_idx = 0;
-    if constexpr (LEFT_SLIDING_WINDOW) {
-      swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
-                                                                       q_tile_idx, qo_len, kv_len);
-    }
+    apply_window_kv_tile_skip<CTA_Q, CTA_KV, LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
+        mainloop_params, qo_indptr, q_tile_idx, qo_len, kv_len, kv_tile_idx, swa_begin_kv_tile_idx);
 
     // All WG proceeds here, only one thread in each WG will issue TMA load
     int lane_predicate = cute::elect_one_sync();

--- a/include/flashinfer/attention/hopper/quantization/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/quantization/mainloop_mma.cuh
@@ -12,12 +12,14 @@
 #include <cutlass/numeric_conversion.h>
 #include <cutlass/numeric_types.h>
 
+#include "../utils.cuh"
+
 namespace flashinfer {
 
-template <typename Ktraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename WarpScheduler,
-          typename AttentionVariant, typename Params, typename MainloopPipeline,
-          typename MainloopPipelineVt, typename PipelineState, typename SharedStorage,
-          typename FrgTensorO, typename AttentionUpdater>
+template <typename Ktraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL, bool LEFT_VARIABLE_WINDOW,
+          typename WarpScheduler, typename AttentionVariant, typename Params,
+          typename MainloopPipeline, typename MainloopPipelineVt, typename PipelineState,
+          typename SharedStorage, typename FrgTensorO, typename AttentionUpdater>
 CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& variant,
                             MainloopPipeline pipeline_k, MainloopPipelineVt pipeline_vt,
                             PipelineState& smem_pipe_read_k, PipelineState& smem_pipe_read_v,
@@ -26,7 +28,8 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
                             int swa_end_kv_tile_idx, int thread_idx, int work_idx, int q_tile_idx,
                             SharedStorage& shared_storage, const int32_t qo_len,
                             const int32_t kv_len, const int32_t qo_head_idx,
-                            const int32_t kv_head_idx, const int32_t batch_idx) {
+                            const int32_t kv_head_idx, const int32_t batch_idx,
+                            const int packed_qo_offset = 0) {
   using DTypeQ = typename Ktraits::DTypeQ;
   using DTypeKV = typename Ktraits::DTypeKV;
   using IdType = typename Ktraits::IdType;
@@ -93,6 +96,11 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
   auto col_limit_left = [&](int qo_idx) {
     return qo_idx + kv_len - qo_len - mainloop_params.window_left;
   };
+  auto apply_variable_window_mask = [&](auto& score, int qo_idx, int kv_idx) {
+    apply_variable_window_score_mask<LEFT_VARIABLE_WINDOW>(mainloop_params, packed_qo_offset,
+                                                           qo_idx, qo_len, kv_idx, kv_len, score,
+                                                           AttentionUpdater::fill_value);
+  };
   {
     Tensor cS = cute::make_identity_tensor(select<0, 1>(TileShape_QKD{}));
     Tensor tScS = threadMmaQK.partition_C(cS);
@@ -116,6 +124,7 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
           tSrS(i) = AttentionUpdater::fill_value;
         }
       }
+      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
   }
 
@@ -163,6 +172,7 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
           tSrS(i) = AttentionUpdater::fill_value;
         }
       }
+      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
     attention_updater.update</*init=*/false>(tSrS);
     // Re-quantize P after softmax
@@ -201,6 +211,7 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
       int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/batch_idx, qo_idx,
                                         kv_idx, qo_head_idx, kv_head_idx);
+      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
 
     attention_updater.update</*init=*/false>(tSrS);
@@ -217,7 +228,7 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
     permute_regs_A_to_C(tOrP);
   }
 
-  if constexpr (LEFT_SLIDING_WINDOW) {
+  if constexpr (LEFT_SLIDING_WINDOW || LEFT_VARIABLE_WINDOW) {
 #pragma unroll 1
     for (; kv_tile_idx > swa_begin_kv_tile_idx; --kv_tile_idx) {
       Tensor tSrS = partition_fragment_C(tiled_mma_qk, select<0, 1>(TileShape_QKD{}));
@@ -240,9 +251,12 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
         int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
         tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/batch_idx, qo_idx,
                                           kv_idx, qo_head_idx, kv_head_idx);
-        if (kv_idx < col_limit_left(qo_idx)) {
-          tSrS(i) = AttentionUpdater::fill_value;
+        if constexpr (LEFT_SLIDING_WINDOW) {
+          if (kv_idx < col_limit_left(qo_idx)) {
+            tSrS(i) = AttentionUpdater::fill_value;
+          }
         }
+        apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
       }
       attention_updater.update</*init=*/false>(tSrS);
       // Re-quantize P after softmax

--- a/include/flashinfer/attention/hopper/quantization/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/quantization/mainloop_mma.cuh
@@ -137,7 +137,21 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
       make_tensor(convert_type<DTypeKV>(tSrS).data(), convert_layout_acc_Aregs_fp8(tSrS.layout()));
   permute_regs_A_to_C(tOrP);
 
-  constexpr int n_masking_steps = CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0;
+  int n_masking_steps;
+  if constexpr (LEFT_VARIABLE_WINDOW) {
+    n_masking_steps = 0;
+    using AdditionalParamsT = decltype(mainloop_params.additional_params);
+    if constexpr (has_maybe_variable_window_token_starts_v<AdditionalParamsT> &&
+                  has_maybe_variable_window_token_ends_v<AdditionalParamsT>) {
+      auto vw_bounds = get_variable_window_kv_tile_bounds<CTA_Q, CTA_KV>(
+          mainloop_params.additional_params.maybe_variable_window_token_starts,
+          mainloop_params.additional_params.maybe_variable_window_token_ends, packed_qo_offset,
+          q_tile_idx, qo_len, kv_len);
+      n_masking_steps = std::max(0, vw_bounds.end - vw_bounds.unmask_end - 1);
+    }
+  } else {
+    n_masking_steps = CAUSAL ? cute::ceil_div(CTA_Q, CTA_KV) : 0;
+  }
   // masking loops
 #pragma unroll
   for (int masking_step = 0; masking_step < n_masking_steps && kv_tile_idx > swa_begin_kv_tile_idx;
@@ -164,8 +178,10 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
       int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/batch_idx, qo_idx,
                                         kv_idx, qo_head_idx, kv_head_idx);
-      if (kv_idx >= col_limit_right(qo_idx)) {
-        tSrS(i) = AttentionUpdater::fill_value;
+      if constexpr (CAUSAL) {
+        if (kv_idx >= col_limit_right(qo_idx)) {
+          tSrS(i) = AttentionUpdater::fill_value;
+        }
       }
       if constexpr (LEFT_SLIDING_WINDOW) {
         if (kv_idx < col_limit_left(qo_idx)) {
@@ -211,7 +227,6 @@ CUTLASS_DEVICE void mma_fp8(const Params& mainloop_params, AttentionVariant& var
       int kv_idx = get<1>(tScS(i)) + (kv_tile_idx - 1) * CTA_KV;
       tSrS(i) = variant.LogitsTransform(mainloop_params, tSrS(i), /*batch_idx=*/batch_idx, qo_idx,
                                         kv_idx, qo_head_idx, kv_head_idx);
-      apply_variable_window_mask(tSrS(i), qo_idx, kv_idx);
     }
 
     attention_updater.update</*init=*/false>(tSrS);

--- a/include/flashinfer/attention/hopper/quantization/mainloop_sparse_load.cuh
+++ b/include/flashinfer/attention/hopper/quantization/mainloop_sparse_load.cuh
@@ -169,8 +169,8 @@ struct FP8SparseCollectiveMainloop {
     return num_kv_tiles;
   }
 
-  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
-            typename SharedStorage>
+  template <bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW = false, typename BlockCoord,
+            typename Scheduler, typename SharedStorage>
   CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
                            MainloopPipeline pipeline_v, MainloopPipelineVt pipeline_vt,
                            PipelineState& smem_pipe_write, PipelineState& smem_pipe_read,
@@ -215,10 +215,8 @@ struct FP8SparseCollectiveMainloop {
     int num_kv_tiles = get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
     int kv_tile_idx = num_kv_tiles - 1;
     int swa_begin_kv_tile_idx = 0;
-    if constexpr (LEFT_SLIDING_WINDOW) {
-      swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
-                                                                       q_tile_idx, qo_len, kv_len);
-    }
+    apply_window_kv_tile_skip<CTA_Q, CTA_KV, LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
+        mainloop_params, qo_indptr, q_tile_idx, qo_len, kv_len, kv_tile_idx, swa_begin_kv_tile_idx);
 
     constexpr int HEAD_DIM = get<2>(TileShape_QKD{});
     constexpr int CTA_KV = get<1>(TileShape_QKD{});

--- a/include/flashinfer/attention/hopper/quantization/mainloop_sparse_load.cuh
+++ b/include/flashinfer/attention/hopper/quantization/mainloop_sparse_load.cuh
@@ -432,11 +432,12 @@ struct FP8SparseCollectiveMainloop {
       }
       scheduler.prefetch_next_work(scheduler_params, work_tile_info);
 
-      // load first v tile (tile 0)
+      // Load V for the earliest remaining KV tile. After the loop above,
+      // kv_tile_idx == swa_begin_kv_tile_idx (not necessarily 0).
       {
-        prefetch_kv_offset(0, v_stride_n, v_page_stride, false);
+        prefetch_kv_offset(kv_tile_idx, v_stride_n, v_page_stride, false);
         pipeline_v.producer_acquire(smem_pipe_write);
-        load_kv_with_prefetch(v_base_ptr, tVsV, 0, smem_pipe_write.index(), false);
+        load_kv_with_prefetch(v_base_ptr, tVsV, kv_tile_idx, smem_pipe_write.index(), false);
         pipeline_v.producer_commit(smem_pipe_write, cutlass::arch::cpasync_barrier_arrive);
 
         // Transpose V

--- a/include/flashinfer/attention/hopper/quantization/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/quantization/prefill_sm90.cuh
@@ -38,7 +38,8 @@ namespace flashinfer {
 using namespace cute;
 
 template <typename CollectiveMainloop, typename CollectiveEpilogue, typename Ktraits,
-          bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename TileScheduler>
+          bool LEFT_SLIDING_WINDOW, bool CAUSAL, typename TileScheduler,
+          bool LEFT_VARIABLE_WINDOW = false>
 __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp, 1)
     FP8PrefillWithKVCacheKernel(CUTE_GRID_CONSTANT
                                 typename CollectiveMainloop::Params const mainloop_params,
@@ -170,7 +171,7 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
         scheduler.broadcast_next_work(work_tile_info);
         continue;
       }
-      collective_mainloop.load<LEFT_SLIDING_WINDOW>(
+      collective_mainloop.load<LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
           mainloop_params, pipeline_k, pipeline_v, pipeline_vt, smem_pipe_write, smem_pipe_read,
           shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx);
       ++work_idx;
@@ -226,19 +227,16 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
 
       int swa_begin_kv_tile_idx = 0;
       int swa_end_kv_tile_idx = -1;
-      if constexpr (LEFT_SLIDING_WINDOW) {
-        swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(
-            mainloop_params.window_left, q_tile_idx, qo_len, kv_len);
-        swa_end_kv_tile_idx = get_swa_end_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
-                                                                     q_tile_idx, qo_len, kv_len);
-      }
+      apply_window_kv_tile_skip_consumer<CTA_Q, CTA_KV, LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
+          mainloop_params, qo_indptr, q_tile_idx, qo_len, kv_len, num_kv_tiles,
+          swa_begin_kv_tile_idx, swa_end_kv_tile_idx);
 
       mma_fp8<Ktraits, /*LEFT_SLIDING_WINDOW=*/LEFT_SLIDING_WINDOW, CAUSAL,
-              CollectiveMainloop::WarpScheduler>(
+              /*LEFT_VARIABLE_WINDOW=*/LEFT_VARIABLE_WINDOW, CollectiveMainloop::WarpScheduler>(
           mainloop_params, variant, pipeline_k, pipeline_vt, smem_pipe_read_k, smem_pipe_read_v,
           tOrO, attention_updater, num_kv_tiles, swa_begin_kv_tile_idx, swa_end_kv_tile_idx,
           threadIdx.x - NUM_COPY_THREADS, work_idx, q_tile_idx, shared_storage, qo_len, kv_len,
-          qo_head_idx, kv_head_idx, batch_idx);
+          qo_head_idx, kv_head_idx, batch_idx, qo_indptr);
 
       collective_epilogue.store(epilogue_params, tOrO, attention_updater.get_lse(), shared_storage,
                                 tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord);
@@ -313,7 +311,7 @@ cudaError_t SingleFP8PrefillWithKVCacheKernelTraitsDispatched(Params& params, cu
 }
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool LEFT_VARIABLE_WINDOW = false>
 cudaError_t BatchFP8PrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
                                                                   cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -367,9 +365,9 @@ cudaError_t BatchFP8PrefillWithPagedKVCacheKernelTraitsDispatched(Params& params
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
 
   // Get the ptr to kernel function.
-  auto kernel =
-      (void*)FP8PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
-                                         LEFT_SLIDING_WINDOW, CAUSAL, Scheduler>;
+  auto kernel = (void*)
+      FP8PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
+                                  LEFT_SLIDING_WINDOW, CAUSAL, Scheduler, LEFT_VARIABLE_WINDOW>;
   int smem_size = sizeof(typename KernelTraits::SharedStorage);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -432,7 +430,8 @@ cudaError_t SingleFP8PrefillWithKVCacheDispatched(Params& params, cudaStream_t s
 }
 
 template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, bool enable_pdl,
                                                       cudaStream_t stream) {
   static_assert(HEAD_DIM == 64 || HEAD_DIM == 128 || HEAD_DIM == 256);
@@ -449,7 +448,8 @@ cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, bool enabl
                                  /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                  typename Params::DTypeKV, typename Params::DTypeO,
                                  typename Params::IdType, AttentionVariant>,
-        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+        params, stream);
   } else if constexpr (HEAD_DIM == 128) {
     BatchFP8PrefillWithPagedKVCacheKernelTraitsDispatched<
         FP8AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM,
@@ -458,7 +458,8 @@ cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, bool enabl
                                  /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                  typename Params::DTypeKV, typename Params::DTypeO,
                                  typename Params::IdType, AttentionVariant>,
-        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+        params, stream);
   } else {
     // HEAD_DIM == 256;
     // NOTE: Use smaller CTA_KV=64 for sparse paged loading to reduce page table lookup overhead
@@ -470,14 +471,15 @@ cudaError_t BatchFP8PrefillWithPagedKVCacheDispatched(Params& params, bool enabl
                                  /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                  typename Params::DTypeKV, typename Params::DTypeO,
                                  typename Params::IdType, AttentionVariant>,
-        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+        params, stream);
   }
   cudaError_t status = cudaGetLastError();
   return status;
 };
 
 template <typename KernelTraits, bool LEFT_SLIDING_WINDOW, bool CAUSAL,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params>
+          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename Params, bool LEFT_VARIABLE_WINDOW = false>
 cudaError_t BatchFP8PrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
                                                                    cudaStream_t stream) {
   using DTypeQ = typename KernelTraits::DTypeQ;
@@ -530,9 +532,9 @@ cudaError_t BatchFP8PrefillWithRaggedKVCacheKernelTraitsDispatched(Params& param
   typename Scheduler::Params scheduler_params = Scheduler::to_underlying_arguments(scheduler_args);
 
   // Get the ptr to kernel function.
-  auto kernel =
-      (void*)FP8PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
-                                         LEFT_SLIDING_WINDOW, CAUSAL, Scheduler>;
+  auto kernel = (void*)
+      FP8PrefillWithKVCacheKernel<CollectiveMainloop, CollectiveEpilogue, KernelTraits,
+                                  LEFT_SLIDING_WINDOW, CAUSAL, Scheduler, LEFT_VARIABLE_WINDOW>;
   int smem_size = sizeof(typename KernelTraits::SharedStorage);
   FLASHINFER_CUDA_CALL(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
@@ -552,7 +554,8 @@ cudaError_t BatchFP8PrefillWithRaggedKVCacheKernelTraitsDispatched(Params& param
 }
 
 template <uint32_t HEAD_DIM, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
-          bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant, typename Params>
+          bool LEFT_VARIABLE_WINDOW, bool SAME_SCHEDULE_FOR_ALL_HEADS, typename AttentionVariant,
+          typename Params>
 cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched(Params& params, bool enable_pdl,
                                                        cudaStream_t stream) {
   static_assert(HEAD_DIM == 64 || HEAD_DIM == 128 || HEAD_DIM == 256);
@@ -568,7 +571,8 @@ cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched(Params& params, bool enab
                                  /*NUM_STAGES_=*/4, typename Params::DTypeQ,
                                  typename Params::DTypeKV, typename Params::DTypeO,
                                  typename Params::IdType, AttentionVariant>,
-        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+        params, stream);
   } else if constexpr (HEAD_DIM == 128) {
     BatchFP8PrefillWithRaggedKVCacheKernelTraitsDispatched<
         FP8AttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM,
@@ -577,7 +581,8 @@ cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched(Params& params, bool enab
                                  /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                  typename Params::DTypeKV, typename Params::DTypeO,
                                  typename Params::IdType, AttentionVariant>,
-        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+        params, stream);
   } else {
     // HEAD_DIM == 256;
     BatchFP8PrefillWithRaggedKVCacheKernelTraitsDispatched<
@@ -587,7 +592,8 @@ cudaError_t BatchFP8PrefillWithRaggedKVCacheDispatched(Params& params, bool enab
                                  /*NUM_STAGES_=*/2, typename Params::DTypeQ,
                                  typename Params::DTypeKV, typename Params::DTypeO,
                                  typename Params::IdType, AttentionVariant>,
-        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, LEFT_VARIABLE_WINDOW>(
+        params, stream);
   }
   cudaError_t status = cudaGetLastError();
   return status;

--- a/include/flashinfer/attention/hopper/sparse_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/sparse_mainloop.cuh
@@ -173,8 +173,8 @@ struct SparseCollectiveMainloop {
     return num_kv_tiles;
   }
 
-  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
-            typename SharedStorage>
+  template <bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW = false, typename BlockCoord,
+            typename Scheduler, typename SharedStorage>
   CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
                            MainloopPipeline pipeline_v, PipelineState& smem_pipe_write_k,
                            PipelineState& smem_pipe_write_v, SharedStorage& shared_storage,
@@ -207,10 +207,8 @@ struct SparseCollectiveMainloop {
     int num_kv_tiles = get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
     int kv_tile_idx = num_kv_tiles - 1;
     int swa_begin_kv_tile_idx = 0;
-    if constexpr (LEFT_SLIDING_WINDOW) {
-      swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
-                                                                       q_tile_idx, qo_len, kv_len);
-    }
+    apply_window_kv_tile_skip<CTA_Q, CTA_KV, LEFT_SLIDING_WINDOW, LEFT_VARIABLE_WINDOW>(
+        mainloop_params, qo_indptr, q_tile_idx, qo_len, kv_len, kv_tile_idx, swa_begin_kv_tile_idx);
 
     constexpr int HEAD_DIM_QK = get<2>(TileShape_QKD{});
     constexpr int HEAD_DIM_VO = get<1>(TileShape_PDV{});

--- a/include/flashinfer/attention/hopper/sparse_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/sparse_mainloop.cuh
@@ -420,11 +420,12 @@ struct SparseCollectiveMainloop {
       }
       scheduler.prefetch_next_work(scheduler_params, work_tile_info);
 
-      // load first v tile (tile 0)
+      // Load V for the earliest remaining KV tile. After the loop above,
+      // kv_tile_idx == swa_begin_kv_tile_idx (not necessarily 0).
       {
-        prefetch_kv_offset(0, false);
+        prefetch_kv_offset(kv_tile_idx, false);
         pipeline_v.producer_acquire(smem_pipe_write_v);
-        load_kv_with_gather(tVsV, tVcV, V_ptr_base, 0, smem_pipe_write_v.index(), false);
+        load_kv_with_gather(tVsV, tVcV, V_ptr_base, kv_tile_idx, smem_pipe_write_v.index(), false);
         pipeline_v.producer_commit(smem_pipe_write_v, cutlass::arch::cpasync_barrier_arrive);
         ++smem_pipe_write_v;
       }

--- a/include/flashinfer/attention/hopper/utils.cuh
+++ b/include/flashinfer/attention/hopper/utils.cuh
@@ -46,6 +46,126 @@ CUTLASS_DEVICE int get_swa_end_kv_tile_idx(int window_left, int q_tile_idx, cons
   return std::max(((q_tile_idx + 1) * CTA_Q + kv_len - qo_len - window_left) / CTA_KV, -1);
 }
 
+struct VariableWindowKvTileBounds {
+  int begin;  // inclusive first KV tile to load
+  int end;    // inclusive last KV tile to load
+};
+
+DEFINE_HAS_MEMBER(maybe_variable_window_token_starts)
+DEFINE_HAS_MEMBER(maybe_variable_window_token_ends)
+
+// Min start / max end over valid Q rows in this CTA tile. packed_qo_offset is
+// qo_indptr[batch] into the packed [nnz_qo] start/end arrays.
+template <int CTA_Q, int CTA_KV>
+CUTLASS_DEVICE VariableWindowKvTileBounds
+get_variable_window_kv_tile_bounds(int32_t const* starts, int32_t const* ends, int packed_qo_offset,
+                                   int q_tile_idx, int qo_len, int kv_len) {
+  int q_start = q_tile_idx * CTA_Q;
+  int q_end = std::min(q_start + CTA_Q, qo_len);
+  int min_start = kv_len;
+  int max_end = -1;
+#pragma unroll 1
+  for (int q = q_start; q < q_end; ++q) {
+    min_start = std::min(min_start, __ldg(starts + packed_qo_offset + q));
+    max_end = std::max(max_end, __ldg(ends + packed_qo_offset + q));
+  }
+  int num_kv_tiles = cute::ceil_div(kv_len, CTA_KV);
+  int first = std::max(min_start / CTA_KV - 1, 0);
+  int last = std::min(num_kv_tiles - 1, std::max(max_end, 0) / CTA_KV);
+  if (last < first) {
+    last = first;
+  }
+  return {first, last};
+}
+
+template <int CTA_Q, int CTA_KV, bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW,
+          typename Params>
+CUTLASS_DEVICE void apply_window_kv_tile_skip(Params const& mainloop_params, int packed_qo_offset,
+                                              int q_tile_idx, int qo_len, int kv_len,
+                                              int& kv_tile_idx, int& swa_begin_kv_tile_idx) {
+  static_assert(!(LEFT_SLIDING_WINDOW && LEFT_VARIABLE_WINDOW),
+                "VariableWindow cannot be combined with sliding window");
+  if constexpr (LEFT_SLIDING_WINDOW) {
+    swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
+                                                                     q_tile_idx, qo_len, kv_len);
+  } else if constexpr (LEFT_VARIABLE_WINDOW) {
+    using AdditionalParamsT = decltype(mainloop_params.additional_params);
+    if constexpr (has_maybe_variable_window_token_starts_v<AdditionalParamsT> &&
+                  has_maybe_variable_window_token_ends_v<AdditionalParamsT>) {
+      auto bounds = get_variable_window_kv_tile_bounds<CTA_Q, CTA_KV>(
+          mainloop_params.additional_params.maybe_variable_window_token_starts,
+          mainloop_params.additional_params.maybe_variable_window_token_ends, packed_qo_offset,
+          q_tile_idx, qo_len, kv_len);
+      swa_begin_kv_tile_idx = bounds.begin;
+      kv_tile_idx = bounds.end;
+    }
+  }
+}
+
+template <int CTA_Q, int CTA_KV, bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW,
+          typename Params>
+CUTLASS_DEVICE void apply_window_kv_tile_skip_consumer(Params const& mainloop_params,
+                                                       int packed_qo_offset, int q_tile_idx,
+                                                       int qo_len, int kv_len, int& num_kv_tiles,
+                                                       int& swa_begin_kv_tile_idx,
+                                                       int& swa_end_kv_tile_idx) {
+  static_assert(!(LEFT_SLIDING_WINDOW && LEFT_VARIABLE_WINDOW),
+                "VariableWindow cannot be combined with sliding window");
+  if constexpr (LEFT_SLIDING_WINDOW) {
+    swa_begin_kv_tile_idx = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
+                                                                     q_tile_idx, qo_len, kv_len);
+    swa_end_kv_tile_idx = get_swa_end_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left,
+                                                                 q_tile_idx, qo_len, kv_len);
+  } else if constexpr (LEFT_VARIABLE_WINDOW) {
+    using AdditionalParamsT = decltype(mainloop_params.additional_params);
+    if constexpr (has_maybe_variable_window_token_starts_v<AdditionalParamsT> &&
+                  has_maybe_variable_window_token_ends_v<AdditionalParamsT>) {
+      auto bounds = get_variable_window_kv_tile_bounds<CTA_Q, CTA_KV>(
+          mainloop_params.additional_params.maybe_variable_window_token_starts,
+          mainloop_params.additional_params.maybe_variable_window_token_ends, packed_qo_offset,
+          q_tile_idx, qo_len, kv_len);
+      // Drain is unused: middle loop consumes (first, last], init consumes last.
+      swa_begin_kv_tile_idx = bounds.begin;
+      swa_end_kv_tile_idx = bounds.begin - 1;
+      num_kv_tiles = bounds.end + 1;
+    }
+  }
+}
+
+template <typename Acc>
+CUTLASS_DEVICE void mask_variable_window_score(int32_t const* starts, int32_t const* ends,
+                                               int packed_qo_offset, int qo_idx, int qo_len,
+                                               int kv_idx, int kv_len, Acc& score, Acc fill_value) {
+  if (qo_idx >= qo_len || kv_idx >= kv_len) {
+    score = fill_value;
+    return;
+  }
+  int32_t window_start = __ldg(starts + packed_qo_offset + qo_idx);
+  int32_t window_end = __ldg(ends + packed_qo_offset + qo_idx);
+  if (kv_idx < window_start || kv_idx > window_end) {
+    score = fill_value;
+  }
+}
+
+// Field access is gated on AdditionalParams so FA3 modules compiled with
+// LEFT_VARIABLE_WINDOW=false (no start/end pointers) stay well-formed under NVCC.
+template <bool LEFT_VARIABLE_WINDOW, typename Params, typename Acc>
+CUTLASS_DEVICE void apply_variable_window_score_mask(Params const& mainloop_params,
+                                                     int packed_qo_offset, int qo_idx, int qo_len,
+                                                     int kv_idx, int kv_len, Acc& score,
+                                                     Acc fill_value) {
+  if constexpr (LEFT_VARIABLE_WINDOW) {
+    using AdditionalParamsT = decltype(mainloop_params.additional_params);
+    if constexpr (has_maybe_variable_window_token_starts_v<AdditionalParamsT> &&
+                  has_maybe_variable_window_token_ends_v<AdditionalParamsT>) {
+      mask_variable_window_score(
+          mainloop_params.additional_params.maybe_variable_window_token_starts,
+          mainloop_params.additional_params.maybe_variable_window_token_ends, packed_qo_offset,
+          qo_idx, qo_len, kv_idx, kv_len, score, fill_value);
+    }
+  }
+}
+
 template <typename TensorT>
 CUTLASS_HOST_DEVICE auto flatten_1(TensorT tensor) {
   Tensor tensor_flatten = cute::flatten(tensor);

--- a/include/flashinfer/attention/hopper/utils.cuh
+++ b/include/flashinfer/attention/hopper/utils.cuh
@@ -47,35 +47,50 @@ CUTLASS_DEVICE int get_swa_end_kv_tile_idx(int window_left, int q_tile_idx, cons
 }
 
 struct VariableWindowKvTileBounds {
-  int begin;  // inclusive first KV tile to load
-  int end;    // inclusive last KV tile to load
+  int begin;         // inclusive first KV tile to load (union)
+  int end;           // inclusive last KV tile to load (union)
+  int unmask_begin;  // first KV tile fully inside every row's window
+  int unmask_end;    // last KV tile fully inside every row's window
 };
 
 DEFINE_HAS_MEMBER(maybe_variable_window_token_starts)
 DEFINE_HAS_MEMBER(maybe_variable_window_token_ends)
 
-// Min start / max end over valid Q rows in this CTA tile. packed_qo_offset is
-// qo_indptr[batch] into the packed [nnz_qo] start/end arrays.
+// trtllm-gen VariableWindow (MR 938): starts/ends are nondecreasing in Q, so a
+// Q CTA only needs the first and last packed rows.
+//   load union:        [start[firstRow], end[lastRow]]
+//   mask-skip inter.:  [start[lastRow], end[firstRow]]
+// A KV tile fully inside the intersection needs no per-row score mask — the
+// same interior fast path as causal / SlidingWindow.
 template <int CTA_Q, int CTA_KV>
 CUTLASS_DEVICE VariableWindowKvTileBounds
 get_variable_window_kv_tile_bounds(int32_t const* starts, int32_t const* ends, int packed_qo_offset,
                                    int q_tile_idx, int qo_len, int kv_len) {
   int q_start = q_tile_idx * CTA_Q;
-  int q_end = std::min(q_start + CTA_Q, qo_len);
-  int min_start = kv_len;
-  int max_end = -1;
-#pragma unroll 1
-  for (int q = q_start; q < q_end; ++q) {
-    min_start = std::min(min_start, __ldg(starts + packed_qo_offset + q));
-    max_end = std::max(max_end, __ldg(ends + packed_qo_offset + q));
-  }
+  int q_last = std::min(q_start + CTA_Q, qo_len) - 1;
+  int32_t union_start = __ldg(starts + packed_qo_offset + q_start);
+  int32_t union_end = __ldg(ends + packed_qo_offset + q_last);
+  int32_t inter_start = __ldg(starts + packed_qo_offset + q_last);
+  int32_t inter_end = __ldg(ends + packed_qo_offset + q_start);
+
   int num_kv_tiles = cute::ceil_div(kv_len, CTA_KV);
-  int first = std::max(min_start / CTA_KV - 1, 0);
-  int last = std::min(num_kv_tiles - 1, std::max(max_end, 0) / CTA_KV);
+  int first = std::max(union_start, 0) / CTA_KV;
+  int last = std::min(num_kv_tiles - 1, std::max(union_end, 0) / CTA_KV);
   if (last < first) {
     last = first;
   }
-  return {first, last};
+
+  // tileOffset >= inter_start && nextTileOffset <= inter_end + 1 (exclusive end)
+  int unmask_begin = inter_start <= 0 ? 0 : (inter_start + CTA_KV - 1) / CTA_KV;
+  int unmask_end = (std::max(inter_end, -1) + 1) / CTA_KV - 1;
+  unmask_begin = std::max(unmask_begin, first);
+  unmask_end = std::min(unmask_end, last);
+  if (unmask_end < unmask_begin) {
+    // No fully-visible tile: mask every loaded tile (inner unmasked loop empty).
+    unmask_begin = last + 1;
+    unmask_end = last;
+  }
+  return {first, last, unmask_begin, unmask_end};
 }
 
 template <int CTA_Q, int CTA_KV, bool LEFT_SLIDING_WINDOW, bool LEFT_VARIABLE_WINDOW,
@@ -124,9 +139,11 @@ CUTLASS_DEVICE void apply_window_kv_tile_skip_consumer(Params const& mainloop_pa
           mainloop_params.additional_params.maybe_variable_window_token_starts,
           mainloop_params.additional_params.maybe_variable_window_token_ends, packed_qo_offset,
           q_tile_idx, qo_len, kv_len);
-      // Drain is unused: middle loop consumes (first, last], init consumes last.
+      // Init + n_masking_steps consume the right-edge tiles (load_end .. unmask_end+1).
+      // Inner loop is unpredicated on (unmask_end .. unmask_begin]. Extra loop
+      // masks the left-edge tiles (unmask_begin-1 .. begin], same as SWA.
       swa_begin_kv_tile_idx = bounds.begin;
-      swa_end_kv_tile_idx = bounds.begin - 1;
+      swa_end_kv_tile_idx = bounds.unmask_begin - 1;
       num_kv_tiles = bounds.end + 1;
     }
   }

--- a/tests/attention/conftest.py
+++ b/tests/attention/conftest.py
@@ -132,7 +132,11 @@ def _hopper_fp8_specs(items):
     for backend, d, hd in sorted(single_keys, key=str):
         add(gen_single_prefill_module(backend, d, d, H, hd, hd, 0, False, False, False))
     for d, hd in sorted(batch_keys, key=str):
-        add(gen_batch_prefill_module("fa3", d, d, H, I, hd, hd, 0, False, False, False))
+        add(
+            gen_batch_prefill_module(
+                "fa3", d, d, H, I, hd, hd, 0, False, False, False, False
+            )
+        )
     if need_quantization:
         add(gen_quantization_module())
     return list(specs.values())
@@ -268,10 +272,10 @@ def _batch_prefill_specs(items):
         # head_dim 64 cases (fixture only builds 128/256); references use
         # single_prefill with backend auto (fa3 on SM90 for pos_encoding 0).
         for p in (0, 1):
-            bp("fa2", H, H, H, I, 64, 64, p, False, False, False)
+            bp("fa2", H, H, H, I, 64, 64, p, False, False, False, False)
             sp("fa2", H, H, H, 64, 64, p, False, False, False)
         if sm90:
-            bp("fa3", H, H, H, I, 64, 64, 0, False, False, False)
+            bp("fa3", H, H, H, I, 64, 64, 0, False, False, False, False)
             sp("fa3", H, H, H, 64, 64, 0, False, False, False)
         # Fixture grid, included here so it gets AOT-staged.
         try:
@@ -282,6 +286,7 @@ def _batch_prefill_specs(items):
                 [torch.float16, torch.float8_e4m3fn, torch.float8_e5m2],
                 [128, 256],
                 [0, 1],
+                [False],
                 [False],
                 [False],
                 [False],
@@ -301,7 +306,7 @@ def _batch_prefill_specs(items):
     }:
         # head_dim 512 forces fa2 for both wrapper and reference.
         for p in (0, 1):
-            bp("fa2", H, H, H, I, 512, 512, p, False, False, False)
+            bp("fa2", H, H, H, I, 512, 512, p, False, False, False, False)
             sp("fa2", H, H, H, 512, 512, p, False, False, False)
 
     if "test_batch_prefill_with_ragged_kv_cache_custom_mask" in fns:
@@ -309,11 +314,11 @@ def _batch_prefill_specs(items):
         for hd in (128, 256):
             for p in (0, 1, 2):
                 for softcap in (False, True):
-                    bp("fa2", H, H, H, I, hd, hd, p, False, softcap, False)
+                    bp("fa2", H, H, H, I, hd, hd, p, False, False, softcap, False)
 
     if "test_batch_prefill_with_paged_kv_cache_multi_item_scoring" in fns:
         for softcap in (False, True):
-            bp("fa2", H, H, H, I, 128, 128, 1, False, softcap, False)
+            bp("fa2", H, H, H, I, 128, 128, 1, False, False, softcap, False)
             sp("fa2", H, H, H, 128, 128, 1, False, softcap, False)
 
     nvfp4_fns = {
@@ -331,13 +336,13 @@ def _batch_prefill_specs(items):
         # NVFP4 KV is uint8 (fp4x2_e2m1) and always fa2; references run on the
         # dequantized dtype (bf16 references are not in the fixture grid).
         for q in (H, B):
-            bp("fa2", q, U8, q, I, 128, 128, 0, False, False, False)
+            bp("fa2", q, U8, q, I, 128, 128, 0, False, False, False, False)
             sp("fa2", q, q, q, 128, 128, 0, False, False, False)
             if sm90:
                 sp("fa3", q, q, q, 128, 128, 0, False, False, False)
             if hd512_ok:
                 for p in (0, 1):
-                    bp("fa2", q, U8, q, I, 512, 512, p, False, False, False)
+                    bp("fa2", q, U8, q, I, 512, 512, p, False, False, False, False)
                     sp("fa2", q, q, q, 512, 512, p, False, False, False)
 
     if (
@@ -345,12 +350,25 @@ def _batch_prefill_specs(items):
         and cc_major >= 10
     ):
         for hd_qk, hd_vo in ((512, 256), (256, 128)):
-            bp("fa2", B, U8, B, I, hd_qk, hd_vo, 0, False, False, False)
+            bp("fa2", B, U8, B, I, hd_qk, hd_vo, 0, False, False, False, False)
 
     if "test_batch_prefill_paged_cta_tile_q_smem_probe_qk448_vo256" in fns and hd512_ok:
-        bp("fa2", H, H, H, I, 448, 256, 0, False, False, False)
+        bp("fa2", H, H, H, I, 448, 256, 0, False, False, False, False)
         if cc_major >= 10:
-            bp("fa2", H, torch.float8_e4m3fn, H, I, 448, 256, 0, False, False, False)
+            bp(
+                "fa2",
+                H,
+                torch.float8_e4m3fn,
+                H,
+                I,
+                448,
+                256,
+                0,
+                False,
+                False,
+                False,
+                False,
+            )
 
     return list(specs.values())
 

--- a/tests/attention/test_alibi.py
+++ b/tests/attention/test_alibi.py
@@ -46,6 +46,7 @@ def warmup_jit():
             [128, 256],  # head_dims
             [0, 2],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_batch_attention.py
+++ b/tests/attention/test_batch_attention.py
@@ -45,6 +45,7 @@ def warmup_jit():
             [64, 128, 256],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False, True],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -88,6 +88,7 @@ def warmup_jit():
             [128, 256],  # head_dims
             [0, 1],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_batch_invariant_fa2.py
+++ b/tests/attention/test_batch_invariant_fa2.py
@@ -45,6 +45,7 @@ def warmup_jit():
             [64, 128, 256],  # head_dims
             [0, 1],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -88,6 +88,7 @@ def warmup_jit():
             [128, 256],  # head_dims
             [0, 1],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_block_sparse.py
+++ b/tests/attention/test_block_sparse.py
@@ -47,6 +47,7 @@ def warmup_jit():
             [128, 256],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -75,9 +75,10 @@ def warmup_jit():
                     192,
                     128,
                     0,
-                    False,
-                    False,
-                    False,
+                    False,  # use_sliding_window
+                    False,  # use_variable_window
+                    False,  # use_logits_soft_cap
+                    False,  # use_fp16_qk_reduction
                 )
             )
 

--- a/tests/attention/test_hopper_variable_window.py
+++ b/tests/attention/test_hopper_variable_window.py
@@ -1,0 +1,498 @@
+"""FA3 Hopper VariableWindow tests for batch prefill (ragged and paged).
+
+Per-token inclusive KV start/end bounds, compiled as a sibling of sliding
+window. Skip unless SM90A; force backend=fa3. Do not import PrimTS tests.
+"""
+
+from typing import List, Optional, Sequence, Tuple
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.utils import is_sm90a_supported
+
+E4M3_MAX = 448.0
+DT = torch.float8_e4m3fn
+
+
+def _require_sm90():
+    if not is_sm90a_supported(torch.device("cuda")):
+        pytest.skip("SM90A is not supported")
+
+
+def _ws():
+    return torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+
+def gemma_variable_window_bounds(
+    seq_len: int,
+    left_window: int,
+    right_window: int,
+    image_segs: Sequence[Tuple[int, int]],
+    device,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    q = torch.arange(seq_len, device=device)
+    starts = torch.clamp(q - left_window, min=0)
+    ends = q.clone()
+    for seg_start, seg_end in image_segs:
+        in_seg = (q >= seg_start) & (q < seg_end)
+        ends = torch.where(in_seg, torch.clamp(q + right_window, max=seg_end - 1), ends)
+    return starts.to(torch.int32), ends.to(torch.int32)
+
+
+def causal_swa_bounds(
+    qo_len: int, kv_len: int, window_left: int, device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    q = torch.arange(qo_len, device=device)
+    q_pos = q + kv_len - qo_len
+    starts = torch.clamp(q_pos - window_left, min=0)
+    ends = q_pos
+    return starts.to(torch.int32), ends.to(torch.int32)
+
+
+def variable_window_attention_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    starts: torch.Tensor,
+    ends: torch.Tensor,
+    sm_scale: Optional[float] = None,
+) -> torch.Tensor:
+    """Inclusive [start, end] mask, GQA by repeating KV heads. FP32 softmax."""
+    hq, hkv = q.shape[1], k.shape[1]
+    if hq % hkv != 0:
+        raise ValueError("num_qo_heads must be divisible by num_kv_heads")
+    k = k.repeat_interleave(hq // hkv, dim=1)
+    v = v.repeat_interleave(hq // hkv, dim=1)
+    if sm_scale is None:
+        sm_scale = q.shape[-1] ** -0.5
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k.float()) * sm_scale
+    kv_idx = torch.arange(k.shape[0], device=q.device).view(1, -1)
+    keep = (kv_idx >= starts.view(-1, 1)) & (kv_idx <= ends.view(-1, 1))
+    scores = scores.masked_fill(~keep.unsqueeze(0), float("-inf"))
+    probs = torch.softmax(scores, dim=-1)
+    out = torch.einsum("hqk,khd->qhd", probs, v.float())
+    return out.to(q.dtype)
+
+
+def ragged_variable_window_ref(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    qo_indptr: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    starts: torch.Tensor,
+    ends: torch.Tensor,
+) -> torch.Tensor:
+    outs: List[torch.Tensor] = []
+    batch = qo_indptr.numel() - 1
+    for b in range(batch):
+        qs, qe = int(qo_indptr[b]), int(qo_indptr[b + 1])
+        ks, ke = int(kv_indptr[b]), int(kv_indptr[b + 1])
+        outs.append(
+            variable_window_attention_ref(
+                q[qs:qe], k[ks:ke], v[ks:ke], starts[qs:qe], ends[qs:qe]
+            )
+        )
+    return torch.cat(outs, dim=0)
+
+
+def _paged_gather(
+    cache: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    kv_last_page_len: torch.Tensor,
+    page_size: int,
+    batch: int,
+) -> torch.Tensor:
+    chunks = []
+    for b in range(batch):
+        ps, pe = int(kv_indptr[b]), int(kv_indptr[b + 1])
+        pages = kv_indices[ps:pe]
+        last = int(kv_last_page_len[b])
+        seq = []
+        for i, page in enumerate(pages.tolist()):
+            n = last if i == pages.numel() - 1 else page_size
+            seq.append(cache[page, :n])
+        chunks.append(torch.cat(seq, dim=0))
+    return torch.cat(chunks, dim=0)
+
+
+def per_head_symmetric_quant(
+    x: torch.Tensor, quant_dtype: torch.dtype = DT
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    x_max = x.abs().amax(dim=(0, 2)).to(torch.float32)
+    s = torch.clamp(x_max / E4M3_MAX, min=1e-6)
+    q = torch.clamp(x / s.view(1, -1, 1), min=-E4M3_MAX, max=E4M3_MAX).to(quant_dtype)
+    return q, s
+
+
+def _run_ragged_vw(
+    q, k, v, qo_indptr, kv_indptr, starts, ends, num_qo, num_kv, head_dim
+):
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo,
+        num_kv,
+        head_dim,
+        causal=False,
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+        q_data_type=q.dtype,
+        kv_data_type=k.dtype,
+        o_data_type=torch.half if q.dtype in (DT, torch.float8_e5m2) else q.dtype,
+    )
+    return wrapper.run(q, k, v)
+
+
+@pytest.mark.parametrize("seq_len", [128, 257, 512])
+@pytest.mark.parametrize("window_left", [64, 128])
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+def test_uniform_window_matches_swa(seq_len, window_left, head_dim):
+    _require_sm90()
+    torch.manual_seed(0)
+    hq, hkv = 32, 8
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = qo_indptr.clone()
+    q = torch.randn(seq_len, hq, head_dim, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, hkv, head_dim, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, hkv, head_dim, dtype=torch.half, device="cuda")
+    starts, ends = causal_swa_bounds(seq_len, seq_len, window_left, q.device)
+
+    swa = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(_ws(), "NHD", backend="fa3")
+    swa.plan(
+        qo_indptr, kv_indptr, hq, hkv, head_dim, causal=True, window_left=window_left
+    )
+    o_swa = swa.run(q, k, v)
+
+    o_vw = _run_ragged_vw(
+        q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, head_dim
+    )
+    torch.testing.assert_close(o_vw, o_swa, rtol=1e-3, atol=1e-3)
+
+
+def test_gemma_text_image_pattern():
+    _require_sm90()
+    torch.manual_seed(1)
+    seq_len, left, right = 2560, 128, 128
+    hq, hkv, d = 32, 8, 128
+    starts, ends = gemma_variable_window_bounds(
+        seq_len, left, right, ((256, 1280), (1536, 2560)), "cuda"
+    )
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = qo_indptr.clone()
+    q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    o = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
+    o_ref = variable_window_attention_ref(q, k, v, starts, ends)
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_chunked_prefill_absolute_kv_indices():
+    _require_sm90()
+    torch.manual_seed(2)
+    qo_len, kv_len, window_left = 128, 512, 64
+    hq, hkv, d = 32, 8, 128
+    starts, ends = causal_swa_bounds(qo_len, kv_len, window_left, "cuda")
+    qo_indptr = torch.tensor([0, qo_len], dtype=torch.int32, device="cuda")
+    kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda")
+    q = torch.randn(qo_len, hq, d, dtype=torch.half, device="cuda")
+    k = torch.randn(kv_len, hkv, d, dtype=torch.half, device="cuda")
+    v = torch.randn(kv_len, hkv, d, dtype=torch.half, device="cuda")
+    o = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
+    o_ref = variable_window_attention_ref(q, k, v, starts, ends)
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_ragged_batch_size_2():
+    _require_sm90()
+    torch.manual_seed(3)
+    lens = [96, 160]
+    hq, hkv, d = 32, 8, 128
+    qo_indptr = torch.tensor([0, lens[0], sum(lens)], dtype=torch.int32, device="cuda")
+    kv_indptr = qo_indptr.clone()
+    nnz = int(qo_indptr[-1])
+    q = torch.randn(nnz, hq, d, dtype=torch.half, device="cuda")
+    k = torch.randn(nnz, hkv, d, dtype=torch.half, device="cuda")
+    v = torch.randn(nnz, hkv, d, dtype=torch.half, device="cuda")
+    start_chunks, end_chunks = [], []
+    for seq in lens:
+        s, e = causal_swa_bounds(seq, seq, 48, "cuda")
+        start_chunks.append(s)
+        end_chunks.append(e)
+    starts = torch.cat(start_chunks)
+    ends = torch.cat(end_chunks)
+    o = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
+    o_ref = ragged_variable_window_ref(q, k, v, qo_indptr, kv_indptr, starts, ends)
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+@pytest.mark.parametrize("page_size", [16, 64])
+def test_paged_variable_window(page_size):
+    _require_sm90()
+    torch.manual_seed(4)
+    seq_len, hq, hkv, d = 257, 32, 8, 128
+    num_pages = (seq_len + page_size - 1) // page_size
+    last = seq_len % page_size or page_size
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda")
+    kv_indices = torch.arange(num_pages, dtype=torch.int32, device="cuda")
+    kv_last = torch.tensor([last], dtype=torch.int32, device="cuda")
+    q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
+    pk = torch.randn(num_pages, page_size, hkv, d, dtype=torch.half, device="cuda")
+    pv = torch.randn(num_pages, page_size, hkv, d, dtype=torch.half, device="cuda")
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 128, "cuda")
+
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last,
+        hq,
+        hkv,
+        d,
+        page_size,
+        causal=False,
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+    )
+    o = wrapper.run(q, (pk, pv))
+    k = _paged_gather(pk, kv_indptr, kv_indices, kv_last, page_size, 1)
+    v = _paged_gather(pv, kv_indptr, kv_indices, kv_last, page_size, 1)
+    o_ref = variable_window_attention_ref(q, k, v, starts, ends)
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_non_monotonic_starts_inside_q_tile():
+    _require_sm90()
+    torch.manual_seed(5)
+    seq_len, hq, hkv, d = 128, 8, 2, 128
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = qo_indptr.clone()
+    q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    # Most rows start at 64; one later row in the same Q tile jumps to 0 so
+    # tile skip cannot use the first row's start. Clamp ends so start <= end
+    # (rows 0-63 would otherwise be empty windows and softmax to NaN).
+    starts = torch.full((seq_len,), 64, dtype=torch.int32, device="cuda")
+    starts[80] = 0
+    ends = torch.arange(seq_len, dtype=torch.int32, device="cuda")
+    ends = torch.maximum(ends, starts)
+    o = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
+    o_ref = variable_window_attention_ref(q, k, v, starts, ends)
+    torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)
+
+
+def _fp8_ragged_vs_fp16(seq_len: int):
+    hq, hkv, d = 32, 8, 128
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = qo_indptr.clone()
+    q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 128, "cuda")
+    o_ref = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
+
+    q8, sq = per_head_symmetric_quant(q)
+    k8, sk = per_head_symmetric_quant(k)
+    v8, sv = per_head_symmetric_quant(v)
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        hq,
+        hkv,
+        d,
+        causal=False,
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+        q_data_type=DT,
+        kv_data_type=DT,
+        o_data_type=torch.half,
+    )
+    o_fp8 = wrapper.run(q8, k8, v8, sq, sk, sv)
+    torch.cuda.synchronize()
+    mse = torch.mean((o_ref.float() - o_fp8.float()) ** 2).item()
+    assert mse < 1.0, f"MSE too high: {mse}"
+
+
+@pytest.mark.timeout(300)
+@pytest.mark.parametrize("seq_len", [257, 512])
+def test_fp8_ragged_variable_window(seq_len):
+    _require_sm90()
+    torch.manual_seed(6)
+    _fp8_ragged_vs_fp16(seq_len)
+
+
+@pytest.mark.timeout(300)
+def test_fp8_paged_variable_window():
+    _require_sm90()
+    torch.manual_seed(7)
+    seq_len, page_size, hq, hkv, d = 257, 32, 32, 8, 128
+    num_pages = (seq_len + page_size - 1) // page_size
+    last = seq_len % page_size or page_size
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda")
+    kv_indices = torch.arange(num_pages, dtype=torch.int32, device="cuda")
+    kv_last = torch.tensor([last], dtype=torch.int32, device="cuda")
+    q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
+    pk = torch.randn(num_pages, page_size, hkv, d, dtype=torch.half, device="cuda")
+    pv = torch.randn(num_pages, page_size, hkv, d, dtype=torch.half, device="cuda")
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 128, "cuda")
+
+    ref_w = flashinfer.BatchPrefillWithPagedKVCacheWrapper(_ws(), "NHD", backend="fa3")
+    ref_w.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last,
+        hq,
+        hkv,
+        d,
+        page_size,
+        causal=False,
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+    )
+    o_ref = ref_w.run(q, (pk, pv))
+
+    q8, sq = per_head_symmetric_quant(q)
+    k8, sk = per_head_symmetric_quant(pk.view(-1, hkv, d))
+    v8, sv = per_head_symmetric_quant(pv.view(-1, hkv, d))
+    k8 = k8.view(num_pages, page_size, hkv, d)
+    v8 = v8.view(num_pages, page_size, hkv, d)
+    fp8_w = flashinfer.BatchPrefillWithPagedKVCacheWrapper(_ws(), "NHD", backend="fa3")
+    fp8_w.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last,
+        hq,
+        hkv,
+        d,
+        page_size,
+        causal=False,
+        variable_window_token_starts=starts,
+        variable_window_token_ends=ends,
+        q_data_type=DT,
+        kv_data_type=DT,
+        o_data_type=torch.half,
+    )
+    o_fp8 = fp8_w.run(q8, (k8, v8), sq, sk, sv)
+    torch.cuda.synchronize()
+    mse = torch.mean((o_ref.float() - o_fp8.float()) ** 2).item()
+    assert mse < 1.0, f"MSE too high: {mse}"
+
+
+def test_rejects_fa2_backend():
+    _require_sm90()
+    seq_len = 32
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 8, "cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="fa3"):
+        wrapper.plan(
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            8,
+            2,
+            128,
+            causal=False,
+            variable_window_token_starts=starts,
+            variable_window_token_ends=ends,
+        )
+
+
+def test_rejects_missing_ends():
+    _require_sm90()
+    seq_len = 32
+    starts, _ = causal_swa_bounds(seq_len, seq_len, 8, "cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    with pytest.raises(ValueError, match="both"):
+        wrapper.plan(
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            8,
+            2,
+            128,
+            causal=False,
+            variable_window_token_starts=starts,
+        )
+
+
+def test_rejects_window_left_combo():
+    _require_sm90()
+    seq_len = 32
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 8, "cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    with pytest.raises(ValueError, match="window_left"):
+        wrapper.plan(
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            8,
+            2,
+            128,
+            causal=False,
+            window_left=8,
+            variable_window_token_starts=starts,
+            variable_window_token_ends=ends,
+        )
+
+
+def test_rejects_causal_true_combo():
+    _require_sm90()
+    seq_len = 32
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 8, "cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    with pytest.raises(ValueError, match="causal"):
+        wrapper.plan(
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            8,
+            2,
+            128,
+            causal=True,
+            variable_window_token_starts=starts,
+            variable_window_token_ends=ends,
+        )
+
+
+def test_rejects_custom_mask_combo():
+    _require_sm90()
+    seq_len = 32
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 8, "cuda")
+    mask = torch.ones(seq_len * seq_len, dtype=torch.bool, device="cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    with pytest.raises(ValueError, match="custom_mask"):
+        wrapper.plan(
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            8,
+            2,
+            128,
+            causal=False,
+            custom_mask=mask,
+            variable_window_token_starts=starts,
+            variable_window_token_ends=ends,
+        )

--- a/tests/attention/test_hopper_variable_window.py
+++ b/tests/attention/test_hopper_variable_window.py
@@ -496,3 +496,24 @@ def test_rejects_custom_mask_combo():
             variable_window_token_starts=starts,
             variable_window_token_ends=ends,
         )
+
+
+def test_rejects_prefix_len_combo():
+    _require_sm90()
+    seq_len = 32
+    starts, ends = causal_swa_bounds(seq_len, seq_len, 8, "cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _ws(), "NHD", backend="fa3"
+    )
+    with pytest.raises(ValueError, match="prefix_len_ptr"):
+        wrapper.plan(
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            torch.tensor([0, seq_len], dtype=torch.int32, device="cuda"),
+            8,
+            2,
+            128,
+            causal=False,
+            prefix_len_ptr=torch.zeros(1, dtype=torch.uint32, device="cuda"),
+            variable_window_token_starts=starts,
+            variable_window_token_ends=ends,
+        )

--- a/tests/attention/test_hopper_variable_window.py
+++ b/tests/attention/test_hopper_variable_window.py
@@ -1,7 +1,10 @@
 """FA3 Hopper VariableWindow tests for batch prefill (ragged and paged).
 
 Per-token inclusive KV start/end bounds, compiled as a sibling of sliding
-window. Skip unless SM90A; force backend=fa3. Do not import PrimTS tests.
+window. Starts/ends must be nondecreasing within each request (trtllm-gen
+VariableWindow): the kernel uses first/last Q-tile rows for load union and
+skips per-row masking on interior KV tiles. Skip unless SM90A; force
+backend=fa3. Do not import PrimTS tests.
 """
 
 from typing import List, Optional, Sequence, Tuple
@@ -272,22 +275,41 @@ def test_paged_variable_window(page_size):
     torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)
 
 
-def test_non_monotonic_starts_inside_q_tile():
+@pytest.mark.parametrize("seq_len", [128, 512, 2048])
+def test_full_causal_vw_matches_causal(seq_len):
+    """Global causal baked into VW must match FA3 prod causal (interior mask skip)."""
     _require_sm90()
-    torch.manual_seed(5)
-    seq_len, hq, hkv, d = 128, 8, 2, 128
+    torch.manual_seed(0)
+    hq, hkv, d = 32, 8, 128
     qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
     kv_indptr = qo_indptr.clone()
     q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
     k = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
     v = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
-    # Most rows start at 64; one later row in the same Q tile jumps to 0 so
-    # tile skip cannot use the first row's start. Clamp ends so start <= end
-    # (rows 0-63 would otherwise be empty windows and softmax to NaN).
-    starts = torch.full((seq_len,), 64, dtype=torch.int32, device="cuda")
-    starts[80] = 0
-    ends = torch.arange(seq_len, dtype=torch.int32, device="cuda")
-    ends = torch.maximum(ends, starts)
+    starts, ends = causal_swa_bounds(seq_len, seq_len, seq_len, q.device)
+
+    causal = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(_ws(), "NHD", backend="fa3")
+    causal.plan(qo_indptr, kv_indptr, hq, hkv, d, causal=True, window_left=-1)
+    o_causal = causal.run(q, k, v)
+
+    o_vw = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
+    torch.testing.assert_close(o_vw, o_causal, rtol=1e-3, atol=1e-3)
+
+
+def test_look_ahead_past_causal_still_matches_ref():
+    """Image-style end > q (still nondecreasing) must not use a causal right clip."""
+    _require_sm90()
+    torch.manual_seed(7)
+    seq_len, hq, hkv, d = 256, 16, 8, 128
+    q_idx = torch.arange(seq_len, device="cuda")
+    starts = torch.zeros(seq_len, dtype=torch.int32, device="cuda")
+    ends = q_idx.clone().to(torch.int32)
+    ends[64:192] = 191
+    qo_indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+    kv_indptr = qo_indptr.clone()
+    q = torch.randn(seq_len, hq, d, dtype=torch.half, device="cuda")
+    k = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
+    v = torch.randn(seq_len, hkv, d, dtype=torch.half, device="cuda")
     o = _run_ragged_vw(q, k, v, qo_indptr, kv_indptr, starts, ends, hq, hkv, d)
     o_ref = variable_window_attention_ref(q, k, v, starts, ends)
     torch.testing.assert_close(o.float(), o_ref.float(), rtol=2e-2, atol=2e-2)

--- a/tests/attention/test_logits_cap.py
+++ b/tests/attention/test_logits_cap.py
@@ -47,6 +47,7 @@ def warmup_jit():
             [128, 256],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False, True],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_non_contiguous_decode.py
+++ b/tests/attention/test_non_contiguous_decode.py
@@ -29,6 +29,7 @@ def warmup_jit():
             [64, 128, 256],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_non_contiguous_prefill.py
+++ b/tests/attention/test_non_contiguous_prefill.py
@@ -34,6 +34,7 @@ def warmup_jit():
             [64, 128, 256],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_shared_prefix_kernels.py
+++ b/tests/attention/test_shared_prefix_kernels.py
@@ -45,6 +45,7 @@ def warmup_jit():
             [128, 256],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_sliding_window.py
+++ b/tests/attention/test_sliding_window.py
@@ -56,6 +56,7 @@ def warmup_jit():
             head_dims,
             [0],  # pos_encoding_modes
             [False, True],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_tensor_cores_decode.py
+++ b/tests/attention/test_tensor_cores_decode.py
@@ -45,6 +45,7 @@ def warmup_jit():
             [64, 128, 256],  # head_dims
             [0, 1],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_caps
             [False],  # use_fp16_qk_reductions
         ),

--- a/tests/attention/test_workspace_size.py
+++ b/tests/attention/test_workspace_size.py
@@ -51,6 +51,27 @@ def _unaligned_byte_workspace(num_bytes: int, device: str = "cuda"):
     return workspace
 
 
+def _prefill_workspace_size_args():
+    batch_size = 3
+    qo_len = 64
+    kv_len = 1024
+    page_size = 16
+    qo_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device="cuda") * qo_len
+    paged_kv_indptr, paged_kv_indices, paged_kv_last_page_len = _paged_kv_inputs(
+        batch_size, kv_len, page_size
+    )
+    return (
+        qo_indptr,
+        paged_kv_indptr,
+        paged_kv_indices,
+        paged_kv_last_page_len,
+        16,  # num_qo_heads
+        4,  # num_kv_heads
+        128,  # head_dim
+        page_size,
+    )
+
+
 @pytest.mark.parametrize("use_cuda_graph", [False, True])
 def test_batch_decode_workspace_size_plans_with_exact_buffers(use_cuda_graph):
     batch_size = 4
@@ -218,6 +239,40 @@ def test_batch_decode_workspace_size_rejects_unaligned_workspace_buffer():
             _byte_workspace(1024),
             _unaligned_byte_workspace(1024),
         )
+
+
+def test_batch_prefill_workspace_size_rejects_fa3():
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024), backend="fa3"
+    )
+    with pytest.raises(NotImplementedError, match="prefill backend 'fa3'"):
+        wrapper.workspace_size(*_prefill_workspace_size_args())
+
+
+def test_batch_prefill_workspace_size_rejects_variable_window():
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024), backend="fa2"
+    )
+    dummy = torch.zeros(1, dtype=torch.int32, device="cuda")
+    with pytest.raises(NotImplementedError, match="variable_window"):
+        wrapper.workspace_size(
+            *_prefill_workspace_size_args(),
+            variable_window_token_starts=dummy,
+            variable_window_token_ends=dummy,
+        )
+
+
+def test_batch_prefill_workspace_size_rejects_auto_fa3():
+    from flashinfer.utils import is_sm90a_supported
+
+    if not is_sm90a_supported(torch.device("cuda")):
+        pytest.skip("auto backend resolves to fa3 only on SM90")
+
+    wrapper = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
+        _byte_workspace(32 * 1024 * 1024), backend="auto"
+    )
+    with pytest.raises(NotImplementedError, match="prefill backend 'fa3'"):
+        wrapper.workspace_size(*_prefill_workspace_size_args())
 
 
 def test_batch_prefill_workspace_size_rejects_unaligned_workspace_buffer():

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -313,6 +313,7 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
         head_dims=[512],
         pos_encoding_modes=[PosEncodingMode.NONE.value],
         use_sliding_window_options=[False],
+        use_variable_window_options=[False],
         use_logits_soft_cap_options=[False],
         use_fp16_qk_reduction_options=[False],
     )
@@ -321,3 +322,57 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa3", 512, 512) not in calls
     assert ("single", "fa2", 512, 512) in calls
     assert ("batch", "fa2", 512, 512) in calls
+
+
+def test_prefill_jit_helper_skips_fa2_for_variable_window(monkeypatch):
+    batch_calls = []
+
+    def fake_batch_prefill_module(
+        backend,
+        dtype_q,
+        dtype_kv,
+        dtype_o,
+        idtype,
+        head_dim_qk,
+        head_dim_vo,
+        pos_encoding_mode,
+        use_sliding_window,
+        use_variable_window,
+        use_logits_soft_cap,
+        use_fp16_qk_reduction,
+    ):
+        batch_calls.append((backend, use_variable_window))
+        return SimpleNamespace(name=f"{backend}_batch_{head_dim_qk}_{head_dim_vo}")
+
+    monkeypatch.setattr(jit_utils, "is_sm90a_supported", lambda device: True)
+    monkeypatch.setattr(
+        flashinfer.prefill,
+        "gen_single_prefill_module",
+        lambda backend, *_args: SimpleNamespace(name=f"{backend}_single"),
+    )
+    monkeypatch.setattr(
+        flashinfer.prefill, "gen_batch_prefill_module", fake_batch_prefill_module
+    )
+    monkeypatch.setattr(
+        flashinfer.quantization,
+        "gen_quantization_module",
+        lambda: SimpleNamespace(name="quantization"),
+    )
+    monkeypatch.setattr(
+        flashinfer.page,
+        "gen_page_module",
+        lambda: SimpleNamespace(name="page"),
+    )
+
+    jit_utils.gen_prefill_attention_modules(
+        q_dtypes=[torch.float16],
+        kv_dtypes=[torch.float16],
+        head_dims=[128],
+        pos_encoding_modes=[PosEncodingMode.NONE.value],
+        use_sliding_window_options=[False],
+        use_variable_window_options=[True],
+        use_logits_soft_cap_options=[False],
+        use_fp16_qk_reduction_options=[False],
+    )
+
+    assert batch_calls == [("fa3", True)]

--- a/tests/test_helpers/jit_utils.py
+++ b/tests/test_helpers/jit_utils.py
@@ -131,6 +131,7 @@ def gen_prefill_attention_modules(
     head_dims,
     pos_encoding_modes,
     use_sliding_window_options,
+    use_variable_window_options,
     use_logits_soft_cap_options,
     use_fp16_qk_reduction_options,
 ) -> list[JitSpec]:
@@ -142,6 +143,7 @@ def gen_prefill_attention_modules(
         head_dim,
         pos_encoding_mode,
         use_sliding_window,
+        use_variable_window,
         use_logits_soft_cap,
         use_fp16_qk_reduction,
     ) in itertools.product(
@@ -150,6 +152,7 @@ def gen_prefill_attention_modules(
         head_dims,
         pos_encoding_modes,
         use_sliding_window_options,
+        use_variable_window_options,
         use_logits_soft_cap_options,
         use_fp16_qk_reduction_options,
     ):
@@ -197,6 +200,7 @@ def gen_prefill_attention_modules(
                     head_dim,  # head_dim_vo
                     pos_encoding_mode,
                     use_sliding_window,
+                    use_variable_window,
                     use_logits_soft_cap,
                     use_fp16_qk_reduction,
                 )
@@ -215,21 +219,23 @@ def gen_prefill_attention_modules(
                 use_fp16_qk_reduction,
             )
         )
-        jit_specs.append(
-            flashinfer.prefill.gen_batch_prefill_module(
-                "fa2",
-                q_dtype,
-                kv_dtype,
-                q_dtype,
-                torch.int32,
-                head_dim,  # head_dim_qk
-                head_dim,  # head_dim_vo
-                pos_encoding_mode,
-                use_sliding_window,
-                use_logits_soft_cap,
-                use_fp16_qk_reduction,
+        if not use_variable_window:
+            jit_specs.append(
+                flashinfer.prefill.gen_batch_prefill_module(
+                    "fa2",
+                    q_dtype,
+                    kv_dtype,
+                    q_dtype,
+                    torch.int32,
+                    head_dim,  # head_dim_qk
+                    head_dim,  # head_dim_vo
+                    pos_encoding_mode,
+                    use_sliding_window,
+                    use_variable_window,
+                    use_logits_soft_cap,
+                    use_fp16_qk_reduction,
+                )
             )
-        )
 
     # required for attention with custom mask
     jit_specs.append(flashinfer.quantization.gen_quantization_module())

--- a/tests/utils/test_jit_warmup.py
+++ b/tests/utils/test_jit_warmup.py
@@ -50,6 +50,7 @@ def test_warmpup_llama():
                 128,  # head_dim_vo
                 PosEncodingMode.NONE.value,
                 False,  # use_sliding_window
+                False,  # use_variable_window
                 False,  # use_logits_soft_cap
                 False,  # use_fp16_qk_reduction
             ),
@@ -91,6 +92,7 @@ def test_warmpup_llama_sm90():
                 128,  # head_dim_vo
                 PosEncodingMode.NONE.value,
                 False,  # use_sliding_window
+                False,  # use_variable_window
                 False,  # use_logits_soft_cap
                 False,  # use_fp16_qk_reduction
             ),
@@ -104,6 +106,7 @@ def test_warmpup_llama_sm90():
                 128,  # head_dim_vo
                 PosEncodingMode.NONE.value,
                 False,  # use_sliding_window
+                False,  # use_variable_window
                 False,  # use_logits_soft_cap
                 False,  # use_fp16_qk_reduction
             ),

--- a/tests/utils/test_pod_kernels.py
+++ b/tests/utils/test_pod_kernels.py
@@ -48,6 +48,7 @@ def warmup_jit():
             [128],  # head_dims
             [0],  # pos_encoding_modes
             [False],  # use_sliding_windows
+            [False],  # use_variable_windows
             [False],  # use_logits_soft_cap
             [False],  # use_fp16_qk_reductions
         )


### PR DESCRIPTION
## Summary
- Add per-token inclusive KV start/end bounds (`variable_window_token_starts` / `ends`, packed `int32 [nnz_qo]`) to FA3 Hopper batch prefill for ragged and paged caches.
- Caller bakes causal, SWA, and image-block into the arrays; VariableWindow forces `causal=False` and is mutually exclusive with `window_left`, custom mask, and multi-item scoring.
- In-kernel Q-tile min(start)/max(end) skip plus per-row mask, with the existing SWA drain reused. Same skip/mask/drain on the FA3 tensor-core FP8 twin (fp16/bf16 and e4m3/e5m2).
- New JIT flag `USE_VARIABLE_WINDOW`; URI suffix `_use_vw_True` only when enabled so existing SWA JIT/AOT cache names stay valid. FA2, decode, single-prefill, FMHA v2, and AOT product for `use_vw=True` are out of scope.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added variable-window attention for FA3 batch prefill with ragged and paged KV caches.
  * Supports per-token key/value bounds, non-uniform windows, chunked prefill, batching, and FP8 execution.
  * Added support for additional compatible head-dimension combinations.
* **Bug Fixes**
  * Improved window-bound handling across Hopper attention execution paths.
* **Tests**
  * Added coverage for uniform, non-monotonic, quantized, and edge-case window configurations.
* **Documentation**
  * Added validation for unsupported backends and incompatible options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->