### PR TITLE
feat(comm): copy-engine based kernel for the PCIe IPC all-reduce

### DIFF
--- a/benchmarks/comm/bench_pcie_ipc_all_reduce.py
+++ b/benchmarks/comm/bench_pcie_ipc_all_reduce.py
@@ -166,6 +166,10 @@ def _parse_args() -> argparse.Namespace:
     p.add_argument("--hidden", type=int, default=None)
     p.add_argument("--batches", type=str, default=None)
     p.add_argument("--dtype", choices=["bfloat16", "float16"], default="bfloat16")
+    # Lower these to look around at prefill sizes, where the default sample
+    # counts make a sweep drag; tune() then refuses to persist the result.
+    p.add_argument("--tune-warmup", type=int, default=None)
+    p.add_argument("--tune-repeat", type=int, default=None)
     p.add_argument("--json", type=str, default=None)
     p.add_argument(
         "--tune",
@@ -589,6 +593,11 @@ def main() -> None:
         group=group,
         max_numel=hidden * max(batches),
         dtype=dtype,
+        # Tune the batches this run actually sweeps. The default TUNE_BATCHES
+        # stops at 128; the bucket mapper floors, so without this a prefill
+        # sweep would replay a config measured at 128 rows on a payload three
+        # orders of magnitude larger and report it as "tuned".
+        tune_batches=batches,
         tune_cache=args.tune_cache,
     )
     # Recorded before tuning overwrites it: under --tune this shows what the
@@ -604,7 +613,12 @@ def main() -> None:
             print(f"tuning {len(batches)} batch buckets at hidden {hidden} ...")
         torch.cuda.synchronize()
         workspace.rebind_stream()
-        workspace.tune([hidden], dtype=dtype)
+        tune_kwargs = {}
+        if args.tune_warmup is not None:
+            tune_kwargs["warmup"] = args.tune_warmup
+        if args.tune_repeat is not None:
+            tune_kwargs["repeat"] = args.tune_repeat
+        workspace.tune([hidden], dtype=dtype, **tune_kwargs)
     if rank == 0:
         print(f"world_size={world_size} hidden={hidden} dtype={args.dtype}")
         print(f"profile={workspace.profile} ({workspace.profile_reason})")

--- a/csrc/pcie_ipc_all_reduce.cu
+++ b/csrc/pcie_ipc_all_reduce.cu
@@ -18,6 +18,7 @@
 #include <cstdint>
 
 #include "flashinfer/comm/pcie_ipc_all_reduce.cuh"
+#include "flashinfer/comm/pcie_ipc_ce_ring.cuh"
 #include "tvm_ffi_utils.h"
 
 namespace fi = flashinfer::comm::pcie_ipc;
@@ -36,12 +37,65 @@ namespace {
 struct PcieIpcHandle {
   fi::PeerViews views;
   fi::WorkspaceLayout layout;
+  fi::CeResources ce;
+  bool ce_ready;
   int rank;
   int world_size;
   int max_blocks;
   int64_t max_numel;
   int elem_size;
 };
+
+// One dtype arm for both data planes, so the switch below does not have to be
+// written twice as the second one grows.
+template <typename T>
+cudaError_t dispatch_one(const PcieIpcHandle* h, const T* in, T* out, int64_t numel, int blocks,
+                         int threads, fi::Variant algo, bool use_pdl, cudaStream_t stream) {
+  if (algo == fi::Variant::kCopyEngineRing) {
+    return fi::ce_ring_all_reduce_flat<T>(in, out, numel, h->views, h->rank, h->world_size,
+                                          h->layout, h->ce, blocks, threads, stream);
+  }
+  if (algo == fi::Variant::kCopyEngineIsland) {
+    return fi::ce_ring_all_reduce_island<T>(in, out, numel, h->views, h->rank, h->world_size,
+                                            h->layout, h->ce, blocks, threads, stream);
+  }
+  return fi::all_reduce<T>(in, out, numel, h->views, h->rank, h->world_size, h->max_blocks,
+                           h->max_numel, blocks, threads, algo, use_pdl, stream);
+}
+
+// Streams and events for the copy-engine ring. Non-blocking so the side streams
+// never implicitly serialise against the legacy default stream, and events with
+// timing disabled because the ring records tens of them per collective and the
+// device-side timestamp write on a timing event is not free.
+cudaError_t ce_resources_create(fi::CeResources* ce) {
+  auto stream = [](cudaStream_t* s) { return cudaStreamCreateWithFlags(s, cudaStreamNonBlocking); };
+  auto event = [](cudaEvent_t* e) { return cudaEventCreateWithFlags(e, cudaEventDisableTiming); };
+  cudaError_t err = stream(&ce->copy_stream);
+  if (err == cudaSuccess) err = stream(&ce->flag_stream);
+  if (err == cudaSuccess) err = event(&ce->input_ready);
+  if (err == cudaSuccess) err = event(&ce->copy_done);
+  if (err == cudaSuccess) err = event(&ce->flag_done);
+  for (int i = 0; err == cudaSuccess && i < fi::kCeMaxPieces; ++i) err = event(&ce->add_done[i]);
+  const int n = 2 * (fi::kMaxWorldSize - 1) * fi::kCeMaxPieces;
+  for (int i = 0; err == cudaSuccess && i < n; ++i) err = event(&ce->copied[i]);
+  return err;
+}
+
+// Events before streams: destroying a stream with queued work is legal and
+// deferred, destroying an event a queued node still references is not.
+void ce_resources_destroy(fi::CeResources* ce) {
+  // Null on the init failure path, where nullptr means the legacy default stream.
+  if (ce->copy_stream != nullptr) cudaStreamSynchronize(ce->copy_stream);
+  if (ce->flag_stream != nullptr) cudaStreamSynchronize(ce->flag_stream);
+  const int n = 2 * (fi::kMaxWorldSize - 1) * fi::kCeMaxPieces;
+  for (int i = 0; i < n; ++i) cudaEventDestroy(ce->copied[i]);
+  for (int i = 0; i < fi::kCeMaxPieces; ++i) cudaEventDestroy(ce->add_done[i]);
+  cudaEventDestroy(ce->flag_done);
+  cudaEventDestroy(ce->copy_done);
+  cudaEventDestroy(ce->input_ready);
+  cudaStreamDestroy(ce->flag_stream);
+  cudaStreamDestroy(ce->copy_stream);
+}
 
 }  // namespace
 
@@ -89,6 +143,10 @@ fptr_t pcie_ipc_init(Array<fptr_t> ipc_ptrs, int64_t rank, int64_t max_numel, in
     ptrs[i] = ipc_ptrs[i];
   }
 
+  // The parentheses are load-bearing: value-initialisation zeroes the POD
+  // members, which is the only reason the ce_resources_destroy on a failed
+  // ce_resources_create below is safe (cudaEventDestroy of a null handle is an
+  // ignored error, not UB). Dropping them turns a failing path into a crash.
   auto* handle = new PcieIpcHandle();
   handle->layout = fi::compute_workspace_layout(world_size, max_numel, static_cast<int>(elem_size),
                                                 static_cast<int>(max_blocks));
@@ -105,10 +163,24 @@ fptr_t pcie_ipc_init(Array<fptr_t> ipc_ptrs, int64_t rank, int64_t max_numel, in
     TVM_FFI_LOG_AND_THROW(RuntimeError)
         << "failed to zero the pcie ipc workspace: " << cudaGetErrorString(err);
   }
+  handle->ce_ready = false;
+  err = ce_resources_create(&handle->ce);
+  if (err != cudaSuccess) {
+    ce_resources_destroy(&handle->ce);
+    delete handle;
+    TVM_FFI_LOG_AND_THROW(RuntimeError)
+        << "failed to create the copy-engine ring's streams and events: "
+        << cudaGetErrorString(err);
+  }
+  handle->ce_ready = true;
   return reinterpret_cast<fptr_t>(handle);
 }
 
