### PR TITLE
feat(rope): add HY3 fused QK RMSNorm/RoPE KV-store

### DIFF
--- a/benchmarks/bench_rope_hy3.py
+++ b/benchmarks/bench_rope_hy3.py
@@ -1,0 +1,395 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark the HY3 fused RoPE/KV-store path on B200.
+
+Two comparisons are reported because existing FlashInfer has no operator that
+matches HY3's dynamic per-token/per-Q-head scale:
+
+* ``static_norm2_flashinfer`` compares the static-Q HY3 fusion with the closest
+  existing FlashInfer pipeline: two RMSNorm calls followed by
+  ``rope_quantize_fp8_append_paged_kv_cache``. Q/K/V views, metadata, and all
+  outputs are prepared outside timing, following the HPC-Ops benchmark. The
+  FlashInfer path does not clear the unused cache tail or write split flags, so
+  this comparison is conservative in its favor.
+* ``dynamic_norm2_b200`` compares the source-faithful HY3 dynamic-Q kernel with
+  its B200 one-token-decode specialization. These two paths have identical
+  outputs and side effects.
+
+Usage:
+$ python -m benchmarks.bench_rope_hy3
+$ python -m benchmarks.bench_rope_hy3 --batches 256 512 --hot-l2
+"""
+
+import argparse
+
+import numpy as np
+import torch
+
+import flashinfer
+from flashinfer.testing.utils import bench_gpu_time
+
+
+NUM_Q_HEADS = 64
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+PAGE_SIZE = 64
+Q_SCALE_INVERSE = 2.0
+KV_SCALE = 0.5
+
+
+def _measure(call, args):
+    values = bench_gpu_time(
+        call,
+        dry_run_iters=args.warmup,
+        repeat_iters=args.iters,
+        enable_cupti=not args.cuda_events,
+        cold_l2_cache=not args.hot_l2,
+    )
+    values = np.asarray(values, dtype=np.float64) * 1e3
+    return (
+        float(np.median(values)),
+        float(np.percentile(values, 20)),
+        float(np.percentile(values, 80)),
+    )
+
+
+def _make_inputs(batch_size, device):
+    packed_width = (NUM_Q_HEADS + 2 * NUM_KV_HEADS) * HEAD_DIM
+    generator = torch.Generator(device=device).manual_seed(1000 + batch_size)
+    packed_qkv = torch.randn(
+        (batch_size, packed_width),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    q_width = NUM_Q_HEADS * HEAD_DIM
+    k_width = NUM_KV_HEADS * HEAD_DIM
+    q = packed_qkv[:, :q_width].reshape(batch_size, NUM_Q_HEADS, HEAD_DIM)
+    k = packed_qkv[:, q_width : q_width + k_width].reshape(
+        batch_size, NUM_KV_HEADS, HEAD_DIM
+    )
+    v = packed_qkv[:, q_width + k_width :].reshape(batch_size, NUM_KV_HEADS, HEAD_DIM)
+
+    sequence_lengths = (
+        torch.arange(batch_size, dtype=torch.int32, device=device) % PAGE_SIZE + 1
+    )
+    q_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    block_table = torch.arange(batch_size, dtype=torch.int32, device=device).reshape(
+        batch_size, 1
+    )
+    positions = sequence_lengths - 1
+    batch_indices = torch.arange(batch_size, dtype=torch.int32, device=device)
+    kv_indices = batch_indices.clone()
+    kv_indptr = q_indptr.clone()
+    kv_last_page_len = sequence_lengths.clone()
+
+    rotary_positions = torch.arange(PAGE_SIZE + 1, dtype=torch.float32, device=device)
+    inverse_frequency = 1.0 / (
+        10000.0
+        ** (torch.arange(0, HEAD_DIM, 2, dtype=torch.float32, device=device) / HEAD_DIM)
+    )
+    frequencies = torch.outer(rotary_positions, inverse_frequency)
+    cos_sin_cache = torch.cat((frequencies.cos(), frequencies.sin()), dim=-1)
+
+    weight_bf16 = torch.linspace(
+        0.75, 1.25, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    return {
+        "packed_qkv": packed_qkv,
+        # Existing APIs consume separated contiguous Q/K/V. Preparing these
+        # outside timing favors the FlashInfer baseline and matches HPC-Ops.
+        "q": q.contiguous(),
+        "k": k.contiguous(),
+        "v": v.contiguous(),
+        "sequence_lengths": sequence_lengths,
+        "q_indptr": q_indptr,
+        "block_table": block_table,
+        "positions": positions,
+        "batch_indices": batch_indices,
+        "kv_indices": kv_indices,
+        "kv_indptr": kv_indptr,
+        "kv_last_page_len": kv_last_page_len,
+        "cos_sin_cache": cos_sin_cache,
+        "weight_bf16": weight_bf16,
+        "weight_fp32": weight_bf16.float(),
+    }
+
+
+def _make_cache(batch_size, device):
+    shape = (batch_size, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM)
+    key = torch.zeros(shape, dtype=torch.float8_e4m3fn, device=device)
+    value = torch.zeros_like(key)
+    return key, value
+
+
+@torch.inference_mode()
+def _benchmark_batch(batch_size, args):
+    device = torch.device(f"cuda:{args.device}")
+    inputs = _make_inputs(batch_size, device)
+    k_scale = torch.tensor([KV_SCALE], dtype=torch.float32, device=device)
+    v_scale = torch.tensor([KV_SCALE], dtype=torch.float32, device=device)
+    q_scale_inverse = torch.tensor(
+        [Q_SCALE_INVERSE], dtype=torch.float32, device=device
+    )
+
+    static_hy3_cache = _make_cache(batch_size, device)
+    static_fi_cache = _make_cache(batch_size, device)
+    static_hy3_q = torch.empty(
+        batch_size,
+        NUM_Q_HEADS,
+        HEAD_DIM,
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    static_fi_q = torch.empty_like(static_hy3_q)
+    static_flags = torch.full(
+        (batch_size, NUM_KV_HEADS), -1, dtype=torch.int32, device=device
+    )
+    q_norm = torch.empty_like(inputs["q"])
+    k_norm = torch.empty_like(inputs["k"])
+    q_nope = torch.empty(
+        batch_size, NUM_Q_HEADS, 0, dtype=torch.bfloat16, device=device
+    )
+    k_nope = torch.empty(
+        batch_size, NUM_KV_HEADS, 0, dtype=torch.bfloat16, device=device
+    )
+    q_nope_out = torch.empty_like(q_nope, dtype=torch.float8_e4m3fn)
+
+    def hy3_static():
+        return flashinfer.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+            inputs["packed_qkv"],
+            inputs["cos_sin_cache"],
+            inputs["sequence_lengths"],
+            inputs["q_indptr"],
+            inputs["block_table"],
+            static_hy3_cache,
+            False,
+            q_norm_weight=inputs["weight_fp32"],
+            k_norm_weight=inputs["weight_fp32"],
+            norm_policy=2,
+            quant_policy=2,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            q_scale_inverse=q_scale_inverse,
+            out_q=static_hy3_q,
+            split_k_flag=static_flags,
+        )
+
+    def flashinfer_static():
+        flashinfer.rmsnorm(
+            inputs["q"],
+            inputs["weight_bf16"],
+            out=q_norm,
+            enable_pdl=False,
+        )
+        flashinfer.rmsnorm(
+            inputs["k"],
+            inputs["weight_bf16"],
+            out=k_norm,
+            enable_pdl=False,
+        )
+        return flashinfer.rope.rope_quantize_fp8_append_paged_kv_cache(
+            q_norm,
+            k_norm,
+            q_nope,
+            k_nope,
+            inputs["v"],
+            inputs["cos_sin_cache"],
+            inputs["positions"],
+            static_fi_cache,
+            inputs["kv_indices"],
+            inputs["kv_indptr"],
+            inputs["batch_indices"],
+            inputs["positions"],
+            is_neox=True,
+            quantize_dtype=torch.float8_e4m3fn,
+            quant_scale_q=Q_SCALE_INVERSE,
+            quant_scale_kv=1.0 / KV_SCALE,
+            page_size=PAGE_SIZE,
+            kv_layout="NHD",
+            q_rope_out=static_fi_q,
+            q_nope_out=q_nope_out,
+            enable_pdl=False,
+        )
+
+    dynamic_source_cache = _make_cache(batch_size, device)
+    dynamic_fast_cache = _make_cache(batch_size, device)
+    dynamic_source_q = torch.empty_like(static_hy3_q)
+    dynamic_fast_q = torch.empty_like(static_hy3_q)
+    dynamic_source_scale = torch.empty(
+        batch_size, NUM_Q_HEADS, dtype=torch.float32, device=device
+    )
+    dynamic_fast_scale = torch.empty_like(dynamic_source_scale)
+    dynamic_source_flags = torch.full_like(static_flags, -1)
+    dynamic_fast_flags = torch.full_like(static_flags, -1)
+
+    def hy3_dynamic_source():
+        return flashinfer.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+            inputs["packed_qkv"],
+            inputs["cos_sin_cache"],
+            inputs["sequence_lengths"],
+            inputs["q_indptr"],
+            inputs["block_table"],
+            dynamic_source_cache,
+            False,
+            q_norm_weight=inputs["weight_fp32"],
+            k_norm_weight=inputs["weight_fp32"],
+            norm_policy=2,
+            quant_policy=1,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            out_q=dynamic_source_q,
+            out_q_scale=dynamic_source_scale,
+            split_k_flag=dynamic_source_flags,
+            uniform_one_token_decode=False,
+        )
+
+    def hy3_dynamic_fast():
+        return flashinfer.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+            inputs["packed_qkv"],
+            inputs["cos_sin_cache"],
+            inputs["sequence_lengths"],
+            inputs["q_indptr"],
+            inputs["block_table"],
+            dynamic_fast_cache,
+            False,
+            q_norm_weight=inputs["weight_fp32"],
+            k_norm_weight=inputs["weight_fp32"],
+            norm_policy=2,
+            quant_policy=1,
+            k_scale=k_scale,
+            v_scale=v_scale,
+            out_q=dynamic_fast_q,
+            out_q_scale=dynamic_fast_scale,
+            split_k_flag=dynamic_fast_flags,
+            uniform_one_token_decode=True,
+        )
+
+    # Compile every provider and establish the common-output correctness
+    # boundary before measuring. Tail clearing and flags are HY3-only work.
+    hy3_static()
+    flashinfer_static()
+    torch.cuda.synchronize(device)
+    written = inputs["positions"].long()
+    pages = torch.arange(batch_size, dtype=torch.long, device=device)
+    torch.testing.assert_close(
+        static_hy3_q.float(), static_fi_q.float(), rtol=0.2, atol=0.5
+    )
+    torch.testing.assert_close(
+        static_hy3_cache[0][pages, written].float(),
+        static_fi_cache[0][pages, written].float(),
+        rtol=0.2,
+        atol=0.5,
+    )
+    torch.testing.assert_close(
+        static_hy3_cache[1][pages, written].float(),
+        static_fi_cache[1][pages, written].float(),
+        rtol=0.0,
+        atol=0.0,
+    )
+    if torch.any(static_flags == -1):
+        raise AssertionError("HY3 static path did not write every split_k_flag")
+
+    hy3_dynamic_source()
+    hy3_dynamic_fast()
+    torch.cuda.synchronize(device)
+    for source, optimized in (
+        (dynamic_source_q, dynamic_fast_q),
+        (dynamic_source_scale, dynamic_fast_scale),
+        (dynamic_source_flags, dynamic_fast_flags),
+        (dynamic_source_cache[0], dynamic_fast_cache[0]),
+        (dynamic_source_cache[1], dynamic_fast_cache[1]),
+    ):
+        if not torch.equal(source, optimized):
+            raise AssertionError(
+                "B200 dynamic fast path differs from source-faithful HY3"
+            )
+
+    results = {
+        "hy3_fused_static": _measure(hy3_static, args),
+        "flashinfer_composed_static": _measure(flashinfer_static, args),
+        "hy3_source_faithful_dynamic": _measure(hy3_dynamic_source, args),
+        "hy3_b200_tail_fused_dynamic": _measure(hy3_dynamic_fast, args),
+    }
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batches", type=int, nargs="+", default=[256, 512])
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--hot-l2",
+        action="store_true",
+        help="reuse hot inputs instead of flushing L2 between measurements",
+    )
+    parser.add_argument(
+        "--cuda-events",
+        action="store_true",
+        help="use CUDA events instead of the preferred CUPTI timer",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        print("HY3 RoPE/KV-store benchmark skipped: CUDA is unavailable")
+        return
+    torch.cuda.set_device(args.device)
+    if torch.cuda.get_device_capability(args.device) != (10, 0):
+        print("HY3 RoPE/KV-store benchmark skipped: requires SM100/B200")
+        return
+
+    cache_mode = "hot" if args.hot_l2 else "cold"
+    timer = "cuda_event" if args.cuda_events else "cupti_or_event_fallback"
+    print(f"# cache={cache_mode}, timer={timer}, heads=64/8, dim=128, page=64")
+    print("case,batch,provider,median_us,p20_us,p80_us,speedup")
+    for batch_size in args.batches:
+        results = _benchmark_batch(batch_size, args)
+        static_speedup = (
+            results["flashinfer_composed_static"][0] / results["hy3_fused_static"][0]
+        )
+        dynamic_speedup = (
+            results["hy3_source_faithful_dynamic"][0]
+            / results["hy3_b200_tail_fused_dynamic"][0]
+        )
+        for case, providers, optimized, speedup in (
+            (
+                "static_norm2_flashinfer",
+                ("flashinfer_composed_static", "hy3_fused_static"),
+                "hy3_fused_static",
+                static_speedup,
+            ),
+            (
+                "dynamic_norm2_b200",
+                (
+                    "hy3_source_faithful_dynamic",
+                    "hy3_b200_tail_fused_dynamic",
+                ),
+                "hy3_b200_tail_fused_dynamic",
+                dynamic_speedup,
+            ),
+        ):
+            for provider in providers:
+                median, p20, p80 = results[provider]
+                row_speedup = speedup if provider == optimized else 1.0
+                print(
+                    f"{case},{batch_size},{provider},{median:.3f},{p20:.3f},"
+                    f"{p80:.3f},{row_speedup:.3f}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/flashinfer_rope_hy3_binding.cu
+++ b/csrc/flashinfer_rope_hy3_binding.cu
@@ -1,0 +1,18 @@
+// Copyright (C) 2026 Tencent.
+// SPDX-License-Identifier: MIT
+
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Tensor;
+
+void qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+    TensorView packed_qkv, TensorView cos_sin_cache, TensorView sequence_lengths,
+    TensorView q_indptr, TensorView block_table, TensorView q_norm_weight, TensorView k_norm_weight,
+    TensorView k_scale, TensorView v_scale, TensorView q_scale_inverse, TensorView output_q,
+    TensorView output_q_scale, TensorView split_k_flag, TensorView output_k, TensorView output_v,
+    TensorView key_cache, TensorView value_cache, bool is_prefill, int64_t norm_policy,
+    int64_t quant_policy, int64_t max_sequence_length, double fp8_upper_bound, bool use_output_k,
+    bool use_output_v, bool enable_sm100_uniform_decode);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(qk_rmsnorm_rope_append_paged_kv_cache_hy3,
+                              qk_rmsnorm_rope_append_paged_kv_cache_hy3);

--- a/csrc/rope_hy3.cu
+++ b/csrc/rope_hy3.cu
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 Tencent.
+// SPDX-License-Identifier: MIT
+
+#include <flashinfer/rope_norm_store_kv_hy3.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+
+using tvm::ffi::Tensor;
+
+// This binding promotes the model-agnostic behavior of Tencent/HPC-Ops' fused
+// Q/K RMSNorm + NeoX RoPE + paged-KV-store operator into FlashInfer. The
+// source-faithful specialization is the fallback for every supported shape;
+// the narrower SM100 uniform-decode path fuses final-page tail clearing, maps
+// one row directly to one request, and reuses RoPE coefficients from registers.
+void qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+    TensorView packed_qkv, TensorView cos_sin_cache, TensorView sequence_lengths,
+    TensorView q_indptr, TensorView block_table, TensorView q_norm_weight, TensorView k_norm_weight,
+    TensorView k_scale, TensorView v_scale, TensorView q_scale_inverse, TensorView output_q,
+    TensorView output_q_scale, TensorView split_k_flag, TensorView output_k, TensorView output_v,
+    TensorView key_cache, TensorView value_cache, bool is_prefill, int64_t norm_policy,
+    int64_t quant_policy, int64_t max_sequence_length, double fp8_upper_bound, bool use_output_k,
+    bool use_output_v, bool enable_sm100_uniform_decode) {
+  CHECK_INPUT(packed_qkv);
+  CHECK_INPUT(cos_sin_cache);
+  CHECK_INPUT(sequence_lengths);
+  CHECK_INPUT(q_indptr);
+  CHECK_INPUT(block_table);
+  CHECK_INPUT(q_norm_weight);
+  CHECK_INPUT(k_norm_weight);
+  CHECK_INPUT(k_scale);
+  CHECK_INPUT(v_scale);
+  CHECK_INPUT(q_scale_inverse);
+  CHECK_INPUT(output_q);
+  CHECK_INPUT(output_q_scale);
+  CHECK_INPUT(split_k_flag);
+  CHECK_INPUT(output_k);
+  CHECK_INPUT(output_v);
+  CHECK_INPUT(key_cache);
+  CHECK_INPUT(value_cache);
+
+  CHECK_DIM(2, packed_qkv);
+  CHECK_DIM(2, cos_sin_cache);
+  CHECK_DIM(1, sequence_lengths);
+  CHECK_DIM(1, q_indptr);
+  CHECK_DIM(2, block_table);
+  CHECK_DIM(3, output_q);
+  CHECK_DIM(4, key_cache);
+  CHECK_DIM(4, value_cache);
+
+  const auto check_same_device = [&](const TensorView& tensor) {
+    TVM_FFI_ICHECK_EQ(packed_qkv.device().device_type, tensor.device().device_type);
+    TVM_FFI_ICHECK_EQ(packed_qkv.device().device_id, tensor.device().device_id);
+  };
+  for (const TensorView* tensor :
+       {&cos_sin_cache, &sequence_lengths, &q_indptr, &block_table, &q_norm_weight, &k_norm_weight,
+        &k_scale, &v_scale, &q_scale_inverse, &output_q, &output_q_scale, &split_k_flag, &output_k,
+        &output_v, &key_cache, &value_cache}) {
+    check_same_device(*tensor);
+  }
+
+  TVM_FFI_ICHECK_EQ(packed_qkv.dtype(), dl_bfloat16) << "packed_qkv must have bfloat16 dtype";
+  TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), dl_float32) << "cos_sin_cache must have float32 dtype";
+  TVM_FFI_ICHECK_EQ(sequence_lengths.dtype(), dl_int32) << "sequence_lengths must have int32 dtype";
+  TVM_FFI_ICHECK_EQ(q_indptr.dtype(), dl_int32) << "q_indptr must have int32 dtype";
+  TVM_FFI_ICHECK_EQ(block_table.dtype(), dl_int32) << "block_table must have int32 dtype";
+
+  const int64_t batch_size = sequence_lengths.size(0);
+  const int64_t num_rows = packed_qkv.size(0);
+  const int64_t num_kv_heads = key_cache.size(2);
+  const int64_t qk_head_dim = key_cache.size(3);
+  const int64_t v_head_dim = value_cache.size(3);
+  const int64_t page_size = key_cache.size(1);
+  const int64_t hidden_size = packed_qkv.size(1);
+  TVM_FFI_ICHECK_GT(batch_size, 0) << "batch_size must be positive";
+  TVM_FFI_ICHECK_GT(num_rows, 0) << "packed_qkv must contain at least one row";
+  TVM_FFI_ICHECK_GT(page_size, 0) << "page_size must be positive";
+  TVM_FFI_ICHECK_EQ(q_indptr.size(0), batch_size + 1)
+      << "q_indptr must have shape [batch_size + 1]";
+  TVM_FFI_ICHECK_EQ(block_table.size(0), batch_size)
+      << "block_table must have shape [batch_size, max_pages_per_request]";
+  TVM_FFI_ICHECK_EQ(key_cache.size(0), value_cache.size(0))
+      << "key/value cache page counts must match";
+  TVM_FFI_ICHECK_EQ(key_cache.size(1), value_cache.size(1))
+      << "key/value cache page sizes must match";
+  TVM_FFI_ICHECK_EQ(key_cache.size(2), value_cache.size(2))
+      << "key/value cache KV-head counts must match";
+  TVM_FFI_ICHECK_EQ(qk_head_dim, 128) << "qk_head_dim must be 128";
+  TVM_FFI_ICHECK_EQ(v_head_dim, 128) << "v_head_dim must be 128";
+  TVM_FFI_ICHECK_EQ(cos_sin_cache.size(1), qk_head_dim)
+      << "cos_sin_cache must have shape [max_position, 128]";
+
+  const int64_t q_width = hidden_size - num_kv_heads * qk_head_dim - num_kv_heads * v_head_dim;
+  TVM_FFI_ICHECK_GE(q_width, 0) << "packed_qkv hidden dimension is too small";
+  TVM_FFI_ICHECK_EQ(q_width % qk_head_dim, 0)
+      << "packed_qkv hidden dimension is incompatible with cache shapes";
+  const int64_t num_q_heads = q_width / qk_head_dim;
+  TVM_FFI_ICHECK((num_q_heads == 8 && num_kv_heads == 1) ||
+                 (num_q_heads == 64 && num_kv_heads == 8))
+      << "supported (num_q_heads, num_kv_heads) pairs are (8, 1) and (64, 8)";
+  TVM_FFI_ICHECK_GE(norm_policy, 0);
+  TVM_FFI_ICHECK_LE(norm_policy, 2)
+      << "norm_policy must be 0 (none), 1 (RoPE then norm), or 2 (norm then RoPE)";
+
+  TVM_FFI_ICHECK_EQ(output_q.size(0), num_rows);
+  TVM_FFI_ICHECK_EQ(output_q.size(1), num_q_heads);
+  TVM_FFI_ICHECK_EQ(output_q.size(2), qk_head_dim);
+
+  if (norm_policy > 0) {
+    // The upstream launcher passes const float* weights; keeping FP32 here is
+    // intentional rather than an omitted BF16 dispatch.
+    CHECK_DIM(1, q_norm_weight);
+    CHECK_DIM(1, k_norm_weight);
+    TVM_FFI_ICHECK_EQ(q_norm_weight.dtype(), dl_float32);
+    TVM_FFI_ICHECK_EQ(k_norm_weight.dtype(), dl_float32);
+    TVM_FFI_ICHECK_EQ(q_norm_weight.numel(), qk_head_dim);
+    TVM_FFI_ICHECK_EQ(k_norm_weight.numel(), qk_head_dim);
+  } else {
+    TVM_FFI_ICHECK_EQ(q_norm_weight.numel(), 0)
+        << "q_norm_weight must be empty when norm_policy is 0";
+    TVM_FFI_ICHECK_EQ(k_norm_weight.numel(), 0)
+        << "k_norm_weight must be empty when norm_policy is 0";
+  }
+
+  const bool is_fp8 = key_cache.dtype() == dl_float8_e4m3fn;
+  TVM_FFI_ICHECK(value_cache.dtype() == key_cache.dtype()) << "key/value cache dtypes must match";
+  TVM_FFI_ICHECK(output_q.dtype() == key_cache.dtype())
+      << "output_q dtype must match the cache dtype";
+  if (is_fp8) {
+    TVM_FFI_ICHECK(quant_policy == 1 || quant_policy == 2)
+        << "FP8 quant_policy must be 1 (dynamic Q) or 2 (static Q)";
+    TVM_FFI_ICHECK_GT(fp8_upper_bound, 0.0);
+    TVM_FFI_ICHECK_LE(fp8_upper_bound, 448.0) << "fp8_upper_bound must be in (0, 448] for E4M3FN";
+    TVM_FFI_ICHECK_EQ(k_scale.dtype(), dl_float32);
+    TVM_FFI_ICHECK_EQ(v_scale.dtype(), dl_float32);
+    TVM_FFI_ICHECK_EQ(k_scale.numel(), 1);
+    TVM_FFI_ICHECK_EQ(v_scale.numel(), 1);
+    if (quant_policy == 2) {
+      TVM_FFI_ICHECK_EQ(q_scale_inverse.dtype(), dl_float32);
+      TVM_FFI_ICHECK_EQ(q_scale_inverse.numel(), 1);
+      TVM_FFI_ICHECK_EQ(output_q_scale.numel(), 0);
+    } else {
+      TVM_FFI_ICHECK_EQ(q_scale_inverse.numel(), 0)
+          << "q_scale_inverse must be empty for dynamic-Q quantization";
+      TVM_FFI_ICHECK_GE(max_sequence_length, 0);
+      const int64_t max_sequence_length_aligned = ((max_sequence_length + 127) / 128) * 128;
+      TVM_FFI_ICHECK_EQ(output_q_scale.dtype(), dl_float32);
+      if (is_prefill) {
+        TVM_FFI_ICHECK_GT(max_sequence_length, 0)
+            << "dynamic-Q prefill requires max_sequence_length > 0";
+        CHECK_DIM(3, output_q_scale);
+        TVM_FFI_ICHECK_EQ(output_q_scale.size(0), batch_size);
+        TVM_FFI_ICHECK_EQ(output_q_scale.size(1), num_q_heads);
+        TVM_FFI_ICHECK_EQ(output_q_scale.size(2), max_sequence_length_aligned);
+      } else {
+        CHECK_DIM(2, output_q_scale);
+        TVM_FFI_ICHECK_EQ(output_q_scale.size(0), num_rows);
+        TVM_FFI_ICHECK_EQ(output_q_scale.size(1), num_q_heads);
+      }
+    }
+    CHECK_DIM(2, split_k_flag);
+    TVM_FFI_ICHECK_EQ(split_k_flag.dtype(), dl_int32);
+    TVM_FFI_ICHECK_EQ(split_k_flag.size(0), batch_size);
+    TVM_FFI_ICHECK_EQ(split_k_flag.size(1), num_kv_heads);
+  } else {
+    TVM_FFI_ICHECK_EQ(key_cache.dtype(), dl_bfloat16)
+        << "cache dtype must be bfloat16 or float8_e4m3fn";
+    TVM_FFI_ICHECK_EQ(quant_policy, 0) << "BF16 path requires quant_policy=0";
+    TVM_FFI_ICHECK_EQ(k_scale.numel(), 0);
+    TVM_FFI_ICHECK_EQ(v_scale.numel(), 0);
+    TVM_FFI_ICHECK_EQ(q_scale_inverse.numel(), 0);
+    TVM_FFI_ICHECK_EQ(output_q_scale.numel(), 0);
+    TVM_FFI_ICHECK_EQ(split_k_flag.numel(), 0);
+  }
+
+  const auto check_optional_output = [&](TensorView output, bool enabled, int64_t head_count,
+                                         int64_t head_dimension, const char* name) {
+    if (!enabled) {
+      TVM_FFI_ICHECK_EQ(output.numel(), 0) << name << " must be empty when disabled";
+      return;
+    }
+    TVM_FFI_ICHECK_EQ(output.ndim(), 3) << name << " must be rank 3";
+    TVM_FFI_ICHECK_EQ(output.dtype(), key_cache.dtype())
+        << name << " dtype must match the cache dtype";
+    TVM_FFI_ICHECK_EQ(output.size(0), num_rows);
+    TVM_FFI_ICHECK_EQ(output.size(1), head_count);
+    TVM_FFI_ICHECK_EQ(output.size(2), head_dimension);
+  };
+  check_optional_output(output_k, use_output_k, num_kv_heads, qk_head_dim, "output_k");
+  check_optional_output(output_v, use_output_v, num_kv_heads, v_head_dim, "output_v");
+
+  // The optimized kernel omits all clear-only CTAs. Its contract therefore
+  // requires a trusted host-side guarantee that q_indptr is exactly
+  // [0, 1, ..., batch_size]. Shape equality alone is not sufficient for
+  // ragged or CUDA-graph-padded batches, so this remains an explicit flag.
+  const bool use_sm100_fast_path = enable_sm100_uniform_decode && !is_prefill && is_fp8 &&
+                                   quant_policy == 1 && norm_policy == 2 && num_q_heads == 64 &&
+                                   num_kv_heads == 8 && batch_size >= 256 && num_rows == batch_size;
+
+  ffi::CUDADeviceGuard device_guard(packed_qkv.device().device_id);
+  const cudaStream_t stream = get_stream(packed_qkv.device());
+  const int max_sequence_length_aligned =
+      quant_policy == 1 ? static_cast<int>(((max_sequence_length + 127) / 128) * 128) : 0;
+
+  namespace fused_rope = flashinfer::rope_norm_store_kv_hy3;
+#define FLASHINFER_LAUNCH_QK_NORM_ROPE(CACHE_TYPE, QUANT_POLICY)                                  \
+  fused_rope::dispatch_shape<CACHE_TYPE, QUANT_POLICY>(                                           \
+      static_cast<CACHE_TYPE*>(output_q.data_ptr()),                                              \
+      static_cast<CACHE_TYPE*>(key_cache.data_ptr()),                                             \
+      static_cast<CACHE_TYPE*>(value_cache.data_ptr()),                                           \
+      use_output_k ? static_cast<CACHE_TYPE*>(output_k.data_ptr()) : nullptr,                     \
+      use_output_v ? static_cast<CACHE_TYPE*>(output_v.data_ptr()) : nullptr,                     \
+      is_fp8 ? static_cast<int32_t*>(split_k_flag.data_ptr()) : nullptr,                          \
+      quant_policy == 1 ? static_cast<float*>(output_q_scale.data_ptr()) : nullptr,               \
+      static_cast<const __nv_bfloat16*>(packed_qkv.data_ptr()),                                   \
+      static_cast<const float*>(cos_sin_cache.data_ptr()),                                        \
+      static_cast<const int32_t*>(sequence_lengths.data_ptr()),                                   \
+      static_cast<const int32_t*>(q_indptr.data_ptr()),                                           \
+      static_cast<const int32_t*>(block_table.data_ptr()),                                        \
+      norm_policy > 0 ? static_cast<const float*>(q_norm_weight.data_ptr()) : nullptr,            \
+      norm_policy > 0 ? static_cast<const float*>(k_norm_weight.data_ptr()) : nullptr,            \
+      is_fp8 ? static_cast<const float*>(k_scale.data_ptr()) : nullptr,                           \
+      is_fp8 ? static_cast<const float*>(v_scale.data_ptr()) : nullptr,                           \
+      quant_policy == 2 ? static_cast<const float*>(q_scale_inverse.data_ptr()) : nullptr,        \
+      static_cast<float>(fp8_upper_bound), max_sequence_length_aligned, key_cache.stride(0),      \
+      value_cache.stride(0), static_cast<int>(batch_size), static_cast<int>(block_table.size(1)), \
+      static_cast<int>(page_size), static_cast<int>(num_rows), static_cast<int>(num_q_heads),     \
+      static_cast<int>(num_kv_heads), is_prefill, static_cast<int>(norm_policy), stream)
+
+  cudaError_t status;
+  if (use_sm100_fast_path) {
+    // Instantiate exactly the one measured fast specialization. Keeping the
+    // runtime-impossible BF16/static-Q/head/norm combinations out of this
+    // branch materially reduces JIT time and the generated fatbin.
+    status = fused_rope::launch_specialized<__nv_fp8_e4m3, 1, 64, 8, 2, true>(
+        static_cast<__nv_fp8_e4m3*>(output_q.data_ptr()),
+        static_cast<__nv_fp8_e4m3*>(key_cache.data_ptr()),
+        static_cast<__nv_fp8_e4m3*>(value_cache.data_ptr()),
+        use_output_k ? static_cast<__nv_fp8_e4m3*>(output_k.data_ptr()) : nullptr,
+        use_output_v ? static_cast<__nv_fp8_e4m3*>(output_v.data_ptr()) : nullptr,
+        static_cast<int32_t*>(split_k_flag.data_ptr()),
+        static_cast<float*>(output_q_scale.data_ptr()),
+        static_cast<const __nv_bfloat16*>(packed_qkv.data_ptr()),
+        static_cast<const float*>(cos_sin_cache.data_ptr()),
+        static_cast<const int32_t*>(sequence_lengths.data_ptr()),
+        static_cast<const int32_t*>(q_indptr.data_ptr()),
+        static_cast<const int32_t*>(block_table.data_ptr()),
+        static_cast<const float*>(q_norm_weight.data_ptr()),
+        static_cast<const float*>(k_norm_weight.data_ptr()),
+        static_cast<const float*>(k_scale.data_ptr()),
+        static_cast<const float*>(v_scale.data_ptr()), nullptr, static_cast<float>(fp8_upper_bound),
+        max_sequence_length_aligned, key_cache.stride(0), value_cache.stride(0),
+        static_cast<int>(batch_size), static_cast<int>(block_table.size(1)),
+        static_cast<int>(page_size), static_cast<int>(num_rows), false, stream);
+  } else if (is_fp8) {
+    status = quant_policy == 1 ? FLASHINFER_LAUNCH_QK_NORM_ROPE(__nv_fp8_e4m3, 1)
+                               : FLASHINFER_LAUNCH_QK_NORM_ROPE(__nv_fp8_e4m3, 2);
+  } else {
+    status = FLASHINFER_LAUNCH_QK_NORM_ROPE(__nv_bfloat16, 0);
+  }
+#undef FLASHINFER_LAUNCH_QK_NORM_ROPE
+
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << "qk_rmsnorm_rope_append_paged_kv_cache_hy3 failed with error code "
+      << cudaGetErrorString(status);
+}

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -257,6 +257,9 @@ from .rope import apply_rope_with_cos_sin_cache as apply_rope_with_cos_sin_cache
 from .rope import (
     apply_rope_with_cos_sin_cache_inplace as apply_rope_with_cos_sin_cache_inplace,
 )
+from .rope import (
+    qk_rmsnorm_rope_append_paged_kv_cache_hy3 as qk_rmsnorm_rope_append_paged_kv_cache_hy3,
+)
 from .sampling import chain_speculative_sampling as chain_speculative_sampling
 from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
 from .sampling import sampling_from_logits as sampling_from_logits

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -148,6 +148,7 @@ from .jit.rmsnorm_silu import (
 from .jit.page import gen_page_module
 from .jit.quantization import gen_quantization_module
 from .jit.rope import gen_rope_module
+from .jit.rope_hy3 import gen_qk_norm_rope_hy3_module
 from .jit.sampling import gen_sampling_module
 from .jit.spdlog import gen_spdlog_module
 from .jit.moe_utils import gen_moe_utils_module
@@ -784,6 +785,7 @@ def gen_all_modules(
             gen_page_module(),
             gen_quantization_module(),
             gen_rope_module(),
+            gen_qk_norm_rope_hy3_module(),
             gen_sampling_module(),
             gen_topk_module(),
         ]

--- a/flashinfer/jit/rope_hy3.py
+++ b/flashinfer/jit/rope_hy3.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec
+
+
+def gen_qk_norm_rope_hy3_module() -> JitSpec:
+    """Build the HY3 fusion with source-faithful FP32 math."""
+    return gen_jit_spec(
+        "qk_norm_rope_hy3",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "rope_hy3.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "flashinfer_rope_hy3_binding.cu",
+        ],
+        extra_cuda_cflags=[
+            "--ftz=false",
+            "--prec-div=true",
+            "--prec-sqrt=true",
+        ],
+    )

--- a/flashinfer/rope.py
+++ b/flashinfer/rope.py
@@ -32,16 +32,53 @@ from .trace.templates.rope import (
     apply_rope_with_cos_sin_cache_inplace_trace,
     apply_rope_with_cos_sin_cache_trace,
     mla_rope_quantize_fp8_trace,
+    qk_rmsnorm_rope_store_hy3_trace_dispatch,
     rope_quantize_fp8_append_paged_kv_cache_trace,
     rope_quantize_fp8_trace,
 )
 from .jit.rope import gen_rope_module
+from .jit.rope_hy3 import gen_qk_norm_rope_hy3_module
 from .utils import register_custom_op, register_fake_op
 
 
 @functools.cache
 def get_rope_module():
     return gen_rope_module().build_and_load()
+
+
+@functools.cache
+def get_qk_norm_rope_hy3_module():
+    return gen_qk_norm_rope_hy3_module().build_and_load()
+
+
+@functools.cache
+def _is_sm100_device(device_index: int) -> bool:
+    """Cache the capability probe so it never enters the decode hot path."""
+
+    return torch.cuda.get_device_capability(device_index) == (10, 0)
+
+
+@functools.cache
+def _qk_norm_rope_hy3_empty_placeholders(
+    device_index: int, output_dtype: torch.dtype
+) -> Tuple[torch.Tensor, ...]:
+    """Return distinct zero-sized tensors for optional FFI arguments.
+
+    Distinct storages avoid aliasing mutable and immutable custom-op arguments,
+    while caching keeps placeholder creation out of the per-token hot path.
+    """
+    device = torch.device("cuda", device_index)
+    return (
+        torch.empty(0, dtype=torch.float32, device=device),  # q norm
+        torch.empty(0, dtype=torch.float32, device=device),  # k norm
+        torch.empty(0, dtype=torch.float32, device=device),  # k scale
+        torch.empty(0, dtype=torch.float32, device=device),  # v scale
+        torch.empty(0, dtype=torch.float32, device=device),  # q scale inverse
+        torch.empty(0, dtype=torch.float32, device=device),  # output q scale
+        torch.empty(0, dtype=torch.int32, device=device),  # split-k flag
+        torch.empty(0, dtype=output_dtype, device=device),  # output k
+        torch.empty(0, dtype=output_dtype, device=device),  # output v
+    )
 
 
 @register_custom_op("flashinfer::apply_rope", mutates_args=("q_rope", "k_rope"))
@@ -337,6 +374,105 @@ def _fake_rope_quantize_fp8_append_paged_kv_cache(
     quant_scale_kv: float,
     interleave: bool,
     enable_pdl: bool,
+) -> None:
+    pass
+
+
+@register_custom_op(
+    "flashinfer::qk_rmsnorm_rope_append_paged_kv_cache_hy3",
+    mutates_args=(
+        "output_q",
+        "output_q_scale",
+        "split_k_flag",
+        "output_k",
+        "output_v",
+        "key_cache",
+        "value_cache",
+    ),
+)
+def _qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+    packed_qkv: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    q_indptr: torch.Tensor,
+    block_table: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    q_scale_inverse: torch.Tensor,
+    output_q: torch.Tensor,
+    output_q_scale: torch.Tensor,
+    split_k_flag: torch.Tensor,
+    output_k: torch.Tensor,
+    output_v: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    is_prefill: bool,
+    norm_policy: int,
+    quant_policy: int,
+    max_sequence_length: int,
+    fp8_upper_bound: float,
+    use_output_k: bool,
+    use_output_v: bool,
+    enable_sm100_uniform_decode: bool,
+) -> None:
+    get_qk_norm_rope_hy3_module().qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        packed_qkv,
+        cos_sin_cache,
+        sequence_lengths,
+        q_indptr,
+        block_table,
+        q_norm_weight,
+        k_norm_weight,
+        k_scale,
+        v_scale,
+        q_scale_inverse,
+        output_q,
+        output_q_scale,
+        split_k_flag,
+        output_k,
+        output_v,
+        key_cache,
+        value_cache,
+        is_prefill,
+        norm_policy,
+        quant_policy,
+        max_sequence_length,
+        fp8_upper_bound,
+        use_output_k,
+        use_output_v,
+        enable_sm100_uniform_decode,
+    )
+
+
+@register_fake_op("flashinfer::qk_rmsnorm_rope_append_paged_kv_cache_hy3")
+def _fake_qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+    packed_qkv: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    q_indptr: torch.Tensor,
+    block_table: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
+    q_scale_inverse: torch.Tensor,
+    output_q: torch.Tensor,
+    output_q_scale: torch.Tensor,
+    split_k_flag: torch.Tensor,
+    output_k: torch.Tensor,
+    output_v: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    is_prefill: bool,
+    norm_policy: int,
+    quant_policy: int,
+    max_sequence_length: int,
+    fp8_upper_bound: float,
+    use_output_k: bool,
+    use_output_v: bool,
+    enable_sm100_uniform_decode: bool,
 ) -> None:
     pass
 
@@ -1548,6 +1684,330 @@ def rope_quantize_fp8(
     )
 
     return q_rope_out, k_rope_out, q_nope_out, k_nope_out
+
+
+@flashinfer_api(trace=qk_rmsnorm_rope_store_hy3_trace_dispatch)
+def qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+    packed_qkv: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    q_indptr: torch.Tensor,
+    block_table: torch.Tensor,
+    paged_kv_cache: Tuple[torch.Tensor, torch.Tensor],
+    is_prefill: bool,
+    q_norm_weight: Optional[torch.Tensor] = None,
+    k_norm_weight: Optional[torch.Tensor] = None,
+    norm_policy: int = 0,
+    quant_policy: Optional[int] = None,
+    k_scale: Optional[torch.Tensor] = None,
+    v_scale: Optional[torch.Tensor] = None,
+    q_scale_inverse: Optional[torch.Tensor] = None,
+    max_sequence_length: int = 0,
+    fp8_upper_bound: float = 448.0,
+    out_q: Optional[torch.Tensor] = None,
+    out_q_scale: Optional[torch.Tensor] = None,
+    split_k_flag: Optional[torch.Tensor] = None,
+    out_k: Optional[torch.Tensor] = None,
+    out_v: Optional[torch.Tensor] = None,
+    uniform_one_token_decode: bool = False,
+) -> Tuple[
+    torch.Tensor,
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+]:
+    r"""Fuse per-head Q/K RMSNorm, NeoX RoPE, and NHD paged-KV storage.
+
+    This operator consumes a packed BF16 ``[Q, K, V]`` projection and writes
+    the transformed query plus K/V cache data in one CUDA launch.  It preserves
+    the cache-tail zero-fill side effect required by the originating serving
+    pipeline and supports both BF16 and FP8 E4M3 output/cache paths.
+
+    ``norm_policy`` selects the ordering: ``0`` disables normalization, ``1``
+    applies RoPE then RMSNorm, and ``2`` applies RMSNorm then RoPE.  The two
+    supported local-head configurations are ``8Q/1KV`` and ``64Q/8KV``, both
+    with QK/V head dimension 128.  Norm weights are float32 by source contract:
+    the originating CUDA entry receives ``const float*`` weights and performs
+    the reduction/multiply in float32.  Prefill, decode, and multi-token
+    prediction layouts are represented by ``q_indptr`` and
+    ``sequence_lengths``.
+
+    For FP8 caches, ``quant_policy=1`` uses a dynamic per-token/per-Q-head
+    scale and returns it; ``quant_policy=2`` consumes ``q_scale_inverse``.
+    K and V always consume scalar ``k_scale`` and ``v_scale``.  The cache dtype
+    determines the output dtype and must be BF16 or ``float8_e4m3fn``.
+
+    Passing ``out_k`` or ``out_v`` preserves the source behavior: that value is
+    written to the contiguous output instead of the corresponding cache entry;
+    final-page cache-tail clearing still occurs.  All output buffers may be
+    preallocated for CUDA-graph-stable addresses.
+
+    ``uniform_one_token_decode`` is a trusted scheduling contract, not a hint.
+    Set it only when ``q_indptr`` is exactly ``[0, 1, ..., batch_size]`` and no
+    graph-padding/ragged request is present.  On an SM100 device, the previously
+    measured narrow FP8 dynamic-Q/norm2/64Q8KV/B>=256 case then maps each row
+    directly to its request, reuses RoPE coefficients from registers, and
+    clears the final cache-page tail inside the compute CTA.  It defaults to
+    ``False``; all other shapes and non-SM100 devices use the source-faithful
+    fallback.
+
+    Parameters
+    ----------
+    packed_qkv : torch.Tensor
+        Contiguous BF16 tensor of shape ``[num_rows, (Q + 2 * KV) * 128]``.
+    cos_sin_cache : torch.Tensor
+        Float32 NeoX cache of shape ``[max_position, 128]``; the first and
+        second halves contain cosine and sine respectively.
+    sequence_lengths : torch.Tensor
+        Int32 final sequence length for each request, shape ``[batch]``.
+    q_indptr : torch.Tensor
+        Int32 row indptr, shape ``[batch + 1]``.  Absolute token positions are
+        derived as ``row + sequence_lengths[request] - q_indptr[request + 1]``.
+    block_table : torch.Tensor
+        Int32 physical-page table, shape ``[batch, max_pages_per_request]``.
+    paged_kv_cache : Tuple[torch.Tensor, torch.Tensor]
+        Contiguous NHD key/value caches shaped
+        ``[num_pages, page_size, num_kv_heads, 128]``.
+    is_prefill : bool
+        Whether rows use the prefill position and dynamic-scale layout.
+    q_norm_weight : Optional[torch.Tensor]
+        Float32 Q RMSNorm weight of shape ``[128]`` when normalization is
+        enabled.
+    k_norm_weight : Optional[torch.Tensor]
+        Float32 K RMSNorm weight of shape ``[128]`` when normalization is
+        enabled.
+    norm_policy : int
+        ``0`` disables normalization, ``1`` runs RoPE then RMSNorm, and ``2``
+        runs RMSNorm then RoPE.
+    quant_policy : Optional[int]
+        ``0`` for BF16, ``1`` for dynamic-Q FP8, or ``2`` for static-Q FP8.
+        The default is inferred from the cache dtype.
+    k_scale : Optional[torch.Tensor]
+        Scalar scale consumed when writing an FP8 K cache.
+    v_scale : Optional[torch.Tensor]
+        Scalar scale consumed when writing an FP8 V cache.
+    q_scale_inverse : Optional[torch.Tensor]
+        Scalar inverse Q scale required by static-Q FP8.
+    max_sequence_length : int
+        Maximum sequence length used to size dynamic-Q prefill scale output.
+    fp8_upper_bound : float
+        Saturation bound for FP8 conversion.
+    out_q : Optional[torch.Tensor]
+        Optional preallocated transformed-Q output.
+    out_q_scale : Optional[torch.Tensor]
+        Optional preallocated dynamic-Q FP8 scale output.
+    split_k_flag : Optional[torch.Tensor]
+        Optional preallocated per-request/per-KV-head completion flags for the
+        FP8 path.
+    out_k : Optional[torch.Tensor]
+        Optional contiguous K output. When present, K is written here instead
+        of to the paged cache.
+    out_v : Optional[torch.Tensor]
+        Optional contiguous V output. When present, V is written here instead
+        of to the paged cache.
+    uniform_one_token_decode : bool
+        Enables the B200 direct row-to-request schedule. The caller must
+        guarantee ``q_indptr == arange(batch_size + 1)``.
+
+    Returns
+    -------
+    Tuple[Tensor, Optional[Tensor], Optional[Tensor], Optional[Tensor], Optional[Tensor]]
+        ``(out_q, q_scale, split_k_flag, out_k, out_v)``.  Inapplicable outputs
+        are returned as ``None``.
+    """
+    if not packed_qkv.is_cuda:
+        raise ValueError("packed_qkv must be a CUDA tensor")
+    if len(paged_kv_cache) != 2:
+        raise ValueError("paged_kv_cache must be a (key_cache, value_cache) tuple")
+    key_cache, value_cache = paged_kv_cache
+    if packed_qkv.ndim != 2:
+        raise ValueError("packed_qkv must have shape [num_rows, hidden]")
+    if key_cache.ndim != 4 or value_cache.ndim != 4:
+        raise ValueError("key_cache and value_cache must be rank-4 NHD tensors")
+
+    num_rows = packed_qkv.shape[0]
+    batch_size = sequence_lengths.shape[0]
+    num_kv_heads = key_cache.shape[2]
+    qk_head_dim = key_cache.shape[3]
+    v_head_dim = value_cache.shape[3]
+    q_width = packed_qkv.shape[1] - num_kv_heads * (qk_head_dim + v_head_dim)
+    if q_width < 0 or qk_head_dim <= 0 or q_width % qk_head_dim != 0:
+        raise ValueError(
+            "packed_qkv hidden dimension is incompatible with cache shapes"
+        )
+    num_q_heads = q_width // qk_head_dim
+    if (num_q_heads, num_kv_heads) not in ((8, 1), (64, 8)):
+        raise ValueError(
+            "supported (num_q_heads, num_kv_heads) pairs are (8, 1) and (64, 8)"
+        )
+    if qk_head_dim != 128 or v_head_dim != 128:
+        raise ValueError("qk_head_dim and v_head_dim must both be 128")
+    if norm_policy not in (0, 1, 2):
+        raise ValueError("norm_policy must be 0, 1, or 2")
+
+    (
+        empty_q_norm,
+        empty_k_norm,
+        empty_k_scale,
+        empty_v_scale,
+        empty_q_scale_inverse,
+        empty_output_q_scale,
+        empty_split_k_flag,
+        empty_output_k,
+        empty_output_v,
+    ) = _qk_norm_rope_hy3_empty_placeholders(packed_qkv.get_device(), key_cache.dtype)
+    if norm_policy == 0:
+        if q_norm_weight is not None or k_norm_weight is not None:
+            raise ValueError("norm weights must be None when norm_policy=0")
+        q_norm_weight = empty_q_norm
+        k_norm_weight = empty_k_norm
+    elif q_norm_weight is None or k_norm_weight is None:
+        raise ValueError(
+            "q_norm_weight and k_norm_weight are required when norm_policy>0"
+        )
+    elif q_norm_weight.dtype != torch.float32 or k_norm_weight.dtype != torch.float32:
+        raise ValueError("q_norm_weight and k_norm_weight must be float32")
+
+    fp8 = key_cache.dtype == torch.float8_e4m3fn
+    if quant_policy is None:
+        quant_policy = 1 if fp8 else 0
+    if fp8:
+        if value_cache.dtype != torch.float8_e4m3fn:
+            raise ValueError("both FP8 caches must have float8_e4m3fn dtype")
+        if quant_policy not in (1, 2):
+            raise ValueError("FP8 quant_policy must be 1 (dynamic Q) or 2 (static Q)")
+        if k_scale is None or v_scale is None:
+            raise ValueError("FP8 cache output requires k_scale and v_scale")
+        if quant_policy == 2 and q_scale_inverse is None:
+            raise ValueError("static-Q quantization requires q_scale_inverse")
+        if quant_policy == 1 and q_scale_inverse is not None:
+            raise ValueError("dynamic-Q quantization does not consume q_scale_inverse")
+        if quant_policy == 1 and is_prefill and max_sequence_length <= 0:
+            raise ValueError("dynamic-Q prefill requires max_sequence_length > 0")
+    else:
+        if key_cache.dtype != torch.bfloat16 or value_cache.dtype != torch.bfloat16:
+            raise ValueError("paged caches must be bfloat16 or float8_e4m3fn")
+        if quant_policy != 0:
+            raise ValueError("BF16 cache output requires quant_policy=0")
+        if k_scale is not None or v_scale is not None or q_scale_inverse is not None:
+            raise ValueError("BF16 cache output does not consume quantization scales")
+        k_scale = empty_k_scale
+        v_scale = empty_v_scale
+
+    if q_scale_inverse is None:
+        q_scale_inverse = empty_q_scale_inverse
+
+    output_dtype = key_cache.dtype
+    expected_q_shape = (num_rows, num_q_heads, qk_head_dim)
+    if out_q is None:
+        out_q = torch.empty(
+            expected_q_shape, dtype=output_dtype, device=packed_qkv.device
+        )
+    elif tuple(out_q.shape) != expected_q_shape or out_q.dtype != output_dtype:
+        raise ValueError(
+            f"out_q must have shape {expected_q_shape} and dtype {output_dtype}"
+        )
+
+    q_scale_result: Optional[torch.Tensor]
+    if fp8 and quant_policy == 1:
+        expected_scale_shape: Tuple[int, ...]
+        if is_prefill:
+            aligned_length = (max_sequence_length + 127) // 128 * 128
+            expected_scale_shape = (batch_size, num_q_heads, aligned_length)
+        else:
+            expected_scale_shape = (num_rows, num_q_heads)
+        if out_q_scale is None:
+            out_q_scale = torch.empty(
+                expected_scale_shape, dtype=torch.float32, device=packed_qkv.device
+            )
+        elif (
+            tuple(out_q_scale.shape) != expected_scale_shape
+            or out_q_scale.dtype != torch.float32
+        ):
+            raise ValueError(
+                f"out_q_scale must have shape {expected_scale_shape} and dtype float32"
+            )
+        q_scale_result = out_q_scale
+    else:
+        if out_q_scale is not None:
+            raise ValueError("out_q_scale is only valid for dynamic-Q FP8")
+        out_q_scale = empty_output_q_scale
+        q_scale_result = None
+
+    split_k_result: Optional[torch.Tensor]
+    if fp8:
+        expected_flag_shape = (batch_size, num_kv_heads)
+        if split_k_flag is None:
+            split_k_flag = torch.empty(
+                expected_flag_shape, dtype=torch.int32, device=packed_qkv.device
+            )
+        elif (
+            tuple(split_k_flag.shape) != expected_flag_shape
+            or split_k_flag.dtype != torch.int32
+        ):
+            raise ValueError(
+                f"split_k_flag must have shape {expected_flag_shape} and dtype int32"
+            )
+        split_k_result = split_k_flag
+    else:
+        if split_k_flag is not None:
+            raise ValueError("split_k_flag is only valid for FP8")
+        split_k_flag = empty_split_k_flag
+        split_k_result = None
+
+    expected_k_shape = (num_rows, num_kv_heads, qk_head_dim)
+    expected_v_shape = (num_rows, num_kv_heads, v_head_dim)
+    if out_k is not None and (
+        tuple(out_k.shape) != expected_k_shape or out_k.dtype != output_dtype
+    ):
+        raise ValueError(
+            f"out_k must have shape {expected_k_shape} and dtype {output_dtype}"
+        )
+    if out_v is not None and (
+        tuple(out_v.shape) != expected_v_shape or out_v.dtype != output_dtype
+    ):
+        raise ValueError(
+            f"out_v must have shape {expected_v_shape} and dtype {output_dtype}"
+        )
+    output_k_arg = out_k if out_k is not None else empty_output_k
+    output_v_arg = out_v if out_v is not None else empty_output_v
+
+    # Python only establishes the user-provided scheduling contract and device
+    # capability here.  The C++ entry repeats the complete dtype/shape/policy
+    # gate before selecting the specialized kernel, so duplicating it on every
+    # decode step would add host-side launch latency without adding safety.
+    enable_sm100_uniform_decode = bool(
+        uniform_one_token_decode and _is_sm100_device(packed_qkv.get_device())
+    )
+    _qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        packed_qkv,
+        cos_sin_cache,
+        sequence_lengths,
+        q_indptr,
+        block_table,
+        q_norm_weight,
+        k_norm_weight,
+        k_scale,
+        v_scale,
+        q_scale_inverse,
+        out_q,
+        out_q_scale,
+        split_k_flag,
+        output_k_arg,
+        output_v_arg,
+        key_cache,
+        value_cache,
+        is_prefill,
+        norm_policy,
+        quant_policy,
+        max_sequence_length,
+        fp8_upper_bound,
+        out_k is not None,
+        out_v is not None,
+        enable_sm100_uniform_decode,
+    )
+    return out_q, q_scale_result, split_k_result, out_k, out_v
 
 
 @flashinfer_api(trace=rope_quantize_fp8_append_paged_kv_cache_trace)

--- a/flashinfer/trace/templates/rope.py
+++ b/flashinfer/trace/templates/rope.py
@@ -1251,3 +1251,221 @@ rope_quantize_fp8_append_paged_kv_cache_trace = TraceTemplate(
     reference=_rope_quantize_fp8_append_paged_kv_cache_reference,
     init=_rope_quantize_fp8_append_paged_kv_cache_init,
 )
+
+
+# ── HY3 Q/K RMSNorm + RoPE + paged KV store (B200 decode fast path) ─────────
+
+
+def _qk_rmsnorm_rope_store_hy3_fp8_decode_init(
+    *,
+    batch_size: int,
+    batch_plus_one: int = 0,
+    pages_per_request: int = 1,
+    num_pages: int = 0,
+    max_position: int = 4096,
+    packed_width: int = 0,
+    num_q_heads: int = 64,
+    num_kv_heads: int = 8,
+    head_dim: int = 128,
+    page_size: int = 64,
+    scale_count: int = 1,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build the validated uniform one-row decode shape for B200."""
+    del batch_plus_one  # derived from batch_size
+    if (num_q_heads, num_kv_heads, head_dim, scale_count) != (64, 8, 128, 1):
+        raise ValueError("HY3 B200 trace requires 64Q/8KV/D128 and one scale")
+    expected_width = (num_q_heads + 2 * num_kv_heads) * head_dim
+    if packed_width not in (0, expected_width):
+        raise ValueError(f"packed_width must be 0 or {expected_width}")
+    if pages_per_request <= 0 or page_size <= 0:
+        raise ValueError("pages_per_request and page_size must be positive")
+    num_pages = max(num_pages, batch_size * pages_per_request)
+    torch.manual_seed(seed)
+    packed_qkv = torch.randn(
+        batch_size, expected_width, dtype=torch.bfloat16, device=device
+    )
+    cos_sin_cache = make_rope_cos_sin_cache(max_position, head_dim, device=device)
+    sequence_lengths = (
+        torch.arange(batch_size, dtype=torch.int32, device=device) % page_size + 1
+    )
+    q_indptr = torch.arange(batch_size + 1, dtype=torch.int32, device=device)
+    block_table = torch.arange(
+        batch_size * pages_per_request, dtype=torch.int32, device=device
+    ).reshape(batch_size, pages_per_request)
+    cache_shape = (num_pages, page_size, num_kv_heads, head_dim)
+    key_cache = torch.zeros(cache_shape, dtype=torch.float8_e4m3fn, device=device)
+    value_cache = torch.zeros_like(key_cache)
+    return {
+        "packed_qkv": packed_qkv,
+        "cos_sin_cache": cos_sin_cache,
+        "sequence_lengths": sequence_lengths,
+        "q_indptr": q_indptr,
+        "block_table": block_table,
+        "paged_kv_cache": (key_cache, value_cache),
+        "is_prefill": False,
+        "q_norm_weight": torch.linspace(0.75, 1.25, head_dim, device=device),
+        "k_norm_weight": torch.linspace(1.25, 0.75, head_dim, device=device),
+        "norm_policy": 2,
+        "quant_policy": 1,
+        "k_scale": torch.tensor([0.5], dtype=torch.float32, device=device),
+        "v_scale": torch.tensor([0.25], dtype=torch.float32, device=device),
+        "out_q": torch.empty(
+            batch_size,
+            num_q_heads,
+            head_dim,
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        ),
+        "out_q_scale": torch.empty(
+            batch_size, num_q_heads, dtype=torch.float32, device=device
+        ),
+        "split_k_flag": torch.empty(
+            batch_size, num_kv_heads, dtype=torch.int32, device=device
+        ),
+        "uniform_one_token_decode": True,
+    }
+
+
+qk_rmsnorm_rope_store_hy3_fp8_decode_trace = TraceTemplate(
+    op_type="rope",
+    name_prefix="qk_rmsnorm_rope_append_paged_kv_cache_hy3_fp8_decode",
+    description=(
+        "B200 uniform one-row decode specialization that fuses Q/K RMSNorm, "
+        "NeoX RoPE, dynamic FP8 Q quantization, and NHD paged K/V storage. "
+        "The paged cache tuple is updated in place. Prefill, BF16, static-FP8, "
+        "and redirected K/V outputs are intentionally outside this trace variant."
+    ),
+    axes={
+        "batch_size": Var(),
+        "batch_plus_one": Var(),
+        "pages_per_request": Var(),
+        "num_pages": Var(),
+        "max_position": Var(),
+        "packed_width": Const(abbrev=""),
+        "num_q_heads": Const(value=64, abbrev="h"),
+        "num_kv_heads": Const(abbrev="kv"),
+        "head_dim": Const(abbrev="d"),
+        "page_size": Const(abbrev="ps"),
+        "scale_count": Const(value=1, abbrev=""),
+    },
+    inputs={
+        "packed_qkv": Tensor(["batch_size", "packed_width"], dtype="bfloat16"),
+        "cos_sin_cache": Tensor(["max_position", "head_dim"], dtype="float32"),
+        "sequence_lengths": Tensor(["batch_size"], dtype="int32"),
+        "q_indptr": Tensor(["batch_plus_one"], dtype="int32"),
+        "block_table": Tensor(["batch_size", "pages_per_request"], dtype="int32"),
+        "k_cache": Tensor(
+            ["num_pages", "page_size", "num_kv_heads", "head_dim"],
+            param="paged_kv_cache",
+            tuple_idx=0,
+            dtype="float8_e4m3fn",
+            description="NHD key cache updated in place.",
+        ),
+        "v_cache": Tensor(
+            ["num_pages", "page_size", "num_kv_heads", "head_dim"],
+            param="paged_kv_cache",
+            tuple_idx=1,
+            dtype="float8_e4m3fn",
+            description="NHD value cache updated in place.",
+        ),
+        "is_prefill": Scalar("int32"),
+        "q_norm_weight": Tensor(["head_dim"], dtype="float32"),
+        "k_norm_weight": Tensor(["head_dim"], dtype="float32"),
+        "norm_policy": Scalar("int32"),
+        "quant_policy": Scalar("int32"),
+        "k_scale": Tensor(["scale_count"], dtype="float32"),
+        "v_scale": Tensor(["scale_count"], dtype="float32"),
+        "max_sequence_length": Scalar("int32", optional=True),
+        "fp8_upper_bound": Scalar("float32", optional=True),
+        "out_q": Tensor(
+            ["batch_size", "num_q_heads", "head_dim"],
+            dtype="float8_e4m3fn",
+            optional=True,
+        ),
+        "out_q_scale": Tensor(
+            ["batch_size", "num_q_heads"], dtype="float32", optional=True
+        ),
+        "split_k_flag": Tensor(
+            ["batch_size", "num_kv_heads"], dtype="int32", optional=True
+        ),
+        "uniform_one_token_decode": Scalar("int32"),
+    },
+    outputs={
+        "out_q": Tensor(
+            ["batch_size", "num_q_heads", "head_dim"],
+            dtype="float8_e4m3fn",
+            param="out_q",
+        ),
+        "out_q_scale": Tensor(
+            ["batch_size", "num_q_heads"],
+            dtype="float32",
+            param="out_q_scale",
+        ),
+        "split_k_flag": Tensor(
+            ["batch_size", "num_kv_heads"],
+            dtype="int32",
+            param="split_k_flag",
+        ),
+    },
+    constraints=[
+        "batch_plus_one == batch_size + 1",
+        "packed_width == (64 + 2 * num_kv_heads) * head_dim",
+        "head_dim == 128",
+        "num_kv_heads == 8",
+        "num_pages >= batch_size * pages_per_request",
+    ],
+    tags=["status:experimental", "fused", "quantize:fp8", "arch:sm100"],
+    init=_qk_rmsnorm_rope_store_hy3_fp8_decode_init,
+)
+
+
+def qk_rmsnorm_rope_store_hy3_trace_dispatch(save_dir=None, name=None, **kwargs):
+    """Trace only the validated SM100 uniform dynamic-FP8 decode shape."""
+    del save_dir, name
+    if "packed_qkv" not in kwargs and "batch_size" in kwargs:
+        return qk_rmsnorm_rope_store_hy3_fp8_decode_trace
+    packed_qkv = kwargs.get("packed_qkv")
+    paged_kv_cache = kwargs.get("paged_kv_cache")
+    if (
+        not isinstance(packed_qkv, torch.Tensor)
+        or packed_qkv.ndim != 2
+        or not isinstance(paged_kv_cache, (tuple, list))
+        or len(paged_kv_cache) != 2
+    ):
+        return None
+    key_cache, value_cache = paged_kv_cache
+    if (
+        not isinstance(key_cache, torch.Tensor)
+        or not isinstance(value_cache, torch.Tensor)
+        or key_cache.ndim != 4
+        or value_cache.shape != key_cache.shape
+        or key_cache.dtype != torch.float8_e4m3fn
+        or value_cache.dtype != torch.float8_e4m3fn
+    ):
+        return None
+    num_kv_heads, head_dim = key_cache.shape[2:]
+    num_q_heads = packed_qkv.shape[1] // head_dim - 2 * num_kv_heads
+    quant_policy = kwargs.get("quant_policy")
+    if (
+        bool(kwargs.get("is_prefill"))
+        or int(kwargs.get("norm_policy", 0)) != 2
+        or quant_policy not in (None, 1)
+        or not bool(kwargs.get("uniform_one_token_decode"))
+        or (num_q_heads, num_kv_heads, head_dim) != (64, 8, 128)
+        or kwargs.get("q_norm_weight") is None
+        or kwargs.get("k_norm_weight") is None
+        or kwargs.get("k_scale") is None
+        or kwargs.get("v_scale") is None
+        or kwargs.get("q_scale_inverse") is not None
+        or kwargs.get("out_k") is not None
+        or kwargs.get("out_v") is not None
+    ):
+        return None
+    return qk_rmsnorm_rope_store_hy3_fp8_decode_trace
+
+
+qk_rmsnorm_rope_store_hy3_trace_dispatch.templates = (  # type: ignore[attr-defined]
+    qk_rmsnorm_rope_store_hy3_fp8_decode_trace,
+)

