### PR TITLE
docs(tests): use SM120/SM121 in XQA MLA skip strings

### DIFF
--- a/tests/trace/test_xqa_batch_decode_mla_reference_correctness.py
+++ b/tests/trace/test_xqa_batch_decode_mla_reference_correctness.py
@@ -24,12 +24,12 @@ from tests.trace.reference_utils import (
     ],
 )
 def test_xqa_batch_decode_mla_reference_correctness(shape_kwargs):
-    """flashinfer.mla.xqa_batch_decode_with_kv_cache_mla kernel vs reference (SM120/121)."""
+    """flashinfer.mla.xqa_batch_decode_with_kv_cache_mla kernel vs reference (SM120/SM121)."""
     from flashinfer.mla import xqa_batch_decode_with_kv_cache_mla
     from flashinfer.trace.templates.attention import xqa_batch_decode_mla_trace
 
     if _cc()[0] != 12:
-        pytest.skip("XQA MLA kernel only supports SM120/121")
+        pytest.skip("XQA MLA kernel only supports SM120/SM121")
     torch.manual_seed(0)
     B = shape_kwargs["batch_size"]
     num_heads = shape_kwargs["num_heads"]

--- a/tests/trace/test_xqa_mla_reference_correctness.py
+++ b/tests/trace/test_xqa_mla_reference_correctness.py
@@ -42,7 +42,7 @@ def test_xqa_mla_reference_correctness(shape_kwargs):
     from flashinfer.trace.templates.page import xqa_mla_trace
 
     if _cc()[0] != 12:
-        pytest.skip("XQA MLA kernel only supports SM120/121")
+        pytest.skip("XQA MLA kernel only supports SM120/SM121")
     inputs = xqa_mla_trace.init(**shape_kwargs)
     sm_count = torch.cuda.get_device_properties(0).multi_processor_count
     xqa_mla(


### PR DESCRIPTION
## Summary
- Align XQA MLA trace-test skip/doc strings from `SM120/121` to `SM120/SM121`.

The original Spark-audit PR also staged `copy2` for monomoe/rmsnorm_silu; that
landed on main via #5063, so those hunks were dropped on rebase.

Refs #3170

## Test plan
- [x] Diff vs main is the two trace-test string files only
- [ ] CI after authorized `@flashinfer-bot run`