-void pcie_ipc_dispose(fptr_t handle) { delete reinterpret_cast<PcieIpcHandle*>(handle); }
+void pcie_ipc_dispose(fptr_t handle) {
+  auto* h = reinterpret_cast<PcieIpcHandle*>(handle);
+  if (h->ce_ready) ce_resources_destroy(&h->ce);
+  delete h;
+}
 
 /*!
  * \brief Out-of-place all-reduce over the shared workspace.
@@ -172,21 +244,48 @@ void pcie_ipc_all_reduce(fptr_t handle, TensorView inp, TensorView out, int64_t 
     TVM_FFI_ICHECK_EQ(blocks % 4, 0)
         << "the TP8 topology kernel requires blocks divisible by 4, got " << blocks;
   }
+  if (algo == fi::Variant::kCopyEngineRing || algo == fi::Variant::kCopyEngineIsland) {
+    // `blocks` carries the sub-chunk depth here, not a grid size; see
+    // IpcVariant.COPY_ENGINE_RING in pcie_ipc_policy.py, and kCeAddThreads for
+    // why the thread count is fixed rather than searched. The candidate grid
+    // never emits either, so these checks only reject a configuration that
+    // arrived by an explicit config=.
+    TVM_FFI_ICHECK_EQ(threads, fi::kCeAddThreads)
+        << "the copy-engine ring fixes its add kernel at " << fi::kCeAddThreads << " threads, got "
+        << threads;
+    TVM_FFI_ICHECK(blocks >= 1 && blocks <= fi::kCeMaxPieces)
+        << "the copy-engine ring reads `blocks` as its sub-chunk depth, which "
+        << "must be in [1, " << fi::kCeMaxPieces << "], got " << blocks;
+    const int64_t pack_elems = 16 / h->elem_size;
+    const int64_t shards =
+        algo == fi::Variant::kCopyEngineIsland ? 4 : static_cast<int64_t>(h->world_size);
+    const int64_t shard_div = shards * pack_elems;
+    TVM_FFI_ICHECK_EQ(numel % shard_div, 0)
+        << "the copy-engine ring splits the payload into " << shards
+        << " shards of whole 16-byte packs, so numel must be divisible by " << shard_div << ", got "
+        << numel;
+    // The ring reads inp[recv_chunk] at every reduce step while writing
+    // out[recv_chunk], and re-reads out[send_chunk] at the next step. In-place
+    // may happen to work, which is the worst state to leave it in.
+    TVM_FFI_ICHECK_NE(inp.data_ptr(), out.data_ptr())
+        << "the copy-engine ring does not support an in-place all-reduce";
+    TVM_FFI_ICHECK(!(algo == fi::Variant::kCopyEngineIsland && h->world_size != 8))
+        << "the island schedule is a 4+4 decomposition and is world_size 8 only, got "
+        << h->world_size;
+  }
 
   cudaError_t err = cudaSuccess;
   switch (encode_dlpack_dtype(out.dtype())) {
     case bfloat16_code:
-      err = fi::all_reduce<nv_bfloat16>(static_cast<const nv_bfloat16*>(inp.data_ptr()),
-                                        static_cast<nv_bfloat16*>(out.data_ptr()), numel, h->views,
-                                        h->rank, h->world_size, h->max_blocks, h->max_numel,
-                                        static_cast<int>(blocks), static_cast<int>(threads), algo,
-                                        enable_pdl, stream);
+      err = dispatch_one<nv_bfloat16>(h, static_cast<const nv_bfloat16*>(inp.data_ptr()),
+                                      static_cast<nv_bfloat16*>(out.data_ptr()), numel,
+                                      static_cast<int>(blocks), static_cast<int>(threads), algo,
+                                      enable_pdl, stream);
       break;
     case float16_code:
-      err = fi::all_reduce<half>(
-          static_cast<const half*>(inp.data_ptr()), static_cast<half*>(out.data_ptr()), numel,
-          h->views, h->rank, h->world_size, h->max_blocks, h->max_numel, static_cast<int>(blocks),
-          static_cast<int>(threads), algo, enable_pdl, stream);
+      err = dispatch_one<half>(h, static_cast<const half*>(inp.data_ptr()),
+                               static_cast<half*>(out.data_ptr()), numel, static_cast<int>(blocks),
+                               static_cast<int>(threads), algo, enable_pdl, stream);
       break;
     default:
       // The kernel templates carry a generic path, but only the two 2-byte

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -183,11 +183,47 @@ shape, dtype or call order hang rather than raise. One workspace serves one
 CUDA stream; use :meth:`~PcieIpcAllReduceWorkspace.rebind_stream` after
 ordering the two if a move is genuinely needed.
 
+Two data planes
+~~~~~~~~~~~~~~~
+
+Above roughly a megabyte the workspace can move the payload with the copy
+engines instead of with SM load/store. The reason is not that the copy engine
+is faster per hop — in isolation the two are comparable — but that it keeps
+its throughput when every rank transfers at once, where SM peer traffic loses
+bandwidth to the concurrency. So the gap widens with world size, which is what
+makes a second plane worth having at these payload sizes.
+
+It is a second protocol rather than a flag on the existing kernels. The SM path
+encodes readiness in the payload — ``+0.0`` means "not yet written" — which a
+copy engine can neither produce nor observe, so the ring synchronises through
+monotonic flags on side streams instead. Nothing about the SM kernels changes.
+
+Both planes are ordinary tuner candidates, so nothing needs to be declared at
+the call site and there is no notion of a prefill or decode "phase": the
+configuration follows the payload in bytes.
+:class:`PcieIpcVariant` gains ``COPY_ENGINE_RING``, a flat neighbour ring, and
+``COPY_ENGINE_ISLAND``, a 4+4 decomposition offered only at world size 8 and
+only on ``rootcplx-noswitch``, where a ring's two socket-crossing hops would
+otherwise set the pace. On that variant ``blocks`` carries the ring's sub-chunk
+depth rather than a grid size.
+
+.. warning::
+
+    Tuning covers the batch sizes it is given, and shapes above the largest one
+    are served by whatever was measured there. Leave ``tune_batches`` unset and
+    the ladder is derived from ``max_numel``, which covers everything the
+    workspace admits; pass it explicitly and the top of the range is yours to
+    get right. :meth:`~PcieIpcAllReduceWorkspace.tune` warns when an explicit
+    list leaves a gap, and refuses to persist results measured below the
+    default sample counts, since a table that is quietly wrong is worse than
+    one that is missing.
+
 .. autosummary::
     :toctree: ../generated
 
     PcieIpcAllReduceWorkspace
     PcieIpcLaunchConfig
+    PcieIpcVariant
     get_pcie_ipc_launch_config
     probe_pcie_ipc_rank_topology
     resolve_pcie_ipc_profile

--- a/flashinfer/comm/pcie_ipc_ar.py
+++ b/flashinfer/comm/pcie_ipc_ar.py
@@ -34,14 +34,15 @@ from .pcie_ipc_policy import IpcLaunchConfig, get_pcie_ipc_launch_config
 from .pcie_ipc_topology import resolve_pcie_ipc_profile
 from .pcie_ipc_tuning import (
     PCIE_IPC_CUSTOM_OP,
-    TUNE_BATCHES,
     TUNE_REPEAT,
     TUNE_WARMUP,
+    generate_tune_batches,
     PcieIpcAllReduceRunner,
     cache_covers_workspace,
     default_cache_path,
     pack_config,
     pcie_ipc_tuning_config,
+    TABLE_TACTIC,
     resolve_tuned_config,
     tuned_batches_for,
     warn_no_tune_group,
@@ -183,7 +184,7 @@ class PcieIpcAllReduceWorkspace:
         dtype: torch.dtype = torch.bfloat16,
         max_blocks: int = 128,
         profile: Optional[str] = None,
-        tune_batches: Sequence[int] = TUNE_BATCHES,
+        tune_batches: Optional[Sequence[int]] = None,
         tune_cache: Optional[str] = None,
     ) -> None:
         # Construction is a staged transaction. Every rank must execute the same
@@ -210,11 +211,17 @@ class PcieIpcAllReduceWorkspace:
         self._tuned: Dict[Tuple[int, int, torch.dtype], IpcLaunchConfig] = {}
         self._runner: Optional[PcieIpcAllReduceRunner] = None
         self._tune_group: Optional[ProcessGroup] = None
-        self._tune_batches = tuple(int(b) for b in tune_batches)
+        # None means "derive a ladder from max_numel at tune() time". An
+        # explicit list is honoured as given and only checked for coverage; see
+        # _warn_if_coverage_falls_short for why that is a warning, not an error.
+        self._tune_batches = (
+            None if tune_batches is None else tuple(int(b) for b in tune_batches)
+        )
         self._tune_cache = tune_cache or default_cache_path(self.world_size)
         self._tune_cache_exists = False
         self._tuned_configs_loaded = False
         self._warned_untuned = False
+        self._warned_stale_entry = False
 
         # --- stage 1: local validation, encoded rather than raised -----------
         error: Optional[str] = None
@@ -470,6 +477,23 @@ class PcieIpcAllReduceWorkspace:
             "loading the tune cache",
         )
 
+    def _warn_stale_tuned_entry(self, tactic) -> None:
+        """Say once that the cache holds entries this build no longer accepts."""
+        if self._warned_stale_entry:
+            return
+        self._warned_stale_entry = True
+        warnings.warn(
+            f"PCIe IPC all-reduce ignored a tuned entry from {self._tune_cache}: "
+            f"tactic {tactic!r} is not launchable in this build, so this shape "
+            "falls back to a seed configuration. The cache key still matches, "
+            "so this is not a stale workspace -- it is a cache written before "
+            "the set of legal configurations narrowed. Re-tune to regain the "
+            "measured configurations; other shapes in the same file may still "
+            "be in use, so the loss is partial and otherwise unsignalled.",
+            UserWarning,
+            stacklevel=4,
+        )
+
     def _warn_if_untuned(self) -> None:
         """Say once that this workspace resolved to seed configurations.
 
@@ -574,7 +598,13 @@ class PcieIpcAllReduceWorkspace:
         """Cold path: search or look up, then make the group agree."""
         hidden = inp.shape[-1]
         batch = inp.numel() // hidden
-        tuning_config = pcie_ipc_tuning_config(self._tune_batches)
+        # The lookup has to use the same buckets the search used, or a
+        # configuration profiled under one mapping is read back under another.
+        # With a derived ladder that means regenerating it for this hidden --
+        # pcie_ipc_tuning_config is lru_cached on the tuple, so an equal ladder
+        # yields the identical mapper object, which _find_nearest_profile's own
+        # cache requires.
+        tuning_config = pcie_ipc_tuning_config(self._batches_for(hidden))
         can_profile = tuner.is_tuning_mode and self._runner.can_profile(inp.device)
         if can_profile:
             _, tactic = tuner.choose_one(
@@ -602,6 +632,18 @@ class PcieIpcAllReduceWorkspace:
                 inputs=[inp],
             )
         config = resolve_tuned_config(seed, tactic, self.world_size, self.max_blocks)
+        if tactic != TABLE_TACTIC and config is seed:
+            # A matching key with an unusable value: world size, profile,
+            # max_blocks, max_numel, dtype and the tune version are all in the
+            # key, so the legal set narrowed without the version moving with it.
+            #
+            # Worth its own message because the two existing ones cannot reach
+            # it: both are gated on `_tuned_configs_loaded`, which is settled
+            # from the loaded *keys*, so they ask "did anyone tune this?" and
+            # not "is this value still legal?". The loss is otherwise silent
+            # and partial -- some shapes keep their tuned configuration, others
+            # quietly drop to the seed.
+            self._warn_stale_tuned_entry(tactic)
 
         # Unconditional, even when the cache missed and `config is seed`. The
         # ranks would otherwise have to agree on whether to run this collective
@@ -884,11 +926,12 @@ class PcieIpcAllReduceWorkspace:
         skipped: List[int] = []
         try:
             for hidden in hiddens:
+                requested = self._batches_for(hidden)
+                if self._tune_batches is not None:
+                    self._warn_if_coverage_falls_short(requested, hidden, dtype)
                 batches = [
                     b
-                    for b in tuned_batches_for(
-                        hidden, self._tune_batches, self.max_numel
-                    )
+                    for b in tuned_batches_for(hidden, requested, self.max_numel)
                     if self.launch_config(
                         torch.empty((b, hidden), dtype=dtype, device=self.device)
                     )
@@ -913,7 +956,7 @@ class PcieIpcAllReduceWorkspace:
                         tuner.choose_one(
                             PCIE_IPC_CUSTOM_OP,
                             [self._runner],
-                            pcie_ipc_tuning_config(self._tune_batches),
+                            pcie_ipc_tuning_config(tuple(requested)),
                             [inp],
                         )
                         covered.append((hidden, batch))
@@ -938,7 +981,25 @@ class PcieIpcAllReduceWorkspace:
         self._tuned.clear()
         self._tuned_configs_loaded = True
         dist.barrier(group=self.group)
-        if self.rank == 0:
+        # What makes this worth refusing rather than warning is stated to the
+        # caller below. The mechanism is not: the copy-engine path has several
+        # internal streams and kernels to load, which a shortened warmup does
+        # not absorb, so too few samples can pick the wrong data plane outright
+        # rather than merely a worse block count within the right one.
+        if warmup < TUNE_WARMUP or repeat < TUNE_REPEAT:
+            if self.rank == 0:
+                warnings.warn(
+                    f"not persisting the tuned configurations: they were "
+                    f"measured with warmup={warmup} repeat={repeat}, below the "
+                    f"defaults ({TUNE_WARMUP}/{TUNE_REPEAT}). Too few samples "
+                    f"can pick the wrong variant outright, and a file written "
+                    f"here is indistinguishable from a good one to every "
+                    f"process that later loads it. The results are live in this "
+                    f"process; re-run at the default counts to persist them.",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+        elif self.rank == 0:
             os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
             tuner.save_configs(path)
         # Nobody leaves before the file is on disk: a peer that rebuilt its
@@ -970,6 +1031,54 @@ class PcieIpcAllReduceWorkspace:
             )
         self._tune_group = dist.new_group(ranks=ranks, backend="gloo")
         return self._tune_group
+
+    def _batches_for(self, hidden: int) -> Tuple[int, ...]:
+        """Single source for the ladder: the tuning search and the serving
+        lookup must agree on it exactly, so both read it from here rather than
+        each deriving it.
+        """
+        if self._tune_batches is not None:
+            return self._tune_batches
+        ladder = generate_tune_batches(hidden, self.max_numel, self.elem_size)
+        # A workspace too small to hold even one row at this hidden yields an
+        # empty ladder, and an empty bucket set is rejected outright by
+        # autotune(). Such a shape is not admissible anyway -- the caller is
+        # about to be told so -- but the lookup path reaches here first, so give
+        # it a one-bucket ladder rather than an exception from three frames down.
+        return ladder or (1,)
+
+    def _warn_if_coverage_falls_short(
+        self, batches: Sequence[int], hidden: int, dtype: torch.dtype
+    ) -> None:
+        """Say when an explicit bucket list leaves the top of the range untuned.
+
+        Buckets map with floor semantics, so a shape above the largest one is
+        served by whatever was measured there. That is fine when the gap is
+        small and wrong when it is two orders of magnitude: at hidden 6144 the
+        default list stops at 1.5 MiB, and the configuration it picks there runs
+        a 96 MiB collective 30% slower than the one measured at 96 MiB.
+
+        A warning rather than an error, because tuning only the decode range is
+        a legitimate choice -- a deployment that never issues a prefill
+        collective has no reason to pay for measuring one.
+        """
+        if not batches:
+            return
+        elem = torch.empty((), dtype=dtype).element_size()
+        tuned_bytes = max(batches) * hidden * elem
+        admitted_bytes = self.max_numel * elem
+        if tuned_bytes * 8 >= admitted_bytes:
+            return
+        warnings.warn(
+            f"tuning stops at {max(batches)} rows ({tuned_bytes >> 20} MiB at "
+            f"hidden {hidden}) but this workspace admits up to "
+            f"{admitted_bytes >> 20} MiB. Buckets map downwards, so every "
+            f"larger shape will run the configuration measured at the top of "
+            f"this list. Pass tune_batches covering the shapes you serve, or "
+            f"leave it unset to have the ladder derived from max_numel.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
 
     def destroy(self) -> None:
         """Release the handle and the shared slab.

--- a/flashinfer/comm/pcie_ipc_policy.py
+++ b/flashinfer/comm/pcie_ipc_policy.py
@@ -55,6 +55,20 @@ class IpcVariant(IntEnum):
     STAGED = 1
     STAGED_RING = 2
     FLAT_STAGED = 3
+    # Copy-engine ring. `blocks` on this variant is not a grid size: it carries
+    # the ring's sub-chunk depth, which moves the collective by an order more
+    # than the add kernel's geometry does -- the geometry is not free, it is
+    # dominated -- so the one tunable integer goes to the knob that decides the
+    # outcome. Reusing the field rather than widening IpcLaunchConfig keeps
+    # the tactic a 3-tuple, which leaves the codec, pack_config and every arity
+    # test untouched, and holds this variant to a handful of candidates.
+    COPY_ENGINE_RING = 4
+    # The 4+4 decomposition. Reachable only at world size 8 and only on a
+    # fabric that grouping describes -- see _is_launchable, and the profile
+    # filter in pcie_ipc_tuning.get_valid_tactics, which keeps it out of the
+    # candidate list on fabrics it does not describe, where it lost to both
+    # the flat ring and the SM path.
+    COPY_ENGINE_ISLAND = 5
 
 
 @dataclass(frozen=True)
@@ -135,12 +149,59 @@ def _seed(
     return IpcLaunchConfig(min(16, max_blocks), 256, IpcVariant.UNSTAGED)
 
 
-def _is_launchable(world_size: int, config: IpcLaunchConfig, max_blocks: int) -> bool:
+CE_MAX_PIECES = 4
+# The copy-engine add kernel's block size. Fixed, not tuned -- see _is_launchable.
+CE_THREADS = 256
+
+
+def _is_launchable(
+    world_size: int,
+    config: IpcLaunchConfig,
+    max_blocks: int,
+    numel: Optional[int] = None,
+    elem_size: int = 2,
+) -> bool:
     """Reject configurations the kernels cannot accept.
 
     A violation here degrades to "unsupported shape" and a caller fallback,
     which is far better than reaching the kernel and failing a hard check.
+
+    `numel` is optional because most callers ask whether a configuration can
+    exist at all, not whether it fits one shape; passing it is what admits the
+    shape-dependent rules below. The tuner must pass it: the copy-engine ring
+    has a divisibility precondition that `_admits` does not imply, and a
+    candidate that reaches the launcher and fails its hard check raises on one
+    rank while its peers spin with no timeout.
     """
+    if config.variant in (IpcVariant.COPY_ENGINE_RING, IpcVariant.COPY_ENGINE_ISLAND):
+        if config.variant == IpcVariant.COPY_ENGINE_ISLAND and world_size != 8:
+            return False
+        # A copy-engine variant is not exempt from the world-size-2 rule just
+        # because it names its own launcher: the launcher admits exactly two
+        # variants there and rejects every other one by number, so a candidate
+        # that gets past this point fails its hard check. The schedule is
+        # correct at two ranks and costs nothing to leave out; the header of
+        # pcie_ipc_ce_ring.cuh says why, and how far that has been established.
+        if world_size == 2:
+            return False
+        if not 0 < config.blocks <= CE_MAX_PIECES:
+            return False
+        # The ring is bound by the fabric rather than by the SM, so the add
+        # kernel's geometry is not worth a search dimension. The SM variants
+        # are the opposite case, which is why their geometry stays tunable.
+        if config.threads != CE_THREADS:
+            return False
+        if numel is not None:
+            pack_elems = 16 // elem_size
+            # The island schedule splits into four chunks whatever the world size.
+            shards = (
+                4 if config.variant == IpcVariant.COPY_ENGINE_ISLAND else world_size
+            )
+            if numel % (shards * pack_elems) != 0:
+                return False
+            if (numel // shards) % (config.blocks * pack_elems) != 0:
+                return False
+        return world_size <= config.threads <= 1024
     if not 0 < config.blocks <= max_blocks:
         return False
     if not world_size <= config.threads <= 1024:

--- a/flashinfer/comm/pcie_ipc_tuning.py
+++ b/flashinfer/comm/pcie_ipc_tuning.py
@@ -52,6 +52,7 @@ from ..autotuner import (
     TuningConfig,
     make_bucket_mapper,
 )
+from .pcie_ipc_topology import PROFILE_ROOTCPLX
 from .pcie_ipc_policy import (
     MAX_BLOCKS,
     IpcLaunchConfig,
@@ -67,7 +68,7 @@ PCIE_IPC_CUSTOM_OP = "flashinfer::pcie_ipc_all_reduce"
 # candidate encoding changes. The autotuner's own metadata records library and
 # driver versions but nothing about this op, and a dev checkout does not move
 # the FlashInfer version.
-PCIE_IPC_TUNE_VERSION = 1
+PCIE_IPC_TUNE_VERSION = 3
 
 # Not all powers of two: the extra entries are block counts the search selected
 # on real hardware, and it cannot converge on a configuration its own grid
@@ -94,29 +95,76 @@ TABLE_TACTIC = -1
 INIT_MAX_VALUE = 16
 
 
+# Above this payload the grid is narrowed before profiling. The screen is a
+# *policy* -- "not worth measuring here" -- not a capability claim, so it lives
+# here and not in `_is_launchable`: an explicit `config=` naming a screened-out
+# configuration must still run. The grid was sized for decode, where measuring
+# every candidate is free; at prefill sizes the cost is dominated by candidates
+# orders of magnitude off the winner, each still paying full warmup and repeat.
+#
+# Only the thread count is screened. A block-count bound was tried and removed:
+# the block counts that win span the whole grid, so a bound fitted to one fabric
+# silently drops another fabric's winner -- tuning faster and running slower,
+# with no error. The thread floor stays because it sits below every winner a
+# search has picked, with margin rather than fitted to them; guarded by
+# `test_the_prefill_screen_keeps_every_measured_prefill_winner`.
+PREFILL_SCREEN_BYTES = 4 * 1024 * 1024
+PREFILL_MIN_THREADS = 256
+
+
 def candidate_tactics(
     world_size: int,
     max_blocks: int = MAX_BLOCKS,
     blocks: Tuple[int, ...] = TUNE_BLOCKS,
     threads: Tuple[int, ...] = TUNE_THREADS,
+    numel: Optional[int] = None,
+    elem_size: int = 2,
+    profile: Optional[str] = None,
 ) -> Tuple[Tuple[int, int, int], ...]:
-    """Every launch configuration the dispatch can reach, as tactics.
+    """Every launch configuration worth profiling for this shape, as tactics.
 
     A pure function of group-identical arguments, so every rank derives the
     same list in the same order -- which the autotuner's collective profiling
-    requires and cannot check.
+    requires and cannot check. `numel` is group-identical too: every rank
+    profiles the same shape.
+
+    `numel=None` means "which configurations can exist at all", not "which are
+    worth measuring here", and returns the unscreened grid.
     """
-    return _candidate_tactics_cached(world_size, max_blocks, blocks, threads)
+    return _candidate_tactics_cached(
+        world_size, max_blocks, blocks, threads, numel, elem_size, profile
+    )
 
 
 @lru_cache(maxsize=None)
-def _candidate_tactics_cached(world_size, max_blocks, blocks, threads):
+def _candidate_tactics_cached(
+    world_size, max_blocks, blocks, threads, numel, elem_size, profile
+):
+    screen = numel is not None and numel * elem_size >= PREFILL_SCREEN_BYTES
     out = []
     for variant in IpcVariant:
+        # The island schedule's 4+4 grouping describes one topology, and on
+        # fabrics it does not describe it measured worse than the flat ring and
+        # the SM path it competes with, so leaving it reachable is worse than
+        # not having it. `profile=None` means the caller is asking which
+        # configurations can exist rather than which to measure here, and does
+        # not filter.
+        if (
+            variant == IpcVariant.COPY_ENGINE_ISLAND
+            and profile is not None
+            and profile != PROFILE_ROOTCPLX
+        ):
+            continue
         for b in blocks:
             for t in threads:
+                if screen and t < PREFILL_MIN_THREADS:
+                    continue
                 if _is_launchable(
-                    world_size, IpcLaunchConfig(b, t, variant), max_blocks
+                    world_size,
+                    IpcLaunchConfig(b, t, variant),
+                    max_blocks,
+                    numel,
+                    elem_size,
                 ):
                     out.append((int(variant), b, t))
     return tuple(out)
@@ -308,6 +356,49 @@ def pack_config(config: IpcLaunchConfig) -> int:
     )
 
 
+# How many candidates the ranking pass keeps. A fixed count, not a "within Nx of
+# the best" rule: a threshold makes the number of survivors a function of
+# measured floats, and ranks whose lists come out different lengths do not pick
+# different kernels, they deadlock in the autotuner's per-tactic timing
+# reduction. The pass only has to cut the tail, and the count is generous
+# because the cost of being wrong is asymmetric -- too many survivors costs
+# tuning time, too few loses a configuration the search can then never choose.
+TUNE_SURVIVORS = 48
+
+# Rounds of the ranking pass. One round separates a hopeless candidate from a
+# contender but not the contenders from each other, and that matters: with a
+# single sample the *set* of survivors is itself a random variable, so the
+# fine-ranking sees a different candidate set each run and the final choice
+# moves with it. The extra rounds cost a small fraction of the launches the
+# survivors then get.
+#
+# The score is the minimum over the rounds, then MAX-reduced across ranks.
+# Minimum because what is estimated is how fast the configuration can go, and a
+# sample is only ever inflated -- by a neighbour, a clock excursion, a queued
+# launch -- never deflated. MAX because every rank has to truncate to the same
+# list: ranks returning different numbers of tactics deadlock in a kernel that
+# spins with no timeout. No number of rounds settles a choice between candidates
+# that differ by less than the capture domain resolves; those remedies -- pinned
+# clocks, a larger repeat, a longer capture window for small shapes -- live
+# outside get_valid_tactics.
+TUNE_RANK_ROUNDS = 3
+
+
+def reduce_timings(times: "torch.Tensor", group) -> "torch.Tensor":
+    """Make every rank rank the candidates identically.
+
+    ``MAX`` because a collective costs what its slowest rank costs; a mean would
+    also make the ranks agree, but it would agree on a number no rank observed.
+
+    Agreement is the load-bearing part, not the statistic: the truncated list
+    this feeds decides how many times each rank enters the profiler, and the
+    autotuner's timing reduction has no check for that. TUNE_SURVIVORS says
+    what a rank that truncates to a different length costs the group.
+    """
+    dist.all_reduce(times, op=dist.ReduceOp.MAX, group=group)
+    return times
+
+
 def reduce_verdict(wrong: "torch.Tensor", group) -> "torch.Tensor":
     """Make every rank agree on which candidates computed the wrong answer.
 
@@ -325,6 +416,62 @@ def reduce_verdict(wrong: "torch.Tensor", group) -> "torch.Tensor":
     """
     dist.all_reduce(wrong, op=dist.ReduceOp.MAX, group=group)
     return wrong
+
+
+MAX_GENERATED_BUCKETS = 14
+
+
+def generate_tune_batches(
+    hidden: int, max_numel: int, elem_size: int = 2
+) -> Tuple[int, ...]:
+    """A bucket ladder covering everything the workspace admits at this hidden.
+
+    The default ``TUNE_BATCHES`` stops far below the payload a prefill-sized
+    ``max_numel`` admits, so every large shape would be served by a measurement
+    taken at a much smaller one -- and the configuration does change with the
+    payload, the sub-chunk depth chosen at the bottom is not the one that wins
+    at the top. Nothing warned, because ``tune_batches`` and ``max_numel`` are
+    independent constructor arguments and only one of them is visible at the
+    ``tune()`` call.
+
+    So the ladder is derived from ``max_numel`` rather than fixed. Shape:
+
+    * dense at the bottom, where the winning kernel genuinely moves from bucket
+      to bucket;
+    * dense again through the crossover, where the decision is which *data
+      plane* to use and getting it wrong is the expensive mistake;
+    * sparse above it -- geometric, so the count stays bounded -- where the
+      bandwidth curve is flat, but not absent: the sub-chunk depth still moves
+      across the largest payloads.
+
+    ``MAX_GENERATED_BUCKETS`` caps the result, so an unexpectedly large
+    ``max_numel`` cannot turn tuning into an all-night job. The bottom is
+    thinned first: the decode end is the cheap end to measure, and the one with
+    the most redundancy once the winner has settled.
+    """
+    # No rounding of `top` itself: the whole-pack constraint is on
+    # ``batch * hidden``, not on the batch count, and it is already enforced by
+    # _admits. Rounding here to a multiple of the pack size sent every
+    # workspace whose largest batch is under eight to an empty ladder.
+    top = int(max_numel) // int(hidden)
+    if top < 1:
+        return ()
+
+    ladder = [1, 2, 4, 8, 16, 32, 64, 128]
+    b = 256
+    while b < top:
+        ladder.append(b)
+        b *= 4
+    ladder.append(top)
+
+    seen = sorted({b for b in ladder if 1 <= b <= top})
+    if len(seen) > MAX_GENERATED_BUCKETS:
+        head, tail = (
+            seen[: len(seen) - MAX_GENERATED_BUCKETS],
+            seen[-MAX_GENERATED_BUCKETS:],
+        )
+        seen = [head[0]] + tail if head else tail
+    return tuple(seen)
 
 
 def tuned_batches_for(
@@ -453,21 +600,55 @@ class PcieIpcAllReduceRunner(TunableRunner):
             warn_no_tune_group(stacklevel=3)
             return [TABLE_TACTIC]
 
-        tactics = candidate_tactics(ws.world_size, ws.max_blocks)
+        tactics = candidate_tactics(
+            ws.world_size,
+            ws.max_blocks,
+            numel=inp.numel(),
+            elem_size=inp.element_size(),
+            profile=ws.profile,
+        )
         configs = [table_config] + [tactic_to_config(t) for t in tactics]
 
         ref = inp.clone()
         dist.all_reduce(ref, group=ws.group)
         out = self._output_for(inp)
         wrong = torch.zeros(len(configs), dtype=torch.int32, device=inp.device)
+        # Allocated before the loop, like every other buffer here: the loop body
+        # must not allocate. Timing the launches costs nothing extra: this pass
+        # already runs every candidate once.
+        starts = [
+            [torch.cuda.Event(enable_timing=True) for _ in configs]
+            for _ in range(TUNE_RANK_ROUNDS)
+        ]
+        ends = [
+            [torch.cuda.Event(enable_timing=True) for _ in configs]
+            for _ in range(TUNE_RANK_ROUNDS)
+        ]
+
+        # One launch per distinct variant first. The first launch of a kernel
+        # loads its module, which shows up as an order-of-magnitude outlier and
+        # would demote whichever candidate happened to be that variant's first.
+        # Per variant, not per candidate: block and thread counts do not pull in
+        # a new module.
+        seen_variants = set()
+        for config in configs:
+            if config.variant not in seen_variants:
+                seen_variants.add(config.variant)
+                ws._launch(inp, out, config)
 
         dist.barrier(group=ws.group)
-        for i, config in enumerate(configs):
-            # A kernel that leaves part of the payload unwritten would
-            # otherwise show the previous candidate's correct result.
-            out.fill_(float("nan"))
-            ws._launch(inp, out, config)
-            wrong[i] = torch.ne(out, ref).any()
+        for r in range(TUNE_RANK_ROUNDS):
+            for i, config in enumerate(configs):
+                # A kernel that leaves part of the payload unwritten would
+                # otherwise show the previous candidate's correct result.
+                out.fill_(float("nan"))
+                starts[r][i].record()
+                ws._launch(inp, out, config)
+                ends[r][i].record()
+                if r == 0:
+                    # Enqueued after the closing event: inside the span, the
+                    # ranking would be timing a full-payload compare too.
+                    wrong[i] = torch.ne(out, ref).any()
         reduce_verdict(wrong, ws.group)
 
         verdict = wrong.tolist()
@@ -481,8 +662,35 @@ class PcieIpcAllReduceRunner(TunableRunner):
                 f"{tuple(inp.shape)} ({table_config}) does not match a "
                 "reference all-reduce; refusing to tune on top of it"
             )
-        survivors = zip(tactics, verdict[1:], strict=True)
-        return [TABLE_TACTIC] + [t for t, bad in survivors if not bad]
+        # Reading the events synchronises with the device, which is why it
+        # happens here and not in the loop above.
+        torch.cuda.synchronize(inp.device)
+        times = torch.tensor(
+            [
+                min(
+                    starts[r][i].elapsed_time(ends[r][i])
+                    for r in range(TUNE_RANK_ROUNDS)
+                )
+                for i in range(len(configs))
+            ],
+            dtype=torch.float64,
+            device=inp.device,
+        )
+        reduce_timings(times, ws.group)
+        scores = times.tolist()
+
+        survivors = [
+            (t, scores[i + 1])
+            for i, (t, bad) in enumerate(zip(tactics, verdict[1:], strict=True))
+            if not bad
+        ]
+        # Sorted by measured time, tie-broken on the tactic itself so the order
+        # is a function of group-identical inputs alone.
+        survivors.sort(key=lambda ts: (ts[1], ts[0]))
+        kept = [t for t, _ in survivors[:TUNE_SURVIVORS]]
+        # The seed stays first: the autotuner breaks ties toward the earlier
+        # element, so this is what makes an exact tie resolve to it.
+        return [TABLE_TACTIC] + kept
 
     def forward(
         self, inputs, tactic=TABLE_TACTIC, do_preparation: bool = False, **kwargs

--- a/include/flashinfer/comm/pcie_ipc_all_reduce.cuh
+++ b/include/flashinfer/comm/pcie_ipc_all_reduce.cuh
@@ -48,6 +48,46 @@ namespace pcie_ipc {
 constexpr int kMaxWorldSize = 8;
 constexpr int kSignalPhases = 8;
 
+// Number of ScratchRegion enumerators. The enum's integer value indexes
+// scratch_state_offset(), which reads a {epoch, arrival} pair per region, so
+// the slot count and the enum must move together. Spelled out here rather than
+// as a literal 2 inside compute_workspace_layout() because getting them out of
+// step lands scratch_state_offset() past signal_slots and inside the pack
+// scratch: silent corruption of the sentinel protocol, not a crash.
+constexpr int kScratchRegionCount = 2;
+
+// Copy-engine ring staging. It lives outside ScratchRegion on purpose: it has
+// no epoch and no arrival counter -- its scratch reuse is guarded by an
+// end-of-call neighbour handshake rather than by a double buffer -- so a
+// ScratchRegion enumerator for it would be state that exists only to be
+// miscalled.
+//
+// Flags are strided a full sector apart because a peer writes them over PCIe;
+// two sharing a sector turn a store into a read-modify-write on the root
+// complex. phase_offset() packs int32 contiguously and so could not host them.
+constexpr int kCeFlagStride = 128;
+constexpr int kCeMaxPieces = 4;
+// Block size of the ring's add kernel. Fixed, not tuned: the ring is bound by
+// the fabric rather than by the SM, so the one tunable integer is spent on the
+// sub-chunk depth instead.
+constexpr int kCeAddThreads = 256;
+
+// Ring slots for the deepest sub-chunking, plus two fixed handshake slots. The
+// handshake indices are fixed rather than derived as steps*pieces, which
+// aliases a ring slot whenever `pieces` varies between calls.
+//
+// Two, not one, because a rank must rendezvous with every rank whose staging it
+// writes and the two schedules write different sets: the flat ring only writes
+// `next`, while the island schedule writes `island_next` in phases A and C and
+// `partner` in phase B. A single global slot leaves at least one consumer
+// uncovered on every rank -- ranks 3 and 7, the two that wrap within their
+// island, cover neither.
+inline int ce_flag_slots(int world_size) { return 2 * (world_size - 1) * kCeMaxPieces + 2; }
+inline int ce_handshake_slot(int world_size) { return 2 * (world_size - 1) * kCeMaxPieces; }
+inline int ce_partner_handshake_slot(int world_size) {
+  return 2 * (world_size - 1) * kCeMaxPieces + 1;
+}
+
 // Which kernel all_reduce() launches, together with world_size. Values are
 // part of the FFI signature, so they are explicit and append-only.
 //
@@ -58,9 +98,13 @@ enum class Variant : int {
   kStaged = 1,      // staged pushes; island-decomposed at world_size 8
   kStagedRing = 2,  // staged pushes in neighbour order; world_size 4 and 8
   kFlatStaged = 3,  // staged pushes without the island decomposition
+  // Copy-engine ring. Dispatched one level up, in csrc, not by all_reduce()
+  // below -- see the guard at the top of that function.
+  kCopyEngineRing = 4,
+  kCopyEngineIsland = 5,  // 4+4 decomposition; world_size 8 and rootcplx only
 };
 
-constexpr int kVariantCount = 4;
+constexpr int kVariantCount = 6;
 
 // Which staging area a kernel uses. The kernels come in two protocol families
 // and a region may hold only one of them.
@@ -2033,7 +2077,12 @@ __global__ __launch_bounds__(1024, 1) void push_oneshot_param_kernel(
 // Byte layout of one rank's workspace slab.
 //
 //   [ epoch slots | barrier phase slots | barrier flags
-//     | block-scratch epoch + arrival | pack scratch | block scratch ]
+//     | block-scratch epoch + arrival | pack scratch | block scratch
+//     | ce flags | ce counters | ce scratch ]
+//
+// The copy-engine block is strictly at the tail so every offset make_peer_views
+// hands out for signal/pack/block is byte-identical with and without it, and a
+// tune cache measured before it stays valid.
 //
 // Both scratch regions are sized for world_size ranks x a double-buffered
 // epoch, so a rank may start collective N+1 before its peer has drained N.
@@ -2045,6 +2094,9 @@ struct WorkspaceLayout {
   size_t signal_bytes;
   size_t max_payload_bytes;
   size_t scratch_bytes;  // per scratch region
+  size_t ce_flag_bytes;
+  size_t ce_counter_bytes;
+  size_t ce_scratch_bytes;  // total, across every ring step
   size_t total_bytes;
 };
 
@@ -2057,7 +2109,7 @@ inline WorkspaceLayout compute_workspace_layout(int world_size, int64_t max_nume
   // {epoch, arrival} per scratch region, in ScratchRegion order. Appended at
   // the tail so phase_offset() and flag_offset(), both anchored at the front,
   // are unchanged. See scratch_state_offset().
-  const size_t scratch_state_slots = 2 * 2;
+  const size_t scratch_state_slots = 2 * static_cast<size_t>(kScratchRegionCount);
   const size_t signal_slots = epoch_slots + barrier_slots + flag_slots + scratch_state_slots;
   auto align128 = [](size_t n) { return (n + 127u) & ~static_cast<size_t>(127u); };
   WorkspaceLayout layout{};
@@ -2065,7 +2117,27 @@ inline WorkspaceLayout compute_workspace_layout(int world_size, int64_t max_nume
   layout.max_payload_bytes =
       align128(static_cast<size_t>(max_numel) * static_cast<size_t>(elem_size));
   layout.scratch_bytes = align128(2 * static_cast<size_t>(world_size) * layout.max_payload_bytes);
-  layout.total_bytes = layout.signal_bytes + 2 * layout.scratch_bytes;
+
+  // One landing buffer per ring step, sized by the shard that step carries.
+  // The flat ring runs 2*(N-1) steps of max_payload/N; at world_size 8 the
+  // island schedule runs 7 steps of max_payload/4, which is why it is zero
+  // below at any other size. There the two agree to within rounding at ~2x the
+  // payload, against the 2*2*N*payload the SM regions above take; take the
+  // larger so either schedule fits and neither needs its own allocation.
+  const size_t ce_slots = static_cast<size_t>(ce_flag_slots(world_size));
+  layout.ce_flag_bytes = align128(ce_slots * static_cast<size_t>(kCeFlagStride));
+  // Send and wait counters, rank-local. In the slab rather than in a torch
+  // tensor so pcie_ipc_init's memset initialises them and teardown needs no
+  // extra step.
+  layout.ce_counter_bytes = align128(2 * ce_slots * sizeof(int32_t));
+  const size_t flat_total = static_cast<size_t>(2 * (world_size - 1)) *
+                            align128(layout.max_payload_bytes / static_cast<size_t>(world_size));
+  const size_t island_total =
+      world_size == 8 ? static_cast<size_t>(7) * align128(layout.max_payload_bytes / 4) : 0;
+  layout.ce_scratch_bytes = flat_total > island_total ? flat_total : island_total;
+
+  layout.total_bytes = layout.signal_bytes + 2 * layout.scratch_bytes + layout.ce_flag_bytes +
+                       layout.ce_counter_bytes + layout.ce_scratch_bytes;
   return layout;
 }
 
@@ -2080,6 +2152,12 @@ struct PeerViews {
   uint64_t signal[kMaxWorldSize];
   uint64_t pack[kMaxWorldSize];
   uint64_t block[kMaxWorldSize];
+  // Copy-engine ring. flags and scratch are written by peers; the counters are
+  // rank-local and only ever touched by this rank's single-thread flag kernels.
+  uint64_t ce_flags[kMaxWorldSize];
+  uint64_t ce_scratch[kMaxWorldSize];
+  int32_t* ce_send_counters;
+  int32_t* ce_wait_counters;
   int32_t* self_signal;
 };
 
@@ -2093,8 +2171,17 @@ inline PeerViews make_peer_views(const int64_t* ipc_ptrs, int world_size, int ra
     auto* scratch = base + static_cast<ptrdiff_t>(layout.signal_bytes);
     views.pack[peer] = reinterpret_cast<uint64_t>(scratch);
     views.block[peer] = reinterpret_cast<uint64_t>(scratch + layout.scratch_bytes);
+    auto* ce = scratch + 2 * static_cast<ptrdiff_t>(layout.scratch_bytes);
+    views.ce_flags[peer] = reinterpret_cast<uint64_t>(ce);
+    views.ce_scratch[peer] = reinterpret_cast<uint64_t>(
+        ce + static_cast<ptrdiff_t>(layout.ce_flag_bytes + layout.ce_counter_bytes));
   }
   views.self_signal = reinterpret_cast<int32_t*>(ipc_ptrs[rank]);
+  auto* self_ce =
+      reinterpret_cast<char*>(ipc_ptrs[rank]) +
+      static_cast<ptrdiff_t>(layout.signal_bytes + 2 * layout.scratch_bytes + layout.ce_flag_bytes);
+  views.ce_send_counters = reinterpret_cast<int32_t*>(self_ce);
+  views.ce_wait_counters = views.ce_send_counters + ce_flag_slots(world_size);
   return views;
 }
 
@@ -2146,6 +2233,14 @@ template <typename T>
 cudaError_t all_reduce(const T* input, T* output, int64_t numel, const PeerViews& views, int rank,
                        int world_size, int max_blocks, int64_t max_numel, int blocks, int threads,
                        Variant variant, bool use_pdl, cudaStream_t stream) {
+  // The copy-engine ring is a different protocol with its own launcher; csrc
+  // routes it before reaching here. Refused explicitly because the
+  // world_size == 2 branch below selects on `variant == kStaged` and would
+  // otherwise silently run the TP2 SM kernel for any variant it does not know.
+  if (variant == Variant::kCopyEngineRing || variant == Variant::kCopyEngineIsland) {
+    return cudaErrorInvalidValue;
+  }
+
   using Traits = PackTraits<T>;
   const int num_packs = static_cast<int>(numel / Traits::kPackElems);
   const int rank_stride_packs = static_cast<int>(max_numel / Traits::kPackElems);

--- a/include/flashinfer/comm/pcie_ipc_ce_ring.cuh
+++ b/include/flashinfer/comm/pcie_ipc_ce_ring.cuh
@@ -1,0 +1,408 @@
+/*!
+ * Copy-engine ring all-reduce: a second data plane beside the SM kernels.
+ *
+ * The seven kernels in pcie_ipc_all_reduce.cuh move every byte with SM
+ * load/store and synchronise through the payload itself: +0.0 means "not yet
+ * written", so a producer rewrites any real +0.0 to -0.0 and a consumer polls
+ * its own 16-byte pack. A copy engine can do neither. It cannot transform data,
+ * so that rewrite would need an SM pass over the whole payload -- most of what
+ * the engine was meant to save -- and it reports only bulk completion, so it
+ * cannot observe a per-pack sentinel either. Readiness therefore leaves the
+ * payload: copy on a side stream, event, a single-thread kernel publishes a
+ * monotonic flag to the peer, another spins on it. This plane shares the
+ * workspace and the policy layer with the SM kernels and nothing else; those
+ * seven are untouched and remain the decode fast path.
+ *
+ * Which plane wins is a per-fabric, per-shape question the tuner settles bucket
+ * by bucket; neither is the default. The argument for this one is scaling, not
+ * raw speed: the SM plane's margin over NCCL narrows as the rank count grows on
+ * some fabrics, where the ring keeps its own.
+ *
+ * Two ranks are excluded -- that schedule is one reduce-scatter hop and one
+ * all-gather hop with nothing to pipeline against, so scheduling jitter lands
+ * directly on the wall clock, and where it was measured the run-to-run spread
+ * came out wider than the ring's whole margin. The tuner measures each
+ * candidate once per round and cannot act on an advantage smaller than the
+ * candidate's own variance. The two-hop structure holds on any fabric; the
+ * size of the margin it has to clear was only established on one.
+ */
+#ifndef FLASHINFER_COMM_PCIE_IPC_CE_RING_CUH_
+#define FLASHINFER_COMM_PCIE_IPC_CE_RING_CUH_
+
+#include "pcie_ipc_all_reduce.cuh"
+
+// This file follows the surrounding style: plain cudaError_t returns, no
+// framework headers. Scoped to the file and undefined at the bottom.
+#define FI_CE_CHECK(expr)                         \
+  do {                                            \
+    const cudaError_t _fi_ce_e = (expr);          \
+    if (_fi_ce_e != cudaSuccess) return _fi_ce_e; \
+  } while (0)
+
+namespace flashinfer {
+namespace comm {
+namespace pcie_ipc {
+
+// Streams and events the ring owns. They live on the handle, not in Python: a
+// captured graph keeps references to recorded events, a lifetime rule Python
+// cannot enforce. Created in pcie_ipc_init, destroyed in pcie_ipc_dispose.
+struct CeResources {
+  cudaStream_t copy_stream;
+  cudaStream_t flag_stream;
+  cudaEvent_t input_ready;
+  cudaEvent_t copy_done;
+  cudaEvent_t flag_done;
+  cudaEvent_t add_done[kCeMaxPieces];
+  cudaEvent_t copied[2 * (kMaxWorldSize - 1) * kCeMaxPieces];
+};
+
+// Announce to one peer that this rank's copy into its slot has landed.
+//
+// grid(1) block(1): the value published is this rank's own monotonic count for
+// the slot, read and advanced on the device. Nothing is supplied by the host,
+// which is what lets a captured graph replay without patching.
+//
+// Nothing here orders the copy-engine writes -- the stream dependency does.
+// This kernel runs on a stream that already waited on the memcpy's event, so
+// the payload has landed by the time it is dispatched. The release store only
+// has to make the counter store, and everything this device had already
+// retired, visible to the peer's acquire.
+__global__ void ce_publish_flag_kernel(int32_t* peer_flag, int32_t* send_counter) {
+  const int32_t next = load_volatile_i32(send_counter) + 1;
+  store_volatile_i32(send_counter, next);
+  store_release_i32(peer_flag, next);
+}
+
+// The matching wait on this rank's own flag.
+//
+// generation_reached() is the wrap-safe comparison the barrier kernels already
+// use; a plain `observed < expected` is correct for two billion calls and then
+// releases early.
+__global__ void ce_wait_flag_kernel(int32_t* self_flag, int32_t* wait_counter) {
+  const int32_t expected = load_volatile_i32(wait_counter) + 1;
+  store_volatile_i32(wait_counter, expected);
+  while (!generation_reached(load_acquire_i32(self_flag), expected)) {
+  }
+}
+
+// out = a + b over whole 16-byte packs.
+//
+// No sentinel and no barrier: the flag wait that precedes this on the same
+// stream is the entire synchronisation. The reduce happens in the payload
+// dtype, one rounding per ring hop, which matches NCCL's ring rather than the
+// SM kernels' single multi-source reduce -- a different summation order, which
+// is already the situation against NCCL and is why the tests compare exact
+// small integers.
+template <typename T>
+__global__ void ce_add_kernel(uint4* out, const uint4* a, const uint4* b, int64_t num_packs) {
+  const int64_t stride = static_cast<int64_t>(gridDim.x) * blockDim.x;
+  for (int64_t i = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; i < num_packs;
+       i += stride) {
+    out[i] = packed_add_u4<T>(a[i], b[i]);
+  }
+}
+
+// Sub-chunk depth. Deeper chunking keeps the copy engine busy -- piece c+1's
+// copy overlaps piece c's wait and reduce -- but each piece adds a flag round
+// trip and two launches, so it stops paying once a piece is small: at the
+// large payloads where the depths were compared, going past two was worse on
+// both fabrics. Between the shallow depths there is no answer that transfers:
+// which one wins flips with the fabric and with the payload size, so two is a
+// starting point and nothing more; the tuner settles it per shape.
+//
+// Must be a pure function of the shape: a rank that picks a different depth
+// uses different flag slots and the group hangs with no timeout.
+inline int ce_pick_pieces(int64_t shard_elems, size_t shard_bytes, int pack_elems, int requested) {
+  const int want = (requested >= 1 && requested <= kCeMaxPieces) ? requested : 2;
+  for (int pieces = want; pieces > 1; --pieces) {
+    if (shard_elems % (static_cast<int64_t>(pieces) * pack_elems) == 0 &&
+        shard_bytes / static_cast<size_t>(pieces) >= (512u << 10)) {
+      return pieces;
+    }
+  }
+  return 1;
+}
+
+namespace detail {
+
+inline size_t ce_slot_stride(const WorkspaceLayout& layout, int world_size) {
+  const size_t shard = layout.max_payload_bytes / static_cast<size_t>(world_size);
+  return (shard + 127u) & ~static_cast<size_t>(127u);
+}
+
+}  // namespace detail
+
+// Flat neighbour ring: reduce-scatter then all-gather, every step writing only
+// to (rank+1)%N so each GPU has exactly one outbound and one inbound stream.
+//
+// There is no upfront copy of the input into the output. The first send reads
+// the caller's buffer directly and every reduce-scatter step is a first touch,
+// out[chunk] = in[chunk] + scratch, so the accumulation base folds into the add
+// instead of costing a full-size copy on the critical path. Note the `a` operand
+// is always the *input*: the scratch already carries the upstream ranks'
+// accumulated partial for that chunk, and this rank adds only its own.
+template <typename T>
+cudaError_t ce_ring_all_reduce_flat(const T* input, T* output, int64_t numel,
+                                    const PeerViews& views, int rank, int world_size,
+                                    const WorkspaceLayout& layout, const CeResources& ce,
+                                    int pieces_hint, int threads, cudaStream_t stream) {
+  constexpr int kPackElems = PackTraits<T>::kPackElems;
+  const int64_t shard_elems = numel / world_size;
+  const size_t shard_bytes = static_cast<size_t>(shard_elems) * sizeof(T);
+  const int pieces = ce_pick_pieces(shard_elems, shard_bytes, kPackElems, pieces_hint);
+  const int64_t piece_elems = shard_elems / pieces;
+  const size_t piece_bytes = static_cast<size_t>(piece_elems) * sizeof(T);
+  const size_t slot_stride = detail::ce_slot_stride(layout, world_size);
+  const int steps = 2 * (world_size - 1);
+  const int next = (rank + 1) % world_size;
+  const int prev = (rank - 1 + world_size) % world_size;
+
+  const int64_t packs = piece_elems / kPackElems;
+  const unsigned grid =
+      static_cast<unsigned>(packs < threads ? 1 : (packs + threads - 1) / threads);
+  const unsigned add_grid = grid > 64u ? 64u : grid;
+
+  auto flag_at = [&](int peer, int slot) {
+    return reinterpret_cast<int32_t*>(views.ce_flags[peer] +
+                                      static_cast<uint64_t>(slot) * kCeFlagStride);
+  };
+  auto scratch_at = [&](int peer, int k, int p) {
+    return reinterpret_cast<char*>(views.ce_scratch[peer]) +
+           static_cast<ptrdiff_t>(k) * static_cast<ptrdiff_t>(slot_stride) +
+           static_cast<ptrdiff_t>(p) * static_cast<ptrdiff_t>(piece_bytes);
+  };
+
+  // Fork: pull both side streams into whatever ordering (or capture) the
+  // caller's stream is under. Without this a capture fails outright and an
+  // eager call races the caller's producer.
+  FI_CE_CHECK(cudaEventRecord(ce.input_ready, stream));
+  FI_CE_CHECK(cudaStreamWaitEvent(ce.copy_stream, ce.input_ready));
+  FI_CE_CHECK(cudaStreamWaitEvent(ce.flag_stream, ce.input_ready));
+
+  for (int k = 0; k < steps; ++k) {
+    const bool reduce_phase = k < world_size - 1;
+    int send_c, recv_c;
+    if (reduce_phase) {
+      send_c = ((rank - k) % world_size + world_size) % world_size;
+      recv_c = ((rank - k - 1) % world_size + world_size) % world_size;
+    } else {
+      const int kk = k - (world_size - 1);
+      send_c = ((rank + 1 - kk) % world_size + world_size) % world_size;
+      recv_c = ((rank - kk) % world_size + world_size) % world_size;
+    }
+    for (int p = 0; p < pieces; ++p) {
+      const int slot = k * pieces + p;
+      const int64_t off = static_cast<int64_t>(send_c) * shard_elems + p * piece_elems;
+      const void* src =
+          k == 0 ? static_cast<const void*>(input + off) : static_cast<const void*>(output + off);
+
+      // The copy stream carries nothing but back-to-back engine work: an SM
+      // kernel between two memcpys stalls the engine for a launch round trip.
+      if (k > 0) {
+        FI_CE_CHECK(cudaStreamWaitEvent(ce.copy_stream, ce.add_done[p]));
+      }
+      FI_CE_CHECK(cudaMemcpyAsync(scratch_at(next, k, p), src, piece_bytes,
+                                  cudaMemcpyDeviceToDevice, ce.copy_stream));
+      FI_CE_CHECK(cudaEventRecord(ce.copied[slot], ce.copy_stream));
+
+      FI_CE_CHECK(cudaStreamWaitEvent(ce.flag_stream, ce.copied[slot]));
+      ce_publish_flag_kernel<<<1, 1, 0, ce.flag_stream>>>(flag_at(next, slot),
+                                                          views.ce_send_counters + slot);
+      ce_wait_flag_kernel<<<1, 1, 0, stream>>>(flag_at(rank, slot), views.ce_wait_counters + slot);
+
+      const int64_t roff = static_cast<int64_t>(recv_c) * shard_elems + p * piece_elems;
+      auto* landed = scratch_at(rank, k, p);
+      if (reduce_phase) {
+        ce_add_kernel<T><<<add_grid, threads, 0, stream>>>(
+            reinterpret_cast<uint4*>(output + roff), reinterpret_cast<const uint4*>(input + roff),
+            reinterpret_cast<const uint4*>(landed), packs);
+      } else {
+        FI_CE_CHECK(
+            cudaMemcpyAsync(output + roff, landed, piece_bytes, cudaMemcpyDeviceToDevice, stream));
+      }
+      FI_CE_CHECK(cudaEventRecord(ce.add_done[p], stream));
+    }
+  }
+
+  // Join. Mandatory: without it cudaStreamEndCapture fails with
+  // cudaErrorStreamCaptureUnjoined, and in eager mode the caller reads a torn
+  // result because the side streams are still running.
+  FI_CE_CHECK(cudaEventRecord(ce.copy_done, ce.copy_stream));
+  FI_CE_CHECK(cudaEventRecord(ce.flag_done, ce.flag_stream));
+  FI_CE_CHECK(cudaStreamWaitEvent(stream, ce.copy_done));
+  FI_CE_CHECK(cudaStreamWaitEvent(stream, ce.flag_done));
+
+  // End-of-call rendezvous with the rank whose staging this one writes.
+  //
+  // It looks like dead weight, and deleting it leaves every test passing -- that
+  // was measured, see _skewed_ranks_worker. The reason is that the current
+  // gating makes the skew it closes unreachable: a step-k copy waits on the
+  // step-(k-1) add, so `r@k` implies `(r-1)@(k-1)`. That is a property of the
+  // `cudaStreamWaitEvent(copy_stream, add_done[p])` above, not of the ring --
+  // relax that to let the copy engine run further ahead and the induction
+  // collapses with nothing to report it.
+  //
+  // Whatever replaces it must still rendezvous with *every* consumer of this
+  // rank's staging, which is why the island schedule below needs two slots and
+  // this one needs one.
+  const int hs = ce_handshake_slot(world_size);
+  ce_publish_flag_kernel<<<1, 1, 0, stream>>>(flag_at(prev, hs), views.ce_send_counters + hs);
+  ce_wait_flag_kernel<<<1, 1, 0, stream>>>(flag_at(rank, hs), views.ce_wait_counters + hs);
+  return cudaGetLastError();
+}
+
+// 4+4 island decomposition: intra-island ring reduce-scatter, one cross-socket
+// owner-pair exchange, intra-island ring all-gather. World size 8 only.
+//
+// Why it exists: in the flat ring every link carries the same 2(N-1)/N of the
+// payload, so on a box whose eight GPUs sit in two NUMA islands the two hops
+// that span the sockets become the critical path. Splitting the schedule puts
+// one chunk per rank across that boundary instead of the full ring traffic,
+// which is what buys it its edge over the flat ring there.
+//
+// And why it must be gated: the grouping below is `rank / 4` and `rank ^ 4`,
+// which describes one topology -- two islands with a single crossing -- and
+// nothing else. On a switch-paired fabric, where a NUMA node holds two PCIe
+// switches with two GPUs behind each and there are three cost levels rather
+// than two, it cuts across the hierarchy it exists to exploit and loses to both
+// the flat ring and the SM path. Deriving the grouping from the topology probe
+// instead of hardcoding it is the real fix and is not done; until then the
+// caller must only select this on a fabric it describes.
+template <typename T>
+cudaError_t ce_ring_all_reduce_island(const T* input, T* output, int64_t numel,
+                                      const PeerViews& views, int rank, int world_size,
+                                      const WorkspaceLayout& layout, const CeResources& ce,
+                                      int pieces_hint, int threads, cudaStream_t stream) {
+  if (world_size != 8) return cudaErrorInvalidValue;
+  constexpr int kPackElems = PackTraits<T>::kPackElems;
+  constexpr int kIsland = 4;
+  const int64_t chunk_elems = numel / kIsland;
+  const size_t chunk_bytes = static_cast<size_t>(chunk_elems) * sizeof(T);
+  const int pieces = ce_pick_pieces(chunk_elems, chunk_bytes, kPackElems, pieces_hint);
+  const int64_t piece_elems = chunk_elems / pieces;
+  const size_t piece_bytes = static_cast<size_t>(piece_elems) * sizeof(T);
+  // Slots here stage a quarter of the payload, not an Nth.
+  const size_t slot_stride = (layout.max_payload_bytes / 4 + 127u) & ~static_cast<size_t>(127u);
+
+  const int island = rank / kIsland;
+  const int local = rank % kIsland;
+  const int next = island * kIsland + (local + 1) % kIsland;
+  const int partner = rank ^ kIsland;
+
+  const int64_t packs = piece_elems / kPackElems;
+  const unsigned grid =
+      static_cast<unsigned>(packs < threads ? 1 : (packs + threads - 1) / threads);
+  const unsigned add_grid = grid > 64u ? 64u : grid;
+
+  auto flag_at = [&](int peer, int slot) {
+    return reinterpret_cast<int32_t*>(views.ce_flags[peer] +
+                                      static_cast<uint64_t>(slot) * kCeFlagStride);
+  };
+  auto scratch_at = [&](int peer, int step, int p) {
+    return reinterpret_cast<char*>(views.ce_scratch[peer]) +
+           static_cast<ptrdiff_t>(step) * static_cast<ptrdiff_t>(slot_stride) +
+           static_cast<ptrdiff_t>(p) * static_cast<ptrdiff_t>(piece_bytes);
+  };
+  auto in_at = [&](int c, int p) {
+    return input + static_cast<int64_t>(c) * chunk_elems + p * piece_elems;
+  };
+  auto out_at = [&](int c, int p) {
+    return output + static_cast<int64_t>(c) * chunk_elems + p * piece_elems;
+  };
+
+  FI_CE_CHECK(cudaEventRecord(ce.input_ready, stream));
+  FI_CE_CHECK(cudaStreamWaitEvent(ce.copy_stream, ce.input_ready));
+  FI_CE_CHECK(cudaStreamWaitEvent(ce.flag_stream, ce.input_ready));
+
+  auto hop = [&](int slot, int peer, char* dst, const void* src,
+                 const cudaEvent_t* gate) -> cudaError_t {
+    if (gate != nullptr) FI_CE_CHECK(cudaStreamWaitEvent(ce.copy_stream, *gate));
+    FI_CE_CHECK(cudaMemcpyAsync(dst, src, piece_bytes, cudaMemcpyDeviceToDevice, ce.copy_stream));
+    FI_CE_CHECK(cudaEventRecord(ce.copied[slot], ce.copy_stream));
+    FI_CE_CHECK(cudaStreamWaitEvent(ce.flag_stream, ce.copied[slot]));
+    ce_publish_flag_kernel<<<1, 1, 0, ce.flag_stream>>>(flag_at(peer, slot),
+                                                        views.ce_send_counters + slot);
+    ce_wait_flag_kernel<<<1, 1, 0, stream>>>(flag_at(rank, slot), views.ce_wait_counters + slot);
+    return cudaSuccess;
+  };
+
+  // After these three steps this rank owns chunk (local+1)%4, summed over its
+  // own island.
+  for (int k = 0; k < 3; ++k) {
+    const int send_c = (local - k + 8) % kIsland;
+    const int recv_c = (local - k - 1 + 8) % kIsland;
+    for (int p = 0; p < pieces; ++p) {
+      const int slot = k * pieces + p;
+      const void* src = k == 0 ? static_cast<const void*>(in_at(send_c, p))
+                               : static_cast<const void*>(out_at(send_c, p));
+      FI_CE_CHECK(hop(slot, next, scratch_at(next, k, p), src, k == 0 ? nullptr : &ce.add_done[p]));
+      ce_add_kernel<T><<<add_grid, threads, 0, stream>>>(
+          reinterpret_cast<uint4*>(out_at(recv_c, p)),
+          reinterpret_cast<const uint4*>(in_at(recv_c, p)),
+          reinterpret_cast<const uint4*>(scratch_at(rank, k, p)), packs);
+      FI_CE_CHECK(cudaEventRecord(ce.add_done[p], stream));
+    }
+  }
+
+  // Phase B: the only cross-socket hop, one chunk each way.
+  //
+  // This step is the one place in either schedule where the send source and the
+  // accumulate destination are the same buffer. ce_wait_flag orders this rank
+  // against the *partner's* copy, not against its own outbound read, so without
+  // the extra wait below the copy stream is still reading out[own] while the
+  // add overwrites it and the partner receives a half-written chunk. The flat
+  // ring cannot hit this -- send_chunk != recv_chunk always holds there -- so
+  // cloning its structure walks straight into it.
+  const int own = (local + 1) % kIsland;
+  for (int p = 0; p < pieces; ++p) {
+    const int slot = 3 * pieces + p;
+    FI_CE_CHECK(hop(slot, partner, scratch_at(partner, 3, p), out_at(own, p), &ce.add_done[p]));
+    FI_CE_CHECK(cudaStreamWaitEvent(stream, ce.copied[slot]));
+    ce_add_kernel<T><<<add_grid, threads, 0, stream>>>(
+        reinterpret_cast<uint4*>(out_at(own, p)), reinterpret_cast<const uint4*>(out_at(own, p)),
+        reinterpret_cast<const uint4*>(scratch_at(rank, 3, p)), packs);
+    FI_CE_CHECK(cudaEventRecord(ce.add_done[p], stream));
+  }
+
+  for (int k = 0; k < 3; ++k) {
+    const int send_c = (local + 1 - k + 8) % kIsland;
+    const int recv_c = (local - k + 8) % kIsland;
+    for (int p = 0; p < pieces; ++p) {
+      const int slot = (4 + k) * pieces + p;
+      FI_CE_CHECK(hop(slot, next, scratch_at(next, 4 + k, p), out_at(send_c, p), &ce.add_done[p]));
+      FI_CE_CHECK(cudaMemcpyAsync(out_at(recv_c, p), scratch_at(rank, 4 + k, p), piece_bytes,
+                                  cudaMemcpyDeviceToDevice, stream));
+      FI_CE_CHECK(cudaEventRecord(ce.add_done[p], stream));
+    }
+  }
+
+  FI_CE_CHECK(cudaEventRecord(ce.copy_done, ce.copy_stream));
+  FI_CE_CHECK(cudaEventRecord(ce.flag_done, ce.flag_stream));
+  FI_CE_CHECK(cudaStreamWaitEvent(stream, ce.copy_done));
+  FI_CE_CHECK(cudaStreamWaitEvent(stream, ce.flag_done));
+
+  // Rendezvous with both consumers of this rank's staging: `island_next`, which
+  // reads what phases A and C wrote, and `partner`, which reads phase B. One
+  // global slot -- what the flat ring uses, where the only consumer is `next` --
+  // leaves at least one of them uncovered on every rank here, and neither on the
+  // two ranks that wrap within their island.
+  const int island_prev = island * kIsland + (local - 1 + kIsland) % kIsland;
+  const int hs = ce_handshake_slot(world_size);
+  const int hs_partner = ce_partner_handshake_slot(world_size);
+  ce_publish_flag_kernel<<<1, 1, 0, stream>>>(flag_at(island_prev, hs),
+                                              views.ce_send_counters + hs);
+  ce_publish_flag_kernel<<<1, 1, 0, stream>>>(flag_at(partner, hs_partner),
+                                              views.ce_send_counters + hs_partner);
+  ce_wait_flag_kernel<<<1, 1, 0, stream>>>(flag_at(rank, hs), views.ce_wait_counters + hs);
+  ce_wait_flag_kernel<<<1, 1, 0, stream>>>(flag_at(rank, hs_partner),
+                                           views.ce_wait_counters + hs_partner);
+  return cudaGetLastError();
+}
+
+}  // namespace pcie_ipc
+}  // namespace comm
+}  // namespace flashinfer
+
+#undef FI_CE_CHECK
+
+#endif  // FLASHINFER_COMM_PCIE_IPC_CE_RING_CUH_