--- a/include/flashinfer/rope_norm_store_kv_hy3.cuh
+++ b/include/flashinfer/rope_norm_store_kv_hy3.cuh
@@ -1,0 +1,706 @@
+// Copyright (C) 2026 Tencent.
+// SPDX-License-Identifier: MIT
+//
+// FlashInfer integration of the public HPC-Ops RoPE + optional Q/K RMSNorm
+// + paged-KV-store kernel from Tencent/HPC-Ops commit
+// 1cd332980ed46bd0172091c1c35d55338fcae47a. The arithmetic and launch
+// decomposition preserve the upstream behavior; the SM100 specialization is
+// selected only for its measured uniform one-token decode shape.
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <flashinfer/fastdiv.cuh>
+#include <type_traits>
+
+namespace flashinfer::rope_norm_store_kv_hy3 {
+
+constexpr int kWarpSize = 32;
+constexpr int kWarpsPerBlock = 4;
+constexpr float kRmsNormEpsilon = 1e-6F;
+
+template <typename T, int N>
+struct Vec {
+  T data[N];
+
+  __device__ __forceinline__ T& operator[](int index) { return data[index]; }
+  __device__ __forceinline__ const T& operator[](int index) const { return data[index]; }
+};
+
+template <typename T, int N>
+__device__ __forceinline__ Vec<T, N> load_vec(const void* pointer) {
+  constexpr int kBytes = sizeof(T) * N;
+  static_assert(kBytes == 1 || kBytes == 2 || kBytes == 4 || kBytes == 8 || kBytes == 16);
+  Vec<T, N> value;
+  if constexpr (kBytes == 1) {
+    *reinterpret_cast<uint8_t*>(&value) = *reinterpret_cast<const uint8_t*>(pointer);
+  } else if constexpr (kBytes == 2) {
+    *reinterpret_cast<uint16_t*>(&value) = *reinterpret_cast<const uint16_t*>(pointer);
+  } else if constexpr (kBytes == 4) {
+    *reinterpret_cast<uint32_t*>(&value) = *reinterpret_cast<const uint32_t*>(pointer);
+  } else if constexpr (kBytes == 8) {
+    *reinterpret_cast<uint64_t*>(&value) = *reinterpret_cast<const uint64_t*>(pointer);
+  } else {
+    *reinterpret_cast<uint4*>(&value) = *reinterpret_cast<const uint4*>(pointer);
+  }
+  return value;
+}
+
+template <typename T, int N>
+__device__ __forceinline__ void store_vec(void* pointer, const Vec<T, N>& value) {
+  constexpr int kBytes = sizeof(T) * N;
+  static_assert(kBytes == 1 || kBytes == 2 || kBytes == 4 || kBytes == 8 || kBytes == 16);
+  if constexpr (kBytes == 1) {
+    *reinterpret_cast<uint8_t*>(pointer) = *reinterpret_cast<const uint8_t*>(&value);
+  } else if constexpr (kBytes == 2) {
+    *reinterpret_cast<uint16_t*>(pointer) = *reinterpret_cast<const uint16_t*>(&value);
+  } else if constexpr (kBytes == 4) {
+    *reinterpret_cast<uint32_t*>(pointer) = *reinterpret_cast<const uint32_t*>(&value);
+  } else if constexpr (kBytes == 8) {
+    *reinterpret_cast<uint64_t*>(pointer) = *reinterpret_cast<const uint64_t*>(&value);
+  } else {
+    *reinterpret_cast<uint4*>(pointer) = *reinterpret_cast<const uint4*>(&value);
+  }
+}
+
+__device__ __forceinline__ float warp_reduce_sum_xor(float value) {
+#pragma unroll
+  for (int offset = 16; offset >= 1; offset /= 2) {
+    value += __shfl_xor_sync(0xffffffffU, value, offset);
+  }
+  return value;
+}
+
+__device__ __forceinline__ float warp_reduce_max_xor(float value) {
+#pragma unroll
+  for (int offset = 16; offset >= 1; offset /= 2) {
+    value = fmaxf(__shfl_xor_sync(0xffffffffU, value, offset), value);
+  }
+  return value;
+}
+
+__device__ __forceinline__ void rotate_neox_pair(float& first, float& second, float cosine,
+                                                 float sine) {
+  const float rotated_first = first * cosine - second * sine;
+  const float rotated_second = second * cosine + first * sine;
+  first = rotated_first;
+  second = rotated_second;
+}
+
+template <int kItemsPerThread, int kHeadDim>
+__device__ __forceinline__ void rms_norm_apply(Vec<float, kItemsPerThread>& values,
+                                               const float* shared_weight, int lane) {
+  float sum_squares = 0.0F;
+#pragma unroll
+  for (int item = 0; item < kItemsPerThread; ++item) {
+    sum_squares += values[item] * values[item];
+  }
+  sum_squares = warp_reduce_sum_xor(sum_squares);
+  const float inverse_rms = rsqrtf(sum_squares / kHeadDim + kRmsNormEpsilon);
+  constexpr int kRoundsPerHalf = (kHeadDim / 2 + kWarpSize - 1) / kWarpSize;
+#pragma unroll
+  for (int round = 0; round < kRoundsPerHalf; ++round) {
+    const int index = round * kWarpSize + lane;
+    if (index < kHeadDim / 2) {
+      values[round * 2] *= inverse_rms * shared_weight[index];
+      values[round * 2 + 1] *= inverse_rms * shared_weight[index + kHeadDim / 2];
+    }
+  }
+}
+
+template <int kItemsPerThread>
+__device__ __forceinline__ float warp_absolute_max(const Vec<float, kItemsPerThread>& values) {
+  float maximum = kRmsNormEpsilon;
+#pragma unroll
+  for (int item = 0; item < kItemsPerThread; ++item) {
+    maximum = fmaxf(maximum, fabsf(values[item]));
+  }
+  return warp_reduce_max_xor(maximum);
+}
+
+template <int kHeadDim, int kItemsPerThread>
+__device__ __forceinline__ void load_neox_head(Vec<float, kItemsPerThread>& values,
+                                               const __nv_bfloat16* source, int lane) {
+  constexpr int kRoundsPerHalf = (kHeadDim / 2 + kWarpSize - 1) / kWarpSize;
+  static_assert(kItemsPerThread == kRoundsPerHalf * 2);
+#pragma unroll
+  for (int round = 0; round < kRoundsPerHalf; ++round) {
+    const int index = round * kWarpSize + lane;
+    if (index < kHeadDim / 2) {
+      values[round * 2] = __bfloat162float(source[index]);
+      values[round * 2 + 1] = __bfloat162float(source[index + kHeadDim / 2]);
+    }
+  }
+}
+
+__device__ __forceinline__ void divide_page_position(int position, const uint_fastdiv& page_size,
+                                                     int& page_index, int& page_offset) {
+  uint32_t quotient;
+  uint32_t remainder;
+  page_size.divmod(static_cast<uint32_t>(position), quotient, remainder);
+  page_index = static_cast<int>(quotient);
+  page_offset = static_cast<int>(remainder);
+}
+
+template <typename CacheType>
+__device__ __forceinline__ CacheType convert_cache_value(float value) {
+  if constexpr (std::is_same_v<CacheType, __nv_bfloat16>) {
+    return __float2bfloat16(value);
+  } else {
+    return __nv_fp8_e4m3(value);
+  }
+}
+
+template <typename CacheType, int kQuantPolicy, int kNumQHeads, int kNumKVHeads, int kQKHeadDim,
+          int kVHeadDim, int kNormPolicy, bool kUniformDecodeFastPath = false>
+__global__ void RopeNormStoreKVKernel(
+    CacheType* output_q, CacheType* key_cache, CacheType* value_cache, CacheType* output_k,
+    CacheType* output_v, int32_t* split_k_flag, float* output_q_scale,
+    const __nv_bfloat16* packed_qkv, const float* cos_sin, const int32_t* sequence_lengths,
+    const int32_t* q_indptr, const int32_t* block_table, const float* q_norm_weight,
+    const float* k_norm_weight, const float* k_scale, const float* v_scale,
+    const float* q_scale_inverse, float fp8_upper_bound, int max_sequence_length_aligned,
+    int64_t key_cache_block_stride, int64_t value_cache_block_stride, int batch_size,
+    int max_pages_per_request, int page_size, uint_fastdiv page_size_fastdiv, int num_rows,
+    int num_compute_blocks, bool is_prefill) {
+  static_assert(kNumQHeads % kNumKVHeads == 0);
+  static_assert(kQKHeadDim == 128);
+  static_assert(kVHeadDim == 128);
+  constexpr bool kFP8 = std::is_same_v<CacheType, __nv_fp8_e4m3>;
+  static_assert((kFP8 && (kQuantPolicy == 1 || kQuantPolicy == 2)) || (!kFP8 && kQuantPolicy == 0));
+
+  constexpr int kQHeadsPerKVHead = kNumQHeads / kNumKVHeads;
+  constexpr int kQElementsPerRow = kQHeadsPerKVHead * kQKHeadDim;
+  constexpr int kKElementsPerRow = kQKHeadDim;
+  constexpr int kSharedElementsPerRow = kQElementsPerRow + kKElementsPerRow;
+  constexpr int kPackedRowElements =
+      kNumQHeads * kQKHeadDim + kNumKVHeads * kQKHeadDim + kNumKVHeads * kVHeadDim;
+  constexpr int kRoundsPerHalf = (kQKHeadDim / 2 + kWarpSize - 1) / kWarpSize;
+  constexpr int kItemsPerThread = kRoundsPerHalf * 2;
+
+  const int thread_id = threadIdx.x;
+  const int warp_id = thread_id / kWarpSize;
+  const int lane = thread_id % kWarpSize;
+  const int block_x = blockIdx.x;
+  const int kv_head = blockIdx.y;
+  const int q_head_begin = kv_head * kQHeadsPerKVHead;
+
+  __shared__ float shared_cos_sin[kWarpsPerBlock][kQKHeadDim];
+  __shared__ float shared_q_norm_weight[kQKHeadDim];
+  __shared__ float shared_k_norm_weight[kQKHeadDim];
+  __shared__ int32_t shared_request_id[kWarpsPerBlock];
+  __shared__ int32_t shared_position[kWarpsPerBlock];
+  extern __shared__ __nv_bfloat16 shared_qk[];
+
+  // The tail of grid.x has one clear CTA per request.  grid.y partitions the
+  // cache by KV head, exactly as in the public optimized HPC-Ops kernel.
+  if constexpr (!kUniformDecodeFastPath) {
+    if (block_x >= num_compute_blocks) {
+      const int request_id = block_x - num_compute_blocks;
+      if (request_id >= batch_size) {
+        return;
+      }
+      const int last_position = sequence_lengths[request_id] - 1;
+      if (last_position < 0) {
+        return;
+      }
+      int logical_page = 0;
+      int position_in_page = 0;
+      divide_page_position(last_position, page_size_fastdiv, logical_page, position_in_page);
+      const int physical_page = block_table[request_id * max_pages_per_request + logical_page];
+      const int first_zero_row = position_in_page + 1;
+      constexpr int kElementsPerVector = 16 / sizeof(CacheType);
+      Vec<CacheType, kElementsPerVector> zero_vector{};
+      for (int row = first_zero_row + warp_id; row < page_size; row += kWarpsPerBlock) {
+        CacheType* key_row = key_cache +
+                             static_cast<int64_t>(physical_page) * key_cache_block_stride +
+                             row * (kNumKVHeads * kQKHeadDim) + kv_head * kQKHeadDim;
+        CacheType* value_row = value_cache +
+                               static_cast<int64_t>(physical_page) * value_cache_block_stride +
+                               row * (kNumKVHeads * kVHeadDim) + kv_head * kVHeadDim;
+        for (int index = lane * kElementsPerVector; index < kQKHeadDim;
+             index += kWarpSize * kElementsPerVector) {
+          store_vec(key_row + index, zero_vector);
+        }
+        for (int index = lane * kElementsPerVector; index < kVHeadDim;
+             index += kWarpSize * kElementsPerVector) {
+          store_vec(value_row + index, zero_vector);
+        }
+      }
+      return;
+    }
+  }
+
+  const int row = block_x * kWarpsPerBlock + warp_id;
+  if constexpr (!kUniformDecodeFastPath) {
+    if (thread_id < kWarpsPerBlock) {
+      shared_request_id[thread_id] = -1;
+      shared_position[thread_id] = -1;
+    }
+    __syncthreads();
+
+    // Parallel segment lookup retained from the public H20 implementation.  It
+    // also handles repeated q_indptr entries used for CUDA-graph padding.
+    constexpr int kSearchThreads = kWarpSize * kWarpsPerBlock;
+    const int search_rounds = (batch_size + kSearchThreads - 1) / kSearchThreads;
+    for (int search_round = 0; search_round < search_rounds; ++search_round) {
+      const int candidate_request = search_round * kSearchThreads + thread_id;
+      if (candidate_request < batch_size) {
+        const int q_begin = q_indptr[candidate_request];
+        const int q_end = q_indptr[candidate_request + 1];
+#pragma unroll
+        for (int local_warp = 0; local_warp < kWarpsPerBlock; ++local_warp) {
+          const int candidate_row = block_x * kWarpsPerBlock + local_warp;
+          if (q_begin <= candidate_row && candidate_row < q_end) {
+            shared_request_id[local_warp] = candidate_request;
+            shared_position[local_warp] = candidate_row + sequence_lengths[candidate_request] -
+                                          q_indptr[candidate_request + 1];
+          }
+        }
+      }
+    }
+  }
+
+  if constexpr (kNormPolicy > 0) {
+    constexpr int kFloatElementsPerVector = 16 / sizeof(float);
+    constexpr int kWeightVectors = kQKHeadDim / kFloatElementsPerVector;
+    if (thread_id < kWeightVectors) {
+      const int offset = thread_id * kFloatElementsPerVector;
+      store_vec(shared_q_norm_weight + offset,
+                load_vec<float, kFloatElementsPerVector>(q_norm_weight + offset));
+      store_vec(shared_k_norm_weight + offset,
+                load_vec<float, kFloatElementsPerVector>(k_norm_weight + offset));
+    }
+  }
+
+  // Stage this CTA's GQA group and one K head using 16-byte transactions.
+  constexpr int kBF16ElementsPerVector = 16 / sizeof(__nv_bfloat16);
+  constexpr int kQVectors = kQElementsPerRow / kBF16ElementsPerVector;
+  constexpr int kKVectors = kKElementsPerRow / kBF16ElementsPerVector;
+  constexpr int kQLoadRounds = (kQVectors + kWarpSize - 1) / kWarpSize;
+  constexpr int kKLoadRounds = (kKVectors + kWarpSize - 1) / kWarpSize;
+  if (row < num_rows) {
+    const __nv_bfloat16* source_q =
+        packed_qkv + static_cast<int64_t>(row) * kPackedRowElements + q_head_begin * kQKHeadDim;
+    const __nv_bfloat16* source_k = packed_qkv + static_cast<int64_t>(row) * kPackedRowElements +
+                                    kNumQHeads * kQKHeadDim + kv_head * kQKHeadDim;
+    __nv_bfloat16* destination_q = shared_qk + warp_id * kSharedElementsPerRow;
+    __nv_bfloat16* destination_k = destination_q + kQElementsPerRow;
+#pragma unroll
+    for (int round = 0; round < kQLoadRounds; ++round) {
+      const int offset = (round * kWarpSize + lane) * kBF16ElementsPerVector;
+      if (offset < kQElementsPerRow) {
+        store_vec(destination_q + offset,
+                  load_vec<__nv_bfloat16, kBF16ElementsPerVector>(source_q + offset));
+      }
+    }
+#pragma unroll
+    for (int round = 0; round < kKLoadRounds; ++round) {
+      const int offset = (round * kWarpSize + lane) * kBF16ElementsPerVector;
+      if (offset < kKElementsPerRow) {
+        store_vec(destination_k + offset,
+                  load_vec<__nv_bfloat16, kBF16ElementsPerVector>(source_k + offset));
+      }
+    }
+  }
+  __syncthreads();
+
+  if (row >= num_rows) {
+    return;
+  }
+  // The host only enables the fused-tail specialization after the caller has
+  // explicitly guaranteed q_indptr == [0, 1, ..., batch_size].  Compile the
+  // general segment search out of that decode-only path.
+  const int request_id = kUniformDecodeFastPath ? row : shared_request_id[warp_id];
+  const int position =
+      kUniformDecodeFastPath ? sequence_lengths[row] - 1 : shared_position[warp_id];
+  if (position < 0) {
+    return;
+  }
+
+  constexpr int kFloatElementsPerVector = 16 / sizeof(float);
+  constexpr int kCosSinVectors = kQKHeadDim / kFloatElementsPerVector;
+  const float* cos_sin_row = cos_sin + static_cast<int64_t>(position) * kQKHeadDim;
+  Vec<float, kRoundsPerHalf> register_cosine;
+  Vec<float, kRoundsPerHalf> register_sine;
+  if constexpr (kUniformDecodeFastPath) {
+#pragma unroll
+    for (int round = 0; round < kRoundsPerHalf; ++round) {
+      const int index = round * kWarpSize + lane;
+      register_cosine[round] = cos_sin_row[index];
+      register_sine[round] = cos_sin_row[index + kQKHeadDim / 2];
+    }
+  } else {
+    if (lane < kCosSinVectors) {
+      const int offset = lane * kFloatElementsPerVector;
+      store_vec(shared_cos_sin[warp_id] + offset,
+                load_vec<float, kFloatElementsPerVector>(cos_sin_row + offset));
+    }
+    __syncwarp();
+  }
+
+  int logical_page = 0;
+  int position_in_page = 0;
+  divide_page_position(position, page_size_fastdiv, logical_page, position_in_page);
+  const int physical_page = block_table[request_id * max_pages_per_request + logical_page];
+  CacheType* key_cache_row = key_cache +
+                             static_cast<int64_t>(physical_page) * key_cache_block_stride +
+                             position_in_page * (kNumKVHeads * kQKHeadDim);
+  CacheType* value_cache_row = value_cache +
+                               static_cast<int64_t>(physical_page) * value_cache_block_stride +
+                               position_in_page * (kNumKVHeads * kVHeadDim);
+  const __nv_bfloat16* shared_row = shared_qk + warp_id * kSharedElementsPerRow;
+  const __nv_bfloat16* global_row = packed_qkv + static_cast<int64_t>(row) * kPackedRowElements;
+
+#pragma unroll
+  for (int local_q_head = 0; local_q_head < kQHeadsPerKVHead; ++local_q_head) {
+    const int q_head = q_head_begin + local_q_head;
+    const __nv_bfloat16* source = shared_row + local_q_head * kQKHeadDim;
+    CacheType* destination =
+        output_q + static_cast<int64_t>(row) * kNumQHeads * kQKHeadDim + q_head * kQKHeadDim;
+    Vec<float, kItemsPerThread> values{};
+    load_neox_head<kQKHeadDim>(values, source, lane);
+    if constexpr (kNormPolicy == 2) {
+      rms_norm_apply<kItemsPerThread, kQKHeadDim>(values, shared_q_norm_weight, lane);
+    }
+#pragma unroll
+    for (int round = 0; round < kRoundsPerHalf; ++round) {
+      const int index = round * kWarpSize + lane;
+      if (index < kQKHeadDim / 2) {
+        const float cosine =
+            kUniformDecodeFastPath ? register_cosine[round] : shared_cos_sin[warp_id][index];
+        const float sine = kUniformDecodeFastPath ? register_sine[round]
+                                                  : shared_cos_sin[warp_id][index + kQKHeadDim / 2];
+        rotate_neox_pair(values[round * 2], values[round * 2 + 1], cosine, sine);
+      }
+    }
+    if constexpr (kNormPolicy == 1) {
+      rms_norm_apply<kItemsPerThread, kQKHeadDim>(values, shared_q_norm_weight, lane);
+    }
+
+    float multiplier = 1.0F;
+    if constexpr (kQuantPolicy == 1) {
+      const float maximum = warp_absolute_max(values);
+      const float scale = maximum / fp8_upper_bound;
+      if (lane == 0) {
+        if constexpr (kUniformDecodeFastPath) {
+          output_q_scale[row * kNumQHeads + q_head] = scale;
+        } else if (is_prefill) {
+          const int token_in_request = row - q_indptr[request_id];
+          output_q_scale[request_id * kNumQHeads * max_sequence_length_aligned +
+                         q_head * max_sequence_length_aligned + token_in_request] = scale;
+        } else {
+          output_q_scale[row * kNumQHeads + q_head] = scale;
+        }
+      }
+      multiplier = __frcp_rn(scale);
+    } else if constexpr (kQuantPolicy == 2) {
+      multiplier = q_scale_inverse[0];
+    }
+
+#pragma unroll
+    for (int round = 0; round < kRoundsPerHalf; ++round) {
+      const int index = round * kWarpSize + lane;
+      if (index < kQKHeadDim / 2) {
+        destination[index] = convert_cache_value<CacheType>(values[round * 2] * multiplier);
+        destination[index + kQKHeadDim / 2] =
+            convert_cache_value<CacheType>(values[round * 2 + 1] * multiplier);
+      }
+    }
+  }
+
+  float key_multiplier = 1.0F;
+  if constexpr (kFP8) {
+    key_multiplier = __frcp_rn(k_scale[0]);
+    if ((kUniformDecodeFastPath || row == q_indptr[request_id]) && lane == 0) {
+      split_k_flag[request_id * kNumKVHeads + kv_head] = 0;
+    }
+  }
+  {
+    const __nv_bfloat16* source = shared_row + kQElementsPerRow;
+    CacheType* destination =
+        output_k != nullptr
+            ? output_k + static_cast<int64_t>(row) * kNumKVHeads * kQKHeadDim + kv_head * kQKHeadDim
+            : key_cache_row + kv_head * kQKHeadDim;
+    Vec<float, kItemsPerThread> values{};
+    load_neox_head<kQKHeadDim>(values, source, lane);
+    if constexpr (kNormPolicy == 2) {
+      rms_norm_apply<kItemsPerThread, kQKHeadDim>(values, shared_k_norm_weight, lane);
+    }
+#pragma unroll
+    for (int round = 0; round < kRoundsPerHalf; ++round) {
+      const int index = round * kWarpSize + lane;
+      if (index < kQKHeadDim / 2) {
+        const float cosine =
+            kUniformDecodeFastPath ? register_cosine[round] : shared_cos_sin[warp_id][index];
+        const float sine = kUniformDecodeFastPath ? register_sine[round]
+                                                  : shared_cos_sin[warp_id][index + kQKHeadDim / 2];
+        rotate_neox_pair(values[round * 2], values[round * 2 + 1], cosine, sine);
+      }
+    }
+    if constexpr (kNormPolicy == 1) {
+      rms_norm_apply<kItemsPerThread, kQKHeadDim>(values, shared_k_norm_weight, lane);
+    }
+#pragma unroll
+    for (int round = 0; round < kRoundsPerHalf; ++round) {
+      const int index = round * kWarpSize + lane;
+      if (index < kQKHeadDim / 2) {
+        destination[index] = convert_cache_value<CacheType>(values[round * 2] * key_multiplier);
+        destination[index + kQKHeadDim / 2] =
+            convert_cache_value<CacheType>(values[round * 2 + 1] * key_multiplier);
+      }
+    }
+  }
+
+  constexpr int kBF16sPerVector = 16 / sizeof(__nv_bfloat16);
+  constexpr int kVLoadVectors = kVHeadDim / kBF16sPerVector;
+  constexpr int kVLoadRounds = (kVLoadVectors + kWarpSize - 1) / kWarpSize;
+  const __nv_bfloat16* value_source =
+      global_row + (kNumQHeads + kNumKVHeads) * kQKHeadDim + kv_head * kVHeadDim;
+  CacheType* value_destination =
+      output_v != nullptr
+          ? output_v + static_cast<int64_t>(row) * kNumKVHeads * kVHeadDim + kv_head * kVHeadDim
+          : value_cache_row + kv_head * kVHeadDim;
+  if constexpr (!kFP8) {
+#pragma unroll
+    for (int round = 0; round < kVLoadRounds; ++round) {
+      const int offset = (round * kWarpSize + lane) * kBF16sPerVector;
+      if (offset < kVHeadDim) {
+        store_vec(value_destination + offset,
+                  load_vec<__nv_bfloat16, kBF16sPerVector>(value_source + offset));
+      }
+    }
+  } else {
+    const float value_multiplier = __frcp_rn(v_scale[0]);
+#pragma unroll
+    for (int round = 0; round < kVLoadRounds; ++round) {
+      const int offset = (round * kWarpSize + lane) * kBF16sPerVector;
+      if (offset < kVHeadDim) {
+        const auto packed_bf16 =
+            load_vec<__nv_bfloat162, kBF16sPerVector / 2>(value_source + offset);
+        Vec<float, kBF16sPerVector> values;
+#pragma unroll
+        for (int pair = 0; pair < kBF16sPerVector / 2; ++pair) {
+          const float2 converted = __bfloat1622float2(packed_bf16[pair]);
+          values[pair * 2] = converted.x * value_multiplier;
+          values[pair * 2 + 1] = converted.y * value_multiplier;
+        }
+        Vec<__nv_fp8x4_e4m3, kBF16sPerVector / 4> packed_fp8;
+#pragma unroll
+        for (int pack = 0; pack < kBF16sPerVector / 4; ++pack) {
+          packed_fp8[pack] = __nv_fp8x4_e4m3(make_float4(
+              values[pack * 4], values[pack * 4 + 1], values[pack * 4 + 2], values[pack * 4 + 3]));
+        }
+        store_vec(value_destination + offset, packed_fp8);
+      }
+    }
+  }
+
+  // Uniform one-token decode gives every warp exclusive ownership of one
+  // request/KV-head pair.  The target-only specialization uses that ownership
+  // to clear the remainder of the last cache page without launching the
+  // source-faithful batch_size * num_kv_heads clear CTAs.  The reference
+  // specialization compiles this block out entirely.
+  if constexpr (kUniformDecodeFastPath) {
+    constexpr int kElementsPerVector = 16 / sizeof(CacheType);
+    Vec<CacheType, kElementsPerVector> zero_vector{};
+    if constexpr (sizeof(CacheType) == 1) {
+      constexpr int kLanesPerRow = kQKHeadDim / kElementsPerVector;
+      constexpr int kRowsPerIteration = kWarpSize / kLanesPerRow;
+      static_assert(kLanesPerRow == 8 && kRowsPerIteration == 4);
+      static_assert(kQKHeadDim == kVHeadDim);
+      const int row_in_iteration = lane / kLanesPerRow;
+      const int vector_in_row = lane % kLanesPerRow;
+      for (int tail_base = position_in_page + 1; tail_base < page_size;
+           tail_base += kRowsPerIteration) {
+        const int tail_row = tail_base + row_in_iteration;
+        if (tail_row < page_size) {
+          CacheType* key_row = key_cache +
+                               static_cast<int64_t>(physical_page) * key_cache_block_stride +
+                               tail_row * (kNumKVHeads * kQKHeadDim) + kv_head * kQKHeadDim;
+          CacheType* value_row = value_cache +
+                                 static_cast<int64_t>(physical_page) * value_cache_block_stride +
+                                 tail_row * (kNumKVHeads * kVHeadDim) + kv_head * kVHeadDim;
+          const int index = vector_in_row * kElementsPerVector;
+          store_vec(key_row + index, zero_vector);
+          store_vec(value_row + index, zero_vector);
+        }
+      }
+    } else {
+      for (int tail_row = position_in_page + 1; tail_row < page_size; ++tail_row) {
+        CacheType* key_row = key_cache +
+                             static_cast<int64_t>(physical_page) * key_cache_block_stride +
+                             tail_row * (kNumKVHeads * kQKHeadDim) + kv_head * kQKHeadDim;
+        CacheType* value_row = value_cache +
+                               static_cast<int64_t>(physical_page) * value_cache_block_stride +
+                               tail_row * (kNumKVHeads * kVHeadDim) + kv_head * kVHeadDim;
+        for (int index = lane * kElementsPerVector; index < kQKHeadDim;
+             index += kWarpSize * kElementsPerVector) {
+          store_vec(key_row + index, zero_vector);
+        }
+        for (int index = lane * kElementsPerVector; index < kVHeadDim;
+             index += kWarpSize * kElementsPerVector) {
+          store_vec(value_row + index, zero_vector);
+        }
+      }
+    }
+  }
+}
+
+template <typename CacheType, int kQuantPolicy, int kNumQHeads, int kNumKVHeads, int kNormPolicy,
+          bool kUniformDecodeFastPath = false>
+cudaError_t launch_specialized(
+    CacheType* output_q, CacheType* key_cache, CacheType* value_cache, CacheType* output_k,
+    CacheType* output_v, int32_t* split_k_flag, float* output_q_scale,
+    const __nv_bfloat16* packed_qkv, const float* cos_sin, const int32_t* sequence_lengths,
+    const int32_t* q_indptr, const int32_t* block_table, const float* q_norm_weight,
+    const float* k_norm_weight, const float* k_scale, const float* v_scale,
+    const float* q_scale_inverse, float fp8_upper_bound, int max_sequence_length_aligned,
+    int64_t key_cache_block_stride, int64_t value_cache_block_stride, int batch_size,
+    int max_pages_per_request, int page_size, int num_rows, bool is_prefill, cudaStream_t stream) {
+  constexpr int kQKHeadDim = 128;
+  constexpr int kVHeadDim = 128;
+  constexpr int kQHeadsPerKVHead = kNumQHeads / kNumKVHeads;
+  constexpr int kSharedElementsPerRow = (kQHeadsPerKVHead + 1) * kQKHeadDim;
+  constexpr int kDynamicSharedBytes =
+      kWarpsPerBlock * kSharedElementsPerRow * sizeof(__nv_bfloat16);
+  const int num_compute_blocks = (num_rows + kWarpsPerBlock - 1) / kWarpsPerBlock;
+  const dim3 grid(num_compute_blocks + (kUniformDecodeFastPath ? 0 : batch_size), kNumKVHeads);
+  const dim3 block(kWarpsPerBlock * kWarpSize);
+  RopeNormStoreKVKernel<CacheType, kQuantPolicy, kNumQHeads, kNumKVHeads, kQKHeadDim, kVHeadDim,
+                        kNormPolicy, kUniformDecodeFastPath>
+      <<<grid, block, kDynamicSharedBytes, stream>>>(
+          output_q, key_cache, value_cache, output_k, output_v, split_k_flag, output_q_scale,
+          packed_qkv, cos_sin, sequence_lengths, q_indptr, block_table, q_norm_weight,
+          k_norm_weight, k_scale, v_scale, q_scale_inverse, fp8_upper_bound,
+          max_sequence_length_aligned, key_cache_block_stride, value_cache_block_stride, batch_size,
+          max_pages_per_request, page_size, uint_fastdiv(static_cast<uint32_t>(page_size)),
+          num_rows, num_compute_blocks, is_prefill);
+  return cudaGetLastError();
+}
+
+template <typename CacheType, int kQuantPolicy, int kNumQHeads, int kNumKVHeads>
+cudaError_t dispatch_uniform_decode_norm(
+    CacheType* output_q, CacheType* key_cache, CacheType* value_cache, CacheType* output_k,
+    CacheType* output_v, int32_t* split_k_flag, float* output_q_scale,
+    const __nv_bfloat16* packed_qkv, const float* cos_sin, const int32_t* sequence_lengths,
+    const int32_t* q_indptr, const int32_t* block_table, const float* q_norm_weight,
+    const float* k_norm_weight, const float* k_scale, const float* v_scale,
+    const float* q_scale_inverse, float fp8_upper_bound, int max_sequence_length_aligned,
+    int64_t key_cache_block_stride, int64_t value_cache_block_stride, int batch_size,
+    int max_pages_per_request, int page_size, int num_rows, int norm_policy, cudaStream_t stream) {
+#define FLASHINFER_ROPE_LAUNCH_FUSED_NORM(NORM)                                                   \
+  return launch_specialized<CacheType, kQuantPolicy, kNumQHeads, kNumKVHeads, NORM, true>(        \
+      output_q, key_cache, value_cache, output_k, output_v, split_k_flag, output_q_scale,         \
+      packed_qkv, cos_sin, sequence_lengths, q_indptr, block_table, q_norm_weight, k_norm_weight, \
+      k_scale, v_scale, q_scale_inverse, fp8_upper_bound, max_sequence_length_aligned,            \
+      key_cache_block_stride, value_cache_block_stride, batch_size, max_pages_per_request,        \
+      page_size, num_rows, false, stream)
+  switch (norm_policy) {
+    case 0:
+      FLASHINFER_ROPE_LAUNCH_FUSED_NORM(0);
+    case 1:
+      FLASHINFER_ROPE_LAUNCH_FUSED_NORM(1);
+    case 2:
+      FLASHINFER_ROPE_LAUNCH_FUSED_NORM(2);
+    default:
+      return cudaErrorInvalidValue;
+  }
+#undef FLASHINFER_ROPE_LAUNCH_FUSED_NORM
+}
+
+template <typename CacheType, int kQuantPolicy, int kNumQHeads, int kNumKVHeads>
+cudaError_t dispatch_norm(CacheType* output_q, CacheType* key_cache, CacheType* value_cache,
+                          CacheType* output_k, CacheType* output_v, int32_t* split_k_flag,
+                          float* output_q_scale, const __nv_bfloat16* packed_qkv,
+                          const float* cos_sin, const int32_t* sequence_lengths,
+                          const int32_t* q_indptr, const int32_t* block_table,
+                          const float* q_norm_weight, const float* k_norm_weight,
+                          const float* k_scale, const float* v_scale, const float* q_scale_inverse,
+                          float fp8_upper_bound, int max_sequence_length_aligned,
+                          int64_t key_cache_block_stride, int64_t value_cache_block_stride,
+                          int batch_size, int max_pages_per_request, int page_size, int num_rows,
+                          bool is_prefill, int norm_policy, cudaStream_t stream) {
+#define FLASHINFER_ROPE_LAUNCH_NORM(NORM)                                                         \
+  return launch_specialized<CacheType, kQuantPolicy, kNumQHeads, kNumKVHeads, NORM>(              \
+      output_q, key_cache, value_cache, output_k, output_v, split_k_flag, output_q_scale,         \
+      packed_qkv, cos_sin, sequence_lengths, q_indptr, block_table, q_norm_weight, k_norm_weight, \
+      k_scale, v_scale, q_scale_inverse, fp8_upper_bound, max_sequence_length_aligned,            \
+      key_cache_block_stride, value_cache_block_stride, batch_size, max_pages_per_request,        \
+      page_size, num_rows, is_prefill, stream)
+  switch (norm_policy) {
+    case 0:
+      FLASHINFER_ROPE_LAUNCH_NORM(0);
+    case 1:
+      FLASHINFER_ROPE_LAUNCH_NORM(1);
+    case 2:
+      FLASHINFER_ROPE_LAUNCH_NORM(2);
+    default:
+      return cudaErrorInvalidValue;
+  }
+#undef FLASHINFER_ROPE_LAUNCH_NORM
+}
+
+template <typename CacheType, int kQuantPolicy>
+cudaError_t dispatch_shape(CacheType* output_q, CacheType* key_cache, CacheType* value_cache,
+                           CacheType* output_k, CacheType* output_v, int32_t* split_k_flag,
+                           float* output_q_scale, const __nv_bfloat16* packed_qkv,
+                           const float* cos_sin, const int32_t* sequence_lengths,
+                           const int32_t* q_indptr, const int32_t* block_table,
+                           const float* q_norm_weight, const float* k_norm_weight,
+                           const float* k_scale, const float* v_scale, const float* q_scale_inverse,
+                           float fp8_upper_bound, int max_sequence_length_aligned,
+                           int64_t key_cache_block_stride, int64_t value_cache_block_stride,
+                           int batch_size, int max_pages_per_request, int page_size, int num_rows,
+                           int num_q_heads, int num_kv_heads, bool is_prefill, int norm_policy,
+                           cudaStream_t stream) {
+#define FLASHINFER_ROPE_DISPATCH_SHAPE(Q_HEADS, KV_HEADS)                                         \
+  return dispatch_norm<CacheType, kQuantPolicy, Q_HEADS, KV_HEADS>(                               \
+      output_q, key_cache, value_cache, output_k, output_v, split_k_flag, output_q_scale,         \
+      packed_qkv, cos_sin, sequence_lengths, q_indptr, block_table, q_norm_weight, k_norm_weight, \
+      k_scale, v_scale, q_scale_inverse, fp8_upper_bound, max_sequence_length_aligned,            \
+      key_cache_block_stride, value_cache_block_stride, batch_size, max_pages_per_request,        \
+      page_size, num_rows, is_prefill, norm_policy, stream)
+  if (num_q_heads == 8 && num_kv_heads == 1) {
+    FLASHINFER_ROPE_DISPATCH_SHAPE(8, 1);
+  }
+  if (num_q_heads == 64 && num_kv_heads == 8) {
+    FLASHINFER_ROPE_DISPATCH_SHAPE(64, 8);
+  }
+#undef FLASHINFER_ROPE_DISPATCH_SHAPE
+  return cudaErrorInvalidValue;
+}
+
+template <typename CacheType, int kQuantPolicy>
+cudaError_t dispatch_uniform_decode_shape(
+    CacheType* output_q, CacheType* key_cache, CacheType* value_cache, CacheType* output_k,
+    CacheType* output_v, int32_t* split_k_flag, float* output_q_scale,
+    const __nv_bfloat16* packed_qkv, const float* cos_sin, const int32_t* sequence_lengths,
+    const int32_t* q_indptr, const int32_t* block_table, const float* q_norm_weight,
+    const float* k_norm_weight, const float* k_scale, const float* v_scale,
+    const float* q_scale_inverse, float fp8_upper_bound, int max_sequence_length_aligned,
+    int64_t key_cache_block_stride, int64_t value_cache_block_stride, int batch_size,
+    int max_pages_per_request, int page_size, int num_rows, int num_q_heads, int num_kv_heads,
+    int norm_policy, cudaStream_t stream) {
+#define FLASHINFER_ROPE_DISPATCH_FUSED_SHAPE(Q_HEADS, KV_HEADS)                                   \
+  return dispatch_uniform_decode_norm<CacheType, kQuantPolicy, Q_HEADS, KV_HEADS>(                \
+      output_q, key_cache, value_cache, output_k, output_v, split_k_flag, output_q_scale,         \
+      packed_qkv, cos_sin, sequence_lengths, q_indptr, block_table, q_norm_weight, k_norm_weight, \
+      k_scale, v_scale, q_scale_inverse, fp8_upper_bound, max_sequence_length_aligned,            \
+      key_cache_block_stride, value_cache_block_stride, batch_size, max_pages_per_request,        \
+      page_size, num_rows, norm_policy, stream)
+  if (num_q_heads == 8 && num_kv_heads == 1) {
+    FLASHINFER_ROPE_DISPATCH_FUSED_SHAPE(8, 1);
+  }
+  if (num_q_heads == 64 && num_kv_heads == 8) {
+    FLASHINFER_ROPE_DISPATCH_FUSED_SHAPE(64, 8);
+  }
+#undef FLASHINFER_ROPE_DISPATCH_FUSED_SHAPE
+  return cudaErrorInvalidValue;
+}
+
+}  // namespace flashinfer::rope_norm_store_kv_hy3

