### PR TITLE
fix(prefill): support host-side `qo_indptr` in cutlass ragged plan

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -3950,9 +3950,10 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._fmha_v2_qo_indptr = self._qo_indptr_buf.to(torch.int32)
                 self._fmha_v2_kv_indptr = self._kv_indptr_buf.to(torch.int32)
             elif self._backend == "cutlass":
-                # insert qo_indptr.device to 9th position (0-indexed) of get_module_args
+                # insert self.device to 9th position (0-indexed) of get_module_args;
+                # qo_indptr may be a host tensor, so its device is not reliable here
                 new_get_module_args = (
-                    get_module_args[:9] + (qo_indptr.device,) + get_module_args[9:]
+                    get_module_args[:9] + (self.device,) + get_module_args[9:]
                 )
                 self._cached_module = get_fmha_module(*new_get_module_args)
             elif self._backend != "cudnn":
@@ -3961,8 +3962,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 )
 
         if self._backend == "cutlass":
+            # Use the device-side indptr buffers: qo_indptr/kv_indptr may live
+            # on the host while fmha_varlen_plan requires CUDA tensors.
             self._plan_info = fmha_varlen_plan(
-                self._cached_module, qo_indptr, kv_indptr, num_qo_heads, causal
+                self._cached_module,
+                self._qo_indptr_buf,
+                self._kv_indptr_buf,
+                num_qo_heads,
+                causal,
             )
             self._max_qo_len = torch.max(qo_indptr[1:] - qo_indptr[:-1]).item()
         elif self._backend == "fmha_v2":


### PR DESCRIPTION
## 📌 Description

`BatchPrefillWithRaggedKVCacheWrapper.plan()` accepts host (CPU) `qo_indptr`/`kv_indptr` for every backend except cutlass (SM100/SM110), which derived the FMHA module-selection device from `qo_indptr.device` (raising `ValueError: device must be a cuda device` for CPU tensors) and passed the raw indptr tensors to `fmha_varlen_plan`, which requires CUDA tensors.

Use `self.device` for module selection and the already-materialized device-side buffers `self._qo_indptr_buf`/`self._kv_indptr_buf` for `fmha_varlen_plan`, so callers holding host-side offsets (e.g. vLLM) can plan without a synchronizing D2H copy.

For callers that already pass CUDA indptr tensors on the workspace device this is a no-op: `.to(self.device)` returns the same tensor object, so `fmha_varlen_plan` receives the identical tensor as before.

Downstream motivation: vLLM threads host-side query offsets through its MLA prefill metadata to avoid a GPU→CPU sync (vllm-project/vllm#52657); this fix unblocks that path on B200/GB200.

## 🔍 Related Issues

- Related: #565
- Downstream: vllm-project/vllm#52657

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- No new test added: behavior for existing callers (CUDA indptr on the workspace device) is unchanged — `self._qo_indptr_buf` is the same tensor object via the `.to()` no-op — so existing ragged prefill tests (e.g. `tests/attention/test_blackwell_fmha.py`, `tests/attention/test_batch_prefill_kernels.py`) cover regression. The host-indptr path previously crashed with `ValueError`.
- The cutlass ragged plan path requires SM100/SM110 hardware, which was not available locally; validation so far is `pre-commit run --all-files` (passing) and code inspection. This was originally surfaced by vLLM's B200 CI (`tests/v1/attention/test_mla_backends.py`, FLASHINFER prefill cases); Blackwell CI here should exercise it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ragged KV-cache prefill planning when using the CUTLASS backend. Ensured planning consistently uses the configured workspace device and device-resident sequence metadata, improving compatibility when input metadata originates on the host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