--- a/tests/comm/test_pcie_ipc_all_reduce.py
+++ b/tests/comm/test_pcie_ipc_all_reduce.py
@@ -829,7 +829,10 @@ def _tune_worker(world_size: int, rank: int, port: int, tmpdir: str) -> None:
             tune_batches=_TUNE_BATCHES,
         )
         before = {b: ws.supports(_tune_input(b, device)) for b in _TUNE_BATCHES}
-        ws.tune([_TUNE_HIDDEN], cache=path, warmup=2, repeat=5)
+        # Default sample counts, not the reduced ones: tune() refuses to write
+        # the file below them, and everything after this line reads it back.
+        # Affordable because these buckets are 12-48 KiB.
+        ws.tune([_TUNE_HIDDEN], cache=path)
 
         resolved = {}
         for batch in _TUNE_BATCHES:
@@ -1128,7 +1131,7 @@ def _untuned_warning_worker(world_size: int, rank: int, port: int, tmpdir: str) 
         assert not during, during
 
         # And silent afterwards, including on a shape tuning did not cover.
-        ws.tune([_TUNE_HIDDEN], cache=path, warmup=2, repeat=5)
+        ws.tune([_TUNE_HIDDEN], cache=path)
         after = _untuned_warnings(lambda: ws.all_reduce(_tune_input(4, device)))
         assert not after, after
 

