### PR TITLE
fix(jit): stabilize cached_ops across environments — canonicalize cuda_home; opt-in stamp for restored caches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Enable API logging (with stats) | `export FLASHINFER_LOGLEVEL=5` |
 | Set API log destination | `export FLASHINFER_LOGDEST=mylog.txt` |
 | Enable verbose JIT logging | `export FLASHINFER_JIT_VERBOSE=1` |
-- `FLASHINFER_JIT_TRUST_CACHE_STAMP`: opt-in ("1"; default "0"). Trust the sha256 stamp recorded after a successful JIT build (build.ninja contents + source file contents) and skip the ninja invocation when it matches — for restored/relocated caches of released packages, where ninja's mtime scan would rebuild despite byte-identical inputs. Transitively included headers are not hashed, so leave it unset for editable checkouts.
+| Trust the JIT cache stamp — skip ninja for restored caches of released packages (headers not hashed; leave unset for editable checkouts) | `export FLASHINFER_JIT_TRUST_CACHE_STAMP=1` |
 | Enable debug build | `export FLASHINFER_JIT_DEBUG=1` |
 | Set target architectures | `export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"` |
 | Set parallel compilation | `export FLASHINFER_NVCC_THREADS=4` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ FlashInfer is a GPU kernel library for LLM serving that uses **JIT (Just-In-Time
 | Enable API logging (with stats) | `export FLASHINFER_LOGLEVEL=5` |
 | Set API log destination | `export FLASHINFER_LOGDEST=mylog.txt` |
 | Enable verbose JIT logging | `export FLASHINFER_JIT_VERBOSE=1` |
+- `FLASHINFER_JIT_TRUST_CACHE_STAMP`: opt-in ("1"; default "0"). Trust the sha256 stamp recorded after a successful JIT build (build.ninja contents + source file contents) and skip the ninja invocation when it matches — for restored/relocated caches of released packages, where ninja's mtime scan would rebuild despite byte-identical inputs. Transitively included headers are not hashed, so leave it unset for editable checkouts.
 | Enable debug build | `export FLASHINFER_JIT_DEBUG=1` |
 | Set target architectures | `export FLASHINFER_CUDA_ARCH_LIST="8.0 9.0a"` |
 | Set parallel compilation | `export FLASHINFER_NVCC_THREADS=4` |

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -1,4 +1,5 @@
 import abc
+import contextlib
 import dataclasses
 import functools
 import hashlib
@@ -443,10 +444,8 @@ class JitSpecNvcc(JitSpec):
             return False
 
     def _write_stamp(self) -> None:
-        try:
+        with contextlib.suppress(OSError):
             self.stamp_path.write_text(self._stamp_digest() + "\n")
-        except OSError:
-            pass
 
     def try_load(self) -> Optional[Any]:
         # Only the AOT artifact is known-valid without building.

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -400,7 +400,23 @@ class JitSpecNvcc(JitSpec):
         return self.ninja_path.parent / "flashinfer_jit.stamp"
 
     def _stamp_digest(self) -> str:
-        return hashlib.sha256(self.ninja_path.read_bytes()).hexdigest()
+        """Digest of the build inputs the stamp vouches for.
+
+        Covers the exact ``build.ninja`` contents (toolkit path, flags,
+        absolute source list) plus the contents of every listed source file,
+        so editing a source in place invalidates the stamp even though the
+        ninja file is unchanged. Transitively included headers are NOT
+        hashed — that residual risk is why the stamp is opt-in and aimed at
+        restored caches of released packages, not editable checkouts.
+        """
+        h = hashlib.sha256(self.ninja_path.read_bytes())
+        for src in sorted(Path(s) for s in self.sources):
+            h.update(str(src).encode())
+            try:
+                h.update(src.read_bytes())
+            except OSError:
+                h.update(b"<unreadable>")
+        return h.hexdigest()
 
     def _stamp_is_current(self) -> bool:
         """Whether a trusted stamp proves the cached library is up to date.

--- a/flashinfer/jit/core.py
+++ b/flashinfer/jit/core.py
@@ -1,6 +1,7 @@
 import abc
 import dataclasses
 import functools
+import hashlib
 import logging
 import os
 from contextlib import nullcontext
@@ -394,6 +395,43 @@ class JitSpecNvcc(JitSpec):
     def is_ninja_generated(self) -> bool:
         return self.ninja_path.exists()
 
+    @property
+    def stamp_path(self) -> Path:
+        return self.ninja_path.parent / "flashinfer_jit.stamp"
+
+    def _stamp_digest(self) -> str:
+        return hashlib.sha256(self.ninja_path.read_bytes()).hexdigest()
+
+    def _stamp_is_current(self) -> bool:
+        """Whether a trusted stamp proves the cached library is up to date.
+
+        Ninja judges staleness by file mtimes, so a JIT cache restored from an
+        archive (CI cache, baked container image, a copied ``$HOME``) under a
+        freshly installed package always rebuilds from scratch: the reinstalled
+        sources are newer than the restored objects even though every input is
+        byte-identical (#4884). When ``FLASHINFER_JIT_TRUST_CACHE_STAMP=1``,
+        trust a stamp of the exact ``build.ninja`` contents instead — the ninja
+        file embeds the toolkit path, all flags and the absolute source list,
+        so any real change to the build inputs changes the digest. Off by
+        default: mtime scanning stays authoritative for editable checkouts
+        where sources legitimately change within one version.
+        """
+        if os.environ.get("FLASHINFER_JIT_TRUST_CACHE_STAMP", "0") != "1":
+            return False
+        try:
+            return (
+                self.jit_library_path.exists()
+                and self.stamp_path.read_text().strip() == self._stamp_digest()
+            )
+        except OSError:
+            return False
+
+    def _write_stamp(self) -> None:
+        try:
+            self.stamp_path.write_text(self._stamp_digest() + "\n")
+        except OSError:
+            pass
+
     def try_load(self) -> Optional[Any]:
         # Only the AOT artifact is known-valid without building.
         # The freshness of the JIT-path .so is owned by ninja's dependency scan,
@@ -426,6 +464,8 @@ class JitSpecNvcc(JitSpec):
         with lock:
             is_cold_build = not self.jit_library_path.exists()
             self.write_ninja()
+            if not is_cold_build and self._stamp_is_current():
+                return
             if is_cold_build:
                 logger.info_once(
                     "Building JIT module %s; this can take several minutes on "
@@ -433,6 +473,7 @@ class JitSpecNvcc(JitSpec):
                     self.name,
                 )
             run_ninja(self.build_dir, self.ninja_path, verbose)
+            self._write_stamp()
 
     def load(self, so_path: Optional[Path] = None):
         module = tvm_ffi.load_module(str(so_path or self.jit_library_path))

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -47,21 +47,26 @@ def _get_glibcxx_abi_build_flags() -> List[str]:
 @functools.cache
 def get_cuda_path() -> str:
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
-    if cuda_home is not None:
-        return cuda_home
-    # get output of "which nvcc"
-    nvcc_path = subprocess.run(["which", "nvcc"], capture_output=True)
-    if nvcc_path.returncode == 0:
-        cuda_home = os.path.dirname(
-            os.path.dirname(nvcc_path.stdout.decode("utf-8").strip())
-        )
-    else:
-        cuda_home = "/usr/local/cuda"  # This default value is from: https://github.com/pytorch/pytorch/blob/ceb11a584d6b3fdc600358577d9bf2644f88def9/torch/utils/cpp_extension.py#L115
-        if not os.path.exists(cuda_home):
-            raise RuntimeError(
-                f"Could not find nvcc and default {cuda_home=} doesn't exist"
+    if cuda_home is None:
+        # get output of "which nvcc"
+        nvcc_path = subprocess.run(["which", "nvcc"], capture_output=True)
+        if nvcc_path.returncode == 0:
+            cuda_home = os.path.dirname(
+                os.path.dirname(nvcc_path.stdout.decode("utf-8").strip())
             )
-    return cuda_home
+        else:
+            cuda_home = "/usr/local/cuda"  # This default value is from: https://github.com/pytorch/pytorch/blob/ceb11a584d6b3fdc600358577d9bf2644f88def9/torch/utils/cpp_extension.py#L115
+            if not os.path.exists(cuda_home):
+                raise RuntimeError(
+                    f"Could not find nvcc and default {cuda_home=} doesn't exist"
+                )
+    # Canonicalize before the path is embedded into every generated
+    # build.ninja: /usr/local/cuda is typically a symlink to the versioned
+    # toolkit directory, and the `which nvcc` fallback follows PATH order, so
+    # the same toolkit can resolve to different strings in different shells
+    # (login vs non-login). A changed string rewrites build.ninja and
+    # invalidates the whole cached op even though nothing changed (#4884).
+    return os.path.realpath(cuda_home)
 
 
 @functools.cache

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -395,9 +395,7 @@ def test_trusted_stamp_skips_ninja_for_restored_cache(monkeypatch, tmp_path):
     monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
     monkeypatch.setattr(core.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
     ninja_content = "ninja_required_version = 1.3\n"
-    monkeypatch.setattr(
-        core, "generate_ninja_build_for_op", lambda **kw: ninja_content
-    )
+    monkeypatch.setattr(core, "generate_ninja_build_for_op", lambda **kw: ninja_content)
     runs = []
     monkeypatch.setattr(core, "run_ninja", lambda *a, **k: runs.append(1))
 
@@ -426,3 +424,31 @@ def test_trusted_stamp_skips_ninja_for_restored_cache(monkeypatch, tmp_path):
     )
     spec.build()
     assert runs == [1, 1, 1]
+
+
+def test_trusted_stamp_rehashes_source_contents(monkeypatch, tmp_path):
+    """Editing a source in place must invalidate the stamp even though the
+    generated build.ninja is byte-identical."""
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(core.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setattr(
+        core,
+        "generate_ninja_build_for_op",
+        lambda **kw: "ninja_required_version = 1.3\n",
+    )
+    runs = []
+    monkeypatch.setattr(core, "run_ninja", lambda *a, **k: runs.append(1))
+    monkeypatch.setenv("FLASHINFER_JIT_TRUST_CACHE_STAMP", "1")
+
+    source = tmp_path / "kernel.cu"
+    source.write_text("__global__ void k() {}\n")
+    spec = core.gen_jit_spec(name="stamp_source_module", sources=[source])
+    spec.build()
+    spec.jit_library_path.parent.mkdir(parents=True, exist_ok=True)
+    spec.jit_library_path.touch()
+    spec.build()
+    assert runs == [1]  # stamp trusted, ninja skipped
+
+    source.write_text("__global__ void k() { /* changed */ }\n")
+    spec.build()
+    assert runs == [1, 1]  # content change re-runs ninja

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -375,3 +375,54 @@ def test_prefill_jit_helper_skips_fa3_unsupported_large_head(monkeypatch):
     assert ("batch", "fa3", 512, 512) not in calls
     assert ("single", "fa2", 512, 512) in calls
     assert ("batch", "fa2", 512, 512) in calls
+
+
+def test_get_cuda_path_canonicalizes_symlinked_toolkit(monkeypatch, tmp_path):
+    real = tmp_path / "cuda-13.2"
+    (real / "bin").mkdir(parents=True)
+    link = tmp_path / "cuda"
+    link.symlink_to(real)
+
+    cpp_ext.get_cuda_path.cache_clear()
+    monkeypatch.setenv("CUDA_HOME", str(link))
+    try:
+        assert cpp_ext.get_cuda_path() == str(real.resolve())
+    finally:
+        cpp_ext.get_cuda_path.cache_clear()
+
+
+def test_trusted_stamp_skips_ninja_for_restored_cache(monkeypatch, tmp_path):
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    monkeypatch.setattr(core.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    ninja_content = "ninja_required_version = 1.3\n"
+    monkeypatch.setattr(
+        core, "generate_ninja_build_for_op", lambda **kw: ninja_content
+    )
+    runs = []
+    monkeypatch.setattr(core, "run_ninja", lambda *a, **k: runs.append(1))
+
+    spec = core.gen_jit_spec(name="stamp_module", sources=[])
+    spec.build()
+    assert runs == [1]
+
+    # run_ninja is stubbed, so fake the library it would have produced.
+    spec.jit_library_path.parent.mkdir(parents=True, exist_ok=True)
+    spec.jit_library_path.touch()
+
+    # Default behaviour is unchanged: ninja still runs.
+    spec.build()
+    assert runs == [1, 1]
+
+    # Opting in trusts the stamp: identical build.ninja -> no ninja invocation.
+    monkeypatch.setenv("FLASHINFER_JIT_TRUST_CACHE_STAMP", "1")
+    spec.build()
+    assert runs == [1, 1]
+
+    # Any change to the generated build.ninja invalidates the stamp.
+    monkeypatch.setattr(
+        core,
+        "generate_ninja_build_for_op",
+        lambda **kw: ninja_content + "# toolchain changed\n",
+    )
+    spec.build()
+    assert runs == [1, 1, 1]


### PR DESCRIPTION
Fixes the two spurious full-rebuild triggers reported in #4884 (each ~30 min for `fused_moe_trtllm_sm100` on sm_100a in our fleet).

## 1. Canonicalize `cuda_home` (default-on, one line of behaviour)

`get_cuda_path()` embeds its result verbatim in every generated `build.ninja`. The default resolution is PATH-dependent (`which nvcc`), and `/usr/local/cuda` is typically a symlink to the versioned toolkit dir — so a login shell (`/usr/local/cuda-13.2/bin` prepended by profile.d) and a non-login shell resolve the **same toolkit** to different strings. `write_if_different` then rewrites `build.ninja`, every command line changes, and ninja rebuilds the op from scratch. `os.path.realpath` before returning makes all spellings of one toolkit converge.

## 2. Opt-in stamp for restored caches (default-off)

Ninja judges staleness by mtimes, so a cache restored from an archive (CI cache restore, baked container image, a copied `$HOME`) under a freshly installed package always rebuilds — the reinstalled sources are newer than the restored `.o` files even though every input is byte-identical. With `FLASHINFER_JIT_TRUST_CACHE_STAMP=1`, a successful build records a sha256 of the exact `build.ninja` contents next to the library; when the stamp matches and the `.so` exists, `build()` returns before invoking ninja. Because the ninja file embeds the toolkit path, all flags and the absolute source list, any real change to the build inputs changes the digest (a cache moved to a venv at a different path also mismatches, conservatively). Default behaviour is completely unchanged — mtime scanning stays authoritative for editable checkouts.

## Tests

Two unit tests in `tests/jit/test_jit_cpp_ext.py`: symlink canonicalization (with `cache_clear` around the `functools.cache`), and the stamp lifecycle (default off → opt-in skip → digest invalidation), with `run_ninja`/`generate_ninja_build_for_op` stubbed so no toolchain is needed.

Happy to split the two commits into separate PRs if you prefer taking the realpath fix alone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Accelerated repeated CUDA JIT builds by reusing verified cached results when cache verification is enabled.
  * Standardized CUDA toolkit paths, including symlinked installations, for more consistent cache reuse.

* **Bug Fixes**
  * Prevented unnecessary rebuilds caused by equivalent CUDA paths resolving differently.
  * Ensured cached results are invalidated when build configuration or source contents change.

* **Documentation**
  * Documented the optional environment variable for enabling trusted JIT cache verification.

* **Tests**
  * Added coverage for cache reuse, cache invalidation, and symlinked CUDA toolkit paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->