### PR TITLE
feat(sampling): add HY3 fused sampling for SM100

### DIFF
--- a/benchmarks/bench_sampling_hy3.py
+++ b/benchmarks/bench_sampling_hy3.py
@@ -1,0 +1,255 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compare the HY3 fused sampler with existing FlashInfer sampling paths.
+
+The benchmark follows the HPC-Ops workload (BF16 logits, vocabulary 120832,
+temperature-only and repetition-penalty/top-k/top-p scenes), while keeping
+input construction, history packing, allocation, and JIT compilation outside
+the timed region. Both providers generate random numbers inside their kernels;
+external Gumbel tensors are intentionally reserved for correctness tests.
+
+Usage:
+$ python -m benchmarks.bench_sampling_hy3
+$ python -m benchmarks.bench_sampling_hy3 --batches 32 128 512 --hot-l2
+"""
+
+import argparse
+
+import numpy as np
+import torch
+
+import flashinfer
+from flashinfer.testing.utils import bench_gpu_time
+
+
+VOCAB_SIZE = 120832
+REPETITION_PENALTY = 1.1
+TEMPERATURE = 1.05
+TOP_K = 20
+TOP_P = 0.9
+SEED = 1
+OFFSET = 0
+
+
+def _measure(call, args):
+    values = bench_gpu_time(
+        call,
+        dry_run_iters=args.warmup,
+        repeat_iters=args.iters,
+        enable_cupti=not args.cuda_events,
+        cold_l2_cache=not args.hot_l2,
+    )
+    values = np.asarray(values, dtype=np.float64) * 1e3
+    return (
+        float(np.median(values)),
+        float(np.percentile(values, 20)),
+        float(np.percentile(values, 80)),
+    )
+
+
+def _make_history_masks(batch_size, device):
+    # A 40% occupancy approximates the unique-token density after drawing two
+    # 32K-token histories from a 120832-token vocabulary. Build both layouts
+    # from the same mask so the providers see identical repetition state.
+    generator = torch.Generator(device=device).manual_seed(batch_size)
+    dense = (
+        torch.rand((batch_size, VOCAB_SIZE), generator=generator, device=device) < 0.4
+    )
+    bits = dense.view(batch_size, VOCAB_SIZE // 8, 8).to(torch.uint8)
+    weights = torch.tensor(
+        [1, 2, 4, 8, 16, 32, 64, 128], dtype=torch.uint8, device=device
+    )
+    packed = (bits * weights).sum(dim=-1, dtype=torch.uint8)
+    return dense, packed
+
+
+@torch.inference_mode()
+def _benchmark_batch(batch_size, args):
+    device = torch.device(f"cuda:{args.device}")
+    generator = torch.Generator(device=device).manual_seed(1000 + batch_size)
+    logits = torch.randn(
+        (batch_size, VOCAB_SIZE),
+        dtype=torch.bfloat16,
+        device=device,
+        generator=generator,
+    )
+    workspace = torch.empty(8 * 1024 * 1024, dtype=torch.uint8, device=device)
+    output = torch.empty((batch_size, 1), dtype=torch.int32, device=device)
+    temperature_work = torch.empty_like(logits, dtype=torch.float32)
+    full_work = torch.empty_like(temperature_work)
+    positive_scaled = torch.empty_like(full_work)
+    negative_scaled = torch.empty_like(full_work)
+    adjusted_work = torch.empty_like(full_work)
+    sample_work = torch.empty_like(full_work)
+    positive_mask = torch.empty_like(logits, dtype=torch.bool)
+    dense_history, packed_history = _make_history_masks(batch_size, device)
+    dense_history = dense_history.clone()
+    packed_history = packed_history.clone()
+    slots = torch.arange(batch_size, dtype=torch.int32, device=device)
+    rows = torch.arange(batch_size, dtype=torch.int64, device=device)
+
+    def hy3_temperature():
+        return flashinfer.fused_sampling_from_logits_hy3(
+            logits,
+            workspace_buffer=workspace,
+            out=output,
+            temperature=TEMPERATURE,
+            seed=SEED,
+            offset=OFFSET,
+        )
+
+    def flashinfer_temperature_logits():
+        temperature_work.copy_(logits)
+        temperature_work.mul_(1.0 / TEMPERATURE)
+        return flashinfer.sampling_from_logits(
+            temperature_work,
+            deterministic=True,
+            seed=SEED,
+            offset=OFFSET,
+        )
+
+    def flashinfer_temperature_probs():
+        probs = flashinfer.softmax(logits, temperature=TEMPERATURE)
+        return flashinfer.sampling_from_probs(
+            probs,
+            deterministic=True,
+            seed=SEED,
+            offset=OFFSET,
+        )
+
+    def hy3_full():
+        return flashinfer.fused_sampling_from_logits_hy3(
+            logits,
+            workspace_buffer=workspace,
+            out=output,
+            penalty_mask=packed_history,
+            slot_id=slots,
+            repetition_penalty=REPETITION_PENALTY,
+            temperature=TEMPERATURE,
+            softmax_policy=flashinfer.sampling.HY3_SAMPLER_SOFTMAX_AFTER_TOP_K,
+            top_k=TOP_K,
+            top_p=TOP_P,
+            max_top_k=32,
+            seed=SEED,
+            offset=OFFSET,
+        )
+
+    def flashinfer_full():
+        full_work.copy_(logits)
+        positive_scaled.copy_(full_work).div_(REPETITION_PENALTY)
+        negative_scaled.copy_(full_work).mul_(REPETITION_PENALTY)
+        torch.gt(full_work, 0, out=positive_mask)
+        torch.where(
+            positive_mask,
+            positive_scaled,
+            negative_scaled,
+            out=adjusted_work,
+        )
+        torch.where(dense_history, adjusted_work, full_work, out=sample_work)
+        sample_work.mul_(1.0 / TEMPERATURE)
+        token = flashinfer.top_k_top_p_sampling_from_logits(
+            sample_work,
+            TOP_K,
+            TOP_P,
+            filter_apply_order="top_k_first",
+            deterministic=True,
+            seed=SEED,
+            offset=OFFSET,
+        )
+        dense_history[rows, token.long()] = True
+        return token
+
+    # Build/load all JIT modules and cached workspaces before timing.
+    for call in (
+        hy3_temperature,
+        flashinfer_temperature_logits,
+        flashinfer_temperature_probs,
+        hy3_full,
+        flashinfer_full,
+    ):
+        call()
+    torch.cuda.synchronize(device)
+
+    results = {
+        "hy3_temperature": _measure(hy3_temperature, args),
+        "flashinfer_temperature_logits": _measure(flashinfer_temperature_logits, args),
+        "flashinfer_temperature_probs": _measure(flashinfer_temperature_probs, args),
+        "hy3_full": _measure(hy3_full, args),
+        "flashinfer_full": _measure(flashinfer_full, args),
+    }
+    return results
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batches", type=int, nargs="+", default=[1, 8, 32, 128, 512])
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iters", type=int, default=100)
+    parser.add_argument(
+        "--hot-l2",
+        action="store_true",
+        help="reuse hot inputs instead of flushing L2 between measurements",
+    )
+    parser.add_argument(
+        "--cuda-events",
+        action="store_true",
+        help="use CUDA events instead of the preferred CUPTI timer",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        print("HY3 fused sampling benchmark skipped: CUDA is unavailable")
+        return
+    torch.cuda.set_device(args.device)
+    if torch.cuda.get_device_capability(args.device) != (10, 0):
+        print("HY3 fused sampling benchmark skipped: requires SM100/B200")
+        return
+
+    cache_mode = "hot" if args.hot_l2 else "cold"
+    timer = "cuda_event" if args.cuda_events else "cupti_or_event_fallback"
+    print(f"# cache={cache_mode}, timer={timer}, dtype=bf16, vocab={VOCAB_SIZE}")
+    print("scene,batch,provider,median_us,p20_us,p80_us,speedup_vs_flashinfer_best")
+    for batch_size in args.batches:
+        results = _benchmark_batch(batch_size, args)
+        fi_temperature_best = min(
+            results["flashinfer_temperature_logits"][0],
+            results["flashinfer_temperature_probs"][0],
+        )
+        hy3_temperature = results["hy3_temperature"][0]
+        full_speedup = results["flashinfer_full"][0] / results["hy3_full"][0]
+        for scene, providers, speedup in (
+            (
+                "temperature",
+                (
+                    "hy3_temperature",
+                    "flashinfer_temperature_logits",
+                    "flashinfer_temperature_probs",
+                ),
+                fi_temperature_best / hy3_temperature,
+            ),
+            ("full", ("hy3_full", "flashinfer_full"), full_speedup),
+        ):
+            for provider in providers:
+                median, p20, p80 = results[provider]
+                row_speedup = speedup if provider.startswith("hy3_") else 1.0
+                print(
+                    f"{scene},{batch_size},{provider},{median:.3f},{p20:.3f},"
+                    f"{p80:.3f},{row_speedup:.3f}"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/flashinfer_sampling_hy3_binding.cu
+++ b/csrc/flashinfer_sampling_hy3_binding.cu
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Optional;
+
+void fused_sampling_from_logits_hy3(
+    TensorView workspace_buffer, TensorView logits, TensorView output,
+    Optional<TensorView> maybe_penalty_mask, Optional<TensorView> maybe_slot_id,
+    Optional<TensorView> maybe_repetition_penalty, double repetition_penalty_val,
+    Optional<TensorView> maybe_temperature, double temperature_val, int64_t softmax_policy,
+    Optional<TensorView> maybe_top_k, int64_t top_k_val, Optional<TensorView> maybe_top_p,
+    double top_p_val, int64_t max_top_k, Optional<TensorView> maybe_gumbel_noise,
+    Optional<TensorView> maybe_draft_token_ids, int64_t sm_count, uint64_t seed, uint64_t offset,
+    bool temperature_only);
+
+// HY3 fused repetition penalty, temperature, top-k/top-p and sampling,
+// optimized for NVIDIA SM100/B200.
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(fused_sampling_from_logits_hy3, fused_sampling_from_logits_hy3);

--- a/csrc/sampling_hy3.cu
+++ b/csrc/sampling_hy3.cu
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <flashinfer/sampling_hy3.cuh>
+#include <limits>
+
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+
+using tvm::ffi::Optional;
+
+namespace sampler_hy3 = flashinfer::sampling::hy3;
+
+// HY3 fused logits processing and Gumbel-max sampling optimized for SM100/B200.
+// The CUDA implementation is derived from Tencent/HPC-Ops and retains its MIT
+// license in include/flashinfer/sampling_hy3.cuh. This wrapper accepts
+// caller-owned workspace so the hot path performs no cudaMalloc/free.
+// seed must be greater than zero when maybe_gumbel_noise is absent.
+void fused_sampling_from_logits_hy3(
+    TensorView workspace_buffer, TensorView logits, TensorView output,
+    Optional<TensorView> maybe_penalty_mask, Optional<TensorView> maybe_slot_id,
+    Optional<TensorView> maybe_repetition_penalty, double repetition_penalty_val,
+    Optional<TensorView> maybe_temperature, double temperature_val, int64_t softmax_policy,
+    Optional<TensorView> maybe_top_k, int64_t top_k_val, Optional<TensorView> maybe_top_p,
+    double top_p_val, int64_t max_top_k, Optional<TensorView> maybe_gumbel_noise,
+    Optional<TensorView> maybe_draft_token_ids, int64_t sm_count, uint64_t seed, uint64_t offset,
+    bool temperature_only) {
+  CHECK_INPUT_AND_TYPE(workspace_buffer, dl_uint8);
+  CHECK_DIM(1, workspace_buffer);
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(workspace_buffer.data_ptr()) % alignof(float), 0U)
+      << "workspace_buffer address must be aligned to four bytes";
+  CHECK_CUDA(logits);
+  CHECK_DIM(2, logits);
+  TVM_FFI_ICHECK_EQ(logits.stride(1), 1) << "logits inner dimension must be contiguous";
+  TVM_FFI_ICHECK(logits.dtype() == dl_float32 || logits.dtype() == dl_bfloat16)
+      << "logits dtype must be float32 or bfloat16";
+  CHECK_INPUT_AND_TYPE(output, dl_int32);
+  CHECK_DIM(2, output);
+  CHECK_DEVICE(workspace_buffer, logits);
+  CHECK_DEVICE(output, logits);
+
+  const int64_t batch_size_i64 = logits.size(0);
+  const int64_t vocab_size_i64 = logits.size(1);
+  TVM_FFI_ICHECK_GT(batch_size_i64, 0) << "batch_size must be positive";
+  TVM_FFI_ICHECK_EQ(vocab_size_i64, sampler_hy3::kVocabSize)
+      << "HY3 fused sampler currently supports vocab_size=" << sampler_hy3::kVocabSize;
+  TVM_FFI_ICHECK_EQ(output.size(0), batch_size_i64);
+  TVM_FFI_ICHECK_EQ(output.size(1), 1);
+  TVM_FFI_ICHECK_LE(batch_size_i64, std::numeric_limits<int>::max());
+  TVM_FFI_ICHECK_LE(logits.stride(0), std::numeric_limits<int>::max());
+  TVM_FFI_ICHECK_GE(logits.stride(0), vocab_size_i64);
+  TVM_FFI_ICHECK_GT(sm_count, 0);
+  TVM_FFI_ICHECK_LE(sm_count, std::numeric_limits<int>::max());
+
+  auto check_optional_vector = [&](const Optional<TensorView>& maybe_tensor, DLDataType dtype,
+                                   const char* name) {
+    if (!maybe_tensor.has_value()) return;
+    const TensorView& tensor = maybe_tensor.value();
+    CHECK_CUDA(tensor);
+    CHECK_CONTIGUOUS(tensor);
+    CHECK_DEVICE(tensor, logits);
+    TVM_FFI_ICHECK_EQ(tensor.dtype(), dtype) << name << " has an invalid dtype";
+    TVM_FFI_ICHECK_EQ(tensor.ndim(), 1) << name << " must have rank 1";
+    TVM_FFI_ICHECK_EQ(tensor.size(0), batch_size_i64) << name << " must have shape [batch_size]";
+  };
+
+  check_optional_vector(maybe_repetition_penalty, dl_float32, "repetition_penalty");
+  check_optional_vector(maybe_temperature, dl_float32, "temperature");
+  check_optional_vector(maybe_top_p, dl_float32, "top_p");
+  check_optional_vector(maybe_draft_token_ids, dl_int64, "draft_token_ids");
+  if (maybe_top_k.has_value()) {
+    const TensorView& top_k = maybe_top_k.value();
+    CHECK_CUDA(top_k);
+    CHECK_CONTIGUOUS(top_k);
+    CHECK_DEVICE(top_k, logits);
+    CHECK_DIM(1, top_k);
+    TVM_FFI_ICHECK_EQ(top_k.size(0), batch_size_i64);
+    TVM_FFI_ICHECK(top_k.dtype() == dl_int32 || top_k.dtype() == dl_int64)
+        << "top_k dtype must be int32 or int64";
+  }
+  if (maybe_gumbel_noise.has_value()) {
+    const TensorView& noise = maybe_gumbel_noise.value();
+    CHECK_INPUT_AND_TYPE(noise, dl_float32);
+    CHECK_DEVICE(noise, logits);
+    CHECK_DIM(2, noise);
+    TVM_FFI_ICHECK_EQ(noise.size(0), batch_size_i64);
+    TVM_FFI_ICHECK_EQ(noise.size(1), vocab_size_i64);
+  } else {
+    TVM_FFI_ICHECK_GT(seed, 0) << "seed must be > 0 without external gumbel_noise";
+  }
+
+  const int logits_dtype = logits.dtype() == dl_float32 ? 0 : 1;
+  const size_t workspace_size =
+      static_cast<size_t>(workspace_buffer.size(0)) * get_element_size(workspace_buffer);
+  ffi::CUDADeviceGuard device_guard(logits.device().device_id);
+  cudaStream_t stream = get_stream(logits.device());
+  cudaError_t status = cudaSuccess;
+
+  if (temperature_only) {
+    TVM_FFI_ICHECK(!maybe_penalty_mask.has_value() && !maybe_slot_id.has_value() &&
+                   !maybe_repetition_penalty.has_value() && repetition_penalty_val == 0.0 &&
+                   !maybe_top_k.has_value() && top_k_val == 0 && !maybe_top_p.has_value() &&
+                   top_p_val == 0.0 && softmax_policy == sampler_hy3::kSoftmaxNone)
+        << "temperature-only path received an incompatible sampler feature";
+    TVM_FFI_ICHECK(maybe_temperature.has_value() || temperature_val > 0.0)
+        << "temperature-only path requires a positive scalar or per-row temperature";
+    status = sampler_hy3::launch_temperature(
+        static_cast<int32_t*>(output.data_ptr()), logits.data_ptr(), logits_dtype,
+        static_cast<int>(logits.stride(0)),
+        maybe_temperature.has_value()
+            ? static_cast<const float*>(maybe_temperature.value().data_ptr())
+            : nullptr,
+        static_cast<float>(temperature_val),
+        maybe_gumbel_noise.has_value()
+            ? static_cast<const float*>(maybe_gumbel_noise.value().data_ptr())
+            : nullptr,
+        maybe_draft_token_ids.has_value()
+            ? static_cast<const int64_t*>(maybe_draft_token_ids.value().data_ptr())
+            : nullptr,
+        static_cast<int>(batch_size_i64), static_cast<int>(vocab_size_i64),
+        workspace_buffer.data_ptr(), workspace_size, static_cast<int>(sm_count), seed, offset,
+        stream);
+  } else {
+    TVM_FFI_ICHECK(!maybe_draft_token_ids.has_value())
+        << "draft_token_ids is supported only by the temperature-only path";
+    TVM_FFI_ICHECK_GE(softmax_policy, sampler_hy3::kSoftmaxNone);
+    TVM_FFI_ICHECK_LE(softmax_policy, sampler_hy3::kSoftmaxAfterTopK);
+    TVM_FFI_ICHECK(max_top_k == 32 || max_top_k == 64) << "max_top_k must be 32 or 64";
+    TVM_FFI_ICHECK_EQ(maybe_penalty_mask.has_value(), maybe_slot_id.has_value())
+        << "penalty_mask and slot_id must be provided together";
+
+    int penalty_rows = 0;
+    int penalty_row_stride = 0;
+    uint8_t* penalty_mask_ptr = nullptr;
+    const int32_t* slot_id_ptr = nullptr;
+    if (maybe_penalty_mask.has_value()) {
+      const TensorView& penalty_mask = maybe_penalty_mask.value();
+      CHECK_INPUT_AND_TYPE(penalty_mask, dl_uint8);
+      CHECK_DEVICE(penalty_mask, logits);
+      CHECK_DIM(2, penalty_mask);
+      TVM_FFI_ICHECK_GE(penalty_mask.size(0), batch_size_i64);
+      TVM_FFI_ICHECK_GE(penalty_mask.size(1), (vocab_size_i64 + 7) / 8);
+      TVM_FFI_ICHECK_EQ(penalty_mask.stride(0) % 4, 0)
+          << "penalty_mask row stride must be a multiple of four bytes";
+      TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(penalty_mask.data_ptr()) % alignof(uint32_t),
+                        0U)
+          << "penalty_mask address must be aligned to four bytes";
+      TVM_FFI_ICHECK_LE(penalty_mask.size(0), std::numeric_limits<int>::max());
+      TVM_FFI_ICHECK_LE(penalty_mask.stride(0), std::numeric_limits<int>::max());
+      check_optional_vector(maybe_slot_id, dl_int32, "slot_id");
+      penalty_rows = static_cast<int>(penalty_mask.size(0));
+      penalty_row_stride = static_cast<int>(penalty_mask.stride(0));
+      penalty_mask_ptr = static_cast<uint8_t*>(penalty_mask.data_ptr());
+      slot_id_ptr = static_cast<const int32_t*>(maybe_slot_id.value().data_ptr());
+    }
+
+    const bool has_repetition_penalty =
+        maybe_repetition_penalty.has_value() || repetition_penalty_val > 0.0;
+    const bool has_top_k = maybe_top_k.has_value() || top_k_val > 0;
+    const bool has_top_p = maybe_top_p.has_value() || top_p_val > 0.0;
+    TVM_FFI_ICHECK(!has_repetition_penalty || maybe_penalty_mask.has_value())
+        << "repetition_penalty requires penalty_mask and slot_id";
+    TVM_FFI_ICHECK(!has_top_p || has_top_k) << "top_p requires top_k";
+    TVM_FFI_ICHECK(!has_top_p || softmax_policy != sampler_hy3::kSoftmaxNone)
+        << "top_p requires softmax_policy != NONE";
+    TVM_FFI_ICHECK(softmax_policy == sampler_hy3::kSoftmaxNone || has_top_p)
+        << "softmax_policy != NONE requires top_p";
+
+    const int top_k_element_bytes =
+        !maybe_top_k.has_value() ? 0 : (maybe_top_k.value().dtype() == dl_int32 ? 4 : 8);
+    status = sampler_hy3::launch_heavy(
+        static_cast<int32_t*>(output.data_ptr()), logits.data_ptr(), logits_dtype, penalty_mask_ptr,
+        slot_id_ptr,
+        maybe_repetition_penalty.has_value()
+            ? static_cast<const float*>(maybe_repetition_penalty.value().data_ptr())
+            : nullptr,
+        static_cast<float>(repetition_penalty_val),
+        maybe_temperature.has_value()
+            ? static_cast<const float*>(maybe_temperature.value().data_ptr())
+            : nullptr,
+        static_cast<float>(temperature_val), static_cast<int>(softmax_policy),
+        maybe_top_k.has_value() ? maybe_top_k.value().data_ptr() : nullptr, top_k_element_bytes,
+        static_cast<int>(top_k_val),
+        maybe_top_p.has_value() ? static_cast<const float*>(maybe_top_p.value().data_ptr())
+                                : nullptr,
+        static_cast<float>(top_p_val),
+        maybe_gumbel_noise.has_value()
+            ? static_cast<const float*>(maybe_gumbel_noise.value().data_ptr())
+            : nullptr,
+        static_cast<int>(batch_size_i64), static_cast<int>(vocab_size_i64), penalty_rows,
+        penalty_row_stride, static_cast<int>(logits.stride(0)), static_cast<int>(max_top_k),
+        workspace_buffer.data_ptr(), workspace_size, static_cast<int>(sm_count), seed, offset,
+        stream);
+  }
+  TVM_FFI_ICHECK(status == cudaSuccess)
+      << "FusedSamplingFromLogitsHY3 failed with error code " << cudaGetErrorString(status);
+}

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -258,6 +258,7 @@ from .rope import (
     apply_rope_with_cos_sin_cache_inplace as apply_rope_with_cos_sin_cache_inplace,
 )
 from .sampling import chain_speculative_sampling as chain_speculative_sampling
+from .sampling import fused_sampling_from_logits_hy3 as fused_sampling_from_logits_hy3
 from .sampling import min_p_sampling_from_probs as min_p_sampling_from_probs
 from .sampling import sampling_from_logits as sampling_from_logits
 from .sampling import sampling_from_probs as sampling_from_probs

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -149,6 +149,7 @@ from .jit.page import gen_page_module
 from .jit.quantization import gen_quantization_module
 from .jit.rope import gen_rope_module
 from .jit.sampling import gen_sampling_module
+from .jit.sampling_hy3 import gen_fused_sampling_hy3_module
 from .jit.spdlog import gen_spdlog_module
 from .jit.moe_utils import gen_moe_utils_module
 from .jit.hash_topk import gen_hash_topk_module
@@ -789,6 +790,8 @@ def gen_all_modules(
         ]
         # Fused RMSNorm+SiLU: pre-compile all LUT configs (SM100+ only)
         if has_sm100:
+            # The fused sampler's CUDA path is specialized for B200 (SM100).
+            jit_specs.append(gen_fused_sampling_hy3_module())
             for C in _SUPPORTED_C:
                 for tokens in _SUPPORTED_TOKENS:
                     for dtype in ["bf16", "fp8", "nvfp4"]:

--- a/flashinfer/jit/sampling_hy3.py
+++ b/flashinfer/jit/sampling_hy3.py
@@ -1,0 +1,40 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec
+
+
+def gen_fused_sampling_hy3_module() -> JitSpec:
+    """Build the HY3 fused sampler optimized for SM100/B200.
+
+    ``gen_jit_spec`` adds ``-use_fast_math`` globally. Appending the explicit
+    precision flags restores the source build's division/FTZ behavior, while
+    the CUDA header calls libdevice directly for precise ``expf``. A separate
+    JIT module keeps the existing FlashInfer sampling implementation untouched.
+    """
+    return gen_jit_spec(
+        "fused_sampling_hy3",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "sampling_hy3.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "flashinfer_sampling_hy3_binding.cu",
+        ],
+        extra_cuda_cflags=[
+            "--ftz=false",
+            "--prec-div=true",
+            "--prec-sqrt=true",
+        ],
+    )

--- a/flashinfer/sampling.py
+++ b/flashinfer/sampling.py
@@ -21,8 +21,10 @@ import torch
 
 from .api_logging import flashinfer_api
 from .jit.sampling import gen_sampling_module
+from .jit.sampling_hy3 import gen_fused_sampling_hy3_module
 from .trace.templates.sampling import (
     chain_speculative_sampling_trace,
+    fused_sampling_hy3_trace_dispatch,
     min_p_sampling_trace,
     sampling_from_logits_trace,
     sampling_from_probs_trace,
@@ -665,6 +667,90 @@ def get_sampling_module():
     )
 
 
+@functools.cache
+def get_fused_sampling_hy3_module():
+    return gen_fused_sampling_hy3_module().build_and_load()
+
+
+@register_custom_op(
+    "flashinfer::fused_sampling_from_logits_hy3",
+    mutates_args=("workspace_buffer", "output", "penalty_mask"),
+)
+def _fused_sampling_from_logits_hy3(
+    workspace_buffer: torch.Tensor,
+    output: torch.Tensor,
+    logits: torch.Tensor,
+    penalty_mask: Optional[torch.Tensor],
+    slot_id: Optional[torch.Tensor],
+    repetition_penalty: Optional[torch.Tensor],
+    repetition_penalty_val: float,
+    temperature: Optional[torch.Tensor],
+    temperature_val: float,
+    softmax_policy: int,
+    top_k: Optional[torch.Tensor],
+    top_k_val: int,
+    top_p: Optional[torch.Tensor],
+    top_p_val: float,
+    max_top_k: int,
+    gumbel_noise: Optional[torch.Tensor],
+    draft_token_ids: Optional[torch.Tensor],
+    sm_count: int,
+    seed: int,
+    offset: int,
+    temperature_only: bool,
+) -> None:
+    get_fused_sampling_hy3_module().fused_sampling_from_logits_hy3(
+        workspace_buffer,
+        logits,
+        output,
+        penalty_mask,
+        slot_id,
+        repetition_penalty,
+        repetition_penalty_val,
+        temperature,
+        temperature_val,
+        softmax_policy,
+        top_k,
+        top_k_val,
+        top_p,
+        top_p_val,
+        max_top_k,
+        gumbel_noise,
+        draft_token_ids,
+        sm_count,
+        seed,
+        offset,
+        temperature_only,
+    )
+
+
+@register_fake_op("flashinfer::fused_sampling_from_logits_hy3")
+def _fake_fused_sampling_from_logits_hy3(
+    workspace_buffer: torch.Tensor,
+    output: torch.Tensor,
+    logits: torch.Tensor,
+    penalty_mask: Optional[torch.Tensor],
+    slot_id: Optional[torch.Tensor],
+    repetition_penalty: Optional[torch.Tensor],
+    repetition_penalty_val: float,
+    temperature: Optional[torch.Tensor],
+    temperature_val: float,
+    softmax_policy: int,
+    top_k: Optional[torch.Tensor],
+    top_k_val: int,
+    top_p: Optional[torch.Tensor],
+    top_p_val: float,
+    max_top_k: int,
+    gumbel_noise: Optional[torch.Tensor],
+    draft_token_ids: Optional[torch.Tensor],
+    sm_count: int,
+    seed: int,
+    offset: int,
+    temperature_only: bool,
+) -> None:
+    pass
+
+
 def _to_tensor_scalar_tuple(x):
     if isinstance(x, torch.Tensor):
         return (x, 0)
@@ -731,6 +817,485 @@ def _validate_and_convert_seed_offset(
             raise ValueError(f"offset tensor length must be 1 or {batch_size}")
 
     return maybe_seed_arr, seed_val, maybe_offset_arr, offset_val
+
+
+HY3_SAMPLER_SOFTMAX_NONE = 0
+HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K = 1
+HY3_SAMPLER_SOFTMAX_AFTER_TOP_K = 2
+_HY3_SAMPLER_VOCAB_SIZE = 120832
+_HY3_UINT64_MODULUS = 1 << 64
+_HY3_INT64_MAX = (1 << 63) - 1
+
+
+@functools.cache
+def _hy3_sampler_device_info(device: torch.device) -> Tuple[bool, int]:
+    """Cache capability/SM queries; neither belongs on the per-token hot path."""
+    if device.type != "cuda":
+        return False, 0
+    major, minor = torch.cuda.get_device_capability(device)
+    sm_count = torch.cuda.get_device_properties(device).multi_processor_count
+    return (major, minor) == (10, 0), sm_count
+
+
+def _hy3_sampler_workspace_size(
+    batch_size: int,
+    sm_count: int,
+    temperature_only: bool,
+    softmax_policy: int,
+) -> int:
+    if temperature_only:
+        return batch_size * (sm_count * 8 + 4)
+    # The accepted B200 dispatch uses 1024 candidate slots/request for B<8 and
+    # 512 otherwise. BEFORE_TOP_K additionally stores a max/sum pair per block.
+    candidate_count = batch_size * (1024 if batch_size < 8 else 512)
+    size = candidate_count * 8
+    if softmax_policy == HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K:
+        size += batch_size * (32 if batch_size < 8 else 16) * 8
+    return size
+
+
+def _hy3_sampler_row_value(
+    value: Union[torch.Tensor, float, int],
+    batch_size: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if isinstance(value, torch.Tensor):
+        return value.to(dtype=dtype)
+    return torch.full((batch_size,), value, dtype=dtype, device=device)
+
+
+def _fused_sampling_from_logits_hy3_fallback(
+    logits: torch.Tensor,
+    *,
+    penalty_mask: Optional[torch.Tensor],
+    slot_id: Optional[torch.Tensor],
+    repetition_penalty: Union[torch.Tensor, float],
+    temperature: Union[torch.Tensor, float],
+    softmax_policy: int,
+    top_k: Union[torch.Tensor, int],
+    top_p: Union[torch.Tensor, float],
+    max_top_k: int,
+    gumbel_noise: Optional[torch.Tensor],
+    draft_token_ids: Optional[torch.Tensor],
+    seed: int,
+    offset: int,
+    temperature_only: bool,
+) -> torch.Tensor:
+    """Portable HY3 semantics when the optimized SM100 path is unsupported."""
+    batch_size, vocab_size = logits.shape
+    work = logits.float()
+    if gumbel_noise is None:
+        fallback_generator = torch.Generator(device=logits.device)
+        mixed_seed = (int(seed) + 0x9E3779B97F4A7C15 * int(offset)) & (
+            _HY3_UINT64_MODULUS - 1
+        )
+        fallback_generator.manual_seed(mixed_seed)
+        uniform = torch.rand(
+            logits.shape,
+            dtype=torch.float32,
+            device=logits.device,
+            generator=fallback_generator,
+        ).clamp_min_(1e-20)
+        gumbel_noise = -(-uniform.log()).log()
+
+    if temperature_only:
+        temp = _hy3_sampler_row_value(
+            temperature, batch_size, logits.device, torch.float32
+        )
+        work = work / torch.where(temp > 0, temp, torch.ones_like(temp))[:, None]
+        if draft_token_ids is not None:
+            valid = (draft_token_ids >= 0) & (draft_token_ids < vocab_size)
+            rows = torch.arange(batch_size, device=logits.device)
+            tokens = draft_token_ids.clamp(0, max(vocab_size - 1, 0)).long()
+            old = work[rows, tokens]
+            work = work.clone()
+            work[rows, tokens] = torch.where(
+                valid, torch.full_like(old, float("-inf")), old
+            )
+        return (work + gumbel_noise).argmax(dim=-1).to(torch.int32).view(-1, 1)
+
+    work = work.clone()
+    rp = _hy3_sampler_row_value(
+        repetition_penalty, batch_size, logits.device, torch.float32
+    )
+    if penalty_mask is not None and slot_id is not None:
+        valid_slot = (slot_id >= 0) & (slot_id < penalty_mask.size(0))
+        safe_slot = slot_id.clamp(0, max(penalty_mask.size(0) - 1, 0)).long()
+        packed = penalty_mask.index_select(0, safe_slot)
+        columns = torch.arange(vocab_size, device=logits.device)
+        bits = ((packed[:, columns >> 3] >> (columns & 7)) & 1).bool()
+        active = bits & valid_slot[:, None] & (rp > 0)[:, None]
+        penalized = torch.where(work > 0, work / rp[:, None], work * rp[:, None])
+        work = torch.where(active, penalized, work)
+
+    temp = _hy3_sampler_row_value(temperature, batch_size, logits.device, torch.float32)
+    work = work / torch.where(temp > 0, temp, torch.ones_like(temp))[:, None]
+    if softmax_policy == HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K:
+        work = torch.softmax(work, dim=-1)
+
+    candidate_count = min(max_top_k, vocab_size)
+    values, tokens = torch.topk(work, candidate_count, dim=-1, sorted=True)
+    requested_k = _hy3_sampler_row_value(top_k, batch_size, logits.device, torch.int64)
+    effective_k = torch.where(
+        requested_k > 0,
+        requested_k.clamp(max=candidate_count),
+        torch.full_like(requested_k, candidate_count),
+    )
+    positions = torch.arange(candidate_count, device=logits.device)[None, :]
+    candidate_valid = positions < effective_k[:, None]
+
+    probabilities: Optional[torch.Tensor] = None
+    if softmax_policy == HY3_SAMPLER_SOFTMAX_AFTER_TOP_K:
+        probabilities = torch.softmax(
+            values.masked_fill(~candidate_valid, float("-inf")), dim=-1
+        )
+        sample_values = torch.where(
+            probabilities > 0,
+            probabilities.log(),
+            torch.full_like(probabilities, float("-inf")),
+        )
+    elif softmax_policy == HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K:
+        probabilities = values
+        sample_values = torch.where(
+            probabilities > 0,
+            probabilities.log(),
+            torch.full_like(probabilities, float("-inf")),
+        )
+    else:
+        sample_values = values
+
+    keep = candidate_valid
+    if probabilities is not None:
+        thresholds = _hy3_sampler_row_value(
+            top_p, batch_size, logits.device, torch.float32
+        )
+        exclusive = probabilities.cumsum(dim=-1) - probabilities
+        keep = keep & (
+            (thresholds <= 0)[:, None]
+            | (positions == 0)
+            | (exclusive < thresholds[:, None])
+        )
+    scores = sample_values + gumbel_noise.gather(1, tokens)
+    scores = scores.masked_fill(~keep, float("-inf"))
+    maxima = scores.max(dim=-1, keepdim=True).values
+    tied_tokens = torch.where(
+        scores == maxima, tokens, torch.full_like(tokens, vocab_size)
+    )
+    sampled = tied_tokens.min(dim=-1).values
+    sampled = torch.where(sampled < vocab_size, sampled, torch.zeros_like(sampled))
+    output = sampled.to(torch.int32).view(-1, 1)
+
+    if penalty_mask is not None and slot_id is not None:
+        valid_slot = (slot_id >= 0) & (slot_id < penalty_mask.size(0))
+        safe_slot = slot_id.clamp(0, max(penalty_mask.size(0) - 1, 0)).long()
+        token = output[:, 0].long()
+        byte = token >> 3
+        bit_position = token & 7
+        active = valid_slot & (rp > 0)
+
+        # Match the CUDA kernel's atomicOr semantics when multiple rows map to
+        # the same slot and byte.  De-duplicating (byte, bit) pairs prevents a
+        # repeated bit from carrying during the subsequent integer sum.
+        flat_byte = safe_slot * penalty_mask.stride(0) + byte
+        encoded_updates = torch.unique(((flat_byte << 3) | bit_position)[active])
+        update_bytes = encoded_updates >> 3
+        update_bits = (torch.ones_like(encoded_updates) << (encoded_updates & 7)).to(
+            torch.int32
+        )
+        unique_bytes, inverse = torch.unique(update_bytes, return_inverse=True)
+        combined_bits = torch.zeros_like(unique_bytes, dtype=torch.int32)
+        combined_bits.scatter_add_(0, inverse, update_bits)
+
+        flat_penalty_mask = penalty_mask.view(-1)
+        old = flat_penalty_mask.index_select(0, unique_bytes).to(torch.int32)
+        flat_penalty_mask[unique_bytes] = (old | combined_bits).to(torch.uint8)
+    return output
+
+
+@flashinfer_api(trace=fused_sampling_hy3_trace_dispatch)
+def fused_sampling_from_logits_hy3(
+    logits: torch.Tensor,
+    *,
+    workspace_buffer: Optional[torch.Tensor] = None,
+    out: Optional[torch.Tensor] = None,
+    penalty_mask: Optional[torch.Tensor] = None,
+    slot_id: Optional[torch.Tensor] = None,
+    repetition_penalty: Union[torch.Tensor, float] = 0.0,
+    temperature: Union[torch.Tensor, float] = 0.0,
+    softmax_policy: int = HY3_SAMPLER_SOFTMAX_NONE,
+    top_k: Union[torch.Tensor, int] = 0,
+    top_p: Union[torch.Tensor, float] = 0.0,
+    max_top_k: int = 32,
+    gumbel_noise: Optional[torch.Tensor] = None,
+    draft_token_ids: Optional[torch.Tensor] = None,
+    generator: Optional[torch.Generator] = None,
+    seed: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> torch.Tensor:
+    r"""HY3 fused repetition penalty, temperature, top-k/top-p and sampling.
+
+    The optimized path targets SM100/B200 and HY3's 120832-token vocabulary.
+    Passing
+    external FP32 Gumbel noise provides the deterministic parity boundary.
+    ``workspace_buffer`` and ``out`` can be preallocated to keep addresses
+    stable during CUDA graph replay. Graph replay with random sampling must
+    update an external ``gumbel_noise`` tensor inside the graph; scalar
+    ``seed``/``offset`` values are fixed at capture time. Callers should pass
+    explicit buffers for graph capture and must not share one workspace across
+    concurrently executing streams. The output has shape ``[batch_size, 1]``
+    and dtype ``int32``.
+
+    Parameters
+    ----------
+    logits : torch.Tensor
+        Rank-2 floating-point logits with shape ``[batch_size, vocab_size]``.
+        The B200 kernel is selected for the HY3 vocabulary size (120832);
+        other supported inputs use the portable PyTorch implementation.
+    workspace_buffer : Optional[torch.Tensor]
+        Optional contiguous 1-D uint8 scratch buffer. Reuse one buffer per
+        concurrently executing CUDA stream.
+    out : Optional[torch.Tensor]
+        Optional contiguous int32 output with shape ``[batch_size, 1]``.
+    penalty_mask : Optional[torch.Tensor]
+        Packed uint8 repetition mask. Each bit marks one vocabulary entry and
+        the sampled entry is set in place.
+    slot_id : Optional[torch.Tensor]
+        Int32 row selector into ``penalty_mask``, shape ``[batch_size]``.
+    repetition_penalty : Union[torch.Tensor, float]
+        Per-row float32 values or one scalar. A positive value requires
+        ``penalty_mask`` and ``slot_id``.
+    temperature : Union[torch.Tensor, float]
+        Per-row float32 values or one scalar temperature. Values greater than
+        zero scale logits; non-positive values disable temperature scaling.
+    softmax_policy : int
+        ``0`` disables softmax, ``1`` applies it before top-k, and ``2``
+        applies it after top-k.
+    top_k : Union[torch.Tensor, int]
+        Per-row int32/int64 values or one scalar top-k cutoff.
+    top_p : Union[torch.Tensor, float]
+        Per-row float32 values or one scalar nucleus threshold.
+    max_top_k : int
+        Compile-time candidate capacity; must be 32 or 64.
+    gumbel_noise : Optional[torch.Tensor]
+        Optional contiguous FP32 noise with the same shape as ``logits``.
+        Providing it gives a deterministic parity boundary.
+    draft_token_ids : Optional[torch.Tensor]
+        Optional int64 IDs excluded by the temperature-only path.
+    generator : Optional[torch.Generator]
+        Generator used to obtain a Philox seed and offset when external noise
+        and an explicit seed are absent.
+    seed : Optional[int]
+        Random seed used by the fused CUDA path. Must be greater than zero
+        when ``gumbel_noise`` is not provided.
+    offset : Optional[int]
+        Random subsequence offset used by the fused CUDA path.
+
+    Returns
+    -------
+    torch.Tensor
+        Sampled int32 IDs with shape ``[batch_size, 1]``.
+    """
+    if logits.ndim != 2 or not logits.dtype.is_floating_point:
+        raise ValueError("logits must be a rank-2 floating-point tensor")
+    batch_size, vocab_size = logits.shape
+    if batch_size <= 0 or vocab_size <= 0:
+        raise ValueError("logits dimensions must be positive")
+    if out is not None and (
+        out.device != logits.device
+        or out.dtype != torch.int32
+        or out.shape != (batch_size, 1)
+        or not out.is_contiguous()
+    ):
+        raise ValueError(
+            "out must be contiguous int32 [batch_size, 1] on logits.device"
+        )
+    if workspace_buffer is not None and (
+        workspace_buffer.device != logits.device
+        or workspace_buffer.dtype != torch.uint8
+        or workspace_buffer.ndim != 1
+        or not workspace_buffer.is_contiguous()
+    ):
+        raise ValueError(
+            "workspace_buffer must be contiguous 1D uint8 on logits.device"
+        )
+    if max_top_k not in (32, 64):
+        raise ValueError("max_top_k must be 32 or 64")
+    if softmax_policy not in (0, 1, 2):
+        raise ValueError("softmax_policy must be 0, 1, or 2")
+
+    def check_row_tensor(
+        value: object, name: str, dtypes: Tuple[torch.dtype, ...]
+    ) -> None:
+        if not isinstance(value, torch.Tensor):
+            return
+        if value.device != logits.device or not value.is_contiguous():
+            raise ValueError(f"{name} must be contiguous and on logits.device")
+        if value.dtype not in dtypes or value.shape != (batch_size,):
+            raise ValueError(f"{name} has an invalid dtype or shape")
+
+    check_row_tensor(repetition_penalty, "repetition_penalty", (torch.float32,))
+    check_row_tensor(temperature, "temperature", (torch.float32,))
+    check_row_tensor(top_k, "top_k", (torch.int32, torch.int64))
+    check_row_tensor(top_p, "top_p", (torch.float32,))
+    check_row_tensor(slot_id, "slot_id", (torch.int32,))
+    check_row_tensor(draft_token_ids, "draft_token_ids", (torch.int64,))
+    if (penalty_mask is None) != (slot_id is None):
+        raise ValueError("penalty_mask and slot_id must be provided together")
+    if penalty_mask is not None:
+        if (
+            penalty_mask.device != logits.device
+            or penalty_mask.dtype != torch.uint8
+            or penalty_mask.ndim != 2
+            or not penalty_mask.is_contiguous()
+            or penalty_mask.size(0) < batch_size
+            or penalty_mask.size(1) < (vocab_size + 7) // 8
+        ):
+            raise ValueError(
+                "penalty_mask must be contiguous uint8 [rows>=B, bytes>=ceil(V/8)]"
+            )
+        if penalty_mask.stride(0) % 4 != 0:
+            raise ValueError("penalty_mask row stride must be a multiple of four bytes")
+        if penalty_mask.data_ptr() % 4 != 0:
+            raise ValueError("penalty_mask address must be aligned to four bytes")
+    if gumbel_noise is not None and (
+        gumbel_noise.device != logits.device
+        or gumbel_noise.dtype != torch.float32
+        or gumbel_noise.shape != logits.shape
+        or not gumbel_noise.is_contiguous()
+    ):
+        raise ValueError("gumbel_noise must be contiguous float32 with logits.shape")
+
+    def scalar_zero(x: Union[torch.Tensor, float]) -> bool:
+        """Return whether a non-tensor scalar is zero."""
+        return not isinstance(x, torch.Tensor) and float(x) == 0.0
+
+    temperature_only = (
+        penalty_mask is None
+        and scalar_zero(repetition_penalty)
+        and scalar_zero(top_p)
+        and not isinstance(top_k, torch.Tensor)
+        and int(top_k) == 0
+        and softmax_policy == HY3_SAMPLER_SOFTMAX_NONE
+        and (isinstance(temperature, torch.Tensor) or float(temperature) > 0.0)
+    )
+    if draft_token_ids is not None and not temperature_only:
+        raise ValueError("draft_token_ids requires the temperature-only path")
+    has_rp = (
+        isinstance(repetition_penalty, torch.Tensor) or float(repetition_penalty) > 0
+    )
+    has_top_k = isinstance(top_k, torch.Tensor) or int(top_k) > 0
+    has_top_p = isinstance(top_p, torch.Tensor) or float(top_p) > 0
+    if has_rp and penalty_mask is None:
+        raise ValueError("repetition_penalty requires penalty_mask and slot_id")
+    if has_top_p and (not has_top_k or softmax_policy == 0):
+        raise ValueError("top_p requires top_k and softmax_policy != NONE")
+    if softmax_policy != 0 and not has_top_p:
+        raise ValueError("softmax_policy != NONE requires top_p")
+
+    if gumbel_noise is None:
+        if seed is None:
+            seed, generated_offset = get_seed_and_offset(
+                batch_size * max_top_k, generator, logits.device
+            )
+            # CUDA generator state stores the full uint64 seed, while
+            # get_seed_and_offset views it as int64.  Recover the original bit
+            # pattern before applying the positive-seed API contract.  Zero is
+            # valid generator state but reserved by this API, so only the
+            # generated value is remapped; an explicit zero remains invalid.
+            seed = int(seed) & (_HY3_UINT64_MODULUS - 1)
+            if seed == 0:
+                seed = 1
+            if offset is None:
+                offset = generated_offset
+        if int(seed) <= 0:
+            raise ValueError("seed must be > 0 without external gumbel_noise")
+        if int(seed) >= _HY3_UINT64_MODULUS:
+            raise ValueError("seed must be less than 2**64")
+    else:
+        seed = 0 if seed is None else seed
+    offset = 0 if offset is None else offset
+
+    is_sm100, sm_count = _hy3_sampler_device_info(logits.device)
+    use_hy3_kernel = (
+        is_sm100
+        and vocab_size == _HY3_SAMPLER_VOCAB_SIZE
+        and logits.dtype in (torch.float32, torch.bfloat16)
+        and logits.stride(1) == 1
+        and (penalty_mask is None or penalty_mask.stride(0) % 4 == 0)
+    )
+    if not use_hy3_kernel:
+        result = _fused_sampling_from_logits_hy3_fallback(
+            logits,
+            penalty_mask=penalty_mask,
+            slot_id=slot_id,
+            repetition_penalty=repetition_penalty,
+            temperature=temperature,
+            softmax_policy=softmax_policy,
+            top_k=top_k,
+            top_p=top_p,
+            max_top_k=max_top_k,
+            gumbel_noise=gumbel_noise,
+            draft_token_ids=draft_token_ids,
+            seed=int(seed),
+            offset=int(offset),
+            temperature_only=temperature_only,
+        )
+        if out is not None:
+            out.copy_(result)
+            return out
+        return result
+
+    workspace_size = _hy3_sampler_workspace_size(
+        batch_size, sm_count, temperature_only, softmax_policy
+    )
+    if workspace_buffer is None:
+        stream_id = torch.cuda.current_stream(logits.device).cuda_stream
+        workspace_buffer = _get_cache_buf(
+            f"fused_sampler_hy3_workspace_{stream_id}", workspace_size, logits.device
+        )
+    elif workspace_buffer.numel() < workspace_size:
+        raise ValueError(
+            f"workspace_buffer is too small: need {workspace_size} bytes, "
+            f"got {workspace_buffer.numel()}"
+        )
+    elif workspace_buffer.data_ptr() % 4 != 0:
+        raise ValueError("workspace_buffer address must be aligned to four bytes")
+    if out is None:
+        out = torch.empty((batch_size, 1), dtype=torch.int32, device=logits.device)
+    rp_tensor, rp_val = _to_tensor_scalar_tuple(repetition_penalty)
+    temp_tensor, temp_val = _to_tensor_scalar_tuple(temperature)
+    top_k_tensor, top_k_val = _to_tensor_scalar_tuple(top_k)
+    top_p_tensor, top_p_val = _to_tensor_scalar_tuple(top_p)
+    ffi_seed = int(seed)
+    if ffi_seed > _HY3_INT64_MAX:
+        # TVM-FFI transports Python integers through signed int64.  C++ then
+        # converts this carrier back to uint64_t without changing its bits.
+        ffi_seed -= _HY3_UINT64_MODULUS
+    _fused_sampling_from_logits_hy3(
+        workspace_buffer,
+        out,
+        logits,
+        penalty_mask,
+        slot_id,
+        rp_tensor,
+        float(rp_val),
+        temp_tensor,
+        float(temp_val),
+        int(softmax_policy),
+        top_k_tensor,
+        int(top_k_val),
+        top_p_tensor,
+        float(top_p_val),
+        max_top_k,
+        gumbel_noise,
+        draft_token_ids,
+        sm_count,
+        ffi_seed,
+        int(offset),
+        temperature_only,
+    )
+    return out
 
 
 @flashinfer_api(trace=softmax_trace)

--- a/flashinfer/trace/templates/sampling.py
+++ b/flashinfer/trace/templates/sampling.py
@@ -684,6 +684,134 @@ top_k_top_p_sampling_from_logits_trace = TraceTemplate(
 )
 
 
+# ── HY3 fused sampling (B200 heavy path) ─────────────────────────────────────
+
+
+def _fused_sampling_hy3_init(
+    *,
+    batch_size: int,
+    vocab_size: int = 120832,
+    penalty_rows: int = 0,
+    vocab_bytes: int = 0,
+    workspace_bytes: int = 8 * 1024 * 1024,
+    output_width: int = 1,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build the scalar-parameter B200 heavy path for the HY3 sampler."""
+    del output_width  # fixed by the public API
+    torch.manual_seed(seed)
+    penalty_rows = max(batch_size, penalty_rows)
+    vocab_bytes = max((vocab_size + 7) // 8, vocab_bytes)
+    return {
+        "logits": make_logits(
+            batch_size, vocab_size, dtype=torch.bfloat16, device=device
+        ),
+        "workspace_buffer": torch.empty(
+            workspace_bytes, dtype=torch.uint8, device=device
+        ),
+        "out": torch.empty(batch_size, 1, dtype=torch.int32, device=device),
+        "penalty_mask": torch.zeros(
+            penalty_rows, vocab_bytes, dtype=torch.uint8, device=device
+        ),
+        "slot_id": torch.arange(batch_size, dtype=torch.int32, device=device),
+        "repetition_penalty": 1.1,
+        "temperature": 0.8,
+        "softmax_policy": 2,
+        "top_k": 20,
+        "top_p": 0.9,
+        "max_top_k": 32,
+        "gumbel_noise": torch.zeros(
+            batch_size, vocab_size, dtype=torch.float32, device=device
+        ),
+    }
+
+
+fused_sampling_hy3_trace = TraceTemplate(
+    op_type="sampling",
+    name_prefix="fused_sampling_hy3",
+    description=(
+        "HY3 B200 heavy sampling path: apply a packed repetition mask, "
+        "temperature, top-k, top-p, and external Gumbel noise in a fused "
+        "pipeline. The sampled vocabulary entry is written back to the "
+        "penalty mask. Tensor-valued scalar parameters and the "
+        "temperature-only path are intentionally outside this trace variant."
+    ),
+    axes={
+        "batch_size": Var(),
+        "vocab_size": Const(abbrev="v"),
+        "penalty_rows": Var(),
+        "vocab_bytes": Var(),
+        "workspace_bytes": Var(),
+        "output_width": Const(value=1, abbrev=""),
+    },
+    inputs={
+        "logits": Tensor(["batch_size", "vocab_size"]),
+        "penalty_mask": Tensor(
+            ["penalty_rows", "vocab_bytes"],
+            dtype="uint8",
+            description="Packed repetition mask, updated in place.",
+        ),
+        "slot_id": Tensor(["batch_size"], dtype="int32"),
+        "repetition_penalty": Scalar("float32"),
+        "temperature": Scalar("float32"),
+        "softmax_policy": Scalar("int32"),
+        "top_k": Scalar("int32"),
+        "top_p": Scalar("float32"),
+        "max_top_k": Scalar("int32"),
+        "gumbel_noise": Tensor(["batch_size", "vocab_size"], dtype="float32"),
+        "workspace_buffer": Tensor(["workspace_bytes"], dtype="uint8", optional=True),
+        "out": Tensor(["batch_size", "output_width"], dtype="int32", optional=True),
+    },
+    outputs={
+        "samples": Tensor(["batch_size", "output_width"], dtype="int32", param="out"),
+        "penalty_mask": Tensor(
+            ["penalty_rows", "vocab_bytes"],
+            dtype="uint8",
+            param="penalty_mask",
+            description="Packed repetition mask after setting each sampled entry.",
+        ),
+    },
+    constraints=[
+        "penalty_rows >= batch_size",
+        "vocab_bytes * 8 >= vocab_size",
+        "softmax_policy == 2",
+        "max_top_k == 32",
+    ],
+    tags=["status:experimental", "fused", "arch:sm100"],
+    init=_fused_sampling_hy3_init,
+)
+
+
+def fused_sampling_hy3_trace_dispatch(save_dir=None, name=None, **kwargs):
+    """Trace only the scalar-parameter heavy path implemented for B200."""
+    del save_dir, name
+    if "logits" not in kwargs and "batch_size" in kwargs:
+        return fused_sampling_hy3_trace
+    logits = kwargs.get("logits")
+    if not isinstance(logits, torch.Tensor) or logits.ndim != 2:
+        return None
+    scalar_params = ("repetition_penalty", "temperature", "top_k", "top_p")
+    if any(isinstance(kwargs.get(param), torch.Tensor) for param in scalar_params):
+        return None
+    if (
+        logits.shape[1] != 120832
+        or kwargs.get("penalty_mask") is None
+        or kwargs.get("slot_id") is None
+        or kwargs.get("gumbel_noise") is None
+        or kwargs.get("draft_token_ids") is not None
+        or int(kwargs.get("softmax_policy", 0)) != 2
+        or int(kwargs.get("max_top_k", 32)) != 32
+    ):
+        return None
+    return fused_sampling_hy3_trace
+
+
+fused_sampling_hy3_trace_dispatch.templates = (  # type: ignore[attr-defined]
+    fused_sampling_hy3_trace,
+)
+
+
 @torch.no_grad()
 def _chain_speculative_sampling_reference(
     draft_probs,

--- a/include/flashinfer/sampling_hy3.cuh
+++ b/include/flashinfer/sampling_hy3.cuh
@@ -1,0 +1,1073 @@
+// Copyright (C) 2026 Tencent.
+// SPDX-License-Identifier: MIT
+// HY3 sampler derived from Tencent/HPC-Ops commit
+// 1cd332980ed46bd0172091c1c35d55338fcae47a and optimized for SM100/B200.
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <stddef.h>
+#include <stdint.h>
+
+namespace flashinfer::sampling::hy3 {
+
+#ifdef __CUDACC__
+// Call libdevice directly so this kernel retains the same expf implementation
+// as the source-faithful build even when FlashInfer's generic JIT defaults to
+// --use_fast_math. The dedicated JIT target restores FTZ/division flags too.
+extern "C" __device__ float __nv_expf(float);
+#endif
+
+constexpr int kVocabSize = 120832;
+constexpr int kSoftmaxNone = 0;
+constexpr int kSoftmaxBeforeTopK = 1;
+constexpr int kSoftmaxAfterTopK = 2;
+
+#ifdef __CUDACC__
+
+template <typename T, int N>
+struct Vec {
+  T data[N];
+  __device__ __forceinline__ T& operator[](int i) { return data[i]; }
+  __device__ __forceinline__ const T& operator[](int i) const { return data[i]; }
+};
+
+template <typename T, int N>
+__device__ __forceinline__ Vec<T, N> load_vec(const T* ptr) {
+  constexpr int kBytes = sizeof(T) * N;
+  static_assert(kBytes == 4 || kBytes == 8 || kBytes == 16);
+  Vec<T, N> out;
+  if constexpr (kBytes == 4) {
+    *reinterpret_cast<uint32_t*>(&out) = *reinterpret_cast<const uint32_t*>(ptr);
+  } else if constexpr (kBytes == 8) {
+    *reinterpret_cast<uint64_t*>(&out) = *reinterpret_cast<const uint64_t*>(ptr);
+  } else {
+    *reinterpret_cast<uint4*>(&out) = *reinterpret_cast<const uint4*>(ptr);
+  }
+  return out;
+}
+
+__device__ __forceinline__ float fast_exp(float x) {
+  float out;
+  asm("ex2.approx.ftz.f32 %0, %1;" : "=f"(out) : "f"(x * 1.4426950408889634f));
+  return out;
+}
+
+__device__ __forceinline__ float precise_exp(float x) { return __nv_expf(x); }
+
+__device__ __forceinline__ float fast_log(float x) {
+  float out;
+  asm("lg2.approx.ftz.f32 %0, %1;" : "=f"(out) : "f"(x));
+  return out * 0.6931471805599453f;
+}
+
+__device__ __forceinline__ float fast_rcp(float x) {
+  float out;
+  asm("rcp.approx.ftz.f32 %0, %1;" : "=f"(out) : "f"(x));
+  return out;
+}
+
+__device__ __forceinline__ float warp_sum(float x) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    x += __shfl_xor_sync(0xffffffff, x, offset);
+  }
+  return x;
+}
+
+__device__ __forceinline__ float warp_max(float x) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    x = fmaxf(x, __shfl_xor_sync(0xffffffff, x, offset));
+  }
+  return x;
+}
+
+__device__ __forceinline__ bool take_other(float other_score, int other_token, float score,
+                                           int token) {
+  if (other_score > score) return true;
+  if (other_score < score || other_token < 0) return false;
+  return token < 0 || other_token < token;
+}
+
+__device__ __forceinline__ float gumbel_from_uniform(float u) {
+  const float inner = fmaxf(-fast_log(u), 1e-20f);
+  return -fast_log(inner);
+}
+
+#endif  // __CUDACC__
+
+cudaError_t launch_temperature(int32_t* output, const void* logits, int logits_dtype,
+                               int logits_row_stride, const float* temperature,
+                               float temperature_value, const float* gumbel_noise,
+                               const int64_t* draft_token_ids, int batch_size, int vocab_size,
+                               void* workspace, size_t workspace_size, int sm_count, uint64_t seed,
+                               uint64_t rng_offset, cudaStream_t stream);
+
+cudaError_t launch_heavy(int32_t* output, const void* logits, int logits_dtype,
+                         uint8_t* penalty_mask, const int32_t* slot_id,
+                         const float* repetition_penalty, float repetition_penalty_value,
+                         const float* temperature, float temperature_value, int softmax_policy,
+                         const void* topk, int topk_element_bytes, int topk_value,
+                         const float* topp, float topp_value, const float* gumbel_noise,
+                         int batch_size, int vocab_size, int penalty_rows, int penalty_row_stride,
+                         int logits_row_stride, int max_topk, void* workspace,
+                         size_t workspace_size, int sm_count, uint64_t seed, uint64_t rng_offset,
+                         cudaStream_t stream);
+
+}  // namespace flashinfer::sampling::hy3
+
+// Kernel implementation retained under the Tencent/HPC-Ops MIT license.
+
+#include <curand_kernel.h>
+
+#include <algorithm>
+#include <cub/cub.cuh>
+#include <limits>
+#include <type_traits>
+
+namespace flashinfer::sampling::hy3 {
+namespace {
+
+constexpr float kNegInf = -std::numeric_limits<float>::infinity();
+
+template <typename DType, int N>
+__device__ __forceinline__ void load_as_float(const DType* ptr, float* out) {
+  constexpr uintptr_t kAlignment = sizeof(DType) * N;
+  if ((reinterpret_cast<uintptr_t>(ptr) & (kAlignment - 1)) != 0) {
+#pragma unroll
+    for (int i = 0; i < N; ++i) {
+      if constexpr (std::is_same_v<DType, float>) {
+        out[i] = ptr[i];
+      } else {
+        out[i] = __bfloat162float(ptr[i]);
+      }
+    }
+    return;
+  }
+  const auto value = load_vec<DType, N>(ptr);
+#pragma unroll
+  for (int i = 0; i < N; ++i) {
+    if constexpr (std::is_same_v<DType, float>) {
+      out[i] = value[i];
+    } else {
+      out[i] = __bfloat162float(value[i]);
+    }
+  }
+}
+
+// --------------------------------------------------------------------------
+// Temperature-only path. The geometry and arithmetic intentionally mirror
+// HPC-Ops first; SM100 tuning is layered on top only after parity is frozen.
+// --------------------------------------------------------------------------
+
+constexpr int kTemperatureThreads = 256;
+constexpr int kTemperatureItems = 4;
+constexpr int kTemperatureStride = kTemperatureThreads * kTemperatureItems;
+constexpr int kTemperatureMinBlocks = 8;
+
+template <typename DType, int VocabSize, bool HasExternalGumbel, bool HasDraftMask>
+__global__ __launch_bounds__(kTemperatureThreads, 2) void temperature_kernel(
+    int32_t* output, const DType* logits, int row_stride, const float* temperature,
+    float temperature_value, const float* gumbel_noise, const int64_t* draft_token_ids,
+    float* partial_score, int32_t* partial_token, int32_t* counters, int blocks_per_row,
+    int scratch_stride, uint64_t seed, uint64_t rng_offset) {
+  constexpr int kWarpCount = kTemperatureThreads / 32;
+  const int bid = static_cast<int>(blockIdx.x);
+  const int row_id = static_cast<int>(blockIdx.y);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int warp_id = tid >> 5;
+  const int lane = tid & 31;
+
+  const int columns_raw = (VocabSize + blocks_per_row - 1) / blocks_per_row;
+  const int columns_per_block =
+      (columns_raw + kTemperatureItems - 1) / kTemperatureItems * kTemperatureItems;
+  const int column_begin = bid * columns_per_block;
+  const int column_end = min(column_begin + columns_per_block, VocabSize);
+  const float t = temperature ? temperature[row_id] : temperature_value;
+  const bool temperature_active = t > 0.0f;
+
+  curandStatePhilox4_32_10_t rng;
+  if constexpr (!HasExternalGumbel) {
+    const uint64_t sequence =
+        (static_cast<uint64_t>(row_id) * scratch_stride + bid) * kTemperatureThreads + tid;
+    curand_init(seed, sequence, rng_offset, &rng);
+  }
+
+  const DType* row = logits + static_cast<int64_t>(row_id) * row_stride;
+  const float* noise_row =
+      HasExternalGumbel ? gumbel_noise + static_cast<int64_t>(row_id) * VocabSize : nullptr;
+
+  __shared__ int32_t shared_mask_token;
+  if constexpr (HasDraftMask) {
+    if (tid == 0) {
+      const int64_t token = draft_token_ids[row_id];
+      shared_mask_token = token >= 0 && token < VocabSize ? static_cast<int32_t>(token) : VocabSize;
+    }
+    __syncthreads();
+  }
+  const int mask_token = HasDraftMask ? shared_mask_token : VocabSize;
+
+  float best_score = kNegInf;
+  int best_token = -1;
+  const int base = column_begin + tid * kTemperatureItems;
+  const int iterations = (columns_per_block + kTemperatureStride - 1) / kTemperatureStride;
+#pragma unroll 1
+  for (int iteration = 0; iteration < iterations; ++iteration) {
+    const int column_base = base + iteration * kTemperatureStride;
+    if (column_base >= column_end) break;
+    float values[kTemperatureItems];
+    if (column_base + kTemperatureItems <= column_end) {
+      load_as_float<DType, kTemperatureItems>(row + column_base, values);
+    } else {
+#pragma unroll
+      for (int i = 0; i < kTemperatureItems; ++i) {
+        const int column = column_base + i;
+        if (column < column_end) {
+          if constexpr (std::is_same_v<DType, float>) {
+            values[i] = row[column];
+          } else {
+            values[i] = __bfloat162float(row[column]);
+          }
+        } else {
+          values[i] = kNegInf;
+        }
+      }
+    }
+
+    float uniforms[kTemperatureItems];
+    if constexpr (!HasExternalGumbel) {
+      const float4 random = curand_uniform4(&rng);
+      uniforms[0] = random.x;
+      uniforms[1] = random.y;
+      uniforms[2] = random.z;
+      uniforms[3] = random.w;
+    }
+#pragma unroll
+    for (int i = 0; i < kTemperatureItems; ++i) {
+      const int column = column_base + i;
+      if (column >= column_end) continue;
+      // Match the heavy path: non-positive per-row values disable scaling.
+      // Keep division on the positive path to preserve source-faithful
+      // rounding for the normal sampling contract.
+      float value = temperature_active ? values[i] / t : values[i];
+      if constexpr (HasDraftMask) {
+        if (column == mask_token) value = kNegInf;
+      }
+      const float noise = HasExternalGumbel ? noise_row[column] : gumbel_from_uniform(uniforms[i]);
+      const float score = value + noise;
+      if (take_other(score, column, best_score, best_token)) {
+        best_score = score;
+        best_token = column;
+      }
+    }
+  }
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    const float score = __shfl_xor_sync(0xffffffff, best_score, offset);
+    const int token = __shfl_xor_sync(0xffffffff, best_token, offset);
+    if (take_other(score, token, best_score, best_token)) {
+      best_score = score;
+      best_token = token;
+    }
+  }
+
+  __shared__ float warp_scores[kWarpCount];
+  __shared__ int warp_tokens[kWarpCount];
+  if (lane == 0) {
+    warp_scores[warp_id] = best_score;
+    warp_tokens[warp_id] = best_token;
+  }
+  __syncthreads();
+
+  __shared__ float block_score;
+  __shared__ int block_token;
+  if (warp_id == 0) {
+    float score = lane < kWarpCount ? warp_scores[lane] : kNegInf;
+    int token = lane < kWarpCount ? warp_tokens[lane] : -1;
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      const float other_score = __shfl_xor_sync(0xffffffff, score, offset);
+      const int other_token = __shfl_xor_sync(0xffffffff, token, offset);
+      if (take_other(other_score, other_token, score, token)) {
+        score = other_score;
+        token = other_token;
+      }
+    }
+    if (lane == 0) {
+      block_score = score;
+      block_token = token;
+    }
+  }
+  __syncthreads();
+
+  __shared__ int previous_counter;
+  if (tid == 0) {
+    const int scratch_index = row_id * scratch_stride + bid;
+    partial_score[scratch_index] = block_score;
+    partial_token[scratch_index] = block_token;
+    __threadfence();
+    previous_counter = atomicAdd(counters + row_id, 1);
+  }
+  __syncthreads();
+  if (previous_counter != blocks_per_row - 1) return;
+
+  __threadfence();
+  best_score = tid < blocks_per_row ? partial_score[row_id * scratch_stride + tid] : kNegInf;
+  best_token = tid < blocks_per_row ? partial_token[row_id * scratch_stride + tid] : -1;
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    const float score = __shfl_xor_sync(0xffffffff, best_score, offset);
+    const int token = __shfl_xor_sync(0xffffffff, best_token, offset);
+    if (take_other(score, token, best_score, best_token)) {
+      best_score = score;
+      best_token = token;
+    }
+  }
+  if (lane == 0) {
+    warp_scores[warp_id] = best_score;
+    warp_tokens[warp_id] = best_token;
+  }
+  __syncthreads();
+  if (warp_id == 0) {
+    float score = lane < kWarpCount ? warp_scores[lane] : kNegInf;
+    int token = lane < kWarpCount ? warp_tokens[lane] : -1;
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+      const float other_score = __shfl_xor_sync(0xffffffff, score, offset);
+      const int other_token = __shfl_xor_sync(0xffffffff, token, offset);
+      if (take_other(other_score, other_token, score, token)) {
+        score = other_score;
+        token = other_token;
+      }
+    }
+    if (lane == 0) {
+      output[row_id] = token >= 0 ? token : 0;
+      counters[row_id] = 0;
+    }
+  }
+}
+
+int temperature_blocks_per_row(int batch_size, int sm_count) {
+  const int occupancy_factor = batch_size >= 8 && batch_size <= 64 ? 4 : 1;
+  int blocks = (occupancy_factor * sm_count + batch_size - 1) / batch_size;
+  blocks = std::max(blocks, kTemperatureMinBlocks);
+  return std::min(blocks, sm_count);
+}
+
+template <typename DType, bool HasExternalGumbel, bool HasDraftMask>
+cudaError_t launch_temperature_typed(int32_t* output, const void* logits, int row_stride,
+                                     const float* temperature, float temperature_value,
+                                     const float* gumbel_noise, const int64_t* draft_token_ids,
+                                     int batch_size, void* workspace, size_t workspace_size,
+                                     int sm_count, uint64_t seed, uint64_t rng_offset,
+                                     cudaStream_t stream) {
+  if (sm_count <= 0 || sm_count > kTemperatureThreads) {
+    return cudaErrorInvalidConfiguration;
+  }
+  const int blocks_per_row = temperature_blocks_per_row(batch_size, sm_count);
+  const size_t partial_count = static_cast<size_t>(batch_size) * sm_count;
+  const size_t score_bytes = partial_count * sizeof(float);
+  const size_t token_bytes = partial_count * sizeof(int32_t);
+  const size_t counter_bytes = static_cast<size_t>(batch_size) * sizeof(int32_t);
+  if (workspace == nullptr || workspace_size < score_bytes + token_bytes + counter_bytes) {
+    return cudaErrorInvalidValue;
+  }
+  auto* bytes = static_cast<uint8_t*>(workspace);
+  auto* partial_score = reinterpret_cast<float*>(bytes);
+  auto* partial_token = reinterpret_cast<int32_t*>(bytes + score_bytes);
+  auto* counters = reinterpret_cast<int32_t*>(bytes + score_bytes + token_bytes);
+  cudaError_t status = cudaMemsetAsync(counters, 0, counter_bytes, stream);
+  if (status != cudaSuccess) return status;
+  const uint64_t offset = HasExternalGumbel ? 0 : rng_offset;
+  temperature_kernel<DType, kVocabSize, HasExternalGumbel, HasDraftMask>
+      <<<dim3(blocks_per_row, batch_size), kTemperatureThreads, 0, stream>>>(
+          output, static_cast<const DType*>(logits), row_stride, temperature, temperature_value,
+          gumbel_noise, draft_token_ids, partial_score, partial_token, counters, blocks_per_row,
+          sm_count, seed, offset);
+  return cudaGetLastError();
+}
+
+template <typename DType>
+cudaError_t dispatch_temperature_flags(int32_t* output, const void* logits, int row_stride,
+                                       const float* temperature, float temperature_value,
+                                       const float* gumbel_noise, const int64_t* draft_token_ids,
+                                       int batch_size, void* workspace, size_t workspace_size,
+                                       int sm_count, uint64_t seed, uint64_t rng_offset,
+                                       cudaStream_t stream) {
+  if (gumbel_noise) {
+    if (draft_token_ids) {
+      return launch_temperature_typed<DType, true, true>(
+          output, logits, row_stride, temperature, temperature_value, gumbel_noise, draft_token_ids,
+          batch_size, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+    }
+    return launch_temperature_typed<DType, true, false>(
+        output, logits, row_stride, temperature, temperature_value, gumbel_noise, nullptr,
+        batch_size, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  if (draft_token_ids) {
+    return launch_temperature_typed<DType, false, true>(
+        output, logits, row_stride, temperature, temperature_value, nullptr, draft_token_ids,
+        batch_size, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  return launch_temperature_typed<DType, false, false>(
+      output, logits, row_stride, temperature, temperature_value, nullptr, nullptr, batch_size,
+      workspace, workspace_size, sm_count, seed, rng_offset, stream);
+}
+
+// --------------------------------------------------------------------------
+// Full fused sampler: scan/local-top-k followed by merge/sample/writeback.
+// --------------------------------------------------------------------------
+
+constexpr int kHeavySingleBatchThreads = 1024;
+constexpr int kHeavyDefaultThreads = 512;
+constexpr int kHeavyItems = 4;
+constexpr int kHeavyMinBlocks = 8;
+
+template <int HeavyThreads, int MaxTopK>
+constexpr int max_heavy_blocks() {
+  return (HeavyThreads / MaxTopK) < 32 ? (HeavyThreads / MaxTopK) : 32;
+}
+
+template <typename DType, int VocabSize>
+__device__ __forceinline__ void load_logits_safe(const DType* row, int column_base, float* values) {
+  if (column_base + kHeavyItems <= VocabSize) {
+    load_as_float<DType, kHeavyItems>(row + column_base, values);
+  } else {
+#pragma unroll
+    for (int i = 0; i < kHeavyItems; ++i) {
+      const int column = column_base + i;
+      if (column < VocabSize) {
+        if constexpr (std::is_same_v<DType, float>) {
+          values[i] = row[column];
+        } else {
+          values[i] = __bfloat162float(row[column]);
+        }
+      } else {
+        values[i] = kNegInf;
+      }
+    }
+  }
+}
+
+__device__ __forceinline__ void apply_penalty_temperature(
+    float* values, int column_base, bool penalty_active, float penalty, float inverse_penalty,
+    const uint8_t* penalty_row, bool temperature_active, float inverse_temperature,
+    int vocab_size) {
+  static_assert(8 % kHeavyItems == 0,
+                "each aligned heavy-item group must fit in one packed-mask byte");
+  if (penalty_active) {
+    // column_base is always four-token aligned, so the four
+    // penalty bits consumed by this loader live in one packed-mask byte.
+    // Load that byte once instead of issuing the same byte load per item.
+    const uint8_t penalty_bits =
+        column_base < vocab_size
+            ? static_cast<uint8_t>(penalty_row[column_base >> 3] >> (column_base & 7))
+            : 0;
+#pragma unroll
+    for (int i = 0; i < kHeavyItems; ++i) {
+      const int column = column_base + i;
+      if (column < vocab_size) {
+        if ((penalty_bits >> i) & 1u) {
+          values[i] *= values[i] > 0.0f ? inverse_penalty : penalty;
+        }
+      }
+    }
+  }
+  if (temperature_active) {
+#pragma unroll
+    for (int i = 0; i < kHeavyItems; ++i) values[i] *= inverse_temperature;
+  }
+}
+
+template <int HeavyThreads>
+__device__ __forceinline__ float block_max(float value, float* scratch) {
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  value = warp_max(value);
+  if (lane == 0) scratch[warp] = value;
+  __syncthreads();
+  if (warp == 0) {
+    float aggregate = lane < HeavyThreads / 32 ? scratch[lane] : kNegInf;
+    aggregate = warp_max(aggregate);
+    if (lane == 0) scratch[0] = aggregate;
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+template <int HeavyThreads>
+__device__ __forceinline__ float block_sum(float value, float* scratch) {
+  const int warp = threadIdx.x >> 5;
+  const int lane = threadIdx.x & 31;
+  value = warp_sum(value);
+  if (lane == 0) scratch[warp] = value;
+  __syncthreads();
+  if (warp == 0) {
+    float aggregate = lane < HeavyThreads / 32 ? scratch[lane] : 0.0f;
+    aggregate = warp_sum(aggregate);
+    if (lane == 0) scratch[0] = aggregate;
+  }
+  __syncthreads();
+  return scratch[0];
+}
+
+template <int HeavyThreads, typename DType, int VocabSize, int MaxTopK, int SoftmaxPolicy>
+__global__ __launch_bounds__(HeavyThreads) void scan_topk_kernel(
+    float* partial_logits, int* partial_tokens, float* partial_max, float* partial_sum,
+    const DType* logits, int row_stride, const uint8_t* penalty_mask, const int32_t* slot_id,
+    const float* repetition_penalty, float repetition_penalty_value, const float* temperature,
+    float temperature_value, int penalty_row_stride, int penalty_rows, int blocks_per_row,
+    int scratch_stride) {
+  const int row_id = static_cast<int>(blockIdx.y);
+  const int block_id = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  constexpr int kKeeperThreads = MaxTopK / kHeavyItems;
+  constexpr int kLoaderThreads = HeavyThreads - kKeeperThreads;
+  const bool keeper = tid < kKeeperThreads;
+  const int loader_id = tid - kKeeperThreads;
+
+  const DType* row = logits + static_cast<int64_t>(row_id) * row_stride;
+  const float penalty = repetition_penalty ? repetition_penalty[row_id] : repetition_penalty_value;
+  const int slot = slot_id ? slot_id[row_id] : -1;
+  const bool slot_valid = static_cast<unsigned>(slot) < static_cast<unsigned>(penalty_rows);
+  const bool penalty_active = penalty > 0.0f && penalty_mask && slot_id && slot_valid;
+  const float inverse_penalty = penalty_active ? fast_rcp(penalty) : 0.0f;
+  const uint8_t* penalty_row = penalty_active ? penalty_mask + slot * penalty_row_stride : nullptr;
+  const float temp = temperature ? temperature[row_id] : temperature_value;
+  const bool temperature_active = temp > 0.0f;
+  const float inverse_temperature = temperature_active ? fast_rcp(temp) : 0.0f;
+
+  using Sort = cub::BlockRadixSort<float, HeavyThreads, kHeavyItems, int>;
+  constexpr int kHeavyWarps = HeavyThreads / 32;
+  __shared__ union {
+    typename Sort::TempStorage sort;
+    // Keep max and sum scratch disjoint.  Warps may leave block_max's final
+    // barrier at different times, so immediately reusing the same words for
+    // block_sum would race warps that have not loaded the maximum yet.
+    struct {
+      float maximum[kHeavyWarps];
+      float sum[kHeavyWarps];
+    } reduction;
+  } shared;
+
+  float keys[kHeavyItems];
+  int values[kHeavyItems];
+  if (keeper) {
+#pragma unroll
+    for (int i = 0; i < kHeavyItems; ++i) {
+      keys[i] = kNegInf;
+      values[i] = -1;
+    }
+  }
+  float thread_max = kNegInf;
+  float thread_sum = 0.0f;
+  const int elements_per_iteration = blocks_per_row * kLoaderThreads * kHeavyItems;
+  const int iterations = (VocabSize + elements_per_iteration - 1) / elements_per_iteration;
+
+#pragma unroll 1
+  for (int iteration = 0; iteration < iterations; ++iteration) {
+    if (!keeper) {
+      const int column_base = iteration * elements_per_iteration +
+                              block_id * kLoaderThreads * kHeavyItems + loader_id * kHeavyItems;
+      float loaded[kHeavyItems];
+      load_logits_safe<DType, VocabSize>(row, column_base, loaded);
+      apply_penalty_temperature(loaded, column_base, penalty_active, penalty, inverse_penalty,
+                                penalty_row, temperature_active, inverse_temperature, VocabSize);
+#pragma unroll
+      for (int i = 0; i < kHeavyItems; ++i) {
+        const int column = column_base + i;
+        if (column < VocabSize) {
+          keys[i] = loaded[i];
+          values[i] = column;
+          if constexpr (SoftmaxPolicy == kSoftmaxBeforeTopK) {
+            const float x = loaded[i];
+            // An empty loader slice has max=-inf and mass=0.  Avoid
+            // exp(-inf - -inf), which would poison the block partial with NaN.
+            if (x != kNegInf) {
+              if (thread_max == kNegInf) {
+                thread_max = x;
+                thread_sum = 1.0f;
+              } else if (x > thread_max) {
+                thread_sum = thread_sum * precise_exp(thread_max - x) + 1.0f;
+                thread_max = x;
+              } else {
+                thread_sum += precise_exp(x - thread_max);
+              }
+            }
+          }
+        } else {
+          keys[i] = kNegInf;
+          values[i] = -1;
+        }
+      }
+    }
+    __syncthreads();
+    Sort(shared.sort).SortDescending(keys, values);
+    __syncthreads();
+  }
+
+  if constexpr (SoftmaxPolicy == kSoftmaxBeforeTopK) {
+    const float reduced_max = keeper ? kNegInf : thread_max;
+    const float maximum = block_max<HeavyThreads>(reduced_max, shared.reduction.maximum);
+    const float reduced_sum = keeper ? 0.0f : thread_sum;
+    const float corrected =
+        maximum == kNegInf ? 0.0f : reduced_sum * precise_exp(reduced_max - maximum);
+    const float sum = block_sum<HeavyThreads>(corrected, shared.reduction.sum);
+    if (tid == 0) {
+      const int index = row_id * scratch_stride + block_id;
+      partial_max[index] = maximum;
+      partial_sum[index] = sum;
+    }
+  }
+
+  if (keeper) {
+    const int destination =
+        row_id * scratch_stride * MaxTopK + block_id * MaxTopK + tid * kHeavyItems;
+#pragma unroll
+    for (int i = 0; i < kHeavyItems; ++i) {
+      partial_logits[destination + i] = keys[i];
+      partial_tokens[destination + i] = values[i];
+    }
+  }
+}
+
+template <int HeavyThreads, int MaxTopK, int SoftmaxPolicy, bool HasTopP,
+          int MergeBlocks = max_heavy_blocks<HeavyThreads, MaxTopK>()>
+__global__ void merge_sample_kernel(int32_t* output, const float* partial_logits,
+                                    const int* partial_tokens, const float* partial_max,
+                                    const float* partial_sum, const void* topk,
+                                    int topk_element_bytes, int topk_value, const float* topp,
+                                    float topp_value, const float* gumbel_noise, int vocab_size,
+                                    uint8_t* penalty_mask, const int32_t* slot_id,
+                                    const float* repetition_penalty, float repetition_penalty_value,
+                                    int penalty_row_stride, int penalty_rows, uint64_t seed,
+                                    uint64_t rng_offset, int blocks_per_row) {
+  constexpr int kMaxBlocks = max_heavy_blocks<HeavyThreads, MaxTopK>();
+  constexpr int kThreads = MergeBlocks * MaxTopK;
+  static_assert(MergeBlocks <= kMaxBlocks);
+  const int row_id = static_cast<int>(blockIdx.x);
+  const int tid = static_cast<int>(threadIdx.x);
+  const int lane = tid & 31;
+
+  int effective_k = MaxTopK;
+  if (topk) {
+    int requested = topk_element_bytes == 4
+                        ? reinterpret_cast<const int32_t*>(topk)[row_id]
+                        : static_cast<int>(reinterpret_cast<const int64_t*>(topk)[row_id]);
+    if (requested > 0) effective_k = min(requested, MaxTopK);
+  } else if (topk_value > 0) {
+    effective_k = min(topk_value, MaxTopK);
+  }
+
+  float global_max = 0.0f;
+  float inverse_sum = 0.0f;
+  if constexpr (SoftmaxPolicy == kSoftmaxBeforeTopK) {
+    __shared__ float shared_global_max;
+    __shared__ float shared_inverse_sum;
+    if (tid < 32) {
+      const float local_max =
+          lane < blocks_per_row ? partial_max[row_id * kMaxBlocks + lane] : kNegInf;
+      const float maximum = warp_max(local_max);
+      const float local_sum =
+          lane < blocks_per_row ? partial_sum[row_id * kMaxBlocks + lane] : 0.0f;
+      const float corrected = (local_max == kNegInf || maximum == kNegInf)
+                                  ? 0.0f
+                                  : local_sum * precise_exp(local_max - maximum);
+      const float sum = warp_sum(corrected);
+      if (lane == 0) {
+        shared_global_max = maximum;
+        shared_inverse_sum = sum > 0.0f ? fast_rcp(sum) : 0.0f;
+      }
+    }
+    __syncthreads();
+    global_max = shared_global_max;
+    inverse_sum = shared_inverse_sum;
+  }
+
+  using Sort = cub::BlockRadixSort<float, kThreads, 1, int>;
+  __shared__ union {
+    typename Sort::TempStorage sort;
+    struct {
+      float logits[kThreads];
+      int tokens[kThreads];
+    } result;
+  } shared;
+
+  const int candidate_block = tid / MaxTopK;
+  float key[1];
+  int token[1];
+  if (candidate_block < blocks_per_row) {
+    const int index = row_id * kMaxBlocks * MaxTopK + tid;
+    key[0] = partial_logits[index];
+    token[0] = partial_tokens[index];
+  } else {
+    key[0] = kNegInf;
+    token[0] = -1;
+  }
+  if constexpr (SoftmaxPolicy == kSoftmaxBeforeTopK) {
+    key[0] = token[0] >= 0 ? precise_exp(key[0] - global_max) * inverse_sum : 0.0f;
+  }
+
+  __syncthreads();
+  Sort(shared.sort).SortDescending(key, token);
+  __syncthreads();
+  shared.result.logits[tid] = key[0];
+  shared.result.tokens[tid] = token[0];
+  __syncthreads();
+  if (tid >= 32) return;
+
+  constexpr int kItemsPerLane = MaxTopK / 32;
+  float lane_logits[kItemsPerLane];
+  float lane_probabilities[kItemsPerLane];
+  int lane_tokens[kItemsPerLane];
+#pragma unroll
+  for (int i = 0; i < kItemsPerLane; ++i) {
+    const int index = lane * kItemsPerLane + i;
+    lane_logits[i] = shared.result.logits[index];
+    lane_tokens[i] = shared.result.tokens[index];
+    lane_probabilities[i] = 0.0f;
+  }
+
+  if constexpr (SoftmaxPolicy == kSoftmaxAfterTopK) {
+    const float maximum = __shfl_sync(0xffffffff, lane_logits[0], 0);
+    float sum = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; ++i) {
+      const int index = lane * kItemsPerLane + i;
+      if (index < effective_k && lane_tokens[i] >= 0) {
+        lane_probabilities[i] = precise_exp(lane_logits[i] - maximum);
+        sum += lane_probabilities[i];
+      }
+    }
+    sum = warp_sum(sum);
+    const float inverse = sum > 0.0f ? fast_rcp(sum) : 0.0f;
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; ++i) {
+      lane_probabilities[i] *= inverse;
+    }
+  } else if constexpr (SoftmaxPolicy == kSoftmaxBeforeTopK) {
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; ++i) {
+      const int index = lane * kItemsPerLane + i;
+      lane_probabilities[i] = index < effective_k && lane_tokens[i] >= 0 ? lane_logits[i] : 0.0f;
+    }
+  }
+
+  float lane_prefix = 0.0f;
+  if constexpr (HasTopP) {
+    const float threshold = topp ? topp[row_id] : topp_value;
+    if (threshold > 0.0f) {
+      float lane_sum = 0.0f;
+#pragma unroll
+      for (int i = 0; i < kItemsPerLane; ++i) {
+        const int index = lane * kItemsPerLane + i;
+        if (index < effective_k) lane_sum += lane_probabilities[i];
+      }
+      float inclusive = lane_sum;
+#pragma unroll
+      for (int offset = 1; offset < 32; offset <<= 1) {
+        const float other = __shfl_up_sync(0xffffffff, inclusive, offset);
+        if (lane >= offset) inclusive += other;
+      }
+      lane_prefix = inclusive - lane_sum;
+    }
+  }
+
+  curandStatePhilox4_32_10_t rng;
+  float uniforms[kItemsPerLane]{};
+  if (!gumbel_noise) {
+    const uint64_t sequence = static_cast<uint64_t>(row_id) * 32 + lane;
+    curand_init(seed, sequence, rng_offset, &rng);
+    const float4 random = curand_uniform4(&rng);
+    const float values[4] = {random.x, random.y, random.z, random.w};
+#pragma unroll
+    for (int i = 0; i < kItemsPerLane; ++i) uniforms[i] = values[i];
+  }
+
+  const float top_p_threshold = HasTopP ? (topp ? topp[row_id] : topp_value) : 0.0f;
+  float running_probability = lane_prefix;
+  float best_score = kNegInf;
+  int best_token = -1;
+#pragma unroll
+  for (int i = 0; i < kItemsPerLane; ++i) {
+    const int index = lane * kItemsPerLane + i;
+    const int candidate = lane_tokens[i];
+    bool keep = index < effective_k && candidate >= 0;
+    if constexpr (HasTopP) {
+      if (top_p_threshold > 0.0f) {
+        keep = keep && (index == 0 || running_probability < top_p_threshold);
+      }
+    }
+    if (keep) {
+      float value;
+      if constexpr (SoftmaxPolicy == kSoftmaxNone) {
+        value = lane_logits[i];
+      } else {
+        const float probability = lane_probabilities[i];
+        value = probability > 0.0f ? fast_log(probability) : kNegInf;
+      }
+      const float noise = gumbel_noise
+                              ? gumbel_noise[static_cast<int64_t>(row_id) * vocab_size + candidate]
+                              : gumbel_from_uniform(uniforms[i]);
+      const float score = value + noise;
+      if (take_other(score, candidate, best_score, best_token)) {
+        best_score = score;
+        best_token = candidate;
+      }
+    }
+    if constexpr (HasTopP) running_probability += lane_probabilities[i];
+  }
+
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    const float score = __shfl_xor_sync(0xffffffff, best_score, offset);
+    const int candidate = __shfl_xor_sync(0xffffffff, best_token, offset);
+    if (take_other(score, candidate, best_score, best_token)) {
+      best_score = score;
+      best_token = candidate;
+    }
+  }
+  if (lane == 0) {
+    const int sampled = best_token >= 0 ? best_token : 0;
+    output[row_id] = sampled;
+    if (penalty_mask && slot_id) {
+      const float penalty =
+          repetition_penalty ? repetition_penalty[row_id] : repetition_penalty_value;
+      const int slot = slot_id[row_id];
+      const bool slot_valid = static_cast<unsigned>(slot) < static_cast<unsigned>(penalty_rows);
+      if (penalty > 0.0f && slot_valid) {
+        uint8_t* row = penalty_mask + slot * penalty_row_stride;
+        uint8_t* byte_pointer = row + (sampled >> 3);
+        const uintptr_t byte_address = reinterpret_cast<uintptr_t>(byte_pointer);
+        const uintptr_t word_address = byte_address & ~uintptr_t{3};
+        const int byte_offset = static_cast<int>(byte_address - word_address);
+        const unsigned bit = (1u << (sampled & 7)) << static_cast<unsigned>(byte_offset * 8);
+        atomicOr(reinterpret_cast<unsigned*>(word_address), bit);
+      }
+    }
+  }
+}
+
+int heavy_blocks_per_row(int batch_size, int sm_count, int maximum) {
+  int blocks = sm_count / batch_size;
+  blocks = std::max(blocks, kHeavyMinBlocks);
+  return std::min(blocks, maximum);
+}
+
+template <int HeavyThreads, typename DType, int MaxTopK, int SoftmaxPolicy, bool HasTopP>
+cudaError_t launch_heavy_threads(int32_t* output, const void* logits, uint8_t* penalty_mask,
+                                 const int32_t* slot_id, const float* repetition_penalty,
+                                 float repetition_penalty_value, const float* temperature,
+                                 float temperature_value, const void* topk, int topk_element_bytes,
+                                 int topk_value, const float* topp, float topp_value,
+                                 const float* gumbel_noise, int batch_size, int vocab_size,
+                                 int penalty_rows, int penalty_row_stride, int row_stride,
+                                 void* workspace, size_t workspace_size, int sm_count,
+                                 uint64_t seed, uint64_t rng_offset, cudaStream_t stream) {
+  constexpr int kMaxBlocks = max_heavy_blocks<HeavyThreads, MaxTopK>();
+  constexpr bool kNeedsSoftmaxPartials = SoftmaxPolicy == kSoftmaxBeforeTopK;
+  if (sm_count <= 0) return cudaErrorInvalidConfiguration;
+  const int blocks_per_row = heavy_blocks_per_row(batch_size, sm_count, kMaxBlocks);
+  const size_t row_blocks = static_cast<size_t>(batch_size) * kMaxBlocks;
+  const size_t candidate_bytes = row_blocks * MaxTopK * sizeof(float);
+  const size_t partial_bytes = kNeedsSoftmaxPartials ? row_blocks * sizeof(float) : 0;
+  const size_t required_bytes = 2 * candidate_bytes + 2 * partial_bytes;
+  if (workspace == nullptr || workspace_size < required_bytes) {
+    return cudaErrorInvalidValue;
+  }
+  auto* bytes = static_cast<uint8_t*>(workspace);
+  auto* logits_scratch = reinterpret_cast<float*>(bytes);
+  auto* token_scratch = reinterpret_cast<int*>(bytes + candidate_bytes);
+  auto* max_scratch =
+      kNeedsSoftmaxPartials ? reinterpret_cast<float*>(bytes + 2 * candidate_bytes) : nullptr;
+  auto* sum_scratch = kNeedsSoftmaxPartials
+                          ? reinterpret_cast<float*>(bytes + 2 * candidate_bytes + partial_bytes)
+                          : nullptr;
+
+  scan_topk_kernel<HeavyThreads, DType, kVocabSize, MaxTopK, SoftmaxPolicy>
+      <<<dim3(blocks_per_row, batch_size), HeavyThreads, 0, stream>>>(
+          logits_scratch, token_scratch, max_scratch, sum_scratch,
+          static_cast<const DType*>(logits), row_stride, penalty_mask, slot_id, repetition_penalty,
+          repetition_penalty_value, temperature, temperature_value, penalty_row_stride,
+          penalty_rows, blocks_per_row, kMaxBlocks);
+  cudaError_t status = cudaGetLastError();
+  if (status != cudaSuccess) return status;
+
+  const uint64_t offset = gumbel_noise ? 0 : rng_offset;
+  if constexpr (HeavyThreads == kHeavyDefaultThreads && MaxTopK == 32) {
+    if (blocks_per_row <= kHeavyMinBlocks) {
+      // Do not sort the eight unused partial-block groups.  Keep the scratch
+      // stride at kMaxBlocks so this launch optimization does not change the
+      // workspace contract shared with the scan kernel.
+      constexpr int kCompactMergeBlocks = kHeavyMinBlocks;
+      constexpr int kCompactMergeThreads = kCompactMergeBlocks * MaxTopK;
+      merge_sample_kernel<HeavyThreads, MaxTopK, SoftmaxPolicy, HasTopP, kCompactMergeBlocks>
+          <<<batch_size, kCompactMergeThreads, 0, stream>>>(
+              output, logits_scratch, token_scratch, max_scratch, sum_scratch, topk,
+              topk_element_bytes, topk_value, topp, topp_value, gumbel_noise, vocab_size,
+              penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+              penalty_row_stride, penalty_rows, seed, offset, blocks_per_row);
+      return cudaGetLastError();
+    }
+  }
+  constexpr int kMergeThreads = kMaxBlocks * MaxTopK;
+  merge_sample_kernel<HeavyThreads, MaxTopK, SoftmaxPolicy, HasTopP>
+      <<<batch_size, kMergeThreads, 0, stream>>>(
+          output, logits_scratch, token_scratch, max_scratch, sum_scratch, topk, topk_element_bytes,
+          topk_value, topp, topp_value, gumbel_noise, vocab_size, penalty_mask, slot_id,
+          repetition_penalty, repetition_penalty_value, penalty_row_stride, penalty_rows, seed,
+          offset, blocks_per_row);
+  return cudaGetLastError();
+}
+
+template <typename DType, int MaxTopK, int SoftmaxPolicy, bool HasTopP>
+cudaError_t launch_heavy_typed(int32_t* output, const void* logits, uint8_t* penalty_mask,
+                               const int32_t* slot_id, const float* repetition_penalty,
+                               float repetition_penalty_value, const float* temperature,
+                               float temperature_value, const void* topk, int topk_element_bytes,
+                               int topk_value, const float* topp, float topp_value,
+                               const float* gumbel_noise, int batch_size, int vocab_size,
+                               int penalty_rows, int penalty_row_stride, int row_stride,
+                               void* workspace, size_t workspace_size, int sm_count, uint64_t seed,
+                               uint64_t rng_offset, cudaStream_t stream) {
+  if (batch_size < 8) {
+    return launch_heavy_threads<kHeavySingleBatchThreads, DType, MaxTopK, SoftmaxPolicy, HasTopP>(
+        output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+        temperature, temperature_value, topk, topk_element_bytes, topk_value, topp, topp_value,
+        gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride, row_stride,
+        workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  return launch_heavy_threads<kHeavyDefaultThreads, DType, MaxTopK, SoftmaxPolicy, HasTopP>(
+      output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+      temperature, temperature_value, topk, topk_element_bytes, topk_value, topp, topp_value,
+      gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride, row_stride, workspace,
+      workspace_size, sm_count, seed, rng_offset, stream);
+}
+
+template <typename DType, int MaxTopK, int SoftmaxPolicy>
+cudaError_t dispatch_heavy_topp(int32_t* output, const void* logits, uint8_t* penalty_mask,
+                                const int32_t* slot_id, const float* repetition_penalty,
+                                float repetition_penalty_value, const float* temperature,
+                                float temperature_value, const void* topk, int topk_element_bytes,
+                                int topk_value, const float* topp, float topp_value,
+                                const float* gumbel_noise, int batch_size, int vocab_size,
+                                int penalty_rows, int penalty_row_stride, int row_stride,
+                                void* workspace, size_t workspace_size, int sm_count, uint64_t seed,
+                                uint64_t rng_offset, cudaStream_t stream) {
+  if (topp || topp_value > 0.0f) {
+    return launch_heavy_typed<DType, MaxTopK, SoftmaxPolicy, true>(
+        output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+        temperature, temperature_value, topk, topk_element_bytes, topk_value, topp, topp_value,
+        gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride, row_stride,
+        workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  return launch_heavy_typed<DType, MaxTopK, SoftmaxPolicy, false>(
+      output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+      temperature, temperature_value, topk, topk_element_bytes, topk_value, topp, topp_value,
+      gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride, row_stride, workspace,
+      workspace_size, sm_count, seed, rng_offset, stream);
+}
+
+template <typename DType, int MaxTopK>
+cudaError_t dispatch_heavy_policy(
+    int32_t* output, const void* logits, uint8_t* penalty_mask, const int32_t* slot_id,
+    const float* repetition_penalty, float repetition_penalty_value, const float* temperature,
+    float temperature_value, int softmax_policy, const void* topk, int topk_element_bytes,
+    int topk_value, const float* topp, float topp_value, const float* gumbel_noise, int batch_size,
+    int vocab_size, int penalty_rows, int penalty_row_stride, int row_stride, void* workspace,
+    size_t workspace_size, int sm_count, uint64_t seed, uint64_t rng_offset, cudaStream_t stream) {
+#define DISPATCH_POLICY(POLICY)                                                               \
+  return dispatch_heavy_topp<DType, MaxTopK, POLICY>(                                         \
+      output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,    \
+      temperature, temperature_value, topk, topk_element_bytes, topk_value, topp, topp_value, \
+      gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride, row_stride,     \
+      workspace, workspace_size, sm_count, seed, rng_offset, stream)
+  switch (softmax_policy) {
+    case kSoftmaxNone:
+      DISPATCH_POLICY(kSoftmaxNone);
+    case kSoftmaxBeforeTopK:
+      DISPATCH_POLICY(kSoftmaxBeforeTopK);
+    case kSoftmaxAfterTopK:
+      DISPATCH_POLICY(kSoftmaxAfterTopK);
+    default:
+      return cudaErrorInvalidValue;
+  }
+#undef DISPATCH_POLICY
+}
+
+template <typename DType>
+cudaError_t dispatch_heavy_topk(int32_t* output, const void* logits, uint8_t* penalty_mask,
+                                const int32_t* slot_id, const float* repetition_penalty,
+                                float repetition_penalty_value, const float* temperature,
+                                float temperature_value, int softmax_policy, const void* topk,
+                                int topk_element_bytes, int topk_value, const float* topp,
+                                float topp_value, const float* gumbel_noise, int batch_size,
+                                int vocab_size, int penalty_rows, int penalty_row_stride,
+                                int row_stride, int max_topk, void* workspace,
+                                size_t workspace_size, int sm_count, uint64_t seed,
+                                uint64_t rng_offset, cudaStream_t stream) {
+#define CALL_TOPK(K)                                                                              \
+  return dispatch_heavy_policy<DType, K>(                                                         \
+      output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,        \
+      temperature, temperature_value, softmax_policy, topk, topk_element_bytes, topk_value, topp, \
+      topp_value, gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride,         \
+      row_stride, workspace, workspace_size, sm_count, seed, rng_offset, stream)
+  if (max_topk == 32) CALL_TOPK(32);
+  if (max_topk == 64) CALL_TOPK(64);
+#undef CALL_TOPK
+  return cudaErrorInvalidValue;
+}
+
+}  // namespace
+
+cudaError_t launch_temperature(int32_t* output, const void* logits, int logits_dtype,
+                               int logits_row_stride, const float* temperature,
+                               float temperature_value, const float* gumbel_noise,
+                               const int64_t* draft_token_ids, int batch_size, int vocab_size,
+                               void* workspace, size_t workspace_size, int sm_count, uint64_t seed,
+                               uint64_t rng_offset, cudaStream_t stream) {
+  if (vocab_size != kVocabSize || batch_size <= 0) return cudaErrorInvalidValue;
+  if (logits_dtype == 0) {
+    return dispatch_temperature_flags<float>(
+        output, logits, logits_row_stride, temperature, temperature_value, gumbel_noise,
+        draft_token_ids, batch_size, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  if (logits_dtype == 1) {
+    return dispatch_temperature_flags<__nv_bfloat16>(
+        output, logits, logits_row_stride, temperature, temperature_value, gumbel_noise,
+        draft_token_ids, batch_size, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  return cudaErrorInvalidValue;
+}
+
+cudaError_t launch_heavy(int32_t* output, const void* logits, int logits_dtype,
+                         uint8_t* penalty_mask, const int32_t* slot_id,
+                         const float* repetition_penalty, float repetition_penalty_value,
+                         const float* temperature, float temperature_value, int softmax_policy,
+                         const void* topk, int topk_element_bytes, int topk_value,
+                         const float* topp, float topp_value, const float* gumbel_noise,
+                         int batch_size, int vocab_size, int penalty_rows, int penalty_row_stride,
+                         int logits_row_stride, int max_topk, void* workspace,
+                         size_t workspace_size, int sm_count, uint64_t seed, uint64_t rng_offset,
+                         cudaStream_t stream) {
+  if (vocab_size != kVocabSize || batch_size <= 0) return cudaErrorInvalidValue;
+  if (logits_dtype == 0) {
+    return dispatch_heavy_topk<float>(
+        output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+        temperature, temperature_value, softmax_policy, topk, topk_element_bytes, topk_value, topp,
+        topp_value, gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride,
+        logits_row_stride, max_topk, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  if (logits_dtype == 1) {
+    return dispatch_heavy_topk<__nv_bfloat16>(
+        output, logits, penalty_mask, slot_id, repetition_penalty, repetition_penalty_value,
+        temperature, temperature_value, softmax_policy, topk, topk_element_bytes, topk_value, topp,
+        topp_value, gumbel_noise, batch_size, vocab_size, penalty_rows, penalty_row_stride,
+        logits_row_stride, max_topk, workspace, workspace_size, sm_count, seed, rng_offset, stream);
+  }
+  return cudaErrorInvalidValue;
+}
+
+}  // namespace flashinfer::sampling::hy3

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -17,6 +17,7 @@ Results:
 bmm_mxfp8_N128_K128.json
 fused_add_rmsnorm_h5120.json
 fused_add_rmsnorm_quant_h7168.json
+fused_sampling_hy3_v120832.json
 fmha_v2_prefill_sm120_h4_d128.json
 gdn_decode_qk4_v8_d128.json
 gdn_fused_decode_h5120_v48_d128.json
@@ -1482,6 +1483,13 @@ with contextlib.suppress(Exception):
     flashinfer.top_k_mask_logits(_sp_logits, 50)
 with contextlib.suppress(Exception):
     flashinfer.top_k_top_p_sampling_from_logits(_sp_logits, 50, 0.9)
+
+# HY3 heavy sampling path (packed penalty + temperature + top-k/top-p + Gumbel).
+with contextlib.suppress(Exception):
+    _hy3_sampling_inputs = flashinfer.fused_sampling_from_logits_hy3.fi_init(
+        batch_size=8, device=device
+    )
+    flashinfer.fused_sampling_from_logits_hy3(**_hy3_sampling_inputs)
 
 # chain_speculative_sampling.
 with contextlib.suppress(Exception):

--- a/tests/utils/test_sampling.py
+++ b/tests/utils/test_sampling.py
@@ -1197,6 +1197,567 @@ def test_sampling_nan_input(batch_size, vocab_size):
     check_result(result, valid)
 
 
+def test_fused_sampling_from_logits_hy3_portable_temperature():
+    """The HY3 API must retain semantics when the SM100 backend is unavailable."""
+    logits = torch.tensor([[0.0, 3.0, 1.0], [4.0, 1.0, 0.0]])
+    noise = torch.zeros_like(logits, dtype=torch.float32)
+    draft = torch.tensor([1, -1], dtype=torch.int64)
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=torch.tensor([1.0, 2.0], dtype=torch.float32),
+        gumbel_noise=noise,
+        draft_token_ids=draft,
+    )
+    assert torch.equal(output, torch.tensor([[2], [0]], dtype=torch.int32))
+
+
+def test_fused_sampling_from_logits_hy3_portable_non_positive_temperature():
+    """Non-positive per-row temperatures disable scaling without division by zero."""
+    logits = torch.full((3, 16), -10.0)
+    logits[:, 9] = 2.0
+    logits[:, 3] = 1.0
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=torch.tensor([0.0, -1.0, 2.0]),
+        gumbel_noise=torch.zeros_like(logits),
+    )
+    assert torch.equal(output, torch.tensor([[9], [9], [9]], dtype=torch.int32))
+
+
+def test_fused_sampling_from_logits_hy3_generated_seed_uses_uint64_bits(monkeypatch):
+    """A signed CUDA generator-state view must retain its uint64 seed bits."""
+    unsigned_seed = (1 << 63) + 123
+    signed_seed = unsigned_seed - (1 << 64)
+    generated_offset = 64
+    monkeypatch.setattr(
+        flashinfer.sampling,
+        "get_seed_and_offset",
+        lambda increment, generator, device: (signed_seed, generated_offset),
+    )
+    logits = torch.tensor([[0.0, 1.0, 2.0], [2.0, 1.0, 0.0]])
+
+    generated = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=1.0,
+    )
+    explicit = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=1.0,
+        seed=unsigned_seed,
+        offset=generated_offset,
+    )
+
+    assert torch.equal(generated, explicit)
+    for invalid_seed in (0, -1):
+        with pytest.raises(ValueError, match="seed must be > 0"):
+            flashinfer.sampling.fused_sampling_from_logits_hy3(
+                logits,
+                temperature=1.0,
+                seed=invalid_seed,
+            )
+    with pytest.raises(ValueError, match=r"seed must be less than 2\*\*64"):
+        flashinfer.sampling.fused_sampling_from_logits_hy3(
+            logits,
+            temperature=1.0,
+            seed=1 << 64,
+        )
+
+
+def test_fused_sampling_from_logits_hy3_uses_signed_ffi_seed_carrier(monkeypatch):
+    """The FFI receives the signed carrier for a high-bit uint64 seed."""
+    unsigned_seed = (1 << 63) + 123
+    signed_seed = unsigned_seed - (1 << 64)
+    captured = {}
+
+    def capture_fused_sampler(*args):
+        """Capture the signed seed passed to the custom-op boundary."""
+        captured["seed"] = args[-3]
+
+    monkeypatch.setattr(
+        flashinfer.sampling,
+        "_hy3_sampler_device_info",
+        lambda device: (True, 1),
+    )
+    monkeypatch.setattr(
+        flashinfer.sampling,
+        "_fused_sampling_from_logits_hy3",
+        capture_fused_sampler,
+    )
+    logits = torch.zeros((1, 120832))
+
+    flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        workspace_buffer=torch.empty(1 << 20, dtype=torch.uint8),
+        out=torch.empty((1, 1), dtype=torch.int32),
+        temperature=1.0,
+        seed=unsigned_seed,
+        offset=0,
+    )
+
+    assert captured["seed"] == signed_seed
+
+
+def test_fused_sampling_from_logits_hy3_remaps_generated_zero_seed(monkeypatch):
+    """A generated zero is remapped without accepting caller-supplied zero."""
+    generated_offset = 64
+    monkeypatch.setattr(
+        flashinfer.sampling,
+        "get_seed_and_offset",
+        lambda increment, generator, device: (0, generated_offset),
+    )
+    logits = torch.tensor([[0.0, 1.0, 2.0], [2.0, 1.0, 0.0]])
+
+    generated = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=1.0,
+    )
+    explicit = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=1.0,
+        seed=1,
+        offset=generated_offset,
+    )
+
+    assert torch.equal(generated, explicit)
+
+
+def test_fused_sampling_from_logits_hy3_portable_batched_penalty_writeback():
+    """Fallback writeback preserves atomic-OR semantics for duplicate slots."""
+    batch_size, vocab_size = 7, 16
+    winners = torch.tensor([1, 2, 2, 9, 5, 6, 7])
+    logits = torch.full((batch_size, vocab_size), -10.0)
+    logits[torch.arange(batch_size), winners] = 10.0
+    penalty_mask = torch.zeros((batch_size, 4), dtype=torch.uint8)
+    penalty_mask[0, 0] = 1
+    slot_id = torch.tensor([0, 0, 0, 1, -1, batch_size, 2], dtype=torch.int32)
+    repetition_penalty = torch.tensor([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
+
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        penalty_mask=penalty_mask,
+        slot_id=slot_id,
+        repetition_penalty=repetition_penalty,
+        temperature=1.0,
+        gumbel_noise=torch.zeros_like(logits),
+    )
+
+    assert torch.equal(output[:, 0], winners.to(torch.int32))
+    assert penalty_mask[0, 0].item() == 1 | (1 << 1) | (1 << 2)
+    assert penalty_mask[1, 1].item() == 1 << (9 & 7)
+    assert torch.count_nonzero(penalty_mask[2:]).item() == 0
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_fused_sampling_from_logits_hy3_temperature(dtype):
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(0) != (10, 0):
+        pytest.skip("requires an SM100 GPU")
+    device = torch.device("cuda:0")
+    batch_size, vocab_size = 2, 120832
+    # Exercise a valid padded row stride as well as the deterministic external
+    # Gumbel boundary used by the source-parity suite.
+    storage = torch.full(
+        (batch_size, vocab_size + 1), -10.0, dtype=dtype, device=device
+    )
+    logits = storage[:, :vocab_size]
+    logits[0, 17] = 8
+    logits[0, 5] = 7
+    logits[1, 31] = 7
+    logits[1, 6] = 6
+    noise = torch.zeros((batch_size, vocab_size), dtype=torch.float32, device=device)
+    workspace = torch.empty(1 << 20, dtype=torch.uint8, device=device)
+    preallocated_output = torch.empty((batch_size, 1), dtype=torch.int32, device=device)
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        workspace_buffer=workspace,
+        out=preallocated_output,
+        temperature=0.75,
+        gumbel_noise=noise,
+    )
+    assert output.data_ptr() == preallocated_output.data_ptr()
+    assert torch.equal(
+        output, torch.tensor([[17], [31]], dtype=torch.int32, device=device)
+    )
+
+    required = flashinfer.sampling._hy3_sampler_workspace_size(
+        batch_size,
+        torch.cuda.get_device_properties(device).multi_processor_count,
+        True,
+        flashinfer.sampling.HY3_SAMPLER_SOFTMAX_NONE,
+    )
+    exact_workspace = torch.empty(required, dtype=torch.uint8, device=device)
+    exact = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        workspace_buffer=exact_workspace,
+        out=preallocated_output,
+        temperature=0.75,
+        gumbel_noise=noise,
+    )
+    assert torch.equal(exact, output)
+
+    non_positive = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        workspace_buffer=exact_workspace,
+        out=preallocated_output,
+        temperature=torch.tensor([0.0, -1.0], dtype=torch.float32, device=device),
+        gumbel_noise=noise,
+    )
+    assert torch.equal(
+        non_positive,
+        torch.tensor([[17], [31]], dtype=torch.int32, device=device),
+    )
+    with pytest.raises(ValueError, match="workspace_buffer is too small"):
+        flashinfer.sampling.fused_sampling_from_logits_hy3(
+            logits,
+            workspace_buffer=exact_workspace[:-1],
+            out=preallocated_output,
+            temperature=0.75,
+            gumbel_noise=noise,
+        )
+    unaligned_storage = torch.empty(required + 1, dtype=torch.uint8, device=device)
+    with pytest.raises(ValueError, match="aligned to four bytes"):
+        flashinfer.sampling.fused_sampling_from_logits_hy3(
+            logits,
+            workspace_buffer=unaligned_storage[1:],
+            out=preallocated_output,
+            temperature=0.75,
+            gumbel_noise=noise,
+        )
+
+
+def test_fused_sampling_from_logits_hy3_heavy_penalty_writeback():
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability(0) != (10, 0):
+        pytest.skip("requires an SM100 GPU")
+    device = torch.device("cuda:0")
+    batch_size, vocab_size = 2, 120832
+    logits = torch.full(
+        (batch_size, vocab_size), -10.0, dtype=torch.bfloat16, device=device
+    )
+    logits[0, 11], logits[0, 12] = 8, 5
+    logits[1, 29], logits[1, 30] = 8, 5
+    row_bytes = (vocab_size + 7) // 8
+    penalty_mask = torch.zeros((2, row_bytes), dtype=torch.uint8, device=device)
+    slot_id = torch.tensor([1, 0], dtype=torch.int32, device=device)
+    penalty_mask[1, 11 >> 3] |= 1 << (11 & 7)
+    penalty_mask[0, 29 >> 3] |= 1 << (29 & 7)
+    noise = torch.zeros_like(logits, dtype=torch.float32)
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        penalty_mask=penalty_mask,
+        slot_id=slot_id,
+        repetition_penalty=2.0,
+        temperature=1.0,
+        softmax_policy=flashinfer.sampling.HY3_SAMPLER_SOFTMAX_AFTER_TOP_K,
+        top_k=20,
+        top_p=0.99,
+        max_top_k=32,
+        gumbel_noise=noise,
+    )
+    assert torch.equal(
+        output, torch.tensor([[12], [30]], dtype=torch.int32, device=device)
+    )
+    assert (penalty_mask[1, 12 >> 3] & (1 << (12 & 7))) != 0
+    assert (penalty_mask[0, 30 >> 3] & (1 << (30 & 7))) != 0
+
+
+def _hy3_test_device():
+    if not torch.cuda.is_available():
+        pytest.skip("requires an SM100 GPU")
+    device = torch.device("cuda", torch.cuda.current_device())
+    if torch.cuda.get_device_capability(device) != (10, 0):
+        pytest.skip("requires an SM100 GPU")
+    return device
+
+
+def _reference_hy3_fused_sampler_candidates(
+    logits,
+    penalty_mask,
+    slot_id,
+    repetition_penalty,
+    temperature,
+    softmax_policy,
+    top_k,
+    max_top_k,
+):
+    """Build the sorted candidate state without calling a FlashInfer sampler."""
+    _batch_size, vocab_size = logits.shape
+    work = logits.float().clone()
+    columns = torch.arange(vocab_size, device=logits.device)
+    packed_mask = penalty_mask.index_select(0, slot_id.long())
+    penalized = ((packed_mask[:, columns >> 3] >> (columns & 7)) & 1).bool()
+    active_penalty = penalized & (repetition_penalty > 0)[:, None]
+    safe_penalty = torch.where(
+        repetition_penalty > 0,
+        repetition_penalty,
+        torch.ones_like(repetition_penalty),
+    )
+    adjusted = torch.where(
+        work > 0,
+        work / safe_penalty[:, None],
+        work * safe_penalty[:, None],
+    )
+    work = torch.where(active_penalty, adjusted, work)
+    work = work / temperature[:, None]
+
+    if softmax_policy == flashinfer.sampling.HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K:
+        work = torch.softmax(work, dim=-1)
+
+    values, tokens = torch.topk(work, max_top_k, dim=-1, sorted=True)
+    requested_k = top_k.long()
+    effective_k = torch.where(
+        requested_k > 0,
+        requested_k.clamp(max=max_top_k),
+        torch.full_like(requested_k, max_top_k),
+    )
+    positions = torch.arange(max_top_k, device=logits.device)[None, :]
+    candidate_valid = positions < effective_k[:, None]
+
+    if softmax_policy == flashinfer.sampling.HY3_SAMPLER_SOFTMAX_AFTER_TOP_K:
+        probabilities = torch.softmax(
+            values.masked_fill(~candidate_valid, float("-inf")), dim=-1
+        )
+    else:
+        probabilities = values
+    sample_values = torch.where(
+        probabilities > 0,
+        probabilities.log(),
+        torch.full_like(probabilities, float("-inf")),
+    )
+    return tokens, probabilities, sample_values, candidate_valid
+
+
+def _reference_hy3_fused_sampler_pick(
+    tokens, probabilities, sample_values, candidate_valid, top_p, gumbel_noise
+):
+    """Apply the fused sampler's exclusive-prefix Top-P and token tie break."""
+    positions = torch.arange(tokens.size(1), device=tokens.device)[None, :]
+    exclusive_probability = probabilities.cumsum(dim=-1) - probabilities
+    keep = candidate_valid & (
+        (top_p <= 0)[:, None]
+        | (positions == 0)
+        | (exclusive_probability < top_p[:, None])
+    )
+    scores = sample_values + gumbel_noise.gather(1, tokens)
+    scores = scores.masked_fill(~keep, float("-inf"))
+    maximum = scores.max(dim=-1, keepdim=True).values
+    vocab_size = gumbel_noise.size(1)
+    tied_tokens = torch.where(
+        scores == maximum, tokens, torch.full_like(tokens, vocab_size)
+    )
+    output = tied_tokens.min(dim=-1).values
+    output = torch.where(output < vocab_size, output, torch.zeros_like(output))
+    return output.to(torch.int32).view(-1, 1), keep
+
+
+@pytest.mark.parametrize(
+    "softmax_policy",
+    [
+        flashinfer.sampling.HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K,
+        flashinfer.sampling.HY3_SAMPLER_SOFTMAX_AFTER_TOP_K,
+    ],
+)
+@pytest.mark.parametrize("batch_size", [2, 8, 32])
+@pytest.mark.parametrize("max_top_k", [32, 64])
+def test_fused_sampling_from_logits_hy3_top_p_boundary_dispatch(
+    max_top_k, batch_size, softmax_policy
+):
+    """Check both heavy dispatch shapes against a self-contained torch oracle."""
+    device = _hy3_test_device()
+    vocab_size = 120832
+    candidate_tokens = torch.arange(64, device=device, dtype=torch.long) * 1733 + 29
+    candidate_logits = torch.linspace(4.0, 0.0, 64, device=device)
+    logits = torch.full(
+        (batch_size, vocab_size), -4.0, dtype=torch.float32, device=device
+    )
+    logits[:, candidate_tokens] = candidate_logits
+
+    row_pattern = torch.arange(batch_size, device=device) % 8
+    top_k_values = torch.tensor(
+        [64, 64, 2, 7, 16, 31, 48, 64], dtype=torch.int64, device=device
+    )
+    temperature_values = torch.tensor(
+        [0.75, 0.9, 1.0, 1.1, 1.2, 1.35, 1.5, 1.75],
+        dtype=torch.float32,
+        device=device,
+    )
+    penalty_values = torch.tensor(
+        [0.0, 1.0, 1.17, 1.43, 1.71, 1.91, 1.29, 2.13],
+        dtype=torch.float32,
+        device=device,
+    )
+    top_k = top_k_values.index_select(0, row_pattern)
+    temperature = temperature_values.index_select(0, row_pattern)
+    repetition_penalty = penalty_values.index_select(0, row_pattern)
+    slot_id = torch.arange(batch_size - 1, -1, -1, dtype=torch.int32, device=device)
+
+    penalty_row_bytes = (vocab_size + 7) // 8
+    initial_penalty_mask = torch.zeros(
+        (batch_size, penalty_row_bytes), dtype=torch.uint8
+    )
+    candidate_tokens_cpu = candidate_tokens.cpu()
+    for row in range(batch_size):
+        token = int(candidate_tokens_cpu[(row * 7) % 32])
+        slot = batch_size - 1 - row
+        initial_penalty_mask[slot, token >> 3] |= 1 << (token & 7)
+    initial_penalty_mask = initial_penalty_mask.to(device)
+
+    tokens, probabilities, sample_values, candidate_valid = (
+        _reference_hy3_fused_sampler_candidates(
+            logits,
+            initial_penalty_mask,
+            slot_id,
+            repetition_penalty,
+            temperature,
+            softmax_policy,
+            top_k,
+            max_top_k,
+        )
+    )
+
+    # Row 0 exercises top_p == 0 (filter disabled). Other rows put top_p in
+    # the middle of one candidate's probability mass, avoiding numerical
+    # ambiguity while checking the exclusive-prefix cutoff on both sides.
+    desired_keep_pattern = [64, 1, 2, 3, 8, 16, 24, 47]
+    top_p = torch.empty(batch_size, dtype=torch.float32, device=device)
+    expected_keep_counts = []
+    for row in range(batch_size):
+        effective_k = min(int(top_k[row]), max_top_k)
+        if row % 8 == 0:
+            top_p[row] = 0.0
+            expected_keep_counts.append(effective_k)
+            continue
+        keep_count = min(desired_keep_pattern[row % 8], effective_k)
+        prefix = probabilities[row, : max(keep_count - 1, 0)].sum()
+        top_p[row] = prefix + probabilities[row, keep_count - 1] * 0.5
+        expected_keep_counts.append(keep_count)
+
+    gumbel_noise = torch.full(
+        (batch_size, vocab_size), -1000.0, dtype=torch.float32, device=device
+    )
+    gumbel_noise[:, candidate_tokens] = (
+        torch.arange(64, dtype=torch.float32, device=device) * 0.5
+    )
+    expected, reference_keep = _reference_hy3_fused_sampler_pick(
+        tokens,
+        probabilities,
+        sample_values,
+        candidate_valid,
+        top_p,
+        gumbel_noise,
+    )
+    assert reference_keep.sum(dim=-1).cpu().tolist() == expected_keep_counts
+
+    penalty_mask = initial_penalty_mask.clone()
+    workspace = torch.empty(1 << 20, dtype=torch.uint8, device=device)
+    preallocated_output = torch.full(
+        (batch_size, 1), -1, dtype=torch.int32, device=device
+    )
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        workspace_buffer=workspace,
+        out=preallocated_output,
+        penalty_mask=penalty_mask,
+        slot_id=slot_id,
+        repetition_penalty=repetition_penalty,
+        temperature=temperature,
+        softmax_policy=softmax_policy,
+        top_k=top_k,
+        top_p=top_p,
+        max_top_k=max_top_k,
+        gumbel_noise=gumbel_noise,
+    )
+    assert output.data_ptr() == preallocated_output.data_ptr()
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+    output_cpu = output.cpu()
+    penalty_mask_cpu = penalty_mask.cpu()
+    initial_penalty_mask_cpu = initial_penalty_mask.cpu()
+    repetition_penalty_cpu = repetition_penalty.cpu()
+    for row in range(batch_size):
+        slot = batch_size - 1 - row
+        if float(repetition_penalty_cpu[row]) == 0.0:
+            assert torch.equal(penalty_mask_cpu[slot], initial_penalty_mask_cpu[slot])
+            continue
+        sampled = int(output_cpu[row, 0])
+        assert penalty_mask_cpu[slot, sampled >> 3] & (1 << (sampled & 7))
+
+
+@pytest.mark.parametrize(
+    "softmax_policy",
+    [
+        flashinfer.sampling.HY3_SAMPLER_SOFTMAX_NONE,
+        flashinfer.sampling.HY3_SAMPLER_SOFTMAX_BEFORE_TOP_K,
+        flashinfer.sampling.HY3_SAMPLER_SOFTMAX_AFTER_TOP_K,
+    ],
+)
+def test_fused_sampling_from_logits_hy3_partition_tie_order(softmax_policy):
+    """Preserve the source kernel's stable Top-K order across block partitions."""
+    device = _hy3_test_device()
+    batch_size, vocab_size = 32, 120832
+    logits = torch.full(
+        (batch_size, vocab_size),
+        float("-inf"),
+        dtype=torch.float32,
+        device=device,
+    )
+    early_partition = torch.arange(992, 1024, device=device)
+    late_partition = torch.arange(15872, 15904, device=device)
+    logits[:, early_partition] = 1.0
+    logits[:, late_partition] = 1.0
+
+    # The late-partition tokens have higher sample scores, but the source
+    # 512-thread/8-block stage-1 partition excludes them at the equal-logit
+    # Top-K cutoff.  A geometry change must not silently change that tie set.
+    noise = torch.full_like(logits, -1000.0, dtype=torch.float32)
+    noise[:, early_partition] = torch.arange(32, dtype=torch.float32, device=device)
+    noise[:, late_partition] = 1000.0 + torch.arange(
+        32, dtype=torch.float32, device=device
+    )
+    output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+        logits,
+        temperature=1.0,
+        softmax_policy=softmax_policy,
+        top_k=32,
+        top_p=0.99 if softmax_policy else 0.0,
+        max_top_k=32,
+        gumbel_noise=noise,
+    )
+    expected = torch.full((batch_size, 1), 1023, dtype=torch.int32, device=device)
+    torch.testing.assert_close(output, expected, rtol=0, atol=0)
+
+
+def test_fused_sampling_from_logits_hy3_non_default_stream():
+    """The public API must honor the current stream with caller-owned buffers."""
+    device = _hy3_test_device()
+    batch_size, vocab_size = 8, 120832
+    stream = torch.cuda.Stream(device=device)
+    with torch.cuda.stream(stream):
+        logits = torch.full(
+            (batch_size, vocab_size), -10.0, dtype=torch.float32, device=device
+        )
+        winners = torch.arange(batch_size, dtype=torch.long, device=device) * 997 + 13
+        logits[torch.arange(batch_size, device=device), winners] = 10.0
+        noise = torch.zeros_like(logits, dtype=torch.float32)
+        workspace = torch.empty(1 << 20, dtype=torch.uint8, device=device)
+        preallocated_output = torch.full(
+            (batch_size, 1), -1, dtype=torch.int32, device=device
+        )
+        output = flashinfer.sampling.fused_sampling_from_logits_hy3(
+            logits,
+            workspace_buffer=workspace,
+            out=preallocated_output,
+            temperature=torch.linspace(
+                0.5, 1.5, batch_size, dtype=torch.float32, device=device
+            ),
+            gumbel_noise=noise,
+        )
+        completed = torch.cuda.Event()
+        completed.record(stream)
+    completed.synchronize()
+
+    assert output.data_ptr() == preallocated_output.data_ptr()
+    torch.testing.assert_close(output[:, 0], winners.to(torch.int32), rtol=0, atol=0)
+
+
 if __name__ == "__main__":
     # test_sampling_freq(128256, gumbel_distribution(0.1), 0.5)
     test_sampling_from_logits_freq(128256, gumbel_distribution(0.1))