--- a/tests/attention/test_rope.py
+++ b/tests/attention/test_rope.py
@@ -1780,6 +1780,558 @@ def test_rope_quantize_fp8_cutile_rejects_unsupported(unsupported):
         flashinfer.rope.rope_quantize_fp8(**kwargs)
 
 
+def _make_qk_norm_rope_store_inputs_hy3(
+    mode,
+    num_q_heads,
+    num_kv_heads,
+    cache_dtype,
+    batch_size=3,
+    *,
+    q_lens=None,
+    prefixes=None,
+    page_size=16,
+    non_identity_block_table=False,
+):
+    device = "cuda:0"
+    head_dim = 128
+    if q_lens is None:
+        if mode == "decode":
+            q_lens = [1] * batch_size
+        elif mode == "mtp":
+            q_lens = [3] * batch_size
+        else:
+            q_lens = [2 + (request_id % 4) for request_id in range(batch_size)]
+    if prefixes is None:
+        prefixes = [1 + (request_id * 7) % 13 for request_id in range(batch_size)]
+    assert len(q_lens) == batch_size
+    assert len(prefixes) == batch_size
+    sequence_lengths_list = [
+        prefix + q_len for prefix, q_len in zip(prefixes, q_lens, strict=True)
+    ]
+    max_position = max(sequence_lengths_list) + 8
+    max_pages_per_request = (max(sequence_lengths_list) + page_size - 1) // page_size
+    block_table = torch.arange(
+        batch_size * max_pages_per_request, dtype=torch.int32, device=device
+    )
+    if non_identity_block_table:
+        block_table = block_table.flip(0)
+    block_table = block_table.reshape(batch_size, max_pages_per_request)
+    q_indptr_list = [0]
+    for q_len in q_lens:
+        q_indptr_list.append(q_indptr_list[-1] + q_len)
+    num_rows = q_indptr_list[-1]
+
+    generator = torch.Generator(device=device).manual_seed(
+        20260830 + num_q_heads * 17 + num_kv_heads
+    )
+    packed_width = (num_q_heads + 2 * num_kv_heads) * head_dim
+    packed_qkv = torch.randn(
+        num_rows,
+        packed_width,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    positions = torch.arange(max_position, dtype=torch.float32, device=device)
+    inverse_frequency = 1.0 / (
+        10000.0
+        ** (torch.arange(0, head_dim, 2, dtype=torch.float32, device=device) / head_dim)
+    )
+    frequencies = torch.outer(positions, inverse_frequency)
+    cos_sin_cache = torch.cat((frequencies.cos(), frequencies.sin()), dim=-1)
+    cache_shape = (
+        batch_size * max_pages_per_request,
+        page_size,
+        num_kv_heads,
+        head_dim,
+    )
+    key_cache = torch.randn(
+        cache_shape,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    value_cache = torch.randn(
+        cache_shape,
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    if cache_dtype == torch.float8_e4m3fn:
+        key_cache = key_cache.float().clamp(-448, 448).to(cache_dtype)
+        value_cache = value_cache.float().clamp(-448, 448).to(cache_dtype)
+    return {
+        "packed_qkv": packed_qkv,
+        "cos_sin_cache": cos_sin_cache,
+        "sequence_lengths": torch.tensor(
+            sequence_lengths_list, dtype=torch.int32, device=device
+        ),
+        "q_indptr": torch.tensor(q_indptr_list, dtype=torch.int32, device=device),
+        "block_table": block_table,
+        "key_cache": key_cache,
+        "value_cache": value_cache,
+        "q_lens": q_lens,
+        "sequence_lengths_list": sequence_lengths_list,
+        "num_q_heads": num_q_heads,
+        "num_kv_heads": num_kv_heads,
+        "page_size": page_size,
+        "max_sequence_length": max(q_lens),
+    }
+
+
+def _qk_norm_rope_store_reference_hy3(
+    inputs, norm_policy, quant_policy, *, redirect_k=False, redirect_v=False
+):
+    packed_qkv = inputs["packed_qkv"]
+    num_q_heads = inputs["num_q_heads"]
+    num_kv_heads = inputs["num_kv_heads"]
+    head_dim = 128
+    q_width = num_q_heads * head_dim
+    k_width = num_kv_heads * head_dim
+    q = packed_qkv[:, :q_width].float().reshape(-1, num_q_heads, head_dim)
+    k = (
+        packed_qkv[:, q_width : q_width + k_width]
+        .float()
+        .reshape(-1, num_kv_heads, head_dim)
+    )
+    v = packed_qkv[:, q_width + k_width :].reshape(-1, num_kv_heads, head_dim)
+    q_weight = torch.linspace(0.75, 1.25, head_dim, device=packed_qkv.device)
+    k_weight = torch.linspace(1.25, 0.75, head_dim, device=packed_qkv.device)
+
+    def rms_norm(x, weight):
+        return x * torch.rsqrt(x.square().mean(dim=-1, keepdim=True) + 1e-6) * weight
+
+    if norm_policy == 2:
+        q = rms_norm(q, q_weight)
+        k = rms_norm(k, k_weight)
+    token_positions = []
+    for sequence_length, q_len in zip(
+        inputs["sequence_lengths_list"], inputs["q_lens"], strict=True
+    ):
+        token_positions.extend(range(sequence_length - q_len, sequence_length))
+    token_positions = torch.tensor(
+        token_positions, dtype=torch.long, device=packed_qkv.device
+    )
+    cos_sin = inputs["cos_sin_cache"].index_select(0, token_positions)
+    half = head_dim // 2
+
+    def neox_rope(x):
+        first, second = x[..., :half], x[..., half:]
+        cosine = cos_sin[:, None, :half]
+        sine = cos_sin[:, None, half:]
+        return torch.cat(
+            (first * cosine - second * sine, second * cosine + first * sine),
+            dim=-1,
+        )
+
+    q = neox_rope(q)
+    k = neox_rope(k)
+    if norm_policy == 1:
+        q = rms_norm(q, q_weight)
+        k = rms_norm(k, k_weight)
+
+    dynamic_scale = None
+    if quant_policy == 0:
+        out_q = q.to(torch.bfloat16)
+        stored_k = k.to(torch.bfloat16)
+        stored_v = v
+    else:
+        if quant_policy == 1:
+            dynamic_scale = q.abs().amax(dim=-1).clamp_min(1e-6) / 448.0
+            q_multiplier = dynamic_scale.reciprocal()[..., None]
+        else:
+            q_multiplier = torch.tensor(2.0, device=q.device)
+        out_q = (q * q_multiplier).clamp(-448, 448).to(torch.float8_e4m3fn)
+        stored_k = (k / 0.5).clamp(-448, 448).to(torch.float8_e4m3fn)
+        stored_v = (v.float() / 0.25).clamp(-448, 448).to(torch.float8_e4m3fn)
+
+    key_cache = inputs["key_cache"].clone()
+    value_cache = inputs["value_cache"].clone()
+    token = 0
+    for request_id, (sequence_length, q_len) in enumerate(
+        zip(inputs["sequence_lengths_list"], inputs["q_lens"], strict=True)
+    ):
+        for position in range(sequence_length - q_len, sequence_length):
+            logical_page, page_offset = divmod(position, inputs["page_size"])
+            physical_page = int(inputs["block_table"][request_id, logical_page])
+            if not redirect_k:
+                key_cache[physical_page, page_offset] = stored_k[token]
+            if not redirect_v:
+                value_cache[physical_page, page_offset] = stored_v[token]
+            token += 1
+        logical_page, page_offset = divmod(sequence_length - 1, inputs["page_size"])
+        physical_page = int(inputs["block_table"][request_id, logical_page])
+        key_cache[physical_page, page_offset + 1 :] = 0
+        value_cache[physical_page, page_offset + 1 :] = 0
+    return (
+        out_q,
+        dynamic_scale,
+        key_cache,
+        value_cache,
+        q_weight,
+        k_weight,
+        stored_k,
+        stored_v,
+    )
+
+
+@pytest.mark.parametrize("num_q_heads,num_kv_heads", [(8, 1), (64, 8)])
+@pytest.mark.parametrize("mode", ["prefill", "decode", "mtp"])
+@pytest.mark.parametrize("norm_policy", [0, 1, 2])
+@pytest.mark.parametrize(
+    "cache_dtype,quant_policy",
+    [
+        (torch.bfloat16, 0),
+        (torch.float8_e4m3fn, 1),
+        (torch.float8_e4m3fn, 2),
+    ],
+)
+def test_qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+    num_q_heads, num_kv_heads, mode, norm_policy, cache_dtype, quant_policy
+):
+    inputs = _make_qk_norm_rope_store_inputs_hy3(
+        mode, num_q_heads, num_kv_heads, cache_dtype
+    )
+    expected = _qk_norm_rope_store_reference_hy3(inputs, norm_policy, quant_policy)
+    key_cache = inputs["key_cache"].clone()
+    value_cache = inputs["value_cache"].clone()
+    q_weight = expected[4] if norm_policy else None
+    k_weight = expected[5] if norm_policy else None
+    k_scale = (
+        torch.tensor([0.5], dtype=torch.float32, device="cuda:0")
+        if quant_policy
+        else None
+    )
+    v_scale = (
+        torch.tensor([0.25], dtype=torch.float32, device="cuda:0")
+        if quant_policy
+        else None
+    )
+    q_scale_inverse = (
+        torch.tensor([2.0], dtype=torch.float32, device="cuda:0")
+        if quant_policy == 2
+        else None
+    )
+    split_k_flag = (
+        torch.full(
+            (inputs["sequence_lengths"].shape[0], inputs["num_kv_heads"]),
+            -1,
+            dtype=torch.int32,
+            device=inputs["packed_qkv"].device,
+        )
+        if quant_policy != 0
+        else None
+    )
+    output = flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        inputs["packed_qkv"],
+        inputs["cos_sin_cache"],
+        inputs["sequence_lengths"],
+        inputs["q_indptr"],
+        inputs["block_table"],
+        (key_cache, value_cache),
+        mode == "prefill",
+        q_norm_weight=q_weight,
+        k_norm_weight=k_weight,
+        norm_policy=norm_policy,
+        quant_policy=quant_policy,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        q_scale_inverse=q_scale_inverse,
+        max_sequence_length=inputs["max_sequence_length"],
+        split_k_flag=split_k_flag,
+    )
+    if quant_policy == 0:
+        torch.testing.assert_close(output[0], expected[0], atol=8e-2, rtol=1e-5)
+        torch.testing.assert_close(key_cache, expected[2], atol=8e-2, rtol=1e-5)
+        torch.testing.assert_close(value_cache, expected[3], atol=0, rtol=0)
+        assert output[1] is None and output[2] is None
+    else:
+        torch.testing.assert_close(
+            output[0].float(), expected[0].float(), atol=1, rtol=0
+        )
+        torch.testing.assert_close(
+            key_cache.float() * k_scale[0],
+            expected[2].float() * k_scale[0],
+            atol=0.5,
+            rtol=0,
+        )
+        torch.testing.assert_close(
+            value_cache.float() * v_scale[0],
+            expected[3].float() * v_scale[0],
+            atol=0.5,
+            rtol=0,
+        )
+        assert torch.equal(output[2], torch.zeros_like(output[2]))
+        if quant_policy == 1:
+            if mode == "prefill":
+                cursor = 0
+                for request_id, q_len in enumerate(inputs["q_lens"]):
+                    actual_scale = output[1][request_id, :, :q_len].transpose(0, 1)
+                    torch.testing.assert_close(
+                        actual_scale,
+                        expected[1][cursor : cursor + q_len],
+                        rtol=2e-4,
+                        atol=1e-7,
+                    )
+                    cursor += q_len
+            else:
+                torch.testing.assert_close(output[1], expected[1], rtol=2e-4, atol=1e-7)
+        else:
+            assert output[1] is None
+
+
+def test_qk_rmsnorm_rope_hy3_multipage_non_identity_and_redirected_outputs():
+    inputs = _make_qk_norm_rope_store_inputs_hy3(
+        "mtp",
+        8,
+        1,
+        torch.float8_e4m3fn,
+        batch_size=2,
+        q_lens=[4, 5],
+        prefixes=[14, 30],
+        non_identity_block_table=True,
+    )
+    expected = _qk_norm_rope_store_reference_hy3(
+        inputs, norm_policy=2, quant_policy=1, redirect_k=True, redirect_v=True
+    )
+    identity_block_table = torch.arange(
+        inputs["block_table"].numel(), dtype=torch.int32, device="cuda:0"
+    ).reshape_as(inputs["block_table"])
+    assert not torch.equal(inputs["block_table"], identity_block_table)
+    for sequence_length, q_len in zip(
+        inputs["sequence_lengths_list"], inputs["q_lens"], strict=True
+    ):
+        assert (sequence_length - q_len) // inputs["page_size"] != (
+            sequence_length - 1
+        ) // inputs["page_size"]
+
+    key_cache = inputs["key_cache"].clone()
+    value_cache = inputs["value_cache"].clone()
+    out_q = torch.empty_like(expected[0])
+    out_q_scale = torch.empty_like(expected[1])
+    split_k_flag = torch.full(
+        (2, 1), -1, dtype=torch.int32, device=inputs["packed_qkv"].device
+    )
+    out_k = torch.empty_like(expected[6])
+    out_v = torch.empty_like(expected[7])
+    k_scale = torch.tensor([0.5], dtype=torch.float32, device="cuda:0")
+    v_scale = torch.tensor([0.25], dtype=torch.float32, device="cuda:0")
+
+    output = flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        inputs["packed_qkv"],
+        inputs["cos_sin_cache"],
+        inputs["sequence_lengths"],
+        inputs["q_indptr"],
+        inputs["block_table"],
+        (key_cache, value_cache),
+        False,
+        q_norm_weight=expected[4],
+        k_norm_weight=expected[5],
+        norm_policy=2,
+        quant_policy=1,
+        k_scale=k_scale,
+        v_scale=v_scale,
+        max_sequence_length=inputs["max_sequence_length"],
+        out_q=out_q,
+        out_q_scale=out_q_scale,
+        split_k_flag=split_k_flag,
+        out_k=out_k,
+        out_v=out_v,
+    )
+
+    assert tuple(tensor.data_ptr() for tensor in output) == tuple(
+        tensor.data_ptr() for tensor in (out_q, out_q_scale, split_k_flag, out_k, out_v)
+    )
+    torch.testing.assert_close(output[0].float(), expected[0].float(), atol=1, rtol=0)
+    torch.testing.assert_close(output[1], expected[1], rtol=2e-4, atol=1e-7)
+    assert torch.equal(output[2], torch.zeros_like(output[2]))
+    torch.testing.assert_close(
+        output[3].float() * k_scale[0],
+        expected[6].float() * k_scale[0],
+        atol=0.5,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        output[4].float() * v_scale[0],
+        expected[7].float() * v_scale[0],
+        atol=0.5,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        key_cache.float() * k_scale[0],
+        expected[2].float() * k_scale[0],
+        atol=0.5,
+        rtol=0,
+    )
+    torch.testing.assert_close(
+        value_cache.float() * v_scale[0],
+        expected[3].float() * v_scale[0],
+        atol=0.5,
+        rtol=0,
+    )
+
+
+@pytest.mark.parametrize(
+    "buffer_name,wrong_dtype,expected_dtype",
+    [
+        ("out_q_scale", torch.float16, "float32"),
+        ("split_k_flag", torch.int8, "int32"),
+    ],
+)
+def test_qk_rmsnorm_rope_hy3_rejects_preallocated_output_dtype(
+    buffer_name, wrong_dtype, expected_dtype
+):
+    inputs = _make_qk_norm_rope_store_inputs_hy3(
+        "decode", 8, 1, torch.float8_e4m3fn, batch_size=2
+    )
+    shapes = {
+        "out_q_scale": (inputs["packed_qkv"].shape[0], 8),
+        "split_k_flag": (inputs["sequence_lengths"].shape[0], 1),
+    }
+    invalid_buffer = torch.empty(
+        shapes[buffer_name], dtype=wrong_dtype, device=inputs["packed_qkv"].device
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=rf"{buffer_name} must have shape .* and dtype {expected_dtype}",
+    ):
+        flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+            inputs["packed_qkv"],
+            inputs["cos_sin_cache"],
+            inputs["sequence_lengths"],
+            inputs["q_indptr"],
+            inputs["block_table"],
+            (inputs["key_cache"], inputs["value_cache"]),
+            False,
+            quant_policy=1,
+            k_scale=torch.tensor([0.5], dtype=torch.float32, device="cuda:0"),
+            v_scale=torch.tensor([0.25], dtype=torch.float32, device="cuda:0"),
+            **{buffer_name: invalid_buffer},
+        )
+
+
+def test_qk_rmsnorm_rope_hy3_uses_current_non_default_stream():
+    inputs = _make_qk_norm_rope_store_inputs_hy3(
+        "mtp", 8, 1, torch.bfloat16, batch_size=2
+    )
+    expected = _qk_norm_rope_store_reference_hy3(inputs, norm_policy=0, quant_policy=0)
+
+    # Warm up lazy module loading so it cannot hide an accidental default-stream launch.
+    warmup_caches = (inputs["key_cache"].clone(), inputs["value_cache"].clone())
+    flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        inputs["packed_qkv"],
+        inputs["cos_sin_cache"],
+        inputs["sequence_lengths"],
+        inputs["q_indptr"],
+        inputs["block_table"],
+        warmup_caches,
+        False,
+        norm_policy=0,
+        quant_policy=0,
+    )
+    torch.cuda.current_stream().synchronize()
+
+    source_qkv = inputs["packed_qkv"]
+    delayed_qkv = torch.zeros_like(source_qkv)
+    key_cache = inputs["key_cache"].clone()
+    value_cache = inputs["value_cache"].clone()
+    out_q = torch.empty_like(expected[0])
+    stream = torch.cuda.Stream()
+    assert stream.cuda_stream != torch.cuda.default_stream().cuda_stream
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        # A kernel launched on the default stream would consume the zero input before
+        # this delayed producer runs; a current-stream launch is ordered after the copy.
+        torch.cuda._sleep(20_000_000)
+        delayed_qkv.copy_(source_qkv)
+        output = flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+            delayed_qkv,
+            inputs["cos_sin_cache"],
+            inputs["sequence_lengths"],
+            inputs["q_indptr"],
+            inputs["block_table"],
+            (key_cache, value_cache),
+            False,
+            norm_policy=0,
+            quant_policy=0,
+            out_q=out_q,
+        )
+    stream.synchronize()
+
+    assert output[0].data_ptr() == out_q.data_ptr()
+    assert output[1:] == (None, None, None, None)
+    torch.testing.assert_close(output[0], expected[0], atol=8e-2, rtol=1e-5)
+    torch.testing.assert_close(key_cache, expected[2], atol=8e-2, rtol=1e-5)
+    torch.testing.assert_close(value_cache, expected[3], atol=0, rtol=0)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.get_device_capability(0) != (10, 0),
+    reason="SM100 fast-path parity test",
+)
+def test_qk_rmsnorm_rope_hy3_sm100_uniform_decode_and_preallocated_outputs():
+    inputs = _make_qk_norm_rope_store_inputs_hy3(
+        "decode", 64, 8, torch.float8_e4m3fn, batch_size=256
+    )
+    q_weight = torch.linspace(0.75, 1.25, 128, device="cuda:0")
+    k_weight = torch.linspace(1.25, 0.75, 128, device="cuda:0")
+    scales = (
+        torch.tensor([0.5], dtype=torch.float32, device="cuda:0"),
+        torch.tensor([0.25], dtype=torch.float32, device="cuda:0"),
+    )
+    reference_caches = (inputs["key_cache"].clone(), inputs["value_cache"].clone())
+    optimized_caches = (inputs["key_cache"].clone(), inputs["value_cache"].clone())
+    reference = flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        inputs["packed_qkv"],
+        inputs["cos_sin_cache"],
+        inputs["sequence_lengths"],
+        inputs["q_indptr"],
+        inputs["block_table"],
+        reference_caches,
+        False,
+        q_norm_weight=q_weight,
+        k_norm_weight=k_weight,
+        norm_policy=2,
+        quant_policy=1,
+        k_scale=scales[0],
+        v_scale=scales[1],
+        uniform_one_token_decode=False,
+    )
+    out_q = torch.empty_like(reference[0])
+    out_scale = torch.empty_like(reference[1])
+    split_flag = torch.full_like(reference[2], -1)
+    pointers = (out_q.data_ptr(), out_scale.data_ptr(), split_flag.data_ptr())
+    optimized = flashinfer.rope.qk_rmsnorm_rope_append_paged_kv_cache_hy3(
+        inputs["packed_qkv"],
+        inputs["cos_sin_cache"],
+        inputs["sequence_lengths"],
+        inputs["q_indptr"],
+        inputs["block_table"],
+        optimized_caches,
+        False,
+        q_norm_weight=q_weight,
+        k_norm_weight=k_weight,
+        norm_policy=2,
+        quant_policy=1,
+        k_scale=scales[0],
+        v_scale=scales[1],
+        out_q=out_q,
+        out_q_scale=out_scale,
+        split_k_flag=split_flag,
+        uniform_one_token_decode=True,
+    )
+    assert pointers == (
+        optimized[0].data_ptr(),
+        optimized[1].data_ptr(),
+        optimized[2].data_ptr(),
+    )
+    for actual, expected in zip(optimized[:3], reference[:3], strict=True):
+        assert torch.equal(actual, expected)
+    assert torch.equal(optimized_caches[0], reference_caches[0])
+    assert torch.equal(optimized_caches[1], reference_caches[1])
+
+
 if __name__ == "__main__":
     # test_rope(2, 1, 8, 8, 1, 128, "llama", 1.0, False)
     # test_rope_pos_ids(2, 1, 8, 8, 1, 128, "llama31", 1.0, False)

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -85,6 +85,7 @@ prims_ts_block_sparse_h8_kv8_d128_qb64_kb64.json
 prims_ts_paged_block_sparse_combined_h8_kv8_d128_qb64_kb64_ps64.json
 prims_ts_paged_block_sparse_tuple_h8_kv8_d128_qb64_kb64_ps64.json
 quantize_nvfp4_smooth_N3072.json
