### PR TITLE
feat(sparse): build the rows the sparse scorer reads

### DIFF
--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -101,6 +101,10 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   TVM_FFI_ICHECK_GE(state_cache.size(3), head_dim + coord_width)
       << "the ring holds a row of head_dim, and its coordinates after it";
   TVM_FFI_ICHECK_EQ(work_metadata.size(1), 2) << "a work item is a request and its index";
+  // Both are divided by, and the ring is also indexed modulo its size, so an
+  // empty one turns every history read into an address off the front.
+  TVM_FFI_ICHECK_GT(state_cache.size(1), 0) << "the ring holds at least one row";
+  TVM_FFI_ICHECK_GT(compressed_cache.size(1), 0) << "a compressed page holds at least one row";
   TVM_FFI_ICHECK_EQ(state_slots.size(0), num_tokens);
   TVM_FFI_ICHECK_EQ(compressed_slots.size(0), num_tokens);
   TVM_FFI_ICHECK_EQ(logical_positions.size(0), num_tokens);
@@ -170,6 +174,7 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
     p.num_state_blocks = static_cast<int32_t>(state_cache.size(0));
     p.num_compressed_blocks = static_cast<int32_t>(compressed_cache.size(0));
     p.num_k_work = static_cast<int32_t>(work_metadata.size(0));
+    p.num_requests = static_cast<int32_t>(state_block_table.size(0));
     p.num_q_heads = static_cast<int32_t>(num_q_heads);
     p.compress_ratio = static_cast<int32_t>(compress_ratio);
     p.state_size = static_cast<int32_t>(state_cache.size(1));

--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -116,6 +116,14 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   // table has to run one past the last of them.
   TVM_FFI_ICHECK_EQ(query_start_loc.size(0), state_block_table.size(0) + 1)
       << "query_start_loc runs one entry past the requests the ring table holds";
+  // A lane reads its slice of the norm weight by head_dim, unconditionally, so
+  // a shorter one is read past its end however contiguous it is.
+  TVM_FFI_ICHECK_EQ(q_norm_weight.numel(), head_dim) << "q_norm_weight is one weight per feature";
+  TVM_FFI_ICHECK_EQ(k_norm_weight.numel(), head_dim) << "k_norm_weight is one weight per feature";
+  // One ring block per request: the kernel reads the first entry of the row it
+  // is given, so a row of no entries reads off the table.
+  TVM_FFI_ICHECK_EQ(state_block_table.size(1), 1)
+      << "state_block_table holds one ring block per request";
 
   // Every half-width tensor is read through one pointer type.
   TVM_FFI_ICHECK_EQ(k.dtype(), q.dtype());

--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -90,6 +90,11 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   // there, so a second KV head would land on top of the first.
   TVM_FFI_ICHECK_EQ(state_cache.size(2), 1) << "the ring holds one KV head";
   TVM_FFI_ICHECK_EQ(compressed_cache.size(2), 1) << "the compressed cache holds one KV head";
+  // Rank first: everything below indexes the last axis, and size(ndim() - 1) on
+  // a rank-zero tensor reads off the front of its own shape.
+  TVM_FFI_ICHECK_GE(cos_sin_cache.ndim(), 1) << "the rotary table has at least one axis";
+  TVM_FFI_ICHECK(positions.ndim() == 1 || positions.ndim() == 2)
+      << "positions is one axis or three";
   // The rotary table is addressed as a flat run of rows of half the head
   // dimension; a row of any other width silently shifts every position.
   TVM_FFI_ICHECK_EQ(cos_sin_cache.size(cos_sin_cache.ndim() - 1), head_dim / 2)
@@ -142,7 +147,6 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   TVM_FFI_ICHECK_EQ(work_metadata.dtype(), dl_int32) << "work_metadata must be int32";
 
   const bool pos_2d = positions.ndim() == 2;
-  TVM_FFI_ICHECK(pos_2d || positions.ndim() == 1) << "positions is one axis or three";
   if (pos_2d) {
     TVM_FFI_ICHECK_EQ(positions.size(0), 3) << "a three-axis position tensor has three rows";
   }
@@ -159,6 +163,9 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
     p.pos_stride_axis = pos_2d ? positions.stride(0) : 0;
     p.pos_stride_token = pos_2d ? positions.stride(1) : positions.stride(0);
     p.cos_sin = static_cast<const c_type*>(cos_sin_cache.data_ptr());
+    // Rows the table holds: the kernel keeps a coordinate inside them rather
+    // than reading off the end.
+    p.cos_sin_rows = cos_sin_cache.numel() / (head_dim / 2);
     p.q_norm_weight = static_cast<const c_type*>(q_norm_weight.data_ptr());
     p.k_norm_weight = static_cast<const c_type*>(k_norm_weight.data_ptr());
     p.eps = static_cast<float>(eps);

--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <flashinfer/attention/sparse_pre_indexer.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+
+namespace {
+
+// A power of two's exponent, or -1 for anything else: the kernel divides by
+// these three, and a shift is the only form of that division worth having.
+int32_t shift_of(int64_t v) {
+  if (v <= 0 || (v & (v - 1)) != 0) return -1;
+  int32_t sh = 0;
+  while ((int64_t{1} << sh) < v) ++sh;
+  return sh;
+}
+
+}  // namespace
+
+void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorView cos_sin_cache,
+                     TensorView q_norm_weight, TensorView k_norm_weight, double eps,
+                     TensorView q_out, TensorView state_cache, TensorView state_slots,
+                     TensorView state_block_table, TensorView query_start_loc,
+                     TensorView logical_positions, TensorView compressed_cache,
+                     TensorView compressed_slots, TensorView work_metadata, int64_t compress_ratio,
+                     int64_t mrope_h, int64_t mrope_w, bool is_k_mrope, bool cache_has_rope_pos) {
+  CHECK_DEVICE(k, q);
+  CHECK_DEVICE(positions, q);
+  CHECK_DEVICE(cos_sin_cache, q);
+  CHECK_DEVICE(q_norm_weight, q);
+  CHECK_DEVICE(k_norm_weight, q);
+  CHECK_DEVICE(q_out, q);
+  CHECK_DEVICE(state_cache, q);
+  CHECK_DEVICE(state_slots, q);
+  CHECK_DEVICE(state_block_table, q);
+  CHECK_DEVICE(query_start_loc, q);
+  CHECK_DEVICE(logical_positions, q);
+  CHECK_DEVICE(compressed_cache, q);
+  CHECK_DEVICE(compressed_slots, q);
+  CHECK_DEVICE(work_metadata, q);
+  CHECK_DIM(2, q);                 // [tokens, heads * head_dim]
+  CHECK_DIM(2, k);                 // [tokens, head_dim]
+  CHECK_DIM(3, q_out);             // [tokens, heads, head_dim]
+  CHECK_DIM(4, state_cache);       // [blocks, ring, 1, head_dim (+ coordinates)]
+  CHECK_DIM(4, compressed_cache);  // [blocks, page, 1, head_dim]
+  CHECK_DIM(2, state_block_table);
+  CHECK_DIM(2, work_metadata);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k);
+  CHECK_LAST_DIM_CONTIGUOUS(q_out);
+  CHECK_LAST_DIM_CONTIGUOUS(state_cache);
+  CHECK_LAST_DIM_CONTIGUOUS(compressed_cache);
+  CHECK_CONTIGUOUS(cos_sin_cache);
+  CHECK_CONTIGUOUS(q_norm_weight);
+  CHECK_CONTIGUOUS(k_norm_weight);
+  CHECK_CONTIGUOUS(state_slots);
+  CHECK_CONTIGUOUS(compressed_slots);
+  CHECK_CONTIGUOUS(logical_positions);
+  CHECK_CONTIGUOUS(query_start_loc);
+  CHECK_CONTIGUOUS(work_metadata);
+
+  const int64_t num_tokens = q.size(0);
+  if (num_tokens == 0) return;
+  const int64_t num_q_heads = q_out.size(1);
+  const int64_t head_dim = q_out.size(2);
+  TVM_FFI_ICHECK(head_dim == 128 || head_dim == 256)
+      << "qsa_pre_indexer builds a head dimension of 128 or 256, got " << head_dim;
+  TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_EQ(q.size(1), num_q_heads * head_dim) << "q must hold every head of a token";
+  TVM_FFI_ICHECK_EQ(k.size(1), head_dim) << "k and q_out head_dim must match";
+  TVM_FFI_ICHECK_EQ(q_out.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(compressed_cache.size(3), head_dim)
+      << "the compressed cache and q_out head_dim must match";
+  // Both caches are strided by their first two axes and the row is read from
+  // there, so a second KV head would land on top of the first.
+  TVM_FFI_ICHECK_EQ(state_cache.size(2), 1) << "the ring holds one KV head";
+  TVM_FFI_ICHECK_EQ(compressed_cache.size(2), 1) << "the compressed cache holds one KV head";
+  // The rotary table is addressed as a flat run of rows of half the head
+  // dimension; a row of any other width silently shifts every position.
+  TVM_FFI_ICHECK_EQ(cos_sin_cache.size(cos_sin_cache.ndim() - 1), head_dim / 2)
+      << "the rotary table is pair-major, so a row is head_dim / 2 wide";
+  // Three int64 coordinates sit after the row, in units of the row's own type.
+  const int64_t coord_width =
+      cache_has_rope_pos ? 3 * static_cast<int64_t>(sizeof(int64_t)) / get_element_size(state_cache)
+                         : 0;
+  TVM_FFI_ICHECK_GE(state_cache.size(3), head_dim + coord_width)
+      << "the ring holds a row of head_dim, and its coordinates after it";
+  TVM_FFI_ICHECK_EQ(work_metadata.size(1), 2) << "a work item is a request and its index";
+  TVM_FFI_ICHECK_EQ(state_slots.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(compressed_slots.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(logical_positions.size(0), num_tokens);
+  // A work item names a request and the kernel reads that request's end, so the
+  // table has to run one past the last of them.
+  TVM_FFI_ICHECK_EQ(query_start_loc.size(0), state_block_table.size(0) + 1)
+      << "query_start_loc runs one entry past the requests the ring table holds";
+
+  // Every half-width tensor is read through one pointer type.
+  TVM_FFI_ICHECK_EQ(k.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(q_norm_weight.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(k_norm_weight.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(q_out.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(state_cache.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(compressed_cache.dtype(), q.dtype());
+  TVM_FFI_ICHECK_EQ(positions.dtype(), dl_int64) << "positions must be int64";
+  TVM_FFI_ICHECK_EQ(state_slots.dtype(), dl_int64) << "state_slots must be int64";
+  TVM_FFI_ICHECK_EQ(compressed_slots.dtype(), dl_int64) << "compressed_slots must be int64";
+  TVM_FFI_ICHECK_EQ(logical_positions.dtype(), dl_int64) << "logical_positions must be int64";
+  TVM_FFI_ICHECK_EQ(query_start_loc.dtype(), dl_int32) << "query_start_loc must be int32";
+  TVM_FFI_ICHECK_EQ(state_block_table.dtype(), dl_int32) << "state_block_table must be int32";
+  TVM_FFI_ICHECK_EQ(work_metadata.dtype(), dl_int32) << "work_metadata must be int32";
+
+  const bool pos_2d = positions.ndim() == 2;
+  TVM_FFI_ICHECK(pos_2d || positions.ndim() == 1) << "positions is one axis or three";
+  if (pos_2d) {
+    TVM_FFI_ICHECK_EQ(positions.size(0), 3) << "a three-axis position tensor has three rows";
+  }
+
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
+  const cudaStream_t stream = get_stream(q.device());
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
+    QSAPreIndexerParams<c_type> p{};
+    p.q = static_cast<const c_type*>(q.data_ptr());
+    p.q_stride_token = q.stride(0);
+    p.k = static_cast<const c_type*>(k.data_ptr());
+    p.k_stride_token = k.stride(0);
+    p.positions = static_cast<const int64_t*>(positions.data_ptr());
+    p.pos_stride_axis = pos_2d ? positions.stride(0) : 0;
+    p.pos_stride_token = pos_2d ? positions.stride(1) : positions.stride(0);
+    p.cos_sin = static_cast<const c_type*>(cos_sin_cache.data_ptr());
+    p.q_norm_weight = static_cast<const c_type*>(q_norm_weight.data_ptr());
+    p.k_norm_weight = static_cast<const c_type*>(k_norm_weight.data_ptr());
+    p.eps = static_cast<float>(eps);
+    p.q_out = static_cast<c_type*>(q_out.data_ptr());
+    p.q_out_stride_token = q_out.stride(0);
+    p.q_out_stride_head = q_out.stride(1);
+    p.state_cache = static_cast<c_type*>(state_cache.data_ptr());
+    p.state_stride_block = state_cache.stride(0);
+    p.state_stride_token = state_cache.stride(1);
+    p.state_slots = static_cast<const int64_t*>(state_slots.data_ptr());
+    p.state_table = static_cast<const int32_t*>(state_block_table.data_ptr());
+    p.state_table_stride_req = state_block_table.stride(0);
+    p.query_start_loc = static_cast<const int32_t*>(query_start_loc.data_ptr());
+    p.logical_positions = static_cast<const int64_t*>(logical_positions.data_ptr());
+    p.compressed_slots = static_cast<const int64_t*>(compressed_slots.data_ptr());
+    p.work_metadata = static_cast<const int32_t*>(work_metadata.data_ptr());
+    p.compressed_cache = static_cast<c_type*>(compressed_cache.data_ptr());
+    p.compressed_stride_block = compressed_cache.stride(0);
+    p.compressed_stride_token = compressed_cache.stride(1);
+    p.num_tokens = static_cast<int32_t>(num_tokens);
+    p.num_state_blocks = static_cast<int32_t>(state_cache.size(0));
+    p.num_compressed_blocks = static_cast<int32_t>(compressed_cache.size(0));
+    p.num_k_work = static_cast<int32_t>(work_metadata.size(0));
+    p.num_q_heads = static_cast<int32_t>(num_q_heads);
+    p.compress_ratio = static_cast<int32_t>(compress_ratio);
+    p.state_size = static_cast<int32_t>(state_cache.size(1));
+    p.comp_page_size = static_cast<int32_t>(compressed_cache.size(1));
+    p.mrope_h = static_cast<int32_t>(mrope_h);
+    p.mrope_w = static_cast<int32_t>(mrope_w);
+    p.ratio_shift = shift_of(compress_ratio);
+    p.state_shift = shift_of(p.state_size);
+    p.comp_shift = shift_of(p.comp_page_size);
+    p.inv_ratio = 1.f / static_cast<float>(compress_ratio);
+
+    const cudaError_t status =
+        head_dim == 128
+            ? QSAPreIndexer<128, c_type>(p, is_k_mrope, pos_2d, cache_has_rope_pos, stream)
+            : QSAPreIndexer<256, c_type>(p, is_k_mrope, pos_2d, cache_has_rope_pos, stream);
+    TVM_FFI_ICHECK(status != cudaErrorInvalidValue)
+        << "qsa_pre_indexer: unsupported rotary configuration (three-axis positions need a "
+           "three-axis key)";
+    TVM_FFI_ICHECK(status == cudaSuccess) << "QSAPreIndexer failed: " << cudaGetErrorString(status);
+    return true;
+  });
+}

--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -81,6 +81,10 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   TVM_FFI_ICHECK(head_dim == 128 || head_dim == 256)
       << "qsa_pre_indexer builds a head dimension of 128 or 256, got " << head_dim;
   TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  // Narrowed to int32 for the kernel while the reciprocal is formed from the
+  // original, so a value past int32 would pool by one ratio and scale by
+  // another.
+  TVM_FFI_ICHECK_LE(compress_ratio, 2147483647LL) << "compress_ratio must fit in 32 bits";
   TVM_FFI_ICHECK_EQ(q.size(1), num_q_heads * head_dim) << "q must hold every head of a token";
   TVM_FFI_ICHECK_EQ(k.size(1), head_dim) << "k and q_out head_dim must match";
   TVM_FFI_ICHECK_EQ(q_out.size(0), num_tokens);
@@ -99,6 +103,9 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   // dimension; a row of any other width silently shifts every position.
   TVM_FFI_ICHECK_EQ(cos_sin_cache.size(cos_sin_cache.ndim() - 1), head_dim / 2)
       << "the rotary table is pair-major, so a row is head_dim / 2 wide";
+  // A table of no rows passes the width check and leaves nothing to read: the
+  // kernel holds a coordinate at the last row, and an empty table has none.
+  TVM_FFI_ICHECK_GT(cos_sin_cache.numel(), 0) << "the rotary table holds at least one row";
   // Three int64 coordinates sit after the row, in units of the row's own type.
   const int64_t coord_width =
       cache_has_rope_pos ? 3 * static_cast<int64_t>(sizeof(int64_t)) / get_element_size(state_cache)

--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -104,6 +104,10 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   TVM_FFI_ICHECK_EQ(state_slots.size(0), num_tokens);
   TVM_FFI_ICHECK_EQ(compressed_slots.size(0), num_tokens);
   TVM_FFI_ICHECK_EQ(logical_positions.size(0), num_tokens);
+  // Both are walked by a token stride, so a shorter axis is read past its end.
+  TVM_FFI_ICHECK_EQ(k.size(0), num_tokens) << "one raw key per token";
+  TVM_FFI_ICHECK_EQ(positions.size(positions.ndim() - 1), num_tokens)
+      << "one rotary position per token";
   // A work item names a request and the kernel reads that request's end, so the
   // table has to run one past the last of them.
   TVM_FFI_ICHECK_EQ(query_start_loc.size(0), state_block_table.size(0) + 1)

--- a/csrc/sparse_pre_indexer.cu
+++ b/csrc/sparse_pre_indexer.cu
@@ -30,7 +30,36 @@ int32_t shift_of(int64_t v) {
   return sh;
 }
 
+// Carries an output type into the generic lambda that launches with it.
+template <typename T>
+struct type_tag {
+  using type = T;
+};
+
 }  // namespace
+
+// The narrowing arm and the bit that advertises it are the same decision, so they come
+// from one guard: a build without e4m3 has neither.
+#ifdef FLASHINFER_ENABLE_FP8_E4M3
+#define QSA_PRE_INDEXER_NARROWING_ARM()                  \
+  if (q_out.dtype() == dl_float8_e4m3fn) {               \
+    return launch_with(type_tag<__nv_fp8_e4m3>{});       \
+  }
+#define QSA_PRE_INDEXER_NARROW_E4M3_BIT (int64_t{1} << 1)
+#else
+#define QSA_PRE_INDEXER_NARROWING_ARM()
+#define QSA_PRE_INDEXER_NARROW_E4M3_BIT int64_t{0}
+#endif
+
+#define QSA_PRE_INDEXER_SAME_AS_COMPUTE_BIT (int64_t{1} << 0)
+
+// Which (compute, output) relations this build dispatches. Bit 0 is "output is the
+// compute dtype", bit 1 is "output narrows to e4m3". Reported as the relation rather
+// than a list of dtypes so no dtype encoding has to cross the FFI boundary and agree
+// with the switch above.
+int64_t qsa_pre_indexer_dispatch_mask() {
+  return QSA_PRE_INDEXER_SAME_AS_COMPUTE_BIT | QSA_PRE_INDEXER_NARROW_E4M3_BIT;
+}
 
 void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorView cos_sin_cache,
                      TensorView q_norm_weight, TensorView k_norm_weight, double eps,
@@ -142,9 +171,14 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), q.dtype());
   TVM_FFI_ICHECK_EQ(q_norm_weight.dtype(), q.dtype());
   TVM_FFI_ICHECK_EQ(k_norm_weight.dtype(), q.dtype());
-  TVM_FFI_ICHECK_EQ(q_out.dtype(), q.dtype());
+  // The raw ring is never quantized: it feeds the compression read path.
   TVM_FFI_ICHECK_EQ(state_cache.dtype(), q.dtype());
-  TVM_FFI_ICHECK_EQ(compressed_cache.dtype(), q.dtype());
+  // The two indexer outputs are one dtype, the caller's indexer_kv_dtype.
+  TVM_FFI_ICHECK_EQ(compressed_cache.dtype(), q_out.dtype());
+  // Either no narrowing at all, or plain e4m3. A bf16 compute with an f16 output is
+  // not a combination anything asks for and is not built.
+  TVM_FFI_ICHECK(q_out.dtype() == q.dtype() || q_out.dtype() == dl_float8_e4m3fn)
+      << "q_out must be " << q.dtype() << " or float8_e4m3fn, got " << q_out.dtype();
   TVM_FFI_ICHECK_EQ(positions.dtype(), dl_int64) << "positions must be int64";
   TVM_FFI_ICHECK_EQ(state_slots.dtype(), dl_int64) << "state_slots must be int64";
   TVM_FFI_ICHECK_EQ(compressed_slots.dtype(), dl_int64) << "compressed_slots must be int64";
@@ -161,7 +195,9 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
   ffi::CUDADeviceGuard device_guard(q.device().device_id);
   const cudaStream_t stream = get_stream(q.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
-    QSAPreIndexerParams<c_type> p{};
+    auto launch_with = [&](auto out_tag) -> bool {
+    using OutDType = typename decltype(out_tag)::type;
+    QSAPreIndexerParams<c_type, OutDType> p{};
     p.q = static_cast<const c_type*>(q.data_ptr());
     p.q_stride_token = q.stride(0);
     p.k = static_cast<const c_type*>(k.data_ptr());
@@ -176,7 +212,7 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
     p.q_norm_weight = static_cast<const c_type*>(q_norm_weight.data_ptr());
     p.k_norm_weight = static_cast<const c_type*>(k_norm_weight.data_ptr());
     p.eps = static_cast<float>(eps);
-    p.q_out = static_cast<c_type*>(q_out.data_ptr());
+    p.q_out = static_cast<OutDType*>(q_out.data_ptr());
     p.q_out_stride_token = q_out.stride(0);
     p.q_out_stride_head = q_out.stride(1);
     p.state_cache = static_cast<c_type*>(state_cache.data_ptr());
@@ -189,7 +225,7 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
     p.logical_positions = static_cast<const int64_t*>(logical_positions.data_ptr());
     p.compressed_slots = static_cast<const int64_t*>(compressed_slots.data_ptr());
     p.work_metadata = static_cast<const int32_t*>(work_metadata.data_ptr());
-    p.compressed_cache = static_cast<c_type*>(compressed_cache.data_ptr());
+    p.compressed_cache = static_cast<OutDType*>(compressed_cache.data_ptr());
     p.compressed_stride_block = compressed_cache.stride(0);
     p.compressed_stride_token = compressed_cache.stride(1);
     p.num_tokens = static_cast<int32_t>(num_tokens);
@@ -210,12 +246,25 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
 
     const cudaError_t status =
         head_dim == 128
-            ? QSAPreIndexer<128, c_type>(p, is_k_mrope, pos_2d, cache_has_rope_pos, stream)
-            : QSAPreIndexer<256, c_type>(p, is_k_mrope, pos_2d, cache_has_rope_pos, stream);
+            ? QSAPreIndexer<128, c_type, OutDType>(p, is_k_mrope, pos_2d, cache_has_rope_pos,
+                                                   stream)
+            : QSAPreIndexer<256, c_type, OutDType>(p, is_k_mrope, pos_2d, cache_has_rope_pos,
+                                                   stream);
     TVM_FFI_ICHECK(status != cudaErrorInvalidValue)
         << "qsa_pre_indexer: unsupported rotary configuration (three-axis positions need a "
            "three-axis key)";
     TVM_FFI_ICHECK(status == cudaSuccess) << "QSAPreIndexer failed: " << cudaGetErrorString(status);
     return true;
+    };
+
+    if (q_out.dtype() == q.dtype()) {
+      return launch_with(type_tag<c_type>{});
+    }
+    QSA_PRE_INDEXER_NARROWING_ARM()
+    // Reachable: with FLASHINFER_ENABLE_FP8_E4M3 off the arm above expands to nothing
+    // and an e4m3 q_out, admitted by the dtype check, arrives here.
+    TVM_FFI_ICHECK(false) << "q_out dtype " << q_out.dtype()
+                          << " is not enabled in this build of the pre-indexer";
+    return false;
   });
 }