### PR DESCRIPTION
## Summary

This PR adds `fused_sampling_from_logits_hy3`, an opt-in HY3 sampling API with an SM100/B200-specialized CUDA path and a portable fallback. Existing FlashInfer sampling entry points are unchanged.

The operator fuses repetition penalty, temperature, optional softmax, top-k/top-p filtering, random sampling, and packed history-mask writeback. It provides a temperature-only fast path, a two-stage full path, caller-provided workspace/output buffers for graph-stable addresses, JIT/AOT registration, trace support, tests, and a standalone benchmark against current FlashInfer paths.

The CUDA implementation is derived from Tencent/HPC-Ops commit `1cd332980ed46bd0172091c1c35d55338fcae47a`; the derived header retains the original copyright, MIT SPDX identifier, and source revision.

This is the sampling-only half of the previously combined submission. The HY3 QK RMSNorm/RoPE KV-store operator is submitted separately.

This PR supersedes #4796, which GitHub automatically closed when the cross-repository head branch was renamed from the earlier combined-operator name to the sampling-only name.

## Duplicate-work check

I searched open FlashInfer PRs for fused logits sampling, top-k/top-p sampling, and repetition penalty. PR #1561 covers radix top-k as an individual stage, but I did not find an open PR implementing this packed-history HY3 end-to-end contract.

