### PR TITLE
fix: check cp_size in Mapping auto_parallel guard

### DIFF
--- a/flashinfer/comm/mapping.py
+++ b/flashinfer/comm/mapping.py
@@ -164,7 +164,7 @@ class Mapping(object):
             )
 
         if auto_parallel:
-            if tp_size != 1 or pp_size != 1 or tp_size != 1:
+            if tp_size != 1 or pp_size != 1 or cp_size != 1:
                 raise ValueError(
                     f"When auto parallel is enabled, tp_size, pp_size, cp_size must be 1, but got {tp_size}, {pp_size}, {cp_size}."
                 )

--- a/tests/comm/test_mapping_validation.py
+++ b/tests/comm/test_mapping_validation.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from flashinfer.comm.mapping import Mapping
+
+
+@pytest.mark.parametrize("dim", ["tp_size", "pp_size", "cp_size"])
+def test_auto_parallel_rejects_non_unit_parallelism(dim):
+    """auto_parallel forces tp/pp/cp_rank to 0, so every parallelism degree
+    must be 1. Each of the three must be rejected on its own."""
+    with pytest.raises(ValueError, match="auto parallel"):
+        Mapping(world_size=1, rank=0, auto_parallel=True, **{dim: 4})
+
+
+def test_auto_parallel_accepts_unit_parallelism():
+    mapping = Mapping(
+        world_size=1, rank=0, tp_size=1, pp_size=1, cp_size=1, auto_parallel=True
+    )
+    assert (mapping.tp_rank, mapping.pp_rank, mapping.cp_rank) == (0, 0, 0)
+
+
+def test_non_auto_parallel_allows_context_parallelism():
+    mapping = Mapping(
+        world_size=4, rank=1, tp_size=1, pp_size=1, cp_size=4, auto_parallel=False
+    )
+    assert mapping.cp_rank == 1


### PR DESCRIPTION
## 📌 Description

`Mapping.__init__` validates the `auto_parallel` configuration with:

```python
if tp_size != 1 or pp_size != 1 or tp_size != 1:
    raise ValueError(
        f"When auto parallel is enabled, tp_size, pp_size, cp_size must be 1, but got {tp_size}, {pp_size}, {cp_size}."
    )
```

`tp_size != 1` is tested twice and `cp_size` is never tested, so the guard cannot reject a non-unit `cp_size` — even though its own message names `cp_size` and interpolates it.

This is load-bearing rather than cosmetic: under `auto_parallel`, `tp_rank`, `pp_rank` and `cp_rank` all unconditionally return `0` (`flashinfer/comm/mapping.py`), which is exactly why the guard requires every parallelism degree to be 1. Today `Mapping(world_size=1, rank=0, auto_parallel=True, cp_size=4)` constructs successfully and every rank reports `cp_rank == 0`, instead of failing at construction with the intended error.

Observed on `main` before the fix (`tp_size` rejected, `cp_size` not):

```
BUG REPRODUCES: constructed with auto_parallel=True and cp_size=4; cp_rank=0
control: tp_size=4 correctly rejected -> When auto parallel is enabled, tp_size, pp_size, cp_size mus
```

One-word fix: `tp_size != 1` → `cp_size != 1`. Configurations that are valid today are unaffected — the only behavior change is that a config the guard was already written to reject now actually gets rejected.

## 🔍 Related Issues

None found; reported from source reading.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] `ruff format --check` and `ruff check` pass on both touched files.
- [ ] Full `pre-commit run --all-files` not run — I do not have the repo's full toolchain installed locally.

## 🧪 Tests

- [x] Added `tests/comm/test_mapping_validation.py` — CPU-only, no GPU or MNNVL required.
- [x] Red/green verified: 5 passed with the fix; with the fix reverted, exactly `test_auto_parallel_rejects_non_unit_parallelism[cp_size]` fails (`DID NOT RAISE <class 'ValueError'>`) while the other 4 still pass.

The test covers all three parallelism degrees, the valid all-ones `auto_parallel` config, and the `auto_parallel=False` path where `cp_size > 1` remains legal.

## Reviewer Notes

- I could not import the installed package on this machine (no `tvm_ffi`), so the tests were executed against `flashinfer/comm/mapping.py` loaded directly, with `flashinfer.comm.mapping` stubbed into `sys.modules`. The test file itself imports normally (`from flashinfer.comm.mapping import Mapping`) and needs no such shim in CI. Worth a maintainer confirming it is collected in your CPU lane.
- Branch is cut from a slightly older `main`; `flashinfer/comm/mapping.py` is byte-identical between that base and current `main`, so the diff applies unchanged.
- AI-assisted, per the guidance in `CLAUDE.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected auto-parallel validation so context parallelism greater than one is properly rejected.
  * Preserved support for context parallelism when auto-parallel mode is disabled.

* **Tests**
  * Added coverage for valid and invalid parallelism configurations, including rank assignment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->