### PR TITLE
Summary improvement

### DIFF
--- a/scripts/test_sharding/runner.py
+++ b/scripts/test_sharding/runner.py
@@ -551,9 +551,6 @@ def _write_new_manifest(
                 selection=request.selection.to_dict(),
                 planning_options=request.planning.to_dict(),
                 pytest_command_prefix=request.pytest_command_prefix,
-                estimate_files=_estimate_checksums(
-                    request.duration_estimates, request.overhead_estimates
-                ),
             )
             _verify_collection(concurrent, nodes)
             return concurrent, Plan.from_dict(concurrent["plan"]), False
@@ -580,9 +577,6 @@ def prepare_manifest(
     junit_dir.mkdir(parents=True, exist_ok=True)
     source_git_sha = source_git_sha_from_env()
     selection_value = selection.to_dict()
-    estimate_files = _estimate_checksums(
-        request.duration_estimates, request.overhead_estimates
-    )
     existing = load_manifest(junit_dir)
     existing_plan: Plan | None = None
     if existing is not None:
@@ -594,7 +588,6 @@ def prepare_manifest(
             selection=selection_value,
             planning_options=planning.to_dict(),
             pytest_command_prefix=request.pytest_command_prefix,
-            estimate_files=estimate_files,
         )
         existing_plan = Plan.from_dict(existing["plan"])
     if existing is None:
@@ -652,6 +645,9 @@ def prepare_manifest(
             error.record_deadline_clock(deadline_clock)
         raise
     nodes = _selected_nodes(raw_nodes, selection)
+    estimate_files = _estimate_checksums(
+        request.duration_estimates, request.overhead_estimates
+    )
     estimates = EstimateBook.from_files(
         request.duration_estimates,
         request.overhead_estimates,

--- a/scripts/test_sharding/state.py
+++ b/scripts/test_sharding/state.py
@@ -93,6 +93,9 @@ def _normalize_source_git_sha(value: Any) -> str | None:
 def source_git_sha_from_env() -> str | None:
     """Return the optional CI archive identity used to validate resume."""
 
+    # SOURCE_GIT_SHA is injected by callers that want plan and run jobs to prove
+    # they are using the same source archive. Local runs and older wrappers may
+    # omit it, so absence is treated as "no SHA guard available".
     return _normalize_source_git_sha(os.environ.get("SOURCE_GIT_SHA"))
 
 
@@ -243,7 +246,6 @@ def verify_manifest(
     selection: dict[str, Any],
     planning_options: dict[str, Any],
     pytest_command_prefix: tuple[str, ...] = (),
-    estimate_files: dict[str, str | None] | None = None,
     test_paths: Sequence[Path] | None = None,
 ) -> None:
     mismatches: list[str] = []
@@ -271,13 +273,14 @@ def verify_manifest(
             manifest.get("test_paths"),
             [str(path) for path in resolved_paths],
         )
-    if estimate_files is not None:
-        checks["estimate_files"] = (manifest.get("estimate_files"), estimate_files)
     for name, (saved, current) in checks.items():
         if saved != current:
             mismatches.append(f"{name}: saved={saved!r}, current={current!r}")
     saved_source_git_sha = _normalize_source_git_sha(manifest.get("source_git_sha"))
     current_source_git_sha = _normalize_source_git_sha(source_git_sha)
+    # The source SHA is an optional compatibility guard. When both sides provide
+    # it, a mismatch means the saved plan belongs to a different source state.
+    # When either side omits it, rely on the mandatory manifest fields above.
     if (
         saved_source_git_sha is not None
         and current_source_git_sha is not None

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import csv
+import importlib.metadata
 import io
 import json
+import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, TypedDict, cast
 
@@ -672,6 +675,41 @@ def _format_test_elapsed(seconds: float) -> str:
     return f"{secs}s"
 
 
+def _package_version(distribution_name: str) -> str:
+    try:
+        return importlib.metadata.version(distribution_name)
+    except importlib.metadata.PackageNotFoundError:
+        return "not-installed"
+    except Exception:
+        return "unknown"
+
+
+def _torch_cuda_version() -> str:
+    try:
+        import torch  # type: ignore[import-not-found]
+
+        return str(torch.version.cuda or "none")
+    except Exception:
+        return "unavailable"
+
+
+@lru_cache(maxsize=1)
+def _runtime_version_line() -> str:
+    versions = [
+        ("python", sys.version.split()[0]),
+        ("flashinfer", _package_version("flashinfer-python")),
+        ("torch", _package_version("torch")),
+        ("CUDA", _torch_cuda_version()),
+        ("CuTE-DSL", _package_version("nvidia-cutlass-dsl")),
+        ("cuda-python", _package_version("cuda-python")),
+        ("cuda-tile", _package_version("cuda-tile")),
+        ("cuDNN-frontend", _package_version("nvidia-cudnn-frontend")),
+        ("triton", _package_version("triton")),
+        ("nccl4py", _package_version("nccl4py")),
+    ]
+    return " ".join(f"{name}={version}" for name, version in versions)
+
+
 def _format_memory(mib: float) -> str:
     return f"{mib / 1024:.1f} GiB" if mib >= 1024 else f"{mib:.0f} MiB"
 
@@ -702,10 +740,11 @@ def _top_source_lines(
 def _failure_detail_lines(
     failed_nodes: list[FailedNodeSummary], diagnostic_limit: int
 ) -> list[str]:
-    if not failed_nodes:
+    real_failures = [failure for failure in failed_nodes if not failure["synthetic"]]
+    if not real_failures:
         return []
     lines = [_TERMINAL_SEPARATOR, "FAILED TEST NODES", _TERMINAL_SEPARATOR]
-    for failure in failed_nodes:
+    for failure in real_failures:
         diagnostic = str(failure["diagnostic"])
         encoded = diagnostic.encode("utf-8")
         truncated = len(encoded) > diagnostic_limit
@@ -719,14 +758,22 @@ def _failure_detail_lines(
         )
         if truncated:
             lines.append(f"    [diagnostic truncated at {diagnostic_limit} bytes]")
-        lines.extend(
-            [
-                f"    log: {failure['log_path']}",
-                f"    results: {failure['results_path']}",
-                f"    junit: {failure['junit_path']}",
-            ]
-        )
+        lines.append(f"    log: {failure['log_path']}")
     return lines
+
+
+def _synthetic_timeout_failure_lines(
+    failed_nodes: list[FailedNodeSummary],
+) -> list[str]:
+    synthetic_failures = [failure for failure in failed_nodes if failure["synthetic"]]
+    if not synthetic_failures:
+        return []
+    return [
+        _TERMINAL_SEPARATOR,
+        "SYNTHETIC FAIL DUE TO TIMEOUT",
+        _TERMINAL_SEPARATOR,
+        *(f"  - {failure['nodeid']}" for failure in synthetic_failures),
+    ]
 
 
 def terminal_summary_lines(
@@ -748,6 +795,7 @@ def terminal_summary_lines(
         f"Start time: {_format_timestamp(test_started_at)}",
         f"End time: {_format_timestamp(test_ended_at)}",
         f"Time elapsed: {_format_test_elapsed(test_ended_at - test_started_at)}",
+        f"Versions: {_runtime_version_line()}",
     ]
     if summary is None:
         lines.extend(
@@ -820,13 +868,40 @@ def terminal_summary_lines(
     if infrastructure_errors:
         lines.extend(["", "INFRASTRUCTURE ERRORS"])
         lines.extend(f"  - {error}" for error in infrastructure_errors)
-    if failed_nodes:
-        failed_sources = sorted(
-            {failure["source_file"] for failure in failed_nodes},
+    real_failed_nodes = [
+        failure for failure in failed_nodes if not failure["synthetic"]
+    ]
+    synthetic_failed_nodes = [
+        failure for failure in failed_nodes if failure["synthetic"]
+    ]
+    if real_failed_nodes:
+        failed_sources = Counter(
+            failure["source_file"] for failure in real_failed_nodes
+        )
+        ordered_failed_sources = sorted(
+            failed_sources,
             key=lambda source: source.encode("utf-8"),
         )
         lines.extend(["", "Failed test files:"])
-        lines.extend(f"  - {source}" for source in failed_sources)
+        lines.extend(
+            f"  - {source} ({failed_sources[source]} failed "
+            f"{'node' if failed_sources[source] == 1 else 'nodes'})"
+            for source in ordered_failed_sources
+        )
+    if synthetic_failed_nodes:
+        timeout_sources = Counter(
+            failure["source_file"] for failure in synthetic_failed_nodes
+        )
+        ordered_timeout_sources = sorted(
+            timeout_sources,
+            key=lambda source: source.encode("utf-8"),
+        )
+        lines.extend(["", "Timeout test files:"])
+        lines.extend(
+            f"  - {source} ({timeout_sources[source]} timeout "
+            f"{'node' if timeout_sources[source] == 1 else 'nodes'})"
+            for source in ordered_timeout_sources
+        )
     lines.extend(
         ["", "TEST RUN RESOURCE SUMMARY", "Top 10 longest-running source files:"]
     )
@@ -847,4 +922,8 @@ def terminal_summary_lines(
             _TERMINAL_SEPARATOR,
         ]
     )
-    return [*_failure_detail_lines(failed_nodes, diagnostic_limit), *lines]
+    return [
+        *_failure_detail_lines(failed_nodes, diagnostic_limit),
+        *_synthetic_timeout_failure_lines(failed_nodes),
+        *lines,
+    ]

--- a/scripts/test_sharding/workers.py
+++ b/scripts/test_sharding/workers.py
@@ -208,13 +208,12 @@ def _forward_pytest_output(
             log.flush()
         nodeid = str(event.get("nodeid", ""))
         if event.get("event") == "start":
-            function, should_print = progress.start(
+            _, should_print = progress.start(
                 nodeid, float(event.get("started_at", time.time()))
             )
             if should_print:
                 state.emit(
-                    f"PYTEST START worker={worker_index} batch={batch_id} "
-                    f"function={function} node={nodeid}"
+                    f"PYTEST START worker={worker_index} batch={batch_id} node={nodeid}"
                 )
         elif event.get("event") == "finish":
             outcome = str(event.get("outcome", "unknown"))

--- a/tests/test_sharding/test_runner_cli.py
+++ b/tests/test_sharding/test_runner_cli.py
@@ -410,7 +410,7 @@ def test_optional_timing_files_use_first_matching_rows(tmp_path: Path) -> None:
     assert set(manifest["estimate_files"]) == {"duration", "overhead"}
 
 
-def test_manifest_freezes_timing_content_not_input_path(tmp_path: Path) -> None:
+def test_manifest_resume_does_not_depend_on_timing_inputs(tmp_path: Path) -> None:
     suite = tmp_path / "suite"
     suite.mkdir()
     (suite / "test_sample.py").write_text("def test_case(): pass\n", encoding="utf-8")
@@ -428,8 +428,8 @@ def test_manifest_freezes_timing_content_not_input_path(tmp_path: Path) -> None:
     assert created.returncode == 0, created.stdout
     assert reused.returncode == 0, reused.stdout
     assert "Using plan" in reused.stdout
-    assert changed.returncode == 3
-    assert "estimate_files" in changed.stdout
+    assert changed.returncode == 0, changed.stdout
+    assert "Using plan" in changed.stdout
 
 
 def test_run_streams_current_pytest_node_before_it_finishes(tmp_path: Path) -> None:

--- a/tests/test_sharding/test_summary.py
+++ b/tests/test_sharding/test_summary.py
@@ -219,7 +219,7 @@ def test_source_summary_aggregates_local_resources_and_failed_diagnostics(
         )
     )
     assert "[diagnostic truncated at 8 bytes]" in terminal
-    assert "results:" in terminal
+    assert "log:" in terminal
     assert "  - tests/test_sample.py::test_case_1" in terminal
 
 


### PR DESCRIPTION
## 📌 Description

Improve the test runner summary and allow verifying repo state with SOURCE_GIT_SHA

The test runner summary will now (1) print the versions of dependent libraries (2) separate failed test nodes due to timeouts from actual failures (3) when printing the test files with failures, also print the count of failed nodes.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

Supersedes https://github.com/flashinfer-ai/flashinfer/pull/4552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Terminal summaries now report Python, CUDA, PyTorch, and related package versions.
  - Test results distinguish genuine test failures from synthetic timeout failures, with separate file lists and node counts.
  - Failure diagnostics and log paths are presented more clearly.

- **Bug Fixes**
  - Resuming a test plan is no longer affected by changes to timing estimate inputs.
  - Test-start output has been simplified for clearer progress reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->