### PR TITLE
Fail loud on autotune cache-hit divergence under a tune process group

### DIFF
--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -1746,6 +1746,11 @@ class AutoTuner:
                     # reduce hangs. All-reduce the hit flag and raise on a
                     # split instead of deadlocking.
                     if _tune_process_group is not None:
+                        if torch.cuda.is_current_stream_capturing():
+                            raise RuntimeError(
+                                "AutoTuner distributed cache-hit agreement check cannot run "
+                                "during an active outer CUDA Graph capture"
+                            )
                         import torch.distributed as dist
 
                         backend = str(dist.get_backend(_tune_process_group)).lower()

--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -1741,6 +1741,39 @@ class AutoTuner:
                         tuning_config,
                         inputs=inputs,
                     )
+                    # A cache hit skips the tactic loop and its per-tactic
+                    # all-reduces, so if ranks disagree on the hit the next
+                    # reduce hangs. All-reduce the hit flag and raise on a
+                    # split instead of deadlocking.
+                    if _tune_process_group is not None:
+                        import torch.distributed as dist
+
+                        backend = str(dist.get_backend(_tune_process_group)).lower()
+                        device = "cuda" if backend == "nccl" else "cpu"
+                        world_size = dist.get_world_size(_tune_process_group)
+                        hit_tensor = torch.tensor(
+                            [1 if is_cache_hit else 0],
+                            dtype=torch.int64,
+                            device=device,
+                        )
+                        dist.all_reduce(
+                            hit_tensor,
+                            op=dist.ReduceOp.SUM,
+                            group=_tune_process_group,
+                        )
+                        hits = int(hit_tensor.item())
+                        if hits not in (0, world_size):
+                            raise ValueError(
+                                f"[AutoTuner]: distributed autotune cache "
+                                f"divergence for '{custom_op}': {hits} of "
+                                f"{world_size} ranks hit the profiling cache "
+                                f"for shapes {p.get_opt_shapes()} while the "
+                                f"rest missed. When a tune process group is "
+                                f"set, all ranks must share identical caches at "
+                                f"entry or the per-tactic all-reduce deadlocks. "
+                                f"Set the group from the first choose_one with "
+                                f"matching (ideally empty) caches on every rank."
+                            )
                     if not is_cache_hit:
                         # Active capture is safe for skipped operations and warm cache hits, but
                         # input synthesis or profiling would mutate the caller's outer graph.


### PR DESCRIPTION
## 📌 Description

`set_autotune_process_group` makes `choose_one` all-reduce per-tactic profile timings so every rank's argmin selects the same tactic. That all-reduce runs only on the profiling path, so a profile that is a cache hit on some ranks and a miss on others leaves the next reduce with fewer participants than the profiling ranks expect, and it blocks forever. The `set_autotune_process_group` docstring already documents this as a caller contract (every rank must start with identical caches), but a violation showed up only as a silent hang with no indication of the cause.

This adds a fail-loud guard. Before the tactic loop, `choose_one` all-reduces a per-profile cache-hit flag when a tune group is set. If the reduced sum is neither `0` (all ranks miss) nor `world_size` (all ranks hit), the ranks have diverged, so it raises the same descriptive `ValueError` on every rank naming the op, the shapes, and how to fix the setup, instead of deadlocking on the next collective. The guard runs one small all-reduce per profile during tuning only and does not touch the inference path.

## 🔍 Related Issues

Relates to the distributed-consistency discussion in #3920.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No test is added. The change is a single guard on the distributed tuning path, which needs CUDA and NCCL and so does not run in CI. `tests/autotuner/test_autotuner_distributed.py` already carries the GPU-free scaffolding (an AST source guard plus a 2-rank gloo reduce check) to extend if reviewers would like coverage for this case. `ruff format --check` and `ruff check` are clean on the changed file.

## Reviewer Notes

The guard runs before the point of divergence, so every rank reaches it the same number of times (once per generated profile, which the caller contract already requires to match across ranks); the guard's own all-reduce is therefore balanced. It mirrors the backend/device selection of the existing per-tactic all-reduce and the precedent set by the OOM handler, which already keeps reduce cardinality in lockstep when a tune group is set. This detects the cache-hit class of desync; the residual per-rank OOM outside `_profile_single_kernel` noted in the docstring is unchanged.

---
This PR was written with AI assistance. I reviewed every changed line, confirmed the reduce-cardinality reasoning against the surrounding tune-group code paths, and take responsibility for the contribution.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved distributed tuning reliability by detecting inconsistent profiling-cache results across processes.
  * Reports a clear error when cache availability differs between processes, preventing potential hangs during tuning.
  * Provides a clear error when cache consistency checks are attempted during an active CUDA Graph capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->