+qk_rmsnorm_rope_append_paged_kv_cache_hy3_fp8_decode_h64_kv8_d128_ps64.json
 rmsnorm_h4096.json
 rmsnorm_h7168.json
 rmsnorm_quant_h7168.json
@@ -2198,3 +2199,10 @@ with contextlib.suppress(Exception):
             _fp4_in["block_table"],
             _fp4_in["max_context_len"],
         )
+
+# HY3 B200 64Q/8KV dynamic-FP8 uniform decode fusion.
+with contextlib.suppress(Exception):
+    _hy3_rope_inputs = flashinfer.qk_rmsnorm_rope_append_paged_kv_cache_hy3.fi_init(
+        batch_size=256, device=device
+    )
+    flashinfer.qk_rmsnorm_rope_append_paged_kv_cache_hy3(**_hy3_rope_inputs)


### PR DESCRIPTION
## Summary

This PR adds `qk_rmsnorm_rope_append_paged_kv_cache_hy3`, an opt-in fused operator for the HY3 packed-QKV serving contract. It performs per-head Q/K RMSNorm, NeoX RoPE, optional FP8 quantization, Q output, paged K/V writes, split-flag writeback, and required final-page tail clearing in one CUDA launch. Existing FlashInfer RoPE, normalization, and cache APIs are unchanged.