--- a/csrc/sparse_pre_indexer_jit_binding.cu
+++ b/csrc/sparse_pre_indexer_jit_binding.cu
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tvm_ffi_utils.h"
+
+void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorView cos_sin_cache,
+                     TensorView q_norm_weight, TensorView k_norm_weight, double eps,
+                     TensorView q_out, TensorView state_cache, TensorView state_slots,
+                     TensorView state_block_table, TensorView query_start_loc,
+                     TensorView logical_positions, TensorView compressed_cache,
+                     TensorView compressed_slots, TensorView work_metadata, int64_t compress_ratio,
+                     int64_t mrope_h, int64_t mrope_w, bool is_k_mrope, bool cache_has_rope_pos);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(qsa_pre_indexer, qsa_pre_indexer);

--- a/csrc/sparse_pre_indexer_jit_binding.cu
+++ b/csrc/sparse_pre_indexer_jit_binding.cu
@@ -23,4 +23,7 @@ void qsa_pre_indexer(TensorView q, TensorView k, TensorView positions, TensorVie
                      TensorView compressed_slots, TensorView work_metadata, int64_t compress_ratio,
                      int64_t mrope_h, int64_t mrope_w, bool is_k_mrope, bool cache_has_rope_pos);
 
+int64_t qsa_pre_indexer_dispatch_mask();
+
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(qsa_pre_indexer, qsa_pre_indexer);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(qsa_pre_indexer_dispatch_mask, qsa_pre_indexer_dispatch_mask);

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -296,6 +296,7 @@ from .topk import top_k_page_table_transform as top_k_page_table_transform
 from .topk import top_k_ragged_transform as top_k_ragged_transform
 from .topk import TopKTieBreak as TopKTieBreak
 from .topk_varlen.topk_varlen import top_k_varlen as top_k_varlen