## Tests

Run from the repository root on an SM100/B200 CUDA GPU:

```bash
python -m pytest -q tests/utils/test_sampling.py -k fused_sampling_from_logits_hy3
python -m pytest -q \
  tests/trace/test_fi_trace_template_consistency.py \
  tests/trace/test_template_init.py \
  tests/trace/test_template_registry.py \
  -k fused_sampling_hy3
```

Results:

```text
25 passed, 1911 deselected
6 passed, 1 skipped, 1325 deselected
```

Ruff 0.12.8 lint and format checks pass for all changed Python files.

## Benchmark

Environment: NVIDIA B200, BF16 logits, vocabulary size 120832, CUDA-event timing after the preferred CUPTI timer reported unavailable, cold L2, 20 warmup iterations, and 100 samples. Setup, allocation, mask construction/packing, and JIT compilation are outside timing. Both providers use internal RNG.

```bash
python -m benchmarks.bench_sampling_hy3 \
  --batches 1 8 32 128 512 \
  --warmup 20 --iters 100
```

Temperature compares against the faster of FlashInfer's `softmax + sampling_from_probs` and temperature scaling plus `sampling_from_logits`. Full sampling compares against FP32 repetition penalty/temperature followed by FlashInfer's current top-k-first small-K path and equivalent history writeback.

| batch | HY3 temperature (us) | FlashInfer best (us) | speedup | HY3 full (us) | FlashInfer full (us) | speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 12.304 | 52.320 | 4.252x | 39.904 | 153.712 | 3.852x |
| 8 | 15.328 | 53.312 | 3.478x | 54.176 | 170.832 | 3.153x |
| 32 | 24.640 | 67.440 | 2.737x | 135.920 | 179.232 | 1.319x |
| 128 | 53.472 | 111.776 | 2.090x | 424.848 | 335.520 | 0.790x |
| 512 | 151.760 | 441.376 | 2.908x | 1621.040 | 1128.848 | 0.696x |

The full path is optimized for low-to-moderate decode batches; the benchmark intentionally reports the crossover where the existing FlashInfer composition is faster.

## AI assistance disclosure

AI assistance was used to help prepare and validate this change. I reviewed the changed lines and test results and am responsible for the contribution.