The implementation supports 8Q/1KV and 64Q/8KV head layouts with head dimension 128, BF16 and FP8 caches, static or dynamic Q scaling, decode/prefill layouts, caller-provided outputs, JIT/AOT registration, trace support, tests, and a B200 benchmark.

For the measured 64Q/8KV dynamic-Q uniform one-token decode shape, the SM100 specialization directly maps rows to requests and folds tail clearing into compute CTAs. `uniform_one_token_decode=False` remains the safe default; enabling it is an explicit promise that `q_indptr == arange(batch_size + 1)`.

The CUDA implementation is derived from Tencent/HPC-Ops commit `1cd332980ed46bd0172091c1c35d55338fcae47a`; the derived header retains the original copyright, MIT SPDX identifier, and source revision.

This is the RoPE/KV-store half of the previously combined submission. HY3 fused sampling remains in #4796.

## Duplicate-work check

I searched open FlashInfer PRs for QK RMSNorm, RoPE, FP8 quantization, and paged KV-cache append. Existing work overlaps with individual stages, but I did not find an open PR covering this packed-QKV contract, dynamic per-token/per-Q-head Q scale, split flags, and cache-tail clearing in one operation.

## Tests

Run from the repository root on an SM100/B200 CUDA GPU:

```bash
python -m pytest -q tests/attention/test_rope.py \
  -k 'qk_rmsnorm_rope_append_paged_kv_cache_hy3 or qk_rmsnorm_rope_hy3'
python -m pytest -q \
  tests/trace/test_fi_trace_template_consistency.py \
  tests/trace/test_template_init.py \
  tests/trace/test_template_registry.py \
  -k qk_rmsnorm_rope_append_paged_kv_cache_hy3
```