--- a/tests/comm/test_pcie_ipc_ce_ring.py
+++ b/tests/comm/test_pcie_ipc_ce_ring.py
@@ -1,0 +1,173 @@
+"""Copy-engine ring: the protocol properties the SM kernels do not have.
+
+The ring synchronises through monotonic flags rather than through the payload,
+and it stages into scratch guarded by an end-of-call handshake rather than by an
+epoch double buffer. Both are the reason it can be a second data plane at all,
+and neither is exercised by the SM path's tests.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from flashinfer import comm
+from flashinfer.comm.pcie_ipc_policy import IpcLaunchConfig, IpcVariant
+from tests.comm.test_pcie_ipc_all_reduce import (
+    _init_process_group,
+    multi_process_parallel,
+)
+
+_HIDDEN = 6144
+_BATCH = 64
+
+# Both schedules, because they do not share a protocol. The island variant is
+# filtered out of the tuner's candidates on any fabric its 4+4 grouping does not
+# describe, so on such a box these tests are the only thing that runs it at all
+# -- an explicit `config=` is documented to reach a kernel the tuner would not
+# choose. Reaching it matters here: it stages into two peers' scratch rather
+# than one, which is the part the end-of-call handshake has to cover.
+_VARIANTS = [IpcVariant.COPY_ENGINE_RING, IpcVariant.COPY_ENGINE_ISLAND]
+
+
+def _ce_config(
+    pieces: int = 2, variant: IpcVariant = IpcVariant.COPY_ENGINE_RING
+) -> IpcLaunchConfig:
+    return IpcLaunchConfig(blocks=pieces, threads=256, variant=variant)
+
+
+def _skip_unless_runnable(world_size: int, variant: IpcVariant) -> None:
+    if world_size > torch.cuda.device_count():
+        pytest.skip(f"not enough GPUs: need {world_size}")
+    if variant == IpcVariant.COPY_ENGINE_ISLAND and world_size != 8:
+        pytest.skip("the island schedule is a 4+4 decomposition, world_size 8 only")
+
+
+def _graph_replay_worker(
+    world_size: int, rank: int, port: int, variant: IpcVariant
+) -> None:
+    _init_process_group(world_size, rank, port)
+    device = torch.device("cuda", rank)
+    group = dist.group.WORLD
+    ws: Optional[comm.PcieIpcAllReduceWorkspace] = None
+    try:
+        ws = comm.PcieIpcAllReduceWorkspace(
+            group=group, max_numel=_BATCH * _HIDDEN, dtype=torch.bfloat16
+        )
+        config = _ce_config(variant=variant)
+        inp = torch.randint(
+            0, 16, (_BATCH, _HIDDEN), dtype=torch.int32, device=device
+        ).to(torch.bfloat16)
+        out = torch.empty_like(inp)
+        ref = inp.clone()
+        dist.all_reduce(ref, group=group)
+
+        # Warm up outside the graph: the first launch of a specialisation loads
+        # its module, which is illegal inside a capture.
+        for _ in range(3):
+            ws.all_reduce(inp, out=out, config=config)
+        torch.cuda.synchronize(device)
+        dist.barrier(group=group)
+
+        for captured in (3, 4):
+            ws.rebind_stream()  # capture warms up on a side stream
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                for _ in range(captured):
+                    ws.all_reduce(inp, out=out, config=config)
+            # Eager calls are interleaved with the replays because a
+            # replay-only loop would also pass if the flag counters were reset
+            # on every call; only calls that advance the counters outside the
+            # graph tell the two apart.
+            for i in range(8):
+                graph.replay()
+                torch.cuda.synchronize(device)
+                torch.testing.assert_close(out, ref, rtol=0, atol=0)
+                if i % 2 == 0:
+                    ws.rebind_stream()
+                    ws.all_reduce(inp, out=out, config=config)
+                    torch.cuda.synchronize(device)
+                    torch.testing.assert_close(out, ref, rtol=0, atol=0)
+            dist.barrier(group=group)
+            del graph
+    finally:
+        if ws is not None:
+            ws.destroy()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _skewed_ranks_worker(
+    world_size: int, rank: int, port: int, variant: IpcVariant, dtype: torch.dtype
+) -> None:
+    """Back-to-back calls with one rank deliberately behind.
+
+    Despite the name this does NOT cover the end-of-call rendezvous: deleting
+    either handshake leaves it passing 20/20 on both schedules, while truncating
+    the island all-gather by one step fails it immediately -- so the detector
+    works and header edits do reach the compiled binary, which is what rules out
+    a stale JIT cache as the explanation for the 20/20. It simply cannot open
+    the window the rendezvous closes, because the ring's own data dependencies
+    (`r@k` implies `(r-1)@(k-1)`) already serialise it. If the rendezvous is ever
+    changed or removed, this test will not notice; the scenario that would is not
+    currently constructible from the public API, see the comment at the handshake.
+
+    The skew is device-side (torch.cuda._sleep) because the collective is
+    stream-ordered and a host delay would only delay submission. The laggard
+    rotates so that ranks 3 and 7 take a turn: they sit at the island wrap, and
+    they are the ranks a single global handshake slot would leave covering
+    neither peer they stage into -- which is why there are two slots. See
+    ce_flag_slots in pcie_ipc_all_reduce.cuh.
+    """
+    _init_process_group(world_size, rank, port)
+    device = torch.device("cuda", rank)
+    group = dist.group.WORLD
+    ws: Optional[comm.PcieIpcAllReduceWorkspace] = None
+    try:
+        ws = comm.PcieIpcAllReduceWorkspace(
+            group=group, max_numel=_BATCH * _HIDDEN, dtype=dtype
+        )
+        config = _ce_config(variant=variant)
+        out = torch.empty(_BATCH, _HIDDEN, dtype=dtype, device=device)
+        for i in range(8 * world_size):
+            # An iteration-dependent value, so staging left over from call i-1
+            # cannot be mistaken for a correct result for call i.
+            inp = torch.full(
+                (_BATCH, _HIDDEN), float(i % 16), dtype=dtype, device=device
+            )
+            if rank == i % world_size:
+                torch.cuda._sleep(2_000_000)
+            ws.all_reduce(inp, out=out, config=config)
+            torch.cuda.synchronize(device)
+            expected = torch.full_like(out, float(i % 16) * world_size)
+            torch.testing.assert_close(out, expected, rtol=0, atol=0)
+        dist.barrier(group=group)
+    finally:
+        if ws is not None:
+            ws.destroy()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+@pytest.mark.parametrize("variant", _VARIANTS, ids=lambda v: v.name.lower())
+@pytest.mark.parametrize("world_size", [4, 8])
+def test_ce_ring_survives_graph_replay(world_size: int, variant: IpcVariant) -> None:
+    _skip_unless_runnable(world_size, variant)
+    multi_process_parallel(world_size, _graph_replay_worker, args=(variant,))
+
+
+# Both 2-byte dtypes take the same path apart from the packed_add_u4
+# specialisation, which the ring shares with the SM kernels, so fp16 rides on
+# the correctness test alone; the replay test stays bf16 because the flag
+# kernels it exercises are not templated on dtype at all.
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16], ids=["bf16", "fp16"])
+@pytest.mark.parametrize("variant", _VARIANTS, ids=lambda v: v.name.lower())
+@pytest.mark.parametrize("world_size", [4, 8])
+def test_ce_ring_is_correct_with_skewed_ranks(
+    world_size: int, variant: IpcVariant, dtype: torch.dtype
+) -> None:
+    _skip_unless_runnable(world_size, variant)
+    multi_process_parallel(world_size, _skewed_ranks_worker, args=(variant, dtype))

--- a/tests/comm/test_pcie_ipc_policy.py
+++ b/tests/comm/test_pcie_ipc_policy.py
@@ -271,14 +271,31 @@ def test_every_dispatchable_variant_is_reachable_from_the_tuner() -> None:
     round. The seed deliberately reaches only some of them, so the tuner's
     candidate list is where this has to hold.
     """
