### PR TITLE
feat(prims-ts): support proxy-compensated block-sparse attention

### DIFF
--- a/flashinfer/api_logging.py
+++ b/flashinfer/api_logging.py
@@ -2185,6 +2185,9 @@ def _log_function_outputs(func_name: str, result: Any, level: int) -> None:
 # Read by tests/trace/test_fi_trace_template_consistency.py to auto-discover
 # all registered templates without requiring manual maintenance.
 _TRACE_REGISTRY: List[Tuple[Callable, Any, str]] = []
+# Runtime selectors are stored separately so the stable registry tuple remains
+# concrete-template-only and decorated callables need no private attributes.
+_TRACE_DISPATCHERS: Dict[Callable, Callable] = {}
 
 _TRACE_FI_API_ALIASES = {
     "flashinfer.mla._batch_mla._wrapper.BatchMLAPagedAttentionWrapper.run": (
@@ -2261,6 +2264,7 @@ def _attach_fi_trace(
                     _label = tpl.name_prefix or tpl.op_type
                     _TRACE_REGISTRY.append((original, tpl, _label))
                 _dispatch_fn = trace_template
+                _TRACE_DISPATCHERS[original] = _dispatch_fn
                 _fi_trace_cache: Dict[int, Callable] = {}
 
                 def fi_trace_fn(

--- a/flashinfer/attention/prims_ts/README.md
+++ b/flashinfer/attention/prims_ts/README.md
@@ -61,6 +61,22 @@ Qualified Q64/coarse-KV profiles retain KV256 routes for page sizes 64 and
 `[B, ceil(max_seq_len_kv / 32)]` over logical KV tokens; it is shared by all KV
 heads and independent of the physical page mapping.
 
+For contiguous block-sparse attention, both `BlockSparseTSWrapper.plan` and
+the `block_sparse_attention` one-shot API can opt into
+`sparse_format="bitmask"` and/or `use_proxy_routes=True`. BSR and packed
+exact-block bitmaps are alternative frontends; both are prepared into the same
+route stream before attention. The bitmask one-shot uses the full structural
+KV-block count as its temporary plan capacity, while reusable plans accept a
+tighter caller-provided bound. Proxy routes are supported across the existing
+contiguous block-sparse profiles and preserve the profile's Q tile, KV route,
+and KeepsAB/SWAPAB geometry. Proxy routes currently require
+`mask_type="dense"`; paged K/V proxy execution remains unsupported. Route rows
+are owned by `(batch, KV head, Q block)`, so all Q heads in one GQA/MQA group
+share sparsity. A proxy run supplies one K arithmetic mean and one V sum per
+semantic KV block. The final partial block uses only its structural tokens.
+Optional `kv_valid_bits` filters exact K/V tokens only and does not change
+proxy summaries or their represented mass.
+
 ## Validation
 
 Run the numerical, graph, scheduler/resource, alias-safety, and public-surface

--- a/flashinfer/attention/prims_ts/_block_sparse/common.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/common.py
@@ -22,6 +22,20 @@ _BLOCK_SPARSE_Q_TILE_SIZES = (8, 16, 32, 64, 128)
 _BLOCK_SPARSE_MAX_HEADS_Q_PER_KV = 32
 
 
+def _validate_contiguous_route_mode(
+    sparse_format: object,
+    use_proxy_routes: object,
+) -> None:
+    """Validate the two public continuous-route axes before device work."""
+
+    if not isinstance(sparse_format, str):
+        raise TypeError("sparse_format must be 'bsr' or 'bitmask'")
+    if sparse_format not in ("bsr", "bitmask"):
+        raise ValueError("sparse_format must be 'bsr' or 'bitmask'")
+    if type(use_proxy_routes) is not bool:
+        raise TypeError("use_proxy_routes must be a bool")
+
+
 def _validate_sparse_q_block_size(value: object) -> int:
     """Return a positive semantic Q block size representable by the ABI."""
 
@@ -110,6 +124,17 @@ def _block_sparse_kv_atom_size(kv_block_size: int) -> int:
     )
 
 
+def _block_sparse_proxy_summary_geometry(
+    seq_len_kv: int,
+    kv_block_size: int,
+) -> tuple[int, int]:
+    """Return the summary count and final summary's represented-token mass."""
+
+    num_summaries = (seq_len_kv + kv_block_size - 1) // kv_block_size
+    tail_mass = seq_len_kv - (num_summaries - 1) * kv_block_size
+    return num_summaries, tail_mass
+
+
 def _prepared_kv_routes_are_block_aligned(
     kv_block_size: int,
     kv_route_size: int,
@@ -117,3 +142,24 @@ def _prepared_kv_routes_are_block_aligned(
     """Return whether each prepared route stays within one semantic BSR block."""
 
     return _validate_sparse_kv_block_size(kv_block_size) % kv_route_size == 0
+
+
+def _block_sparse_contiguous_kv_copy_geometry(
+    *,
+    kv_block_size: int,
+    kv_route_size: int,
+) -> tuple[int, int, bool]:
+    """Return source-independent primary/atom TensorMap geometry.
+
+    Exact and proxy routes address different logical matrices, but a route's
+    physical copy shape depends only on its semantic block and physical route
+    sizes. Coarse routes prefer KV128 copies and keep a KV64 descriptor only
+    when KV256 staging or runtime adjacency requires it.
+    """
+
+    atom_size = _block_sparse_kv_atom_size(kv_block_size)
+    primary_box_size = 2 * atom_size if atom_size == 64 else atom_size
+    needs_aux_atom = atom_size == 64 and (
+        kv_route_size == 256 or kv_block_size % kv_route_size != 0
+    )
+    return primary_box_size, atom_size, needs_aux_atom

--- a/flashinfer/attention/prims_ts/_block_sparse/compiler.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/compiler.py
@@ -36,31 +36,45 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
 
     from ..kernels.fmha_decode.fmha_decode_config import FmhaDecodeConfig
     from ..kernels.fmha_decode.block_sparse_prepare import (
-        _PrepareBlockSparseRoutes,
+        _PrepareBitmaskRoutes,
+        _PrepareBsrRoutes,
     )
     from ..kernels.fmha_decode.fmha_decode_kernel import (
         fmha_block_sparse_launch,
     )
 
     config = _make_block_sparse_config(key)
-    prepare_routes = _PrepareBlockSparseRoutes(
-        batch_size=key.batch_size,
-        num_kv_heads=key.num_kv_heads,
-        seq_len_q=key.seq_len_q,
-        seq_len_kv=key.seq_len_kv,
-        q_block_size=key.q_block_size,
-        kv_block_size=key.kv_block_size,
-        kv_route_size=key.kv_route_size,
-        has_token_bits=key.use_kv_valid_bits,
-        page_size=key.page_size,
-        mask_type=key.mask_type,
-    )
+    prepare_kwargs = {
+        "batch_size": key.batch_size,
+        "num_kv_heads": key.num_kv_heads,
+        "seq_len_q": key.seq_len_q,
+        "seq_len_kv": key.seq_len_kv,
+        "q_block_size": key.q_block_size,
+        "kv_block_size": key.kv_block_size,
+        "kv_route_size": key.kv_route_size,
+        "use_proxy_routes": key.use_proxy_routes,
+        "use_causal_mask": key.mask_type == "causal",
+        "apply_token_mask": key.use_kv_valid_bits,
+    }
+    if key.page_size is not None:
+        if key.sparse_format != "bsr" or key.use_proxy_routes:
+            raise AssertionError("paged block-sparse supports exact BSR routes only")
+        prepare_kwargs["page_size"] = key.page_size
+
+    if key.sparse_format == "bsr":
+        prepare_routes = _PrepareBsrRoutes(**prepare_kwargs)
+    elif key.sparse_format == "bitmask":
+        prepare_routes = _PrepareBitmaskRoutes(**prepare_kwargs)
+    else:
+        raise AssertionError("sparse_format must be 'bsr' or 'bitmask'")
+
+    route_metadata_base = prepare_routes.route_metadata_base_word_offset
     Int32 = cutlass.Int32
     Int64 = cutlass.Int64
     Float32 = cutlass.Float32
 
     @cute.jit
-    def contiguous_tensor_adapter(
+    def exact_bsr_adapter(
         q: cute.Tensor,
         k: cute.Tensor,
         v: cute.Tensor,
@@ -95,8 +109,57 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
         )
         # Live per-row route counts occupy the first words of run scratch.
         row_route_counts = route_workspace.iterator
-        route_metadata = route_workspace.iterator + Int32(
-            prepare_routes.route_metadata_base_word_offset
+        route_metadata = route_workspace.iterator + Int32(route_metadata_base)
+        fmha_block_sparse_launch(
+            (
+                Int32(static_batch_size),
+                Int32(static_num_qo_heads),
+                Int32(static_num_kv_heads),
+                Int32(static_seq_len_kv),
+                Int32(static_head_dim),
+            ),
+            q.iterator,
+            k.iterator,
+            v.iterator,
+            k.iterator,
+            v.iterator,
+            out.iterator,
+            row_route_offsets.iterator,
+            row_route_counts,
+            route_metadata,
+            sm_scale,
+            stream,
+            static_config,
+            static_seq_len_kv,
+        )
+
+    @cute.jit
+    def exact_bitmask_adapter(
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        out: cute.Tensor,
+        exact_block_bits: cute.Tensor,
+        kv_valid_bits: cute.Tensor,
+        row_route_offsets: cute.Tensor,
+        route_workspace: cute.Tensor,
+        max_blocks_per_row: cutlass.Int32,
+        sm_scale: cutlass.Float32,
+        stream: cuda_drv.CUstream,
+        static_config: cutlass.Constexpr[FmhaDecodeConfig],
+        static_batch_size: cutlass.Constexpr[int],
+        static_seq_len_kv: cutlass.Constexpr[int],
+        static_num_qo_heads: cutlass.Constexpr[int],
+        static_num_kv_heads: cutlass.Constexpr[int],
+        static_head_dim: cutlass.Constexpr[int],
+    ) -> None:
+        prepare_routes(
+            exact_block_bits,
+            kv_valid_bits,
+            row_route_offsets,
+            route_workspace,
+            max_blocks_per_row,
+            stream,
         )
         fmha_block_sparse_launch(
             (
@@ -109,10 +172,124 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
             q.iterator,
             k.iterator,
             v.iterator,
+            k.iterator,
+            v.iterator,
             out.iterator,
             row_route_offsets.iterator,
-            row_route_counts,
-            route_metadata,
+            route_workspace.iterator,
+            route_workspace.iterator + Int32(route_metadata_base),
+            sm_scale,
+            stream,
+            static_config,
+            static_seq_len_kv,
+        )
+
+    @cute.jit
+    def proxy_bsr_adapter(
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        k_summary: cute.Tensor,
+        v_summary: cute.Tensor,
+        out: cute.Tensor,
+        block_indptr: cute.Tensor,
+        block_indices: cute.Tensor,
+        kv_valid_bits: cute.Tensor,
+        row_route_offsets: cute.Tensor,
+        route_workspace: cute.Tensor,
+        max_blocks_per_row: cutlass.Int32,
+        sm_scale: cutlass.Float32,
+        stream: cuda_drv.CUstream,
+        static_config: cutlass.Constexpr[FmhaDecodeConfig],
+        static_batch_size: cutlass.Constexpr[int],
+        static_seq_len_kv: cutlass.Constexpr[int],
+        static_num_qo_heads: cutlass.Constexpr[int],
+        static_num_kv_heads: cutlass.Constexpr[int],
+        static_head_dim: cutlass.Constexpr[int],
+    ) -> None:
+        prepare_routes(
+            block_indptr,
+            block_indices,
+            kv_valid_bits,
+            None,
+            None,
+            None,
+            Int64(0),
+            row_route_offsets,
+            route_workspace,
+            max_blocks_per_row,
+            stream,
+        )
+        fmha_block_sparse_launch(
+            (
+                Int32(static_batch_size),
+                Int32(static_num_qo_heads),
+                Int32(static_num_kv_heads),
+                Int32(static_seq_len_kv),
+                Int32(static_head_dim),
+            ),
+            q.iterator,
+            k.iterator,
+            v.iterator,
+            k_summary.iterator,
+            v_summary.iterator,
+            out.iterator,
+            row_route_offsets.iterator,
+            route_workspace.iterator,
+            route_workspace.iterator + Int32(route_metadata_base),
+            sm_scale,
+            stream,
+            static_config,
+            static_seq_len_kv,
+        )
+
+    @cute.jit
+    def proxy_bitmask_adapter(
+        q: cute.Tensor,
+        k: cute.Tensor,
+        v: cute.Tensor,
+        k_summary: cute.Tensor,
+        v_summary: cute.Tensor,
+        out: cute.Tensor,
+        exact_block_bits: cute.Tensor,
+        kv_valid_bits: cute.Tensor,
+        row_route_offsets: cute.Tensor,
+        route_workspace: cute.Tensor,
+        max_blocks_per_row: cutlass.Int32,
+        sm_scale: cutlass.Float32,
+        stream: cuda_drv.CUstream,
+        static_config: cutlass.Constexpr[FmhaDecodeConfig],
+        static_batch_size: cutlass.Constexpr[int],
+        static_seq_len_kv: cutlass.Constexpr[int],
+        static_num_qo_heads: cutlass.Constexpr[int],
+        static_num_kv_heads: cutlass.Constexpr[int],
+        static_head_dim: cutlass.Constexpr[int],
+    ) -> None:
+        prepare_routes(
+            exact_block_bits,
+            kv_valid_bits,
+            row_route_offsets,
+            route_workspace,
+            max_blocks_per_row,
+            stream,
+        )
+        fmha_block_sparse_launch(
+            (
+                Int32(static_batch_size),
+                Int32(static_num_qo_heads),
+                Int32(static_num_kv_heads),
+                Int32(static_seq_len_kv),
+                Int32(static_head_dim),
+            ),
+            q.iterator,
+            k.iterator,
+            v.iterator,
+            k_summary.iterator,
+            v_summary.iterator,
+            out.iterator,
+            row_route_offsets.iterator,
+            route_workspace.iterator,
+            route_workspace.iterator + Int32(route_metadata_base),
             sm_scale,
             stream,
             static_config,
@@ -160,9 +337,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
             stream,
         )
         row_route_counts = route_workspace.iterator
-        route_metadata = route_workspace.iterator + Int32(
-            prepare_routes.route_metadata_base_word_offset
-        )
+        route_metadata = route_workspace.iterator + Int32(route_metadata_base)
         fmha_block_sparse_launch(
             (
                 Int32(static_batch_size),
@@ -172,6 +347,8 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
                 Int32(static_head_dim),
             ),
             q.iterator,
+            k_cache.iterator,
+            v_cache.iterator,
             k_cache.iterator,
             v_cache.iterator,
             out.iterator,
@@ -203,6 +380,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
     logical_workspace_words = cute.sym_int()
     q_shape = (key.batch_size, key.seq_len_q, key.num_qo_heads, key.head_dim)
     num_q_blocks = ceil_div(key.seq_len_q, key.q_block_size)
+    num_kv_blocks = ceil_div(key.seq_len_kv, key.kv_block_size)
     indptr_fake = fake_compact(
         Int32,
         (key.batch_size, key.num_kv_heads, num_q_blocks + 1),
@@ -238,22 +416,93 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
         )
         k_fake = fake_compact(config.kv_dtype, kv_shape, 16)
         v_fake = fake_compact(config.kv_dtype, kv_shape, 16)
-        tensor_adapter = contiguous_tensor_adapter
-        dynamic_args = (
-            q_fake,
-            k_fake,
-            v_fake,
-            out_fake,
-            indptr_fake,
-            indices_fake,
+        exact_bits_fake = fake_compact(
+            cutlass.Uint32,
+            (
+                key.batch_size,
+                key.num_kv_heads,
+                num_q_blocks,
+                ceil_div(num_kv_blocks, 32),
+            ),
+            4,
+        )
+        common_tail = (
             valid_bits_fake,
             row_route_offsets_fake,
             route_workspace_fake,
             Int32(0),
             Float32(1.0),
         )
+        if key.sparse_format == "bsr" and not key.use_proxy_routes:
+            tensor_adapter = exact_bsr_adapter
+            dynamic_args = (
+                q_fake,
+                k_fake,
+                v_fake,
+                out_fake,
+                indptr_fake,
+                indices_fake,
+                *common_tail,
+            )
+        elif key.sparse_format == "bitmask" and not key.use_proxy_routes:
+            tensor_adapter = exact_bitmask_adapter
+            dynamic_args = (
+                q_fake,
+                k_fake,
+                v_fake,
+                out_fake,
+                exact_bits_fake,
+                *common_tail,
+            )
+        elif key.sparse_format == "bsr" and key.use_proxy_routes:
+            summary_shape = (
+                key.batch_size,
+                num_kv_blocks,
+                key.num_kv_heads,
+                key.head_dim,
+            )
+            k_summary_fake = fake_compact(config.kv_dtype, summary_shape, 16)
+            v_summary_fake = fake_compact(config.kv_dtype, summary_shape, 16)
+            proxy_prefix = (
+                q_fake,
+                k_fake,
+                v_fake,
+                k_summary_fake,
+                v_summary_fake,
+                out_fake,
+            )
+            tensor_adapter = proxy_bsr_adapter
+            dynamic_args = (
+                *proxy_prefix,
+                indptr_fake,
+                indices_fake,
+                *common_tail,
+            )
+        elif key.sparse_format == "bitmask" and key.use_proxy_routes:
+            summary_shape = (
+                key.batch_size,
+                num_kv_blocks,
+                key.num_kv_heads,
+                key.head_dim,
+            )
+            k_summary_fake = fake_compact(config.kv_dtype, summary_shape, 16)
+            v_summary_fake = fake_compact(config.kv_dtype, summary_shape, 16)
+            tensor_adapter = proxy_bitmask_adapter
+            dynamic_args = (
+                q_fake,
+                k_fake,
+                v_fake,
+                k_summary_fake,
+                v_summary_fake,
+                out_fake,
+                exact_bits_fake,
+                *common_tail,
+            )
+        else:
+            raise AssertionError("continuous sparse_format must be 'bsr' or 'bitmask'")
     else:
         page_size = key.page_size
+        assert page_size is not None
         physical_pages = cute.sym_int()
         logical_pages = cute.sym_int()
         k_outer_stride = cute.sym_int64(divisibility=1)

--- a/flashinfer/attention/prims_ts/_block_sparse/config.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/config.py
@@ -64,7 +64,7 @@ _B16_MIN_PARALLEL_ROUTE_PAIRS = 4
 
 @dataclass(frozen=True)
 class _BlockSparseCompileKey:
-    """Named, hashable inputs that determine one compiled adapter."""
+    """Named, hashable inputs that determine one compiled sparse adapter."""
 
     device_index: int
     batch_size: int
@@ -81,6 +81,8 @@ class _BlockSparseCompileKey:
     use_kv_valid_bits: bool
     use_persistent_scheduler: bool
     use_parallel_sparse_kv_loads: bool
+    sparse_format: Literal["bsr", "bitmask"] = "bsr"
+    use_proxy_routes: bool = False
     page_size: int | None = None
 
 
@@ -193,13 +195,9 @@ def _select_block_sparse_scheduler(
     mask_type: Literal["dense", "causal"],
     use_kv_valid_bits: bool,
     max_row_route_capacity: int,
+    use_proxy_routes: bool,
 ) -> tuple[int, bool]:
     """Select the Q tile and scheduler without depending on KV storage."""
-
-    from ..kernels.fmha_decode.fmha_decode_config import (
-        _select_auto_launch_mode,
-        make_q_tile_geometry,
-    )
 
     heads_q_per_kv = num_qo_heads // num_kv_heads
     q_tile_size = _select_block_sparse_q_tile_size(
@@ -207,6 +205,11 @@ def _select_block_sparse_scheduler(
         heads_q_per_kv=heads_q_per_kv,
         kv_block_size=kv_block_size,
     )
+    # Reusable planning sees route capacity, not the live exact-route work.
+    # Keep proxy execution on the direct grid as a conservative workload-level
+    # default until runtime work can participate in scheduling.
+    if use_proxy_routes:
+        return q_tile_size, False
     if not _should_consider_clc(
         q_tile_size=q_tile_size,
         kv_block_size=kv_block_size,
@@ -215,6 +218,11 @@ def _select_block_sparse_scheduler(
         use_kv_valid_bits=use_kv_valid_bits,
     ):
         return q_tile_size, False
+
+    from ..kernels.fmha_decode.fmha_decode_config import (
+        _select_auto_launch_mode,
+        make_q_tile_geometry,
+    )
 
     q_geometry = make_q_tile_geometry(
         rows_per_cta=q_tile_size,
@@ -413,6 +421,8 @@ def _make_block_sparse_config(key: _BlockSparseCompileKey) -> "FmhaDecodeConfig"
     }
     if key.use_persistent_scheduler:
         config_args["use_persistent_scheduler"] = True
+    if key.use_proxy_routes:
+        config_args["use_block_sparse_proxy_routes"] = True
     layout_args: dict[str, object]
     if key.page_size is None:
         layout_args = {"qkv_layout": "contiguousKv"}
@@ -455,14 +465,17 @@ def _resolve_block_sparse_launch_spec(
     mask_type: Literal["dense", "causal"],
     use_kv_valid_bits: bool,
     max_row_route_capacity: int,
+    sparse_format: Literal["bsr", "bitmask"] = "bsr",
+    use_proxy_routes: bool = False,
     page_size: int | None = None,
 ) -> _BlockSparseLaunchSpec:
     """Resolve and cache one validated static or CLC launch.
 
     ``max_row_route_capacity`` is a conservative prepared-route bound. Live
     index values and physical-tail morphology never specialize this cache
-    entry. If the selected persistent profile is unsupported, retain the valid
-    static profile instead.
+    entry. Proxy routes use the direct grid; exact routes retain the common
+    automatic scheduler. An unsupported persistent profile falls back to its
+    valid static counterpart.
     """
 
     q_tile_size, use_persistent_scheduler = _select_block_sparse_scheduler(
@@ -477,6 +490,7 @@ def _resolve_block_sparse_launch_spec(
         mask_type=mask_type,
         use_kv_valid_bits=use_kv_valid_bits,
         max_row_route_capacity=max_row_route_capacity,
+        use_proxy_routes=use_proxy_routes,
     )
     compile_key = _BlockSparseCompileKey(
         device_index=device_index,
@@ -499,6 +513,8 @@ def _resolve_block_sparse_launch_spec(
             max_row_route_capacity=max_row_route_capacity,
             use_persistent_scheduler=use_persistent_scheduler,
         ),
+        sparse_format=sparse_format,
+        use_proxy_routes=use_proxy_routes,
         page_size=page_size,
     )
     try:
@@ -521,6 +537,10 @@ def _resolve_block_sparse_launch_spec(
     policy_entries: list[tuple[str, object]] = [
         ("tile_size_q", q_tile_size),
         ("tile_size_kv", kv_route_size),
+        (
+            "scheduler",
+            "persistent" if compile_key.use_persistent_scheduler else "static",
+        ),
     ]
     if page_size is not None:
         policy_entries.append(("page_size", page_size))

--- a/flashinfer/attention/prims_ts/_block_sparse/plan.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/plan.py
@@ -18,13 +18,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 import functools
 import _thread
-from typing import Concatenate, ParamSpec, Protocol, TypeVar, cast
+from typing import Concatenate, Literal, ParamSpec, Protocol, TypeVar, cast
 
 import torch
 
 from flashinfer.utils import ceil_div
 
-from .common import _SIGNED_INT32_MAX
+from .common import _SIGNED_INT32_MAX, _block_sparse_proxy_summary_geometry
 from .compiler import _get_compiled_block_sparse
 from .config import (
     _BlockSparseStaticProfile,
@@ -85,6 +85,8 @@ class _BlockSparsePlanState:
     cannot prevent in-place modification or replace graph ownership.
     """
 
+    sparse_format: Literal["bsr", "bitmask"]
+    use_proxy_routes: bool
     device: torch.device
     batch_size: int
     seq_len_q: int
@@ -93,6 +95,7 @@ class _BlockSparsePlanState:
     num_kv_heads: int
     head_dim: int
     q_block_size: int
+    kv_block_size: int
     q_dtype: torch.dtype
     kv_dtype: torch.dtype
     output_dtype: torch.dtype
@@ -179,24 +182,36 @@ def _build_block_sparse_plan_state(
     device: torch.device,
     device_index: int,
     plan_stream: torch.cuda.Stream,
+    sparse_format: Literal["bsr", "bitmask"] = "bsr",
+    use_proxy_routes: bool = False,
 ) -> _BlockSparsePlanState:
-    """Build and close one complete state after storage validation."""
+    """Build one format- and route-specialized plan atomically."""
 
     assert static.max_blocks_per_row is not None
-    max_row_route_capacity = ceil_div(
-        static.max_blocks_per_row * static.kv_block_size,
-        static.kv_route_size,
-    )
+    if static.page_size is not None:
+        assert sparse_format == "bsr" and not use_proxy_routes
     num_rows = (
         static.batch_size
         * static.num_kv_heads
         * ceil_div(static.seq_len_q, static.q_block_size)
     )
+    if num_rows > _SIGNED_INT32_MAX:
+        raise OverflowError("row_count must fit in signed int32")
+    max_row_route_capacity = ceil_div(
+        static.max_blocks_per_row * static.kv_block_size,
+        static.kv_route_size,
+    )
+    if use_proxy_routes:
+        num_summaries, _ = _block_sparse_proxy_summary_geometry(
+            static.seq_len_kv,
+            static.kv_block_size,
+        )
+        max_row_route_capacity += ceil_div(num_summaries, static.kv_route_size)
     route_layout = _BlockSparseRouteLayout.create(
         kv_route_size=static.kv_route_size,
         kv_block_size=static.kv_block_size,
         page_size=static.page_size,
-        has_token_bits=static.use_kv_valid_bits,
+        has_token_bits=static.use_kv_valid_bits or use_proxy_routes,
         route_metadata_capacity=num_rows * max_row_route_capacity,
         num_rows=num_rows,
     )
@@ -217,6 +232,8 @@ def _build_block_sparse_plan_state(
             mask_type=static.mask_type,
             use_kv_valid_bits=static.use_kv_valid_bits,
             max_row_route_capacity=max_row_route_capacity,
+            sparse_format=sparse_format,
+            use_proxy_routes=use_proxy_routes,
         )
         policy = (
             *spec.policy,
@@ -240,6 +257,8 @@ def _build_block_sparse_plan_state(
         ready_event = _record_block_sparse_plan_ready_event(plan_stream)
 
     return _BlockSparsePlanState(
+        sparse_format=sparse_format,
+        use_proxy_routes=use_proxy_routes,
         device=device,
         batch_size=static.batch_size,
         seq_len_q=static.seq_len_q,
@@ -248,6 +267,7 @@ def _build_block_sparse_plan_state(
         num_kv_heads=static.num_kv_heads,
         head_dim=static.head_dim,
         q_block_size=static.q_block_size,
+        kv_block_size=static.kv_block_size,
         q_dtype=static.q_dtype,
         kv_dtype=static.kv_dtype,
         output_dtype=static.output_dtype,

--- a/flashinfer/attention/prims_ts/_block_sparse/prepared.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/prepared.py
@@ -22,6 +22,7 @@ from .common import _SIGNED_INT32_MAX, _block_sparse_kv_atom_size
 
 _SECTION_ALIGNMENT_WORDS = 4
 _PREPARED_ROUTE_IS_FULL_FLAG = 1 << 0
+_PREPARED_ROUTE_IS_PROXY_FLAG = 1 << 1
 _SUPPORTED_KV_ROUTE_SIZES = (128, 256)
 _SUPPORTED_PAGED_KV_PAGE_SIZES = (16, 32, 64, 128)
 
@@ -91,13 +92,16 @@ class _BlockSparseRouteLayout:
 
     Each route's metadata stores logical KV-token atom origins, optional
     physical page IDs, one atom-valid-mask word, one route-flags word, and
-    optional token-valid words. ``page_size is None`` selects the contiguous
+    optional token-mask words. ``page_size is None`` selects the contiguous
     record; otherwise the paged record adds one page-ID word per logical
     origin. Logical origins remain independent of the K/V storage locator used
-    by the attention load path. An invalid logical origin is encoded as
-    ``-1``. Bit ``i`` of the atom-valid mask corresponds to logical origin
-    ``i``. ``_PREPARED_ROUTE_IS_FULL_FLAG`` (bit 0) states that the route is
-    both structurally full and, when token bits are present, token-full.
+    by the attention load path. Exact routes address raw-token origins, while
+    proxy routes address summary-token origins and set
+    ``_PREPARED_ROUTE_IS_PROXY_FLAG`` (bit 1). An invalid logical origin is
+    encoded as ``-1``. Bit ``i`` of the atom-valid mask corresponds to logical
+    origin ``i``. ``_PREPARED_ROUTE_IS_FULL_FLAG`` (bit 0) states that the
+    route is both structurally full and, when token-mask bits are present,
+    mask-full.
     """
 
     # Store semantic inputs plus the three validated allocation values. All
@@ -239,6 +243,17 @@ class _BlockSparseRouteLayout:
         return self.route_flags_word_offset + 1 if self.has_token_bits else None
 
     @property
+    def uses_one_warp_transport(self) -> bool:
+        """Whether this layout uses the continuous one-warp transport."""
+
+        token_words_word_offset = self.token_words_word_offset
+        return (
+            not self.is_paged
+            and token_words_word_offset is not None
+            and token_words_word_offset + self.token_words_per_route <= 32
+        )
+
+    @property
     def route_metadata_capacity(self) -> int:
         """Number of routes whose metadata fits in the mutable workspace."""
 
@@ -249,5 +264,6 @@ class _BlockSparseRouteLayout:
 
 __all__ = [
     "_PREPARED_ROUTE_IS_FULL_FLAG",
+    "_PREPARED_ROUTE_IS_PROXY_FLAG",
     "_BlockSparseRouteLayout",
 ]

--- a/flashinfer/attention/prims_ts/_block_sparse/runtime.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/runtime.py
@@ -16,7 +16,7 @@
 
 from dataclasses import dataclass
 import math
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import torch
 
@@ -72,12 +72,15 @@ class _BlockSparseRunArgs:
     k: torch.Tensor
     v: torch.Tensor
     out: torch.Tensor
-    block_indptr: torch.Tensor
-    block_indices: torch.Tensor
+    block_indptr: torch.Tensor | None
+    block_indices: torch.Tensor | None
     kv_valid_bits: torch.Tensor
     kv_valid_bits_is_live: bool
     sm_scale: float
     paged_kv: _PagedKVLaunchPayload | None
+    exact_block_bits: torch.Tensor | None = None
+    k_summary: torch.Tensor | None = None
+    v_summary: torch.Tensor | None = None
 
 
 def _validate_metadata_tensor(
@@ -113,36 +116,71 @@ def _validate_metadata_tensor(
 
 
 def validate_block_sparse_metadata(
-    block_indptr: torch.Tensor,
-    block_indices: torch.Tensor,
-    kv_valid_bits: torch.Tensor | None,
     *,
+    sparse_format: Literal["bsr", "bitmask"],
+    block_indptr: torch.Tensor | None,
+    block_indices: torch.Tensor | None,
+    exact_block_bits: torch.Tensor | None,
+    kv_valid_bits: torch.Tensor | None,
     device: torch.device,
     batch_size: int,
     seq_len_q: int,
     seq_len_kv: int,
     num_kv_heads: int,
     q_block_size: int,
+    kv_block_size: int,
     use_kv_valid_bits: bool,
 ) -> None:
-    """Validate raw runtime routing without reading device-side values."""
+    """Validate the planned route frontend without reading tensor values."""
 
     num_q_blocks = (seq_len_q + q_block_size - 1) // q_block_size
-    _validate_metadata_tensor(
-        block_indptr,
-        "block_indptr",
-        ndim=3,
-        dtype=torch.int32,
-        expected_device=device,
-        expected_shape=(batch_size, num_kv_heads, num_q_blocks + 1),
-    )
-    _validate_metadata_tensor(
-        block_indices,
-        "block_indices",
-        ndim=1,
-        dtype=torch.int32,
-        expected_device=device,
-    )
+    if sparse_format == "bsr":
+        if block_indptr is None or block_indices is None:
+            raise ValueError(
+                "block_indptr and block_indices are required by a BSR plan"
+            )
+        if exact_block_bits is not None:
+            raise ValueError("exact_block_bits is valid only for a bitmask plan")
+        _validate_metadata_tensor(
+            block_indptr,
+            "block_indptr",
+            ndim=3,
+            dtype=torch.int32,
+            expected_device=device,
+            expected_shape=(batch_size, num_kv_heads, num_q_blocks + 1),
+        )
+        _validate_metadata_tensor(
+            block_indices,
+            "block_indices",
+            ndim=1,
+            dtype=torch.int32,
+            expected_device=device,
+        )
+    elif sparse_format == "bitmask":
+        if (
+            exact_block_bits is None
+            or block_indptr is not None
+            or block_indices is not None
+        ):
+            raise ValueError(
+                "runtime route inputs must match planned sparse_format='bitmask'"
+            )
+        num_kv_blocks = (seq_len_kv + kv_block_size - 1) // kv_block_size
+        _validate_metadata_tensor(
+            exact_block_bits,
+            "exact_block_bits",
+            ndim=4,
+            dtype=torch.uint32,
+            expected_device=device,
+            expected_shape=(
+                batch_size,
+                num_kv_heads,
+                num_q_blocks,
+                (num_kv_blocks + 31) // 32,
+            ),
+        )
+    else:
+        raise AssertionError(f"unsupported sparse format {sparse_format!r}")
 
     if use_kv_valid_bits:
         if kv_valid_bits is None:
@@ -214,8 +252,11 @@ def validate_block_sparse_run(
     kv_storage: _ContiguousKVStorage | _PagedKVStorage,
     *,
     state: "_BlockSparsePlanState",
-    block_indptr: torch.Tensor,
-    block_indices: torch.Tensor,
+    block_indptr: torch.Tensor | None,
+    block_indices: torch.Tensor | None,
+    exact_block_bits: torch.Tensor | None = None,
+    k_summary: torch.Tensor | None = None,
+    v_summary: torch.Tensor | None = None,
     kv_valid_bits: torch.Tensor | None,
     sm_scale: float | None,
     out: torch.Tensor | None,
@@ -229,18 +270,44 @@ def validate_block_sparse_run(
     input. ``sm_scale=None`` is materialized as ``1 / sqrt(D)``.
     """
 
+    use_proxy_routes = state.use_proxy_routes
+    num_kv_blocks = (state.seq_len_kv + state.kv_block_size - 1) // state.kv_block_size
     validate_block_sparse_metadata(
-        block_indptr,
-        block_indices,
-        kv_valid_bits,
+        sparse_format=state.sparse_format,
+        block_indptr=block_indptr,
+        block_indices=block_indices,
+        exact_block_bits=exact_block_bits,
+        kv_valid_bits=kv_valid_bits,
         device=state.device,
         batch_size=state.batch_size,
         seq_len_q=state.seq_len_q,
         seq_len_kv=state.seq_len_kv,
         num_kv_heads=state.num_kv_heads,
         q_block_size=state.q_block_size,
+        kv_block_size=state.kv_block_size,
         use_kv_valid_bits=state.use_kv_valid_bits,
     )
+
+    if use_proxy_routes:
+        if k_summary is None or v_summary is None:
+            raise ValueError("K/V summaries are required when proxy routes are enabled")
+        summary_shape = (
+            state.batch_size,
+            num_kv_blocks,
+            state.num_kv_heads,
+            state.head_dim,
+        )
+        for tensor, name in ((k_summary, "k_summary"), (v_summary, "v_summary")):
+            _validate_bshd_tensor(
+                tensor,
+                name,
+                expected_shape=summary_shape,
+                expected_dtype=state.kv_dtype,
+                expected_device=state.device,
+            )
+    elif k_summary is not None or v_summary is not None:
+        raise ValueError("summaries are valid only when proxy routes are enabled")
+
     if state.use_kv_valid_bits:
         assert kv_valid_bits is not None
         effective_kv_valid_bits = kv_valid_bits
@@ -258,7 +325,7 @@ def validate_block_sparse_run(
         expected_device=state.device,
     )
     paged_kv: _PagedKVLaunchPayload | None = None
-    overlap_inputs: tuple[tuple[str, torch.Tensor], ...]
+    overlap_inputs: list[tuple[str, torch.Tensor]]
     if isinstance(kv_storage, _ContiguousKVStorage):
         if state.page_size is not None:
             raise TypeError("contiguous K/V storage requires a contiguous plan state")
@@ -278,16 +345,11 @@ def validate_block_sparse_run(
             )
         k = kv_storage.k
         v = kv_storage.v
-        overlap_inputs = (
+        overlap_inputs = [
             ("q", q),
             ("k", k),
             ("v", v),
-            ("block_indptr", block_indptr),
-            ("block_indices", block_indices),
-            ("kv_valid_bits", effective_kv_valid_bits),
-            ("row_route_offsets", state.row_route_offsets),
-            ("route_workspace", state.route_workspace),
-        )
+        ]
     elif isinstance(kv_storage, _PagedKVStorage):
         page_size = state.page_size
         if page_size is None:
@@ -339,21 +401,32 @@ def validate_block_sparse_run(
             k_page_stride=k_page_stride,
             v_page_stride=v_page_stride,
         )
-        overlap_inputs = (
+        overlap_inputs = [
             ("q", q),
             ("k_cache", k),
             ("v_cache", v),
-            ("block_indptr", block_indptr),
-            ("block_indices", block_indices),
-            ("kv_valid_bits", effective_kv_valid_bits),
             ("paged_kv_indptr", kv_storage.paged_kv_indptr),
             ("paged_kv_indices", kv_storage.paged_kv_indices),
             ("seq_lens_kv", kv_storage.seq_lens_kv),
+        ]
+    else:
+        raise TypeError("kv_storage must be _ContiguousKVStorage or _PagedKVStorage")
+
+    if block_indptr is not None and block_indices is not None:
+        overlap_inputs.extend(
+            (("block_indptr", block_indptr), ("block_indices", block_indices))
+        )
+    if exact_block_bits is not None:
+        overlap_inputs.append(("exact_block_bits", exact_block_bits))
+    if k_summary is not None and v_summary is not None:
+        overlap_inputs.extend((("k_summary", k_summary), ("v_summary", v_summary)))
+    overlap_inputs.extend(
+        (
+            ("kv_valid_bits", effective_kv_valid_bits),
             ("row_route_offsets", state.row_route_offsets),
             ("route_workspace", state.route_workspace),
         )
-    else:
-        raise TypeError("kv_storage must be _ContiguousKVStorage or _PagedKVStorage")
+    )
 
     effective_scale = _validate_scale(
         1.0 / math.sqrt(state.head_dim) if sm_scale is None else sm_scale,
@@ -377,6 +450,9 @@ def validate_block_sparse_run(
         out=out,
         block_indptr=block_indptr,
         block_indices=block_indices,
+        exact_block_bits=exact_block_bits,
+        k_summary=k_summary,
+        v_summary=v_summary,
         kv_valid_bits=effective_kv_valid_bits,
         kv_valid_bits_is_live=state.use_kv_valid_bits,
         sm_scale=effective_scale,
@@ -390,12 +466,20 @@ def record_block_sparse_run_args(
 ) -> None:
     """Extend tensor lifetimes for the asynchronous launch currently in flight."""
 
-    run_args.q.record_stream(stream)
-    run_args.k.record_stream(stream)
-    run_args.v.record_stream(stream)
+    for tensor in (run_args.q, run_args.k, run_args.v):
+        tensor.record_stream(stream)
+    if run_args.k_summary is not None:
+        run_args.k_summary.record_stream(stream)
+        assert run_args.v_summary is not None
+        run_args.v_summary.record_stream(stream)
     run_args.out.record_stream(stream)
-    run_args.block_indptr.record_stream(stream)
-    run_args.block_indices.record_stream(stream)
+    if run_args.block_indptr is not None:
+        run_args.block_indptr.record_stream(stream)
+        assert run_args.block_indices is not None
+        run_args.block_indices.record_stream(stream)
+    else:
+        assert run_args.exact_block_bits is not None
+        run_args.exact_block_bits.record_stream(stream)
     if run_args.kv_valid_bits_is_live:
         run_args.kv_valid_bits.record_stream(stream)
     if run_args.paged_kv is not None:
@@ -409,23 +493,13 @@ def launch_block_sparse(
     *,
     state: "_BlockSparsePlanState",
 ) -> torch.Tensor:
-    """Invoke the exact contiguous or paged ABI chosen by validated payload."""
+    """Invoke the layout- and route-specific ABI chosen by the frozen plan."""
 
-    if run_args.paged_kv is None:
-        state.compiled(
-            run_args.q,
-            run_args.k,
-            run_args.v,
-            run_args.out,
-            run_args.block_indptr,
-            run_args.block_indices,
-            run_args.kv_valid_bits,
-            state.row_route_offsets,
-            state.route_workspace,
-            state.max_blocks_per_row,
-            run_args.sm_scale,
-        )
-    else:
+    sparse_format = state.sparse_format
+    use_proxy_routes = state.use_proxy_routes
+    if run_args.paged_kv is not None:
+        assert run_args.block_indptr is not None
+        assert run_args.block_indices is not None
         state.compiled(
             run_args.q,
             run_args.k,
@@ -445,6 +519,76 @@ def launch_block_sparse(
             run_args.paged_kv.v_page_stride,
             run_args.sm_scale,
         )
+    elif sparse_format == "bsr" and not use_proxy_routes:
+        assert run_args.block_indptr is not None
+        assert run_args.block_indices is not None
+        state.compiled(
+            run_args.q,
+            run_args.k,
+            run_args.v,
+            run_args.out,
+            run_args.block_indptr,
+            run_args.block_indices,
+            run_args.kv_valid_bits,
+            state.row_route_offsets,
+            state.route_workspace,
+            state.max_blocks_per_row,
+            run_args.sm_scale,
+        )
+    elif sparse_format == "bitmask" and not use_proxy_routes:
+        assert run_args.exact_block_bits is not None
+        state.compiled(
+            run_args.q,
+            run_args.k,
+            run_args.v,
+            run_args.out,
+            run_args.exact_block_bits,
+            run_args.kv_valid_bits,
+            state.row_route_offsets,
+            state.route_workspace,
+            state.max_blocks_per_row,
+            run_args.sm_scale,
+        )
+    elif sparse_format == "bsr" and use_proxy_routes:
+        assert run_args.block_indptr is not None
+        assert run_args.block_indices is not None
+        assert run_args.k_summary is not None
+        assert run_args.v_summary is not None
+        state.compiled(
+            run_args.q,
+            run_args.k,
+            run_args.v,
+            run_args.k_summary,
+            run_args.v_summary,
+            run_args.out,
+            run_args.block_indptr,
+            run_args.block_indices,
+            run_args.kv_valid_bits,
+            state.row_route_offsets,
+            state.route_workspace,
+            state.max_blocks_per_row,
+            run_args.sm_scale,
+        )
+    elif sparse_format == "bitmask" and use_proxy_routes:
+        assert run_args.exact_block_bits is not None
+        assert run_args.k_summary is not None
+        assert run_args.v_summary is not None
+        state.compiled(
+            run_args.q,
+            run_args.k,
+            run_args.v,
+            run_args.k_summary,
+            run_args.v_summary,
+            run_args.out,
+            run_args.exact_block_bits,
+            run_args.kv_valid_bits,
+            state.row_route_offsets,
+            state.route_workspace,
+            state.max_blocks_per_row,
+            run_args.sm_scale,
+        )
+    else:
+        raise AssertionError("frozen block-sparse plan has an unsupported route mode")
     return run_args.out
 
 

--- a/flashinfer/attention/prims_ts/block_sparse.py
+++ b/flashinfer/attention/prims_ts/block_sparse.py
@@ -36,12 +36,13 @@ import torch
 
 from flashinfer.api_logging import flashinfer_api
 from flashinfer.trace.templates.attention import (
-    prims_ts_block_sparse_trace,
+    prims_ts_block_sparse_trace_dispatch,
     prims_ts_block_sparse_wrapper_trace_dispatch,
     prims_ts_paged_block_sparse_trace_dispatch,
     prims_ts_paged_block_sparse_wrapper_trace_dispatch,
 )
 
+from ._block_sparse.common import _validate_contiguous_route_mode
 from ._block_sparse.config import _validate_block_sparse_static_profile
 from ._block_sparse.inspection import (
     _inspect_block_sparse_bsr,
@@ -116,10 +117,12 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
     Q is ``[B, Sq, Hq, D]`` and K/V are ``[B, Skv, Hkv, D]``. Sparse rows are
     owned per batch, KV head, and query block, so every Q head in one grouped
     KV head consumes the same sparse row. A plan fixes geometry and a per-row
-    capacity; every run supplies its own BSR and optional token mask.
-    Callers must keep those tensors alive and immutable until the queued run or
-    captured graph finishes using them. CUDA Graph capture pins plan-owned
-    state only, so captured routing storage remains the caller's responsibility.
+    capacity; every run supplies either BSR or a packed exact-block bitmask.
+    Proxy-enabled plans additionally consume caller-owned K/V summaries, while
+    an optional token mask applies only to exact routes. Callers must keep those
+    tensors alive and immutable until the queued run or captured graph finishes
+    using them. CUDA Graph capture pins plan-owned state only, so captured
+    routing storage remains the caller's responsibility.
 
     One plan revision owns one mutable route workspace. Its runs must be ordered
     on one stream or externally synchronized; unordered concurrent runs require
@@ -141,6 +144,8 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         device: torch.device | str | int,
         max_blocks_per_row: int,
         use_kv_valid_bits: bool,
+        sparse_format: Literal["bsr", "bitmask"] = "bsr",
+        use_proxy_routes: bool = False,
         mask_type: Literal["dense", "causal"] = "dense",
         q_data_type: torch.dtype = torch.float16,
         kv_data_type: torch.dtype | None = None,
@@ -149,11 +154,16 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         """Choose a legal profile and allocate reusable routing capacity.
 
         The plan owns immutable geometry and a uniform route workspace, not a
-        sparse pattern. ``max_blocks_per_row`` bounds each runtime BSR row in
-        semantic ``kv_block_size`` blocks. ``use_kv_valid_bits`` selects whether
-        every :meth:`run` must supply the shared batch token mask. Callers may
-        pass different routing tensor identities and index extents to each run
-        as long as they fit this declared capacity.
+        sparse pattern. ``max_blocks_per_row`` bounds each runtime sparse row in
+        semantic ``kv_block_size`` blocks. ``sparse_format="bsr"`` consumes
+        canonical CSR-style rows, while ``"bitmask"`` consumes packed exact-
+        block bits. Enabling proxy routes represents unselected blocks through
+        caller-provided K/V summaries and currently requires
+        ``mask_type="dense"``. Exact-only plans continue to support causal
+        masking. ``use_kv_valid_bits`` selects whether every :meth:`run` must
+        supply the shared batch token mask. Callers may pass different routing
+        tensor identities and index extents to each run as long as they fit
+        this declared capacity.
 
         MHA, GQA, and MQA are supported with ``Hq / Hkv`` a power of two no
         greater than 32 and ``D=128``. Q, K, V, and O use one matching
@@ -167,10 +177,13 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         respectively. ``kv_block_size`` may be 8, 16, 32, or a positive
         multiple of 64. The Q tile groups complete Q-head groups and as many Q
         tokens as fit without crossing a semantic Q-block row, up to Q128;
-        fine KV blocks cap this at a SWAPAB Q32 tile. Every run prepares
-        per-KV-head canonical BSR into compact, profile-selected fixed-width
-        route metadata, and the attention core consumes only that metadata.
-        This remains true when every KV block is selected;
+        fine KV blocks cap this at a SWAPAB Q32 tile. Proxy routes reuse the
+        same Q-tile, KV-route, and MMA geometry as exact routes, but currently
+        use the direct scheduler because reusable planning cannot observe live
+        exact-route work. Every run prepares its selected BSR or bitmask into
+        compact, profile-selected fixed-width route metadata, and the attention
+        core consumes only that metadata. This remains true when every KV block
+        is selected;
         callers that know a pattern is dense should choose the dense FMHA API
         explicitly.
 
@@ -187,6 +200,7 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         runs require distinct wrappers.
         """
 
+        _validate_contiguous_route_mode(sparse_format, use_proxy_routes)
         static = _validate_block_sparse_static_profile(
             batch_size=batch_size,
             seq_len_q=seq_len_q,
@@ -203,6 +217,8 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
             output_dtype=o_data_type,
             max_blocks_per_row=max_blocks_per_row,
         )
+        if use_proxy_routes and static.mask_type != "dense":
+            raise ValueError("block-sparse proxy routes require mask_type='dense'")
         device, device_index = _resolve_cuda_device(device)
         plan_stream = torch.cuda.current_stream(device)
         with torch.cuda.device(device_index), torch.cuda.stream(plan_stream):
@@ -215,6 +231,8 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
                 device=device,
                 device_index=device_index,
                 plan_stream=plan_stream,
+                sparse_format=sparse_format,
+                use_proxy_routes=use_proxy_routes,
             )
         # This is the only wrapper mutation. Every failure above leaves the
         # previously published revision intact and runnable.
@@ -226,9 +244,12 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         q: torch.Tensor,
         k: torch.Tensor,
         v: torch.Tensor,
-        block_indptr: torch.Tensor,
-        block_indices: torch.Tensor,
+        block_indptr: torch.Tensor | None = None,
+        block_indices: torch.Tensor | None = None,
         *,
+        exact_block_bits: torch.Tensor | None = None,
+        k_summary: torch.Tensor | None = None,
+        v_summary: torch.Tensor | None = None,
         kv_valid_bits: torch.Tensor | None = None,
         sm_scale: float | None = None,
         out: torch.Tensor | None = None,
@@ -243,17 +264,27 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         Only O is returned; this PrimTS API does not return LSE. The launch is
         enqueued asynchronously on the caller's current CUDA stream.
 
-        ``block_indptr`` is compact Int32
-        ``[B, Hkv, ceil(Sq / q_block_size) + 1]`` and indexes compact
-        ``block_indices``. Every row must fit the planned semantic-block
-        capacity; referenced block IDs must be strictly increasing, unique,
-        and in range. Reusable runs trust these device-side values. CuTe DSL
-        assertions can diagnose violations when enabled before compilation;
-        otherwise invalid values have undefined behavior and may access out of
-        bounds. A masked plan requires
+        A BSR plan consumes compact Int32 ``block_indptr`` with shape
+        ``[B, Hkv, ceil(Sq / q_block_size) + 1]`` and compact Int32
+        ``block_indices``. A bitmask plan instead requires both BSR arguments
+        to be ``None`` and consumes packed UInt32 ``exact_block_bits`` with
+        shape ``[B, Hkv, ceil(Sq / q_block_size), ceil(num_kv_blocks / 32)]``.
+        Bit ``r`` of word ``w`` selects block ``32 * w + r``; final-word
+        padding bits are ignored. A proxy plan additionally consumes compact
+        ``k_summary`` and ``v_summary`` with shape
+        ``[B, num_kv_blocks, Hkv, D]``. K summaries are block means and V
+        summaries are block sums; the final partial block covers only its
+        structural tokens.
+
+        Every row must fit the planned semantic-block capacity. Reusable runs
+        trust routing values. CuTe DSL assertions can diagnose violations when
+        enabled before compilation; otherwise invalid values have undefined
+        behavior and may access out of bounds. A masked plan requires
         ``kv_valid_bits`` with shape
         ``[B, ceil(Skv / 32)]`` and dtype UInt32; an unmasked plan requires
-        ``None``. Routing tensors may have different identities on every run.
+        ``None``. The mask applies only to raw exact routes; proxy summaries and
+        their represented-token mass remain caller-defined. Routing tensors may
+        have different identities on every run.
 
         Keep this wrapper alive until every captured CUDA Graph is destroyed.
 
@@ -266,12 +297,18 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         v : torch.Tensor
             Compact value tensor with the same shape, dtype, and strides as
             ``k``.
-        block_indptr : torch.Tensor
+        block_indptr : torch.Tensor, optional
             Contiguous Int32 BSR row offsets with shape
-            ``[B, Hkv, ceil(Sq / q_block_size) + 1]``.
-        block_indices : torch.Tensor
+            ``[B, Hkv, ceil(Sq / q_block_size) + 1]``. Required by BSR plans.
+        block_indices : torch.Tensor, optional
             Contiguous Int32 semantic KV-block IDs referenced by
-            ``block_indptr``.
+            ``block_indptr``. Required by BSR plans.
+        exact_block_bits : torch.Tensor, optional
+            Compact packed UInt32 exact-block bitmap required by bitmask plans.
+        k_summary : torch.Tensor, optional
+            Per-block mean K tensor required by proxy plans.
+        v_summary : torch.Tensor, optional
+            Per-block summed V tensor required by proxy plans.
         kv_valid_bits : torch.Tensor, optional
             Contiguous UInt32 token-validity bitmap ``[B, ceil(Skv / 32)]``.
             Supply it exactly when the plan enabled token validity bits.
@@ -288,42 +325,51 @@ class BlockSparseTSWrapper(_BlockSparseWrapperBase):
         """
 
         state = self._require_run_state()
-        run_stream = torch.cuda.current_stream(state.device)
         run_args = _validate_block_sparse_run(
             q,
             _ContiguousKVStorage(k=k, v=v),
             state=state,
             block_indptr=block_indptr,
             block_indices=block_indices,
+            exact_block_bits=exact_block_bits,
+            k_summary=k_summary,
+            v_summary=v_summary,
             kv_valid_bits=kv_valid_bits,
             sm_scale=sm_scale,
             out=out,
         )
+        run_stream = torch.cuda.current_stream(state.device)
         return self._launch_validated_run(state, run_args, run_stream)
 
 
-@flashinfer_api(trace=prims_ts_block_sparse_trace)
+@flashinfer_api(trace=prims_ts_block_sparse_trace_dispatch)
 def block_sparse_attention(
     q: torch.Tensor,
     k: torch.Tensor,
     v: torch.Tensor,
-    block_indptr: torch.Tensor,
-    block_indices: torch.Tensor,
+    block_indptr: torch.Tensor | None,
+    block_indices: torch.Tensor | None,
     q_block_size: int,
     kv_block_size: int,
     *,
+    exact_block_bits: torch.Tensor | None = None,
+    k_summary: torch.Tensor | None = None,
+    v_summary: torch.Tensor | None = None,
     kv_valid_bits: torch.Tensor | None = None,
+    sparse_format: Literal["bsr", "bitmask"] = "bsr",
+    use_proxy_routes: bool = False,
     mask_type: Literal["dense", "causal"] = "dense",
     sm_scale: float | None = None,
     out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Plan and run one compact-BSHD block-sparse attention launch.
 
-    This one-shot form synchronously inspects canonical BSR, derives its largest
-    semantic row, creates a capacity-only plan, and passes the original routing
-    tensors to :meth:`BlockSparseTSWrapper.run`. It therefore cannot be invoked
-    inside CUDA Graph capture; plan a wrapper outside capture and capture only
-    ``run()`` instead.
+    This one-shot form creates a capacity-only plan and passes the original
+    routing tensors to :meth:`BlockSparseTSWrapper.run`. BSR inputs are
+    synchronously inspected to validate canonical rows and derive their maximum
+    width. Bitmask inputs use the structural KV-block count as a conservative
+    capacity bound. It therefore cannot be invoked inside CUDA Graph capture;
+    plan a wrapper outside capture and capture only ``run()`` instead.
 
     Parameters
     ----------
@@ -333,11 +379,12 @@ def block_sparse_attention(
         Compact key tensor ``[B, Skv, Hkv, D]``.
     v : torch.Tensor
         Compact value tensor with the same shape, dtype, and strides as ``k``.
-    block_indptr : torch.Tensor
+    block_indptr : torch.Tensor, optional
         Contiguous Int32 BSR row offsets with shape
-        ``[B, Hkv, ceil(Sq / q_block_size) + 1]``.
-    block_indices : torch.Tensor
+        ``[B, Hkv, ceil(Sq / q_block_size) + 1]``. Required in BSR mode.
+    block_indices : torch.Tensor, optional
         Contiguous Int32 semantic KV-block IDs referenced by ``block_indptr``.
+        Required in BSR mode.
     q_block_size : int
         Positive number of logical query tokens represented by one BSR row.
         The product with ``Hq / Hkv`` must be divisible by 8 so a physical Q
@@ -345,8 +392,19 @@ def block_sparse_attention(
     kv_block_size : int
         Number of logical KV tokens represented by one BSR block ID; it must
         be 8, 16, 32, or a positive multiple of 64.
+    exact_block_bits : torch.Tensor, optional
+        Compact UInt32 exact-block bitmap required in bitmask mode.
+    k_summary : torch.Tensor, optional
+        Per-block mean K tensor required when proxy routes are enabled.
+    v_summary : torch.Tensor, optional
+        Per-block summed V tensor required when proxy routes are enabled.
     kv_valid_bits : torch.Tensor, optional
         Contiguous UInt32 token-validity bitmap ``[B, ceil(Skv / 32)]``.
+    sparse_format : {"bsr", "bitmask"}, optional
+        Runtime sparse representation. Defaults to ``"bsr"``.
+    use_proxy_routes : bool, optional
+        Represent unselected blocks through K/V summaries. Proxy routes
+        currently require dense masking.
     mask_type : {"dense", "causal"}, optional
         Attention mask applied inside each selected sparse block.
     sm_scale : float, optional
@@ -375,6 +433,7 @@ def block_sparse_attention(
         raise ValueError("K and V must have identical shapes")
 
     use_kv_valid_bits = kv_valid_bits is not None
+    _validate_contiguous_route_mode(sparse_format, use_proxy_routes)
     static = _validate_block_sparse_static_profile(
         batch_size=batch_size,
         seq_len_q=seq_len_q,
@@ -390,25 +449,37 @@ def block_sparse_attention(
         kv_dtype=k.dtype,
         output_dtype=q.dtype if out is None else out.dtype,
     )
+    if use_proxy_routes and static.mask_type != "dense":
+        raise ValueError("block-sparse proxy routes require mask_type='dense'")
     device, _ = _resolve_cuda_device(q.device)
     _validate_block_sparse_metadata(
-        block_indptr,
-        block_indices,
-        kv_valid_bits,
+        sparse_format=sparse_format,
+        block_indptr=block_indptr,
+        block_indices=block_indices,
+        exact_block_bits=exact_block_bits,
+        kv_valid_bits=kv_valid_bits,
         device=device,
         batch_size=static.batch_size,
         seq_len_q=static.seq_len_q,
         seq_len_kv=static.seq_len_kv,
         num_kv_heads=static.num_kv_heads,
         q_block_size=static.q_block_size,
+        kv_block_size=static.kv_block_size,
         use_kv_valid_bits=static.use_kv_valid_bits,
     )
-    max_blocks_per_row = _inspect_block_sparse_bsr(
-        block_indptr,
-        block_indices,
-        static=static,
-        stream=torch.cuda.current_stream(device),
-    )
+    if sparse_format == "bsr":
+        max_blocks_per_row = _inspect_block_sparse_bsr(
+            block_indptr,
+            block_indices,
+            static=static,
+            stream=torch.cuda.current_stream(device),
+        )
+    elif sparse_format == "bitmask":
+        max_blocks_per_row = (
+            static.seq_len_kv + static.kv_block_size - 1
+        ) // static.kv_block_size
+    else:
+        raise AssertionError(f"unsupported sparse format {sparse_format!r}")
 
     wrapper = BlockSparseTSWrapper()
     wrapper.plan(
@@ -423,6 +494,8 @@ def block_sparse_attention(
         device=device,
         max_blocks_per_row=max_blocks_per_row,
         use_kv_valid_bits=static.use_kv_valid_bits,
+        sparse_format=sparse_format,
+        use_proxy_routes=use_proxy_routes,
         mask_type=static.mask_type,
         q_data_type=static.q_dtype,
         kv_data_type=static.kv_dtype,
@@ -434,6 +507,9 @@ def block_sparse_attention(
         v,
         block_indptr,
         block_indices,
+        exact_block_bits=exact_block_bits,
+        k_summary=k_summary,
+        v_summary=v_summary,
         kv_valid_bits=kv_valid_bits,
         sm_scale=sm_scale,
         out=out,
@@ -740,15 +816,18 @@ def block_sparse_attention_with_paged_kv_cache(
         output_dtype=q.dtype if out is None else out.dtype,
     )
     _validate_block_sparse_metadata(
-        block_indptr,
-        block_indices,
-        kv_valid_bits,
+        sparse_format="bsr",
+        block_indptr=block_indptr,
+        block_indices=block_indices,
+        exact_block_bits=None,
+        kv_valid_bits=kv_valid_bits,
         device=metadata_device,
         batch_size=static.batch_size,
         seq_len_q=static.seq_len_q,
         seq_len_kv=static.seq_len_kv,
         num_kv_heads=static.num_kv_heads,
         q_block_size=static.q_block_size,
+        kv_block_size=static.kv_block_size,
         use_kv_valid_bits=static.use_kv_valid_bits,
     )
     max_blocks_per_row = _inspect_paged_block_sparse_metadata(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
@@ -135,6 +135,47 @@ def _positive_i32_ceil_div(
 
 
 @cute.jit
+def _prepared_route_counts(
+    selected_block_count: cutlass.Int32,
+    cfg: cutlass.Constexpr[_RouteConfig],
+) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]:
+    """Return exact atoms, exact routes, and total prepared routes for one row."""
+
+    exact_atom_count = selected_block_count * cutlass.Int32(cfg.atoms_per_block)
+    exact_route_count = (
+        exact_atom_count + cutlass.Int32(cfg.logical_origins_per_route - 1)
+    ) // cutlass.Int32(cfg.logical_origins_per_route)
+    total_route_count = exact_route_count
+    if cutlass.const_expr(cfg.use_proxy_routes):
+        total_route_count += cutlass.Int32(cfg.num_proxy_groups)
+    return exact_atom_count, exact_route_count, total_route_count
+
+
+@cute.jit
+def _prepared_row_route_begin(
+    row_route_offsets: cute.Tensor,
+    linear_row_idx: cutlass.Int32,
+    lane_idx: cutlass.Int32,
+    row_is_valid: cutlass.Boolean,
+    total_route_count: cutlass.Int32,
+) -> cutlass.Int32:
+    """Load and validate one row's plan-owned prepared-route span."""
+
+    row_route_begin = cutlass.Int32(0)
+    if lane_idx == cutlass.Int32(0) and row_is_valid:
+        row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
+        row_route_end = cutlass.Int32(row_route_offsets[linear_row_idx + 1])
+        row_capacity = row_route_end - row_route_begin
+        runtime_assert(
+            row_route_begin >= cutlass.Int32(0)
+            and row_capacity >= cutlass.Int32(0)
+            and total_route_count <= row_capacity,
+            "prepared routes exceed planned row capacity",
+        )
+    return _warp_broadcast_i32(row_route_begin, 0)
+
+
+@cute.jit
 def _resolve_route_logical_atom_origin(
     block_indices: cute.Tensor,
     row_begin: cutlass.Int32,
@@ -497,7 +538,8 @@ def _load_bsr_proxy_word(
 @cute.jit
 def _emit_proxy_route(
     route_workspace: cute.Tensor,
-    route_metadata_word_index: cutlass.Int32,
+    row_route_begin: cutlass.Int32,
+    exact_route_count: cutlass.Int32,
     group_idx: cutlass.Int32,
     proxy_word: cutlass.Uint32,
     lane_idx: cutlass.Int32,
@@ -505,6 +547,9 @@ def _emit_proxy_route(
 ) -> None:
     """Emit one fixed summary-group proxy record, including an empty mask."""
 
+    route_metadata_word_index = cutlass.Int32(cfg.route_metadata_base_word_offset) + (
+        row_route_begin + exact_route_count + group_idx
+    ) * cutlass.Int32(cfg.route_metadata_stride_words)
     group_start = group_idx * cutlass.Int32(cfg.token_words_per_route * _WARP_SIZE)
     group_size = cutlass.Int32(cfg.num_kv_blocks) - group_start
     if group_size > cutlass.Int32(cfg.token_words_per_route * _WARP_SIZE):
@@ -725,33 +770,22 @@ class _PrepareBsrRoutes(_PrepareRoutesBase):
                 )
             request_begin = _warp_broadcast_i32(request_begin, 0)
 
-        exact_atom_count = selected_block_count * cutlass.Int32(
-            self.cfg.atoms_per_block
+        _, exact_route_count, total_route_count = _prepared_route_counts(
+            selected_block_count,
+            self.cfg,
         )
-        exact_route_count = (
-            exact_atom_count + cutlass.Int32(self.cfg.logical_origins_per_route - 1)
-        ) // cutlass.Int32(self.cfg.logical_origins_per_route)
-
-        total_route_count = exact_route_count
-        if cutlass.const_expr(self.cfg.use_proxy_routes):
-            total_route_count += cutlass.Int32(self.cfg.num_proxy_groups)
-
-        row_route_begin = cutlass.Int32(0)
         if lane_idx == cutlass.Int32(0) and row_is_valid:
-            row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
-            row_route_end = cutlass.Int32(row_route_offsets[linear_row_idx + 1])
-            row_capacity = row_route_end - row_route_begin
             runtime_assert(
                 selected_block_count <= max_blocks_per_row,
                 "selected BSR blocks exceed planned semantic capacity",
             )
-            runtime_assert(
-                row_route_begin >= cutlass.Int32(0)
-                and row_capacity >= cutlass.Int32(0)
-                and total_route_count <= row_capacity,
-                "prepared routes exceed planned row capacity",
-            )
-        row_route_begin = _warp_broadcast_i32(row_route_begin, 0)
+        row_route_begin = _prepared_row_route_begin(
+            row_route_offsets,
+            linear_row_idx,
+            lane_idx,
+            row_is_valid,
+            total_route_count,
+        )
 
         if row_is_valid:
             route_idx = cutlass.Int32(0)
@@ -828,14 +862,10 @@ class _PrepareBsrRoutes(_PrepareRoutesBase):
                                 logical_word_idx,
                                 self.cfg,
                             )
-                    route_word_index = cutlass.Int32(
-                        self.cfg.route_metadata_base_word_offset
-                    ) + (
-                        row_route_begin + exact_route_count + group_idx
-                    ) * cutlass.Int32(self.cfg.route_metadata_stride_words)
                     _emit_proxy_route(
                         route_workspace,
-                        route_word_index,
+                        row_route_begin,
+                        exact_route_count,
                         group_idx,
                         proxy_word,
                         lane_idx,
@@ -944,31 +974,22 @@ class _PrepareBitmaskRoutes(_PrepareRoutesBase):
             cute.arch.warp_redux_sync(lane_exact_count, "add")
         )
 
-        exact_atom_count = exact_block_count * cutlass.Int32(self.cfg.atoms_per_block)
-        exact_route_count = (
-            exact_atom_count + cutlass.Int32(self.cfg.logical_origins_per_route - 1)
-        ) // cutlass.Int32(self.cfg.logical_origins_per_route)
-
-        total_route_count = exact_route_count
-        if cutlass.const_expr(self.cfg.use_proxy_routes):
-            total_route_count += cutlass.Int32(self.cfg.num_proxy_groups)
-
-        row_route_begin = cutlass.Int32(0)
+        exact_atom_count, exact_route_count, total_route_count = _prepared_route_counts(
+            exact_block_count,
+            self.cfg,
+        )
         if lane_idx == cutlass.Int32(0) and row_is_valid:
-            row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
-            row_route_end = cutlass.Int32(row_route_offsets[linear_row_idx + 1])
-            row_capacity = row_route_end - row_route_begin
             runtime_assert(
                 exact_block_count <= max_blocks_per_row,
                 "selected bitmask blocks exceed planned semantic capacity",
             )
-            runtime_assert(
-                row_route_begin >= cutlass.Int32(0)
-                and row_capacity >= cutlass.Int32(0)
-                and total_route_count <= row_capacity,
-                "prepared routes exceed planned row capacity",
-            )
-        row_route_begin = _warp_broadcast_i32(row_route_begin, 0)
+        row_route_begin = _prepared_row_route_begin(
+            row_route_offsets,
+            linear_row_idx,
+            lane_idx,
+            row_is_valid,
+            total_route_count,
+        )
 
         if row_is_valid:
             exact_prefix = cutlass.Int32(0)
@@ -1067,14 +1088,10 @@ class _PrepareBitmaskRoutes(_PrepareRoutesBase):
                                 self.cfg,
                                 for_proxy=True,
                             )
-                    route_word_index = cutlass.Int32(
-                        self.cfg.route_metadata_base_word_offset
-                    ) + (
-                        row_route_begin + exact_route_count + group_idx
-                    ) * cutlass.Int32(self.cfg.route_metadata_stride_words)
                     _emit_proxy_route(
                         route_workspace,
-                        route_word_index,
+                        row_route_begin,
+                        exact_route_count,
                         group_idx,
                         proxy_word,
                         lane_idx,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Prepare live canonical BSR rows for the PrimTS FMHA route consumer.
+"""Prepare exact-first sparse routes for the PrimTS FMHA route consumer.
 
-The kernel converts caller-owned semantic KV blocks into fixed-stride route
-metadata on every run. Route origins are logical KV-token coordinates;
-the paged specialization also resolves each origin to a physical page ID for
-the attention load path. One warp handles one BSR row and iterates only that
-row's live routes, while four warps share a CTA.
+The BSR frontend is shared by continuous exact/proxy and paged exact storage.
+It validates each canonical row once, emits the same logical exact records,
+then either resolves paged locators or appends continuous proxy records. The
+bitmask frontend shares the record geometry and emitters but remains limited
+to continuous storage. Proxy suffixes contain one stable record per summary
+group; a fully exact group remains present with zero score words. One warp owns
+one sparse row and four warps share a CTA.
 
 ``row_route_offsets`` is a separate plan-owned immutable Int32 tensor.
 ``route_workspace`` contains only mutable row counts and route metadata
@@ -27,21 +29,20 @@ count is intentionally stale. ``max_blocks_per_row`` is the plan-declared
 semantic BSR-block limit, which remains distinct from packed-route capacity.
 """
 
-import math
 from dataclasses import dataclass
 
 import cutlass
 import cutlass.cute as cute
 from cuda.bindings import driver as cuda_drv
 from cutlass.cute.testing import assert_ as runtime_assert
-from cutlass.experimental import primitives as prims
 
 from ..._block_sparse.prepared import (
     _PREPARED_ROUTE_IS_FULL_FLAG,
+    _PREPARED_ROUTE_IS_PROXY_FLAG,
     _BlockSparseRouteLayout,
 )
-from .block_sparse_inspect import _validate_bsr_row_lane
 from .fmha_decode_resources.helpers_common import _warp_broadcast_i32
+from .block_sparse_inspect import _validate_bsr_row_lane
 
 
 _WARPS_PER_CTA = 4
@@ -50,22 +51,27 @@ _THREADS_PER_CTA = _WARPS_PER_CTA * _WARP_SIZE
 
 
 @dataclass(frozen=True)
-class _PreparedRouteConfig:
-    """Compile-time geometry shared by contiguous and paged route packing."""
+class _RouteConfig:
+    """Compile-time route geometry shared across sparse input/storage modes."""
 
     num_kv_heads: int
-    num_q_block_rows: int
+    num_q_blocks: int
     num_kv_blocks: int
+    num_exact_words: int
+    num_proxy_groups: int
     num_rows: int
     seq_len_kv: int
     kv_block_size: int
     atom_size: int
+    atoms_per_block: int
     logical_origins_per_route: int
     token_words_per_route: int
     atom_valid_mask_word_offset: int
     route_flags_word_offset: int
     token_words_word_offset: int
-    has_token_bits: bool
+    stores_score_words: bool
+    apply_token_mask: bool
+    use_proxy_routes: bool
     route_metadata_stride_words: int
     route_metadata_base_word_offset: int
 
@@ -78,18 +84,30 @@ class _PreparedRouteConfig:
         seq_len_kv: int,
         q_block_size: int,
         kv_block_size: int,
-    ) -> "_PreparedRouteConfig":
-        """Build shared prepare geometry without adding a storage-mode flag."""
+        apply_token_mask: bool,
+        use_proxy_routes: bool,
+    ) -> "_RouteConfig":
+        """Build storage-independent route geometry and policy flags."""
 
-        num_q_block_rows = (seq_len_q + q_block_size - 1) // q_block_size
-        return _PreparedRouteConfig(
+        stores_score_words = layout.token_words_word_offset is not None
+        if apply_token_mask and not stores_score_words:
+            raise ValueError("token masking requires prepared score words")
+        if use_proxy_routes and not stores_score_words:
+            raise ValueError("proxy routes require prepared score words")
+        num_q_blocks = (seq_len_q + q_block_size - 1) // q_block_size
+        num_kv_blocks = (seq_len_kv + kv_block_size - 1) // kv_block_size
+        return _RouteConfig(
             num_kv_heads=num_kv_heads,
-            num_q_block_rows=num_q_block_rows,
-            num_kv_blocks=(seq_len_kv + kv_block_size - 1) // kv_block_size,
+            num_q_blocks=num_q_blocks,
+            num_kv_blocks=num_kv_blocks,
+            num_exact_words=(num_kv_blocks + _WARP_SIZE - 1) // _WARP_SIZE,
+            num_proxy_groups=(num_kv_blocks + layout.kv_route_size - 1)
+            // layout.kv_route_size,
             num_rows=layout.num_rows,
             seq_len_kv=seq_len_kv,
             kv_block_size=kv_block_size,
             atom_size=layout.atom_size,
+            atoms_per_block=kv_block_size // layout.atom_size,
             logical_origins_per_route=layout.logical_origins_per_route,
             token_words_per_route=layout.token_words_per_route,
             atom_valid_mask_word_offset=layout.atom_valid_mask_word_offset,
@@ -99,7 +117,9 @@ class _PreparedRouteConfig:
                 if layout.token_words_word_offset is not None
                 else 0
             ),
-            has_token_bits=layout.has_token_bits,
+            stores_score_words=stores_score_words,
+            apply_token_mask=apply_token_mask,
+            use_proxy_routes=use_proxy_routes,
             route_metadata_stride_words=layout.route_metadata_stride_words,
             route_metadata_base_word_offset=layout.route_metadata_base_word_offset,
         )
@@ -112,38 +132,6 @@ def _positive_i32_ceil_div(
     """Ceil-divide a positive Int32 without overflowing its upper bound."""
 
     return (value - cutlass.Int32(1)) // cutlass.Int32(divisor) + cutlass.Int32(1)
-
-
-@cute.jit
-def _retained_atom_count(
-    block_indices: cute.Tensor,
-    row_begin: cutlass.Int32,
-    row_end: cutlass.Int32,
-    kv_block_size: cutlass.Constexpr[int],
-    atom_size: cutlass.Constexpr[int],
-    seq_len_kv: cutlass.Int32,
-) -> cutlass.Int32:
-    """Count selected atoms whose logical origin precedes ``seq_len_kv``."""
-
-    row_nnz = row_end - row_begin
-    retained_atoms = cutlass.Int32(0)
-    if row_nnz > cutlass.Int32(0):
-        atoms_per_block = kv_block_size // atom_size
-        retained_atoms = (row_nnz - cutlass.Int32(1)) * cutlass.Int32(atoms_per_block)
-        last_block_idx = cutlass.Int32(block_indices[row_end - cutlass.Int32(1)])
-        last_block_origin = last_block_idx * cutlass.Int32(kv_block_size)
-        remaining_tokens = cutlass.Int32(seq_len_kv) - last_block_origin
-        runtime_assert(
-            remaining_tokens > cutlass.Int32(0),
-            "block_indices row exceeds the live KV block range",
-        )
-        retained_last_atoms = (remaining_tokens - cutlass.Int32(1)) // cutlass.Int32(
-            atom_size
-        ) + cutlass.Int32(1)
-        if retained_last_atoms > cutlass.Int32(atoms_per_block):
-            retained_last_atoms = cutlass.Int32(atoms_per_block)
-        retained_atoms = retained_atoms + retained_last_atoms
-    return retained_atoms
 
 
 @cute.jit
@@ -177,71 +165,72 @@ def _resolve_route_logical_atom_origin(
 
 
 @cute.jit
-def _load_coarse_token_word(
-    block_indices: cute.Tensor,
-    kv_valid_bits: cute.Tensor,
-    row_begin: cutlass.Int32,
-    row_end: cutlass.Int32,
-    route_idx: cutlass.Int32,
-    logical_word_idx: cutlass.Int32,
-    batch_idx: cutlass.Int32,
-    kv_block_size: cutlass.Constexpr[int],
-    atom_size: cutlass.Constexpr[int],
-    logical_origins_per_route: cutlass.Constexpr[int],
-    seq_len_kv: cutlass.Int32,
-) -> cutlass.Uint32:
-    """Load one logical K32 word from a coarse atom larger than K32."""
+def _low_bits_mask(valid_bits: cutlass.Int32) -> cutlass.Uint32:
+    """Return a Uint32 mask with its lowest clamped bit count set."""
 
-    logical_word = cutlass.Uint32(0)
-    words_per_atom = atom_size // 32
-    atom_in_route = logical_word_idx // cutlass.Int32(words_per_atom)
-    word_in_atom = logical_word_idx % cutlass.Int32(words_per_atom)
-    logical_origin, valid = _resolve_route_logical_atom_origin(
-        block_indices,
-        row_begin,
-        row_end,
-        route_idx,
-        atom_in_route,
-        kv_block_size,
-        atom_size,
-        logical_origins_per_route,
-        seq_len_kv,
-    )
-    logical_word_origin = logical_origin + word_in_atom * cutlass.Int32(32)
-    if valid and logical_word_origin < cutlass.Int32(seq_len_kv):
-        valid_bits_word_idx = logical_word_origin >> cutlass.Int32(5)
-        logical_word = cutlass.Uint32(kv_valid_bits[batch_idx, valid_bits_word_idx])
-        remaining_tokens = cutlass.Int32(seq_len_kv) - logical_word_origin
-        if remaining_tokens < cutlass.Int32(32):
-            logical_word = logical_word & (
-                (cutlass.Uint32(1) << remaining_tokens) - cutlass.Uint32(1)
-            )
-    return logical_word
+    mask = cutlass.Uint32(0)
+    if valid_bits >= cutlass.Int32(_WARP_SIZE):
+        mask = cutlass.Uint32(0xFFFFFFFF)
+    elif valid_bits > cutlass.Int32(0):
+        mask = (cutlass.Uint32(1) << valid_bits) - cutlass.Uint32(1)
+    return mask
 
 
 @cute.jit
-def _load_atom_token_chunk(
+def _load_exact_score_word(
+    route_workspace: cute.Tensor,
     kv_valid_bits: cute.Tensor,
+    route_metadata_word_index: cutlass.Int32,
+    logical_word_idx: cutlass.Int32,
     batch_idx: cutlass.Int32,
-    logical_origin: cutlass.Int32,
-    origin_is_valid: cutlass.Boolean,
-    atom_size: cutlass.Constexpr[int],
     seq_len_kv: cutlass.Int32,
+    cfg: cutlass.Constexpr[_RouteConfig],
 ) -> cutlass.Uint32:
-    """Load the <=K32 mask chunk owned by one resolved-origin lane."""
+    """Build one exact score word with optional caller-token masking."""
 
-    token_chunk = cutlass.Uint32(0)
-    if origin_is_valid:
-        valid_bits_word_idx = logical_origin >> cutlass.Int32(5)
-        source_word = cutlass.Uint32(kv_valid_bits[batch_idx, valid_bits_word_idx])
-        token_chunk = source_word >> (logical_origin & cutlass.Int32(31))
-        token_chunk = token_chunk & cutlass.Uint32((1 << atom_size) - 1)
-        remaining_tokens = cutlass.Int32(seq_len_kv) - logical_origin
-        if remaining_tokens < cutlass.Int32(atom_size):
-            token_chunk = token_chunk & (
-                (cutlass.Uint32(1) << remaining_tokens) - cutlass.Uint32(1)
-            )
-    return token_chunk
+    token_word = cutlass.Uint32(0)
+    if cutlass.const_expr(cfg.atom_size <= _WARP_SIZE):
+        atoms_per_word = _WARP_SIZE // cfg.atom_size
+        first_atom_idx = logical_word_idx * cutlass.Int32(atoms_per_word)
+        for atom_in_word in cutlass.range_constexpr(atoms_per_word):
+            atom_idx = first_atom_idx + cutlass.Int32(atom_in_word)
+            if atom_idx < cutlass.Int32(cfg.logical_origins_per_route):
+                origin = cutlass.Int32(
+                    route_workspace[route_metadata_word_index + atom_idx]
+                )
+                atom_word = cutlass.Uint32(0)
+                if origin >= cutlass.Int32(0):
+                    if cutlass.const_expr(cfg.apply_token_mask):
+                        source_word_idx = origin >> cutlass.Int32(5)
+                        atom_word = cutlass.Uint32(
+                            kv_valid_bits[batch_idx, source_word_idx]
+                        )
+                        atom_word = atom_word >> (origin & cutlass.Int32(31))
+                        atom_word = atom_word & cutlass.Uint32((1 << cfg.atom_size) - 1)
+                        atom_word = atom_word & _low_bits_mask(seq_len_kv - origin)
+                    else:
+                        atom_word = _low_bits_mask(
+                            seq_len_kv - origin
+                        ) & cutlass.Uint32((1 << cfg.atom_size) - 1)
+                token_word = token_word | (
+                    atom_word << cutlass.Int32(atom_in_word * cfg.atom_size)
+                )
+    else:
+        words_per_atom = cfg.atom_size // _WARP_SIZE
+        atom_idx = logical_word_idx // cutlass.Int32(words_per_atom)
+        word_in_atom = logical_word_idx % cutlass.Int32(words_per_atom)
+        origin = cutlass.Int32(route_workspace[route_metadata_word_index + atom_idx])
+        word_origin = origin + word_in_atom * cutlass.Int32(_WARP_SIZE)
+        if origin >= cutlass.Int32(0):
+            if cutlass.const_expr(cfg.apply_token_mask):
+                if word_origin < seq_len_kv:
+                    source_word_idx = word_origin >> cutlass.Int32(5)
+                    token_word = cutlass.Uint32(
+                        kv_valid_bits[batch_idx, source_word_idx]
+                    ) & _low_bits_mask(seq_len_kv - word_origin)
+            else:
+                token_word = _low_bits_mask(seq_len_kv - word_origin)
+    return token_word
 
 
 @cute.jit
@@ -251,7 +240,7 @@ def _resolve_prepared_bsr_row(
     linear_row_idx: cutlass.Int32,
     lane_idx: cutlass.Int32,
     row_is_valid: cutlass.Boolean,
-    cfg: cutlass.Constexpr[_PreparedRouteConfig],
+    cfg: cutlass.Constexpr[_RouteConfig],
 ) -> tuple[cutlass.Int32, cutlass.Int32, cutlass.Int32]:
     """Resolve one trusted canonical runtime BSR row."""
 
@@ -259,8 +248,8 @@ def _resolve_prepared_bsr_row(
     row_end = cutlass.Int32(0)
     batch_idx = cutlass.Int32(0)
     if lane_idx == cutlass.Int32(0) and row_is_valid:
-        q_block_row_idx = linear_row_idx % cfg.num_q_block_rows
-        linear_batch_head_idx = linear_row_idx // cfg.num_q_block_rows
+        q_block_row_idx = linear_row_idx % cfg.num_q_blocks
+        linear_batch_head_idx = linear_row_idx // cfg.num_q_blocks
         kv_head_idx = linear_batch_head_idx % cfg.num_kv_heads
         batch_idx = linear_batch_head_idx // cfg.num_kv_heads
         row_begin = cutlass.Int32(block_indptr[batch_idx, kv_head_idx, q_block_row_idx])
@@ -297,153 +286,60 @@ def _resolve_prepared_bsr_row(
 
 
 @cute.jit
-def _publish_prepared_route_count(
-    block_indices: cute.Tensor,
-    row_route_offsets: cute.Tensor,
+def _finalize_exact_route(
     route_workspace: cute.Tensor,
-    row_begin: cutlass.Int32,
-    row_end: cutlass.Int32,
-    linear_row_idx: cutlass.Int32,
-    lane_idx: cutlass.Int32,
-    row_is_valid: cutlass.Boolean,
-    max_blocks_per_row: cutlass.Int32,
-    seq_len_kv: cutlass.Int32,
-    cfg: cutlass.Constexpr[_PreparedRouteConfig],
-) -> tuple[cutlass.Int32, cutlass.Int32]:
-    """Assert semantic capacity, publish the header, and return its live span."""
-
-    row_route_begin = cutlass.Int32(0)
-    required_route_count = cutlass.Int32(0)
-    if lane_idx == cutlass.Int32(0) and row_is_valid:
-        row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
-        selected_block_count = row_end - row_begin
-        runtime_assert(
-            selected_block_count <= max_blocks_per_row,
-            "selected BSR blocks exceed planned semantic capacity",
-        )
-        retained_atom_count = _retained_atom_count(
-            block_indices,
-            row_begin,
-            row_end,
-            cfg.kv_block_size,
-            cfg.atom_size,
-            seq_len_kv,
-        )
-        required_route_count = (
-            retained_atom_count + cutlass.Int32(cfg.logical_origins_per_route - 1)
-        ) // cutlass.Int32(cfg.logical_origins_per_route)
-        route_workspace[linear_row_idx] = required_route_count
-    row_route_begin = _warp_broadcast_i32(row_route_begin, 0)
-    required_route_count = _warp_broadcast_i32(required_route_count, 0)
-    return required_route_count, row_route_begin
-
-
-@cute.jit
-def _store_prepared_route_validity(
-    block_indices: cute.Tensor,
     kv_valid_bits: cute.Tensor,
-    route_workspace: cute.Tensor,
-    row_begin: cutlass.Int32,
-    row_end: cutlass.Int32,
-    route_idx: cutlass.Int32,
+    route_metadata_word_index: cutlass.Int32,
     batch_idx: cutlass.Int32,
     lane_idx: cutlass.Int32,
-    logical_origin: cutlass.Int32,
-    logical_origin_is_valid: cutlass.Boolean,
-    stored_atom_is_full: cutlass.Boolean,
-    route_metadata_word_index: cutlass.Int32,
+    atom_is_valid: cutlass.Boolean,
     seq_len_kv: cutlass.Int32,
-    cfg: cutlass.Constexpr[_PreparedRouteConfig],
+    cfg: cutlass.Constexpr[_RouteConfig],
 ) -> None:
-    """Store storage-independent atom, token, and route validity metadata."""
+    """Finalize an exact record after its logical origins are stored."""
 
-    stored_atom_valid_mask = cutlass.Int32(
-        cute.arch.vote_ballot_sync(logical_origin_is_valid)
-    )
-    structural_route_is_full = cute.arch.vote_all_sync(
-        lane_idx >= cutlass.Int32(cfg.logical_origins_per_route) or stored_atom_is_full
-    )
-    route_is_full = structural_route_is_full
-    if cutlass.const_expr(cfg.has_token_bits):
-        token_word = cutlass.Uint32(0)
-        if cutlass.const_expr(cfg.atom_size <= 32):
-            token_chunk = _load_atom_token_chunk(
-                kv_valid_bits,
-                batch_idx,
-                logical_origin,
-                logical_origin_is_valid,
-                cfg.atom_size,
-                seq_len_kv,
-            )
-            atoms_per_word = 32 // cfg.atom_size
-            if lane_idx < cutlass.Int32(cfg.logical_origins_per_route):
-                atom_in_word = lane_idx % cutlass.Int32(atoms_per_word)
-                token_word = token_chunk << (
-                    atom_in_word * cutlass.Int32(cfg.atom_size)
-                )
-                active_origin_lanes = (1 << cfg.logical_origins_per_route) - 1
-                for shuffle_step in cutlass.range_constexpr(
-                    int(math.log2(atoms_per_word))
-                ):
-                    peer_word = cutlass.Uint32(
-                        prims.shfl_sync(
-                            thread_mask=active_origin_lanes,
-                            val=token_word,
-                            offset=1 << shuffle_step,
-                            mask_and_clamp=0x1F,
-                            kind=prims.Shfl.BFLY,
-                        )
-                    )
-                    token_word = token_word | peer_word
-                if atom_in_word == cutlass.Int32(0):
-                    logical_word_idx = lane_idx // cutlass.Int32(atoms_per_word)
-                    route_workspace[
-                        route_metadata_word_index
-                        + cutlass.Int32(cfg.token_words_word_offset)
-                        + logical_word_idx
-                    ] = cutlass.Int32(token_word)
-            full_atom_mask = cutlass.Uint32((1 << cfg.atom_size) - 1)
-            token_route_is_full = cute.arch.vote_all_sync(
-                lane_idx >= cutlass.Int32(cfg.logical_origins_per_route)
-                or token_chunk == full_atom_mask
-            )
-        else:
-            if lane_idx < cutlass.Int32(cfg.token_words_per_route):
-                token_word = _load_coarse_token_word(
-                    block_indices,
-                    kv_valid_bits,
-                    row_begin,
-                    row_end,
-                    route_idx,
-                    lane_idx,
-                    batch_idx,
-                    cfg.kv_block_size,
-                    cfg.atom_size,
-                    cfg.logical_origins_per_route,
-                    seq_len_kv,
-                )
-                route_workspace[
-                    route_metadata_word_index
-                    + cutlass.Int32(cfg.token_words_word_offset)
-                    + lane_idx
-                ] = cutlass.Int32(token_word)
-            token_route_is_full = cute.arch.vote_all_sync(
-                lane_idx >= cutlass.Int32(cfg.token_words_per_route)
-                or token_word == cutlass.Uint32(0xFFFFFFFF)
-            )
-        route_is_full = cutlass.Boolean(
-            structural_route_is_full and token_route_is_full
+    atom_is_full = cutlass.Boolean(False)
+    if lane_idx < cutlass.Int32(cfg.logical_origins_per_route):
+        origin = cutlass.Int32(route_workspace[route_metadata_word_index + lane_idx])
+        atom_is_full = cutlass.Boolean(
+            atom_is_valid and origin <= seq_len_kv - cutlass.Int32(cfg.atom_size)
         )
+    atom_valid_mask = cutlass.Int32(cute.arch.vote_ballot_sync(atom_is_valid))
+    structural_full = cute.arch.vote_all_sync(
+        lane_idx >= cutlass.Int32(cfg.logical_origins_per_route) or atom_is_full
+    )
 
+    score_words_are_full = cutlass.Boolean(True)
+    if cutlass.const_expr(cfg.stores_score_words):
+        score_word = cutlass.Uint32(0)
+        if lane_idx < cutlass.Int32(cfg.token_words_per_route):
+            score_word = _load_exact_score_word(
+                route_workspace,
+                kv_valid_bits,
+                route_metadata_word_index,
+                lane_idx,
+                batch_idx,
+                seq_len_kv,
+                cfg,
+            )
+            route_workspace[
+                route_metadata_word_index
+                + cutlass.Int32(cfg.token_words_word_offset)
+                + lane_idx
+            ] = cutlass.Int32(score_word)
+        score_words_are_full = cute.arch.vote_all_sync(
+            lane_idx >= cutlass.Int32(cfg.token_words_per_route)
+            or score_word == cutlass.Uint32(0xFFFFFFFF)
+        )
     if lane_idx == cutlass.Int32(0):
         route_workspace[
             route_metadata_word_index + cutlass.Int32(cfg.atom_valid_mask_word_offset)
-        ] = stored_atom_valid_mask
+        ] = atom_valid_mask
         route_workspace[
             route_metadata_word_index + cutlass.Int32(cfg.route_flags_word_offset)
         ] = (
             cutlass.Int32(_PREPARED_ROUTE_IS_FULL_FLAG)
-            if route_is_full
+            if structural_full and score_words_are_full
             else cutlass.Int32(0)
         )
 
@@ -475,19 +371,18 @@ def _resolve_paged_route_atom_page_id(
     page_size: cutlass.Constexpr[int],
     num_physical_kv_pages: cutlass.Int64,
 ) -> cutlass.Int32:
-    """Resolve one trusted selected logical atom to its raw physical page ID."""
+    """Resolve one trusted selected logical atom to its physical page ID."""
 
     physical_page_id = cutlass.Int32(-1)
     page_id_is_valid = cutlass.Boolean(True)
     if logical_origin_is_valid:
         logical_page_idx = logical_origin // cutlass.Int32(page_size)
-        candidate_page_id = cutlass.Int32(
+        physical_page_id = cutlass.Int32(
             paged_kv_indices[request_begin + logical_page_idx]
         )
-        physical_page_id = candidate_page_id
         page_id_is_valid = cutlass.Boolean(
-            candidate_page_id >= cutlass.Int32(0)
-            and cutlass.Int64(candidate_page_id) < num_physical_kv_pages
+            physical_page_id >= cutlass.Int32(0)
+            and cutlass.Int64(physical_page_id) < num_physical_kv_pages
         )
     page_ids_are_valid = cute.arch.vote_all_sync(page_id_is_valid)
     if lane_idx == cutlass.Int32(0):
@@ -498,8 +393,158 @@ def _resolve_paged_route_atom_page_id(
     return physical_page_id
 
 
-class _PrepareBlockSparseRoutes:
-    """Prepare contiguous or paged sparse routes for one static geometry."""
+@cute.jit
+def _exact_lane_rank(
+    exact_ballot: cutlass.Uint32,
+    lane_idx: cutlass.Int32,
+    exact_prefix: cutlass.Int32,
+) -> cutlass.Int32:
+    """Return one exact lane's global semantic-block rank."""
+
+    lower_lane_mask = (cutlass.Uint32(1) << lane_idx) - cutlass.Uint32(1)
+    return exact_prefix + cutlass.Int32(cute.arch.popc(exact_ballot & lower_lane_mask))
+
+
+@cute.jit
+def _emit_exact_block_atoms(
+    route_workspace: cute.Tensor,
+    row_route_begin: cutlass.Int32,
+    semantic_block_idx: cutlass.Int32,
+    exact_block_rank: cutlass.Int32,
+    cfg: cutlass.Constexpr[_RouteConfig],
+) -> None:
+    """Expand one bitmask-selected block into fixed row-global atom slots."""
+
+    first_atom_rank = exact_block_rank * cutlass.Int32(cfg.atoms_per_block)
+    atom_in_block = cutlass.Int32(0)
+    while atom_in_block < cutlass.Int32(cfg.atoms_per_block):
+        atom_rank = first_atom_rank + atom_in_block
+        route_idx = atom_rank // cutlass.Int32(cfg.logical_origins_per_route)
+        atom_in_route = atom_rank % cutlass.Int32(cfg.logical_origins_per_route)
+        route_word_index = cutlass.Int32(cfg.route_metadata_base_word_offset) + (
+            (row_route_begin + route_idx)
+            * cutlass.Int32(cfg.route_metadata_stride_words)
+        )
+        logical_origin = semantic_block_idx * cutlass.Int32(
+            cfg.kv_block_size
+        ) + atom_in_block * cutlass.Int32(cfg.atom_size)
+        stored_origin = cutlass.Int32(-1)
+        if logical_origin < cutlass.Int32(cfg.seq_len_kv):
+            stored_origin = logical_origin
+        route_workspace[route_word_index + atom_in_route] = stored_origin
+        atom_in_block += cutlass.Int32(1)
+
+
+@cute.jit
+def _load_bitmask_word(
+    exact_block_bits: cute.Tensor,
+    batch_idx: cutlass.Int32,
+    kv_head_idx: cutlass.Int32,
+    q_block_idx: cutlass.Int32,
+    logical_word_idx: cutlass.Int32,
+    cfg: cutlass.Constexpr[_RouteConfig],
+    for_proxy: cutlass.Constexpr[bool],
+) -> cutlass.Uint32:
+    """Load one in-range exact or proxy semantic-block word."""
+
+    valid_word = _low_bits_mask(
+        cutlass.Int32(cfg.num_kv_blocks) - logical_word_idx * cutlass.Int32(_WARP_SIZE)
+    )
+    selected_word = cutlass.Uint32(
+        exact_block_bits[batch_idx, kv_head_idx, q_block_idx, logical_word_idx]
+    )
+    if cutlass.const_expr(for_proxy):
+        selected_word = ~selected_word
+    return valid_word & selected_word
+
+
+@cute.jit
+def _load_bsr_proxy_word(
+    block_indices: cute.Tensor,
+    row_begin: cutlass.Int32,
+    row_end: cutlass.Int32,
+    logical_word_idx: cutlass.Int32,
+    cfg: cutlass.Constexpr[_RouteConfig],
+) -> cutlass.Uint32:
+    """Build one proxy word from a canonical sorted-BSR interval."""
+
+    word_begin = logical_word_idx * cutlass.Int32(_WARP_SIZE)
+    valid_word = _low_bits_mask(cutlass.Int32(cfg.num_kv_blocks) - word_begin)
+    selected_word = cutlass.Uint32(0)
+    lower = row_begin
+    upper = row_end
+    while lower < upper:
+        middle = lower + (upper - lower) // cutlass.Int32(2)
+        if cutlass.Int32(block_indices[middle]) < word_begin:
+            lower = middle + cutlass.Int32(1)
+        else:
+            upper = middle
+    cursor = lower
+    word_end = word_begin + cutlass.Int32(_WARP_SIZE)
+    scanning = cutlass.Boolean(True)
+    while cursor < row_end and scanning:
+        block_idx = cutlass.Int32(block_indices[cursor])
+        if block_idx < word_end:
+            selected_word = selected_word | (
+                cutlass.Uint32(1) << (block_idx - word_begin)
+            )
+            cursor += cutlass.Int32(1)
+        else:
+            scanning = cutlass.Boolean(False)
+    return valid_word & ~selected_word
+
+
+@cute.jit
+def _emit_proxy_route(
+    route_workspace: cute.Tensor,
+    route_metadata_word_index: cutlass.Int32,
+    group_idx: cutlass.Int32,
+    proxy_word: cutlass.Uint32,
+    lane_idx: cutlass.Int32,
+    cfg: cutlass.Constexpr[_RouteConfig],
+) -> None:
+    """Emit one fixed summary-group proxy record, including an empty mask."""
+
+    group_start = group_idx * cutlass.Int32(cfg.token_words_per_route * _WARP_SIZE)
+    group_size = cutlass.Int32(cfg.num_kv_blocks) - group_start
+    if group_size > cutlass.Int32(cfg.token_words_per_route * _WARP_SIZE):
+        group_size = cutlass.Int32(cfg.token_words_per_route * _WARP_SIZE)
+    origin_is_valid = cutlass.Boolean(False)
+    if lane_idx < cutlass.Int32(cfg.logical_origins_per_route):
+        summary_origin = group_start + lane_idx * cutlass.Int32(cfg.atom_size)
+        origin_is_valid = cutlass.Boolean(summary_origin < cfg.num_kv_blocks)
+        stored_origin = cutlass.Int32(-1)
+        if origin_is_valid:
+            stored_origin = summary_origin
+        route_workspace[route_metadata_word_index + lane_idx] = stored_origin
+    atom_valid_mask = cutlass.Int32(cute.arch.vote_ballot_sync(origin_is_valid))
+    if lane_idx < cutlass.Int32(cfg.token_words_per_route):
+        route_workspace[
+            route_metadata_word_index
+            + cutlass.Int32(cfg.token_words_word_offset)
+            + lane_idx
+        ] = cutlass.Int32(proxy_word)
+    score_full = cute.arch.vote_all_sync(
+        lane_idx >= cutlass.Int32(cfg.token_words_per_route)
+        or proxy_word == cutlass.Uint32(0xFFFFFFFF)
+    )
+    if lane_idx == cutlass.Int32(0):
+        route_workspace[
+            route_metadata_word_index + cutlass.Int32(cfg.atom_valid_mask_word_offset)
+        ] = atom_valid_mask
+        proxy_is_full = cutlass.Boolean(
+            group_size == cutlass.Int32(cfg.token_words_per_route * _WARP_SIZE)
+            and score_full
+        )
+        route_workspace[
+            route_metadata_word_index + cutlass.Int32(cfg.route_flags_word_offset)
+        ] = cutlass.Int32(_PREPARED_ROUTE_IS_PROXY_FLAG) | (
+            cutlass.Int32(proxy_is_full) * cutlass.Int32(_PREPARED_ROUTE_IS_FULL_FLAG)
+        )
+
+
+class _PrepareRoutesBase:
+    """Own shared route geometry and compile-time storage/policy flags."""
 
     def __init__(
         self,
@@ -511,37 +556,52 @@ class _PrepareBlockSparseRoutes:
         q_block_size: int,
         kv_block_size: int,
         kv_route_size: int,
-        has_token_bits: bool,
+        use_proxy_routes: bool,
+        use_causal_mask: bool = False,
+        apply_token_mask: bool = False,
         page_size: int | None = None,
-        mask_type: str,
     ) -> None:
-        if mask_type not in ("dense", "causal"):
-            raise ValueError(f"unsupported mask_type: {mask_type}")
-        num_q_block_rows = (seq_len_q + q_block_size - 1) // q_block_size
-        num_rows = batch_size * num_kv_heads * num_q_block_rows
+        if not isinstance(use_proxy_routes, bool):
+            raise TypeError("use_proxy_routes must be a bool")
+        if not isinstance(apply_token_mask, bool):
+            raise TypeError("apply_token_mask must be a bool")
+        if not isinstance(use_causal_mask, bool):
+            raise TypeError("use_causal_mask must be a bool")
+        if use_proxy_routes and page_size is not None:
+            raise ValueError("paged KV does not support proxy routes")
+
+        num_q_blocks = (seq_len_q + q_block_size - 1) // q_block_size
+        num_rows = batch_size * num_kv_heads * num_q_blocks
+        stores_score_words = use_proxy_routes or apply_token_mask
         layout = _BlockSparseRouteLayout.create(
             kv_route_size=kv_route_size,
             kv_block_size=kv_block_size,
             page_size=page_size,
-            has_token_bits=has_token_bits,
+            has_token_bits=stores_score_words,
             route_metadata_capacity=0,
             num_rows=num_rows,
         )
-        self.cfg = _PreparedRouteConfig.create(
+        self.route_layout = layout
+        self.cfg = _RouteConfig.create(
             layout=layout,
             num_kv_heads=num_kv_heads,
             seq_len_q=seq_len_q,
             seq_len_kv=seq_len_kv,
             q_block_size=q_block_size,
             kv_block_size=kv_block_size,
+            apply_token_mask=apply_token_mask,
+            use_proxy_routes=use_proxy_routes,
         )
-        self.route_layout = layout
         self.page_size = page_size if page_size is not None else 1
-        self.minimum_seq_len_kv = seq_len_q if mask_type == "causal" else 1
+        self.minimum_seq_len_kv = seq_len_q if use_causal_mask else 1
         self.physical_page_ids_word_offset = (
             layout.physical_page_ids_word_offset if layout.is_paged else 0
         )
         self.route_metadata_base_word_offset = layout.route_metadata_base_word_offset
+
+
+class _PrepareBsrRoutes(_PrepareRoutesBase):
+    """Prepare continuous exact/proxy or paged exact routes from one BSR flow."""
 
     @cute.jit
     def __call__(
@@ -558,7 +618,7 @@ class _PrepareBlockSparseRoutes:
         max_blocks_per_row: cutlass.Int32,
         stream: cuda_drv.CUstream,
     ) -> None:
-        """Launch four independent row preparers per CTA."""
+        """Launch four independent BSR row preparers per CTA."""
 
         self.kernel(
             block_indptr,
@@ -595,7 +655,7 @@ class _PrepareBlockSparseRoutes:
         route_workspace: cute.Tensor,
         max_blocks_per_row: cutlass.Int32,
     ) -> None:
-        """Pack logical routes and, when paged, translate physical locators."""
+        """Assert trusted inputs, emit routes, resolve storage, then publish."""
 
         thread_idx, _, _ = cute.arch.thread_idx()
         block_idx, _, _ = cute.arch.block_idx()
@@ -615,6 +675,7 @@ class _PrepareBlockSparseRoutes:
 
         request_begin = cutlass.Int32(0)
         live_seq_len_kv = cutlass.Int32(self.cfg.seq_len_kv)
+        selected_block_count = row_end - row_begin
         if cutlass.const_expr(self.route_layout.is_paged):
             raw_seq_len_kv = cutlass.Int32(self.cfg.seq_len_kv)
             if lane_idx == cutlass.Int32(0) and row_is_valid:
@@ -624,8 +685,21 @@ class _PrepareBlockSparseRoutes:
                     and raw_seq_len_kv <= cutlass.Int32(self.cfg.seq_len_kv),
                     "seq_lens_kv is outside the planned live-length range",
                 )
-            raw_seq_len_kv = _warp_broadcast_i32(raw_seq_len_kv, 0)
-            live_seq_len_kv = raw_seq_len_kv
+            live_seq_len_kv = _warp_broadcast_i32(raw_seq_len_kv, 0)
+
+            if (
+                lane_idx == cutlass.Int32(0)
+                and row_is_valid
+                and selected_block_count > cutlass.Int32(0)
+            ):
+                last_block_idx = cutlass.Int32(
+                    block_indices[row_end - cutlass.Int32(1)]
+                )
+                runtime_assert(
+                    last_block_idx * cutlass.Int32(self.cfg.kv_block_size)
+                    < live_seq_len_kv,
+                    "block_indices row exceeds the live KV block range",
+                )
 
             if lane_idx == cutlass.Int32(0) and row_is_valid:
                 required_pages = _positive_i32_ceil_div(
@@ -651,83 +725,365 @@ class _PrepareBlockSparseRoutes:
                 )
             request_begin = _warp_broadcast_i32(request_begin, 0)
 
-        route_count, row_route_begin = _publish_prepared_route_count(
-            block_indices,
-            row_route_offsets,
-            route_workspace,
-            row_begin,
-            row_end,
-            linear_row_idx,
-            lane_idx,
-            row_is_valid,
-            max_blocks_per_row,
-            live_seq_len_kv,
-            self.cfg,
+        exact_atom_count = selected_block_count * cutlass.Int32(
+            self.cfg.atoms_per_block
+        )
+        exact_route_count = (
+            exact_atom_count + cutlass.Int32(self.cfg.logical_origins_per_route - 1)
+        ) // cutlass.Int32(self.cfg.logical_origins_per_route)
+
+        total_route_count = exact_route_count
+        if cutlass.const_expr(self.cfg.use_proxy_routes):
+            total_route_count += cutlass.Int32(self.cfg.num_proxy_groups)
+
+        row_route_begin = cutlass.Int32(0)
+        if lane_idx == cutlass.Int32(0) and row_is_valid:
+            row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
+            row_route_end = cutlass.Int32(row_route_offsets[linear_row_idx + 1])
+            row_capacity = row_route_end - row_route_begin
+            runtime_assert(
+                selected_block_count <= max_blocks_per_row,
+                "selected BSR blocks exceed planned semantic capacity",
+            )
+            runtime_assert(
+                row_route_begin >= cutlass.Int32(0)
+                and row_capacity >= cutlass.Int32(0)
+                and total_route_count <= row_capacity,
+                "prepared routes exceed planned row capacity",
+            )
+        row_route_begin = _warp_broadcast_i32(row_route_begin, 0)
+
+        if row_is_valid:
+            route_idx = cutlass.Int32(0)
+            while route_idx < exact_route_count:
+                route_word_index = cutlass.Int32(
+                    self.cfg.route_metadata_base_word_offset
+                ) + (row_route_begin + route_idx) * cutlass.Int32(
+                    self.cfg.route_metadata_stride_words
+                )
+                logical_origin = cutlass.Int32(-1)
+                logical_origin_is_valid = cutlass.Boolean(False)
+                physical_page_id = cutlass.Int32(-1)
+                if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
+                    (
+                        logical_origin,
+                        logical_origin_is_valid,
+                    ) = _resolve_route_logical_atom_origin(
+                        block_indices,
+                        row_begin,
+                        row_end,
+                        route_idx,
+                        lane_idx,
+                        self.cfg.kv_block_size,
+                        self.cfg.atom_size,
+                        self.cfg.logical_origins_per_route,
+                        live_seq_len_kv,
+                    )
+                if cutlass.const_expr(self.route_layout.is_paged):
+                    physical_page_id = _resolve_paged_route_atom_page_id(
+                        paged_kv_indices,
+                        request_begin,
+                        logical_origin,
+                        logical_origin_is_valid,
+                        lane_idx,
+                        self.page_size,
+                        num_physical_kv_pages,
+                    )
+                if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
+                    route_workspace[route_word_index + lane_idx] = logical_origin
+                    if cutlass.const_expr(self.route_layout.is_paged):
+                        route_workspace[
+                            route_word_index
+                            + cutlass.Int32(self.physical_page_ids_word_offset)
+                            + lane_idx
+                        ] = physical_page_id
+                cute.arch.sync_warp()
+
+                _finalize_exact_route(
+                    route_workspace,
+                    kv_valid_bits,
+                    route_word_index,
+                    batch_idx,
+                    lane_idx,
+                    logical_origin_is_valid,
+                    live_seq_len_kv,
+                    self.cfg,
+                )
+                route_idx += cutlass.Int32(1)
+
+            if cutlass.const_expr(self.cfg.use_proxy_routes):
+                group_idx = cutlass.Int32(0)
+                while group_idx < cutlass.Int32(self.cfg.num_proxy_groups):
+                    proxy_word = cutlass.Uint32(0)
+                    logical_word_idx = (
+                        group_idx * cutlass.Int32(self.cfg.token_words_per_route)
+                        + lane_idx
+                    )
+                    if lane_idx < cutlass.Int32(self.cfg.token_words_per_route):
+                        if logical_word_idx < cutlass.Int32(self.cfg.num_exact_words):
+                            proxy_word = _load_bsr_proxy_word(
+                                block_indices,
+                                row_begin,
+                                row_end,
+                                logical_word_idx,
+                                self.cfg,
+                            )
+                    route_word_index = cutlass.Int32(
+                        self.cfg.route_metadata_base_word_offset
+                    ) + (
+                        row_route_begin + exact_route_count + group_idx
+                    ) * cutlass.Int32(self.cfg.route_metadata_stride_words)
+                    _emit_proxy_route(
+                        route_workspace,
+                        route_word_index,
+                        group_idx,
+                        proxy_word,
+                        lane_idx,
+                        self.cfg,
+                    )
+                    group_idx += cutlass.Int32(1)
+
+        if lane_idx == cutlass.Int32(0) and row_is_valid:
+            route_workspace[linear_row_idx] = total_route_count
+
+
+class _PrepareBitmaskRoutes(_PrepareRoutesBase):
+    """Lower packed exact-block bits to continuous exact-first routes."""
+
+    def __init__(
+        self,
+        *,
+        batch_size: int,
+        num_kv_heads: int,
+        seq_len_q: int,
+        seq_len_kv: int,
+        q_block_size: int,
+        kv_block_size: int,
+        kv_route_size: int,
+        use_proxy_routes: bool,
+        use_causal_mask: bool = False,
+        apply_token_mask: bool = False,
+    ) -> None:
+        super().__init__(
+            batch_size=batch_size,
+            num_kv_heads=num_kv_heads,
+            seq_len_q=seq_len_q,
+            seq_len_kv=seq_len_kv,
+            q_block_size=q_block_size,
+            kv_block_size=kv_block_size,
+            kv_route_size=kv_route_size,
+            use_proxy_routes=use_proxy_routes,
+            use_causal_mask=use_causal_mask,
+            apply_token_mask=apply_token_mask,
         )
 
-        route_idx = cutlass.Int32(0)
-        while route_idx < route_count:
-            route_ordinal = row_route_begin + route_idx
-            route_metadata_word_index = cutlass.Int32(
-                self.cfg.route_metadata_base_word_offset
-            ) + route_ordinal * cutlass.Int32(self.cfg.route_metadata_stride_words)
-            logical_origin = cutlass.Int32(-1)
-            logical_origin_is_valid = cutlass.Boolean(False)
-            physical_page_id = cutlass.Int32(-1)
-            atom_is_full = cutlass.Boolean(False)
-            if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
-                (
-                    logical_origin,
-                    logical_origin_is_valid,
-                ) = _resolve_route_logical_atom_origin(
-                    block_indices,
-                    row_begin,
-                    row_end,
-                    route_idx,
-                    lane_idx,
-                    self.cfg.kv_block_size,
-                    self.cfg.atom_size,
-                    self.cfg.logical_origins_per_route,
-                    live_seq_len_kv,
-                )
-            if cutlass.const_expr(self.route_layout.is_paged):
-                physical_page_id = _resolve_paged_route_atom_page_id(
-                    paged_kv_indices,
-                    request_begin,
-                    logical_origin,
-                    logical_origin_is_valid,
-                    lane_idx,
-                    self.page_size,
-                    num_physical_kv_pages,
-                )
-            if logical_origin_is_valid:
-                atom_is_full = cutlass.Boolean(
-                    logical_origin
-                    <= live_seq_len_kv - cutlass.Int32(self.cfg.atom_size)
-                )
-            if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
-                route_workspace[route_metadata_word_index + lane_idx] = logical_origin
-                if cutlass.const_expr(self.route_layout.is_paged):
-                    route_workspace[
-                        route_metadata_word_index
-                        + cutlass.Int32(self.physical_page_ids_word_offset)
-                        + lane_idx
-                    ] = physical_page_id
+    @cute.jit
+    def __call__(
+        self,
+        exact_block_bits: cute.Tensor,
+        kv_valid_bits: cute.Tensor,
+        row_route_offsets: cute.Tensor,
+        route_workspace: cute.Tensor,
+        max_blocks_per_row: cutlass.Int32,
+        stream: cuda_drv.CUstream,
+    ) -> None:
+        self.kernel(
+            exact_block_bits,
+            kv_valid_bits,
+            row_route_offsets,
+            route_workspace,
+            max_blocks_per_row,
+        ).launch(
+            grid=[
+                (self.cfg.num_rows + _WARPS_PER_CTA - 1) // _WARPS_PER_CTA,
+                1,
+                1,
+            ],
+            block=[_THREADS_PER_CTA, 1, 1],
+            stream=stream,
+        )
 
-            _store_prepared_route_validity(
-                block_indices,
-                kv_valid_bits,
-                route_workspace,
-                row_begin,
-                row_end,
-                route_idx,
-                batch_idx,
-                lane_idx,
-                logical_origin,
-                logical_origin_is_valid,
-                atom_is_full,
-                route_metadata_word_index,
-                live_seq_len_kv,
-                self.cfg,
+    @cute.kernel
+    def kernel(
+        self,
+        exact_block_bits: cute.Tensor,
+        kv_valid_bits: cute.Tensor,
+        row_route_offsets: cute.Tensor,
+        route_workspace: cute.Tensor,
+        max_blocks_per_row: cutlass.Int32,
+    ) -> None:
+        """Pack one bitmask row after proving its complete payload fits."""
+
+        thread_idx, _, _ = cute.arch.thread_idx()
+        block_idx, _, _ = cute.arch.block_idx()
+        warp_idx = thread_idx // _WARP_SIZE
+        lane_idx = thread_idx % _WARP_SIZE
+        linear_row_idx = block_idx * _WARPS_PER_CTA + warp_idx
+        row_is_valid = linear_row_idx < self.cfg.num_rows
+        q_block_idx = linear_row_idx % self.cfg.num_q_blocks
+        linear_batch_head_idx = linear_row_idx // self.cfg.num_q_blocks
+        kv_head_idx = linear_batch_head_idx % self.cfg.num_kv_heads
+        batch_idx = linear_batch_head_idx // self.cfg.num_kv_heads
+
+        lane_exact_count = cutlass.Int32(0)
+        word_idx = lane_idx
+        while word_idx < cutlass.Int32(self.cfg.num_exact_words):
+            if row_is_valid:
+                exact_word = _load_bitmask_word(
+                    exact_block_bits,
+                    batch_idx,
+                    kv_head_idx,
+                    q_block_idx,
+                    word_idx,
+                    self.cfg,
+                    for_proxy=False,
+                )
+                lane_exact_count += cutlass.Int32(cute.arch.popc(exact_word))
+            word_idx += cutlass.Int32(_WARP_SIZE)
+        exact_block_count = cutlass.Int32(
+            cute.arch.warp_redux_sync(lane_exact_count, "add")
+        )
+
+        exact_atom_count = exact_block_count * cutlass.Int32(self.cfg.atoms_per_block)
+        exact_route_count = (
+            exact_atom_count + cutlass.Int32(self.cfg.logical_origins_per_route - 1)
+        ) // cutlass.Int32(self.cfg.logical_origins_per_route)
+
+        total_route_count = exact_route_count
+        if cutlass.const_expr(self.cfg.use_proxy_routes):
+            total_route_count += cutlass.Int32(self.cfg.num_proxy_groups)
+
+        row_route_begin = cutlass.Int32(0)
+        if lane_idx == cutlass.Int32(0) and row_is_valid:
+            row_route_begin = cutlass.Int32(row_route_offsets[linear_row_idx])
+            row_route_end = cutlass.Int32(row_route_offsets[linear_row_idx + 1])
+            row_capacity = row_route_end - row_route_begin
+            runtime_assert(
+                exact_block_count <= max_blocks_per_row,
+                "selected bitmask blocks exceed planned semantic capacity",
             )
-            route_idx = route_idx + cutlass.Int32(1)
+            runtime_assert(
+                row_route_begin >= cutlass.Int32(0)
+                and row_capacity >= cutlass.Int32(0)
+                and total_route_count <= row_capacity,
+                "prepared routes exceed planned row capacity",
+            )
+        row_route_begin = _warp_broadcast_i32(row_route_begin, 0)
+
+        if row_is_valid:
+            exact_prefix = cutlass.Int32(0)
+            word_idx = cutlass.Int32(0)
+            while word_idx < cutlass.Int32(self.cfg.num_exact_words):
+                exact_word_i32 = cutlass.Int32(0)
+                if lane_idx == cutlass.Int32(0):
+                    exact_word_i32 = _load_bitmask_word(
+                        exact_block_bits,
+                        batch_idx,
+                        kv_head_idx,
+                        q_block_idx,
+                        word_idx,
+                        self.cfg,
+                        for_proxy=False,
+                    ).bitcast(cutlass.Int32)
+                exact_word = _warp_broadcast_i32(exact_word_i32, 0).bitcast(
+                    cutlass.Uint32
+                )
+                is_exact = cutlass.Boolean(
+                    (exact_word & (cutlass.Uint32(1) << lane_idx)) != cutlass.Uint32(0)
+                )
+                exact_ballot = cute.arch.vote_ballot_sync(is_exact).bitcast(
+                    cutlass.Uint32
+                )
+                exact_rank = _exact_lane_rank(exact_ballot, lane_idx, exact_prefix)
+                if is_exact:
+                    _emit_exact_block_atoms(
+                        route_workspace,
+                        row_route_begin,
+                        word_idx * cutlass.Int32(_WARP_SIZE) + lane_idx,
+                        exact_rank,
+                        self.cfg,
+                    )
+                exact_prefix += cutlass.Int32(cute.arch.popc(exact_ballot))
+                word_idx += cutlass.Int32(1)
+
+            final_route_atom_count = exact_atom_count % cutlass.Int32(
+                self.cfg.logical_origins_per_route
+            )
+            if final_route_atom_count != cutlass.Int32(0):
+                if lane_idx >= final_route_atom_count and lane_idx < cutlass.Int32(
+                    self.cfg.logical_origins_per_route
+                ):
+                    final_route_word_index = cutlass.Int32(
+                        self.cfg.route_metadata_base_word_offset
+                    ) + (row_route_begin + exact_route_count - cutlass.Int32(1)) * (
+                        cutlass.Int32(self.cfg.route_metadata_stride_words)
+                    )
+                    route_workspace[final_route_word_index + lane_idx] = cutlass.Int32(
+                        -1
+                    )
+            cute.arch.sync_warp()
+
+            route_idx = cutlass.Int32(0)
+            while route_idx < exact_route_count:
+                route_word_index = cutlass.Int32(
+                    self.cfg.route_metadata_base_word_offset
+                ) + (row_route_begin + route_idx) * cutlass.Int32(
+                    self.cfg.route_metadata_stride_words
+                )
+                atom_is_valid = cutlass.Boolean(False)
+                if lane_idx < cutlass.Int32(self.cfg.logical_origins_per_route):
+                    atom_is_valid = cutlass.Boolean(
+                        cutlass.Int32(route_workspace[route_word_index + lane_idx])
+                        >= cutlass.Int32(0)
+                    )
+                _finalize_exact_route(
+                    route_workspace,
+                    kv_valid_bits,
+                    route_word_index,
+                    batch_idx,
+                    lane_idx,
+                    atom_is_valid,
+                    cutlass.Int32(self.cfg.seq_len_kv),
+                    self.cfg,
+                )
+                route_idx += cutlass.Int32(1)
+
+            if cutlass.const_expr(self.cfg.use_proxy_routes):
+                group_idx = cutlass.Int32(0)
+                while group_idx < cutlass.Int32(self.cfg.num_proxy_groups):
+                    proxy_word = cutlass.Uint32(0)
+                    logical_word_idx = (
+                        group_idx * cutlass.Int32(self.cfg.token_words_per_route)
+                        + lane_idx
+                    )
+                    if lane_idx < cutlass.Int32(self.cfg.token_words_per_route):
+                        if logical_word_idx < cutlass.Int32(self.cfg.num_exact_words):
+                            proxy_word = _load_bitmask_word(
+                                exact_block_bits,
+                                batch_idx,
+                                kv_head_idx,
+                                q_block_idx,
+                                logical_word_idx,
+                                self.cfg,
+                                for_proxy=True,
+                            )
+                    route_word_index = cutlass.Int32(
+                        self.cfg.route_metadata_base_word_offset
+                    ) + (
+                        row_route_begin + exact_route_count + group_idx
+                    ) * cutlass.Int32(self.cfg.route_metadata_stride_words)
+                    _emit_proxy_route(
+                        route_workspace,
+                        route_word_index,
+                        group_idx,
+                        proxy_word,
+                        lane_idx,
+                        self.cfg,
+                    )
+                    group_idx += cutlass.Int32(1)
+
+        if lane_idx == cutlass.Int32(0) and row_is_valid:
+            route_workspace[linear_row_idx] = total_route_count
+
+
+__all__ = ["_PrepareBitmaskRoutes", "_PrepareBsrRoutes"]

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -505,6 +505,10 @@ class FmhaDecodeConfig:
     # restricted to 8/16/32 or positive multiples of 64 and are assembled into
     # a profile-selected fixed KV128 or KV256 route.
     use_block_sparse: bool = False
+    # Interpret prepared records as a typed proxy/exact stream. Proxy records
+    # source semantic-block summaries while exact records retain the K/V
+    # atom path. Source selection is orthogonal to the physical Q/KV profile.
+    use_block_sparse_proxy_routes: bool = False
     q_block_size: int = 0
     kv_block_size: int = 0
     # Optional batch-wide physical-token validity metadata shared by every head
@@ -1246,6 +1250,10 @@ class FmhaDecodeConfig:
 
     def validate_block_sparse_profile(self, *, heads_q_per_kv: int) -> None:
         """Validate the qualified host profile for block-sparse."""
+        if self.use_block_sparse_proxy_routes and not self.use_block_sparse:
+            raise ValueError("proxy routes require block-sparse attention")
+        if self.use_block_sparse_proxy_routes and self.mask_type != DENSE:
+            raise ValueError("block-sparse proxy routes require mask_type='dense'")
         if not self.use_block_sparse:
             if self.use_parallel_sparse_kv_loads:
                 raise ValueError(
@@ -1330,6 +1338,27 @@ class FmhaDecodeConfig:
         return tuple(
             (config_field.name, getattr(self, config_field.name))
             for config_field in fields(self)
+        )
+
+    @property
+    def uses_prepared_score_keep_words(self) -> bool:
+        """Whether prepared routes carry BMM1 score-column validity words."""
+
+        return self.use_kv_valid_bits or self.use_block_sparse_proxy_routes
+
+    @property
+    def trusts_prepared_score_words(self) -> bool:
+        """Whether prepared words fully describe dense score-column validity.
+
+        Dense prepared routes have already combined structural tail validity
+        with any caller-provided exact-token bits. Their K32 words therefore
+        apply to exact and proxy sources alike.
+        """
+
+        return (
+            self.use_block_sparse
+            and self.uses_prepared_score_keep_words
+            and self.mask_type == DENSE
         )
 
     @property

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
@@ -3092,91 +3092,48 @@ def fmha_block_sparse_launch(
     seqlens_kv_iter = (
         g_seqlens_kv if cutlass.const_expr(use_variable_seqlens_kv) else null_i32_ptr
     )
-    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
-        decode_gen_kernel(
-            q_desc,
-            k_desc_primary,
-            v_desc_primary,
-            k_desc_atom,
-            v_desc_atom,
-            o_iter,
-            s_k,
-            h_k,
-            Float32(scale_s * log2_e),
-            Float32(1.0),
-            seqlens_kv_iter,
-            null_i32_ptr,
-            null_i32_ptr,
-            o_iter,
-            null_f32_ptr,
-            null_i32_ptr,
-            null_f32_ptr,
-            h_r,
-            tile_sched_params,
-            cfg,
-            seq_len_kv,
-            use_variable_seqlens_kv,
-            False,  # use_native_paged_kv
-            False,  # use_static_native_seqlens_kv
-            null_i32_ptr,  # g_paged_kv_indptr
-            null_i32_ptr,  # g_paged_kv_indices
-            row_route_offsets_iter,
-            row_route_counts_iter,
-            route_metadata_iter,
-            False,  # static_full_split_prefix
-            tma_desc_k_summary=k_desc_summary_primary,
-            tma_desc_v_summary=v_desc_summary_primary,
-            tma_desc_k_summary_atom=k_desc_summary_atom,
-            tma_desc_v_summary_atom=v_desc_summary_atom,
-        ).launch(
-            grid=grid,
-            block=[cfg.threads_per_cta, 1, 1],
-            cluster=[1, 1, 1],
-            stream=stream,
-            # Reuse dense decode's entry-occupancy contract, including the long
-            # KV256 profiles that execute dynamic register reallocation.
-            min_blocks_per_mp=_decode_min_blocks_per_mp(cfg, seq_len_kv),
-            use_pdl=cfg.use_parallel_separate_reduction_pdl,
-        )
-    else:
-        decode_gen_kernel(
-            q_desc,
-            k_desc_primary,
-            v_desc_primary,
-            k_desc_atom,
-            v_desc_atom,
-            o_iter,
-            s_k,
-            h_k,
-            Float32(scale_s * log2_e),
-            Float32(1.0),
-            seqlens_kv_iter,
-            null_i32_ptr,
-            null_i32_ptr,
-            o_iter,
-            null_f32_ptr,
-            null_i32_ptr,
-            null_f32_ptr,
-            h_r,
-            tile_sched_params,
-            cfg,
-            seq_len_kv,
-            use_variable_seqlens_kv,
-            False,  # use_native_paged_kv
-            False,  # use_static_native_seqlens_kv
-            null_i32_ptr,  # g_paged_kv_indptr
-            null_i32_ptr,  # g_paged_kv_indices
-            row_route_offsets_iter,
-            row_route_counts_iter,
-            route_metadata_iter,
-            False,  # static_full_split_prefix
-        ).launch(
-            grid=grid,
-            block=[cfg.threads_per_cta, 1, 1],
-            cluster=[1, 1, 1],
-            stream=stream,
-            # Reuse dense decode's entry-occupancy contract, including the long
-            # KV256 profiles that execute dynamic register reallocation.
-            min_blocks_per_mp=_decode_min_blocks_per_mp(cfg, seq_len_kv),
-            use_pdl=cfg.use_parallel_separate_reduction_pdl,
-        )
+    decode_gen_kernel(
+        q_desc,
+        k_desc_primary,
+        v_desc_primary,
+        k_desc_atom,
+        v_desc_atom,
+        o_iter,
+        s_k,
+        h_k,
+        Float32(scale_s * log2_e),
+        Float32(1.0),
+        seqlens_kv_iter,
+        null_i32_ptr,
+        null_i32_ptr,
+        o_iter,
+        null_f32_ptr,
+        null_i32_ptr,
+        null_f32_ptr,
+        h_r,
+        tile_sched_params,
+        cfg,
+        seq_len_kv,
+        use_variable_seqlens_kv,
+        False,  # use_native_paged_kv
+        False,  # use_static_native_seqlens_kv
+        null_i32_ptr,  # g_paged_kv_indptr
+        null_i32_ptr,  # g_paged_kv_indices
+        row_route_offsets_iter,
+        row_route_counts_iter,
+        route_metadata_iter,
+        False,  # static_full_split_prefix
+        tma_desc_k_summary=k_desc_summary_primary,
+        tma_desc_v_summary=v_desc_summary_primary,
+        tma_desc_k_summary_atom=k_desc_summary_atom,
+        tma_desc_v_summary_atom=v_desc_summary_atom,
+    ).launch(
+        grid=grid,
+        block=[cfg.threads_per_cta, 1, 1],
+        cluster=[1, 1, 1],
+        stream=stream,
+        # Reuse dense decode's entry-occupancy contract, including the long
+        # KV256 profiles that execute dynamic register reallocation.
+        min_blocks_per_mp=_decode_min_blocks_per_mp(cfg, seq_len_kv),
+        use_pdl=cfg.use_parallel_separate_reduction_pdl,
+    )

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
@@ -56,8 +56,8 @@ from cutlass.experimental.task_scheduling.task import Task
 from cutlass.experimental.task_scheduling.task_manager import TaskManager
 
 from ..._block_sparse.common import (
-    _block_sparse_kv_atom_size,
-    _prepared_kv_routes_are_block_aligned,
+    _block_sparse_contiguous_kv_copy_geometry,
+    _block_sparse_proxy_summary_geometry,
 )
 from ..._block_sparse.prepared import _BlockSparseRouteLayout
 from ..tensor_map import (
@@ -113,7 +113,6 @@ from .fmha_decode_tasks import (
     create_softmax0_task,
     create_softmax1_task,
 )
-
 from .reduction import (  # noqa: F401
     decode_gen_separate_reduction_kernel,
     fmha_decode_separate_reduction_launch,
@@ -322,6 +321,10 @@ def _build_decode_gen_schedule(
     tma_desc_v: cutlass.Pointer | None = None,
     tma_desc_k_atom: cutlass.Pointer | None = None,
     tma_desc_v_atom: cutlass.Pointer | None = None,
+    tma_desc_k_summary: cutlass.Pointer | None = None,
+    tma_desc_v_summary: cutlass.Pointer | None = None,
+    tma_desc_k_summary_atom: cutlass.Pointer | None = None,
+    tma_desc_v_summary_atom: cutlass.Pointer | None = None,
     page_idx_kv: cute.Pointer | None = None,
     h_k_idx: Int32 | None = None,
     b_idx: Int32 | None = None,
@@ -399,6 +402,15 @@ def _build_decode_gen_schedule(
                 "tma_desc_k_atom": tma_desc_k_atom,
                 "tma_desc_v_atom": tma_desc_v_atom,
             }
+            if cfg.use_block_sparse_proxy_routes:
+                segment_tensormaps.update(
+                    {
+                        "tma_desc_k_summary": tma_desc_k_summary,
+                        "tma_desc_v_summary": tma_desc_v_summary,
+                        "tma_desc_k_summary_atom": tma_desc_k_summary_atom,
+                        "tma_desc_v_summary_atom": tma_desc_v_summary_atom,
+                    }
+                )
             for name, descriptor in segment_tensormaps.items():
                 if descriptor is None:
                     raise ValueError(
@@ -864,10 +876,12 @@ def _build_decode_gen_schedule(
     sparse_softmax_metadata0 = None
     sparse_softmax_metadata1 = None
     if cfg.use_block_sparse:
+        # This selects the prepared-record storage ABI. Causal consumers still
+        # intersect these column-validity words with each Q row's causal mask.
         prepared_route_layout = _BlockSparseRouteLayout.create(
             kv_route_size=cfg.tile_size_kv,
             kv_block_size=cfg.kv_block_size,
-            has_token_bits=cfg.use_kv_valid_bits,
+            has_token_bits=cfg.uses_prepared_score_keep_words,
             route_metadata_capacity=0,
             num_rows=1,
             page_size=cfg.num_tokens_per_page if cfg.use_paged_kv else None,
@@ -919,6 +933,10 @@ def _build_decode_gen_schedule(
             tma_desc_v=tma_desc_v,
             tma_desc_k_atom=tma_desc_k_atom,
             tma_desc_v_atom=tma_desc_v_atom,
+            tma_desc_k_summary=tma_desc_k_summary,
+            tma_desc_v_summary=tma_desc_v_summary,
+            tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+            tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             sparse_kv_metadata=sparse_kv_metadata0,
             page_offsets_kv=smem_page_offsets,
             seqlens_kv=kv_seqlens,
@@ -938,6 +956,10 @@ def _build_decode_gen_schedule(
             tma_desc_v=tma_desc_v,
             tma_desc_k_atom=tma_desc_k_atom,
             tma_desc_v_atom=tma_desc_v_atom,
+            tma_desc_k_summary=tma_desc_k_summary,
+            tma_desc_v_summary=tma_desc_v_summary,
+            tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+            tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             sparse_kv_metadata=sparse_kv_metadata1,
             page_offsets_kv=smem_page_offsets,
             seqlens_kv=kv_seqlens,
@@ -957,6 +979,10 @@ def _build_decode_gen_schedule(
             tma_desc_v=tma_desc_v,
             tma_desc_k_atom=tma_desc_k_atom,
             tma_desc_v_atom=tma_desc_v_atom,
+            tma_desc_k_summary=tma_desc_k_summary,
+            tma_desc_v_summary=tma_desc_v_summary,
+            tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+            tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             sparse_kv_metadata=sparse_kv_metadata0,
             page_offsets_kv=smem_page_offsets_v or smem_page_offsets,
             seqlens_kv=kv_seqlens,
@@ -976,6 +1002,10 @@ def _build_decode_gen_schedule(
             tma_desc_v=tma_desc_v,
             tma_desc_k_atom=tma_desc_k_atom,
             tma_desc_v_atom=tma_desc_v_atom,
+            tma_desc_k_summary=tma_desc_k_summary,
+            tma_desc_v_summary=tma_desc_v_summary,
+            tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+            tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             sparse_kv_metadata=sparse_kv_metadata1,
             page_offsets_kv=smem_page_offsets_v or smem_page_offsets,
             seqlens_kv=kv_seqlens,
@@ -996,6 +1026,10 @@ def _build_decode_gen_schedule(
             tma_desc_v=tma_desc_v,
             tma_desc_k_atom=tma_desc_k_atom,
             tma_desc_v_atom=tma_desc_v_atom,
+            tma_desc_k_summary=tma_desc_k_summary,
+            tma_desc_v_summary=tma_desc_v_summary,
+            tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+            tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             sparse_kv_metadata0=sparse_kv_metadata0,
             sparse_kv_metadata1=sparse_kv_metadata1,
             page_offsets_kv=smem_page_offsets,
@@ -1692,17 +1726,18 @@ def _build_decode_gen_schedule(
         # KV256 direct-output correction rotates one compact 35,840-byte
         # payload through the shared 192-KiB K/V ring. Split-KV retains the
         # fixed full exchange. Neither path increases the CTA SMEM footprint.
-        smem_allocator.add_alias_group(
-            [
-                smem_kv.get_smem_requirements(),
-                tmem_corr1.get_smem_requirements(),
-            ]
-        )
+        correction_exchange_requirements = tmem_corr1.get_smem_requirements()
+        if correction_exchange_requirements:
+            smem_allocator.add_alias_group(
+                [
+                    smem_kv.get_smem_requirements(),
+                    correction_exchange_requirements,
+                ]
+            )
     smem_allocator.add_tmem_ptr(
         SmemAllocation("fmha_tmem_ptr_i32", dtype=cutlass.Int32, alignment=4)
     )
     smem_allocator.compute_layout()
-
     tmem_allocator = TmemAllocator()
     if cfg.use_keeps_mma_ab:
         if use_one_inst_qkv:
@@ -1826,7 +1861,7 @@ def _build_decode_gen_schedule(
         # Initialize the persistent ring cursor under the same CTA-wide fence
         # and barrier used by other manually managed SMEM control state.
         eager_init_resources.append(smem_kv_reuse_credit)
-    if cfg.tile_size_kv == 256:
+    if cfg.streams_tmem_p_fragments:
         # KV256's TMEM P operands use one-way per-fragment ready barriers.
         # Initialize them beside correction's manually managed SMEM state.
         eager_init_resources.extend([smem_p0, smem_p1])
@@ -1968,6 +2003,10 @@ def _run_decode_gen_active(
     g_sparse_row_route_offsets: cute.Pointer | None = None,
     g_sparse_row_route_counts: cute.Pointer | None = None,
     g_sparse_route_metadata: cute.Pointer | None = None,
+    tma_desc_k_summary: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_v_summary: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_k_summary_atom: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_v_summary_atom: cutlass.GridConstant[cuda.TensorMap] | None = None,
 ) -> None:
     """Run the complete decode body for one runtime-valid Q tile.
 
@@ -2007,28 +2046,43 @@ def _run_decode_gen_active(
         else Int32(cfg.static_seq_len_kv)
     )
     use_clc_dynamic_scheduler = cfg.use_persistent_scheduler
+    tma_desc_k_summary_ptr = None
+    tma_desc_v_summary_ptr = None
+    tma_desc_k_summary_atom_ptr = None
+    tma_desc_v_summary_atom_ptr = None
+    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+        assert tma_desc_k_summary is not None
+        assert tma_desc_v_summary is not None
+        assert tma_desc_k_summary_atom is not None
+        assert tma_desc_v_summary_atom is not None
+        tma_desc_k_summary_ptr = tma_desc_k_summary.get_ptr()
+        tma_desc_v_summary_ptr = tma_desc_v_summary.get_ptr()
+        tma_desc_k_summary_atom_ptr = tma_desc_k_summary_atom.get_ptr()
+        tma_desc_v_summary_atom_ptr = tma_desc_v_summary_atom.get_ptr()
 
     # Prefetch TMA
+    uses_atom_desc = False
+    if cutlass.const_expr(cfg.use_block_sparse):
+        _, _, uses_atom_desc = _block_sparse_contiguous_kv_copy_geometry(
+            kv_block_size=cfg.kv_block_size,
+            kv_route_size=cfg.tile_size_kv,
+        )
     init_warp = 1
     if warp_idx == init_warp:
         prims.prefetch_tensormap(tma_desc_q.get_ptr())
         prims.prefetch_tensormap(tma_desc_k.get_ptr())
         prims.prefetch_tensormap(tma_desc_v.get_ptr())
-        if cutlass.const_expr(
-            cfg.use_block_sparse
-            and _block_sparse_kv_atom_size(cfg.kv_block_size) == 64
-            and (
-                cfg.tile_size_kv == 256
-                or not _prepared_kv_routes_are_block_aligned(
-                    cfg.kv_block_size,
-                    cfg.tile_size_kv,
-                )
-            )
-        ):
-            # KV256 always issues semantic KV64 atoms. KV128 needs this second
-            # descriptor only for non-aligned coarse routes.
+        if cutlass.const_expr(cfg.use_block_sparse and uses_atom_desc):
+            # KV256 and non-aligned coarse KV128 may select the exact atom maps.
             prims.prefetch_tensormap(tma_desc_k_atom.get_ptr())
             prims.prefetch_tensormap(tma_desc_v_atom.get_ptr())
+        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+            if cutlass.const_expr(cfg.tile_size_kv != 256):
+                prims.prefetch_tensormap(tma_desc_k_summary_ptr)
+                prims.prefetch_tensormap(tma_desc_v_summary_ptr)
+            if cutlass.const_expr(uses_atom_desc):
+                prims.prefetch_tensormap(tma_desc_k_summary_atom_ptr)
+                prims.prefetch_tensormap(tma_desc_v_summary_atom_ptr)
     init_warp += 1
 
     clc_response_ptr = None
@@ -2069,6 +2123,10 @@ def _run_decode_gen_active(
         tma_desc_v=tma_desc_v.get_ptr(),
         tma_desc_k_atom=tma_desc_k_atom.get_ptr(),
         tma_desc_v_atom=tma_desc_v_atom.get_ptr(),
+        tma_desc_k_summary=tma_desc_k_summary_ptr,
+        tma_desc_v_summary=tma_desc_v_summary_ptr,
+        tma_desc_k_summary_atom=tma_desc_k_summary_atom_ptr,
+        tma_desc_v_summary_atom=tma_desc_v_summary_atom_ptr,
         page_idx_kv=g_page_idx_kv,
         h_k_idx=h_k_idx,
         b_idx=b_idx,
@@ -2248,6 +2306,10 @@ def _run_decode_gen_runtime_prefix(
     g_sparse_row_route_offsets: cute.Pointer | None,
     g_sparse_row_route_counts: cute.Pointer | None,
     g_sparse_route_metadata: cute.Pointer | None,
+    tma_desc_k_summary: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_v_summary: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_k_summary_atom: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_v_summary_atom: cutlass.GridConstant[cuda.TensorMap] | None = None,
 ) -> None:
     """Run the general runtime split-prefix producer or retire its suffix."""
 
@@ -2311,6 +2373,10 @@ def _run_decode_gen_runtime_prefix(
                 g_sparse_row_route_offsets,
                 g_sparse_row_route_counts,
                 g_sparse_route_metadata,
+                tma_desc_k_summary=tma_desc_k_summary,
+                tma_desc_v_summary=tma_desc_v_summary,
+                tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+                tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             )
         else:
             _run_decode_gen_inactive_cluster_rank()
@@ -2353,6 +2419,10 @@ def _run_decode_gen_runtime_prefix(
                 g_sparse_row_route_offsets,
                 g_sparse_row_route_counts,
                 g_sparse_route_metadata,
+                tma_desc_k_summary=tma_desc_k_summary,
+                tma_desc_v_summary=tma_desc_v_summary,
+                tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+                tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             )
         else:
             _signal_padded_pdl_producer(cfg)
@@ -2390,6 +2460,10 @@ def decode_gen_kernel(
     g_sparse_row_route_counts: cute.Pointer | None = None,
     g_sparse_route_metadata: cute.Pointer | None = None,
     static_full_split_prefix: cutlass.Constexpr[bool] = False,
+    tma_desc_k_summary: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_v_summary: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_k_summary_atom: cutlass.GridConstant[cuda.TensorMap] | None = None,
+    tma_desc_v_summary_atom: cutlass.GridConstant[cuda.TensorMap] | None = None,
 ) -> None:
     """Dispatch one static Q/split tile and drain padded launch slots safely."""
     q_group_cta_idx, h_k_idx, b_idx = cute.arch.block_idx()
@@ -2450,6 +2524,10 @@ def decode_gen_kernel(
                 g_sparse_row_route_offsets,
                 g_sparse_row_route_counts,
                 g_sparse_route_metadata,
+                tma_desc_k_summary=tma_desc_k_summary,
+                tma_desc_v_summary=tma_desc_v_summary,
+                tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+                tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             )
         else:
             _run_decode_gen_runtime_prefix(
@@ -2489,6 +2567,10 @@ def decode_gen_kernel(
                 g_sparse_row_route_offsets,
                 g_sparse_row_route_counts,
                 g_sparse_route_metadata,
+                tma_desc_k_summary=tma_desc_k_summary,
+                tma_desc_v_summary=tma_desc_v_summary,
+                tma_desc_k_summary_atom=tma_desc_k_summary_atom,
+                tma_desc_v_summary_atom=tma_desc_v_summary_atom,
             )
     else:
         # Packed-Q grids use a batch-wide maximum envelope. These Q CTAs own no
@@ -2732,7 +2814,6 @@ def fmha_decode_launch(
         tma_desc_q,
         tma_desc_k,
         tma_desc_v,
-        # Dense/paged profiles never inspect the 64-token descriptor slots.
         tma_desc_k,
         tma_desc_v,
         o_iter,
@@ -2776,6 +2857,8 @@ def fmha_block_sparse_launch(
     q_iter: cute.Pointer,
     k_iter: cute.Pointer,
     v_iter: cute.Pointer,
+    k_summary_iter: cute.Pointer,
+    v_summary_iter: cute.Pointer,
     o_iter: cute.Pointer,
     row_route_offsets_iter: cute.Pointer,
     row_route_counts_iter: cute.Pointer,
@@ -2790,14 +2873,18 @@ def fmha_block_sparse_launch(
     k_page_stride: Int64 = 0,
     v_page_stride: Int64 = 0,
 ) -> None:
-    """Launch attention over contiguous or paged prepared KV routes.
+    """Launch attention over exact and typed exact/proxy prepared KV routes.
 
     A preceding prepare kernel has already resolved each BSR row into compact
     logical atom origins, storage locators, validity flags, and optional token
-    words. Both layouts execute the same ``decode_gen_kernel`` schedule.
+    words. Exact routes address K/V; proxy routes address summary K/V. Both
+    layouts execute the same ``decode_gen_kernel`` schedule and
+    physical copy policy. Exact builds constexpr-elide summary TensorMaps.
     """
     if cutlass.const_expr(not cfg.use_block_sparse):
-        raise ValueError("fmha_block_sparse_launch requires cfg.use_block_sparse=True")
+        raise ValueError("fmha_block_sparse_launch requires block-sparse config")
+    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes and cfg.use_paged_kv):
+        raise ValueError("block-sparse proxy routes require contiguous K/V")
 
     log2_e = math.log2(math.e)
     b, h_q, h_k, s_k, d = problem_shape
@@ -2832,7 +2919,18 @@ def fmha_block_sparse_launch(
         swizzle=tma_swizzle,
     )
 
-    kv_atom_size = _block_sparse_kv_atom_size(cfg.kv_block_size)
+    (
+        primary_kv_box_size,
+        kv_atom_size,
+        uses_atom_desc,
+    ) = _block_sparse_contiguous_kv_copy_geometry(
+        kv_block_size=cfg.kv_block_size,
+        kv_route_size=cfg.tile_size_kv,
+    )
+    k_desc_summary_primary = None
+    v_desc_summary_primary = None
+    k_desc_summary_atom = None
+    v_desc_summary_atom = None
     if cutlass.const_expr(cfg.use_paged_kv):
         # Paged HND storage is addressed as (D, token-in-page, Hkv, page).
         # Prepared routes already contain each atom's physical page ID, so no
@@ -2876,9 +2974,10 @@ def fmha_block_sparse_launch(
         k_desc_primary = k_desc_atom
         v_desc_primary = v_desc_atom
     else:
-        # Contiguous sparse coordinates retain the logical (D, S, H, B)
-        # order and the established primary/atom descriptor split.
-        primary_kv_box_size = 2 * kv_atom_size if kv_atom_size == 64 else kv_atom_size
+        # Exact and summary tensors form one logical segmented KV coordinate
+        # space. Each physical source owns the same primary/atom descriptor
+        # pair; the prepared route kind selects the pair, while the loader
+        # retains the existing KV128/fine/KV256 copy policy.
         kv_dims = (d, s_k, h_k, b)
         k_desc_primary = create_tensor_map_tiled(
             global_address=k_iter.toint(),
@@ -2898,16 +2997,7 @@ def fmha_block_sparse_launch(
         )
         k_desc_atom = k_desc_primary
         v_desc_atom = v_desc_primary
-        if cutlass.const_expr(
-            kv_atom_size == 64
-            and (
-                cfg.tile_size_kv == 256
-                or not _prepared_kv_routes_are_block_aligned(
-                    cfg.kv_block_size,
-                    cfg.tile_size_kv,
-                )
-            )
-        ):
+        if cutlass.const_expr(uses_atom_desc):
             # KV256 always stages four semantic KV64 atoms. KV128 needs this
             # map only when a route may join unrelated BSR entries.
             k_desc_atom = create_tensor_map_tiled(
@@ -2926,6 +3016,55 @@ def fmha_block_sparse_launch(
                 box_dims=(tma_box0, kv_atom_size, 1, 1),
                 swizzle=tma_swizzle,
             )
+
+        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+            num_kv_blocks, _ = _block_sparse_proxy_summary_geometry(
+                seq_len_kv,
+                cfg.kv_block_size,
+            )
+            _, summary_kv_strides = _block_sparse_bshd_tma_strides(
+                q_seq=q_seq,
+                h_q=h_q,
+                h_k=h_k,
+                s_k=num_kv_blocks,
+                d=d,
+            )
+            summary_dims = (d, num_kv_blocks, h_k, b)
+            k_desc_summary_primary = create_tensor_map_tiled(
+                global_address=k_summary_iter.toint(),
+                dtype=cfg.kv_dtype,
+                global_dims=summary_dims,
+                global_strides=summary_kv_strides,
+                box_dims=(tma_box0, primary_kv_box_size, 1, 1),
+                swizzle=tma_swizzle,
+            )
+            v_desc_summary_primary = create_tensor_map_tiled(
+                global_address=v_summary_iter.toint(),
+                dtype=cfg.kv_dtype,
+                global_dims=summary_dims,
+                global_strides=summary_kv_strides,
+                box_dims=(tma_box0, primary_kv_box_size, 1, 1),
+                swizzle=tma_swizzle,
+            )
+            k_desc_summary_atom = k_desc_summary_primary
+            v_desc_summary_atom = v_desc_summary_primary
+            if cutlass.const_expr(uses_atom_desc):
+                k_desc_summary_atom = create_tensor_map_tiled(
+                    global_address=k_summary_iter.toint(),
+                    dtype=cfg.kv_dtype,
+                    global_dims=summary_dims,
+                    global_strides=summary_kv_strides,
+                    box_dims=(tma_box0, kv_atom_size, 1, 1),
+                    swizzle=tma_swizzle,
+                )
+                v_desc_summary_atom = create_tensor_map_tiled(
+                    global_address=v_summary_iter.toint(),
+                    dtype=cfg.kv_dtype,
+                    global_dims=summary_dims,
+                    global_strides=summary_kv_strides,
+                    box_dims=(tma_box0, kv_atom_size, 1, 1),
+                    swizzle=tma_swizzle,
+                )
 
     q_groups = Int32(
         (cfg.max_seq_len_q + cfg.q_tokens_per_cta - 1) // cfg.q_tokens_per_cta
@@ -2953,44 +3092,91 @@ def fmha_block_sparse_launch(
     seqlens_kv_iter = (
         g_seqlens_kv if cutlass.const_expr(use_variable_seqlens_kv) else null_i32_ptr
     )
-    decode_gen_kernel(
-        q_desc,
-        k_desc_primary,
-        v_desc_primary,
-        k_desc_atom,
-        v_desc_atom,
-        o_iter,
-        s_k,
-        h_k,
-        Float32(scale_s * log2_e),
-        Float32(1.0),
-        seqlens_kv_iter,
-        null_i32_ptr,
-        null_i32_ptr,
-        o_iter,
-        null_f32_ptr,
-        null_i32_ptr,
-        null_f32_ptr,
-        h_r,
-        tile_sched_params,
-        cfg,
-        seq_len_kv,
-        use_variable_seqlens_kv,
-        False,  # use_native_paged_kv
-        False,  # use_static_native_seqlens_kv
-        null_i32_ptr,  # g_paged_kv_indptr
-        null_i32_ptr,  # g_paged_kv_indices
-        row_route_offsets_iter,
-        row_route_counts_iter,
-        route_metadata_iter,
-        False,  # static_full_split_prefix
-    ).launch(
-        grid=grid,
-        block=[cfg.threads_per_cta, 1, 1],
-        cluster=[1, 1, 1],
-        stream=stream,
-        # Reuse dense decode's entry-occupancy contract, including the long
-        # KV256 profiles that execute dynamic register reallocation.
-        min_blocks_per_mp=_decode_min_blocks_per_mp(cfg, seq_len_kv),
-        use_pdl=cfg.use_parallel_separate_reduction_pdl,
-    )
+    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+        decode_gen_kernel(
+            q_desc,
+            k_desc_primary,
+            v_desc_primary,
+            k_desc_atom,
+            v_desc_atom,
+            o_iter,
+            s_k,
+            h_k,
+            Float32(scale_s * log2_e),
+            Float32(1.0),
+            seqlens_kv_iter,
+            null_i32_ptr,
+            null_i32_ptr,
+            o_iter,
+            null_f32_ptr,
+            null_i32_ptr,
+            null_f32_ptr,
+            h_r,
+            tile_sched_params,
+            cfg,
+            seq_len_kv,
+            use_variable_seqlens_kv,
+            False,  # use_native_paged_kv
+            False,  # use_static_native_seqlens_kv
+            null_i32_ptr,  # g_paged_kv_indptr
+            null_i32_ptr,  # g_paged_kv_indices
+            row_route_offsets_iter,
+            row_route_counts_iter,
+            route_metadata_iter,
+            False,  # static_full_split_prefix
+            tma_desc_k_summary=k_desc_summary_primary,
+            tma_desc_v_summary=v_desc_summary_primary,
+            tma_desc_k_summary_atom=k_desc_summary_atom,
+            tma_desc_v_summary_atom=v_desc_summary_atom,
+        ).launch(
+            grid=grid,
+            block=[cfg.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+            # Reuse dense decode's entry-occupancy contract, including the long
+            # KV256 profiles that execute dynamic register reallocation.
+            min_blocks_per_mp=_decode_min_blocks_per_mp(cfg, seq_len_kv),
+            use_pdl=cfg.use_parallel_separate_reduction_pdl,
+        )
+    else:
+        decode_gen_kernel(
+            q_desc,
+            k_desc_primary,
+            v_desc_primary,
+            k_desc_atom,
+            v_desc_atom,
+            o_iter,
+            s_k,
+            h_k,
+            Float32(scale_s * log2_e),
+            Float32(1.0),
+            seqlens_kv_iter,
+            null_i32_ptr,
+            null_i32_ptr,
+            o_iter,
+            null_f32_ptr,
+            null_i32_ptr,
+            null_f32_ptr,
+            h_r,
+            tile_sched_params,
+            cfg,
+            seq_len_kv,
+            use_variable_seqlens_kv,
+            False,  # use_native_paged_kv
+            False,  # use_static_native_seqlens_kv
+            null_i32_ptr,  # g_paged_kv_indptr
+            null_i32_ptr,  # g_paged_kv_indices
+            row_route_offsets_iter,
+            row_route_counts_iter,
+            route_metadata_iter,
+            False,  # static_full_split_prefix
+        ).launch(
+            grid=grid,
+            block=[cfg.threads_per_cta, 1, 1],
+            cluster=[1, 1, 1],
+            stream=stream,
+            # Reuse dense decode's entry-occupancy contract, including the long
+            # KV256 profiles that execute dynamic register reallocation.
+            min_blocks_per_mp=_decode_min_blocks_per_mp(cfg, seq_len_kv),
+            use_pdl=cfg.use_parallel_separate_reduction_pdl,
+        )

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/helpers_common.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/helpers_common.py
@@ -127,6 +127,33 @@ def _warp_broadcast_i32(value: Int32, source_lane: Constexpr[int]) -> Int32:
     )
 
 
+@cute.jit
+def _swaps_routed_coordinate(
+    cfg: Constexpr[FmhaDecodeConfig],
+    lane_k_offset: Int32,
+    origin0: Int32,
+    origin1: Int32,
+    origin2: Int32,
+    origin3: Int32,
+    *,
+    token_group_idx: Constexpr[int],
+) -> tuple[Int32, Int32]:
+    """Map one SWAP register group to its staged atom and logical coordinate."""
+
+    atom_size = min(cfg.kv_block_size, 32)
+    groups_per_atom = atom_size // 8
+    origin_idx = token_group_idx // groups_per_atom
+    atom_origin = origin0
+    if cutlass.const_expr(origin_idx == 1):
+        atom_origin = origin1
+    elif cutlass.const_expr(origin_idx == 2):
+        atom_origin = origin2
+    elif cutlass.const_expr(origin_idx == 3):
+        atom_origin = origin3
+    token_offset = (token_group_idx % groups_per_atom) * 8
+    return atom_origin, atom_origin + Int32(token_offset) + lane_k_offset
+
+
 def _mma_kind_for_qkv(cfg: FmhaDecodeConfig) -> prims.Tcgen05MMAKind:
     """Select the tcgen05 MMA opcode family used for Q/K/V operands."""
     return prims.Tcgen05MMAKind.F8F6F4 if cfg.use_fp8_qkv else prims.Tcgen05MMAKind.F16

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/helpers_common.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/helpers_common.py
@@ -25,6 +25,8 @@ from typing import ClassVar
 import cutlass
 import cutlass.cute as cute
 from cutlass import BFloat16, Float16, Float32, Int32, Int64, Uint32
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
 from cutlass.experimental import primitives as prims
 
 from cutlass.experimental.task_scheduling.resources import (
@@ -58,6 +60,22 @@ ResourceVarValue = (
     Int32 | Float32 | Uint32 | cutlass.Int64 | cutlass.Array | DescriptorValue
 )
 ResourceVars = dict[str, ResourceVarValue]
+
+
+@dsl_user_op
+def _assume_nonnegative_i32(value: Int32, *, loc=None, ip=None) -> Int32:
+    """Express a caller-guaranteed nonnegative Int32 contract to codegen."""
+
+    condition = cutlass.Boolean(value >= Int32(0))
+    llvm.intr_assume(
+        condition.ir_value(loc=loc, ip=ip),
+        [],
+        [],
+        loc=loc,
+        ip=ip,
+    )
+    return value
+
 
 # Offsets into DecodeGenTask.make_task_cache(). Keeping these symbolic makes
 # resource code explicit about which task-local lane or address value it needs.

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_block_sparse_metadata.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_block_sparse_metadata.py
@@ -43,6 +43,7 @@ from cutlass.experimental.task_scheduling.resources import (
 
 from ...._block_sparse.prepared import (
     _PREPARED_ROUTE_IS_FULL_FLAG,
+    _PREPARED_ROUTE_IS_PROXY_FLAG,
     _BlockSparseRouteLayout,
 )
 from ...placeholder_helpers import _placeholder_smem_array
@@ -67,11 +68,16 @@ from .helpers_common import (
 # carries the conservative prepared summary that token masking can be skipped;
 # structural, tail, and causal masking remain independent.
 _SOFTMAX_TOKEN_MASK_IS_FULL_FLAG = 1 << 4
+# Keeps reserves bit 5 for the prepared route kind. The low four structural
+# validity bits and bit 4 keep their existing meaning.
+_SOFTMAX_ROUTE_IS_PROXY_FLAG = 1 << 5
 
-# B8 SWAP origins are eight-token aligned, so bit 0 is free while the route is
-# in Softmax's private staging payload. Reusing it avoids adding a word to every
-# pipeline stage merely to forward prepare's route-full summary.
-_SWAPS_PACKED_ROUTE_FULL_CLEAR_MASK = ~_PREPARED_ROUTE_IS_FULL_FLAG
+# SWAP origins are at least eight-token aligned, so their low two bits are free
+# while the route is in Softmax's private staging payload. Reusing them avoids
+# adding a word to every pipeline stage for prepared FULL/PROXY route flags.
+_SWAPS_PACKED_ROUTE_FLAGS_CLEAR_MASK = ~(
+    _PREPARED_ROUTE_IS_FULL_FLAG | _PREPARED_ROUTE_IS_PROXY_FLAG
+)
 
 
 @cute.jit
@@ -108,7 +114,7 @@ def _swaps_forwards_packed_route_full(cfg: FmhaDecodeConfig) -> bool:
     return (
         cfg.tile_size_q == 8
         and cfg.kv_block_size == 8
-        and not cfg.use_kv_valid_bits
+        and not cfg.uses_prepared_score_keep_words
         and not cfg.uses_uniform_causal_mask
         and not cfg.uses_per_row_causal_mask
     )
@@ -116,18 +122,24 @@ def _swaps_forwards_packed_route_full(cfg: FmhaDecodeConfig) -> bool:
 
 def _kv_retained_route_words(
     route_layout: _BlockSparseRouteLayout,
+    *,
+    retain_proxy_kind: bool = False,
 ) -> int:
     """Return the aligned SMEM words retained from K issue through V.
 
-    Contiguous routes retain their existing load-origin payload. Paged routes
-    retain parallel logical-origin and physical-page-ID arrays so every atom
-    has an independent storage locator; invalid entries use ``(-1, -1)``.
+    Contiguous routes retain their load-origin payload. Paged routes retain
+    parallel logical-origin and physical-page-ID arrays so every atom has an
+    independent storage locator. A two-origin contiguous route additionally
+    keeps its atom-valid mask. Proxy-capable exact/proxy routes reserve the
+    final aligned word for an explicit source kind.
     """
 
     payload_words = route_layout.logical_origins_per_route
     if route_layout.is_paged:
         payload_words *= 2
     elif route_layout.logical_origins_per_route == 2:
+        payload_words += 1
+    if retain_proxy_kind:
         payload_words += 1
     return ((payload_words + 3) // 4) * 4
 
@@ -139,9 +151,9 @@ class _BlockSparseSoftmaxStagingLayout:
     Keeps retains all route origins, a flags word, alignment padding, and the
     optional K32 token words. KV256 consumers then select the four words owned
     by their spatial half. SWAP stores execution-ordered origins followed by
-    optional logical K32 token words, one for each consumer warp. Its
-    noncausal Q8/B8 profile without token bits packs route-full into the
-    otherwise-zero low bit of each warp's first aligned origin.
+    optional logical K32 token words, one for each consumer warp. Selected
+    prepared route flags travel in the otherwise-zero low bits of each warp's
+    first aligned origin.
     """
 
     # Logical-origin scalars staged for one complete KV route.
@@ -206,14 +218,23 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
     """Pipeline-free route metadata retained from one K issue through V.
 
     ``route_metadata`` points at the first prepared GMEM record. Resolution
-    returns logical origins to masking consumers. The private SMEM copy keeps
-    contiguous load origins or paged ``(logical origin, physical page ID)``
-    pairs through the matching V issue. Invalid atoms are retained as safe
-    storage-specific OOB coordinates.
+    returns logical/source-domain origins to masking consumers. The private
+    SMEM copy keeps contiguous load origins or paged ``(logical origin,
+    physical page ID)`` pairs through the matching V issue. Invalid atoms are
+    retained as safe storage-specific OOB coordinates. The proxy-capable
+    contiguous specialization interprets origins in the selected source domain
+    (summary tokens for proxy routes, K/V tokens for exact routes) and
+    retains the prepared route kind in a separate aligned word. Exact-only
+    specializations keep their original allocation.
     """
 
     _task_local_specs: ClassVar[tuple[tuple, ...]] = (
-        ("resolved_origin0_slot", Int32, Int32(0), "First logical origin."),
+        (
+            "resolved_record_word_slot",
+            Int32,
+            Int32(0),
+            "Lane-owned record word; locator lanes carry route origins.",
+        ),
         ("resolved_origin1_slot", Int32, Int32(0), "Second logical origin."),
         (
             "resolved_atom_validity_slot",
@@ -236,7 +257,7 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
     _retained_route_words: Constexpr[int] = 0
     _alloc: Constexpr[SmemAllocation | None] = None
     _smem_words: cutlass.Array = None
-    resolved_origin0_slot: Constexpr[TaskLocalVariable] = (
+    resolved_record_word_slot: Constexpr[TaskLocalVariable] = (
         TaskLocalVariable.uninitialized()
     )
     resolved_origin1_slot: Constexpr[TaskLocalVariable] = (
@@ -254,7 +275,13 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
 
         assert self.route_layout is not None
         assert self.route_layout.is_paged == self.cfg.use_paged_kv
-        self._retained_route_words = _kv_retained_route_words(self.route_layout)
+        if self.cfg.use_block_sparse_proxy_routes:
+            assert not self.route_layout.is_paged
+            assert self.route_layout.uses_one_warp_transport
+        self._retained_route_words = _kv_retained_route_words(
+            self.route_layout,
+            retain_proxy_kind=self.cfg.use_block_sparse_proxy_routes,
+        )
         super().__post_init__()
 
     def _init_placeholder_state(self) -> None:
@@ -334,7 +361,7 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
 
     @consumer_work(
         returns=(
-            resolved_origin0_slot,
+            resolved_record_word_slot,
             resolved_origin1_slot,
             resolved_atom_validity_slot,
             route_record_word_offset_slot,
@@ -378,13 +405,48 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         atom_valid_mask = Int32(0)
         route_record_is_valid = route_record_word_offset >= Int32(0)
 
+        if cutlass.const_expr(self.route_layout.uses_one_warp_transport):
+            assert self.route_layout.token_words_word_offset is not None
+            meaningful_words = (
+                self.route_layout.token_words_word_offset
+                + self.route_layout.token_words_per_route
+            )
+            resolved_record_word = Int32(0)
+            if lane_idx < Int32(num_logical_origins):
+                resolved_record_word = Int32(-1)
+            if route_record_is_valid and lane_idx < Int32(meaningful_words):
+                resolved_record_word = Int32(
+                    self.route_metadata[route_record_word_offset + lane_idx]
+                )
+            atom_valid_mask = _warp_broadcast_i32(
+                resolved_record_word,
+                self.route_layout.atom_valid_mask_word_offset,
+            )
+            if cutlass.const_expr(uses_two_fragment_route):
+                return (
+                    resolved_record_word,
+                    _warp_broadcast_i32(resolved_record_word, 1),
+                    atom_valid_mask,
+                    route_record_word_offset,
+                )
+            atom_is_valid = cutlass.Boolean(
+                lane_idx < Int32(num_logical_origins)
+                and (atom_valid_mask & (Int32(1) << lane_idx)) != Int32(0)
+            )
+            return (
+                resolved_record_word,
+                Int32(0),
+                Int32(atom_is_valid),
+                route_record_word_offset,
+            )
+
         if route_record_is_valid:
             if lane_idx < Int32(num_logical_origins):
                 logical_origin = self._prepared_route_logical_origin(
                     route_record_word_offset,
                     lane_idx,
                 )
-            if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+            if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
                 if lane_idx == Int32(valid_mask_lane):
                     atom_valid_mask = Int32(
                         self.route_metadata[
@@ -396,7 +458,7 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         if cutlass.const_expr(uses_two_fragment_route):
             origin0 = _warp_broadcast_i32(logical_origin, 0)
             origin1 = _warp_broadcast_i32(logical_origin, 1)
-            if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+            if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
                 # The validity word shares the prepared record's cache line
                 # with fields consumed shortly afterward by Softmax.
                 atom_valid_mask = _warp_broadcast_i32(atom_valid_mask, valid_mask_lane)
@@ -412,7 +474,7 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         # Wider routes stay lane-distributed: each active lane carries only
         # its origin and validity through the existing three-scalar K/V ABI.
         valid = cutlass.Boolean(False)
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             atom_valid_mask = _warp_broadcast_i32(atom_valid_mask, valid_mask_lane)
             if lane_idx < Int32(num_logical_origins):
                 valid = (atom_valid_mask & (Int32(1) << lane_idx)) != Int32(0)
@@ -427,7 +489,7 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         self,
         stage_info: StageInfo,
         *,
-        resolved_origin0: Int32,
+        resolved_record_word: Int32,
         resolved_origin1: Int32,
         resolved_atom_validity: Int32,
         route_record_word_offset: Int32,
@@ -439,11 +501,11 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         num_origins = self.route_layout.logical_origins_per_route
         if cutlass.const_expr(self.route_layout.is_paged):
             if lane_idx < Int32(num_origins):
-                logical_origin = Int32(resolved_origin0)
+                logical_origin = Int32(resolved_record_word)
                 atom_is_valid = resolved_atom_validity != Int32(0)
                 if cutlass.const_expr(num_origins == 2):
                     if lane_idx == Int32(0):
-                        logical_origin = resolved_origin0
+                        logical_origin = resolved_record_word
                     else:
                         logical_origin = resolved_origin1
                     atom_is_valid = (
@@ -463,14 +525,14 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
                 ] = physical_page_id
         elif cutlass.const_expr(num_origins == 2):
             if lane_idx == Int32(0):
-                self._smem_words[Int32(0)] = resolved_origin0
+                self._smem_words[Int32(0)] = resolved_record_word
                 self._smem_words[Int32(1)] = resolved_origin1
                 self._smem_words[
                     Int32(self.route_layout.atom_valid_mask_word_offset)
                 ] = resolved_atom_validity
         else:
-            if lane_idx < Int32(self.route_layout.logical_origins_per_route):
-                load_origin = Int32(resolved_origin0)
+            if lane_idx < Int32(num_origins):
+                load_origin = Int32(resolved_record_word)
                 if resolved_atom_validity == Int32(0):
                     # Fine-route K and V both consume this retained value.
                     # Materialize their TensorMap OOB coordinate once here
@@ -478,6 +540,12 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
                     # every atom copy in both producer passes.
                     load_origin = Int32(self.tma_oob_origin)
                 self._smem_words[lane_idx] = load_origin
+        if cutlass.const_expr(self.cfg.use_block_sparse_proxy_routes):
+            if lane_idx == Int32(self.route_layout.route_flags_word_offset):
+                prepared_route_flags = Int32(resolved_record_word)
+                self._smem_words[Int32(self._retained_route_words - 1)] = Int32(
+                    prepared_route_flags
+                ) & Int32(_PREPARED_ROUTE_IS_PROXY_FLAG)
         # K consumes this slot immediately, while V consumes it at the start
         # of the next cadence.  Both execute in this warp, so a warp fence is
         # sufficient; no cross-warp mbarrier belongs here.
@@ -523,6 +591,20 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
             self._smem_words[Int32(self.route_layout.atom_valid_mask_word_offset)]
         )
 
+    @cute.jit
+    def route_is_proxy(self) -> cutlass.Boolean:
+        """Return the retained prepared route kind for the current K/V pair."""
+
+        if cutlass.const_expr(not self.cfg.use_block_sparse_proxy_routes):
+            return cutlass.Boolean(False)
+        return cutlass.Boolean(
+            (
+                Int32(self._smem_words[Int32(self._retained_route_words - 1)])
+                & Int32(_PREPARED_ROUTE_IS_PROXY_FLAG)
+            )
+            != Int32(0)
+        )
+
 
 @dataclass(kw_only=True)
 class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
@@ -533,8 +615,8 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
     producer passes the resolved payload explicitly instead of recomputing it.
     For Keeps, every route token word moves through SMEM without a
     data-dependent branch; each consumer receives at most four words through
-    the stable task-local ABI. A runtime route-full bit can skip per-score token
-    predicates while leaving structural masking independent.
+    the stable task-local ABI. Runtime route flags carry the conservative FULL
+    summary and, for proxy-capable builds, the route source kind.
     """
 
     _task_local_specs: ClassVar[tuple[tuple, ...]] = (
@@ -562,7 +644,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
             "softmax_token_word2_slot",
             Uint32,
             Uint32(0xFFFFFFFF),
-            "Loaded third Keeps token word or SWAP's B8 route-full summary.",
+            "Loaded third Keeps token word or SWAP's packed route flags.",
         ),
         (
             "softmax_token_word3_slot",
@@ -605,6 +687,8 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
 
         assert self.route_layout is not None
         assert self.route_layout.is_paged == self.cfg.use_paged_kv
+        if self.cfg.use_block_sparse_proxy_routes:
+            assert self.route_layout.uses_one_warp_transport
         self.staging_layout = _BlockSparseSoftmaxStagingLayout.create(
             use_keeps_mma_ab=self.cfg.use_keeps_mma_ab,
             route_layout=self.route_layout,
@@ -680,57 +764,82 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
     def _store_route_swaps(
         self,
         stage_info: StageInfo,
-        resolved_origin0: Int32,
+        resolved_record_word: Int32,
         resolved_origin1: Int32,
         resolved_atom_validity: Int32,
         route_record_word_offset: Int32,
     ) -> None:
         """Stage SWAP origins and optional logical-K32 token metadata.
 
-        The noncausal Q8/B8 profile without token bits also packs prepare's
-        route-full summary into bit 0 of each warp's first aligned origin.
+        Selected prepared route flags use the free low bits of each warp's
+        first aligned origin.
         """
 
         lane_idx = cute.arch.thread_idx()[0] & Int32(0x1F)
         stage_base = self._producer_stage_base(stage_info)
         task_cache = _decode_gen_task_cache(stage_info)
         seq_len_kv = Int32(task_cache[_TASK_CACHE_SEQ_LEN_KV])
-        route_record_is_valid = route_record_word_offset >= Int32(0)
+        uses_one_warp_transport = self.route_layout.uses_one_warp_transport
+        if cutlass.const_expr(
+            not uses_one_warp_transport
+            and (
+                _swaps_forwards_packed_route_full(self.cfg)
+                or self.cfg.uses_prepared_score_keep_words
+            )
+        ):
+            route_record_is_valid = route_record_word_offset >= Int32(0)
 
-        packed_route_full = Int32(0)
-        if cutlass.const_expr(_swaps_forwards_packed_route_full(self.cfg)):
-            if lane_idx == Int32(0) and route_record_is_valid:
-                packed_route_full = Int32(
-                    self.route_metadata[
-                        route_record_word_offset
-                        + Int32(self.route_layout.route_flags_word_offset)
-                    ]
-                ) & Int32(_PREPARED_ROUTE_IS_FULL_FLAG)
-            packed_route_full = _warp_broadcast_i32(packed_route_full, 0)
+        packed_route_flags = Int32(0)
+        if cutlass.const_expr(
+            _swaps_forwards_packed_route_full(self.cfg)
+            or self.cfg.use_block_sparse_proxy_routes
+        ):
+            if cutlass.const_expr(uses_one_warp_transport):
+                packed_route_flags = _warp_broadcast_i32(
+                    resolved_record_word,
+                    self.route_layout.route_flags_word_offset,
+                )
+            else:
+                if lane_idx == Int32(0) and route_record_is_valid:
+                    packed_route_flags = Int32(
+                        self.route_metadata[
+                            route_record_word_offset
+                            + Int32(self.route_layout.route_flags_word_offset)
+                        ]
+                    ) & Int32(_PREPARED_ROUTE_IS_FULL_FLAG)
+                packed_route_flags = _warp_broadcast_i32(packed_route_flags, 0)
 
         softmax_origin = Int32(-1)
         if cutlass.const_expr(self.cfg.kv_block_size < 64):
             if lane_idx < Int32(self.staging_layout.num_origin_words):
-                softmax_origin = Int32(resolved_origin0)
+                softmax_origin = Int32(resolved_record_word)
                 if resolved_atom_validity == Int32(0):
                     softmax_origin = Int32(-1)
-                if cutlass.const_expr(_swaps_forwards_packed_route_full(self.cfg)):
-                    # Replicate route-full in each K32 slice's first origin;
-                    # B8 alignment leaves bit 0 free for the summary.
+                if cutlass.const_expr(
+                    _swaps_forwards_packed_route_full(self.cfg)
+                    or self.cfg.use_block_sparse_proxy_routes
+                ):
+                    # Every SWAP atom is at least B8 aligned. Replicate the
+                    # route flags in each K32 slice's first origin so the
+                    # established seven-slot Softmax ABI also carries source
+                    # kind without growing the staged payload.
                     if lane_idx % Int32(self.staging_layout.origins_per_warp) == Int32(
                         0
                     ):
                         softmax_origin = (
-                            softmax_origin & Int32(_SWAPS_PACKED_ROUTE_FULL_CLEAR_MASK)
-                        ) | packed_route_full
+                            softmax_origin & Int32(_SWAPS_PACKED_ROUTE_FLAGS_CLEAR_MASK)
+                        ) | packed_route_flags
                 self._smem_words[stage_base + lane_idx] = softmax_origin
         else:
             # SWAP with a coarse KV atom expands the two resolved KV64
             # fragments into the four logical K32 origins consumed by its
             # four softmax warps.
+            coarse_origin0 = Int32(resolved_record_word)
+            if cutlass.const_expr(uses_one_warp_transport):
+                coarse_origin0 = _warp_broadcast_i32(resolved_record_word, 0)
             if lane_idx < Int32(4):
                 fragment_idx = lane_idx >> Int32(1)
-                softmax_origin = Int32(resolved_origin0)
+                softmax_origin = coarse_origin0
                 valid = (resolved_atom_validity & Int32(1)) != Int32(0)
                 if fragment_idx == Int32(1):
                     softmax_origin = Int32(resolved_origin1)
@@ -738,13 +847,30 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
                 softmax_origin = softmax_origin + (lane_idx & Int32(1)) * Int32(32)
                 if not valid or softmax_origin >= seq_len_kv:
                     softmax_origin = Int32(-1)
+                if cutlass.const_expr(self.cfg.use_block_sparse_proxy_routes):
+                    # Coarse SWAP expands KV64 atoms to K32-aligned origins;
+                    # their low bits carry the same typed-route flags as the
+                    # fine-route representation above.
+                    softmax_origin = (
+                        softmax_origin & Int32(_SWAPS_PACKED_ROUTE_FLAGS_CLEAR_MASK)
+                    ) | packed_route_flags
                 self._smem_words[stage_base + lane_idx] = softmax_origin
 
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             assert self.route_metadata is not None
             assert self.route_layout.token_words_word_offset is not None
             assert self.staging_layout.token_words_word_offset is not None
-            if lane_idx < Int32(self.route_layout.token_words_per_route):
+            if cutlass.const_expr(uses_one_warp_transport):
+                token_begin = Int32(self.route_layout.token_words_word_offset)
+                token_end = token_begin + Int32(self.route_layout.token_words_per_route)
+                if lane_idx >= token_begin and lane_idx < token_end:
+                    self._smem_words[
+                        stage_base
+                        + Int32(self.staging_layout.token_words_word_offset)
+                        + lane_idx
+                        - token_begin
+                    ] = Int32(resolved_record_word)
+            elif lane_idx < Int32(self.route_layout.token_words_per_route):
                 logical_word = Uint32(0)
                 if route_record_is_valid:
                     logical_word = Uint32(
@@ -765,7 +891,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
     def _store_route_keeps(
         self,
         stage_info: StageInfo,
-        resolved_origin0: Int32,
+        resolved_record_word: Int32,
         resolved_origin1: Int32,
         resolved_atom_validity: Int32,
         route_record_word_offset: Int32,
@@ -779,8 +905,12 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
 
         assert self.staging_layout.route_flags_word_offset is not None
         lane_idx = cute.arch.thread_idx()[0] & Int32(0x1F)
-        route_record_is_valid = route_record_word_offset >= Int32(0)
         num_origins = self.route_layout.logical_origins_per_route
+        uses_one_warp_transport = self.route_layout.uses_one_warp_transport
+        if cutlass.const_expr(
+            not uses_one_warp_transport and self.cfg.uses_prepared_score_keep_words
+        ):
+            route_record_is_valid = route_record_word_offset >= Int32(0)
         route_flags = Int32(resolved_atom_validity)
         if cutlass.const_expr(num_origins > 2):
             route_flags = Int32(
@@ -788,47 +918,73 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
                     lane_idx < Int32(num_origins) and resolved_atom_validity != Int32(0)
                 )
             )
+
         token_word = Uint32(0)
         route_token_mask_is_full = cutlass.Boolean(False)
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
-            assert self.route_metadata is not None
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             assert self.route_layout.token_words_word_offset is not None
-            gmem_route_flags = Int32(0)
-            if lane_idx == Int32(0) and route_record_is_valid:
-                gmem_route_flags = Int32(
-                    self.route_metadata[
-                        route_record_word_offset
-                        + Int32(self.route_layout.route_flags_word_offset)
-                    ]
+            assert self.route_metadata is not None
+            if cutlass.const_expr(not uses_one_warp_transport):
+                gmem_route_flags = Int32(0)
+                if lane_idx == Int32(0) and route_record_is_valid:
+                    gmem_route_flags = Int32(
+                        self.route_metadata[
+                            route_record_word_offset
+                            + Int32(self.route_layout.route_flags_word_offset)
+                        ]
+                    )
+                gmem_route_flags = _warp_broadcast_i32(gmem_route_flags, 0)
+                # Prepared bit 0 summarizes the whole route. Staged low bits
+                # already hold fragment validity, so remap it above them.
+                route_token_mask_is_full = cutlass.Boolean(
+                    (gmem_route_flags & Int32(_PREPARED_ROUTE_IS_FULL_FLAG)) != Int32(0)
                 )
-            gmem_route_flags = _warp_broadcast_i32(gmem_route_flags, 0)
-            # Prepared bit 0 summarizes the whole route. Staged low bits are
-            # already fragment validity, so remap the summary above them.
-            route_token_mask_is_full = cutlass.Boolean(
-                (gmem_route_flags & Int32(_PREPARED_ROUTE_IS_FULL_FLAG)) != Int32(0)
-            )
-            if (
-                lane_idx < Int32(self.route_layout.token_words_per_route)
-                and route_record_is_valid
-            ):
-                token_word = Uint32(
-                    self.route_metadata[
-                        route_record_word_offset
-                        + Int32(self.route_layout.token_words_word_offset)
-                        + lane_idx
-                    ]
-                )
+                if (
+                    lane_idx < Int32(self.route_layout.token_words_per_route)
+                    and route_record_is_valid
+                ):
+                    token_word = Uint32(
+                        self.route_metadata[
+                            route_record_word_offset
+                            + Int32(self.route_layout.token_words_word_offset)
+                            + lane_idx
+                        ]
+                    )
 
         stage_base = self._producer_stage_base(stage_info)
         if cutlass.const_expr(num_origins == 2):
             if lane_idx == Int32(0):
-                self._smem_words[stage_base] = Int32(resolved_origin0)
+                self._smem_words[stage_base] = Int32(resolved_record_word)
                 self._smem_words[stage_base + Int32(1)] = Int32(resolved_origin1)
-        else:
-            if lane_idx < Int32(num_origins):
-                self._smem_words[stage_base + lane_idx] = Int32(resolved_origin0)
-        if lane_idx == Int32(0):
-            if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        elif lane_idx < Int32(num_origins):
+            self._smem_words[stage_base + lane_idx] = Int32(resolved_record_word)
+
+        if cutlass.const_expr(uses_one_warp_transport):
+            if lane_idx == Int32(self.route_layout.route_flags_word_offset):
+                prepared_route_flags = Int32(resolved_record_word)
+                route_flags = route_flags | (
+                    Int32(
+                        (prepared_route_flags & Int32(_PREPARED_ROUTE_IS_FULL_FLAG))
+                        != Int32(0)
+                    )
+                    * Int32(_SOFTMAX_TOKEN_MASK_IS_FULL_FLAG)
+                )
+                if cutlass.const_expr(self.cfg.use_block_sparse_proxy_routes):
+                    route_flags = route_flags | (
+                        Int32(
+                            (
+                                prepared_route_flags
+                                & Int32(_PREPARED_ROUTE_IS_PROXY_FLAG)
+                            )
+                            != Int32(0)
+                        )
+                        * Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)
+                    )
+                self._smem_words[
+                    stage_base + Int32(self.staging_layout.route_flags_word_offset)
+                ] = route_flags
+        elif lane_idx == Int32(0):
+            if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
                 route_flags = route_flags | (
                     Int32(route_token_mask_is_full)
                     * Int32(_SOFTMAX_TOKEN_MASK_IS_FULL_FLAG)
@@ -836,9 +992,20 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
             self._smem_words[
                 stage_base + Int32(self.staging_layout.route_flags_word_offset)
             ] = route_flags
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             assert self.staging_layout.token_words_word_offset is not None
-            if lane_idx < Int32(self.route_layout.token_words_per_route):
+            if cutlass.const_expr(uses_one_warp_transport):
+                token_begin = Int32(self.route_layout.token_words_word_offset)
+                token_end = token_begin + Int32(self.route_layout.token_words_per_route)
+                if lane_idx >= token_begin and lane_idx < token_end:
+                    self._smem_words[
+                        stage_base
+                        + Int32(self.staging_layout.token_words_word_offset)
+                        + lane_idx
+                        - token_begin
+                    ] = Int32(resolved_record_word)
+            elif lane_idx < Int32(self.route_layout.token_words_per_route):
                 self._smem_words[
                     stage_base
                     + Int32(self.staging_layout.token_words_word_offset)
@@ -852,7 +1019,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
         self,
         stage_info: StageInfo,
         *,
-        resolved_origin0: Int32,
+        resolved_record_word: Int32,
         resolved_origin1: Int32,
         resolved_atom_validity: Int32,
         route_record_word_offset: Int32,
@@ -862,7 +1029,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
         if cutlass.const_expr(self.cfg.use_keeps_mma_ab):
             self._store_route_keeps(
                 stage_info,
-                resolved_origin0,
+                resolved_record_word,
                 resolved_origin1,
                 resolved_atom_validity,
                 route_record_word_offset,
@@ -870,7 +1037,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
         else:
             self._store_route_swaps(
                 stage_info,
-                resolved_origin0,
+                resolved_record_word,
                 resolved_origin1,
                 resolved_atom_validity,
                 route_record_word_offset,
@@ -886,8 +1053,8 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
         this Softmax warp's logical K32 slice; unused or invalid origins are
         negative. To preserve the shared seven-slot task ABI, origin 2/3
         subsequently travel through the shared route-flags/token-word-0 slots.
-        Token-word 1 carries the logical K32 mask, token-word 2 carries
-        route-full, and token-word 3 is unused.
+        Token-word 1 carries the logical K32 mask, token-word 2 carries packed
+        route flags, and token-word 3 is unused.
         """
 
         stage_base = self._consumer_stage_base()
@@ -907,7 +1074,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
             origin3 = Int32(self._smem_words[warp_origin_base + Int32(3)])
 
         token_word = Uint32(0xFFFFFFFF)
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             assert self.staging_layout.token_words_word_offset is not None
             token_word = Uint32(
                 self._smem_words[
@@ -917,9 +1084,25 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
                 ]
             )
         route_flags = Uint32(0)
-        if cutlass.const_expr(_swaps_forwards_packed_route_full(self.cfg)):
-            route_flags = Uint32(origin0 & Int32(1))
-            origin0 = origin0 & Int32(_SWAPS_PACKED_ROUTE_FULL_CLEAR_MASK)
+        if cutlass.const_expr(
+            _swaps_forwards_packed_route_full(self.cfg)
+            or self.cfg.use_block_sparse_proxy_routes
+        ):
+            packed_route_flags = origin0 & Int32(
+                _PREPARED_ROUTE_IS_FULL_FLAG | _PREPARED_ROUTE_IS_PROXY_FLAG
+            )
+            route_flags = Uint32(
+                packed_route_flags & Int32(_PREPARED_ROUTE_IS_FULL_FLAG)
+            )
+            if cutlass.const_expr(self.cfg.use_block_sparse_proxy_routes):
+                route_flags = route_flags | Uint32(
+                    Int32(
+                        (packed_route_flags & Int32(_PREPARED_ROUTE_IS_PROXY_FLAG))
+                        != Int32(0)
+                    )
+                    * Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)
+                )
+            origin0 = origin0 & Int32(_SWAPS_PACKED_ROUTE_FLAGS_CLEAR_MASK)
         return (
             origin0,
             origin1,
@@ -986,9 +1169,13 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
             valid0 = (stored_route_flags >> origin0_idx) & Int32(1)
             valid1 = (stored_route_flags >> origin1_idx) & Int32(1)
             route_flags = valid0 | (valid1 << Int32(1))
-            if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+            if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
                 route_flags = route_flags | (
                     stored_route_flags & Int32(_SOFTMAX_TOKEN_MASK_IS_FULL_FLAG)
+                )
+            if cutlass.const_expr(self.cfg.use_block_sparse_proxy_routes):
+                route_flags = route_flags | (
+                    stored_route_flags & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)
                 )
         origin0 = Int32(self._smem_words[stage_base + origin0_idx])
         origin1 = Int32(self._smem_words[stage_base + origin1_idx])
@@ -996,7 +1183,7 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
         token_word1 = Uint32(0xFFFFFFFF)
         token_word2 = Uint32(0xFFFFFFFF)
         token_word3 = Uint32(0xFFFFFFFF)
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             assert self.staging_layout.token_words_word_offset is not None
             if cutlass.const_expr(self.route_layout.kv_route_size == 256):
                 token_base = Int32(self.staging_layout.token_words_word_offset)

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -64,6 +64,7 @@ from .helpers_common import (
     _neg_max_f32,
     _pack_float2_to_bf16,
     _pack_float2_to_fp16,
+    _swaps_routed_coordinate,
     _wait_for_mbarrier_phase,
 )
 from .helpers_output import (
@@ -322,32 +323,6 @@ class SmemPResource(DecodeGenResourceBase):
             if cutlass.const_expr(tail_delta != 0):
                 local_sum += Float32(tail_delta) * tail_p
         return local_sum
-
-    @cute.jit
-    def _proxy_swaps_logical_k(
-        self,
-        lane_k_offset: Int32,
-        origin0: Int32,
-        origin1: Int32,
-        origin2: Int32,
-        origin3: Int32,
-        *,
-        token_group_idx: Constexpr[int],
-    ) -> tuple[Int32, Int32]:
-        """Return a SWAP probability register's atom and summary coordinates."""
-
-        atom_size = min(self.cfg.kv_block_size, 32)
-        groups_per_atom = atom_size // 8
-        origin_idx = token_group_idx // groups_per_atom
-        atom_origin = origin0
-        if cutlass.const_expr(origin_idx == 1):
-            atom_origin = origin1
-        elif cutlass.const_expr(origin_idx == 2):
-            atom_origin = origin2
-        elif cutlass.const_expr(origin_idx == 3):
-            atom_origin = origin3
-        token_offset = (token_group_idx % groups_per_atom) * 8
-        return atom_origin, atom_origin + Int32(token_offset) + lane_k_offset
 
     @cute.jit
     def _compute_p_fragment_impl(
@@ -1012,7 +987,8 @@ class SmemPResource(DecodeGenResourceBase):
                                 cfg.static_seq_len_kv,
                                 cfg.kv_block_size,
                             )
-                            atom_origin, logical_summary = self._proxy_swaps_logical_k(
+                            atom_origin, logical_summary = _swaps_routed_coordinate(
+                                cfg,
                                 lane_idx >> Int32(2),
                                 route_origin0,
                                 route_origin1,
@@ -1266,7 +1242,8 @@ class SmemPResource(DecodeGenResourceBase):
                 for scale_idx in cutlass.range_constexpr(cfg.num_softmax_scale_groups):
                     proxy_tail_p = Float32(0.0)
                     for token_group_idx in cutlass.range_constexpr(4):
-                        atom_origin, logical_summary = self._proxy_swaps_logical_k(
+                        atom_origin, logical_summary = _swaps_routed_coordinate(
+                            cfg,
                             lane_idx >> Int32(2),
                             route_origin0,
                             route_origin1,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -25,7 +25,7 @@ from typing import ClassVar
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Float32, Int32, Int64
+from cutlass import Float32, Int32, Int64, Uint32
 from cutlass.experimental import primitives as prims
 
 from cutlass.experimental.task_scheduling.memory import (
@@ -42,6 +42,7 @@ from cutlass.experimental.task_scheduling.resources import (
 )
 
 from ..fmha_decode_config import FmhaDecodeConfig
+from ...._block_sparse.common import _block_sparse_proxy_summary_geometry
 from ...placeholder_helpers import _placeholder_smem_array
 from .helpers_common import (
     Constexpr,
@@ -79,6 +80,7 @@ from .helpers_softmax import (
     _pack_float4_to_fp8_e4m3,
     _pack_float4_to_fp8_e4m3_inline,
 )
+from .smem_block_sparse_metadata import _SOFTMAX_ROUTE_IS_PROXY_FLAG
 from .tmem_s import TmemSResource
 
 
@@ -299,20 +301,70 @@ class SmemPResource(DecodeGenResourceBase):
         # work can publish a valid descriptor or TMEM address for this tile.
         self._create_initial_task_locals(stage_info.context)
 
-    @producer_work
     @cute.jit
-    def compute_p_fragment(
+    def _apply_proxy_route_denominator_mass(
+        self,
+        local_sum: Float32,
+        tail_p: Float32,
+        route_is_proxy: Int32,
+    ) -> Float32:
+        """Weight only a proxy route's softmax denominator by block mass."""
+
+        if cutlass.const_expr(not self.cfg.use_block_sparse_proxy_routes):
+            return local_sum
+        if route_is_proxy != Int32(0):
+            _, tail_len = _block_sparse_proxy_summary_geometry(
+                self.cfg.static_seq_len_kv,
+                self.cfg.kv_block_size,
+            )
+            local_sum *= Float32(self.cfg.kv_block_size)
+            tail_delta = tail_len - self.cfg.kv_block_size
+            if cutlass.const_expr(tail_delta != 0):
+                local_sum += Float32(tail_delta) * tail_p
+        return local_sum
+
+    @cute.jit
+    def _proxy_swaps_logical_k(
+        self,
+        lane_k_offset: Int32,
+        origin0: Int32,
+        origin1: Int32,
+        origin2: Int32,
+        origin3: Int32,
+        *,
+        token_group_idx: Constexpr[int],
+    ) -> tuple[Int32, Int32]:
+        """Return a SWAP probability register's atom and summary coordinates."""
+
+        atom_size = min(self.cfg.kv_block_size, 32)
+        groups_per_atom = atom_size // 8
+        origin_idx = token_group_idx // groups_per_atom
+        atom_origin = origin0
+        if cutlass.const_expr(origin_idx == 1):
+            atom_origin = origin1
+        elif cutlass.const_expr(origin_idx == 2):
+            atom_origin = origin2
+        elif cutlass.const_expr(origin_idx == 3):
+            atom_origin = origin3
+        token_offset = (token_group_idx % groups_per_atom) * 8
+        return atom_origin, atom_origin + Int32(token_offset) + lane_k_offset
+
+    @cute.jit
+    def _compute_p_fragment_impl(
         self,
         stage_info: StageInfo,
         *,
         fragment_idx: Constexpr[int],
         new_max_arr: cutlass.Array,
         s_arr: cutlass.Array,
+        route_is_proxy: Int32,
+        route_origin0: Int32,
+        route_origin1: Int32,
     ) -> None:
-        """Convert one KV256 K32 score fragment and publish its TMEM P slice."""
+        """Convert one KV256 K32 score fragment into its selected P storage."""
         cfg = self.cfg
         assert cfg.streams_tmem_p_fragments
-        assert not cfg.use_fp8_qkv and cfg.uses_two_inst_tmem_p
+        assert not cfg.use_fp8_qkv
         assert cfg.softmax_score_fragment_regs == 32
 
         new_max = new_max_arr[0]
@@ -360,10 +412,39 @@ class SmemPResource(DecodeGenResourceBase):
         total_pair = cute.arch.add_packed_f32x2(sum01, sum23)
         local_sum = Float32(total_pair[0] + total_pair[1])
 
+        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+            if route_is_proxy != Int32(0):
+                # KC stores one mean K vector per semantic KV block while VC
+                # stores its V sum. Keep P itself unweighted for PV, and
+                # account for represented token mass only in the denominator.
+                num_summaries, tail_len = _block_sparse_proxy_summary_geometry(
+                    cfg.static_seq_len_kv,
+                    cfg.kv_block_size,
+                )
+                local_sum *= Float32(cfg.kv_block_size)
+                final_summary_idx = num_summaries - 1
+                tail_delta = tail_len - cfg.kv_block_size
+                if cutlass.const_expr(tail_delta != 0):
+                    fragment_origin = Int32(route_origin0)
+                    if cutlass.const_expr(fragment_idx >= 2):
+                        fragment_origin = Int32(route_origin1)
+                    fragment_origin += Int32((fragment_idx % 2) * 32)
+                    final_summary_offset = Int32(final_summary_idx) - fragment_origin
+                    if final_summary_offset >= Int32(
+                        0
+                    ) and final_summary_offset < Int32(32):
+                        # Proxy fragment origins are K32-aligned in summary
+                        # coordinates, so the tail's in-fragment lane is a
+                        # compile-time constant even though route ownership is
+                        # decided at runtime.  Keeping this index fixed avoids
+                        # materializing the whole FP32 probability array in
+                        # local memory.
+                        tail_lane = final_summary_idx % 32
+                        local_sum += Float32(tail_delta) * Float32(s_arr[tail_lane])
+
         packed_p = (
             s_arr.data_ptr().load(count=32, alignment=4).to(cfg.q_dtype).bitcast(Int32)
         )
-
         fragment_cols = cfg.softmax_score_fragment_regs // 2
         p_tmem_addr = (
             self._tmem_base_addr
@@ -382,16 +463,70 @@ class SmemPResource(DecodeGenResourceBase):
         cute.arch.fence_view_async_tmem_store()
         prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
 
-        # KV256 aliases P with the score tile that produced it. Each softmax
-        # warp publishes its own rows after the TMEM store drains; BMM2 waits
-        # for all producer warps before consuming the fragment.
-        tidx, _, _ = cute.arch.thread_idx()
-        if (tidx & Int32(31)) == Int32(0):
-            prims.mbarrier_arrive(self._fragment_ready.data_ptr() + Int32(fragment_idx))
+        if cutlass.const_expr(cfg.streams_tmem_p_fragments):
+            # Streamed KV256 aliases P with the score tile that produced it.
+            # Each softmax warp publishes its rows after the TMEM store drains.
+            tidx, _, _ = cute.arch.thread_idx()
+            if (tidx & Int32(31)) == Int32(0):
+                prims.mbarrier_arrive(
+                    self._fragment_ready.data_ptr() + Int32(fragment_idx)
+                )
 
         if cutlass.const_expr(fragment_idx != 0):
             local_sum += self.tmem_s_ref.load_p_local_sum(0)
         self.tmem_s_ref.store_p_local_sum(0, local_sum)
+
+    # Task Scheduling treats every non-constexpr work argument as required.
+    # Keep the established exact-only ABI separate from the proxy route
+    # transport while sharing the generated P implementation.
+    @producer_work
+    @cute.jit
+    def compute_p_fragment(
+        self,
+        stage_info: StageInfo,
+        *,
+        fragment_idx: Constexpr[int],
+        new_max_arr: cutlass.Array,
+        s_arr: cutlass.Array,
+    ) -> None:
+        """Convert one ordinary KV256 K32 score fragment into its TMEM P slice."""
+        self._compute_p_fragment_impl(
+            stage_info,
+            fragment_idx=fragment_idx,
+            new_max_arr=new_max_arr,
+            s_arr=s_arr,
+            route_is_proxy=Int32(0),
+            route_origin0=Int32(0),
+            route_origin1=Int32(0),
+        )
+
+    @producer_work
+    @cute.jit
+    def compute_proxy_route_p_fragment(
+        self,
+        stage_info: StageInfo,
+        *,
+        fragment_idx: Constexpr[int],
+        new_max_arr: cutlass.Array,
+        s_arr: cutlass.Array,
+        route_flags: Int32,
+        route_origin0: Int32,
+        route_origin1: Int32,
+    ) -> None:
+        """Convert one proxy-capable fragment with conditional proxy weighting."""
+        assert self.cfg.use_block_sparse_proxy_routes
+        route_is_proxy = Int32(
+            (route_flags & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Int32(0)
+        )
+        self._compute_p_fragment_impl(
+            stage_info,
+            fragment_idx=fragment_idx,
+            new_max_arr=new_max_arr,
+            s_arr=s_arr,
+            route_is_proxy=route_is_proxy,
+            route_origin0=route_origin0,
+            route_origin1=route_origin1,
+        )
 
     @cute.jit
     def _compute_keeps_p(
@@ -400,6 +535,9 @@ class SmemPResource(DecodeGenResourceBase):
         *,
         new_max_arr: cutlass.Array,
         s_arr: cutlass.Array,
+        route_is_proxy: Int32,
+        route_origin0: Int32,
+        route_origin1: Int32,
     ) -> None:
         """Materialize one non-KV256 row-major Keeps probability tile.
 
@@ -439,6 +577,7 @@ class SmemPResource(DecodeGenResourceBase):
         # without keeping a second 16-value P array live beside the S row.
         local_sum_pair_01 = (Float32(0.0), Float32(0.0))
         local_sum_pair_23 = (Float32(0.0), Float32(0.0))
+        proxy_tail_p = Float32(0.0)
 
         # Each vector block is exactly 16 bytes after conversion. Compute and
         # pack adjacent pairs directly into their final register payload.
@@ -499,6 +638,29 @@ class SmemPResource(DecodeGenResourceBase):
                         cute.math.exp2(scaled_pair[0], fastmath=True),
                         cute.math.exp2(scaled_pair[1], fastmath=True),
                     )
+                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                        num_summaries, _ = _block_sparse_proxy_summary_geometry(
+                            cfg.static_seq_len_kv,
+                            cfg.kv_block_size,
+                        )
+                        final_summary_idx = num_summaries - 1
+                        for pair_element in cutlass.range_constexpr(2):
+                            reg_idx = s_base + val_base + pair_element
+                            summary_origin = route_origin0
+                            summary_offset = Int32(reg_idx)
+                            if cutlass.const_expr(
+                                cfg.tile_size_q == 128 and reg_idx >= 64
+                            ):
+                                summary_origin = route_origin1
+                                summary_offset = Int32(reg_idx - 64)
+                            elif cutlass.const_expr(cfg.tile_size_q == 64):
+                                if col_base >= Int32(64):
+                                    summary_origin = route_origin1
+                            logical_summary = summary_origin + summary_offset
+                            if summary_origin >= Int32(0) and logical_summary == Int32(
+                                final_summary_idx
+                            ):
+                                proxy_tail_p = Float32(p_pair[pair_element])
                     if cutlass.const_expr(packed_idx % 2 == 0):
                         local_sum_pair_01 = fadd2(local_sum_pair_01, p_pair)
                     else:
@@ -573,6 +735,11 @@ class SmemPResource(DecodeGenResourceBase):
                 )
         local_sum_pair0 = fadd2(local_sum_pair_01, local_sum_pair_23)
         local_sum = local_sum_pair0[0] + local_sum_pair0[1]
+        local_sum = self._apply_proxy_route_denominator_mass(
+            local_sum,
+            proxy_tail_p,
+            route_is_proxy,
+        )
         self.tmem_s_ref.store_p_local_sum(0, local_sum)
 
         # Publish the selected memory view before the task-level P pipeline
@@ -591,14 +758,18 @@ class SmemPResource(DecodeGenResourceBase):
             # point and no extra named barrier is needed here.
             cute.arch.fence_view_async_shared()
 
-    @producer_work
     @cute.jit
-    def compute_p(
+    def _compute_p_impl(
         self,
         stage_info: StageInfo,
         *,
         new_max_arr: cutlass.Array,
         s_arr: cutlass.Array,
+        route_is_proxy: Int32,
+        route_origin0: Int32,
+        route_origin1: Int32,
+        route_origin2: Int32,
+        route_origin3: Int32,
     ) -> None:
         """Compute P from S, stage its BMM2 operand, and publish local sums."""
         cfg = self.cfg
@@ -607,6 +778,9 @@ class SmemPResource(DecodeGenResourceBase):
                 stage_info,
                 new_max_arr=new_max_arr,
                 s_arr=s_arr,
+                route_is_proxy=route_is_proxy,
+                route_origin0=route_origin0,
+                route_origin1=route_origin1,
             )
             return
         # ProdWork: transform the softmax S registers into the P operand layout
@@ -616,6 +790,7 @@ class SmemPResource(DecodeGenResourceBase):
         # warp/lane ownership for SMEM offsets and STSM swizzles.
         task_cache = _decode_gen_task_cache(stage_info)
         warp_grp_thread_idx = task_cache[_TASK_CACHE_WARP_GRP_THREAD_IDX]
+        lane_idx = Int32(task_cache[_TASK_CACHE_LANE_IDX])
         if cutlass.const_expr(cfg.tile_size_q == 32 and cfg.use_fp8_qkv):
             # Tile-Q=32 FP8 fast path: compute E4M3 P registers in the
             # same order consumed by the STSM helper, while also capturing
@@ -796,10 +971,14 @@ class SmemPResource(DecodeGenResourceBase):
             local_sums = cutlass.Array(
                 Float32, num_scale_groups, space=cutlass.AddressSpace.rmem
             )
+            proxy_tail_p = cutlass.Array(
+                Float32, num_scale_groups, space=cutlass.AddressSpace.rmem
+            )
             for idx in cutlass.range_constexpr(num_s_regs):
                 p_vals[idx] = Float32(0.0)
             for idx in cutlass.range_constexpr(num_scale_groups):
                 local_sums[idx] = Float32(0.0)
+                proxy_tail_p[idx] = Float32(0.0)
 
             for scale_idx in cutlass.range_constexpr(num_scale_groups):
                 # Convert each softmax scale group from S to P. Masked rows have
@@ -828,9 +1007,31 @@ class SmemPResource(DecodeGenResourceBase):
                         )
                         p_vals[s_idx] = p_val
                         local_sums[scale_idx] += p_val
+                        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                            num_summaries, _ = _block_sparse_proxy_summary_geometry(
+                                cfg.static_seq_len_kv,
+                                cfg.kv_block_size,
+                            )
+                            atom_origin, logical_summary = self._proxy_swaps_logical_k(
+                                lane_idx >> Int32(2),
+                                route_origin0,
+                                route_origin1,
+                                route_origin2,
+                                route_origin3,
+                                token_group_idx=k_pair_idx,
+                            )
+                            if atom_origin >= Int32(0) and logical_summary == Int32(
+                                num_summaries - 1
+                            ):
+                                proxy_tail_p[scale_idx] = p_val
             # Hand off denominator contributions through TmemS. P remains a pure
             # MMA operand in SMEM; sums are not reloaded from the P tile.
             for scale_idx in cutlass.range_constexpr(num_scale_groups):
+                local_sums[scale_idx] = self._apply_proxy_route_denominator_mass(
+                    local_sums[scale_idx],
+                    proxy_tail_p[scale_idx],
+                    route_is_proxy,
+                )
                 self.tmem_s_ref.store_p_local_sum(scale_idx, local_sums[scale_idx])
 
             if cutlass.const_expr(cfg.use_fp8_qkv):
@@ -1057,6 +1258,32 @@ class SmemPResource(DecodeGenResourceBase):
                             p_vals[p_base + 4] = p_pair[1]
                             local_sum[scale_idx] += p_pair[0]
                             local_sum[scale_idx] += p_pair[1]
+            if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                num_summaries, _ = _block_sparse_proxy_summary_geometry(
+                    cfg.static_seq_len_kv,
+                    cfg.kv_block_size,
+                )
+                for scale_idx in cutlass.range_constexpr(cfg.num_softmax_scale_groups):
+                    proxy_tail_p = Float32(0.0)
+                    for token_group_idx in cutlass.range_constexpr(4):
+                        atom_origin, logical_summary = self._proxy_swaps_logical_k(
+                            lane_idx >> Int32(2),
+                            route_origin0,
+                            route_origin1,
+                            route_origin2,
+                            route_origin3,
+                            token_group_idx=token_group_idx,
+                        )
+                        if atom_origin >= Int32(0) and logical_summary == Int32(
+                            num_summaries - 1
+                        ):
+                            p_idx = scale_idx + token_group_idx * 2
+                            proxy_tail_p = Float32(p_vals[p_idx])
+                    local_sum[scale_idx] = self._apply_proxy_route_denominator_mass(
+                        local_sum[scale_idx],
+                        proxy_tail_p,
+                        route_is_proxy,
+                    )
             # Pack the P scalars to match the dtype consumed by BMM2.
             regs_p = cutlass.Array(
                 Int32, cfg.num_packed_p_regs, space=cutlass.AddressSpace.rmem
@@ -1106,6 +1333,77 @@ class SmemPResource(DecodeGenResourceBase):
             # warpgroup before the UMMA-consumer pipeline is committed so
             # BMM2 cannot observe a partially written P tile.
             prims.barrier_cta_sync(4 + self.inst_id, thread_count=128)
+
+    @producer_work
+    @cute.jit
+    def compute_p(
+        self,
+        stage_info: StageInfo,
+        *,
+        new_max_arr: cutlass.Array,
+        s_arr: cutlass.Array,
+    ) -> None:
+        """Compute an exact/dense P tile without typed-route metadata."""
+
+        self._compute_p_impl(
+            stage_info,
+            new_max_arr=new_max_arr,
+            s_arr=s_arr,
+            route_is_proxy=Int32(0),
+            route_origin0=Int32(0),
+            route_origin1=Int32(0),
+            route_origin2=Int32(0),
+            route_origin3=Int32(0),
+        )
+
+    @producer_work
+    @cute.jit
+    def compute_proxy_route_p(
+        self,
+        stage_info: StageInfo,
+        *,
+        new_max_arr: cutlass.Array,
+        s_arr: cutlass.Array,
+        route_origin0: Int32,
+        route_origin1: Int32,
+        keeps_route_flags_or_swaps_origin2: Int32,
+        swaps_route_origin3_bits: Uint32,
+        swaps_route_flags: Uint32,
+    ) -> None:
+        """Normalize the active Keeps/SWAP metadata view and compute P.
+
+        The shared Int32 input is Keeps route flags or SWAP origin2.  SWAP's
+        origin3 and flags stay bit-preserving Uint32 values until this work
+        boundary because schedule-level dataflow tokens cannot be cast.
+        """
+
+        assert self.cfg.use_block_sparse_proxy_routes
+        route_origin2 = Int32(0)
+        route_origin3 = Int32(0)
+        if cutlass.const_expr(self.cfg.use_keeps_mma_ab):
+            route_is_proxy = Int32(
+                (
+                    keeps_route_flags_or_swaps_origin2
+                    & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)
+                )
+                != Int32(0)
+            )
+        else:
+            route_is_proxy = Int32(
+                (swaps_route_flags & Uint32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Uint32(0)
+            )
+            route_origin2 = keeps_route_flags_or_swaps_origin2
+            route_origin3 = swaps_route_origin3_bits.bitcast(Int32)
+        self._compute_p_impl(
+            stage_info,
+            new_max_arr=new_max_arr,
+            s_arr=s_arr,
+            route_is_proxy=route_is_proxy,
+            route_origin0=route_origin0,
+            route_origin1=route_origin1,
+            route_origin2=route_origin2,
+            route_origin3=route_origin3,
+        )
 
     @consumer_work(
         returns=(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_resources.py
@@ -498,6 +498,10 @@ class SmemKvTileResource(DecodeGenResourceBase):
     tma_desc_v: cutlass.Pointer | None = None
     tma_desc_k_atom: cutlass.Pointer | None = None
     tma_desc_v_atom: cutlass.Pointer | None = None
+    tma_desc_k_summary: cutlass.Pointer | None = None
+    tma_desc_v_summary: cutlass.Pointer | None = None
+    tma_desc_k_summary_atom: cutlass.Pointer | None = None
+    tma_desc_v_summary_atom: cutlass.Pointer | None = None
     sparse_kv_metadata: "SmemBlockSparseKvMetadataResource | None" = None
     page_offsets_kv: "SmemPageOffsetsKvResource | None" = None
     seqlens_kv: cute.Pointer | None = None
@@ -704,14 +708,23 @@ class SmemKvTileResource(DecodeGenResourceBase):
             assert self.sparse_kv_metadata is not None
             assert self.tma_desc_k_atom is not None
             assert self.tma_desc_v_atom is not None
-            # The positional TensorMaps keep the decode ABI stable. The
-            # primary K/V descriptors are KV128 for coarse routes and one atom
-            # for fine routes. The auxiliary slots always expose the atom
-            # descriptor and alias the primary descriptor for fine routes.
+            # K/V and summary sources expose the same primary/atom descriptor
+            # pair. Route kind selects the source; the geometry below alone
+            # selects the physical copy policy.
             tma_desc_atom = (
                 self.tma_desc_v_atom
                 if cutlass.const_expr(self.kv_kind == KV_KIND_V)
                 else self.tma_desc_k_atom
+            )
+            tma_desc_summary = (
+                self.tma_desc_v_summary
+                if cutlass.const_expr(self.kv_kind == KV_KIND_V)
+                else self.tma_desc_k_summary
+            )
+            tma_desc_summary_atom = (
+                self.tma_desc_v_summary_atom
+                if cutlass.const_expr(self.kv_kind == KV_KIND_V)
+                else self.tma_desc_k_summary_atom
             )
             kv_atom_size = _block_sparse_kv_atom_size(cfg.kv_block_size)
             head_dim_stage = cfg.head_dim_kv_stage
@@ -776,6 +789,12 @@ class SmemKvTileResource(DecodeGenResourceBase):
                 # join unrelated entries and must prove physical adjacency.
                 fragment_chunk_elems = chunk_hd * 64
                 if prims.elect_sync():
+                    route_tma_desc = tma_desc
+                    route_tma_desc_atom = tma_desc_atom
+                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                        if self.sparse_kv_metadata.route_is_proxy():
+                            route_tma_desc = tma_desc_summary
+                            route_tma_desc_atom = tma_desc_summary_atom
                     origin0, _ = self.sparse_kv_metadata.route_tma_coordinate(
                         Int32(0),
                         logical_b_idx,
@@ -801,7 +820,7 @@ class SmemKvTileResource(DecodeGenResourceBase):
                             local_tile_offset = chunk_idx * tile_chunk_elems
                             prims.cp_async_bulk_tensor_shared_cta_global(
                                 stage_base.subview(local_tile_offset),
-                                tma_desc,
+                                route_tma_desc,
                                 (
                                     Int32(global_head_dim_offset),
                                     origin0,
@@ -833,7 +852,7 @@ class SmemKvTileResource(DecodeGenResourceBase):
                             if adjacent:
                                 prims.cp_async_bulk_tensor_shared_cta_global(
                                     stage_base.subview(local_tile_offset),
-                                    tma_desc,
+                                    route_tma_desc,
                                     (
                                         Int32(global_head_dim_offset),
                                         origin0,
@@ -845,7 +864,7 @@ class SmemKvTileResource(DecodeGenResourceBase):
                             else:
                                 prims.cp_async_bulk_tensor_shared_cta_global(
                                     stage_base.subview(local_tile_offset),
-                                    tma_desc_atom,
+                                    route_tma_desc_atom,
                                     (
                                         Int32(global_head_dim_offset),
                                         origin0,
@@ -858,7 +877,7 @@ class SmemKvTileResource(DecodeGenResourceBase):
                                     stage_base.subview(
                                         local_tile_offset + fragment_chunk_elems
                                     ),
-                                    tma_desc_atom,
+                                    route_tma_desc_atom,
                                     (
                                         Int32(global_head_dim_offset),
                                         origin1,
@@ -876,6 +895,10 @@ class SmemKvTileResource(DecodeGenResourceBase):
                 atom_chunk_elems = chunk_hd * kv_atom_size
                 atoms_per_route = cfg.tile_size_kv // kv_atom_size
                 if prims.elect_sync():
+                    route_tma_desc_atom = tma_desc_atom
+                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                        if self.sparse_kv_metadata.route_is_proxy():
+                            route_tma_desc_atom = tma_desc_summary_atom
                     stage_base = self._stage_base(stage_info)
                     # Reuse each retained origin across all head-dimension
                     # chunks. The copies still target disjoint SMEM regions
@@ -914,7 +937,7 @@ class SmemKvTileResource(DecodeGenResourceBase):
                                 stage_base.subview(
                                     local_tile_offset + atom_idx * atom_chunk_elems
                                 ),
-                                tma_desc_atom,
+                                route_tma_desc_atom,
                                 (
                                     Int32(global_head_dim_offset),
                                     origin,
@@ -1487,6 +1510,10 @@ class SmemKvResource(DecodeGenResourceBase):
     tma_desc_v: cutlass.Pointer | None = None
     tma_desc_k_atom: cutlass.Pointer | None = None
     tma_desc_v_atom: cutlass.Pointer | None = None
+    tma_desc_k_summary: cutlass.Pointer | None = None
+    tma_desc_v_summary: cutlass.Pointer | None = None
+    tma_desc_k_summary_atom: cutlass.Pointer | None = None
+    tma_desc_v_summary_atom: cutlass.Pointer | None = None
     sparse_kv_metadata0: "SmemBlockSparseKvMetadataResource | None" = None
     sparse_kv_metadata1: "SmemBlockSparseKvMetadataResource | None" = None
     page_offsets_kv: SmemPageOffsetsKvResource | None = None
@@ -1922,6 +1949,29 @@ class SmemKvResource(DecodeGenResourceBase):
             ):
                 assert self.page_offsets_kv is not None
                 dense_page_ids = self.page_offsets_kv.page_ids(grouped_tile_idx)
+            # Select the logical source before the constexpr 4 x 2 loop so K/V
+            # and summary routes retain one physical KV256 staging body.
+            route_tma_desc = tma_desc
+            if cutlass.const_expr(cfg.use_block_sparse):
+                sparse_tma_desc = (
+                    self.tma_desc_v_atom
+                    if cutlass.const_expr(kv_kind == KV_KIND_V)
+                    else self.tma_desc_k_atom
+                )
+                assert sparse_tma_desc is not None
+                route_tma_desc = sparse_tma_desc
+                if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                    assert sparse_kv_metadata is not None
+                    summary_tma_desc = (
+                        self.tma_desc_v_summary_atom
+                        if cutlass.const_expr(kv_kind == KV_KIND_V)
+                        else self.tma_desc_k_summary_atom
+                    )
+                    assert summary_tma_desc is not None
+                    route_is_proxy = sparse_kv_metadata.route_is_proxy()
+                    route_tma_desc = (
+                        summary_tma_desc if route_is_proxy else sparse_tma_desc
+                    )
             for semantic_block in cutlass.range_constexpr(4):
                 token_coord = Int32(0)
                 storage_coord = logical_b_idx
@@ -1950,15 +2000,9 @@ class SmemKvResource(DecodeGenResourceBase):
                         )
 
                     if cutlass.const_expr(cfg.use_block_sparse):
-                        sparse_tma_desc = (
-                            self.tma_desc_v_atom
-                            if cutlass.const_expr(kv_kind == KV_KIND_V)
-                            else self.tma_desc_k_atom
-                        )
-                        assert sparse_tma_desc is not None
                         prims.cp_async_bulk_tensor_shared_cta_global(
                             stage_base.subview(block_base),
-                            sparse_tma_desc,
+                            route_tma_desc,
                             (
                                 Int32(dim_half * 64),
                                 token_coord,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
@@ -76,6 +76,7 @@ from .helpers_common import (
     _mma_kind_for_qkv,
     _neg_max_f32,
     _softmax_scale_pair_width,
+    _swaps_routed_coordinate,
     _q_row_is_valid_for_seq,
     _q_row_token_and_local_head,
     _q_group_token_base,
@@ -1655,32 +1656,6 @@ class TmemSResource(DecodeGenResourceBase):
         return s_arr
 
     @cute.jit
-    def _sparse_swaps_logical_k(
-        self,
-        lane_k_offset: Int32,
-        sparse_origin0: Int32,
-        sparse_origin1: Int32,
-        sparse_origin2: Int32,
-        sparse_origin3: Int32,
-        *,
-        token_group_idx: Constexpr[int],
-    ) -> tuple[Int32, Int32]:
-        """Map one SWAP register group to its routed logical K position."""
-
-        atom_size = min(self.cfg.kv_block_size, 32)
-        groups_per_atom = atom_size // 8
-        origin_idx = token_group_idx // groups_per_atom
-        atom_origin = sparse_origin0
-        if cutlass.const_expr(origin_idx == 1):
-            atom_origin = sparse_origin1
-        elif cutlass.const_expr(origin_idx == 2):
-            atom_origin = sparse_origin2
-        elif cutlass.const_expr(origin_idx == 3):
-            atom_origin = sparse_origin3
-        token_offset = (token_group_idx % groups_per_atom) * 8
-        return atom_origin, atom_origin + Int32(token_offset) + lane_k_offset
-
-    @cute.jit
     def _compute_softmax_loop_swaps(
         self,
         stage_info: StageInfo,
@@ -1912,7 +1887,8 @@ class TmemSResource(DecodeGenResourceBase):
                 lane_k_offset = Int32(task_cache[_TASK_CACHE_LANE_IDX]) >> Int32(2)
                 token_word_covers_kv_tail = _swaps_token_word_covers_kv_tail(cfg)
                 for token_group_idx in cutlass.range_constexpr(4):
-                    atom_origin, logical_k = self._sparse_swaps_logical_k(
+                    atom_origin, logical_k = _swaps_routed_coordinate(
+                        cfg,
                         lane_k_offset,
                         sparse_origin0,
                         sparse_origin1,
@@ -2080,7 +2056,8 @@ class TmemSResource(DecodeGenResourceBase):
                             tile_offset_k + local_idx_k0 + Int32(token_group_idx * 8)
                         )
                         if cutlass.const_expr(use_sparse):
-                            _, token_idx = self._sparse_swaps_logical_k(
+                            _, token_idx = _swaps_routed_coordinate(
+                                cfg,
                                 lane_idx >> Int32(2),
                                 sparse_origin0,
                                 sparse_origin1,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
@@ -82,6 +82,7 @@ from .helpers_common import (
     _softmax_tile_idx,
 )
 from .smem_block_sparse_metadata import (
+    _SOFTMAX_ROUTE_IS_PROXY_FLAG,
     _SOFTMAX_TOKEN_MASK_IS_FULL_FLAG,
     _swaps_forwards_packed_route_full,
 )
@@ -116,7 +117,7 @@ def _swaps_uses_origin0_k32_full_guard(cfg: FmhaDecodeConfig) -> bool:
 
     return (
         cfg.kv_block_size >= 32
-        and not cfg.use_kv_valid_bits
+        and not cfg.uses_prepared_score_keep_words
         and not cfg.uses_uniform_causal_mask
         and not cfg.uses_per_row_causal_mask
     )
@@ -126,7 +127,7 @@ def _swaps_token_word_covers_kv_tail(cfg: FmhaDecodeConfig) -> bool:
     """Whether SWAP's prepared token word covers the logical KV tail."""
 
     return (
-        cfg.use_kv_valid_bits
+        cfg.uses_prepared_score_keep_words
         and not cfg.uses_uniform_causal_mask
         and not cfg.uses_per_row_causal_mask
     )
@@ -180,7 +181,7 @@ def _can_skip_sparse_keeps_structural_mask(
 
 
 @cute.jit
-def _sparse_k32_effective_keep_word(
+def _sparse_effective_keep_word(
     q_row_is_valid: Boolean,
     fragment_origin: Int32,
     fragment_valid: Int32,
@@ -1179,7 +1180,7 @@ class TmemSResource(DecodeGenResourceBase):
         valid0 = route_flags & Int32(1)
         valid1 = (route_flags >> Int32(1)) & Int32(1)
         route_token_mask_is_full = cutlass.Boolean(False)
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             route_token_mask_is_full = cutlass.Boolean(
                 (route_flags & Int32(_SOFTMAX_TOKEN_MASK_IS_FULL_FLAG)) != Int32(0)
             )
@@ -1192,7 +1193,7 @@ class TmemSResource(DecodeGenResourceBase):
         )
         for word_idx in cutlass.range_constexpr(num_local_words):
             local_token_words[word_idx] = Uint32(0xFFFFFFFF)
-        if cutlass.const_expr(self.cfg.use_kv_valid_bits):
+        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
             if not route_token_mask_is_full:
                 if cutlass.const_expr(self.cfg.tile_size_q == 128):
                     local_token_words[0] = Uint32(routed_token_word0)
@@ -1271,7 +1272,9 @@ class TmemSResource(DecodeGenResourceBase):
             + self._softmax_loop_stage_slot_offset(stage_info)
         )
         num_load_atoms = num_s_regs // 32
-        if cutlass.const_expr(cfg.tile_size_q == 64 and cfg.use_kv_valid_bits):
+        if cutlass.const_expr(
+            cfg.tile_size_q == 64 and cfg.uses_prepared_score_keep_words
+        ):
             token_mask_is_required = not route_token_mask_is_full
 
             # Keep each Q64 atom's load, wait, and mask together. A/B testing
@@ -1332,6 +1335,14 @@ class TmemSResource(DecodeGenResourceBase):
             causal_end,
             apply_causal_mask=cfg.mask_type == CAUSAL,
         )
+        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+            route_is_proxy = cutlass.Boolean(
+                (routed_route_flags & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Int32(0)
+            )
+            if route_is_proxy and q_row_is_valid:
+                # Summary-row origins must not enter K/V-token tail predicates;
+                # prepared score words carry proxy validity.
+                can_skip_structural_mask = cutlass.Boolean(True)
         # This guard covers only route/Q/tail/causal structure. Q64 token
         # holes were applied while materializing its two LDTM atoms; Q128
         # applies them in the post-pass below.
@@ -1363,7 +1374,9 @@ class TmemSResource(DecodeGenResourceBase):
         # interleaving each load with mask control flow regresses its codegen.
         # The post-pass follows structural masking; the producer's runtime
         # route flag skips it only when all four current token words are full.
-        if cutlass.const_expr(cfg.tile_size_q == 128 and cfg.use_kv_valid_bits):
+        if cutlass.const_expr(
+            cfg.tile_size_q == 128 and cfg.uses_prepared_score_keep_words
+        ):
             token_mask_is_required = not route_token_mask_is_full
             if token_mask_is_required:
                 for word_idx in cutlass.range_constexpr(4):
@@ -1860,6 +1873,11 @@ class TmemSResource(DecodeGenResourceBase):
                 s_vals[q_repeats * 4 + ld_base + 2] = loaded1[ld_base + 2]
                 s_vals[q_repeats * 4 + ld_base + 3] = loaded1[ld_base + 3]
 
+        route_is_proxy = cutlass.Boolean(False)
+        if cutlass.const_expr(use_sparse and cfg.use_block_sparse_proxy_routes):
+            route_is_proxy = cutlass.Boolean(
+                (sparse_route_flags & Uint32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Uint32(0)
+            )
         if cutlass.const_expr(use_sparse):
             # Route, KV-tail, uniform-causal, and token validity depend only on
             # K, so one predicate masks the adjacent pair of Q-row registers.
@@ -1906,19 +1924,20 @@ class TmemSResource(DecodeGenResourceBase):
                     # tail. Qualified profiles can therefore omit the local
                     # atom-origin guard, independently of the K/V issuer warp.
                     score_is_valid = cutlass.Boolean(True)
-                    if cutlass.const_expr(
-                        not _swaps_uses_token_only_score_validity(cfg)
-                    ):
-                        score_is_valid = cutlass.Boolean(atom_origin >= Int32(0))
-                    if cutlass.const_expr(not token_word_covers_kv_tail):
-                        score_is_valid = cutlass.Boolean(
-                            score_is_valid and logical_k < seq_len_kv
-                        )
-                    if cutlass.const_expr(cfg.uses_uniform_causal_mask):
-                        score_is_valid = cutlass.Boolean(
-                            score_is_valid and logical_k < element_mask_end_idx
-                        )
-                    if cutlass.const_expr(cfg.use_kv_valid_bits):
+                    if not route_is_proxy:
+                        if cutlass.const_expr(
+                            not _swaps_uses_token_only_score_validity(cfg)
+                        ):
+                            score_is_valid = cutlass.Boolean(atom_origin >= Int32(0))
+                        if cutlass.const_expr(not token_word_covers_kv_tail):
+                            score_is_valid = cutlass.Boolean(
+                                score_is_valid and logical_k < seq_len_kv
+                            )
+                        if cutlass.const_expr(cfg.uses_uniform_causal_mask):
+                            score_is_valid = cutlass.Boolean(
+                                score_is_valid and logical_k < element_mask_end_idx
+                            )
+                    if cutlass.const_expr(cfg.uses_prepared_score_keep_words):
                         token_bit_idx = Int32(token_group_idx * 8) + lane_k_offset
                         token_is_valid = (
                             (sparse_token_word >> token_bit_idx) & Uint32(1)
@@ -2367,13 +2386,7 @@ class TmemSResource(DecodeGenResourceBase):
         sparse_token_word2: Uint32,
         sparse_token_word3: Uint32,
     ) -> tuple[object, object, object, object]:
-        """Reduce one sparse KV256 route as four bounded K32 fragments.
-
-        The full route path only loads and reduces scores. A partial route
-        predicates one native 32-score fragment at a time and writes it back
-        to TMEM, so the later P pass can replay masked scores without keeping
-        the logical 128-score tile live in registers.
-        """
+        """Preserve the established KV256 online-softmax state update."""
 
         cfg = self.cfg
         assert cfg.tile_size_kv == 256
@@ -2419,16 +2432,22 @@ class TmemSResource(DecodeGenResourceBase):
             if cutlass.const_expr(fragment_idx >= 2):
                 fragment_origin = origin1 + Int32((fragment_idx % 2) * 32)
                 fragment_valid = valid1
-            keep_words[fragment_idx] = _sparse_k32_effective_keep_word(
-                q_row_is_valid,
-                fragment_origin,
-                fragment_valid,
-                Uint32(token_words[fragment_idx]),
-                seq_len_kv,
-                causal_end,
-                apply_causal_mask=cfg.mask_type == CAUSAL,
-                apply_token_mask=cfg.use_kv_valid_bits,
-            )
+            if cutlass.const_expr(cfg.trusts_prepared_score_words):
+                prepared_keep_word = Uint32(0)
+                if q_row_is_valid:
+                    prepared_keep_word = Uint32(token_words[fragment_idx])
+                keep_words[fragment_idx] = prepared_keep_word
+            else:
+                keep_words[fragment_idx] = _sparse_effective_keep_word(
+                    q_row_is_valid,
+                    fragment_origin,
+                    fragment_valid,
+                    Uint32(token_words[fragment_idx]),
+                    seq_len_kv,
+                    causal_end,
+                    apply_causal_mask=cfg.mask_type == CAUSAL,
+                    apply_token_mask=cfg.uses_prepared_score_keep_words,
+                )
 
         warp_scores_are_unmasked = cutlass.Boolean(True)
         for fragment_idx in cutlass.range_constexpr(4):

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -65,6 +65,7 @@ from .fmha_decode_constants import (
 )
 from .fmha_decode_resources.helpers_common import (
     ResourceVars,
+    _assume_nonnegative_i32,
     _q_group_token_base,
     _q_seq_bounds,
     _warp_broadcast_i32,
@@ -652,7 +653,7 @@ def _load_prepared_sparse_row_warp(
         loaded_row_route_begin = cutlass.Int32(row_route_offsets[row_address])
         loaded_route_count = cutlass.Int32(row_route_counts[row_address])
     row_route_begin = _warp_broadcast_i32(loaded_row_route_begin, 0)
-    route_count = _warp_broadcast_i32(loaded_route_count, 0)
+    route_count = _assume_nonnegative_i32(_warp_broadcast_i32(loaded_route_count, 0))
     return row_route_begin, route_count
 
 
@@ -1078,19 +1079,19 @@ def _resolve_and_store_sparse_route(
     if sparse_kv_metadata is None:
         return None
     (
-        resolved_origin0,
+        resolved_record_word,
         resolved_origin1,
         resolved_atom_validity,
         route_record_word_offset,
     ) = sparse_kv_metadata.resolve_route(section=section)
     sparse_kv_metadata.store_route(
-        resolved_origin0=resolved_origin0,
+        resolved_record_word=resolved_record_word,
         resolved_origin1=resolved_origin1,
         resolved_atom_validity=resolved_atom_validity,
         route_record_word_offset=route_record_word_offset,
     )
     return (
-        resolved_origin0,
+        resolved_record_word,
         resolved_origin1,
         resolved_atom_validity,
         route_record_word_offset,
@@ -1107,14 +1108,14 @@ def _publish_sparse_softmax_route(
         return
     assert route is not None
     (
-        resolved_origin0,
+        resolved_record_word,
         resolved_origin1,
         resolved_atom_validity,
         route_record_word_offset,
     ) = route
     sparse_softmax_metadata.acquire()
     sparse_softmax_metadata.store_route(
-        resolved_origin0=resolved_origin0,
+        resolved_record_word=resolved_record_word,
         resolved_origin1=resolved_origin1,
         resolved_atom_validity=resolved_atom_validity,
         route_record_word_offset=route_record_word_offset,
@@ -1234,8 +1235,9 @@ def create_load_task(
                 for label in loop_labels:
                     _kv_load(label, FmhaStage.Loop)
             else:
-                # Follow the dense KV256 stage order exactly. Each V consumes
-                # its retained route before the matching K label replaces it.
+                # Follow the dense stage order exactly. Generic V-first
+                # profiles consume their retained route before the matching K
+                # label replaces it.
                 loop_routes = []
                 for label in loop_labels:
                     route = None
@@ -2662,8 +2664,9 @@ def create_mma_task(
         )
 
         # LOOP: consume aliased TMEM P before the next same-instance QK
-        # overwrites its S columns. SMEM-P profiles retain their established
-        # K-before-V cadence because P no longer depends on S lifetime.
+        # overwrites its S columns. Full-SMEM P remains score-dependent during
+        # Softmax replay, but owns independent storage once the replay commits
+        # and releases S; that completed handoff enables the QK-before-PV cadence.
         with domain_loop(0, domain, 1, unroll=1):
             if cfg.uses_two_inst_tmem_p:
                 _consume_staged_pv_mma(
@@ -2935,11 +2938,21 @@ def create_softmax0_task(
                         fragment_idx=fragment_idx,
                         s_arr=s_arr,
                     )
-                    smem_p0.compute_p_fragment(
-                        fragment_idx=fragment_idx,
-                        new_max_arr=new_max_arr,
-                        s_arr=s_arr,
-                    )
+                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                        smem_p0.compute_proxy_route_p_fragment(
+                            fragment_idx=fragment_idx,
+                            new_max_arr=new_max_arr,
+                            s_arr=s_arr,
+                            route_flags=sparse_route_flags,
+                            route_origin0=sparse_origin0,
+                            route_origin1=sparse_origin1,
+                        )
+                    else:
+                        smem_p0.compute_p_fragment(
+                            fragment_idx=fragment_idx,
+                            new_max_arr=new_max_arr,
+                            s_arr=s_arr,
+                        )
             else:
                 # Wait for a free P stage before entering the ordered window so
                 # BMM2 backpressure on this group's P pipeline cannot extend the
@@ -2950,16 +2963,27 @@ def create_softmax0_task(
                 # ProdWork: compute P=exp(S-new_max), store it in the profile's
                 # SMEM or staged-TMEM operand, and record local sums for the
                 # running softmax sum update.
-                smem_p0.compute_p(
-                    new_max_arr=new_max_arr,
-                    s_arr=s_arr,
-                )  # publishes the local denominator through tmem_s0
+                if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                    smem_p0.compute_proxy_route_p(
+                        new_max_arr=new_max_arr,
+                        s_arr=s_arr,
+                        route_origin0=sparse_origin0,
+                        route_origin1=sparse_origin1,
+                        keeps_route_flags_or_swaps_origin2=sparse_route_flags,
+                        swaps_route_origin3_bits=sparse_token_word0,
+                        swaps_route_flags=sparse_token_word2,
+                    )
+                else:
+                    smem_p0.compute_p(
+                        new_max_arr=new_max_arr,
+                        s_arr=s_arr,
+                    )  # publishes the local denominator through tmem_s0
                 smem_p0.commit()
                 if tmem_softmax_order is not None:
                     tmem_softmax_order.release_softmax1()
             if cutlass.const_expr(cfg.use_keeps_mma_ab and cfg.uses_tmem_p):
-                # The TMEM-P store has consumed the aliased S columns, so the
-                # next QK wave can now overwrite them.
+                # TMEM-P has consumed the aliased S columns, so the next QK
+                # wave can now overwrite S.
                 tmem_s0.release()
             # ProdWork: FP8 path applies the cross-resource sum correction
             # before TmemS.reduce_sums publishes the new running sums.
@@ -3153,11 +3177,21 @@ def create_softmax1_task(
                         fragment_idx=fragment_idx,
                         s_arr=s_arr,
                     )
-                    smem_p1.compute_p_fragment(
-                        fragment_idx=fragment_idx,
-                        new_max_arr=new_max_arr,
-                        s_arr=s_arr,
-                    )
+                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                        smem_p1.compute_proxy_route_p_fragment(
+                            fragment_idx=fragment_idx,
+                            new_max_arr=new_max_arr,
+                            s_arr=s_arr,
+                            route_flags=sparse_route_flags,
+                            route_origin0=sparse_origin0,
+                            route_origin1=sparse_origin1,
+                        )
+                    else:
+                        smem_p1.compute_p_fragment(
+                            fragment_idx=fragment_idx,
+                            new_max_arr=new_max_arr,
+                            s_arr=s_arr,
+                        )
             else:
                 # Wait for a free P stage before entering the ordered window so
                 # BMM2 backpressure on this group's P pipeline cannot extend the
@@ -3166,7 +3200,18 @@ def create_softmax1_task(
                 if tmem_softmax_order is not None:
                     tmem_softmax_order.wait_softmax1()
                 # ProdWork: compute and publish P1 for BMM2.
-                smem_p1.compute_p(new_max_arr=new_max_arr, s_arr=s_arr)
+                if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                    smem_p1.compute_proxy_route_p(
+                        new_max_arr=new_max_arr,
+                        s_arr=s_arr,
+                        route_origin0=sparse_origin0,
+                        route_origin1=sparse_origin1,
+                        keeps_route_flags_or_swaps_origin2=sparse_route_flags,
+                        swaps_route_origin3_bits=sparse_token_word0,
+                        swaps_route_flags=sparse_token_word2,
+                    )
+                else:
+                    smem_p1.compute_p(new_max_arr=new_max_arr, s_arr=s_arr)
                 smem_p1.commit()
                 if tmem_softmax_order is not None:
                     tmem_softmax_order.release_softmax0()

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -2878,9 +2878,9 @@ def create_softmax0_task(
             sparse_softmax_metadata.init_read_state()
 
         with domain_loop(0, domain, 1, unroll=1) as d:
-            # ConsWait/ConsWork: load S from TMEM and compute the tile max.
-            tmem_s0.wait()
             if sparse_softmax_metadata is not None:
+                # Consume the independent metadata stream first so its SMEM
+                # loads and release can overlap the subsequent score wait.
                 sparse_softmax_metadata.wait()
                 # Copy the complete payload to registers before release, so
                 # masking cannot race the producer's next SMEM-stage reuse.
@@ -2894,6 +2894,9 @@ def create_softmax0_task(
                     sparse_token_word3,
                 ) = sparse_softmax_metadata.load_route()
                 sparse_softmax_metadata.release()
+            # ConsWait/ConsWork: load S from TMEM and compute the tile max.
+            tmem_s0.wait()
+            if sparse_softmax_metadata is not None:
                 old_max_arr, sum_arr, new_max_arr, s_arr = (
                     tmem_s0.compute_block_sparse_softmax_loop(
                         old_max_arr=old_max_arr,
@@ -3121,9 +3124,9 @@ def create_softmax1_task(
             sparse_softmax_metadata.init_read_state()
 
         with domain_loop(0, domain, 1, unroll=1) as d:
-            # ConsWait/ConsWork: load the second S instance and compute max.
-            tmem_s1.wait()
             if sparse_softmax_metadata is not None:
+                # Consume the independent metadata stream first so its SMEM
+                # loads and release can overlap the subsequent score wait.
                 sparse_softmax_metadata.wait()
                 # Copy to registers before release so the producer can reuse
                 # the SMEM stage while this warp group applies the masks.
@@ -3137,6 +3140,9 @@ def create_softmax1_task(
                     sparse_token_word3,
                 ) = sparse_softmax_metadata.load_route()
                 sparse_softmax_metadata.release()
+            # ConsWait/ConsWork: load the second S instance and compute max.
+            tmem_s1.wait()
+            if sparse_softmax_metadata is not None:
                 old_max_arr, sum_arr, new_max_arr, s_arr = (
                     tmem_s1.compute_block_sparse_softmax_loop(
                         old_max_arr=old_max_arr,

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -27,7 +27,7 @@ the backend column indicates which kernel the API wraps.
 | ``prims_ts_batch_decode``       | batched, ragged   | paged HND tuple/combined  | kv_indptr + optional qo | decode  | PrimTS SM100/SM103 |
 | ``gqa_paged_prefill``           | batched, ragged   | paged tuple (k, v)        | +qo_indptr              | prefill | FA2/FA3/cuDNN   |
 | ``gqa_ragged``                  | batched, ragged   | contiguous                | qo_indptr + kv_indptr   | prefill | FA2/FA3         |
-| ``prims_ts_block_sparse``       | batched, fixed    | contiguous BSHD           | per-KV-head BSR + bits  | both    | PrimTS SM100a   |
+| ``prims_ts_block_sparse``       | batched, fixed    | contiguous BSHD           | BSR/bitmask + summaries | both    | PrimTS SM100a   |
 | ``prims_ts_paged_block_sparse`` | batched, fixed    | paged HND tuple/combined  | page table + BSR + bits | both    | PrimTS SM100a   |
 | ``mla_paged_decode``            | batched, ragged   | paged MLA (ckv + kpe)     | kv_indptr + kv_indices  | decode  | DeepSeek MLA    |
 | ``prims_ts_decode_mla``         | batched, ragged Q | paged MLA (ckv + kpe)     | block tables + qo/seq   | decode  | PrimTS SM100/SM103 |
@@ -328,11 +328,15 @@ gqa_paged_decode_plan_trace = _BatchDecodePlanTraceTemplate(
 )
 
 
-# PrimTS block-sparse schema. Only the one-shot API can fully express its BSR
-# metadata and block geometry in a trace definition.
+# PrimTS block-sparse schemas. One-shot inputs carry block geometry directly;
+# reusable wrapper traces retain the same geometry as optional plan context.
 
 
-def _make_prims_ts_block_sparse_trace() -> TraceTemplate:
+def _make_prims_ts_block_sparse_trace(
+    *, sparse_format: str = "bsr", use_proxy_routes: bool = False
+) -> TraceTemplate:
+    """Describe one contiguous route frontend and exact/proxy source mode."""
+
     axes: dict[str, Var | Const] = {
         "batch_size": Var(description="Number of requests."),
         "seq_len_q": Var(description="Fixed query length per request."),
@@ -340,58 +344,157 @@ def _make_prims_ts_block_sparse_trace() -> TraceTemplate:
         "num_qo_heads": Const(abbrev="h"),
         "num_kv_heads": Const(abbrev="kv"),
         "head_dim": Const(abbrev="d"),
-        "num_q_block_offsets": Var(
-            description="Number of BSR row offsets per batch and KV head."
-        ),
-        "num_block_indices": Var(
-            description="Capacity of the runtime KV-block ID tensor."
-        ),
         "num_kv_valid_words": Var(
             description="Number of optional token-validity words per batch."
         ),
         "q_block_size": Const(abbrev="qb"),
         "kv_block_size": Const(abbrev="kb"),
     }
+    if sparse_format == "bsr":
+        axes.update(
+            {
+                "num_q_block_offsets": Var(
+                    description="Number of BSR row offsets per batch and KV head."
+                ),
+                "num_block_indices": Var(
+                    description="Capacity of the runtime KV-block ID tensor."
+                ),
+            }
+        )
+    elif sparse_format == "bitmask":
+        axes.update(
+            {
+                "num_q_blocks": Var(description="Number of semantic query-block rows."),
+                "num_exact_block_words": Var(
+                    description="Packed exact-block words in each sparse row."
+                ),
+            }
+        )
+    else:
+        raise ValueError(f"unsupported sparse format {sparse_format!r}")
+    if use_proxy_routes:
+        axes["num_kv_blocks"] = Var(
+            description="Number of semantic K/V blocks represented by summaries."
+        )
+
     inputs: dict[str, Tensor | Scalar] = {
         "q": Tensor(["batch_size", "seq_len_q", "num_qo_heads", "head_dim"]),
         "k": Tensor(["batch_size", "seq_len_kv", "num_kv_heads", "head_dim"]),
         "v": Tensor(["batch_size", "seq_len_kv", "num_kv_heads", "head_dim"]),
-        "block_indptr": Tensor(
-            ["batch_size", "num_kv_heads", "num_q_block_offsets"],
-            dtype="int32",
-            description=(
-                "Absolute offsets into block_indices, consumed by the one-shot call."
-            ),
-        ),
-        "block_indices": Tensor(
-            ["num_block_indices"],
-            dtype="int32",
-            description=(
-                "Runtime KV-block ID capacity; only entries referenced by "
-                "block_indptr are live."
-            ),
-        ),
-        "kv_valid_bits": Tensor(
-            ["batch_size", "num_kv_valid_words"],
-            dtype="uint32",
-            optional=True,
-            description=(
-                "Batch-only token validity bits: token t uses bit t % 32 of "
-                "word t // 32 (LSB-first); one means valid. Padding bits "
-                "beyond Skv are ignored; consumed by the one-shot call."
-            ),
-        ),
-        "q_block_size": Scalar("int32"),
-        "kv_block_size": Scalar("int32"),
-        "mask_type": Scalar("string", optional=True),
-        "sm_scale": Scalar("float32", optional=True),
     }
+    if sparse_format == "bsr":
+        inputs.update(
+            {
+                "block_indptr": Tensor(
+                    ["batch_size", "num_kv_heads", "num_q_block_offsets"],
+                    dtype="int32",
+                    description=(
+                        "Absolute offsets into block_indices, consumed by the one-shot call."
+                    ),
+                ),
+                "block_indices": Tensor(
+                    ["num_block_indices"],
+                    dtype="int32",
+                    description=(
+                        "Runtime KV-block ID capacity; only entries referenced by "
+                        "block_indptr are live."
+                    ),
+                ),
+            }
+        )
+    else:
+        inputs["exact_block_bits"] = Tensor(
+            [
+                "batch_size",
+                "num_kv_heads",
+                "num_q_blocks",
+                "num_exact_block_words",
+            ],
+            dtype="uint32",
+            description=(
+                "LSB-first packed exact-block selections for every query-block row."
+            ),
+        )
+    if use_proxy_routes:
+        summary_shape = ["batch_size", "num_kv_blocks", "num_kv_heads", "head_dim"]
+        inputs.update(
+            {
+                "k_summary": Tensor(
+                    summary_shape,
+                    description="Per-block mean K vectors for proxy routes.",
+                ),
+                "v_summary": Tensor(
+                    summary_shape,
+                    description="Per-block summed V vectors for proxy routes.",
+                ),
+            }
+        )
+    inputs.update(
+        {
+            "kv_valid_bits": Tensor(
+                ["batch_size", "num_kv_valid_words"],
+                dtype="uint32",
+                optional=True,
+                description=(
+                    "Batch-only token validity bits: token t uses bit t % 32 of "
+                    "word t // 32 (LSB-first); one means valid. Padding bits "
+                    "beyond Skv are ignored; the mask applies only to exact routes."
+                ),
+            ),
+            "q_block_size": Scalar("int32"),
+            "kv_block_size": Scalar("int32"),
+            "mask_type": Scalar("string", optional=True),
+            "sm_scale": Scalar("float32", optional=True),
+        }
+    )
+    route_name = "BSR" if sparse_format == "bsr" else "bitmask"
+    if use_proxy_routes:
+        route_name += " proxy"
+    name_suffix = "" if sparse_format == "bsr" and not use_proxy_routes else "_"
+    if name_suffix:
+        name_suffix += (
+            sparse_format if not use_proxy_routes else f"{sparse_format}_proxy"
+        )
+    constraints = [
+        "num_qo_heads % num_kv_heads == 0",
+        "num_qo_heads // num_kv_heads in (1, 2, 4, 8, 16, 32)",
+        "head_dim == 128",
+        "q_block_size > 0",
+        "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
+        (
+            "kv_block_size in (8, 16, 32) or "
+            "(kv_block_size > 0 and kv_block_size % 64 == 0)"
+        ),
+        "kv_valid_bits is None or num_kv_valid_words == (seq_len_kv + 31) // 32",
+    ]
+    if sparse_format == "bsr":
+        constraints.append(
+            "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1"
+        )
+    else:
+        constraints.extend(
+            [
+                "num_q_blocks == (seq_len_q + q_block_size - 1) // q_block_size",
+                "num_exact_block_words == "
+                "(((seq_len_kv + kv_block_size - 1) // kv_block_size) + 31) // 32",
+            ]
+        )
+    if use_proxy_routes:
+        constraints.extend(
+            [
+                "num_kv_blocks == (seq_len_kv + kv_block_size - 1) // kv_block_size",
+                "mask_type is None or mask_type == 'dense'",
+            ]
+        )
+    else:
+        constraints.append("mask_type is None or mask_type in ('dense', 'causal')")
+
     return TraceTemplate(
         op_type="block_sparse",
-        name_prefix="prims_ts_block_sparse",
+        name_prefix=f"prims_ts_block_sparse{name_suffix}",
         description=(
             "One-shot PrimTS block-sparse MHA/GQA/MQA attention over compact "
-            "BSHD Q/K/V and per-KV-head BSR metadata."
+            f"BSHD Q/K/V and per-KV-head {route_name} metadata."
         ),
         axes=axes,
         inputs=inputs,
@@ -402,29 +505,39 @@ def _make_prims_ts_block_sparse_trace() -> TraceTemplate:
                 param="out",
             )
         },
-        constraints=[
-            "num_qo_heads % num_kv_heads == 0",
-            "num_qo_heads // num_kv_heads in (1, 2, 4, 8, 16, 32)",
-            "head_dim == 128",
-            "q_block_size > 0",
-            "(q_block_size * (num_qo_heads // num_kv_heads)) % 8 == 0",
-            (
-                "kv_block_size in (8, 16, 32) or "
-                "(kv_block_size > 0 and kv_block_size % 64 == 0)"
-            ),
-            "num_q_block_offsets == (seq_len_q + q_block_size - 1) // q_block_size + 1",
-            "kv_valid_bits is None or num_kv_valid_words == (seq_len_kv + 31) // 32",
-            "mask_type is None or mask_type in ('dense', 'causal')",
-        ],
+        constraints=constraints,
         tags=[
             "backend:prims-ts",
             "sparse:block",
+            f"sparse-format:{sparse_format}",
+            "routes:proxy" if use_proxy_routes else "routes:exact",
             "status:experimental",
         ],
     )
 
 
-prims_ts_block_sparse_trace = _make_prims_ts_block_sparse_trace()
+_PRIMS_TS_BLOCK_SPARSE_TRACES = {
+    (sparse_format, use_proxy_routes): _make_prims_ts_block_sparse_trace(
+        sparse_format=sparse_format,
+        use_proxy_routes=use_proxy_routes,
+    )
+    for sparse_format in ("bsr", "bitmask")
+    for use_proxy_routes in (False, True)
+}
+prims_ts_block_sparse_trace = _PRIMS_TS_BLOCK_SPARSE_TRACES[("bsr", False)]
+
+
+def prims_ts_block_sparse_trace_dispatch(**kwargs):
+    """Select a continuous one-shot schema from its explicit route mode."""
+
+    sparse_format = kwargs.get("sparse_format", "bsr")
+    use_proxy_routes = kwargs.get("use_proxy_routes", False)
+    return _PRIMS_TS_BLOCK_SPARSE_TRACES[(sparse_format, use_proxy_routes)]
+
+
+prims_ts_block_sparse_trace_dispatch.templates = list(  # type: ignore[attr-defined]
+    _PRIMS_TS_BLOCK_SPARSE_TRACES.values()
+)
 
 
 def _make_prims_ts_paged_block_sparse_trace(*, combined: bool) -> TraceTemplate:
@@ -610,11 +723,18 @@ def _make_block_sparse_wrapper_inputs(
     inputs = dict(one_shot.inputs)
     for name in plan_scalars:
         _copy_scalar_as_optional(inputs, name)
-    _copy_tensor_with_description(
-        inputs,
-        "block_indptr",
-        "Absolute offsets into live block_indices for this wrapper run.",
-    )
+    if "block_indptr" in inputs:
+        _copy_tensor_with_description(
+            inputs,
+            "block_indptr",
+            "Absolute offsets into live block_indices for this wrapper run.",
+        )
+    else:
+        _copy_tensor_with_description(
+            inputs,
+            "exact_block_bits",
+            "LSB-first packed exact-block selections for this wrapper run.",
+        )
     _copy_tensor_with_description(
         inputs,
         "kv_valid_bits",
@@ -627,10 +747,12 @@ def _make_block_sparse_wrapper_inputs(
     return inputs
 
 
-def _make_prims_ts_block_sparse_wrapper_trace() -> TraceTemplate:
+def _make_prims_ts_block_sparse_wrapper_trace(
+    *, sparse_format: str, use_proxy_routes: bool
+) -> TraceTemplate:
     """Describe ``BlockSparseTSWrapper.run`` and its plan-owned geometry."""
 
-    one_shot = _make_prims_ts_block_sparse_trace()
+    one_shot = _PRIMS_TS_BLOCK_SPARSE_TRACES[(sparse_format, use_proxy_routes)]
     axes = dict(one_shot.axes)
     # Unlike the one-shot API, run() does not receive these plan-owned values.
     # Keep them as optional schema context, matching the dense PrimTS wrapper
@@ -641,12 +763,15 @@ def _make_prims_ts_block_sparse_wrapper_trace() -> TraceTemplate:
     )
     return TraceTemplate(
         op_type=one_shot.op_type,
-        name_prefix="prims_ts_block_sparse_wrapper",
+        name_prefix=one_shot.name_prefix.replace(
+            "prims_ts_block_sparse", "prims_ts_block_sparse_wrapper", 1
+        ),
         description=(
             "Reusable PrimTS block-sparse MHA/GQA/MQA attention over compact "
-            "BSHD Q/K/V and live per-KV-head BSR metadata. Block geometry and "
-            "mask type are retained by plan() and represented as optional "
-            "trace context."
+            f"BSHD Q/K/V and live per-KV-head {sparse_format} metadata"
+            f"{' with proxy summaries' if use_proxy_routes else ''}. Block "
+            "geometry and mask type are retained by plan() and represented "
+            "as optional trace context."
         ),
         axes=axes,
         inputs=inputs,
@@ -656,12 +781,17 @@ def _make_prims_ts_block_sparse_wrapper_trace() -> TraceTemplate:
     )
 
 
-_PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACE = _make_prims_ts_block_sparse_wrapper_trace()
+_PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACES = {
+    key: _make_prims_ts_block_sparse_wrapper_trace(
+        sparse_format=key[0], use_proxy_routes=key[1]
+    )
+    for key in _PRIMS_TS_BLOCK_SPARSE_TRACES
+}
 
 
 def _require_prims_ts_block_sparse_wrapper_state(
     kwargs: dict[str, object], wrapper_name: str
-) -> None:
+) -> object:
     """Require bound-method tracing after the reusable wrapper is planned."""
 
     wrapper = kwargs.get("self")
@@ -671,20 +801,26 @@ def _require_prims_ts_block_sparse_wrapper_state(
             "Use flashinfer.fi_trace(wrapper.run, ...) instead of "
             "wrapper.run.fi_trace(...)."
         )
-    if getattr(wrapper, "_plan_state", None) is None:
+    state = getattr(wrapper, "_plan_state", None)
+    if state is None:
         raise RuntimeError("plan() must be called before run()")
+    return state
 
 
 def prims_ts_block_sparse_wrapper_trace_dispatch(**kwargs):
     """Trace a planned contiguous block-sparse wrapper run."""
 
-    _require_prims_ts_block_sparse_wrapper_state(kwargs, "BlockSparseTSWrapper")
-    return _PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACE
+    state = _require_prims_ts_block_sparse_wrapper_state(kwargs, "BlockSparseTSWrapper")
+    route_mode = (
+        state.sparse_format,  # type: ignore[attr-defined]
+        state.use_proxy_routes,  # type: ignore[attr-defined]
+    )
+    return _PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACES[route_mode]
 
 
-prims_ts_block_sparse_wrapper_trace_dispatch.templates = [  # type: ignore[attr-defined]
-    _PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACE
-]
+prims_ts_block_sparse_wrapper_trace_dispatch.templates = list(  # type: ignore[attr-defined]
+    _PRIMS_TS_BLOCK_SPARSE_WRAPPER_TRACES.values()
+)
 
 
 def _make_prims_ts_paged_block_sparse_wrapper_trace(*, combined: bool) -> TraceTemplate:

--- a/flashinfer/trace_apply/apply.py
+++ b/flashinfer/trace_apply/apply.py
@@ -106,24 +106,28 @@ def bind_namespace(
     return dict(bound.arguments)
 
 
-def build_extractor_maps(templates: list) -> list[dict[str, Callable]]:
-    """Pre-build each template's per-axis extractor callables (once, at install)."""
-    maps: list[dict[str, Callable]] = []
+def build_extractor_maps(
+    templates: list,
+) -> list[dict[str, Callable] | None]:
+    """Pre-build each template's axis extractors, preserving failed entries."""
+    maps: list[dict[str, Callable] | None] = []
     for tmpl in templates:
         try:
             maps.append(tmpl._build_axis_extractors())
         except Exception:  # noqa: BLE001 — a malformed template must not break others
-            continue
+            maps.append(None)
     return maps
 
 
 def extract_axes(
-    extractor_maps: list[dict[str, Callable]], namespace: dict[str, Any]
+    extractor_maps: list[dict[str, Callable] | None], namespace: dict[str, Any]
 ) -> dict[str, int]:
     """Run extractors over a (param → value) namespace → full concrete axis vector.
     Multiple templates merge: each axis is filled by the first that resolves it."""
     axes: dict[str, int] = {}
     for emap in extractor_maps:
+        if emap is None:
+            continue
         for axis_name, fn in emap.items():
             if axis_name in axes:
                 continue
@@ -236,27 +240,52 @@ def _make_wrapper(
     original: Callable,
     build_namespace: Callable[[tuple, dict], dict[str, Any]],
     extractor_maps: list,
-    template: Any,
-    dests: dict,
+    templates: list,
+    template_dispatch: Callable | None,
+    dests_by_template: list[dict],
     is_inplace: bool,
+    stateful_adapter: Any | None,
     solutions_by_name: dict[str, Any],
 ) -> Callable:
     """Wrapper that routes a call to a registered solution by *definition name*.
 
-    Per call: build the namespace, extract the const axes, compute this
-    template's definition name (``name_prefix`` + const-axis abbrevs — the same
-    logic the trace collector uses), and look it up in ``solutions_by_name``. The
-    per-name decision (resolved entry or miss) is cached, so later calls for the
-    same shape are a dict lookup. Inside CUDA-graph capture only the cached path
-    runs (eager warmup populates the cache before capture)."""
+    Per call: build the namespace, resolve the same template selected by
+    ``fi_trace``, extract its const axes, compute its definition name, and look
+    it up in ``solutions_by_name``.  The per-name decision (resolved entry or
+    miss) is cached, so later calls for the same shape are a dict lookup. Inside
+    CUDA-graph capture only the cached path runs (eager warmup populates the
+    cache before capture)."""
     cache_lock = Lock()
     by_name: dict[str, _Entry | None] = {}
+    template_indices = {id(template): idx for idx, template in enumerate(templates)}
 
     @functools.wraps(original)
     def wrapper(*args, **kwargs):
         try:
             namespace = build_namespace(args, kwargs)
-            axes = extract_axes(extractor_maps, namespace)
+            template = (
+                templates[0]
+                if template_dispatch is None
+                else template_dispatch(save_dir=None, name=None, **namespace)
+            )
+            # Apply only a canonical template published by this dispatcher.
+            # A dynamic or unknown template remains traceable but has no
+            # registered Apply binding, so preserve the original API call.
+            template_idx = template_indices.get(id(template))
+            if template_idx is None:
+                return original(*args, **kwargs)
+            extractor_map = extractor_maps[template_idx]
+            if extractor_map is None:
+                return original(*args, **kwargs)
+            if stateful_adapter is not None:
+                self_obj = args[0] if args else None
+                namespace = plan_capture.augment_namespace(
+                    stateful_adapter, template, namespace, self_obj
+                )
+            dests = dests_by_template[template_idx]
+            if is_inplace and not dests:
+                return original(*args, **kwargs)
+            axes = extract_axes([extractor_map], namespace)
             name = template.definition_name(axes)
         except Exception:  # noqa: BLE001 — never let extraction break the engine
             return original(*args, **kwargs)
@@ -505,6 +534,15 @@ def _registry_by_fi_api() -> dict[str, tuple[Callable, list]]:
     return out
 
 
+def _trace_dispatcher_for(original: Callable) -> Callable | None:
+    """Return the trace-time runtime selector registered for ``original``."""
+    try:
+        from flashinfer.api_logging import _TRACE_DISPATCHERS  # noqa: PLC0415
+    except Exception:  # noqa: BLE001
+        return None
+    return _TRACE_DISPATCHERS.get(original)
+
+
 # ---------------------------------------------------------------------------
 # Install / state
 # ---------------------------------------------------------------------------
@@ -602,10 +640,11 @@ def enable_apply(solutions: dict[str, Any] | None = None) -> int:
         wrapped = 0
         matched_apis = 0
         for fi_api, (original, templates) in registry.items():
-            template0 = templates[0] if templates else None
-            if template0 is None:
+            if not templates:
                 continue
-            if not _template_matches_any(template0, sol_map):
+            if not any(
+                _template_matches_any(template, sol_map) for template in templates
+            ):
                 continue  # skip-wrap: no registered solution can target this API
             resolved = _resolve_target(fi_api)
             if resolved is None:
@@ -618,43 +657,40 @@ def enable_apply(solutions: dict[str, Any] | None = None) -> int:
 
             matched_apis += 1
             extractor_maps = build_extractor_maps(templates)
-            dests = _derive_output_dests(template0, original)
+            dests_by_template = [
+                _derive_output_dests(template, original) for template in templates
+            ]
             is_inplace = _is_inplace_api(original)
-            if is_inplace and not dests:
-                _log.warning(
-                    "Trace Apply: %s is in-place but has no output destination map; "
-                    "skipping to avoid silent corruption.",
-                    fi_api,
-                )
-                continue
-
+            stateful_adapter = None
+            build_ns = _stateless_namespace_builder(original)
             if plan_capture.is_stateful(fi_api):
-                adapter = plan_capture.adapter_for(fi_api)
-                build_ns = _stateful_namespace_builder(original, template0, adapter)
-                if hasattr(owner, adapter.plan_attr):
-                    plan_current = getattr(owner, adapter.plan_attr)
+                stateful_adapter = plan_capture.adapter_for(fi_api)
+                if hasattr(owner, stateful_adapter.plan_attr):
+                    plan_current = getattr(owner, stateful_adapter.plan_attr)
                     if not getattr(plan_current, "_trace_apply", False):
                         setattr(
-                            owner, adapter.plan_attr, _make_plan_wrapper(plan_current)
+                            owner,
+                            stateful_adapter.plan_attr,
+                            _make_plan_wrapper(plan_current),
                         )
                         _patches.append(
                             _Patch(
                                 owner=owner,
-                                attr=adapter.plan_attr,
+                                attr=stateful_adapter.plan_attr,
                                 original=plan_current,
                             )
                         )
-            else:
-                build_ns = _stateless_namespace_builder(original)
 
             wrapper = _make_wrapper(
                 fi_api=fi_api,
                 original=current,
                 build_namespace=build_ns,
                 extractor_maps=extractor_maps,
-                template=template0,
-                dests=dests,
+                templates=templates,
+                template_dispatch=_trace_dispatcher_for(original),
+                dests_by_template=dests_by_template,
                 is_inplace=is_inplace,
+                stateful_adapter=stateful_adapter,
                 solutions_by_name=sol_map,
             )
             # Patch the canonical target + module-level aliases for the same

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -515,6 +515,42 @@ _GQA_CASES = (
 )
 
 
+_PROXY_ROUTE_CASES = (
+    _Case(
+        "proxy_bk8_swaps",
+        1,
+        1,
+        128,
+        269,
+        64,
+        8,
+        torch.bfloat16,
+        "dense",
+        "holey",
+        "static",
+        pattern="proxy_tail",
+        expected_q_tile=32,
+        expected_kv_tile=128,
+    ),
+    _Case(
+        "proxy_bk64_keeps",
+        1,
+        1,
+        64,
+        269,
+        64,
+        64,
+        torch.bfloat16,
+        "dense",
+        "none",
+        "static",
+        pattern="proxy_tail",
+        expected_q_tile=64,
+        expected_kv_tile=256,
+    ),
+)
+
+
 def _make_patterns(case: _Case) -> _Patterns:
     num_q_rows = math.ceil(case.seq_len_q / case.q_block_size)
     num_kv_blocks = math.ceil(case.seq_len_kv / case.kv_block_size)
@@ -561,6 +597,11 @@ def _make_patterns(case: _Case) -> _Patterns:
                 if case.pattern == "unaligned_tail":
                     rows.append((*range(1, 9), *range(22, 30)))
                     continue
+                if case.pattern == "proxy_tail":
+                    rows.append(
+                        (0, 32) if row_idx % 2 == 1 and num_kv_blocks > 32 else (1, 3)
+                    )
+                    continue
                 selected = {0, num_kv_blocks - 1}
                 if num_kv_blocks > 2:
                     selected.add(
@@ -588,6 +629,43 @@ def _make_bsr(patterns: _Patterns) -> tuple[torch.Tensor, torch.Tensor]:
         torch.tensor(pointer_batches, device="cuda", dtype=torch.int32),
         torch.tensor(flat_indices, device="cuda", dtype=torch.int32),
     )
+
+
+def _make_exact_block_bits(
+    patterns: _Patterns,
+    num_kv_blocks: int,
+) -> torch.Tensor:
+    words_per_row = math.ceil(num_kv_blocks / 32)
+    packed_batches: list[list[list[list[int]]]] = []
+    for batch in patterns:
+        packed_heads: list[list[list[int]]] = []
+        for head in batch:
+            packed_rows: list[list[int]] = []
+            for exact_blocks in head:
+                words = [0] * words_per_row
+                for block_idx in exact_blocks:
+                    words[block_idx // 32] |= 1 << (block_idx % 32)
+                if num_kv_blocks % 32:
+                    # Out-of-range bits are intentionally high: prepare must ignore them.
+                    words[-1] |= (-1 << (num_kv_blocks % 32)) & 0xFFFFFFFF
+                packed_rows.append(words)
+            packed_heads.append(packed_rows)
+        packed_batches.append(packed_heads)
+    return torch.tensor(packed_batches, device="cuda", dtype=torch.uint32)
+
+
+def _summarize_kv(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kv_block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    k_blocks: list[torch.Tensor] = []
+    v_blocks: list[torch.Tensor] = []
+    for begin in range(0, k.shape[1], kv_block_size):
+        end = min(begin + kv_block_size, k.shape[1])
+        k_blocks.append(k[:, begin:end].float().mean(dim=1).to(k.dtype))
+        v_blocks.append(v[:, begin:end].float().sum(dim=1).to(v.dtype))
+    return torch.stack(k_blocks, dim=1), torch.stack(v_blocks, dim=1)
 
 
 def _pack_token_mask(
@@ -694,6 +772,66 @@ def _reference(
             head_outputs.append(probabilities @ v[batch_idx, :, kv_head_idx].float())
         batch_outputs.append(torch.stack(head_outputs, dim=1))
     return torch.stack(batch_outputs).to(case.dtype)
+
+
+@torch.no_grad()
+def _single_row_proxy_reference(
+    case: _Case,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    exact_blocks: tuple[int, ...],
+    valid_tokens: frozenset[int],
+    k_summary: torch.Tensor,
+    v_summary: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Evaluate one MHA row with exact tokens and proxy block summaries."""
+
+    assert case.batch_size == case.num_heads == case.effective_num_kv_heads == 1
+    assert q.shape[1] <= case.q_block_size
+    exact_tokens = torch.tensor(
+        [
+            token_idx
+            for token_idx in valid_tokens
+            if token_idx // case.kv_block_size in exact_blocks
+        ],
+        device=q.device,
+        dtype=torch.int64,
+    )
+    num_kv_blocks = math.ceil(case.seq_len_kv / case.kv_block_size)
+    proxy_blocks = tuple(
+        block_idx for block_idx in range(num_kv_blocks) if block_idx not in exact_blocks
+    )
+    q_rows = q[0, :, 0].float()
+    exact_logits = (q_rows @ k[0, exact_tokens, 0].float().transpose(0, 1)) * sm_scale
+    proxy_logits = (
+        q_rows @ k_summary[0, proxy_blocks, 0].float().transpose(0, 1)
+    ) * sm_scale
+    logits = torch.cat((exact_logits, proxy_logits), dim=1)
+    weights = torch.exp(logits - logits.amax(dim=1, keepdim=True))
+    exact_count = exact_logits.shape[1]
+    exact_weights = weights[:, :exact_count]
+    proxy_weights = weights[:, exact_count:]
+    numerator = exact_weights @ v[0, exact_tokens, 0].float()
+    numerator = numerator + proxy_weights @ v_summary[0, proxy_blocks, 0].float()
+    proxy_masses = torch.tensor(
+        [
+            min(
+                case.kv_block_size,
+                case.seq_len_kv - block_idx * case.kv_block_size,
+            )
+            for block_idx in proxy_blocks
+        ],
+        device=q.device,
+        dtype=torch.float32,
+    )
+    denominator = exact_weights.sum(dim=1, keepdim=True)
+    denominator = denominator + (proxy_weights * proxy_masses[None, :]).sum(
+        dim=1,
+        keepdim=True,
+    )
+    return (numerator / denominator).to(case.dtype)[None, :, None]
 
 
 @pytest.mark.parametrize(
@@ -803,6 +941,9 @@ def test_block_sparse_wrapper_routes_are_run_inputs() -> None:
     plan_routing_parameters = {
         "block_indptr",
         "block_indices",
+        "exact_block_bits",
+        "k_summary",
+        "v_summary",
         "kv_valid_bits",
         "dynamic_metadata",
     }
@@ -814,12 +955,22 @@ def test_block_sparse_wrapper_routes_are_run_inputs() -> None:
         block_sparse_module.BlockSparseTSWrapper.run
     ).parameters
     for name in ("block_indptr", "block_indices"):
-        assert run_parameters[name].default is inspect.Parameter.empty
-    assert "kv_valid_bits" in run_parameters
+        assert run_parameters[name].default is None
+    assert {
+        "exact_block_bits",
+        "k_summary",
+        "v_summary",
+        "kv_valid_bits",
+    } <= set(run_parameters)
 
     state_fields = {field.name for field in fields(_BlockSparsePlanState)}
-    assert {"block_indptr", "block_indices", "kv_valid_bits"}.isdisjoint(state_fields)
-    assert {"num_qo_heads", "num_kv_heads"} <= state_fields
+    assert plan_routing_parameters.isdisjoint(state_fields)
+    assert {
+        "num_qo_heads",
+        "num_kv_heads",
+        "sparse_format",
+        "use_proxy_routes",
+    } <= state_fields
     assert "num_heads" not in state_fields
 
 
@@ -848,9 +999,11 @@ def test_block_sparse_contiguous_wrapper_trace_uses_bound_plan_state() -> None:
     with pytest.raises(RuntimeError, match=r"plan\(\) must be called before run\(\)"):
         fi_trace(wrapper.run, **kwargs)
 
-    # A successful plan atomically publishes this state. Its contents are not
-    # needed to select the single contiguous schema, so avoid a CUDA plan here.
-    wrapper._plan_state = SimpleNamespace()
+    # A successful plan atomically publishes this state. Avoid a CUDA plan here.
+    wrapper._plan_state = SimpleNamespace(
+        sparse_format="bsr",
+        use_proxy_routes=False,
+    )
     defn = fi_trace(wrapper.run, **kwargs)
     assert defn["name"].startswith("prims_ts_block_sparse_wrapper")
     assert defn["inputs"]["q"]["shape"] == [
@@ -868,6 +1021,84 @@ def test_block_sparse_contiguous_wrapper_trace_uses_bound_plan_state() -> None:
     for name in ("q_block_size", "kv_block_size", "mask_type"):
         assert defn["inputs"][name]["optional"] is True
     assert defn["inputs"]["block_indptr"].get("optional") is not True
+
+
+@pytest.mark.parametrize(
+    ("sparse_format", "use_proxy_routes", "expected_max_blocks"),
+    (
+        ("bsr", False, 3),
+        ("bitmask", False, 4),
+        ("bsr", True, 3),
+        ("bitmask", True, 4),
+    ),
+)
+def test_contiguous_one_shot_forwards_route_mode_and_capacity(
+    monkeypatch: pytest.MonkeyPatch,
+    sparse_format: str,
+    use_proxy_routes: bool,
+    expected_max_blocks: int,
+) -> None:
+    """One-shot planning should differ from the wrapper only by inspection."""
+
+    calls: list[tuple[str, dict[str, object]]] = []
+    sentinel = object()
+    monkeypatch.setattr(
+        block_sparse_module,
+        "_resolve_cuda_device",
+        lambda _device: (torch.device("cpu"), 0),
+    )
+    monkeypatch.setattr(torch.cuda, "current_stream", lambda _device: object())
+    monkeypatch.setattr(
+        block_sparse_module,
+        "_inspect_block_sparse_bsr",
+        lambda *_args, **_kwargs: 3,
+    )
+    monkeypatch.setattr(
+        block_sparse_module.BlockSparseTSWrapper,
+        "plan",
+        lambda _self, *_args, **kwargs: calls.append(("plan", kwargs)),
+    )
+    monkeypatch.setattr(
+        block_sparse_module.BlockSparseTSWrapper,
+        "run",
+        lambda _self, *_args, **kwargs: calls.append(("run", kwargs)) or sentinel,
+    )
+
+    q = torch.empty((1, 64, 2, 128), dtype=torch.float16)
+    k = torch.empty((1, 256, 1, 128), dtype=torch.float16)
+    block_indptr = torch.tensor([[[0, 2]]], dtype=torch.int32)
+    block_indices = torch.tensor([0, 2], dtype=torch.int32)
+    exact_block_bits = torch.tensor([[[[0b0101]]]], dtype=torch.uint32)
+    summaries = torch.empty((1, 4, 1, 128), dtype=torch.float16)
+
+    result = block_sparse_module.block_sparse_attention(
+        q,
+        k,
+        k,
+        block_indptr if sparse_format == "bsr" else None,
+        block_indices if sparse_format == "bsr" else None,
+        64,
+        64,
+        exact_block_bits=(exact_block_bits if sparse_format == "bitmask" else None),
+        k_summary=summaries if use_proxy_routes else None,
+        v_summary=summaries if use_proxy_routes else None,
+        sparse_format=sparse_format,
+        use_proxy_routes=use_proxy_routes,
+    )
+
+    assert result is sentinel
+    plan_kwargs = calls[0][1]
+    run_kwargs = calls[1][1]
+    assert calls[0][0] == "plan"
+    assert plan_kwargs["max_blocks_per_row"] == expected_max_blocks
+    assert plan_kwargs["sparse_format"] == sparse_format
+    assert plan_kwargs["use_proxy_routes"] is use_proxy_routes
+    assert calls[1][0] == "run"
+    assert run_kwargs["exact_block_bits"] is (
+        exact_block_bits if sparse_format == "bitmask" else None
+    )
+    assert run_kwargs["k_summary"] is (summaries if use_proxy_routes else None)
+    assert run_kwargs["v_summary"] is (summaries if use_proxy_routes else None)
 
 
 def test_block_sparse_paged_wrapper_trace_uses_bound_plan_state() -> None:
@@ -935,13 +1166,7 @@ def test_public_paged_wrapper_uses_only_live_run_metadata() -> None:
     """Paged plans own capacity, while attention consumes caller live lengths."""
 
     from flashinfer.attention.prims_ts._block_sparse import (
-        compiler as block_sparse_compiler,
-    )
-    from flashinfer.attention.prims_ts._block_sparse import (
         runtime as block_sparse_runtime,
-    )
-    from flashinfer.attention.prims_ts.kernels.fmha_decode import (
-        block_sparse_prepare,
     )
 
     plan_parameters = inspect.signature(
@@ -1003,53 +1228,6 @@ def test_public_paged_wrapper_uses_only_live_run_metadata() -> None:
     assert "validated_seq_lens_kv" not in {
         field.name for field in fields(block_sparse_runtime._PagedKVLaunchPayload)
     }
-    assert (
-        "validated_seq_lens_kv"
-        not in inspect.signature(
-            block_sparse_prepare._PrepareBlockSparseRoutes.__call__
-        ).parameters
-    )
-    assert "validated_seq_lens_kv" not in inspect.getsource(
-        block_sparse_compiler._compile_block_sparse
-    )
-
-
-def test_reusable_block_sparse_metadata_is_trusted_with_opt_in_assertions() -> None:
-    """Reusable prepare keeps assertions opt-in and has no fail-closed path."""
-
-    from flashinfer.attention.prims_ts._block_sparse import (
-        compiler as block_sparse_compiler,
-    )
-    from flashinfer.attention.prims_ts.kernels.fmha_decode import (
-        block_sparse_prepare,
-        fmha_decode_tasks,
-    )
-
-    kernel_source = inspect.getsource(
-        block_sparse_prepare._PrepareBlockSparseRoutes.kernel
-    )
-    publish_source = inspect.getsource(
-        block_sparse_prepare._publish_prepared_route_count
-    )
-    consumer_source = inspect.getsource(
-        fmha_decode_tasks._load_prepared_sparse_row_warp
-    )
-
-    assert callable(block_sparse_prepare.runtime_assert)
-    assert "--enable-assertions" not in block_sparse_compiler._COMPILE_OPTIONS
-    assert (
-        "live_seq_len_kv = cutlass.Int32(self.minimum_seq_len_kv)" not in kernel_source
-    )
-    assert "live_seq_len_kv = raw_seq_len_kv" in kernel_source
-    assert all(
-        fragment not in publish_source
-        for fragment in (
-            "stored_route_count",
-            "-required_route_count",
-            "-selected_block_count",
-        )
-    )
-    assert "cute.math.max(route_count" not in consumer_source
 
 
 @pytest.mark.skipif(
@@ -1964,6 +2142,34 @@ def test_prepared_block_sparse_layout_geometry(
     assert layout.workspace_size_words == 4 + 3 * layout.route_metadata_stride_words
 
 
+@pytest.mark.parametrize(
+    ("kv_route_size", "kv_block_size", "has_token_bits", "page_size", "expected"),
+    (
+        (128, 8, True, None, True),
+        (256, 8, True, None, False),
+        (128, 64, False, None, False),
+        (128, 64, True, 64, False),
+    ),
+)
+def test_prepared_route_layout_selects_one_warp_transport(
+    kv_route_size: int,
+    kv_block_size: int,
+    has_token_bits: bool,
+    page_size: int | None,
+    expected: bool,
+) -> None:
+    layout = _BlockSparseRouteLayout.create(
+        kv_route_size=kv_route_size,
+        kv_block_size=kv_block_size,
+        has_token_bits=has_token_bits,
+        route_metadata_capacity=0,
+        num_rows=1,
+        page_size=page_size,
+    )
+
+    assert layout.uses_one_warp_transport is expected
+
+
 def test_keeps_softmax_staging_rejects_more_than_four_route_origins() -> None:
     """Keeps consumers have registers for at most four staged origins."""
 
@@ -1983,75 +2189,6 @@ def test_keeps_softmax_staging_rejects_more_than_four_route_origins() -> None:
             route_layout=route_layout,
             num_stages=2,
         )
-
-
-def test_prepared_route_logical_origin_accessors_are_layout_nfc() -> None:
-    """Naming logical origins must not add or move prepared-record words."""
-
-    layout = _BlockSparseRouteLayout.create(
-        kv_route_size=128,
-        kv_block_size=64,
-        has_token_bits=True,
-        route_metadata_capacity=3,
-        num_rows=2,
-    )
-
-    assert tuple(field.name for field in fields(layout)) == (
-        "kv_route_size",
-        "atom_size",
-        "has_token_bits",
-        "num_rows",
-        "route_metadata_stride_words",
-        "route_metadata_base_word_offset",
-        "workspace_size_words",
-        "page_size",
-    )
-    assert tuple(getattr(layout, field.name) for field in fields(layout)) == (
-        128,
-        64,
-        True,
-        2,
-        8,
-        4,
-        28,
-        None,
-    )
-    assert layout.logical_origins_per_route == 2
-    # Logical origins remain the unchanged two-word record prefix.
-    assert layout.atom_valid_mask_word_offset == 2
-    assert layout.route_flags_word_offset == 3
-    assert layout.token_words_word_offset == 4
-
-
-def test_logical_origins_feed_masks_while_contiguous_loads_are_identity() -> None:
-    """Mask coordinates stay logical; contiguous K/V loads preserve them."""
-
-    from flashinfer.attention.prims_ts.kernels.fmha_decode import (
-        block_sparse_prepare,
-    )
-    from flashinfer.attention.prims_ts.kernels.fmha_decode.fmha_decode_resources import (
-        smem_block_sparse_metadata,
-        smem_resources,
-        tmem_s,
-    )
-
-    assert (
-        "logical_origin"
-        in inspect.signature(block_sparse_prepare._load_atom_token_chunk).parameters
-    )
-    assert hasattr(block_sparse_prepare, "_resolve_route_logical_atom_origin")
-
-    resource = smem_block_sparse_metadata.SmemBlockSparseKvMetadataResource
-    assert "_prepared_route_logical_origin" in inspect.getsource(resource.resolve_route)
-    assert (
-        "logical_b_idx" in inspect.signature(resource.route_tma_coordinate).parameters
-    )
-    kv_load_sources = inspect.getsource(
-        smem_resources.SmemKvTileResource
-    ) + inspect.getsource(smem_resources.SmemKvResource)
-    assert ".route_tma_coordinate(" in kv_load_sources
-    assert ".route_origin(" not in kv_load_sources
-    assert "route_load_origin" not in inspect.getsource(tmem_s.TmemSResource)
 
 
 def test_sparse_task_cache_accessors_reuse_the_existing_two_slots() -> None:
@@ -2078,37 +2215,6 @@ def test_sparse_task_cache_accessors_reuse_the_existing_two_slots() -> None:
     route_begin = helpers_common._sparse_task_cache_route_begin.__wrapped__(cache)
     route_count = helpers_common._sparse_task_cache_route_count.__wrapped__(cache)
     assert (int(route_begin), int(route_count)) == (5, 6)
-
-
-def test_paged_route_seam_extends_only_the_shared_compile_key() -> None:
-    """Storage axes live on the shared key without an intermediate policy type."""
-
-    assert tuple(
-        field.name for field in fields(block_sparse_config._BlockSparseCompileKey)
-    ) == (
-        "device_index",
-        "batch_size",
-        "seq_len_q",
-        "seq_len_kv",
-        "num_qo_heads",
-        "num_kv_heads",
-        "head_dim",
-        "q_block_size",
-        "kv_block_size",
-        "kv_route_size",
-        "dtype_key",
-        "mask_type",
-        "use_kv_valid_bits",
-        "use_persistent_scheduler",
-        "use_parallel_sparse_kv_loads",
-        "page_size",
-    )
-    assert not hasattr(block_sparse_module, "_BlockSparseExecutionPolicy")
-    assert not hasattr(block_sparse_module, "_resolve_block_sparse_execution_policy")
-    assert not hasattr(
-        block_sparse_module,
-        "_resolve_validated_block_sparse_execution_policy",
-    )
 
 
 @pytest.mark.parametrize(
@@ -2306,7 +2412,7 @@ def test_prepared_block_sparse_layout_allows_empty_route_metadata() -> None:
     assert layout.workspace_size_words == layout.route_metadata_base_word_offset
 
 
-def test_public_api_rejects_invalid_usage() -> None:
+def test_public_api_rejects_invalid_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     metadata = torch.empty((1, 1, 2), dtype=torch.int32)
     indices = torch.empty((0,), dtype=torch.int32)
     with pytest.raises(RuntimeError, match=r"plan\(\).*before run"):
@@ -2331,11 +2437,63 @@ def test_public_api_rejects_invalid_usage() -> None:
             64,
         )
 
+    def unexpected_device_work(_device: object) -> None:
+        pytest.fail("causal proxy routes must fail before resolving the CUDA device")
+
+    monkeypatch.setattr(
+        block_sparse_module,
+        "_resolve_cuda_device",
+        unexpected_device_work,
+    )
+    with pytest.raises(ValueError, match="proxy routes require mask_type='dense'"):
+        block_sparse_module.BlockSparseTSWrapper().plan(
+            batch_size=1,
+            seq_len_q=64,
+            seq_len_kv=128,
+            num_qo_heads=1,
+            num_kv_heads=1,
+            head_dim=_HEAD_DIM,
+            q_block_size=64,
+            kv_block_size=64,
+            device="cuda:0",
+            max_blocks_per_row=1,
+            use_kv_valid_bits=False,
+            use_proxy_routes=True,
+            mask_type="causal",
+        )
+
+    from flashinfer.attention.prims_ts.kernels.fmha_decode.fmha_decode_config import (
+        CAUSAL,
+        FmhaDecodeConfig,
+    )
+
+    cfg = FmhaDecodeConfig(
+        use_block_sparse=True,
+        use_block_sparse_proxy_routes=True,
+        mask_type=CAUSAL,
+    )
+    with pytest.raises(ValueError, match="proxy routes require mask_type='dense'"):
+        cfg.validate_block_sparse_profile(heads_q_per_kv=1)
+
+    exact_causal_cfg = FmhaDecodeConfig(
+        use_block_sparse=True,
+        groups_tokens_heads_q=True,
+        q_block_size=64,
+        kv_block_size=64,
+        tile_size_q=64,
+        tile_size_kv=128,
+        use_keeps_mma_ab=True,
+        mask_type=CAUSAL,
+    )
+    exact_causal_cfg.validate_block_sparse_profile(heads_q_per_kv=1)
+
 
 def _validate_cpu_routing(
     *,
+    sparse_format: str = "bsr",
     block_indptr: torch.Tensor | None = None,
     block_indices: torch.Tensor | None = None,
+    exact_block_bits: torch.Tensor | None = None,
     kv_valid_bits: torch.Tensor | None = None,
     use_kv_valid_bits: bool = False,
 ) -> None:
@@ -2344,27 +2502,40 @@ def _validate_cpu_routing(
     )
 
     validate_block_sparse_metadata(
-        torch.tensor([[[0, 0]]], dtype=torch.int32)
-        if block_indptr is None
-        else block_indptr,
-        torch.empty(0, dtype=torch.int32) if block_indices is None else block_indices,
-        kv_valid_bits,
+        sparse_format=sparse_format,
+        block_indptr=(
+            torch.tensor([[[0, 0]]], dtype=torch.int32)
+            if sparse_format == "bsr" and block_indptr is None
+            else block_indptr
+        ),
+        block_indices=(
+            torch.empty(0, dtype=torch.int32)
+            if sparse_format == "bsr" and block_indices is None
+            else block_indices
+        ),
+        exact_block_bits=exact_block_bits,
+        kv_valid_bits=kv_valid_bits,
         device=torch.device("cpu"),
         batch_size=1,
         seq_len_q=1,
         seq_len_kv=1,
         num_kv_heads=1,
         q_block_size=1,
+        kv_block_size=8,
         use_kv_valid_bits=use_kv_valid_bits,
     )
 
 
 def test_runtime_metadata_allows_unreferenced_spare_indices() -> None:
-    """Per-row capacity is checked on device; spare flat storage is legal."""
+    """Both planned frontends accept their compact host structural ABI."""
 
     _validate_cpu_routing(
         block_indptr=torch.tensor([[[0, 1]]], dtype=torch.int32),
         block_indices=torch.arange(17, dtype=torch.int32),
+    )
+    _validate_cpu_routing(
+        sparse_format="bitmask",
+        exact_block_bits=torch.zeros((1, 1, 1, 1), dtype=torch.uint32),
     )
 
 
@@ -2469,6 +2640,9 @@ def test_gqa_runtime_uses_distinct_q_and_kv_head_shapes() -> None:
         num_kv_heads=1,
         head_dim=_HEAD_DIM,
         q_block_size=8,
+        kv_block_size=64,
+        sparse_format="bsr",
+        use_proxy_routes=False,
         use_kv_valid_bits=False,
         q_dtype=torch.float16,
         kv_dtype=torch.float16,
@@ -2545,6 +2719,8 @@ def test_contiguous_launch_forwards_the_exact_compiled_adapter_abi() -> None:
 
     state = SimpleNamespace(
         page_size=None,
+        sparse_format="bsr",
+        use_proxy_routes=False,
         row_route_offsets=object(),
         route_workspace=object(),
         max_blocks_per_row=3,
@@ -2604,6 +2780,8 @@ def test_paged_launch_forwards_caller_live_lengths_to_attention() -> None:
     calls: list[tuple[object, ...]] = []
     state = SimpleNamespace(
         page_size=64,
+        sparse_format="bsr",
+        use_proxy_routes=False,
         row_route_offsets=object(),
         route_workspace=object(),
         max_blocks_per_row=3,
@@ -2706,6 +2884,9 @@ def test_runtime_output_must_not_alias_sparse_metadata(aliased_name: str) -> Non
             num_kv_heads=1,
             head_dim=_HEAD_DIM,
             q_block_size=1,
+            kv_block_size=8,
+            sparse_format="bsr",
+            use_proxy_routes=False,
             use_kv_valid_bits=True,
             q_dtype=torch.float16,
             kv_dtype=torch.float16,
@@ -2752,6 +2933,9 @@ def test_runtime_output_must_not_alias_plan_owned_route_workspace() -> None:
         num_kv_heads=1,
         head_dim=_HEAD_DIM,
         q_block_size=1,
+        kv_block_size=8,
+        sparse_format="bsr",
+        use_proxy_routes=False,
         use_kv_valid_bits=False,
         q_dtype=torch.float16,
         kv_dtype=torch.float16,
@@ -3068,6 +3252,63 @@ def test_gqa_launch_spec_uses_q_token_cta_geometry(
     ]
     assert spec.compile_key.num_qo_heads == 8
     assert spec.compile_key.num_kv_heads == 1
+
+
+@pytest.mark.parametrize("use_proxy_routes", (False, True))
+def test_proxy_routes_select_static_while_exact_routes_preserve_auto(
+    monkeypatch: pytest.MonkeyPatch,
+    use_proxy_routes: bool,
+) -> None:
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import fmha_decode_config
+
+    selector_calls: list[dict[str, object]] = []
+
+    def select_persistent(**kwargs: object) -> str:
+        selector_calls.append(kwargs)
+        return "persistent"
+
+    monkeypatch.setattr(
+        fmha_decode_config,
+        "_select_auto_launch_mode",
+        select_persistent,
+    )
+    monkeypatch.setattr(
+        block_sparse_config,
+        "_make_block_sparse_config",
+        lambda _key: None,
+    )
+    monkeypatch.setattr(torch.cuda, "device", lambda _index: nullcontext())
+
+    block_sparse_config._resolve_block_sparse_launch_spec.cache_clear()
+    try:
+        spec = block_sparse_config._resolve_block_sparse_launch_spec(
+            device_index=0,
+            batch_size=1,
+            seq_len_q=128,
+            seq_len_kv=4096,
+            num_qo_heads=8,
+            num_kv_heads=8,
+            head_dim=_HEAD_DIM,
+            q_block_size=64,
+            kv_block_size=64,
+            kv_route_size=256,
+            dtype_key="bfloat16",
+            mask_type="dense",
+            use_kv_valid_bits=False,
+            max_row_route_capacity=16,
+            sparse_format="bitmask",
+            use_proxy_routes=use_proxy_routes,
+        )
+    finally:
+        block_sparse_config._resolve_block_sparse_launch_spec.cache_clear()
+
+    policy = dict(spec.policy)
+    expected_persistent = not use_proxy_routes
+    assert len(selector_calls) == int(expected_persistent)
+    assert spec.compile_key.use_persistent_scheduler is expected_persistent
+    assert policy["scheduler"] == ("persistent" if expected_persistent else "static")
+    assert policy["use_persistent_scheduler"] is expected_persistent
+    assert "scheduler_policy" not in policy
 
 
 def test_clc_capacity_gates_control_launch_resolution(
@@ -3787,6 +4028,134 @@ def test_public_block_sparse_correctness(
             rtol=tolerance,
             atol=tolerance,
         )
+
+
+@_REQUIRES_PRIMTS_GPU
+@pytest.mark.arch_blackwell
+@pytest.mark.parametrize(
+    "case",
+    _PROXY_ROUTE_CASES,
+    ids=("bk8-swaps", "bk64-keeps"),
+)
+@torch.no_grad()
+def test_public_proxy_bsr_and_bitmask_match_reference_for_tail(
+    case: _Case,
+) -> None:
+    """Both route frontends preserve exact/proxy mass, including the KV tail."""
+
+    block_sparse_config._resolve_block_sparse_launch_spec.cache_clear()
+    torch.manual_seed(2026082602)
+    patterns = _make_patterns(case)
+    block_indptr, block_indices = _make_bsr(patterns)
+    num_kv_blocks = math.ceil(case.seq_len_kv / case.kv_block_size)
+    exact_block_bits = _make_exact_block_bits(patterns, num_kv_blocks)
+    valid_bits, valid_by_batch = _make_token_mask(case)
+    q = torch.randn(
+        (case.batch_size, case.seq_len_q, case.num_heads, _HEAD_DIM),
+        device="cuda",
+        dtype=case.dtype,
+    )
+    k = torch.randn(
+        (
+            case.batch_size,
+            case.seq_len_kv,
+            case.effective_num_kv_heads,
+            _HEAD_DIM,
+        ),
+        device="cuda",
+        dtype=case.dtype,
+    )
+    v = torch.randn_like(k)
+    k_summary, v_summary = _summarize_kv(k, v, case.kv_block_size)
+    sm_scale = 1.0 / math.sqrt(_HEAD_DIM)
+    expected = torch.cat(
+        [
+            _single_row_proxy_reference(
+                case,
+                q[:, row_idx * case.q_block_size : (row_idx + 1) * case.q_block_size],
+                k,
+                v,
+                exact_blocks,
+                valid_by_batch[0],
+                k_summary,
+                v_summary,
+                sm_scale,
+            )
+            for row_idx, exact_blocks in enumerate(patterns[0][0])
+        ],
+        dim=1,
+    )
+    max_blocks_per_row = max(
+        len(row) for batch in patterns for head in batch for row in head
+    )
+    outputs: list[torch.Tensor] = []
+
+    try:
+        for sparse_format in ("bsr", "bitmask"):
+            wrapper = block_sparse_module.BlockSparseTSWrapper()
+            wrapper.plan(
+                case.batch_size,
+                case.seq_len_q,
+                case.seq_len_kv,
+                case.num_heads,
+                case.effective_num_kv_heads,
+                _HEAD_DIM,
+                case.q_block_size,
+                case.kv_block_size,
+                device=q.device,
+                max_blocks_per_row=max_blocks_per_row,
+                use_kv_valid_bits=valid_bits is not None,
+                sparse_format=sparse_format,
+                use_proxy_routes=True,
+                mask_type=case.mask_type,
+                q_data_type=case.dtype,
+            )
+            policy = dict(wrapper._policy)
+            assert policy["tile_size_q"] == case.expected_q_tile
+            assert policy["tile_size_kv"] == case.expected_kv_tile
+            assert policy["scheduler"] == case.scheduler
+
+            out = torch.full_like(q, float("nan"))
+            routing = (
+                {
+                    "block_indptr": block_indptr,
+                    "block_indices": block_indices,
+                }
+                if sparse_format == "bsr"
+                else {"exact_block_bits": exact_block_bits}
+            )
+            returned = wrapper.run(
+                q,
+                k,
+                v,
+                k_summary=k_summary,
+                v_summary=v_summary,
+                kv_valid_bits=valid_bits,
+                sm_scale=sm_scale,
+                out=out,
+                **routing,
+            )
+            assert returned is out
+            outputs.append(out)
+        torch.cuda.synchronize()
+    finally:
+        block_sparse_config._resolve_block_sparse_launch_spec.cache_clear()
+
+    tolerance = 2e-2
+    for output in outputs:
+        assert torch.isfinite(output).all()
+        torch.testing.assert_close(
+            output,
+            expected,
+            rtol=tolerance,
+            atol=tolerance,
+        )
+    torch.testing.assert_close(
+        outputs[0],
+        outputs[1],
+        rtol=tolerance,
+        atol=tolerance,
+    )
 
 
 @_REQUIRES_PRIMTS_GPU

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -1727,10 +1727,10 @@ def test_block_sparse_builds_standard_decode_schedule(
     else:
         assert "smemKv" not in resource_names
         assert {"smemK0", "smemK1", "smemV0", "smemV1"} <= resource_names
-    for task_name, resource_name in (
-        ("Softmax0Task", "tmemS0"),
-        ("Softmax1Task", "tmemS1"),
-    ):
+    for inst_idx in (0, 1):
+        task_name = f"Softmax{inst_idx}Task"
+        resource_name = f"tmemS{inst_idx}"
+        metadata_name = f"smemBlockSparseSoftmaxMetadata{inst_idx}"
         softmax_task = tasks_by_name[task_name]
         tmem_s = next(
             resource
@@ -1744,6 +1744,23 @@ def test_block_sparse_builds_standard_decode_schedule(
             if entry[0] is tmem_s and entry[1] == ScheduleStage.ConsumerWork
         ]
         assert consumer_labels == ["compute_block_sparse_softmax_loop"]
+        schedule_positions = {
+            (entry[0].name, entry[1], entry[-1]): position
+            for position, entry in enumerate(softmax_task.loop_schedule_list)
+        }
+        metadata_wait = schedule_positions[
+            (metadata_name, ScheduleStage.ConsumerWait, None)
+        ]
+        metadata_load = schedule_positions[
+            (metadata_name, ScheduleStage.ConsumerWork, "load_route")
+        ]
+        metadata_release = schedule_positions[
+            (metadata_name, ScheduleStage.ConsumerRelease, None)
+        ]
+        score_wait = schedule_positions[
+            (resource_name, ScheduleStage.ConsumerWait, None)
+        ]
+        assert metadata_wait < metadata_load < metadata_release < score_wait
 
 
 @pytest.mark.parametrize("storage", ("dense", "sparse"))

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -548,6 +548,22 @@ _PROXY_ROUTE_CASES = (
         expected_q_tile=64,
         expected_kv_tile=256,
     ),
+    _Case(
+        "proxy_bk64_keeps_kv128",
+        1,
+        1,
+        128,
+        269,
+        128,
+        64,
+        torch.bfloat16,
+        "dense",
+        "none",
+        "static",
+        pattern="proxy_tail",
+        expected_q_tile=128,
+        expected_kv_tile=128,
+    ),
 )
 
 
@@ -2543,16 +2559,20 @@ def _validate_cpu_routing(
     )
 
 
-def test_runtime_metadata_allows_unreferenced_spare_indices() -> None:
-    """Both planned frontends accept their compact host structural ABI."""
+def test_reusable_runtime_trusts_routing_values() -> None:
+    """Reusable validation checks tensor ABI without inspecting route values."""
 
     _validate_cpu_routing(
         block_indptr=torch.tensor([[[0, 1]]], dtype=torch.int32),
-        block_indices=torch.arange(17, dtype=torch.int32),
+        block_indices=torch.tensor([17], dtype=torch.int32),
     )
     _validate_cpu_routing(
         sparse_format="bitmask",
-        exact_block_bits=torch.zeros((1, 1, 1, 1), dtype=torch.uint32),
+        exact_block_bits=torch.full(
+            (1, 1, 1, 1),
+            0xFFFFFFFF,
+            dtype=torch.uint32,
+        ),
     )
 
 
@@ -4052,7 +4072,7 @@ def test_public_block_sparse_correctness(
 @pytest.mark.parametrize(
     "case",
     _PROXY_ROUTE_CASES,
-    ids=("bk8-swaps", "bk64-keeps"),
+    ids=("bk8-swaps", "bk64-keeps", "bk64-keeps-kv128"),
 )
 @torch.no_grad()
 def test_public_proxy_bsr_and_bitmask_match_reference_for_tail(

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -4627,7 +4627,8 @@ def test_runtime_routes_cuda_graph_replays_routes_and_token_mask() -> None:
     torch.cuda.synchronize()
     torch.testing.assert_close(graph_out, initial_expected, rtol=1e-2, atol=1e-2)
     state = wrapper._published_state()
-    assert state.route_workspace[0].item() == 1
+    # Two KV192 blocks contain six KV64 atoms, which require two KV256 routes.
+    assert state.route_workspace[0].item() == 2
 
     block_indices.copy_(torch.tensor([0, 1], device="cuda", dtype=torch.int32))
     valid_bits.copy_(replay_valid_bits)
@@ -4646,7 +4647,7 @@ def test_runtime_routes_cuda_graph_replays_routes_and_token_mask() -> None:
     torch.cuda.synchronize()
 
     torch.testing.assert_close(graph_out, initial_expected, rtol=1e-2, atol=1e-2)
-    assert state.route_workspace[0].item() == 1
+    assert state.route_workspace[0].item() == 2
 
 
 @_REQUIRES_PRIMTS_GPU

--- a/tests/trace/test_fi_trace_template_consistency.py
+++ b/tests/trace/test_fi_trace_template_consistency.py
@@ -41,6 +41,7 @@ generic checks are insufficient.  See the docstring in
 import ast
 from collections import Counter
 import inspect
+from types import SimpleNamespace
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
@@ -374,7 +375,7 @@ _EXPECTED_PRIMTS_TRACE_VARIANTS = {
     (
         "flashinfer.attention.prims_ts.block_sparse",
         "BlockSparseTSWrapper.run",
-    ): 1,
+    ): 4,
     (
         "flashinfer.attention.prims_ts.block_sparse",
         "BlockSparsePagedTSWrapper.run",
@@ -382,7 +383,7 @@ _EXPECTED_PRIMTS_TRACE_VARIANTS = {
     (
         "flashinfer.attention.prims_ts.block_sparse",
         "block_sparse_attention",
-    ): 1,
+    ): 4,
     (
         "flashinfer.attention.prims_ts.block_sparse",
         "block_sparse_attention_with_paged_kv_cache",
@@ -440,14 +441,13 @@ def test_attention_ts_trace_registry_coverage():
         if func.__module__.startswith("flashinfer.attention.prims_ts")
     )
     assert discovered == Counter(_EXPECTED_PRIMTS_TRACE_VARIANTS)
-    assert sum(discovered.values()) == 54
 
 
 def test_attention_ts_trace_constraints_match_cache_axes():
     """PrimTS constraints are valid expressions over defined axes."""
     from flashinfer.trace.templates.attention import (
         attention_ts_decode_trace_dispatch,
-        prims_ts_block_sparse_trace,
+        prims_ts_block_sparse_trace_dispatch,
         prims_ts_block_sparse_wrapper_trace_dispatch,
         prims_ts_paged_block_sparse_trace_dispatch,
         prims_ts_paged_block_sparse_wrapper_trace_dispatch,
@@ -469,7 +469,7 @@ def test_attention_ts_trace_constraints_match_cache_axes():
         prims_ts_decode_mla_wrapper_trace_dispatch,
     )
     block_sparse_templates = (
-        prims_ts_block_sparse_trace,
+        *prims_ts_block_sparse_trace_dispatch.templates,
         *prims_ts_paged_block_sparse_trace_dispatch.templates,
         *prims_ts_block_sparse_wrapper_trace_dispatch.templates,
         *prims_ts_paged_block_sparse_wrapper_trace_dispatch.templates,
@@ -499,13 +499,103 @@ def test_attention_ts_trace_constraints_match_cache_axes():
 
 
 def test_prims_ts_block_sparse_trace_describes_gqa_contract():
+    from flashinfer.api_logging import _TRACE_DISPATCHERS
+    from flashinfer.attention.prims_ts.block_sparse import (
+        BlockSparseTSWrapper,
+        block_sparse_attention,
+    )
     from flashinfer.trace.templates.attention import (
-        prims_ts_block_sparse_trace,
+        prims_ts_block_sparse_trace_dispatch,
         prims_ts_block_sparse_wrapper_trace_dispatch,
         prims_ts_paged_block_sparse_trace_dispatch,
         prims_ts_paged_block_sparse_wrapper_trace_dispatch,
     )
 
+    assert (
+        _TRACE_DISPATCHERS[block_sparse_attention.__wrapped__]
+        is prims_ts_block_sparse_trace_dispatch
+    )
+    assert (
+        _TRACE_DISPATCHERS[BlockSparseTSWrapper.run.__wrapped__]
+        is prims_ts_block_sparse_wrapper_trace_dispatch
+    )
+
+    one_shot_traces = {
+        template.name_prefix: template
+        for template in prims_ts_block_sparse_trace_dispatch.templates
+    }
+    assert set(one_shot_traces) == {
+        "prims_ts_block_sparse",
+        "prims_ts_block_sparse_bitmask",
+        "prims_ts_block_sparse_bsr_proxy",
+        "prims_ts_block_sparse_bitmask_proxy",
+    }
+    contiguous_wrapper_traces = {
+        template.name_prefix: template
+        for template in prims_ts_block_sparse_wrapper_trace_dispatch.templates
+    }
+    assert set(contiguous_wrapper_traces) == {
+        "prims_ts_block_sparse_wrapper",
+        "prims_ts_block_sparse_wrapper_bitmask",
+        "prims_ts_block_sparse_wrapper_bsr_proxy",
+        "prims_ts_block_sparse_wrapper_bitmask_proxy",
+    }
+    route_modes = {
+        ("bsr", False): ("", {"block_indptr", "block_indices"}),
+        ("bitmask", False): ("_bitmask", {"exact_block_bits"}),
+        ("bsr", True): (
+            "_bsr_proxy",
+            {"block_indptr", "block_indices", "k_summary", "v_summary"},
+        ),
+        ("bitmask", True): (
+            "_bitmask_proxy",
+            {"exact_block_bits", "k_summary", "v_summary"},
+        ),
+    }
+    all_route_inputs = {
+        "block_indptr",
+        "block_indices",
+        "exact_block_bits",
+        "k_summary",
+        "v_summary",
+    }
+    assert (
+        prims_ts_block_sparse_trace_dispatch()
+        is one_shot_traces["prims_ts_block_sparse"]
+    )
+    for (sparse_format, use_proxy_routes), (
+        suffix,
+        expected_inputs,
+    ) in route_modes.items():
+        one_shot_template = one_shot_traces[f"prims_ts_block_sparse{suffix}"]
+        wrapper_template = contiguous_wrapper_traces[
+            f"prims_ts_block_sparse_wrapper{suffix}"
+        ]
+        assert (
+            prims_ts_block_sparse_trace_dispatch(
+                sparse_format=sparse_format,
+                use_proxy_routes=use_proxy_routes,
+            )
+            is one_shot_template
+        )
+        wrapper = SimpleNamespace(
+            _plan_state=SimpleNamespace(
+                sparse_format=sparse_format,
+                use_proxy_routes=use_proxy_routes,
+            )
+        )
+        assert (
+            prims_ts_block_sparse_wrapper_trace_dispatch(self=wrapper)
+            is wrapper_template
+        )
+        for template in (one_shot_template, wrapper_template):
+            assert set(template.inputs) & all_route_inputs == expected_inputs
+            proxy_constraint = "mask_type is None or mask_type == 'dense'"
+            assert (proxy_constraint in template.constraints) == suffix.endswith(
+                "proxy"
+            )
+
+    prims_ts_block_sparse_trace = one_shot_traces["prims_ts_block_sparse"]
     constraints = set(prims_ts_block_sparse_trace.constraints)
     assert "num_qo_heads % num_kv_heads == 0" in constraints
     assert "num_qo_heads // num_kv_heads in (1, 2, 4, 8, 16, 32)" in constraints
@@ -538,6 +628,11 @@ def test_prims_ts_block_sparse_trace_describes_gqa_contract():
     }
     for template in (tuple_trace, combined_trace):
         assert common_inputs <= template.inputs.keys()
+        assert {
+            "exact_block_bits",
+            "k_summary",
+            "v_summary",
+        }.isdisjoint(template.inputs)
         assert "paged KV" in template.description
         assert "max_seq_len_kv" in template.axes
         assert "seq_len_kv" not in template.axes
@@ -578,8 +673,9 @@ def test_prims_ts_block_sparse_trace_describes_gqa_contract():
         is combined_trace
     )
 
-    contiguous_wrapper_trace = prims_ts_block_sparse_wrapper_trace_dispatch.templates[0]
-    assert contiguous_wrapper_trace.name_prefix == "prims_ts_block_sparse_wrapper"
+    contiguous_wrapper_trace = contiguous_wrapper_traces[
+        "prims_ts_block_sparse_wrapper"
+    ]
     wrapper_paged_templates = {
         template.name_prefix: template
         for template in prims_ts_paged_block_sparse_wrapper_trace_dispatch.templates

--- a/tests/trace_apply/test_trace_apply.py
+++ b/tests/trace_apply/test_trace_apply.py
@@ -93,8 +93,9 @@ def _ref_rmsnorm(x, w, eps=1e-6):
 
 
 @pytest.fixture(autouse=True)
-def _reset_trace_apply():
-    """Apply is process-global; ensure every test starts and ends disabled."""
+def _reset_trace_apply(monkeypatch: pytest.MonkeyPatch):
+    """Reset process-global Apply state without requiring a CUDA device."""
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
     ta.disable_apply()
     yield
     ta.disable_apply()
@@ -646,3 +647,110 @@ def test_solutions_positional_and_keyword_equivalent():
 def test_enable_apply_empty_is_noop():
     assert ta.enable_apply({}) == 0
     assert not ta.is_enabled()
+
+
+def test_multi_template_apply_uses_only_selected_metadata(monkeypatch):
+    """A runtime-selected template owns extraction, plan state, and outputs."""
+
+    from flashinfer.api_logging import _TRACE_DISPATCHERS
+    import flashinfer.trace_apply.apply as apply_module
+    from flashinfer.trace.template import Const, Tensor, TraceTemplate
+    from flashinfer.trace_apply import plan_capture
+    from flashinfer.trace_apply.plan_capture import StatefulAdapter
+
+    def make_template(name, state_param, *, destination=True):
+        output = (
+            Tensor(["width"], dtype_from="state", param="target")
+            if destination
+            else Tensor(["width"], dtype_from="state")
+        )
+        return TraceTemplate(
+            op_type="synthetic_multi_template",
+            name_prefix=name,
+            axes={"width": Const(abbrev="w")},
+            inputs={"state": Tensor(["width"], param=state_param)},
+            outputs={"output": output},
+        )
+
+    other = make_template("other", "other_state")
+    broken = make_template("broken", "broken_state")
+    selected = make_template("selected", "selected_state")
+    no_destination = make_template(
+        "no_destination", "no_destination_state", destination=False
+    )
+    unknown = make_template("unknown", "unknown_state")
+
+    def fail_to_build_extractors():
+        raise ValueError("invalid template")
+
+    monkeypatch.setattr(broken, "_build_axis_extractors", fail_to_build_extractors)
+    templates = [other, broken, selected, no_destination]
+    extractor_maps = build_extractor_maps(templates)
+    state = torch.empty(4)
+    assert extractor_maps[1] is None
+    assert extract_axes(extractor_maps, {"selected_state": state}) == {"width": 4}
+
+    class Owner:
+        def plan(self):
+            return None
+
+        def run(self, target, other_state=None) -> None:
+            del other_state
+            target.fill_(-1)
+
+    original = Owner.run
+    modes = {
+        "broken": broken,
+        "selected": selected,
+        "no_destination": no_destination,
+        "unknown": unknown,
+    }
+
+    def dispatch(*, self, save_dir=None, name=None, **_kwargs):
+        del save_dir, name
+        return modes[self.mode]
+
+    fi_api = "tests.synthetic_multi_template.Owner.run"
+    adapter = StatefulAdapter(plan_attr="plan", self_attrs={"state": "_state"})
+    monkeypatch.setattr(
+        apply_module,
+        "_registry_by_fi_api",
+        lambda: {fi_api: (original, templates)},
+    )
+    monkeypatch.setattr(apply_module, "_resolve_target", lambda _fi_api: (Owner, "run"))
+    monkeypatch.setattr(apply_module, "_build_alias_map", lambda: {})
+    monkeypatch.setitem(_TRACE_DISPATCHERS, original, dispatch)
+    monkeypatch.setattr(plan_capture, "is_stateful", lambda name: name == fi_api)
+    monkeypatch.setattr(plan_capture, "adapter_for", lambda _name: adapter)
+
+    def should_not_run(**_kwargs):
+        raise AssertionError("unselected solution was called")
+
+    def selected_solution(*, state):
+        return torch.ones_like(state)
+
+    assert (
+        ta.enable_apply(
+            {
+                "broken_w4": should_not_run,
+                "broken": should_not_run,
+                "selected_w4": selected_solution,
+                "no_destination_w4": should_not_run,
+                "unknown_w4": should_not_run,
+            }
+        )
+        == 1
+    )
+
+    owner = Owner()
+    owner._state = state
+    target = torch.zeros_like(state)
+    owner.mode = "selected"
+    assert owner.run(target, other_state=torch.empty(7)) is None
+    torch.testing.assert_close(target, torch.ones_like(target))
+
+    for mode in ("broken", "no_destination", "unknown"):
+        owner.mode = mode
+        target.zero_()
+        assert owner.run(target) is None
+        torch.testing.assert_close(target, -torch.ones_like(target))


### PR DESCRIPTION
## 📌 Description

This PR extends PrimTS contiguous block-sparse attention with **proxy compensation** and a packed **bitmask** sparse format.

The proxy path keeps selected blocks exact while approximating omitted KV blocks with one arithmetic-mean K summary and one summed-V summary per semantic KV block. Route preparation emits score-keep metadata so a block already covered by an exact route is not counted again by its proxy. The softmax denominator is corrected by the represented token mass, including the true length of the final partial KV block.

### Sol-Attn motivation and scope

This PR is intended to provide the PrimTS **core-attention** substrate for [Sol-Attn's sparse-attention flow](https://github.com/NVlabs/Sana/tree/sol-engine/techniques/sparse_backends), described in the [Sol-Attn paper](https://arxiv.org/abs/2607.24027). Sol-Attn identifies critical KV blocks for exact computation and reuses block-level proxy information from omitted blocks to approximate their contribution during online softmax.

At the API boundary, the intended flow is:

`prediction / routing (out of scope) → exact-block BSR or bitmask + K/V summaries → PrimTS route preparation → proxy-compensated core attention`

This PR implements only the PrimTS route-preparation and core-attention stages. It does **not** include the Sol-Attn predictor, thresholding and exact-block selection, summary generation, or the end-to-end Sana integration; callers provide the selected-block metadata and K/V summaries.

### Bitmask format

In addition to canonical BSR `block_indptr` / `block_indices`, contiguous block-sparse attention can now consume packed `UInt32` exact-block bitmaps owned per `(batch, KV head, Q block)`. Each bit selects one semantic KV block and out-of-range padding bits in the final word are ignored. BSR and bitmask inputs are prepared into the same internal route stream, so the attention core remains format-independent.

Bitmask and proxy modes can be combined: set bits use raw K/V exact routes, while unset blocks are represented by proxy summaries. Both reusable plan/run and one-shot contiguous APIs are supported. Proxy execution currently requires a dense mask; paged-KV proxy execution is outside this PR.

The PR also teaches Trace Apply to honor a runtime-selected trace template, which keeps BSR/bitmask and exact/proxy schemas isolated instead of binding every call to template zero.

## 📊 Proxy overhead

Controlled A/B on one NVIDIA B200 with identical inputs, exact-block pattern, capacity, and static scheduler; only `use_proxy_routes` and the required summaries change.

| Path | Proxy disabled | Proxy enabled | Additional overhead |
| --- | ---: | ---: | ---: |
| Public `BlockSparseTSWrapper.run` | 1.3172 ms | 1.4298 ms | **+8.55%** |
| Prevalidated adapter | 1.3162 ms | 1.4318 ms | **+8.78%** |

Workload: BF16 Q/K/V `[1, 32760, 12, 128]`, Q-block 64, KV-block 64, physical KV route 256, dense bitmask, and 84 of 512 exact blocks per row (16.4%). Proxy adds two prepared routes per row (21 → 23). Results use five balanced rounds with 80 CUDA-event samples per arm (400 samples/arm). Timings include route preparation and attention; summary construction is excluded. Each mode was checked against its own independent reference because proxy compensation intentionally changes the output semantics.

Kernel split diagnostic: attention p50 increased by 7.64% (1.1261 → 1.2121 ms); prepare increased by 0.0030 ms (0.0145 → 0.0176 ms).

## 🧪 Tests

- [x] `tests/trace_apply/test_trace_apply.py`: 26 passed
- [x] `tests/trace/test_fi_trace_template_consistency.py`: 774 passed
- [x] `tests/attention/test_attention_ts_block_sparse.py`: 140 passed, 88 skipped
- [x] BK8 SWAPS and BK64 Keeps GPU proxy validation passed for both BSR and bitmask
- [x] BSR/bitmask results are bitwise identical in the focused GPU cases; final-word padding bits are ignored
- [x] Repository pre-commit hooks passed, including mypy, Ruff check, and Ruff format

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have run the hooks manually and fixed all reported issues.

### ✅ Tests

- [x] Tests have been added or updated as needed.
- [x] All targeted tests are passing.

## Reviewer Notes

The commits are separated into generic runtime trace dispatch, block-sparse functionality, focused correctness/trace tests, and review-driven cleanup. `experimental/sol_attention` is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added BSR and bitmask routing options for block-sparse attention.
  * Added proxy-route support using caller-provided K/V summaries.
  * Added route-specific validation and metadata handling for wrapper and one-shot APIs.
  * Expanded tracing to support all sparse format and route-mode combinations.
  * Improved trace application to select and execute only the runtime-matched template.

* **Documentation**
  * Documented contiguous bitmask routing, proxy routes, capacity semantics, and summary behavior.

* **Tests**
  * Added GPU coverage for BSR and bitmask proxy routes and multi-template trace dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
## Current integration stack (2026-09-04)

- This branch is rebased onto FlashInfer `main` `60b49158ab4fb81718aef486c2d3c89aec4c1901`; current PR head: `6b5b2d31f3314be77ccf6655c899b7b971863a1a`.
- The TRT-LLM composite pin is [heyuhhh/flashinfer@`71bf7842`](https://github.com/heyuhhh/flashinfer/tree/yuhangh/tmp-sol-attn-trtllm-pr17399), which reapplies all eight commits from Yuxian's newest `trtllm-prims-ts` head (`edddf6f5`) on top of this PR.
- TensorRT-LLM stack: [#17399 PrimTS base](https://github.com/NVIDIA/TensorRT-LLM/pull/17399) → [general block-sparse FMHA](https://github.com/yuxianq/TensorRT-LLM/pull/2) → [VisualGen VSA/shared workflow](https://github.com/heyuhhh/TensorRT-LLM/pull/7) → [VisualGen SOL integration](https://github.com/heyuhhh/TensorRT-LLM/pull/9).
- Final B200 integration verification includes raw/proxy/paged generic routes, VSA CUDA Graph live routes, SOL all-exact parity, and mixed proxy parity at sequence lengths 256 and 257.