+from .sparse_pre_indexer import qsa_pre_indexer as qsa_pre_indexer
 from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper
 from .sparse import (
     VariableBlockSparseAttentionWrapper as VariableBlockSparseAttentionWrapper,

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -170,6 +170,7 @@ from .jit.hash_topk import gen_hash_topk_module
 from .jit.tllm_utils import gen_trtllm_utils_module
 from .jit.topk import gen_topk_module
 from .jit.xqa import gen_xqa_module, gen_xqa_module_mla
+from .jit.sparse_pre_indexer import gen_sparse_pre_indexer_module
 
 
 def gen_fa2(
@@ -845,6 +846,7 @@ def gen_all_modules(
             gen_quantization_module(),
             gen_rope_module(),
             gen_sampling_module(),
+            gen_sparse_pre_indexer_module(),
             gen_topk_module(),
         ]
         # Fused RMSNorm+SiLU: pre-compile all LUT configs (SM100+ only)

--- a/flashinfer/jit/sparse_pre_indexer.py
+++ b/flashinfer/jit/sparse_pre_indexer.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec
+
+
+def gen_sparse_pre_indexer_module() -> JitSpec:
+    return gen_jit_spec(
+        "sparse_pre_indexer",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_pre_indexer.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_pre_indexer_jit_binding.cu",
+        ],
+        extra_cuda_cflags=["-DENABLE_BF16"],
+    )

--- a/flashinfer/sparse_pre_indexer.py
+++ b/flashinfer/sparse_pre_indexer.py
@@ -1,0 +1,235 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+
+import torch
+
+from .jit.sparse_pre_indexer import gen_sparse_pre_indexer_module
+from .utils import register_custom_op, register_fake_op
+
+
+@functools.cache
+def get_sparse_pre_indexer_module():
+    return gen_sparse_pre_indexer_module().build_and_load()
+
+
+@register_custom_op(
+    "flashinfer::qsa_pre_indexer",
+    mutates_args=("q_out", "state_cache", "compressed_cache"),
+)
+def _qsa_pre_indexer(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    eps: float,
+    q_out: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_slots: torch.Tensor,
+    state_block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_cache: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    work_metadata: torch.Tensor,
+    compress_ratio: int,
+    mrope_h: int,
+    mrope_w: int,
+    is_k_mrope: bool,
+    cache_has_rope_pos: bool,
+) -> None:
+    get_sparse_pre_indexer_module().qsa_pre_indexer(
+        q,
+        k,
+        positions,
+        cos_sin_cache,
+        q_norm_weight,
+        k_norm_weight,
+        eps,
+        q_out,
+        state_cache,
+        state_slots,
+        state_block_table,
+        query_start_loc,
+        logical_positions,
+        compressed_cache,
+        compressed_slots,
+        work_metadata,
+        compress_ratio,
+        mrope_h,
+        mrope_w,
+        is_k_mrope,
+        cache_has_rope_pos,
+    )
+
+
+@register_fake_op("flashinfer::qsa_pre_indexer")
+def _qsa_pre_indexer_fake(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    eps: float,
+    q_out: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_slots: torch.Tensor,
+    state_block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_cache: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    work_metadata: torch.Tensor,
+    compress_ratio: int,
+    mrope_h: int,
+    mrope_w: int,
+    is_k_mrope: bool,
+    cache_has_rope_pos: bool,
+) -> None:
+    pass
+
+
+def qsa_pre_indexer(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    q_norm_weight: torch.Tensor,
+    k_norm_weight: torch.Tensor,
+    eps: float,
+    q_out: torch.Tensor,
+    state_cache: torch.Tensor,
+    state_slots: torch.Tensor,
+    state_block_table: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    logical_positions: torch.Tensor,
+    compressed_cache: torch.Tensor,
+    compressed_slots: torch.Tensor,
+    work_metadata: torch.Tensor,
+    compress_ratio: int,
+    mrope_h: int = 0,
+    mrope_w: int = 0,
+    is_k_mrope: bool = False,
+    cache_has_rope_pos: bool = False,
+) -> None:
+    r"""Build the query and compressed-key rows a sparse route is scored on.
+
+    One launch does two things. Every query row is RMS-normalised with a
+    stored-plus-one weight and rotated by a partial NeoX RoPE -- the first half
+    of the row turns, pairing each element with the one a quarter-row away.
+    Every completed compression group is mean-pooled from its raw keys,
+    normalised, rotated the same way and written to the compressed cache; the
+    keys a group needs may reach back past the start of this step's chunk, into
+    the per-request ring, and the first work item of a request also commits that
+    request's raw-key suffix to that ring for the next step to read.
+
+    The result of this is what :func:`sparse_paged_scores` scores.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Queries, shape ``[tokens, num_heads * head_dim]``, float16 or bfloat16.
+        ``head_dim`` must be 128 or 256.
+    k : torch.Tensor
+        Raw keys, shape ``[tokens, head_dim]``, same dtype as ``q``.
+    positions : torch.Tensor
+        Rotary coordinates, int64. Shape ``[tokens]``, or ``[3, tokens]`` for the
+        temporal, height and width axes of an interleaved three-axis rope.
+    cos_sin_cache : torch.Tensor
+        Pair-major rotary table, shape ``[max_position, head_dim // 2]``: a row
+        is cosine and sine interleaved so that one pair is a single access.
+    q_norm_weight, k_norm_weight : torch.Tensor
+        Norm weights of one row, held as the offset from one.
+    eps : float
+        Added to the mean square before the reciprocal square root.
+    q_out : torch.Tensor
+        Receives the normalised, rotated queries, shape
+        ``[tokens, num_heads, head_dim]``.
+    state_cache : torch.Tensor
+        The per-request ring of raw keys, shape ``[blocks, ring, 1, width]``.
+        ``width`` is ``head_dim``, plus room for three int64 coordinates after it
+        when ``cache_has_rope_pos``.
+    state_slots : torch.Tensor
+        Ring slot each token commits to, int64, shape ``[tokens]``. Negative to skip.
+    state_block_table : torch.Tensor
+        Ring block of each request, int32, shape ``[num_requests, 1]``.
+    query_start_loc : torch.Tensor
+        Token each request starts at, int32, shape ``[num_requests + 1]``.
+    logical_positions : torch.Tensor
+        Position of each token in its request's whole sequence, int64.
+    compressed_cache : torch.Tensor
+        Receives the pooled keys, shape ``[blocks, page, 1, head_dim]``.
+    compressed_slots : torch.Tensor
+        Compressed slot each group boundary writes to, int64, shape ``[tokens]``.
+    work_metadata : torch.Tensor
+        One row per compression group, int32, shape ``[num_work, 2]``: the request
+        and the index of the group within it. A negative request skips the row.
+    compress_ratio : int
+        Raw keys pooled into one compressed entry.
+    mrope_h, mrope_w : int
+        Section widths of the height and width axes of a three-axis rope.
+    is_k_mrope : bool
+        Whether the compressed key picks its rotary axis per pair.
+    cache_has_rope_pos : bool
+        Whether the ring keeps each row's rotary coordinates after its elements,
+        which is what lets a group that reaches into it rotate by the right ones.
+
+    Notes
+    -----
+    The query picks its axis per pair exactly when ``positions`` carries three of
+    them, so three-axis positions with ``is_k_mrope=False`` is not a supported
+    configuration.
+    """
+    if q.ndim != 2:
+        raise ValueError(f"q must be [tokens, heads * head_dim], got {q.ndim}D")
+    if q_out.ndim != 3:
+        raise ValueError(f"q_out must be [tokens, heads, head_dim], got {q_out.ndim}D")
+    head_dim = q_out.shape[2]
+    if head_dim not in (128, 256):
+        raise ValueError(f"qsa_pre_indexer builds head_dim 128 or 256, got {head_dim}")
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    if positions.ndim == 2 and not is_k_mrope:
+        raise ValueError("three-axis positions need a three-axis key")
+    if q.shape[0] == 0:
+        return
+    _qsa_pre_indexer(
+        q,
+        k,
+        positions,
+        cos_sin_cache,
+        q_norm_weight,
+        k_norm_weight,
+        eps,
+        q_out,
+        state_cache,
+        state_slots,
+        state_block_table,
+        query_start_loc,
+        logical_positions,
+        compressed_cache,
+        compressed_slots,
+        work_metadata,
+        compress_ratio,
+        mrope_h,
+        mrope_w,
+        is_k_mrope,
+        cache_has_rope_pos,
+    )

--- a/flashinfer/sparse_pre_indexer.py
+++ b/flashinfer/sparse_pre_indexer.py
@@ -27,6 +27,28 @@ def get_sparse_pre_indexer_module():
     return gen_sparse_pre_indexer_module().build_and_load()
 
 
+# Which (compute, output) relations a build dispatches. Bit 0 is "the output is the
+# compute dtype", bit 1 is "the output narrows to e4m3".
+QSA_PRE_INDEXER_SAME_AS_COMPUTE = 1 << 0
+QSA_PRE_INDEXER_NARROW_E4M3 = 1 << 1
+# A build predating the query only ever wrote the compute dtype.
+_QSA_PRE_INDEXER_LEGACY_MASK = QSA_PRE_INDEXER_SAME_AS_COMPUTE
+
+
+def qsa_pre_indexer_dispatch_mask() -> int:
+    """Which output dtypes the built pre-indexer actually instantiates.
+
+    Read off the compiled module rather than a constant here: a cached build can lag
+    this source, and only the binary knows what it was compiled with. A module without
+    the query is one of those older builds, and wrote the compute dtype alone.
+    """
+    module = get_sparse_pre_indexer_module()
+    query = getattr(module, "qsa_pre_indexer_dispatch_mask", None)
+    if query is None:
+        return _QSA_PRE_INDEXER_LEGACY_MASK
+    return int(query())
+
+
 @register_custom_op(
     "flashinfer::qsa_pre_indexer",
     mutates_args=("q_out", "state_cache", "compressed_cache"),

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -383,12 +383,14 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
 
   const int32_t query_start = a.query_start_loc[request];
   const int32_t query_end = a.query_start_loc[request + 1];
-  const int32_t query_len = query_end - query_start;
   // The offsets are the caller's too, and only their length was checked. A
   // request with no tokens has nothing to pool and no last token to read the
   // chunk's end from, and a range that runs off either end of the token axis
-  // would make the read below land outside logical_positions.
-  if (query_len <= 0 || query_start < 0 || query_end > a.num_tokens) return;
+  // would make the read below land outside logical_positions. The bounds come
+  // before the subtraction: [INT32_MAX, INT32_MIN] wraps to a length of 1 and
+  // would walk straight past the guard.
+  if (query_start < 0 || query_end > a.num_tokens || query_end <= query_start) return;
+  const int32_t query_len = query_end - query_start;
   const int64_t chunk_end = a.logical_positions[query_end - 1];
   const int64_t chunk_start = chunk_end - query_len + 1;
   const int32_t ratio = a.compress_ratio;

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -1,0 +1,600 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ATTENTION_SPARSE_PRE_INDEXER_CUH_
+#define FLASHINFER_ATTENTION_SPARSE_PRE_INDEXER_CUH_
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include "../utils.cuh"
+
+// What a sparse-route indexer reads has to be built before it can be scored:
+// the query rows normalised and rotated, and the key rows pooled into the
+// compression the route addresses. This does both in one launch.
+//
+// Every query row is RMS-normalised and rotated into the form the scorer takes.
+// Every completed compression group is pooled from its raw keys -- which may
+// straddle the chunk boundary into the per-request ring -- normalised, rotated
+// and written to the compressed cache; the first work item of each request also
+// commits that request's raw-key suffix back to the ring.
+//
+// A warp owns one row of head_dim. That is the whole shape of this file: the
+// row is 128 or 256 elements, a lane holds four of them, and the only thing
+// that crosses lanes is the norm's sum -- the rotation's partner is a quarter
+// row away, which this layout puts in the same lane.
+
+namespace flashinfer {
+
+namespace sparse_pre_indexer {
+
+constexpr int kWarp = 32;
+constexpr int kWarpsPerBlock = 4;
+constexpr int kBlock = kWarp * kWarpsPerBlock;
+// A row is spread over one warp, so a lane holds head_dim/32 of it.
+template <int D>
+constexpr int kPer = D / kWarp;
+// Rotating pairs a lane owns: the row's first quarter, spread over the warp.
+template <int D>
+constexpr int kPairs = D / (4 * kWarp);
+
+// A cosine and its sine, adjacent in the pair-major table, read as one access.
+template <typename T>
+struct __align__(4) CosSin {
+  T c, s;
+};
+
+__device__ __forceinline__ float warp_sum(float v) {
+#pragma unroll
+  for (int offset = 16; offset > 0; offset >>= 1) {
+    v += __shfl_xor_sync(0xffffffffu, v, offset);
+  }
+  return v;
+}
+
+template <typename T>
+__device__ __forceinline__ float to_float(T x);
+template <>
+__device__ __forceinline__ float to_float<__nv_bfloat16>(__nv_bfloat16 x) {
+  return __bfloat162float(x);
+}
+template <>
+__device__ __forceinline__ float to_float<half>(half x) {
+  return __half2float(x);
+}
+
+template <typename T>
+__device__ __forceinline__ T from_float(float x);
+template <>
+__device__ __forceinline__ __nv_bfloat16 from_float<__nv_bfloat16>(float x) {
+  return __float2bfloat16(x);
+}
+template <>
+__device__ __forceinline__ half from_float<half>(float x) {
+  return __float2half(x);
+}
+
+// A value as the cache will hold it. The pooled group and the normalised row
+// both round here so that a fused result matches an unfused one bit for bit.
+template <typename T>
+__device__ __forceinline__ float round_to(float v) {
+  return to_float<T>(from_float<T>(v));
+}
+
+/*!
+ * \brief Which rotary axis each pair a lane owns belongs to.
+ *
+ * The choice is a function of the pair index alone, and a lane's pair indices
+ * never change, so this is settled once for the warp rather than again for
+ * every token it goes on to handle.
+ */
+template <int D, bool MROPE>
+__device__ __forceinline__ void lane_axes(int lane, int mrope_h, int mrope_w,
+                                          int (&axis)[kPairs<D>]) {
+#pragma unroll
+  for (int r = 0; r < kPairs<D>; ++r) {
+    if constexpr (!MROPE) {
+      axis[r] = 0;
+    } else {
+      const int p = lane + r * kWarp;
+      const int mod = p % 3;
+      axis[r] = (mod == 1 && p <= 3 * mrope_h) ? 1 : (mod == 2 && p <= 3 * mrope_w) ? 2 : 0;
+    }
+  }
+}
+
+/*!
+ * \brief The rotary factors a lane needs, read once for a position.
+ *
+ * A lane holds the elements thirty-two apart starting at its own index, so the
+ * pairs it rotates are both in its registers and the factors it needs are one
+ * per rotating pair. Across the warp those factors are contiguous, and they are
+ * the same for every head of a token.
+ *
+ * The table is pair-major: a row is cosine and sine interleaved, so a pair is
+ * four bytes in one place rather than two halves of the row apart. The rotary
+ * axes sit on this kernel's dependency chain -- a position is read, then its
+ * factors -- so halving the reads on it is worth a table of its own.
+ */
+template <int D, bool MROPE, typename DType>
+__device__ __forceinline__ void load_cos_sin(const DType* __restrict__ cos_sin, int lane,
+                                             int64_t pos_t, int64_t pos_h, int64_t pos_w,
+                                             const int (&axis)[kPairs<D>], float (&c)[kPairs<D>],
+                                             float (&s)[kPairs<D>]) {
+  constexpr int kHalf = D / 2;
+  constexpr int kP = kPairs<D>;
+
+  if constexpr (!MROPE) {
+    const CosSin<DType>* row = reinterpret_cast<const CosSin<DType>*>(cos_sin + pos_t * kHalf);
+#pragma unroll
+    for (int r = 0; r < kP; ++r) {
+      const CosSin<DType> cs = row[lane + r * kWarp];
+      c[r] = to_float<DType>(cs.c);
+      s[r] = to_float<DType>(cs.s);
+    }
+    return;
+  }
+  // Interleaved temporal, height and width pairs; the three axes index the same
+  // table. Selected, not indexed: an array the compiler cannot fold an index
+  // for lands in local memory, and this is the query path's inner step.
+#pragma unroll
+  for (int r = 0; r < kP; ++r) {
+    const int p = lane + r * kWarp;
+    const int64_t pos = axis[r] == 1 ? pos_h : axis[r] == 2 ? pos_w : pos_t;
+    const CosSin<DType> cs = reinterpret_cast<const CosSin<DType>*>(cos_sin + pos * kHalf)[p];
+    c[r] = to_float<DType>(cs.c);
+    s[r] = to_float<DType>(cs.s);
+  }
+}
+
+template <int D>
+__device__ __forceinline__ float row_sumsq(const float (&v)[kPer<D>]) {
+  float sum = 0.f;
+#pragma unroll
+  for (int j = 0; j < kPer<D>; ++j) sum += v[j] * v[j];
+  return sum;
+}
+
+/*!
+ * \brief Finish the RMSNorm and apply partial NeoX RoPE to one row.
+ *
+ * The row's sum of squares arrives already reduced, so a caller holding several
+ * rows can put all their reductions in flight before finishing any of them --
+ * a reduction is a chain of shuffles, and one row at a time leaves the warp
+ * waiting on that chain with nothing else to issue.
+ *
+ * Lane L holds elements L, L+32, L+64 and so on. The first half of the row
+ * rotates and the second half passes through; an element pairs with the one a
+ * quarter-row away, which this layout puts in the same lane.
+ */
+template <int D, typename DType>
+__device__ __forceinline__ void apply_norm_rope(float (&v)[kPer<D>], float sum,
+                                                const float (&weight)[kPer<D>],
+                                                const float (&c)[kPairs<D>],
+                                                const float (&s)[kPairs<D>], float eps) {
+  constexpr int kN = kPer<D>;
+  constexpr int kP = kPairs<D>;
+  const float rrms = rsqrtf(sum / static_cast<float>(D) + eps);
+  // The result rounds to the cache dtype before the rotation reads it.
+#pragma unroll
+  for (int j = 0; j < kN; ++j) v[j] = round_to<DType>(v[j] * rrms * weight[j]);
+#pragma unroll
+  for (int r = 0; r < kP; ++r) {
+    const float low = v[r];
+    const float high = v[r + kP];
+    v[r] = low * c[r] - high * s[r];
+    v[r + kP] = high * c[r] + low * s[r];
+  }
+}
+
+template <int D, typename DType>
+__device__ __forceinline__ void norm_rope(float (&v)[kPer<D>], const float (&weight)[kPer<D>],
+                                          const float (&c)[kPairs<D>], const float (&s)[kPairs<D>],
+                                          float eps) {
+  apply_norm_rope<D, DType>(v, warp_sum(row_sumsq<D>(v)), weight, c, s, eps);
+}
+
+// A lane's elements are strided by the warp width, which keeps every one of the
+// row's loads coalesced across the warp and the rotating pairs in registers.
+template <int D, typename DType>
+__device__ __forceinline__ void load_row(float (&v)[kPer<D>], const DType* __restrict__ src,
+                                         int lane, bool valid) {
+#pragma unroll
+  for (int j = 0; j < kPer<D>; ++j) {
+    v[j] = valid ? to_float<DType>(src[lane + j * kWarp]) : 0.f;
+  }
+}
+
+template <int D, typename DType>
+__device__ __forceinline__ void store_row(DType* __restrict__ dst, const float (&v)[kPer<D>],
+                                          int lane) {
+#pragma unroll
+  for (int j = 0; j < kPer<D>; ++j) dst[lane + j * kWarp] = from_float<DType>(v[j]);
+}
+
+// The stored weight is the offset from one, as the Gemma checkpoints keep it.
+template <int D, typename DType>
+__device__ __forceinline__ void load_weight(float (&w)[kPer<D>], const DType* __restrict__ src,
+                                            int lane) {
+#pragma unroll
+  for (int j = 0; j < kPer<D>; ++j) {
+    w[j] = to_float<DType>(src[lane + j * kWarp]) + 1.f;
+  }
+}
+
+}  // namespace sparse_pre_indexer
+
+/*!
+ * \brief Everything one launch of the pre-indexer reads and writes.
+ *
+ * The three shifts stand in for divisions that are otherwise sixty-four bit and
+ * runtime; a negative one means that divisor is not a power of two and the
+ * launch takes the general path.
+ */
+template <typename DType>
+struct QSAPreIndexerParams {
+  const DType* q;
+  int64_t q_stride_token;
+  const DType* k;
+  int64_t k_stride_token;
+  const int64_t* positions;
+  int64_t pos_stride_axis;
+  int64_t pos_stride_token;
+  const DType* cos_sin;
+  const DType* q_norm_weight;
+  const DType* k_norm_weight;
+  float eps;
+  DType* q_out;
+  int64_t q_out_stride_token;
+  int64_t q_out_stride_head;
+  DType* state_cache;
+  int64_t state_stride_block;
+  int64_t state_stride_token;
+  const int64_t* state_slots;
+  const int32_t* state_table;
+  int64_t state_table_stride_req;
+  const int32_t* query_start_loc;
+  const int64_t* logical_positions;
+  const int64_t* compressed_slots;
+  const int32_t* work_metadata;
+  DType* compressed_cache;
+  int64_t compressed_stride_block;
+  int64_t compressed_stride_token;
+  int32_t num_tokens;
+  int32_t num_state_blocks;
+  int32_t num_compressed_blocks;
+  int32_t num_k_work;
+  int32_t num_q_heads;
+  int32_t compress_ratio;
+  int32_t state_size;
+  int32_t comp_page_size;
+  int32_t mrope_h;
+  int32_t mrope_w;
+  int32_t k_blocks;
+  int32_t ratio_shift;
+  int32_t state_shift;
+  int32_t comp_shift;
+  float inv_ratio;
+};
+
+namespace sparse_pre_indexer {
+
+/*!
+ * \tparam D head dimension
+ * \tparam MROPE_Q whether the query's rotary axes are chosen per pair
+ * \tparam MROPE_K same for the compressed key
+ * \tparam POS_2D whether the position tensor carries three axes
+ * \tparam CACHE_POS whether the ring stores each row's rotary coordinates
+ * \tparam POW2 whether the compression ratio, the ring and the compressed page
+ *   are all powers of two, which is what turns their divisions into shifts
+ */
+template <int D, bool MROPE_Q, bool MROPE_K, bool POS_2D, bool CACHE_POS, bool POW2, typename DType>
+__global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParams<DType> a) {
+  const int lane = threadIdx.x % kWarp;
+  const int warp = threadIdx.x / kWarp;
+  const int block = static_cast<int>(blockIdx.x);
+
+  // A lane's slice of the norm weight is the same for every row it will ever
+  // see, so it is read once.
+  float weight[kPer<D>];
+  load_weight<D, DType>(weight, a.q_norm_weight, lane);
+  int q_axis[kPairs<D>];
+  lane_axes<D, MROPE_Q>(lane, a.mrope_h, a.mrope_w, q_axis);
+
+  if (block >= a.k_blocks) {
+    // Two tokens per warp. Their eight rows are all in flight before any is
+    // normalised, which is what keeps a warp with something to issue while a
+    // row is still arriving; one row at a time leaves the warp waiting.
+    constexpr int kTokens = 2;
+    const int token0 = ((block - a.k_blocks) * kWarpsPerBlock + warp) * kTokens;
+    if (token0 >= a.num_tokens) return;
+    // Only the last warp of a step can run past the end, so the rest are spared
+    // carrying a validity predicate through every load and address.
+    const bool tail = token0 + kTokens > a.num_tokens;
+
+    float c[kTokens][kPairs<D>], sn[kTokens][kPairs<D>];
+#pragma unroll
+    for (int t = 0; t < kTokens; ++t) {
+      const int token = token0 + t;
+      const int safe = tail && token >= a.num_tokens ? token0 : token;
+      const int64_t pos_t = a.positions[safe * a.pos_stride_token];
+      int64_t pos_h = pos_t, pos_w = pos_t;
+      if constexpr (POS_2D) {
+        pos_h = a.positions[a.pos_stride_axis + safe * a.pos_stride_token];
+        pos_w = a.positions[2 * a.pos_stride_axis + safe * a.pos_stride_token];
+      }
+      load_cos_sin<D, MROPE_Q, DType>(a.cos_sin, lane, pos_t, pos_h, pos_w, q_axis, c[t], sn[t]);
+    }
+
+    constexpr int kHeadGroup = 4;
+    for (int h0 = 0; h0 < a.num_q_heads; h0 += kHeadGroup) {
+      const int n = min(kHeadGroup, a.num_q_heads - h0);
+      float v[kTokens][kHeadGroup][kPer<D>];
+#pragma unroll
+      for (int t = 0; t < kTokens; ++t) {
+        const int token = token0 + t;
+        const int safe = tail && token >= a.num_tokens ? token0 : token;
+        const DType* q_row = a.q + static_cast<int64_t>(safe) * a.q_stride_token;
+#pragma unroll
+        for (int i = 0; i < kHeadGroup; ++i) {
+          load_row<D, DType>(v[t][i], q_row + static_cast<int64_t>(h0 + i) * D, lane, i < n);
+        }
+      }
+#pragma unroll
+      for (int t = 0; t < kTokens; ++t) {
+#pragma unroll
+        for (int i = 0; i < kHeadGroup; ++i) {
+          // Predicated, not broken out of: a runtime trip count would stop the
+          // unroll and put the staged rows in local memory.
+          if (i < n && (!tail || token0 + t < a.num_tokens)) {
+            norm_rope<D, DType>(v[t][i], weight, c[t], sn[t], a.eps);
+            store_row<D, DType>(a.q_out + static_cast<int64_t>(token0 + t) * a.q_out_stride_token +
+                                    static_cast<int64_t>(h0 + i) * a.q_out_stride_head,
+                                v[t][i], lane);
+          }
+        }
+      }
+    }
+    return;
+  }
+
+  // Compression work. One warp owns one completed group.
+  const int pid = block * kWarpsPerBlock + warp;
+  if (pid >= a.num_k_work) return;
+  const int32_t request = a.work_metadata[2 * pid];
+  const int32_t work_in_request = a.work_metadata[2 * pid + 1];
+  if (request < 0) return;
+
+  const int32_t query_start = a.query_start_loc[request];
+  const int32_t query_end = a.query_start_loc[request + 1];
+  const int32_t query_len = query_end - query_start;
+  const int64_t chunk_end = a.logical_positions[query_end - 1];
+  const int64_t chunk_start = chunk_end - query_len + 1;
+  const int32_t ratio = a.compress_ratio;
+  auto div_ratio = [&](int64_t v) -> int64_t { return POW2 ? (v >> a.ratio_shift) : v / ratio; };
+  const int32_t num_groups =
+      static_cast<int32_t>(div_ratio(chunk_end + 1) - div_ratio(chunk_start));
+
+  if (work_in_request < num_groups) {
+    const int64_t first_boundary = div_ratio(chunk_start + ratio) * ratio - 1;
+    const int64_t end_position = first_boundary + static_cast<int64_t>(work_in_request) * ratio;
+    const int64_t boundary_token = query_start + end_position - chunk_start;
+    const bool valid_token = boundary_token >= query_start && boundary_token < query_end &&
+                             boundary_token < a.num_tokens;
+    const int64_t compressed_slot = valid_token ? a.compressed_slots[boundary_token] : -1;
+    const bool valid =
+        valid_token && compressed_slot >= 0 &&
+        compressed_slot < static_cast<int64_t>(a.num_compressed_blocks) * a.comp_page_size;
+    const int32_t state_block =
+        a.state_table[static_cast<int64_t>(request) * a.state_table_stride_req];
+    const bool state_block_valid = state_block >= 0 && state_block < a.num_state_blocks;
+    const int64_t safe_state_block = state_block > 0 ? state_block : 0;
+
+    float acc[kPer<D>] = {};
+    // The group's source rows are fetched together. One at a time leaves a
+    // single row in flight and the warp waits out every one of them in turn,
+    // which is what the compression half spent its time on.
+    constexpr int kGroupBatch = 4;
+    for (int32_t g0 = 0; g0 < ratio; g0 += kGroupBatch) {
+      float rows[kGroupBatch][kPer<D>];
+#pragma unroll
+      for (int i = 0; i < kGroupBatch; ++i) {
+        const int32_t g = g0 + i;
+        const int64_t source_position = end_position - (ratio - 1) + g;
+        const bool in_chunk = source_position >= chunk_start;
+        const int64_t source_token = query_start + source_position - chunk_start;
+        const bool token_valid =
+            source_token >= query_start && source_token < query_end && source_token < a.num_tokens;
+        // Only the first completed group can reach behind the chunk, into the
+        // ring the previous step left.
+        const DType* src = in_chunk ? a.k + (source_token > 0 ? source_token : 0) * a.k_stride_token
+                                    : a.state_cache + safe_state_block * a.state_stride_block +
+                                          (POW2 ? (source_position & (a.state_size - 1))
+                                                : source_position % a.state_size) *
+                                              a.state_stride_token;
+        const bool live = g < ratio && valid && (in_chunk ? token_valid : state_block_valid);
+        load_row<D, DType>(rows[i], src, lane, live);
+      }
+#pragma unroll
+      for (int i = 0; i < kGroupBatch; ++i) {
+#pragma unroll
+        for (int j = 0; j < kPer<D>; ++j) acc[j] += rows[i][j];
+      }
+    }
+    // An unfused caller pools in the cache dtype before the norm sees it.
+#pragma unroll
+    for (int j = 0; j < kPer<D>; ++j) {
+      acc[j] = round_to<DType>(acc[j] * a.inv_ratio);
+    }
+
+    const int64_t first_position = end_position - (ratio - 1);
+    int64_t pos_t = first_position, pos_h = first_position, pos_w = first_position;
+    if constexpr (CACHE_POS) {
+      // The rotation uses the first token of the pooled group, whose exact
+      // coordinates are either in this chunk or in the ring beside its row.
+      const bool first_in_chunk = first_position >= chunk_start;
+      const int64_t first_token = query_start + first_position - chunk_start;
+      const bool first_token_valid =
+          first_token >= query_start && first_token < query_end && first_token < a.num_tokens;
+      if (first_in_chunk && first_token_valid) {
+        pos_t = a.positions[first_token * a.pos_stride_token];
+        if constexpr (POS_2D) {
+          pos_h = a.positions[a.pos_stride_axis + first_token * a.pos_stride_token];
+          pos_w = a.positions[2 * a.pos_stride_axis + first_token * a.pos_stride_token];
+        } else {
+          pos_h = pos_t;
+          pos_w = pos_t;
+        }
+      } else if (!first_in_chunk && state_block_valid) {
+        const int64_t* tail = reinterpret_cast<const int64_t*>(
+            a.state_cache + safe_state_block * a.state_stride_block +
+            (POW2 ? (first_position & (a.state_size - 1)) : first_position % a.state_size) *
+                a.state_stride_token +
+            D);
+        pos_t = tail[0];
+        pos_h = tail[1];
+        pos_w = tail[2];
+      } else {
+        pos_t = 0;
+        pos_h = 0;
+        pos_w = 0;
+      }
+    }
+    float kw[kPer<D>];
+    load_weight<D, DType>(kw, a.k_norm_weight, lane);
+    int k_axis[kPairs<D>];
+    lane_axes<D, MROPE_K>(lane, a.mrope_h, a.mrope_w, k_axis);
+    float kc[kPairs<D>], ks[kPairs<D>];
+    load_cos_sin<D, MROPE_K, DType>(a.cos_sin, lane, pos_t, pos_h, pos_w, k_axis, kc, ks);
+    norm_rope<D, DType>(acc, kw, kc, ks, a.eps);
+    if (valid) {
+      const int64_t comp_block =
+          POW2 ? (compressed_slot >> a.comp_shift) : compressed_slot / a.comp_page_size;
+      const int64_t comp_row =
+          POW2 ? (compressed_slot & (a.comp_page_size - 1)) : compressed_slot % a.comp_page_size;
+      store_row<D, DType>(a.compressed_cache + comp_block * a.compressed_stride_block +
+                              comp_row * a.compressed_stride_token,
+                          acc, lane);
+    }
+  }
+
+  if (work_in_request == 0) {
+    // This warp may have just read history out of the ring it is about to
+    // overwrite, so it finishes those reads first.
+    __syncwarp();
+    const int32_t rows = min(query_len, a.state_size);
+    for (int32_t offset = 0; offset < rows; ++offset) {
+      const int32_t token = query_end - rows + offset;
+      const bool token_valid = token >= query_start && token < query_end && token < a.num_tokens;
+      const int64_t slot = token_valid ? a.state_slots[token] : -1;
+      const bool live = token_valid && slot >= 0 &&
+                        slot < static_cast<int64_t>(a.num_state_blocks) * a.state_size;
+      if (!live) continue;
+      const int64_t ring_block = POW2 ? (slot >> a.state_shift) : slot / a.state_size;
+      const int64_t ring_row = POW2 ? (slot & (a.state_size - 1)) : slot % a.state_size;
+      DType* row =
+          a.state_cache + ring_block * a.state_stride_block + ring_row * a.state_stride_token;
+      float v[kPer<D>];
+      load_row<D, DType>(v, a.k + static_cast<int64_t>(token) * a.k_stride_token, lane, true);
+      store_row<D, DType>(row, v, lane);
+      if constexpr (CACHE_POS) {
+        if (lane == 0) {
+          int64_t* tail = reinterpret_cast<int64_t*>(row + D);
+          const int64_t p_t = a.positions[token * a.pos_stride_token];
+          tail[0] = p_t;
+          if constexpr (POS_2D) {
+            tail[1] = a.positions[a.pos_stride_axis + token * a.pos_stride_token];
+            tail[2] = a.positions[2 * a.pos_stride_axis + token * a.pos_stride_token];
+          } else {
+            tail[1] = p_t;
+            tail[2] = p_t;
+          }
+        }
+      }
+    }
+  }
+}
+
+}  // namespace sparse_pre_indexer
+
+/*!
+ * \brief Build the query and compressed-key rows a sparse route is scored on.
+ *
+ * \tparam HEAD_DIM 128 or 256
+ * \param mrope_k whether the compressed key picks its rotary axis per pair
+ * \param pos_2d whether \p params.positions carries three axes
+ * \param cache_pos whether the ring keeps each row's rotary coordinates after
+ *   its head_dim elements
+ *
+ * The query picks its axis per pair exactly when the positions carry three of
+ * them, so a two-dimensional position tensor with a single-axis key is not a
+ * configuration this builds; it returns cudaErrorInvalidValue.
+ *
+ * The norm accumulates in float32, so a row whose RMS passes about 1.6e18
+ * squares to infinity and comes out zero rather than normalised. That is far
+ * outside anything an activation reaches, but it is silent, so it is stated
+ * rather than left to be discovered.
+ */
+template <uint32_t HEAD_DIM, typename DType>
+cudaError_t QSAPreIndexer(QSAPreIndexerParams<DType> params, bool mrope_k, bool pos_2d,
+                          bool cache_pos, cudaStream_t stream = nullptr) {
+  using namespace sparse_pre_indexer;
+  static_assert(HEAD_DIM == 128 || HEAD_DIM == 256,
+                "the pre-indexer builds a head dimension of 128 or 256");
+  if (params.num_tokens <= 0) return cudaSuccess;
+  if (params.compress_ratio <= 0) return cudaErrorInvalidValue;
+
+  const bool pow2 = params.ratio_shift >= 0 && params.state_shift >= 0 && params.comp_shift >= 0;
+  // Two tokens to a warp, so a block covers twice its warps.
+  constexpr int kTokensPerBlock = 2 * kWarpsPerBlock;
+  const int64_t q_blocks = (params.num_tokens + kTokensPerBlock - 1) / kTokensPerBlock;
+  const int64_t k_blocks = (params.num_k_work + kWarpsPerBlock - 1) / kWarpsPerBlock;
+  params.k_blocks = static_cast<int32_t>(k_blocks);
+  const dim3 grid(static_cast<unsigned>(k_blocks + q_blocks));
+
+  cudaError_t status = cudaErrorInvalidValue;
+  auto launch = [&](auto mrope_q_tag, auto mrope_k_tag, auto pos_2d_tag, auto cache_pos_tag) {
+    if (pow2) {
+      QSAPreIndexerKernel<HEAD_DIM, decltype(mrope_q_tag)::value, decltype(mrope_k_tag)::value,
+                          decltype(pos_2d_tag)::value, decltype(cache_pos_tag)::value, true, DType>
+          <<<grid, kBlock, 0, stream>>>(params);
+    } else {
+      QSAPreIndexerKernel<HEAD_DIM, decltype(mrope_q_tag)::value, decltype(mrope_k_tag)::value,
+                          decltype(pos_2d_tag)::value, decltype(cache_pos_tag)::value, false, DType>
+          <<<grid, kBlock, 0, stream>>>(params);
+    }
+    status = cudaGetLastError();
+  };
+
+#define FI_QSA_PRE_INDEXER_CASE(MQ, MK, P2, CP)                                     \
+  if (pos_2d == (P2) && mrope_k == (MK) && cache_pos == (CP)) {                     \
+    launch(std::integral_constant<bool, MQ>{}, std::integral_constant<bool, MK>{},  \
+           std::integral_constant<bool, P2>{}, std::integral_constant<bool, CP>{}); \
+    return status;                                                                  \
+  }
+  FI_QSA_PRE_INDEXER_CASE(true, true, true, true)
+  FI_QSA_PRE_INDEXER_CASE(true, true, true, false)
+  FI_QSA_PRE_INDEXER_CASE(false, true, false, true)
+  FI_QSA_PRE_INDEXER_CASE(false, true, false, false)
+  FI_QSA_PRE_INDEXER_CASE(false, false, false, true)
+  FI_QSA_PRE_INDEXER_CASE(false, false, false, false)
+#undef FI_QSA_PRE_INDEXER_CASE
+  return cudaErrorInvalidValue;
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ATTENTION_SPARSE_PRE_INDEXER_CUH_

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -381,6 +381,9 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
   const int32_t query_start = a.query_start_loc[request];
   const int32_t query_end = a.query_start_loc[request + 1];
   const int32_t query_len = query_end - query_start;
+  // A request with no tokens has nothing to pool and no last token to read the
+  // chunk's end from; query_end - 1 would index behind the tensor.
+  if (query_len <= 0) return;
   const int64_t chunk_end = a.logical_positions[query_end - 1];
   const int64_t chunk_start = chunk_end - query_len + 1;
   const int32_t ratio = a.compress_ratio;

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -384,9 +384,11 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
   const int32_t query_start = a.query_start_loc[request];
   const int32_t query_end = a.query_start_loc[request + 1];
   const int32_t query_len = query_end - query_start;
-  // A request with no tokens has nothing to pool and no last token to read the
-  // chunk's end from; query_end - 1 would index behind the tensor.
-  if (query_len <= 0) return;
+  // The offsets are the caller's too, and only their length was checked. A
+  // request with no tokens has nothing to pool and no last token to read the
+  // chunk's end from, and a range that runs off either end of the token axis
+  // would make the read below land outside logical_positions.
+  if (query_len <= 0 || query_start < 0 || query_end > a.num_tokens) return;
   const int64_t chunk_end = a.logical_positions[query_end - 1];
   const int64_t chunk_start = chunk_end - query_len + 1;
   const int32_t ratio = a.compress_ratio;

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -308,14 +308,15 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
   const int warp = threadIdx.x / kWarp;
   const int block = static_cast<int>(blockIdx.x);
 
-  // A lane's slice of the norm weight is the same for every row it will ever
-  // see, so it is read once.
-  float weight[kPer<D>];
-  load_weight<D, DType>(weight, a.q_norm_weight, lane);
-  int q_axis[kPairs<D>];
-  lane_axes<D, MROPE_Q>(lane, a.mrope_h, a.mrope_w, q_axis);
-
   if (block >= a.k_blocks) {
+    // A lane's slice of the norm weight is the same for every row it will ever
+    // see, so it is read once. Inside the branch: the compression blocks below
+    // read the key weight instead and would otherwise pay for this one.
+    float weight[kPer<D>];
+    load_weight<D, DType>(weight, a.q_norm_weight, lane);
+    int q_axis[kPairs<D>];
+    lane_axes<D, MROPE_Q>(lane, a.mrope_h, a.mrope_w, q_axis);
+
     // Two tokens per warp. Their eight rows are all in flight before any is
     // normalised, which is what keeps a warp with something to issue while a
     // row is still arriving; one row at a time leaves the warp waiting.

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -277,6 +277,7 @@ struct QSAPreIndexerParams {
   int32_t num_state_blocks;
   int32_t num_compressed_blocks;
   int32_t num_k_work;
+  int32_t num_requests;
   int32_t num_q_heads;
   int32_t compress_ratio;
   int32_t state_size;
@@ -376,7 +377,9 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
   if (pid >= a.num_k_work) return;
   const int32_t request = a.work_metadata[2 * pid];
   const int32_t work_in_request = a.work_metadata[2 * pid + 1];
-  if (request < 0) return;
+  // The work list is the caller's, and the request it names indexes both ends
+  // of a prefix-sum entry; past the last request that reads off the table.
+  if (request < 0 || request >= a.num_requests) return;
 
   const int32_t query_start = a.query_start_loc[request];
   const int32_t query_end = a.query_start_loc[request + 1];

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -130,12 +130,21 @@ __device__ __forceinline__ void lane_axes(int lane, int mrope_h, int mrope_w,
  * factors -- so halving the reads on it is worth a table of its own.
  */
 template <int D, bool MROPE, typename DType>
-__device__ __forceinline__ void load_cos_sin(const DType* __restrict__ cos_sin, int lane,
-                                             int64_t pos_t, int64_t pos_h, int64_t pos_w,
+__device__ __forceinline__ void load_cos_sin(const DType* __restrict__ cos_sin, int64_t rows,
+                                             int lane, int64_t pos_t, int64_t pos_h, int64_t pos_w,
                                              const int (&axis)[kPairs<D>], float (&c)[kPairs<D>],
                                              float (&s)[kPairs<D>]) {
   constexpr int kHalf = D / 2;
   constexpr int kP = kPairs<D>;
+
+  // The coordinates are the caller's, and a table row is what they index. One
+  // outside the table would read off the end of it, so it is held at the edge
+  // instead: the rotation that comes out is not the caller's, but the read is
+  // its own. Supplying a table that covers every position is the contract.
+  const int64_t last = rows > 0 ? rows - 1 : 0;
+  pos_t = min(max(pos_t, int64_t(0)), last);
+  pos_h = min(max(pos_h, int64_t(0)), last);
+  pos_w = min(max(pos_w, int64_t(0)), last);
 
   if constexpr (!MROPE) {
     const CosSin<DType>* row = reinterpret_cast<const CosSin<DType>*>(cos_sin + pos_t * kHalf);
@@ -254,6 +263,8 @@ struct QSAPreIndexerParams {
   int64_t pos_stride_axis;
   int64_t pos_stride_token;
   const DType* cos_sin;
+  // Rows the rotary table holds, so a coordinate cannot index past it.
+  int64_t cos_sin_rows;
   const DType* q_norm_weight;
   const DType* k_norm_weight;
   float eps;
@@ -338,7 +349,8 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
         pos_h = a.positions[a.pos_stride_axis + safe * a.pos_stride_token];
         pos_w = a.positions[2 * a.pos_stride_axis + safe * a.pos_stride_token];
       }
-      load_cos_sin<D, MROPE_Q, DType>(a.cos_sin, lane, pos_t, pos_h, pos_w, q_axis, c[t], sn[t]);
+      load_cos_sin<D, MROPE_Q, DType>(a.cos_sin, a.cos_sin_rows, lane, pos_t, pos_h, pos_w, q_axis,
+                                      c[t], sn[t]);
     }
 
     constexpr int kHeadGroup = 4;
@@ -489,7 +501,8 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
     int k_axis[kPairs<D>];
     lane_axes<D, MROPE_K>(lane, a.mrope_h, a.mrope_w, k_axis);
     float kc[kPairs<D>], ks[kPairs<D>];
-    load_cos_sin<D, MROPE_K, DType>(a.cos_sin, lane, pos_t, pos_h, pos_w, k_axis, kc, ks);
+    load_cos_sin<D, MROPE_K, DType>(a.cos_sin, a.cos_sin_rows, lane, pos_t, pos_h, pos_w, k_axis,
+                                    kc, ks);
     norm_rope<D, DType>(acc, kw, kc, ks, a.eps);
     if (valid) {
       const int64_t comp_block =

--- a/include/flashinfer/attention/sparse_pre_indexer.cuh
+++ b/include/flashinfer/attention/sparse_pre_indexer.cuh
@@ -16,6 +16,7 @@
 #ifndef FLASHINFER_ATTENTION_SPARSE_PRE_INDEXER_CUH_
 #define FLASHINFER_ATTENTION_SPARSE_PRE_INDEXER_CUH_
 
+#include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
 #include <cstdint>
@@ -85,6 +86,16 @@ __device__ __forceinline__ __nv_bfloat16 from_float<__nv_bfloat16>(float x) {
 template <>
 __device__ __forceinline__ half from_float<half>(float x) {
   return __float2half(x);
+}
+// Narrowing to the indexer's output dtype. There is deliberately no matching
+// ``to_float``: ``round_to`` is defined in terms of both, so leaving this one out
+// turns an accidental ``round_to<__nv_fp8_e4m3>`` into a compile error instead of a
+// silent precision loss. Only the final store may narrow -- see ``apply_norm_rope``,
+// which must keep rounding to the compute dtype so a fused result still matches an
+// unfused one.
+template <>
+__device__ __forceinline__ __nv_fp8_e4m3 from_float<__nv_fp8_e4m3>(float x) {
+  return __nv_fp8_e4m3(x);
 }
 
 // A value as the cache will hold it. The pooled group and the normalised row
@@ -253,7 +264,7 @@ __device__ __forceinline__ void load_weight(float (&w)[kPer<D>], const DType* __
  * runtime; a negative one means that divisor is not a power of two and the
  * launch takes the general path.
  */
-template <typename DType>
+template <typename DType, typename OutDType = DType>
 struct QSAPreIndexerParams {
   const DType* q;
   int64_t q_stride_token;
@@ -268,7 +279,7 @@ struct QSAPreIndexerParams {
   const DType* q_norm_weight;
   const DType* k_norm_weight;
   float eps;
-  DType* q_out;
+  OutDType* q_out;
   int64_t q_out_stride_token;
   int64_t q_out_stride_head;
   DType* state_cache;
@@ -281,7 +292,7 @@ struct QSAPreIndexerParams {
   const int64_t* logical_positions;
   const int64_t* compressed_slots;
   const int32_t* work_metadata;
-  DType* compressed_cache;
+  OutDType* compressed_cache;
   int64_t compressed_stride_block;
   int64_t compressed_stride_token;
   int32_t num_tokens;
@@ -313,8 +324,10 @@ namespace sparse_pre_indexer {
  * \tparam POW2 whether the compression ratio, the ring and the compressed page
  *   are all powers of two, which is what turns their divisions into shifts
  */
-template <int D, bool MROPE_Q, bool MROPE_K, bool POS_2D, bool CACHE_POS, bool POW2, typename DType>
-__global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParams<DType> a) {
+template <int D, bool MROPE_Q, bool MROPE_K, bool POS_2D, bool CACHE_POS, bool POW2, typename DType,
+          typename OutDType = DType>
+__global__ void __launch_bounds__(kBlock)
+    QSAPreIndexerKernel(QSAPreIndexerParams<DType, OutDType> a) {
   const int lane = threadIdx.x % kWarp;
   const int warp = threadIdx.x / kWarp;
   const int block = static_cast<int>(blockIdx.x);
@@ -375,9 +388,10 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
           // unroll and put the staged rows in local memory.
           if (i < n && (!tail || token0 + t < a.num_tokens)) {
             norm_rope<D, DType>(v[t][i], weight, c[t], sn[t], a.eps);
-            store_row<D, DType>(a.q_out + static_cast<int64_t>(token0 + t) * a.q_out_stride_token +
-                                    static_cast<int64_t>(h0 + i) * a.q_out_stride_head,
-                                v[t][i], lane);
+            store_row<D, OutDType>(a.q_out +
+                                       static_cast<int64_t>(token0 + t) * a.q_out_stride_token +
+                                       static_cast<int64_t>(h0 + i) * a.q_out_stride_head,
+                                   v[t][i], lane);
           }
         }
       }
@@ -509,9 +523,9 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
           POW2 ? (compressed_slot >> a.comp_shift) : compressed_slot / a.comp_page_size;
       const int64_t comp_row =
           POW2 ? (compressed_slot & (a.comp_page_size - 1)) : compressed_slot % a.comp_page_size;
-      store_row<D, DType>(a.compressed_cache + comp_block * a.compressed_stride_block +
-                              comp_row * a.compressed_stride_token,
-                          acc, lane);
+      store_row<D, OutDType>(a.compressed_cache + comp_block * a.compressed_stride_block +
+                                 comp_row * a.compressed_stride_token,
+                             acc, lane);
     }
   }
 
@@ -572,8 +586,8 @@ __global__ void __launch_bounds__(kBlock) QSAPreIndexerKernel(QSAPreIndexerParam
  * outside anything an activation reaches, but it is silent, so it is stated
  * rather than left to be discovered.
  */
-template <uint32_t HEAD_DIM, typename DType>
-cudaError_t QSAPreIndexer(QSAPreIndexerParams<DType> params, bool mrope_k, bool pos_2d,
+template <uint32_t HEAD_DIM, typename DType, typename OutDType = DType>
+cudaError_t QSAPreIndexer(QSAPreIndexerParams<DType, OutDType> params, bool mrope_k, bool pos_2d,
                           bool cache_pos, cudaStream_t stream = nullptr) {
   using namespace sparse_pre_indexer;
   static_assert(HEAD_DIM == 128 || HEAD_DIM == 256,
@@ -593,12 +607,12 @@ cudaError_t QSAPreIndexer(QSAPreIndexerParams<DType> params, bool mrope_k, bool 
   auto launch = [&](auto mrope_q_tag, auto mrope_k_tag, auto pos_2d_tag, auto cache_pos_tag) {
     if (pow2) {
       QSAPreIndexerKernel<HEAD_DIM, decltype(mrope_q_tag)::value, decltype(mrope_k_tag)::value,
-                          decltype(pos_2d_tag)::value, decltype(cache_pos_tag)::value, true, DType>
-          <<<grid, kBlock, 0, stream>>>(params);
+                          decltype(pos_2d_tag)::value, decltype(cache_pos_tag)::value, true, DType,
+                          OutDType><<<grid, kBlock, 0, stream>>>(params);
     } else {
       QSAPreIndexerKernel<HEAD_DIM, decltype(mrope_q_tag)::value, decltype(mrope_k_tag)::value,
-                          decltype(pos_2d_tag)::value, decltype(cache_pos_tag)::value, false, DType>
-          <<<grid, kBlock, 0, stream>>>(params);
+                          decltype(pos_2d_tag)::value, decltype(cache_pos_tag)::value, false, DType,
+                          OutDType><<<grid, kBlock, 0, stream>>>(params);
     }
     status = cudaGetLastError();
   };

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -508,6 +508,29 @@ def test_rejects_a_short_query_start_loc():
     _expect_rejected(case, "one entry past")
 
 
+@pytest.mark.parametrize("which", ["q_weight", "k_weight"])
+def test_rejects_a_norm_weight_shorter_than_the_head(which):
+    """A lane reads its slice of the weight by head_dim whatever the tensor
+    holds, so a short one is read past its end however contiguous it is."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    case[which] = case[which][:-8].contiguous()
+    _expect_rejected(case, "one weight per feature")
+
+
+@pytest.mark.parametrize("width", [0, 2])
+def test_rejects_a_ring_table_that_is_not_one_block_per_request(width):
+    """The kernel reads the first entry of the row it is given. A row of no
+    entries reads off the table, and a wider one is a layout it does not walk."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    table = case["state_block_table"]
+    case["state_block_table"] = (
+        table[:, :0].contiguous() if width == 0 else table.repeat(1, 2).contiguous()
+    )
+    _expect_rejected(case, "one ring block per request")
+
+
 def _constant_row_out(fill, num_tokens=8, head_dim=128, dtype=torch.bfloat16):
     """A row of one value, normalised with a zero affine, and what came out."""
     case = _case(num_tokens=num_tokens, num_heads=1, head_dim=head_dim, dtype=dtype)

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -1,0 +1,643 @@
+"""Tests for :func:`flashinfer.qsa_pre_indexer`."""
+
+import pytest
+import torch
+
+import flashinfer
+
+DTYPES = [torch.bfloat16, torch.float16]
+
+
+def _skip_unless_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("qsa_pre_indexer runs on CUDA")
+
+
+def _pair_major_table(max_pos, head_dim, device, dtype, seed=0):
+    """The rotary table the kernel reads: cosine and sine interleaved per pair."""
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    theta = torch.rand(max_pos, head_dim // 4, generator=gen) * 6.0
+    table = torch.zeros(max_pos, head_dim // 2)
+    table[:, 0::2] = torch.cos(theta)
+    table[:, 1::2] = torch.sin(theta)
+    return table.to(device=device, dtype=dtype)
+
+
+def _axis_of(pair, mrope_h, mrope_w, mrope):
+    if not mrope:
+        return 0
+    mod = pair % 3
+    if mod == 1 and pair <= 3 * mrope_h:
+        return 1
+    if mod == 2 and pair <= 3 * mrope_w:
+        return 2
+    return 0
+
+
+def _norm_rope_row(row, weight, table, pos, mrope_h, mrope_w, mrope, eps, dtype):
+    """One row through the norm and the partial rope, in float64."""
+    head_dim = row.numel()
+    quarter = head_dim // 4
+    v = row.double()
+    rrms = torch.rsqrt(v.square().mean() + eps)
+    # Rounded to the cache dtype before the rotation reads it, as the kernel does.
+    v = (v * rrms * (weight.double() + 1.0)).to(dtype).double()
+    out = v.clone()
+    for i in range(quarter):
+        axis = _axis_of(i, mrope_h, mrope_w, mrope)
+        p = pos[axis]
+        c = table[p, 2 * i].double()
+        s = table[p, 2 * i + 1].double()
+        lo, hi = v[i], v[i + quarter]
+        out[i] = lo * c - hi * s
+        out[i + quarter] = hi * c + lo * s
+    return out
+
+
+def _reference(
+    q,
+    k,
+    positions,
+    table,
+    q_weight,
+    k_weight,
+    eps,
+    state_cache,
+    state_slots,
+    state_block_table,
+    query_start_loc,
+    logical_positions,
+    compressed_cache,
+    compressed_slots,
+    work_metadata,
+    compress_ratio,
+    num_heads,
+    head_dim,
+    mrope_h,
+    mrope_w,
+    mrope_q,
+    mrope_k,
+    cache_pos,
+    dtype,
+):
+    """What the kernel should produce, computed row by row on the host."""
+    num_tokens = q.shape[0]
+    state_size = state_cache.shape[1]
+    comp_page = compressed_cache.shape[1]
+    q_out = torch.zeros(num_tokens, num_heads, head_dim, dtype=dtype, device=q.device)
+    state = state_cache.clone()
+    compressed = compressed_cache.clone()
+
+    def coords(token):
+        if positions.ndim == 2:
+            return [int(positions[a, token]) for a in range(3)]
+        p = int(positions[token])
+        return [p, p, p]
+
+    for token in range(num_tokens):
+        pos = coords(token)
+        for head in range(num_heads):
+            row = q[token, head * head_dim : (head + 1) * head_dim]
+            out = _norm_rope_row(
+                row, q_weight, table, pos, mrope_h, mrope_w, mrope_q, eps, dtype
+            )
+            q_out[token, head] = out.to(dtype)
+
+    # The compression reads the ring as the previous step left it.
+    history = state_cache.clone()
+    for pid in range(work_metadata.shape[0]):
+        request = int(work_metadata[pid, 0])
+        work_in_request = int(work_metadata[pid, 1])
+        if request < 0:
+            continue
+        start = int(query_start_loc[request])
+        end = int(query_start_loc[request + 1])
+        query_len = end - start
+        chunk_end = int(logical_positions[end - 1])
+        chunk_start = chunk_end - query_len + 1
+        num_groups = (chunk_end + 1) // compress_ratio - chunk_start // compress_ratio
+        block = int(state_block_table[request, 0])
+
+        if work_in_request < num_groups:
+            first_boundary = (
+                (chunk_start + compress_ratio) // compress_ratio
+            ) * compress_ratio - 1
+            end_position = first_boundary + work_in_request * compress_ratio
+            boundary_token = start + end_position - chunk_start
+            slot = (
+                int(compressed_slots[boundary_token])
+                if start <= boundary_token < min(end, num_tokens)
+                else -1
+            )
+            if 0 <= slot < compressed.shape[0] * comp_page:
+                acc = torch.zeros(head_dim, dtype=torch.float64, device=q.device)
+                for g in range(compress_ratio):
+                    source_position = end_position - (compress_ratio - 1) + g
+                    if source_position >= chunk_start:
+                        source_token = start + source_position - chunk_start
+                        if start <= source_token < min(end, num_tokens):
+                            acc += k[source_token].double()
+                    elif 0 <= block < state.shape[0]:
+                        acc += history[
+                            block, source_position % state_size, 0, :head_dim
+                        ].double()
+                acc = (acc / compress_ratio).to(dtype).double()
+
+                first_position = end_position - (compress_ratio - 1)
+                pos = [first_position] * 3
+                if cache_pos:
+                    first_token = start + first_position - chunk_start
+                    if first_position >= chunk_start and start <= first_token < min(
+                        end, num_tokens
+                    ):
+                        pos = coords(first_token)
+                    elif first_position < chunk_start and 0 <= block < state.shape[0]:
+                        tail = history[
+                            block, first_position % state_size, 0, head_dim:
+                        ].view(torch.int64)
+                        pos = [int(tail[0]), int(tail[1]), int(tail[2])]
+                    else:
+                        pos = [0, 0, 0]
+                out = _norm_rope_row(
+                    acc, k_weight, table, pos, mrope_h, mrope_w, mrope_k, eps, dtype
+                )
+                compressed[slot // comp_page, slot % comp_page, 0] = out.to(dtype)
+
+        if work_in_request == 0:
+            rows = min(query_len, state_size)
+            for offset in range(rows):
+                token = end - rows + offset
+                if not (start <= token < min(end, num_tokens)):
+                    continue
+                slot = int(state_slots[token])
+                if not (0 <= slot < state.shape[0] * state_size):
+                    continue
+                state[slot // state_size, slot % state_size, 0, :head_dim] = k[token]
+                if cache_pos:
+                    pos = coords(token)
+                    tail = state[slot // state_size, slot % state_size, 0, head_dim:]
+                    tail.view(torch.int64)[:3] = torch.tensor(
+                        pos, dtype=torch.int64, device=q.device
+                    )
+    return q_out, state, compressed
+
+
+def _case(
+    *,
+    num_tokens,
+    num_heads=4,
+    head_dim=128,
+    compress_ratio=4,
+    state_size=8,
+    comp_page=4,
+    dtype=torch.bfloat16,
+    mrope=False,
+    mrope_k=None,
+    cache_pos=False,
+    num_requests=1,
+    seed=0,
+    history=False,
+):
+    device = torch.device("cuda")
+    torch.manual_seed(seed)
+    mrope_k = mrope if mrope_k is None else mrope_k
+    mrope_h, mrope_w = 11, 11
+    eps = 1e-6
+    max_pos = 512
+
+    q = torch.randn(num_tokens, num_heads * head_dim, dtype=dtype, device=device)
+    k = torch.randn(num_tokens, head_dim, dtype=dtype, device=device)
+    q_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.2
+    k_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.2
+    table = _pair_major_table(max_pos, head_dim, device, dtype, seed)
+
+    per = num_tokens // num_requests
+    starts = [i * per for i in range(num_requests)] + [num_tokens]
+    query_start_loc = torch.tensor(starts, dtype=torch.int32, device=device)
+
+    # A prior chunk sits behind this one whenever history is asked for, which is
+    # what makes a group reach back into the ring.
+    offset = state_size if history else 0
+    logical = torch.cat(
+        [
+            torch.arange(offset, offset + starts[i + 1] - starts[i], dtype=torch.int64)
+            for i in range(num_requests)
+        ]
+    ).to(device)
+    positions_1d = logical.clone()
+    positions = (
+        torch.stack([positions_1d, positions_1d // 7, positions_1d // 13])
+        if mrope
+        else positions_1d
+    )
+
+    width = head_dim + (12 if cache_pos else 0)
+    state_cache = torch.randn(
+        num_requests, state_size, 1, width, dtype=dtype, device=device
+    )
+    if cache_pos:
+        # Plausible coordinates for the rows a group may reach back into.
+        for b in range(num_requests):
+            for r in range(state_size):
+                state_cache[b, r, 0, head_dim:].view(torch.int64)[:3] = torch.tensor(
+                    [r, r // 7, r // 13], dtype=torch.int64, device=device
+                )
+    state_block_table = torch.arange(
+        num_requests, dtype=torch.int32, device=device
+    ).reshape(num_requests, 1)
+
+    token_to_req = torch.zeros(num_tokens, dtype=torch.int64, device=device)
+    for r in range(num_requests):
+        token_to_req[starts[r] : starts[r + 1]] = r
+
+    state_slots = token_to_req * state_size + logical % state_size
+
+    # Each request owns its own run of compressed slots, so two of them never
+    # write the same row and the order they run in cannot matter.
+    slots_per_request = (offset + per) // compress_ratio + 1
+    comp_blocks = max(
+        1, (num_requests * slots_per_request + comp_page - 1) // comp_page
+    )
+    compressed_cache = torch.zeros(
+        comp_blocks, comp_page, 1, head_dim, dtype=dtype, device=device
+    )
+    compressed_slots = (
+        token_to_req * slots_per_request + logical // compress_ratio
+    ).clamp(max=comp_blocks * comp_page - 1)
+
+    work = []
+    for r in range(num_requests):
+        length = starts[r + 1] - starts[r]
+        chunk_end = int(logical[starts[r + 1] - 1])
+        chunk_start = chunk_end - length + 1
+        groups = (chunk_end + 1) // compress_ratio - chunk_start // compress_ratio
+        for g in range(max(groups, 1)):
+            work.append([r, g])
+    work_metadata = torch.tensor(work, dtype=torch.int32, device=device)
+
+    return dict(
+        q=q,
+        k=k,
+        positions=positions,
+        table=table,
+        q_weight=q_weight,
+        k_weight=k_weight,
+        eps=eps,
+        state_cache=state_cache,
+        state_slots=state_slots,
+        state_block_table=state_block_table,
+        query_start_loc=query_start_loc,
+        logical_positions=logical,
+        compressed_cache=compressed_cache,
+        compressed_slots=compressed_slots,
+        work_metadata=work_metadata,
+        compress_ratio=compress_ratio,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        mrope_h=mrope_h,
+        mrope_w=mrope_w,
+        mrope_q=mrope,
+        mrope_k=mrope_k,
+        cache_pos=cache_pos,
+        dtype=dtype,
+    )
+
+
+def _run(case):
+    q_out = torch.zeros(
+        case["q"].shape[0],
+        case["num_heads"],
+        case["head_dim"],
+        dtype=case["dtype"],
+        device=case["q"].device,
+    )
+    state = case["state_cache"].clone()
+    compressed = case["compressed_cache"].clone()
+    flashinfer.qsa_pre_indexer(
+        case["q"],
+        case["k"],
+        case["positions"],
+        case["table"],
+        case["q_weight"],
+        case["k_weight"],
+        case["eps"],
+        q_out,
+        state,
+        case["state_slots"],
+        case["state_block_table"],
+        case["query_start_loc"],
+        case["logical_positions"],
+        compressed,
+        case["compressed_slots"],
+        case["work_metadata"],
+        case["compress_ratio"],
+        mrope_h=case["mrope_h"],
+        mrope_w=case["mrope_w"],
+        is_k_mrope=case["mrope_k"],
+        cache_has_rope_pos=case["cache_pos"],
+    )
+    return q_out, state, compressed
+
+
+def _assert_matches(case):
+    q_out, state, compressed = _run(case)
+    want_q, want_state, want_compressed = _reference(**case)
+    tol = dict(rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(q_out.float(), want_q.float(), **tol)
+    torch.testing.assert_close(state.float(), want_state.float(), **tol)
+    torch.testing.assert_close(compressed.float(), want_compressed.float(), **tol)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("num_heads", [1, 4, 8])
+def test_query_path(dtype, head_dim, num_heads):
+    _skip_unless_cuda()
+    _assert_matches(
+        _case(num_tokens=16, num_heads=num_heads, head_dim=head_dim, dtype=dtype)
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 3, 7, 8, 9, 33, 64, 129])
+def test_token_counts(num_tokens):
+    """Odd counts land on the tail warp, which carries the validity predicate."""
+    _skip_unless_cuda()
+    _assert_matches(_case(num_tokens=num_tokens))
+
+
+@pytest.mark.parametrize("compress_ratio", [2, 4, 8])
+@pytest.mark.parametrize("history", [False, True])
+def test_compression(compress_ratio, history):
+    _skip_unless_cuda()
+    _assert_matches(
+        _case(num_tokens=32, compress_ratio=compress_ratio, history=history)
+    )
+
+
+@pytest.mark.parametrize("cache_pos", [False, True])
+def test_mrope(cache_pos):
+    """Three-axis positions, and the coordinates a group reads out of the ring."""
+    _skip_unless_cuda()
+    _assert_matches(_case(num_tokens=32, mrope=True, cache_pos=cache_pos, history=True))
+
+
+def test_key_mrope_with_one_axis_positions():
+    """A three-axis key over a single-axis position tensor is a supported pair."""
+    _skip_unless_cuda()
+    _assert_matches(_case(num_tokens=16, mrope=False, mrope_k=True))
+
+
+@pytest.mark.parametrize("num_requests", [2, 4])
+def test_multiple_requests(num_requests):
+    _skip_unless_cuda()
+    _assert_matches(_case(num_tokens=32, num_requests=num_requests, history=True))
+
+
+def test_non_power_of_two_divisors():
+    """The general path: no shift stands in for these divisions."""
+    _skip_unless_cuda()
+    _assert_matches(_case(num_tokens=24, compress_ratio=3, state_size=6, comp_page=3))
+
+
+def test_dead_work_item_is_skipped():
+    _skip_unless_cuda()
+    case = _case(num_tokens=16)
+    case["work_metadata"][0, 0] = -1
+    _assert_matches(case)
+
+
+def test_no_tokens_is_a_no_op():
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    empty = case["q"][:0]
+    before = case["compressed_cache"].clone()
+    flashinfer.qsa_pre_indexer(
+        empty,
+        case["k"][:0],
+        case["positions"][:0]
+        if case["positions"].ndim == 1
+        else case["positions"][:, :0],
+        case["table"],
+        case["q_weight"],
+        case["k_weight"],
+        case["eps"],
+        torch.zeros(
+            0,
+            case["num_heads"],
+            case["head_dim"],
+            dtype=case["dtype"],
+            device=empty.device,
+        ),
+        case["state_cache"],
+        case["state_slots"][:0],
+        case["state_block_table"],
+        case["query_start_loc"],
+        case["logical_positions"][:0],
+        case["compressed_cache"],
+        case["compressed_slots"][:0],
+        case["work_metadata"],
+        case["compress_ratio"],
+    )
+    torch.testing.assert_close(case["compressed_cache"], before)
+
+
+def test_rejects_three_axis_positions_with_one_axis_key():
+    _skip_unless_cuda()
+    case = _case(num_tokens=8, mrope=True)
+    case["mrope_k"] = False
+    with pytest.raises(ValueError, match="three-axis"):
+        _run(case)
+
+
+def test_rejects_unsupported_head_dim():
+    _skip_unless_cuda()
+    case = _case(num_tokens=8, head_dim=128)
+    case["head_dim"] = 64
+    case["num_heads"] = 1
+    with pytest.raises(ValueError, match="head_dim"):
+        _run(case)
+
+
+def _expect_rejected(case, match):
+    with pytest.raises(Exception, match=match):
+        _run(case)
+
+
+def test_rejects_a_rotary_table_of_the_wrong_width():
+    """A row of any other width silently shifts every position."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    case["table"] = case["table"][:, : case["head_dim"] // 4].contiguous()
+    _expect_rejected(case, "pair-major")
+
+
+def test_rejects_a_second_kv_head():
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    case["state_cache"] = case["state_cache"].repeat(1, 1, 2, 1)
+    _expect_rejected(case, "one KV head")
+
+
+def test_rejects_a_ring_too_narrow_for_its_coordinates():
+    """With cache_has_rope_pos the row is followed by three int64."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8, cache_pos=True)
+    case["state_cache"] = case["state_cache"][..., : case["head_dim"] + 4].contiguous()
+    _expect_rejected(case, "coordinates after it")
+
+
+def test_rejects_a_short_query_start_loc():
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    case["query_start_loc"] = case["query_start_loc"][:-1].contiguous()
+    _expect_rejected(case, "one entry past")
+
+
+def _constant_row_out(fill, num_tokens=8, head_dim=128, dtype=torch.bfloat16):
+    """A row of one value, normalised with a zero affine, and what came out."""
+    case = _case(num_tokens=num_tokens, num_heads=1, head_dim=head_dim, dtype=dtype)
+    case["q"] = torch.full_like(case["q"], fill)
+    case["q_weight"] = torch.zeros_like(case["q_weight"])
+    q_out, _, _ = _run(case)
+    return q_out[0, 0].float()
+
+
+@pytest.mark.parametrize("fill", [1e-2, 1.0, 1e6, 1e12, 1e18])
+def test_a_constant_row_normalises_to_one(fill):
+    """Across the range the norm is exact: every element is +/-1 before it turns.
+
+    The rotation mixes an element with its partner, so the largest an element
+    can come out is sqrt(2); what matters is that none of it is lost.
+    """
+    _skip_unless_cuda()
+    out = _constant_row_out(fill)
+    assert torch.isfinite(out).all()
+    magnitude = out.abs().max().item()
+    assert 0.9 < magnitude < 1.5, magnitude
+
+
+def test_a_row_that_overflows_the_sum_of_squares_comes_out_zero():
+    """Documented, not desired: the sum of squares is accumulated in float32.
+
+    A row whose RMS passes about 1.6e18 squares to infinity there, the
+    reciprocal square root of which is zero, so the row is lost rather than
+    normalised. Real activations are nowhere near this; the point of pinning it
+    is that the failure is silent, and a caller that does get here should know
+    it reads zeros rather than a normalised row.
+    """
+    _skip_unless_cuda()
+    assert _constant_row_out(1e18).abs().max().item() > 0.9
+    assert _constant_row_out(1e19).abs().max().item() == 0.0
+
+
+def test_eps_bounds_the_gain_on_a_vanishing_row():
+    """Below an RMS of about 1e-3 the epsilon is the whole denominator."""
+    _skip_unless_cuda()
+    out = _constant_row_out(1e-20)
+    # rsqrt(eps) is 1e3, so the row is scaled by that rather than to one.
+    assert 0.9e-17 < out.abs().max().item() < 2e-17
+
+
+@pytest.mark.parametrize("fill", [float("inf"), float("-inf"), float("nan")])
+def test_non_finite_input_propagates(fill):
+    """It arrives as a NaN rather than as a plausible number."""
+    _skip_unless_cuda()
+    assert torch.isnan(_constant_row_out(fill)).all()
+
+
+def test_an_affine_of_minus_one_zeroes_the_row():
+    """The weight is the offset from one, so -1 is a zero gain."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8, num_heads=1)
+    case["q_weight"] = torch.full_like(case["q_weight"], -1.0)
+    q_out, _, _ = _run(case)
+    assert q_out.abs().max().item() == 0.0
+
+
+def test_runs_on_a_non_default_stream():
+    """The launch takes the caller's stream, not whatever stream zero is doing."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=32, history=True)
+    expected = _run(case)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        got = _run(case)
+    stream.synchronize()
+    for a, b in zip(got, expected, strict=True):
+        torch.testing.assert_close(a, b)
+
+
+def test_replays_inside_a_cuda_graph():
+    """Captured and replayed, with the inputs changed between replays.
+
+    A launch that allocated, synchronised or read a host value would either
+    fail to capture or replay the first call's answer for the second.
+    """
+    _skip_unless_cuda()
+    case = _case(num_tokens=32, history=True)
+    q_out = torch.zeros(
+        case["q"].shape[0],
+        case["num_heads"],
+        case["head_dim"],
+        dtype=case["dtype"],
+        device=case["q"].device,
+    )
+    state = case["state_cache"].clone()
+    compressed = case["compressed_cache"].clone()
+
+    def launch():
+        flashinfer.qsa_pre_indexer(
+            case["q"],
+            case["k"],
+            case["positions"],
+            case["table"],
+            case["q_weight"],
+            case["k_weight"],
+            case["eps"],
+            q_out,
+            state,
+            case["state_slots"],
+            case["state_block_table"],
+            case["query_start_loc"],
+            case["logical_positions"],
+            compressed,
+            case["compressed_slots"],
+            case["work_metadata"],
+            case["compress_ratio"],
+            mrope_h=case["mrope_h"],
+            mrope_w=case["mrope_w"],
+            is_k_mrope=case["mrope_k"],
+            cache_has_rope_pos=case["cache_pos"],
+        )
+
+    # Warm up on a side stream, which is what capture requires.
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        for _ in range(3):
+            launch()
+    torch.cuda.current_stream().wait_stream(side)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    for _ in range(2):
+        state.copy_(case["state_cache"])
+        compressed.copy_(case["compressed_cache"])
+        graph.replay()
+        torch.cuda.synchronize()
+        want_q, want_state, want_compressed = _reference(**case)
+        tol = dict(rtol=2e-2, atol=2e-2)
+        torch.testing.assert_close(q_out.float(), want_q.float(), **tol)
+        torch.testing.assert_close(state.float(), want_state.float(), **tol)
+        torch.testing.assert_close(compressed.float(), want_compressed.float(), **tol)
+
+    # A different query through the same graph has to give a different answer.
+    case["q"].normal_()
+    state.copy_(case["state_cache"])
+    compressed.copy_(case["compressed_cache"])
+    graph.replay()
+    torch.cuda.synchronize()
+    want_q, _, _ = _reference(**case)
+    torch.testing.assert_close(q_out.float(), want_q.float(), rtol=2e-2, atol=2e-2)

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -112,9 +112,9 @@ def _reference(
             continue
         start = int(query_start_loc[request])
         end = int(query_start_loc[request + 1])
-        query_len = end - start
-        if query_len <= 0 or start < 0 or end > num_tokens:
+        if start < 0 or end > num_tokens or end <= start:
             continue
+        query_len = end - start
         chunk_end = int(logical_positions[end - 1])
         chunk_start = chunk_end - query_len + 1
         num_groups = (chunk_end + 1) // compress_ratio - chunk_start // compress_ratio
@@ -674,7 +674,7 @@ def test_a_request_with_no_tokens_is_skipped():
     _assert_matches(case)
 
 
-@pytest.mark.parametrize("bad", ["past_the_end", "reversed", "negative"])
+@pytest.mark.parametrize("bad", ["past_the_end", "reversed", "negative", "wraps"])
 def test_a_request_whose_offsets_leave_the_token_axis_is_skipped(bad):
     """Only the length of query_start_loc is checked on the host, so a value
     that runs off the token axis would put logical_positions[end - 1] outside
@@ -687,6 +687,11 @@ def test_a_request_whose_offsets_leave_the_token_axis_is_skipped(bad):
     elif bad == "reversed":
         offsets[0] = 8
         offsets[1] = 4
+    elif bad == "wraps":
+        # The difference of these two overflows int32 and comes out as 1, so a
+        # guard that subtracts before it bounds the ends lets them through.
+        offsets[0] = 2147483647
+        offsets[1] = -2147483648
     else:
         offsets[0] = -8
     case["query_start_loc"] = offsets

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -813,3 +813,23 @@ def test_rejects_a_tensor_with_no_axes(which):
     case[key] = case[key].flatten()[0].clone()  # rank zero
     match = "at least one axis" if which == "cos_sin_cache" else "one axis or three"
     _expect_rejected(case, match)
+
+
+def test_rejects_a_rotary_table_with_no_rows():
+    """A table of no rows passes the width check and leaves nothing to read.
+    The kernel holds a coordinate at the last row, and an empty table has
+    none."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    case["table"] = case["table"][:0].contiguous()
+    _expect_rejected(case, "at least one row")
+
+
+def test_rejects_a_compress_ratio_that_is_not_an_int32():
+    """The kernel takes the ratio as int32 while the reciprocal it scales by is
+    formed from the original, so a value past int32 pools by one ratio and
+    scales by another."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    case["compress_ratio"] = 4294967297
+    _expect_rejected(case, "fit in 32 bits")

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -672,3 +672,49 @@ def test_rejects_a_short_token_axis(short):
         case["positions"] = case["positions"][:-1].contiguous()
     with pytest.raises(Exception, match="per token"):
         _run(case)
+
+
+def test_a_work_item_naming_a_request_that_does_not_exist_is_skipped():
+    """The work list is the caller's, and the request it names indexes both
+    ends of a prefix-sum entry. One past the last request reads off the table."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=16, num_requests=1)
+    case["work_metadata"] = case["work_metadata"].clone()
+    case["work_metadata"][0, 0] = 1  # only request 0 exists
+    q_out, _, _ = _run(case)
+    torch.cuda.synchronize()
+    assert torch.isfinite(q_out.float()).all()
+
+
+def test_rejects_an_empty_ring():
+    """The ring is indexed modulo its size, so an empty one addresses off the
+    front of the cache rather than reading nothing."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=16)
+    case["state_cache"] = case["state_cache"][:, :0].contiguous()
+    with pytest.raises(Exception, match="at least one row"):
+        _run(case)
+
+
+def test_rejects_an_empty_compressed_page():
+    _skip_unless_cuda()
+    case = _case(num_tokens=16)
+    case["compressed_cache"] = case["compressed_cache"][:, :0].contiguous()
+    with pytest.raises(Exception, match="at least one row"):
+        _run(case)
+
+
+@pytest.mark.parametrize("state_size,compress_ratio", [(7, 4), (6, 4), (5, 2)])
+def test_a_group_reaching_into_an_unaligned_ring(state_size, compress_ratio):
+    """A ring whose size is not a multiple of the ratio makes the wrap land
+    inside a group, which is the case the aligned sizes never produce."""
+    _skip_unless_cuda()
+    _assert_matches(
+        _case(
+            num_tokens=32,
+            state_size=state_size,
+            compress_ratio=compress_ratio,
+            history=True,
+            cache_pos=True,
+        )
+    )

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -113,6 +113,8 @@ def _reference(
         start = int(query_start_loc[request])
         end = int(query_start_loc[request + 1])
         query_len = end - start
+        if query_len <= 0 or start < 0 or end > num_tokens:
+            continue
         chunk_end = int(logical_positions[end - 1])
         chunk_start = chunk_end - query_len + 1
         num_groups = (chunk_end + 1) // compress_ratio - chunk_start // compress_ratio
@@ -197,6 +199,7 @@ def _case(
     num_requests=1,
     seed=0,
     history=False,
+    starts=None,
 ):
     device = torch.device("cuda")
     torch.manual_seed(seed)
@@ -211,8 +214,15 @@ def _case(
     k_weight = torch.randn(head_dim, dtype=dtype, device=device) * 0.2
     table = _pair_major_table(max_pos, head_dim, device, dtype, seed)
 
-    per = num_tokens // num_requests
-    starts = [i * per for i in range(num_requests)] + [num_tokens]
+    # An even split unless the caller wants a specific one; every tensor below
+    # is derived from these offsets, so a caller-supplied split stays consistent
+    # with the slots and the work list rather than only moving the boundaries.
+    if starts is None:
+        per = num_tokens // num_requests
+        starts = [i * per for i in range(num_requests)] + [num_tokens]
+    else:
+        assert len(starts) == num_requests + 1 and starts[-1] == num_tokens
+    per = max(starts[i + 1] - starts[i] for i in range(num_requests))
     query_start_loc = torch.tensor(starts, dtype=torch.int32, device=device)
 
     # A prior chunk sits behind this one whenever history is asked for, which is
@@ -268,6 +278,11 @@ def _case(
     work = []
     for r in range(num_requests):
         length = starts[r + 1] - starts[r]
+        if length == 0:
+            # The scheduler still emits a group for a request it gave nothing
+            # to; there is no last token to read the chunk's end from.
+            work.append([r, 0])
+            continue
         chunk_end = int(logical[starts[r + 1] - 1])
         chunk_start = chunk_end - length + 1
         groups = (chunk_end + 1) // compress_ratio - chunk_start // compress_ratio
@@ -651,14 +666,31 @@ def test_a_request_with_no_tokens_is_skipped():
     behind the tensor.
     """
     _skip_unless_cuda()
-    case = _case(num_tokens=16, num_requests=2)
-    # Collapse the first request: same start and end, all tokens in the second.
-    case["query_start_loc"] = torch.tensor(
-        [0, 0, case["q"].shape[0]], dtype=torch.int32, device=case["q"].device
-    )
-    q_out, state, compressed = _run(case)
-    assert torch.isfinite(q_out.float()).all()
-    assert torch.isfinite(compressed.float()).all()
+    # The whole case is built from this split, so the slots and the work list
+    # describe the collapsed request rather than an even one; the work list
+    # still names it, which is what reaches the guard.
+    case = _case(num_tokens=16, num_requests=2, starts=[0, 0, 16])
+    assert (case["work_metadata"][:, 0] == 0).any()
+    _assert_matches(case)
+
+
+@pytest.mark.parametrize("bad", ["past_the_end", "reversed", "negative"])
+def test_a_request_whose_offsets_leave_the_token_axis_is_skipped(bad):
+    """Only the length of query_start_loc is checked on the host, so a value
+    that runs off the token axis would put logical_positions[end - 1] outside
+    the tensor."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=16, num_requests=1)
+    offsets = case["query_start_loc"].clone()
+    if bad == "past_the_end":
+        offsets[1] = 64
+    elif bad == "reversed":
+        offsets[0] = 8
+        offsets[1] = 4
+    else:
+        offsets[0] = -8
+    case["query_start_loc"] = offsets
+    _assert_matches(case)
 
 
 @pytest.mark.parametrize("short", ["k", "positions"])

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -108,7 +108,10 @@ def _reference(
     for pid in range(work_metadata.shape[0]):
         request = int(work_metadata[pid, 0])
         work_in_request = int(work_metadata[pid, 1])
-        if request < 0:
+        # The work list is the caller's and the request it names indexes both
+        # ends of a prefix-sum entry, so one past the last request reads off
+        # the table. Same bound the kernel applies.
+        if request < 0 or request >= state_block_table.shape[0]:
             continue
         start = int(query_start_loc[request])
         end = int(query_start_loc[request + 1])
@@ -741,9 +744,10 @@ def test_a_work_item_naming_a_request_that_does_not_exist_is_skipped():
     case = _case(num_tokens=16, num_requests=1)
     case["work_metadata"] = case["work_metadata"].clone()
     case["work_metadata"][0, 0] = 1  # only request 0 exists
-    q_out, _, _ = _run(case)
-    torch.cuda.synchronize()
-    assert torch.isfinite(q_out.float()).all()
+    # Against the reference, not just for finiteness: the query path does not
+    # read the work list at all, so a finite q_out says nothing about whether
+    # the request index was bounded. The ring and the compressed rows do.
+    _assert_matches(case)
 
 
 def test_rejects_an_empty_ring():
@@ -778,3 +782,34 @@ def test_a_group_reaching_into_an_unaligned_ring(state_size, compress_ratio):
             cache_pos=True,
         )
     )
+
+
+@pytest.mark.parametrize("axis", ["t", "h", "w"])
+def test_a_rotary_coordinate_past_the_table_is_held_at_its_edge(axis):
+    """The coordinates are the caller's and a table row is what they index, so
+    one past the table would read off the end of it. The kernel holds it at the
+    last row instead: the rotation is not the caller's, but the read is inside
+    the table."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8, mrope=True)
+    rows = case["table"].shape[0]
+    pos = case["positions"].clone()
+    row = {"t": 0, "h": 1, "w": 2}[axis]
+    pos[row, 0] = rows + 1000
+    case["positions"] = pos.contiguous()
+    q_out, _, _ = _run(case)
+    torch.cuda.synchronize()
+    assert torch.isfinite(q_out.float()).all()
+
+
+@pytest.mark.parametrize("which", ["positions", "cos_sin_cache"])
+def test_rejects_a_tensor_with_no_axes(which):
+    """size(ndim() - 1) on a rank-zero tensor reads off the front of its own
+    shape, so the rank has to be checked before anything indexes the last
+    axis."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8)
+    key = "table" if which == "cos_sin_cache" else "positions"
+    case[key] = case[key].flatten()[0].clone()  # rank zero
+    match = "at least one axis" if which == "cos_sin_cache" else "one axis or three"
+    _expect_rejected(case, match)

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -641,3 +641,34 @@ def test_replays_inside_a_cuda_graph():
     torch.cuda.synchronize()
     want_q, _, _ = _reference(**case)
     torch.testing.assert_close(q_out.float(), want_q.float(), rtol=2e-2, atol=2e-2)
+
+
+def test_a_request_with_no_tokens_is_skipped():
+    """A work item may name a request the step gave nothing to.
+
+    Its end is also its start, so there is no last token to read the chunk's
+    end from; the group loop has to stop before that read rather than index
+    behind the tensor.
+    """
+    _skip_unless_cuda()
+    case = _case(num_tokens=16, num_requests=2)
+    # Collapse the first request: same start and end, all tokens in the second.
+    case["query_start_loc"] = torch.tensor(
+        [0, 0, case["q"].shape[0]], dtype=torch.int32, device=case["q"].device
+    )
+    q_out, state, compressed = _run(case)
+    assert torch.isfinite(q_out.float()).all()
+    assert torch.isfinite(compressed.float()).all()
+
+
+@pytest.mark.parametrize("short", ["k", "positions"])
+def test_rejects_a_short_token_axis(short):
+    """Both are walked by a token stride, so a short axis reads past its end."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=16)
+    if short == "k":
+        case["k"] = case["k"][:-1].contiguous()
+    else:
+        case["positions"] = case["positions"][:-1].contiguous()
+    with pytest.raises(Exception, match="per token"):
+        _run(case)

--- a/tests/attention/test_sparse_pre_indexer.py
+++ b/tests/attention/test_sparse_pre_indexer.py
@@ -79,12 +79,20 @@ def _reference(
     mrope_k,
     cache_pos,
     dtype,
+    out_dtype,
 ):
-    """What the kernel should produce, computed row by row on the host."""
+    """What the kernel should produce, computed row by row on the host.
+
+    ``dtype`` is the compute dtype and every intermediate rounds to it, exactly as
+    ``apply_norm_rope`` does. ``out_dtype`` is reached only by the final stores, which
+    is what keeps a narrowed result equal to the un-narrowed one rounded once.
+    """
     num_tokens = q.shape[0]
     state_size = state_cache.shape[1]
     comp_page = compressed_cache.shape[1]
-    q_out = torch.zeros(num_tokens, num_heads, head_dim, dtype=dtype, device=q.device)
+    q_out = torch.zeros(
+        num_tokens, num_heads, head_dim, dtype=out_dtype, device=q.device
+    )
     state = state_cache.clone()
     compressed = compressed_cache.clone()
 
@@ -101,7 +109,7 @@ def _reference(
             out = _norm_rope_row(
                 row, q_weight, table, pos, mrope_h, mrope_w, mrope_q, eps, dtype
             )
-            q_out[token, head] = out.to(dtype)
+            q_out[token, head] = out.to(out_dtype)
 
     # The compression reads the ring as the previous step left it.
     history = state_cache.clone()
@@ -166,7 +174,7 @@ def _reference(
                 out = _norm_rope_row(
                     acc, k_weight, table, pos, mrope_h, mrope_w, mrope_k, eps, dtype
                 )
-                compressed[slot // comp_page, slot % comp_page, 0] = out.to(dtype)
+                compressed[slot // comp_page, slot % comp_page, 0] = out.to(out_dtype)
 
         if work_in_request == 0:
             rows = min(query_len, state_size)
@@ -196,6 +204,7 @@ def _case(
     state_size=8,
     comp_page=4,
     dtype=torch.bfloat16,
+    out_dtype=None,
     mrope=False,
     mrope_k=None,
     cache_pos=False,
@@ -272,7 +281,12 @@ def _case(
         1, (num_requests * slots_per_request + comp_page - 1) // comp_page
     )
     compressed_cache = torch.zeros(
-        comp_blocks, comp_page, 1, head_dim, dtype=dtype, device=device
+        comp_blocks,
+        comp_page,
+        1,
+        head_dim,
+        dtype=dtype if out_dtype is None else out_dtype,
+        device=device,
     )
     compressed_slots = (
         token_to_req * slots_per_request + logical // compress_ratio
@@ -318,6 +332,7 @@ def _case(
         mrope_k=mrope_k,
         cache_pos=cache_pos,
         dtype=dtype,
+        out_dtype=dtype if out_dtype is None else out_dtype,
     )
 
 
@@ -326,7 +341,7 @@ def _run(case):
         case["q"].shape[0],
         case["num_heads"],
         case["head_dim"],
-        dtype=case["dtype"],
+        dtype=case["out_dtype"],
         device=case["q"].device,
     )
     state = case["state_cache"].clone()
@@ -357,13 +372,31 @@ def _run(case):
     return q_out, state, compressed
 
 
+def _assert_fp8_within_one_ulp(actual, expected):
+    # e4m3 is sign-magnitude, so within a sign the uint8 code order matches the value
+    # order and one ulp is one code step. The two paths' intermediates differ in the
+    # pooling accumulation order, which at denormal magnitudes (absolute grid step
+    # 2**-9) shows up as up to 2 code steps.
+    code_diff = (
+        actual.view(torch.uint8).int() - expected.view(torch.uint8).int()
+    ).abs()
+    abs_diff = (actual.float() - expected.float()).abs()
+    assert bool(((code_diff <= 1) | (abs_diff <= 2**-8)).all())
+
+
 def _assert_matches(case):
     q_out, state, compressed = _run(case)
     want_q, want_state, want_compressed = _reference(**case)
     tol = dict(rtol=2e-2, atol=2e-2)
-    torch.testing.assert_close(q_out.float(), want_q.float(), **tol)
+    if case["out_dtype"] == torch.float8_e4m3fn:
+        _assert_fp8_within_one_ulp(q_out, want_q)
+        _assert_fp8_within_one_ulp(compressed, want_compressed)
+    else:
+        torch.testing.assert_close(q_out.float(), want_q.float(), **tol)
+        torch.testing.assert_close(compressed.float(), want_compressed.float(), **tol)
+    # The raw ring is never narrowed, whatever the outputs do.
+    assert state.dtype == case["dtype"]
     torch.testing.assert_close(state.float(), want_state.float(), **tol)
-    torch.testing.assert_close(compressed.float(), want_compressed.float(), **tol)
 
 
 @pytest.mark.parametrize("dtype", DTYPES)
@@ -833,3 +866,78 @@ def test_rejects_a_compress_ratio_that_is_not_an_int32():
     case = _case(num_tokens=8)
     case["compress_ratio"] = 4294967297
     _expect_rejected(case, "fit in 32 bits")
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_narrowing_output_to_fp8(dtype, head_dim):
+    """The indexer's two outputs may narrow to e4m3 while the ring stays wide."""
+    _skip_unless_cuda()
+    _assert_matches(
+        _case(
+            num_tokens=16,
+            head_dim=head_dim,
+            dtype=dtype,
+            out_dtype=torch.float8_e4m3fn,
+        )
+    )
+
+
+def test_narrowing_leaves_the_ring_at_the_compute_dtype():
+    """A narrowed run must write the same raw ring as an un-narrowed one."""
+    _skip_unless_cuda()
+    wide = _case(num_tokens=16)
+    narrow = _case(num_tokens=16, out_dtype=torch.float8_e4m3fn)
+    _, wide_state, _ = _run(wide)
+    _, narrow_state, _ = _run(narrow)
+    assert narrow_state.dtype == torch.bfloat16
+    assert torch.equal(wide_state, narrow_state)
+
+
+def test_output_dtypes_must_agree():
+    """``q_out`` and the compressed cache are one dtype, so a split is rejected."""
+    _skip_unless_cuda()
+    case = _case(num_tokens=8, out_dtype=torch.float8_e4m3fn)
+    case["compressed_cache"] = case["compressed_cache"].to(torch.bfloat16)
+    with pytest.raises(
+        RuntimeError, match=r"compressed_cache\.dtype\(\) == q_out\.dtype\(\)"
+    ):
+        _run(case)
+
+
+@pytest.mark.parametrize(
+    "out_dtype",
+    [torch.float16, torch.float8_e5m2, torch.float8_e4m3fnuz],
+    ids=["cross-width", "e5m2", "e4m3fnuz"],
+)
+def test_rejected_output_dtypes(out_dtype):
+    """Only the compute dtype and plain e4m3 are dispatched."""
+    _skip_unless_cuda()
+    with pytest.raises(RuntimeError, match="q_out must be .* or float8_e4m3fn"):
+        _run(_case(num_tokens=8, dtype=torch.bfloat16, out_dtype=out_dtype))
+
+
+def test_dispatch_mask_matches_the_arms():
+    """Every advertised relation is one the dispatch really runs.
+
+    Both directions of the coupling would need a second build with
+    ``FLASHINFER_ENABLE_FP8_E4M3`` off, which this suite does not produce; the guard in
+    ``sparse_pre_indexer.cu`` is what ties the missing arm to the missing bit. What is
+    checked here is the direction that can be: nothing is advertised that the dispatch
+    refuses.
+    """
+    from flashinfer.sparse_pre_indexer import (
+        QSA_PRE_INDEXER_NARROW_E4M3,
+        QSA_PRE_INDEXER_SAME_AS_COMPUTE,
+        qsa_pre_indexer_dispatch_mask,
+    )
+
+    _skip_unless_cuda()
+    mask = qsa_pre_indexer_dispatch_mask()
+    # The same-dtype arm is unconditional; e4m3 rides on the build flag, and this build
+    # has it (jit/core.py passes -DFLASHINFER_ENABLE_FP8_E4M3 to every spec).
+    assert mask & QSA_PRE_INDEXER_SAME_AS_COMPUTE
+    assert mask & QSA_PRE_INDEXER_NARROW_E4M3
+    # And each advertised relation runs rather than raising.
+    _assert_matches(_case(num_tokens=8))
+    _assert_matches(_case(num_tokens=8, out_dtype=torch.float8_e4m3fn))


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds the QSA pre-indexer: the kernel that builds the rows a sparse scorer reads, and the public API that reaches it.

A quantized sparse attention step runs in two halves. The second half scores a paged KV cache against a query and keeps the top tokens; the first half has to produce what that scorer reads — the query and the compressed keys, normalized, rotated and written into their caches. Without it a caller does that in a chain of small ops: an RMS norm, a rope, a quantize, a scatter into the state cache, a second scatter into the compressed cache. Each is a launch, each reads and writes the same tensors, and the whole chain has to be replayed inside a CUDA graph for the step to be capturable.

This fuses the chain into one kernel.

- `flashinfer.qsa_pre_indexer(...)` normalizes and rotates the query and the key, writes the key into the state cache at the caller's slots, and folds every `compress_ratio` tokens into one compressed key written at the caller's compressed slots.
- Positions come in as `logical_positions`, so a caller whose sequence is longer than its cache window does not have to renumber them.
- `work_metadata` carries the per-row work assignment the caller built, so the kernel does not scan for it and the launch geometry does not depend on the batch's contents.
- `qsa_pre_indexer_dispatch_mask()` reports which `(q_dtype, kv_dtype)` pairs the compiled module serves, so a caller can decide once at startup instead of discovering it at the first step.
- Everything is written into buffers the caller owns. The module holds no device-wide cache, and nothing is allocated inside a call, so a step is capturable.

### Scope

This is one of four QSA pieces. It is independent of the others: the kernel, the binding, the Python entry point and its tests are all new files, and the only shared files touched are `flashinfer/__init__.py` and `flashinfer/aot.py` for the export and the AOT registration.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/attention/test_sparse_pre_indexer.py` — 40 tests covering the fused path against a per-op reference, the dtype pairs the dispatch mask advertises, the slot and block-table mapping, rows the work metadata marks dead, and capture safety.

Run on compute capability 8.0. The kernel is not architecture-specific, but 9.0 and newer are untested here.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

## Reviewer Notes

The dispatch mask is deliberately a capability query rather than a `supports(...)` predicate: the set of compiled pairs is a property of the build, and a caller that asks once at startup can refuse a deployment instead of failing at the first step.