Results:

```text
59 passed, 30881 deselected
4 passed, 3 skipped, 1325 deselected
```

Ruff 0.12.8 lint and format checks pass for all changed Python files.

## Benchmark

Environment: NVIDIA B200, 64 Q heads, 8 KV heads, head dimension 128, page size 64, CUDA-event timing after the preferred CUPTI timer reported unavailable, cold L2, 20 warmup iterations, and 100 samples. Input splitting, metadata, outputs, allocation, and JIT compilation are outside timing.

```bash
python -m benchmarks.bench_rope_hy3 \
  --batches 256 512 \
  --warmup 20 --iters 100
```

The static-Q comparison uses `norm_policy=2` and matches the common output semantics of two FlashInfer RMSNorm calls followed by `rope_quantize_fp8_append_paged_kv_cache`. The FlashInfer composition does not clear unused cache tails or write split flags, so it performs less work and is a conservative baseline. The dynamic-Q comparison is HY3 source-faithful versus HY3 B200-specialized and is bitwise checked for Q, Q scale, flags, and K/V caches before timing.

| case | batch | baseline (us) | optimized (us) | speedup |
|---|---:|---:|---:|---:|
| FlashInfer composed static-Q vs HY3 fused | 256 | 18.400 | 15.552 | 1.183x |
| FlashInfer composed static-Q vs HY3 fused | 512 | 23.184 | 20.432 | 1.135x |
| HY3 source-faithful dynamic-Q vs B200 specialized | 256 | 17.536 | 15.728 | 1.115x |
| HY3 source-faithful dynamic-Q vs B200 specialized | 512 | 22.336 | 19.808 | 1.128x |

## AI assistance disclosure

AI assistance was used to help prepare and validate this change. I reviewed the changed lines and test results and am responsible for the contribution.