+    # World size 2 admits two variants and no more: the launcher's check is a
+    # whitelist of variant numbers, so naming a launcher of your own does not
+    # exempt a variant from it. A ring listed here hits that hard check on the
+    # first candidate of a two-rank tune -- on every rank at once, since the
+    # rule is shape-independent; a shape-dependent one would throw on one rank
+    # while the others spun.
     expected = {
         2: {IpcVariant.UNSTAGED, IpcVariant.STAGED},
-        4: {IpcVariant.UNSTAGED, IpcVariant.STAGED, IpcVariant.STAGED_RING},
+        4: {
+            IpcVariant.UNSTAGED,
+            IpcVariant.STAGED,
+            IpcVariant.STAGED_RING,
+            IpcVariant.COPY_ENGINE_RING,
+        },
         8: {
             IpcVariant.UNSTAGED,
             IpcVariant.STAGED,
             IpcVariant.STAGED_RING,
             IpcVariant.FLAT_STAGED,
+            IpcVariant.COPY_ENGINE_RING,
+            # World size 8 only -- it is a 4+4 decomposition. Reachable here
+            # because this asks with no profile, i.e. which configurations can
+            # exist; get_valid_tactics passes one and drops it on a fabric the
+            # grouping does not describe.
+            IpcVariant.COPY_ENGINE_ISLAND,
         },
     }
     seen = {

--- a/tests/comm/test_pcie_ipc_tuning.py
+++ b/tests/comm/test_pcie_ipc_tuning.py
@@ -21,12 +21,14 @@ reduced with the wrong operator. The multi-GPU tests can only observe the
 consequences, and one of the consequences is a hang.
 """
 
+import inspect
 import json
 
 import pytest
 import torch
 
 from flashinfer.autotuner import _json_to_tactic, _tactic_to_json, make_bucket_mapper
+from flashinfer.comm import pcie_ipc_policy as policy
 from flashinfer.comm import pcie_ipc_tuning as tuning
 from flashinfer.comm.pcie_ipc_ar import PcieIpcAllReduceWorkspace
 from flashinfer.comm.pcie_ipc_policy import (
@@ -69,21 +71,44 @@ def test_candidate_rejections_match_the_documented_rules() -> None:
 
     # World size 8: the block-partitioned kernel needs blocks % 4 == 0.
     rejected = set(grid) - set(tuning.candidate_tactics(8))
-    assert rejected == {
+    expected_rejected = {
         (int(IpcVariant.STAGED), b, t)
         for b in tuning.TUNE_BLOCKS
         if b % 4 != 0
         for t in tuning.TUNE_THREADS
+    } | {
+        # `blocks` is the sub-chunk depth on the copy-engine variants, so
+        # anything past CE_MAX_PIECES names a depth that does not exist; and
+        # their add kernel's thread count is fixed rather than searched.
+        (int(v), b, t)
+        for v in (IpcVariant.COPY_ENGINE_RING, IpcVariant.COPY_ENGINE_ISLAND)
+        for b in tuning.TUNE_BLOCKS
+        for t in tuning.TUNE_THREADS
+        if b > policy.CE_MAX_PIECES or t != policy.CE_THREADS
     }
+    assert rejected == expected_rejected
 
     # World size 4: no FLAT_STAGED, and threads must be at least world_size
     # (which every entry in the grid already satisfies).
     rejected4 = set(grid) - set(tuning.candidate_tactics(4))
-    assert all(t[0] == int(IpcVariant.FLAT_STAGED) for t in rejected4)
+    # The island schedule is a 4+4 decomposition, so world size 4 rejects it.
+    assert all(
+        t[0] in (int(IpcVariant.FLAT_STAGED), int(IpcVariant.COPY_ENGINE_ISLAND))
+        or (
+            t[0] == int(IpcVariant.COPY_ENGINE_RING)
+            and (t[1] > policy.CE_MAX_PIECES or t[2] != policy.CE_THREADS)
+        )
+        for t in rejected4
+    )
 
-    # World size 2: only the two variants that name a TP2 kernel.
+    # World size 2: only the two variants the launcher admits there. Its check
+    # is a whitelist of variant numbers, so the copy-engine ring is excluded
+    # like everything else -- naming a launcher of its own does not exempt it.
     for tactic in tuning.candidate_tactics(2):
-        assert tactic[0] in (int(IpcVariant.UNSTAGED), int(IpcVariant.STAGED))
+        assert tactic[0] in (
+            int(IpcVariant.UNSTAGED),
+            int(IpcVariant.STAGED),
+        )
 
 
 # Every distinct winner in the tuned caches of the two fabrics this operator
@@ -142,6 +167,98 @@ _MEASURED_WINNERS = {
         (3, 1, 64),
     ),
 }
+
+
+# Prefill winners a real tactic search chose on rootcplx-noswitch, bf16:
+# (world_size, payload_bytes) -> tactic. These are what the prefill screen in
+# candidate_tactics must not throw away; _MEASURED_WINNERS above carries no
+# payload, so it cannot police a screen that only applies above one.
+_MEASURED_PREFILL_WINNERS = (
+    (4, 1536 * 4096 * 2, (2, 4, 1024)),
+    (4, 3072 * 4096 * 2, (2, 8, 1024)),
+    (4, 6144 * 4096 * 2, (2, 8, 1024)),
+    (4, 12288 * 4096 * 2, (2, 8, 1024)),
+    (8, 1024 * 6144 * 2, (2, 4, 512)),
+    (8, 2048 * 6144 * 2, (2, 4, 512)),
+    (8, 4096 * 6144 * 2, (2, 12, 512)),
+    (8, 8192 * 6144 * 2, (2, 4, 1024)),
+    # Below: pcieswitch-pairs, where a NUMA node holds two switches with two
+    # GPUs behind each -- three cost levels, not two -- and TP4 wants a much
+    # higher block count. These are extra points on a second fabric, not
+    # corrections to the rows above, which are a different hidden size.
+    (4, 1024 * 6144 * 2, (2, 128, 1024)),
+    (4, 2048 * 6144 * 2, (2, 128, 1024)),
+    (4, 4096 * 6144 * 2, (2, 128, 1024)),
+    (4, 8192 * 6144 * 2, (2, 128, 1024)),
+)
+
+
+def test_survivor_count_is_a_constant_not_a_threshold() -> None:
+    """The truncation must not depend on the timings it sorts by.
+
+    Ranks that return different numbers of tactics do not disagree about which
+    kernel is fastest -- they deadlock, inside a kernel that spins with no
+    timeout, on the autotuner's per-tactic timing reduction. A "keep everything
+    within Nx of the best" rule makes the count a function of measured floats;
+    a fixed count makes it a function of the candidate list, which
+    candidate_tactics already guarantees is group-identical.
+    """
+    assert isinstance(tuning.TUNE_SURVIVORS, int)
+    assert tuning.TUNE_SURVIVORS > 0
+    src = inspect.getsource(tuning.PcieIpcAllReduceRunner.get_valid_tactics)
+    assert "[:TUNE_SURVIVORS]" in src, (
+        "the survivor list must be truncated by the constant, not by a "
+        "predicate over the measured times"
+    )
+    # The seed has to stay at the head: the autotuner breaks ties toward the
+    # earlier element, so its position is what decides an exact tie.
+    assert "return [TABLE_TACTIC] + kept" in src
+
+
+def test_timings_are_reduced_with_max(monkeypatch) -> None:
+    """MAX, and reduced at all -- a rank-local ranking is the deadlock above."""
+    seen = {}
+
+    class _FakeDist:
+        class ReduceOp:
+            MAX = "max"
+
+        @staticmethod
+        def all_reduce(tensor, op=None, group=None):
+            seen["op"] = op
+
+    monkeypatch.setattr(tuning, "dist", _FakeDist)
+    tuning.reduce_timings(torch.tensor([1.0, 2.0]), group=None)
+    assert seen["op"] == _FakeDist.ReduceOp.MAX
+
+
+def test_the_prefill_screen_keeps_every_measured_prefill_winner() -> None:
+    """A screened-out winner is one the tuner can never choose again.
+
+    The screen exists to stop prefill tuning spending its time on candidates
+    orders of magnitude off the winner. It pays for itself only while it keeps
+    every configuration a real search actually picked.
+    """
+    for world_size, payload, winner in _MEASURED_PREFILL_WINNERS:
+        assert payload >= tuning.PREFILL_SCREEN_BYTES, (
+            f"{payload} is below the screen; this row proves nothing"
+        )
+        tactics = tuning.candidate_tactics(world_size, numel=payload // 2, elem_size=2)
+        assert winner in tactics, (
+            f"world_size={world_size} payload={payload}: the screen dropped "
+            f"{winner}, which a search measured as the winner"
+        )
+
+
+def test_the_prefill_screen_only_applies_above_its_threshold() -> None:
+    """Below the threshold, and with no shape at all, nothing is screened."""
+    full = tuning.candidate_tactics(8)
+    small = tuning.candidate_tactics(8, numel=1024, elem_size=2)
+    assert small == full
+    big = tuning.candidate_tactics(8, numel=tuning.PREFILL_SCREEN_BYTES, elem_size=2)
+    assert set(big) < set(full), "the screen removed nothing at prefill size"
+    for _variant, _blocks, threads in big:
+        assert threads >= tuning.PREFILL_MIN_THREADS
 
 
 def test_the_grid_can_express_every_measured_winner() -> None:
@@ -439,10 +556,29 @@ def test_workspace_capacity_filters_buckets() -> None:
     )
 
 
+def test_pinning_a_searched_dimension_moved_the_tune_version() -> None:
+    """A narrowed legal set must not reuse the previous version's cache keys.
+
+    The version is the first element of cache_key_extras, so leaving it alone
+    keeps old keys matching. cache_covers_workspace then reports the workspace
+    as tuned, _warn_if_untuned stays silent because it is gated on that, and
+    resolve_tuned_config quietly drops each newly-illegal entry to the seed --
+    a partial, unsignalled loss on whichever shapes happen to be affected.
+
+    Fixing the copy-engine thread count is exactly such a narrowing: a cache
+    written when it was searched can hold threads=512 on those variants.
+    """
+    assert tuning.PCIE_IPC_TUNE_VERSION >= 3
+    stale = IpcLaunchConfig(blocks=1, threads=512, variant=IpcVariant.COPY_ENGINE_RING)
+    assert not policy._is_launchable(8, stale, 128), (
+        "this is the configuration whose rejection motivated the bump"
+    )
+
+
 def test_custom_op_name_is_stable() -> None:
     """It is baked into every persisted cache key; renaming it orphans the file."""
     assert tuning.PCIE_IPC_CUSTOM_OP == "flashinfer::pcie_ipc_all_reduce"
-    assert tuning.PCIE_IPC_TUNE_VERSION == 1
+    assert tuning.PCIE_IPC_TUNE_VERSION == 3
 
 
 def test_pack_config_is_injective_over_the_candidate_space() -> None:

--- a/tests/comm/test_pcie_ipc_workspace_layout.py
+++ b/tests/comm/test_pcie_ipc_workspace_layout.py
@@ -1,0 +1,109 @@
+"""The workspace's byte count, checked against an independent restatement.
+
+The arithmetic is restated rather than imported: deriving the expectation from
+the function under test would make this vacuous, and nothing else in the suite
+notices a layout that is correct but wasteful -- an oversized copy-engine
+region still produces the right answer on every collective.
+
+Single process, one GPU: workspace_size() is a pure function and needs no
+collective.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.comm.pcie_ipc_ar import get_pcie_ipc_comm_module
+
+
+def _align128(n: int) -> int:
+    return (n + 127) & ~127
+
+
+def _expected_total(
+    world_size: int, max_numel: int, elem_size: int, max_blocks: int
+) -> int:
+    """Independent restatement of compute_workspace_layout()."""
+    k_signal_phases, k_regions, k_ce_pieces, k_ce_stride = 8, 2, 4, 128
+
+    signal_slots = (
+        max_blocks  # epoch
+        + k_signal_phases * max_blocks * world_size  # barrier phases
+        + max_blocks  # barrier flags
+        + 2 * k_regions  # {epoch, arrival} per region
+    )
+    signal_bytes = _align128(4 * signal_slots)
+    max_payload = _align128(max_numel * elem_size)
+    scratch_bytes = _align128(2 * world_size * max_payload)
+
+    ce_slots = 2 * (world_size - 1) * k_ce_pieces + 2
+    ce_flag_bytes = _align128(ce_slots * k_ce_stride)
+    ce_counter_bytes = _align128(2 * ce_slots * 4)
+    flat = 2 * (world_size - 1) * _align128(max_payload // world_size)
+    island = 7 * _align128(max_payload // 4) if world_size == 8 else 0
+    ce_scratch_bytes = max(flat, island)
+
+    return (
+        signal_bytes
+        + 2 * scratch_bytes
+        + ce_flag_bytes
+        + ce_counter_bytes
+        + ce_scratch_bytes
+    )
+
+
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+@pytest.mark.parametrize("max_numel", [8 * 1024, 128 * 6144, 8192 * 6144])
+def test_workspace_size_matches_the_documented_layout(
+    world_size: int, max_numel: int
+) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("needs a GPU to load the module")
+    module = get_pcie_ipc_comm_module()
+    got = module.workspace_size(world_size, max_numel, 2, 128)
+    assert got == _expected_total(world_size, max_numel, 2, 128)
+
+
+@pytest.mark.parametrize("world_size", [2, 4, 8])
+def test_the_copy_engine_region_stays_proportional_to_the_payload(
+    world_size: int,
+) -> None:
+    """The ring stages 2*(N-1) shards of payload/N, i.e. 2*(N-1)/N of the payload.
+
+    Pinned by name because the failure is silent: a copy-engine region sized
+    like an SM region (2 x 2 x N x payload) runs correctly and wastes gigabytes.
+    At world_size 8 with a 96 MiB payload that is 1.5 GiB against 168 MiB.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("needs a GPU to load the module")
+    module = get_pcie_ipc_comm_module()
+    max_numel = 8192 * 6144
+    payload = _align128(max_numel * 2)
+
+    ce_slots = 2 * (world_size - 1) * 4 + 2
+    ce_flag_bytes = _align128(ce_slots * 128)
+    ce_counter_bytes = _align128(2 * ce_slots * 4)
+    flat = 2 * (world_size - 1) * _align128(payload // world_size)
+    island = 7 * _align128(payload // 4) if world_size == 8 else 0
+    ce_scratch = max(flat, island)
+
+    # The whole slab must equal the SM part plus exactly these three terms.
+    signal_bytes = _align128(4 * (128 + 8 * 128 * world_size + 128 + 4))
+    sm_bytes = signal_bytes + 2 * _align128(2 * world_size * payload)
+    assert module.workspace_size(world_size, max_numel, 2, 128) == (
+        sm_bytes + ce_flag_bytes + ce_counter_bytes + ce_scratch
+    )
+
+    expected_ratio = 2 * (world_size - 1) / world_size
+    ratio = ce_scratch / payload
+    assert abs(ratio - expected_ratio) < 0.01, (
+        f"world_size={world_size}: staging is {ratio:.3f}x the payload, expected "
+        f"{expected_ratio:.3f} = 2*(N-1)/N. Anything near 2*world_size means it "
+        f"was sized like an SM region."
+    )
+
+    # And the flags/counters must stay negligible next to it -- they are a few
+    # KiB, and a layout that made them scale with the payload would be wrong in
+    # a way the ratio check above cannot see.
+    assert ce_flag_bytes + ce_counter_bytes < 64 * 1024


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds a copy-engine data plane to the PCIe IPC all-reduce, alongside the SM
kernels from #4393, and extends the autotuner to select between the two.

The new plane moves the payload with `cudaMemcpyAsync` on side streams and
synchronises through monotonic flags in the workspace rather than through
sentinels in the payload. It is a separate kernel family: the seven SM kernels
are unchanged, and a workspace that has not been tuned selects exactly what it
selected before.

Two schedules are added:

| variant | shape | where |
|---|---|---|
| `COPY_ENGINE_RING` | flat neighbour ring, reduce-scatter then all-gather | 4 and 8 ranks |
| `COPY_ENGINE_ISLAND` | 4+4 decomposition, one cross-socket exchange | 8 ranks, and only where the topology probe reports that grouping |

Both are reached through the existing `IpcVariant` enum and the existing tactic
encoding: `blocks` carries the ring's sub-chunk depth on these variants, and the
add kernel's thread count is fixed rather than searched.

Workspace layout gains three regions appended at the tail — flag slots, rank-local
counters, and ring staging — so every existing offset is unchanged and tuned
entries from #4393 remain valid.

### Autotuner changes

- **The bucket ladder is derived from `max_numel`** when `tune_batches` is not
  given, instead of a fixed list that stopped far below the payload a
  prefill-sized workspace admits.
- **A ranking pass before profiling.** Every candidate is already launched once
  for a zero-tolerance check against a reference; that launch is now timed, and
  only the top candidates go on to full sampling.
- **A thread-count screen above a payload threshold**, so prefill-sized tuning
  does not spend full warmup and repeat on candidates orders of magnitude off
  the winner.
- `PCIE_IPC_TUNE_VERSION` is bumped, so caches written before this change miss
  cleanly rather than resolving to a configuration that is no longer legal.

## 🔍 Related Issues

Follows #4393, which added the SM data plane this sits beside.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing.

- `tests/comm/test_pcie_ipc_ce_ring.py` — zero-tolerance correctness against
  NCCL on exact small integers, both schedules, bf16 and fp16; and survival
  across interleaved eager calls and CUDA-graph replays.
- `tests/comm/test_pcie_ipc_workspace_layout.py` — restates the layout
  arithmetic independently and pins the copy-engine region at `2*(N-1)/N` of the
  payload.
- Updated: policy, tuning and dispatch tests for the two new variants.

On 8x L40S: 81 CPU-only passed / 1 xfailed, 9 passed / 3 skipped for the
copy-engine suite, 25 passed for the SM regressions. The same suites were run
independently on an 8x sm_120 box.

## Reviewer Notes

**Performance.** bf16, `benchmarks/comm/bench_pcie_ipc_all_reduce.py`, against
the tuned SM path on the same machine. Clocks are not locked on the L40S box, so
those numbers carry a few percent of noise; NCCL reproduced its pre-existing
figures to within 1.3% across all eight buckets.

8x L40S, PCIe Gen4, `rootcplx-noswitch`:

| | payload | SM tuned | this PR | | selected |
|---|---|---|---|---|---|
| TP4, hidden 4096 | 12 MB | 1163 us | 992.7 | 1.17x | flat ring |
| | 24 MB | 2198 | 1906.9 | 1.15x | flat ring |
| | 48 MB | 4381 | 3863.4 | 1.13x | flat ring |
| | 96 MB | 8973 | 7636.0 | **1.18x** | flat ring |
| TP8, hidden 6144 | 12 MB | 1650 | 1337.2 | 1.23x | island |
| | 24 MB | 3255 | 2663.9 | 1.22x | island |
| | 48 MB | 6467 | 5387.5 | 1.20x | island |
| | 96 MB | 12819 | 10415.6 | **1.23x** | island |

8x sm_120, PCIe Gen5, `pcieswitch-pairs`, at 96 MiB: **1.71x** at four ranks and
**1.73x** at eight, measured there by that machine's owners. At two ranks the
tuner selects the SM path at every bucket.
