### PR TITLE
docs: clarify cubin/jit-cache hosting and upgrade path (#4781)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ pip install flashinfer-python
 **Package Options:**
 
 - **flashinfer-python**: Core package that compiles/downloads kernels on first use
-- **flashinfer-cubin**: Pre-compiled kernel binaries for all supported GPU architectures
-- **flashinfer-jit-cache**: Pre-built kernel cache for specific CUDA versions
+- **flashinfer-cubin**: Pre-compiled kernel binaries (datacenter GPUs). Install from
+  `https://flashinfer.ai/whl`, not PyPI.
+- **flashinfer-jit-cache**: Pre-built kernel cache for specific CUDA versions. Also on
+  `https://flashinfer.ai/whl`.
 
 **For faster initialization and offline usage**, install the optional packages to have most kernels pre-compiled:
 
@@ -105,6 +107,11 @@ pip install flashinfer-python
 flashinfer install-cubin-wheel
 flashinfer install-jit-cache-wheel
 ```
+
+> **Note:** Upgrading `flashinfer-python` while an old `flashinfer-cubin` remains installed
+> can fail at import with a version mismatch. Re-run `flashinfer install-cubin-wheel`, or
+> uninstall `flashinfer-cubin` to use runtime JIT. On DGX Spark / GB10, `flashinfer-cubin`
+> is optional. See the [installation guide](https://docs.flashinfer.ai/installation.html).
 
 **For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
 

--- a/README.md
+++ b/README.md
@@ -108,10 +108,11 @@ flashinfer install-cubin-wheel
 flashinfer install-jit-cache-wheel
 ```
 
-> **Note:** Upgrading `flashinfer-python` while an old `flashinfer-cubin` remains installed
-> can fail at import with a version mismatch. Re-run `flashinfer install-cubin-wheel`, or
-> uninstall `flashinfer-cubin` to use runtime JIT. On DGX Spark / GB10, `flashinfer-cubin`
-> is optional. See the [installation guide](https://docs.flashinfer.ai/installation.html).
+> **Note:** Upgrading `flashinfer-python` while old `flashinfer-cubin` or
+> `flashinfer-jit-cache` remains installed can fail at import with a version mismatch.
+> Re-run `flashinfer install-cubin-wheel` and `flashinfer install-jit-cache-wheel`, or
+> uninstall both optional packages to use runtime JIT. On DGX Spark / GB10,
+> `flashinfer-cubin` is optional. See the [installation guide](https://docs.flashinfer.ai/installation.html).
 
 **For Blackwell (SM100+) CuTe DSL kernels**, install with the CUDA 13 extra to enable Blackwell-optimized kernels:
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -108,6 +108,9 @@ environment:
 
 This command installs from the flat FlashInfer wheel index.
 
+Run this after upgrading ``flashinfer-python`` if a stale
+``flashinfer-cubin`` install triggers a version mismatch at import time.
+
 Install JIT Cache Wheel
 -----------------------
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -109,7 +109,7 @@ environment:
 This command installs from the flat FlashInfer wheel index.
 
 Run this after upgrading ``flashinfer-python`` if a stale
-``flashinfer-cubin`` install triggers a version mismatch at import time.
+``flashinfer-cubin`` or ``flashinfer-jit-cache`` install triggers a version mismatch at import time.
 
 Install JIT Cache Wheel
 -----------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -37,20 +37,47 @@ Package Options
 FlashInfer provides three packages:
 
 - **flashinfer-python**: Core package that compiles/downloads kernels on first use
-- **flashinfer-cubin**: Pre-compiled kernel binaries for all supported GPU architectures
-- **flashinfer-jit-cache**: Pre-built kernel cache for specific CUDA versions
+- **flashinfer-cubin**: Pre-compiled kernel binaries (datacenter GPUs). Hosted on
+  ``https://flashinfer.ai/whl``, not PyPI (PyPI may list older releases).
+- **flashinfer-jit-cache**: Pre-built kernel cache for specific CUDA versions.
+  Also hosted on ``https://flashinfer.ai/whl`` (CUDA-specific sub-index).
 
 **For faster initialization and offline usage**, install the optional packages to have most kernels pre-compiled:
 
 .. code-block:: bash
 
     pip install flashinfer-python
-    # cubin package
-    pip install flashinfer-cubin --index-url https://flashinfer.ai/whl
-    # JIT cache package (replace cu129 with your CUDA version: cu129, cu130, or cu134)
-    pip install flashinfer-jit-cache --index-url https://flashinfer.ai/whl/cu129
+    flashinfer install-cubin-wheel
+    flashinfer install-jit-cache-wheel
 
 This eliminates compilation and downloading overhead at runtime.
+
+Upgrading
+"""""""""
+
+If you upgrade ``flashinfer-python`` (for example via ``pip install -U vllm``)
+but keep an older ``flashinfer-cubin`` install, ``import flashinfer`` can fail
+with a version mismatch. Upgrade the optional packages together:
+
+.. code-block:: bash
+
+    pip install -U flashinfer-python
+    flashinfer install-cubin-wheel
+    flashinfer install-jit-cache-wheel
+
+Or uninstall the optional packages and use runtime JIT instead:
+
+.. code-block:: bash
+
+    pip uninstall flashinfer-cubin flashinfer-jit-cache
+
+DGX Spark / GB10 (SM121)
+"""""""""""""""""""""""
+
+The ``flashinfer-cubin`` wheel ships datacenter GPU cubins. Kernels on DGX Spark
+/ GB10 are JIT-compiled at runtime. You do not need ``flashinfer-cubin`` on
+Spark; if an old cubin install is left over from a previous setup, uninstalling
+it avoids version-mismatch errors after upgrades.
 
 
 .. _install-from-source:


### PR DESCRIPTION
## Summary
- Document that flashinfer-cubin and flashinfer-jit-cache are on flashinfer.ai/whl, not current PyPI.
- Recommend `flashinfer install-*-wheel` CLI helpers.
- Add upgrade troubleshooting for version mismatch after `pip install -U vllm`.
- Note DGX Spark/GB10 does not require flashinfer-cubin.

## Related
Addresses #4781

## Pre-commit Checks
- [x] Hooks pass on changed files (pre-commit on commit)

## Tests
- [x] Docs-only change; no runtime tests required.

## Reviewer Notes
No GPU/runtime behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified installation guidance for core, cubin, and JIT-cache packages.
  - Added troubleshooting steps for version-mismatch import errors, including upgrading or uninstalling stale optional packages.
  - Documented runtime JIT fallback and DGX Spark/GB10-specific cubin installation guidance.
  - Updated CLI instructions for refreshing optional packages after upgrading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->