### PR TITLE
feat(sparse): build a paged attention route from a block selection

### DIFF
--- a/csrc/sparse_route.cu
+++ b/csrc/sparse_route.cu
@@ -107,18 +107,25 @@ void qsa_route_from_blocks(TensorView block_indices, TensorView query_positions,
 
   const int64_t rows = block_indices.size(0);
   const int64_t block_topk = block_indices.size(1);
-  const int64_t output_width = block_topk * compress_ratio + compress_ratio - 1;
-  const int64_t mask_bytes = (output_width + 7) / 8;
   // These are narrowed to uint32 for the kernel, so a value past that wraps:
-  // 2^32 would arrive as a page size or a compression ratio of zero.
+  // 2^32 would arrive as a page size or a compression ratio of zero. Bounded
+  // before the width is derived from them: block_topk * compress_ratio is
+  // signed overflow long before the check below would reject the ratio.
   constexpr int64_t kUint32Max = 4294967295LL;
   TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
   TVM_FFI_ICHECK_LE(compress_ratio, kUint32Max) << "compress_ratio must fit in 32 bits";
+  const int64_t output_width = block_topk * compress_ratio + compress_ratio - 1;
+  const int64_t mask_bytes = (output_width + 7) / 8;
   TVM_FFI_ICHECK_GT(page_size, 0) << "page_size must be positive";
   TVM_FFI_ICHECK_LE(page_size, kUint32Max) << "page_size must fit in 32 bits";
   TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
   TVM_FFI_ICHECK_LE(num_slots, kUint32Max) << "num_slots must fit in 32 bits";
   TVM_FFI_ICHECK_EQ(out_route.size(0), rows);
+  // A slot is stored in the route's dtype, so num_slots also has to fit it:
+  // an int32 route would take 2^31 back out as a negative index with its
+  // mask bit set.
+  TVM_FFI_ICHECK_LE(num_slots, out_route.dtype() == dl_int32 ? 2147483647LL : kUint32Max)
+      << "num_slots must fit the route dtype";
   TVM_FFI_ICHECK_EQ(out_route.size(1), output_width);
   TVM_FFI_ICHECK_EQ(out_logical.size(1), output_width);
   TVM_FFI_ICHECK_GE(out_logical.size(0), rows);
@@ -193,6 +200,11 @@ void qsa_route_from_logical(TensorView logical, TensorView token_to_req, TensorV
   TVM_FFI_ICHECK_LE(page_size, kUint32Max) << "page_size must fit in 32 bits";
   TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
   TVM_FFI_ICHECK_LE(num_slots, kUint32Max) << "num_slots must fit in 32 bits";
+  // A slot is stored in the route's dtype, so num_slots also has to fit it:
+  // an int32 route would take 2^31 back out as a negative index with its
+  // mask bit set.
+  TVM_FFI_ICHECK_LE(num_slots, out_route.dtype() == dl_int32 ? 2147483647LL : kUint32Max)
+      << "num_slots must fit the route dtype";
   TVM_FFI_ICHECK_GE(logical.size(0), valid_rows) << "logical route must cover every live row";
   TVM_FFI_ICHECK_EQ(logical.size(1), width) << "logical route width must match the route";
   TVM_FFI_ICHECK_GE(valid_rows, 0);

--- a/csrc/sparse_route.cu
+++ b/csrc/sparse_route.cu
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <flashinfer/sparse_route.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+
+void expand_block_route(TensorView block_indices, TensorView query_positions,
+                        TensorView sequence_lengths, TensorView token_to_req, TensorView out,
+                        int64_t compress_ratio) {
+  CHECK_DEVICE(block_indices, out);
+  CHECK_DEVICE(query_positions, out);
+  CHECK_DEVICE(sequence_lengths, out);
+  CHECK_DEVICE(token_to_req, out);
+  CHECK_DIM(2, block_indices);
+  CHECK_DIM(2, out);
+  CHECK_DIM(1, query_positions);
+  CHECK_DIM(1, sequence_lengths);
+  CHECK_DIM(1, token_to_req);
+  CHECK_CONTIGUOUS(query_positions);
+  CHECK_CONTIGUOUS(sequence_lengths);
+  CHECK_CONTIGUOUS(token_to_req);
+
+  const int64_t rows = block_indices.size(0);
+  const int64_t block_topk = block_indices.size(1);
+  const int64_t output_width = out.size(1);
+  TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_EQ(out.size(0), rows) << "route must have one row per query";
+  TVM_FFI_ICHECK_EQ(query_positions.size(0), rows) << "one query position per row";
+  TVM_FFI_ICHECK_EQ(token_to_req.size(0), rows) << "one request index per row";
+  TVM_FFI_ICHECK_GT(sequence_lengths.size(0), 0) << "sequence_lengths must be non-empty";
+  // The tail of the query's own block never exceeds compress_ratio - 1 tokens.
+  TVM_FFI_ICHECK_EQ(output_width, block_topk * compress_ratio + compress_ratio - 1)
+      << "route width must be block_topk * compress_ratio + compress_ratio - 1, got "
+      << output_width;
+  TVM_FFI_ICHECK_EQ(query_positions.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(sequence_lengths.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(token_to_req.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(out.dtype(), block_indices.dtype());
+
+  ffi::CUDADeviceGuard device_guard(out.device().device_id);
+  const cudaStream_t stream = get_stream(out.device());
+  DISPATCH_DLPACK_IDTYPE_TO_CTYPE(block_indices.dtype(), c_idtype, [&] {
+    cudaError_t status = ExpandBlockRoute<c_idtype>(
+        static_cast<const c_idtype*>(block_indices.data_ptr()),
+        static_cast<const c_idtype*>(query_positions.data_ptr()),
+        static_cast<const c_idtype*>(sequence_lengths.data_ptr()),
+        static_cast<const c_idtype*>(token_to_req.data_ptr()),
+        static_cast<c_idtype*>(out.data_ptr()), static_cast<uint32_t>(block_indices.stride(0)),
+        static_cast<uint32_t>(block_indices.stride(1)), static_cast<uint32_t>(out.stride(0)),
+        static_cast<uint32_t>(out.stride(1)), static_cast<uint32_t>(rows),
+        static_cast<uint32_t>(sequence_lengths.size(0)), static_cast<uint32_t>(block_topk),
+        static_cast<uint32_t>(compress_ratio), static_cast<uint32_t>(output_width), stream);
+    TVM_FFI_ICHECK(status != cudaErrorInvalidValue)
+        << "unsupported compress_ratio " << compress_ratio << "; expected a power of two <= 32";
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "ExpandBlockRoute failed: " << cudaGetErrorString(status);
+    return true;
+  });
+}
+
+void qsa_route_from_blocks(TensorView block_indices, TensorView query_positions,
+                           TensorView sequence_lengths, TensorView token_to_req,
+                           TensorView block_table, TensorView out_logical, TensorView out_route,
+                           TensorView out_mask, int64_t compress_ratio, int64_t page_size,
+                           int64_t num_slots) {
+  CHECK_DEVICE(block_indices, out_route);
+  CHECK_DEVICE(block_table, out_route);
+  CHECK_DEVICE(query_positions, out_route);
+  CHECK_DEVICE(sequence_lengths, out_route);
+  CHECK_DEVICE(token_to_req, out_route);
+  CHECK_DEVICE(out_logical, out_route);
+  CHECK_DEVICE(out_mask, out_route);
+  CHECK_DIM(2, block_indices);
+  CHECK_DIM(2, block_table);
+  CHECK_DIM(2, out_logical);
+  CHECK_DIM(2, out_route);
+  CHECK_DIM(1, query_positions);
+  CHECK_DIM(1, sequence_lengths);
+  CHECK_DIM(1, token_to_req);
+  CHECK_CONTIGUOUS(out_route);
+  CHECK_CONTIGUOUS(out_mask);
+  CHECK_CONTIGUOUS(query_positions);
+  CHECK_CONTIGUOUS(sequence_lengths);
+  CHECK_CONTIGUOUS(token_to_req);
+  // The kernel walks the row of each of these with a stride of one element.
+  CHECK_LAST_DIM_CONTIGUOUS(out_logical);
+  CHECK_LAST_DIM_CONTIGUOUS(block_table);
+
+  const int64_t rows = block_indices.size(0);
+  const int64_t block_topk = block_indices.size(1);
+  const int64_t output_width = block_topk * compress_ratio + compress_ratio - 1;
+  const int64_t mask_bytes = (output_width + 7) / 8;
+  TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_GT(page_size, 0) << "page_size must be positive";
+  TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
+  TVM_FFI_ICHECK_EQ(out_route.size(0), rows);
+  TVM_FFI_ICHECK_EQ(out_route.size(1), output_width);
+  TVM_FFI_ICHECK_EQ(out_logical.size(1), output_width);
+  TVM_FFI_ICHECK_GE(out_logical.size(0), rows);
+  TVM_FFI_ICHECK_EQ(out_mask.numel(), rows * mask_bytes)
+      << "mask must hold ceil(width/8) bytes per row";
+  TVM_FFI_ICHECK_EQ(out_mask.dtype(), dl_uint8) << "mask must be uint8";
+  TVM_FFI_ICHECK_EQ(query_positions.size(0), rows);
+  TVM_FFI_ICHECK_EQ(token_to_req.size(0), rows);
+  // Every index tensor is read through one pointer type.
+  TVM_FFI_ICHECK_EQ(out_logical.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(out_route.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(block_table.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(query_positions.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(sequence_lengths.dtype(), block_indices.dtype());
+  TVM_FFI_ICHECK_EQ(token_to_req.dtype(), block_indices.dtype());
+  // A row indexes both by the same request, so a shorter table would be read
+  // past its end.
+  TVM_FFI_ICHECK_EQ(block_table.size(0), sequence_lengths.size(0))
+      << "block table and sequence lengths must cover the same requests";
+
+  ffi::CUDADeviceGuard device_guard(out_route.device().device_id);
+  const cudaStream_t stream = get_stream(out_route.device());
+  DISPATCH_DLPACK_IDTYPE_TO_CTYPE(block_indices.dtype(), c_idtype, [&] {
+    cudaError_t status = QSARouteFromBlocks<c_idtype>(
+        static_cast<const c_idtype*>(block_indices.data_ptr()),
+        static_cast<const c_idtype*>(query_positions.data_ptr()),
+        static_cast<const c_idtype*>(sequence_lengths.data_ptr()),
+        static_cast<const c_idtype*>(token_to_req.data_ptr()),
+        static_cast<const c_idtype*>(block_table.data_ptr()),
+        static_cast<c_idtype*>(out_logical.data_ptr()),
+        static_cast<c_idtype*>(out_route.data_ptr()), static_cast<uint8_t*>(out_mask.data_ptr()),
+        static_cast<uint32_t>(block_indices.stride(0)),
+        static_cast<uint32_t>(block_indices.stride(1)),
+        static_cast<uint32_t>(out_logical.stride(0)), static_cast<uint32_t>(block_table.stride(0)),
+        static_cast<uint32_t>(rows), static_cast<uint32_t>(sequence_lengths.size(0)),
+        static_cast<uint32_t>(block_topk), static_cast<uint32_t>(block_table.size(1)),
+        static_cast<uint32_t>(page_size), static_cast<uint32_t>(num_slots),
+        static_cast<uint32_t>(mask_bytes), static_cast<uint32_t>(compress_ratio), stream);
+    TVM_FFI_ICHECK(status != cudaErrorInvalidValue)
+        << "unsupported compress_ratio " << compress_ratio << "; expected a power of two <= 32";
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "QSARouteFromBlocks failed: " << cudaGetErrorString(status);
+    return true;
+  });
+}
+
+void qsa_route_from_logical(TensorView logical, TensorView token_to_req, TensorView block_table,
+                            TensorView out_route, TensorView out_mask, int64_t valid_rows,
+                            int64_t page_size, int64_t num_slots) {
+  CHECK_DEVICE(logical, out_route);
+  CHECK_DEVICE(block_table, out_route);
+  CHECK_DEVICE(token_to_req, out_route);
+  CHECK_DEVICE(out_mask, out_route);
+  CHECK_DIM(2, logical);
+  CHECK_DIM(2, block_table);
+  CHECK_DIM(2, out_route);
+  CHECK_DIM(1, token_to_req);
+  CHECK_CONTIGUOUS(out_route);
+  CHECK_CONTIGUOUS(out_mask);
+  CHECK_CONTIGUOUS(token_to_req);
+  // The kernel walks the row of each of these with a stride of one element.
+  CHECK_LAST_DIM_CONTIGUOUS(logical);
+  CHECK_LAST_DIM_CONTIGUOUS(block_table);
+
+  const int64_t rows = out_route.size(0);
+  const int64_t width = out_route.size(1);
+  const int64_t mask_bytes = (width + 7) / 8;
+  TVM_FFI_ICHECK_GT(page_size, 0) << "page_size must be positive";
+  TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
+  TVM_FFI_ICHECK_GE(logical.size(0), valid_rows) << "logical route must cover every live row";
+  TVM_FFI_ICHECK_EQ(logical.size(1), width) << "logical route width must match the route";
+  TVM_FFI_ICHECK_GE(valid_rows, 0);
+  TVM_FFI_ICHECK_LE(valid_rows, rows) << "valid_rows must not exceed the route rows";
+  TVM_FFI_ICHECK_GE(token_to_req.size(0), valid_rows) << "one request index per live row";
+  TVM_FFI_ICHECK_EQ(out_mask.numel(), rows * mask_bytes)
+      << "mask must hold ceil(width/8) bytes per row";
+  TVM_FFI_ICHECK_EQ(out_mask.dtype(), dl_uint8) << "mask must be uint8";
+  TVM_FFI_ICHECK_EQ(out_route.dtype(), logical.dtype());
+  TVM_FFI_ICHECK_EQ(block_table.dtype(), logical.dtype());
+  TVM_FFI_ICHECK_EQ(token_to_req.dtype(), logical.dtype());
+
+  ffi::CUDADeviceGuard device_guard(out_route.device().device_id);
+  const cudaStream_t stream = get_stream(out_route.device());
+  DISPATCH_DLPACK_IDTYPE_TO_CTYPE(logical.dtype(), c_idtype, [&] {
+    cudaError_t status = QSARouteFromLogical<c_idtype>(
+        static_cast<const c_idtype*>(logical.data_ptr()),
+        static_cast<const c_idtype*>(token_to_req.data_ptr()),
+        static_cast<const c_idtype*>(block_table.data_ptr()),
+        static_cast<c_idtype*>(out_route.data_ptr()), static_cast<uint8_t*>(out_mask.data_ptr()),
+        static_cast<uint32_t>(logical.stride(0)), static_cast<uint32_t>(block_table.stride(0)),
+        static_cast<uint32_t>(rows), static_cast<uint32_t>(valid_rows),
+        static_cast<uint32_t>(block_table.size(0)), static_cast<uint32_t>(width),
+        static_cast<uint32_t>(block_table.size(1)), static_cast<uint32_t>(page_size),
+        static_cast<uint32_t>(num_slots), static_cast<uint32_t>(mask_bytes), stream);
+    TVM_FFI_ICHECK(status == cudaSuccess)
+        << "QSARouteFromLogical failed: " << cudaGetErrorString(status);
+    return true;
+  });
+}

--- a/csrc/sparse_route.cu
+++ b/csrc/sparse_route.cu
@@ -121,10 +121,11 @@ void qsa_route_from_blocks(TensorView block_indices, TensorView query_positions,
   TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
   TVM_FFI_ICHECK_LE(num_slots, kUint32Max) << "num_slots must fit in 32 bits";
   TVM_FFI_ICHECK_EQ(out_route.size(0), rows);
-  // A slot is stored in the route's dtype, so num_slots also has to fit it:
-  // an int32 route would take 2^31 back out as a negative index with its
-  // mask bit set.
-  TVM_FFI_ICHECK_LE(num_slots, out_route.dtype() == dl_int32 ? 2147483647LL : kUint32Max)
+  // A slot is stored in the route's dtype, so the largest one has to fit it.
+  // num_slots is a count, so that is num_slots - 1: an int32 route holds a
+  // slot space of 2^31 exactly, and one more than that comes back out as a
+  // negative index with its mask bit set.
+  TVM_FFI_ICHECK_LE(num_slots, out_route.dtype() == dl_int32 ? 2147483648LL : kUint32Max)
       << "num_slots must fit the route dtype";
   TVM_FFI_ICHECK_EQ(out_route.size(1), output_width);
   TVM_FFI_ICHECK_EQ(out_logical.size(1), output_width);
@@ -200,10 +201,11 @@ void qsa_route_from_logical(TensorView logical, TensorView token_to_req, TensorV
   TVM_FFI_ICHECK_LE(page_size, kUint32Max) << "page_size must fit in 32 bits";
   TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
   TVM_FFI_ICHECK_LE(num_slots, kUint32Max) << "num_slots must fit in 32 bits";
-  // A slot is stored in the route's dtype, so num_slots also has to fit it:
-  // an int32 route would take 2^31 back out as a negative index with its
-  // mask bit set.
-  TVM_FFI_ICHECK_LE(num_slots, out_route.dtype() == dl_int32 ? 2147483647LL : kUint32Max)
+  // A slot is stored in the route's dtype, so the largest one has to fit it.
+  // num_slots is a count, so that is num_slots - 1: an int32 route holds a
+  // slot space of 2^31 exactly, and one more than that comes back out as a
+  // negative index with its mask bit set.
+  TVM_FFI_ICHECK_LE(num_slots, out_route.dtype() == dl_int32 ? 2147483648LL : kUint32Max)
       << "num_slots must fit the route dtype";
   TVM_FFI_ICHECK_GE(logical.size(0), valid_rows) << "logical route must cover every live row";
   TVM_FFI_ICHECK_EQ(logical.size(1), width) << "logical route width must match the route";

--- a/csrc/sparse_route.cu
+++ b/csrc/sparse_route.cu
@@ -38,7 +38,11 @@ void expand_block_route(TensorView block_indices, TensorView query_positions,
   const int64_t rows = block_indices.size(0);
   const int64_t block_topk = block_indices.size(1);
   const int64_t output_width = out.size(1);
+  // These are narrowed to uint32 for the kernel, so a value past that wraps:
+  // 2^32 would arrive as a page size or a compression ratio of zero.
+  constexpr int64_t kUint32Max = 4294967295LL;
   TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_LE(compress_ratio, kUint32Max) << "compress_ratio must fit in 32 bits";
   TVM_FFI_ICHECK_EQ(out.size(0), rows) << "route must have one row per query";
   TVM_FFI_ICHECK_EQ(query_positions.size(0), rows) << "one query position per row";
   TVM_FFI_ICHECK_EQ(token_to_req.size(0), rows) << "one request index per row";
@@ -105,9 +109,15 @@ void qsa_route_from_blocks(TensorView block_indices, TensorView query_positions,
   const int64_t block_topk = block_indices.size(1);
   const int64_t output_width = block_topk * compress_ratio + compress_ratio - 1;
   const int64_t mask_bytes = (output_width + 7) / 8;
+  // These are narrowed to uint32 for the kernel, so a value past that wraps:
+  // 2^32 would arrive as a page size or a compression ratio of zero.
+  constexpr int64_t kUint32Max = 4294967295LL;
   TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_LE(compress_ratio, kUint32Max) << "compress_ratio must fit in 32 bits";
   TVM_FFI_ICHECK_GT(page_size, 0) << "page_size must be positive";
+  TVM_FFI_ICHECK_LE(page_size, kUint32Max) << "page_size must fit in 32 bits";
   TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
+  TVM_FFI_ICHECK_LE(num_slots, kUint32Max) << "num_slots must fit in 32 bits";
   TVM_FFI_ICHECK_EQ(out_route.size(0), rows);
   TVM_FFI_ICHECK_EQ(out_route.size(1), output_width);
   TVM_FFI_ICHECK_EQ(out_logical.size(1), output_width);
@@ -176,8 +186,13 @@ void qsa_route_from_logical(TensorView logical, TensorView token_to_req, TensorV
   const int64_t rows = out_route.size(0);
   const int64_t width = out_route.size(1);
   const int64_t mask_bytes = (width + 7) / 8;
+  // These are narrowed to uint32 for the kernel, so a value past that wraps:
+  // 2^32 would arrive as a page size or a compression ratio of zero.
+  constexpr int64_t kUint32Max = 4294967295LL;
   TVM_FFI_ICHECK_GT(page_size, 0) << "page_size must be positive";
+  TVM_FFI_ICHECK_LE(page_size, kUint32Max) << "page_size must fit in 32 bits";
   TVM_FFI_ICHECK_GT(num_slots, 0) << "num_slots must be positive";
+  TVM_FFI_ICHECK_LE(num_slots, kUint32Max) << "num_slots must fit in 32 bits";
   TVM_FFI_ICHECK_GE(logical.size(0), valid_rows) << "logical route must cover every live row";
   TVM_FFI_ICHECK_EQ(logical.size(1), width) << "logical route width must match the route";
   TVM_FFI_ICHECK_GE(valid_rows, 0);

--- a/csrc/sparse_route_jit_binding.cu
+++ b/csrc/sparse_route_jit_binding.cu
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tvm_ffi_utils.h"
+
+void expand_block_route(TensorView block_indices, TensorView query_positions,
+                        TensorView sequence_lengths, TensorView token_to_req, TensorView out,
+                        int64_t compress_ratio);
+
+void qsa_route_from_blocks(TensorView block_indices, TensorView query_positions,
+                           TensorView sequence_lengths, TensorView token_to_req,
+                           TensorView block_table, TensorView out_logical, TensorView out_route,
+                           TensorView out_mask, int64_t compress_ratio, int64_t page_size,
+                           int64_t num_slots);
+
+void qsa_route_from_logical(TensorView logical, TensorView token_to_req, TensorView block_table,
+                            TensorView out_route, TensorView out_mask, int64_t valid_rows,
+                            int64_t page_size, int64_t num_slots);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(expand_block_route, expand_block_route);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(qsa_route_from_logical, qsa_route_from_logical);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(qsa_route_from_blocks, qsa_route_from_blocks);

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -297,6 +297,9 @@ from .topk import top_k_ragged_transform as top_k_ragged_transform
 from .topk import TopKTieBreak as TopKTieBreak
 from .topk_varlen.topk_varlen import top_k_varlen as top_k_varlen
 from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper
+from .sparse_route import expand_block_route as expand_block_route
+from .sparse_route import qsa_route_from_blocks as qsa_route_from_blocks
+from .sparse_route import qsa_route_from_logical as qsa_route_from_logical
 from .sparse import (
     VariableBlockSparseAttentionWrapper as VariableBlockSparseAttentionWrapper,
 )

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -169,6 +169,7 @@ from .jit.moe_utils import gen_moe_utils_module
 from .jit.hash_topk import gen_hash_topk_module
 from .jit.tllm_utils import gen_trtllm_utils_module
 from .jit.topk import gen_topk_module
+from .jit.sparse_route import gen_sparse_route_module
 from .jit.xqa import gen_xqa_module, gen_xqa_module_mla
 
 
@@ -526,6 +527,9 @@ def gen_all_modules(
 ) -> List[JitSpec]:
     jit_specs: List[JitSpec] = []
     jit_specs.append(gen_spdlog_module())
+    # The route kernels are plain CUDA and build everywhere; without this an
+    # install with JIT disabled has no artifact to load.
+    jit_specs.append(gen_sparse_route_module())
     has_bgmv_moe = sm_capabilities.get("bgmv_moe", False)
     has_sm80 = sm_capabilities.get("sm80", False)
     has_sm90 = sm_capabilities.get("sm90", False)

--- a/flashinfer/jit/sparse_route.py
+++ b/flashinfer/jit/sparse_route.py
@@ -1,0 +1,28 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec
+
+
+def gen_sparse_route_module() -> JitSpec:
+    return gen_jit_spec(
+        "sparse_route",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_route.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_route_jit_binding.cu",
+        ],
+    )

--- a/flashinfer/sparse_route.py
+++ b/flashinfer/sparse_route.py
@@ -73,10 +73,14 @@ def expand_block_route(
     each. Attention works on tokens, so every selected block becomes its
     ``compress_ratio`` tokens, in selection order.
 
-    The block a query sits in is only partially in the past, so it is never selected
+    The block a query sits in is only partially in the past, so it is never expanded
     whole; its already-seen tokens are appended after the expanded blocks instead. That
     tail is at most ``compress_ratio - 1`` tokens, which fixes the route width at
     ``block_topk * compress_ratio + compress_ratio - 1``.
+
+    The selection is the caller's, so this is enforced rather than assumed: a selected
+    block the query has not passed is dropped whole, all ``compress_ratio`` of its
+    positions. Keeping only its seen tokens would repeat exactly what the tail appends.
 
     Positions no token reaches are written as ``-1``, for the consumer to mask.
 
@@ -105,12 +109,19 @@ def expand_block_route(
     --------
     >>> import torch
     >>> import flashinfer
-    >>> blocks = torch.tensor([[2, 0]], dtype=torch.int32, device="cuda")
+    >>> blocks = torch.tensor([[1, 0]], dtype=torch.int32, device="cuda")
     >>> positions = torch.tensor([9], dtype=torch.int32, device="cuda")
     >>> seq_lens = torch.tensor([16], dtype=torch.int32, device="cuda")
     >>> token_to_req = torch.tensor([0], dtype=torch.int32, device="cuda")
     >>> flashinfer.expand_block_route(blocks, positions, seq_lens, token_to_req, 4)
-    tensor([[8, 9, 10, 11, 0, 1, 2, 3, 8, 9, -1]], device='cuda:0', dtype=torch.int32)
+    tensor([[4, 5, 6, 7, 0, 1, 2, 3, 8, 9, -1]], device='cuda:0', dtype=torch.int32)
+
+    Block 2 is the one the query at position 9 sits in, so selecting it drops those
+    four positions instead:
+
+    >>> blocks = torch.tensor([[2, 0]], dtype=torch.int32, device="cuda")
+    >>> flashinfer.expand_block_route(blocks, positions, seq_lens, token_to_req, 4)
+    tensor([[-1, -1, -1, -1, 0, 1, 2, 3, 8, 9, -1]], device='cuda:0', dtype=torch.int32)
     """
     if block_indices.ndim != 2:
         raise ValueError(

--- a/flashinfer/sparse_route.py
+++ b/flashinfer/sparse_route.py
@@ -1,0 +1,370 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from typing import Optional
+
+import torch
+
+from .jit.sparse_route import gen_sparse_route_module
+from .utils import register_custom_op, register_fake_op
+
+
+@functools.cache
+def get_sparse_route_module():
+    return gen_sparse_route_module().build_and_load()
+
+
+@register_custom_op("flashinfer::expand_block_route", mutates_args=("out",))
+def _expand_block_route(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor,
+    compress_ratio: int,
+) -> None:
+    get_sparse_route_module().expand_block_route(
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        out,
+        compress_ratio,
+    )
+
+
+@register_fake_op("flashinfer::expand_block_route")
+def _expand_block_route_fake(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    out: torch.Tensor,
+    compress_ratio: int,
+) -> None:
+    pass
+
+
+def expand_block_route(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    compress_ratio: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    r"""Expand a per-query list of selected blocks into the token route it stands for.
+
+    A block-granular selector picks ``block_topk`` blocks of ``compress_ratio`` tokens
+    each. Attention works on tokens, so every selected block becomes its
+    ``compress_ratio`` tokens, in selection order.
+
+    The block a query sits in is only partially in the past, so it is never selected
+    whole; its already-seen tokens are appended after the expanded blocks instead. That
+    tail is at most ``compress_ratio - 1`` tokens, which fixes the route width at
+    ``block_topk * compress_ratio + compress_ratio - 1``.
+
+    Positions no token reaches are written as ``-1``, for the consumer to mask.
+
+    Parameters
+    ----------
+    block_indices : torch.Tensor
+        Selected block ids, shape ``[rows, block_topk]``, int32 or int64.
+    query_positions : torch.Tensor
+        Position of each query inside its request, shape ``[rows]``.
+    sequence_lengths : torch.Tensor
+        KV length of each request, shape ``[num_requests]``.
+    token_to_req : torch.Tensor
+        Request each row belongs to, shape ``[rows]``. A negative entry empties the row.
+    compress_ratio : int
+        Tokens per block.
+    out : Optional[torch.Tensor]
+        Route to write, shape ``[rows, block_topk * compress_ratio + compress_ratio - 1]``.
+        Allocated when omitted.
+
+    Returns
+    -------
+    torch.Tensor
+        The token route, ``-1`` padded.
+
+    Examples
+    --------
+    >>> import torch
+    >>> import flashinfer
+    >>> blocks = torch.tensor([[2, 0]], dtype=torch.int32, device="cuda")
+    >>> positions = torch.tensor([9], dtype=torch.int32, device="cuda")
+    >>> seq_lens = torch.tensor([16], dtype=torch.int32, device="cuda")
+    >>> token_to_req = torch.tensor([0], dtype=torch.int32, device="cuda")
+    >>> flashinfer.expand_block_route(blocks, positions, seq_lens, token_to_req, 4)
+    tensor([[8, 9, 10, 11, 0, 1, 2, 3, 8, 9, -1]], device='cuda:0', dtype=torch.int32)
+    """
+    if block_indices.ndim != 2:
+        raise ValueError(
+            f"block_indices must be 2D [rows, block_topk], got {block_indices.ndim}D"
+        )
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    rows, block_topk = block_indices.shape
+    width = block_topk * compress_ratio + compress_ratio - 1
+    if out is None:
+        out = torch.empty(
+            (rows, width), dtype=block_indices.dtype, device=block_indices.device
+        )
+    elif tuple(out.shape) != (rows, width):
+        raise ValueError(f"out must have shape {(rows, width)}, got {tuple(out.shape)}")
+    if rows:
+        _expand_block_route(
+            block_indices,
+            query_positions,
+            sequence_lengths,
+            token_to_req,
+            out,
+            compress_ratio,
+        )
+    return out
+
+
+@register_custom_op(
+    "flashinfer::qsa_route_from_blocks",
+    mutates_args=("out_logical", "out_route", "out_mask"),
+)
+def _qsa_route_from_blocks(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    block_table: torch.Tensor,
+    out_logical: torch.Tensor,
+    out_route: torch.Tensor,
+    out_mask: torch.Tensor,
+    compress_ratio: int,
+    page_size: int,
+    num_slots: int,
+) -> None:
+    get_sparse_route_module().qsa_route_from_blocks(
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        block_table,
+        out_logical,
+        out_route,
+        out_mask,
+        compress_ratio,
+        page_size,
+        num_slots,
+    )
+
+
+@register_fake_op("flashinfer::qsa_route_from_blocks")
+def _qsa_route_from_blocks_fake(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    block_table: torch.Tensor,
+    out_logical: torch.Tensor,
+    out_route: torch.Tensor,
+    out_mask: torch.Tensor,
+    compress_ratio: int,
+    page_size: int,
+    num_slots: int,
+) -> None:
+    pass
+
+
+def qsa_route_from_blocks(
+    block_indices: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    token_to_req: torch.Tensor,
+    block_table: torch.Tensor,
+    out_logical: torch.Tensor,
+    out_route: torch.Tensor,
+    out_mask: torch.Tensor,
+    compress_ratio: int,
+    page_size: int,
+    num_slots: int,
+) -> None:
+    r"""Turn a per-query block selection straight into a paged attention route.
+
+    Fuses what would otherwise be three passes over the same route: expanding the
+    selected blocks into tokens (see :func:`expand_block_route`), mapping each token
+    through the block table into a physical KV slot, and packing per-entry validity
+    into the bitmask a block-sparse attention reads.
+
+    An entry is valid when it names a real token: inside the request, on a logical
+    page the block table covers, on a page the table maps, and in a slot the cache
+    holds. Invalid entries route to slot 0 with their mask bit clear -- an
+    out-of-range slot would be read before the mask applies.
+
+    The logical route is written out as well, for callers that reuse a selection
+    across steps after the physical route derived from it has been consumed.
+
+    Parameters
+    ----------
+    block_indices : torch.Tensor
+        Selected block ids, shape ``[rows, block_topk]``, int32 or int64.
+    query_positions : torch.Tensor
+        Position of each query inside its request, shape ``[rows]``.
+    sequence_lengths : torch.Tensor
+        KV length of each request, shape ``[num_requests]``.
+    token_to_req : torch.Tensor
+        Request each row belongs to, shape ``[rows]``. A negative entry empties the row.
+    block_table : torch.Tensor
+        Logical page to physical page per request, shape ``[num_requests, table_width]``.
+        A negative entry marks an unmapped page.
+    out_logical : torch.Tensor
+        Receives the logical token route, shape ``[>= rows, width]``.
+    out_route : torch.Tensor
+        Receives the physical slot route, shape ``[rows, width]``, contiguous.
+    out_mask : torch.Tensor
+        Receives the packed validity, ``ceil(width / 8)`` uint8 per row, contiguous.
+    compress_ratio : int
+        Tokens per block.
+    page_size : int
+        KV entries per physical page.
+    num_slots : int
+        Total KV entries the cache holds.
+
+    Notes
+    -----
+    ``width`` is ``block_topk * compress_ratio + compress_ratio - 1``: every selected
+    block expands to ``compress_ratio`` tokens, and the query's own block contributes
+    at most ``compress_ratio - 1`` already-seen tokens.
+    """
+    if block_indices.ndim != 2:
+        raise ValueError(
+            f"block_indices must be 2D [rows, block_topk], got {block_indices.ndim}D"
+        )
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    if block_indices.shape[0] == 0:
+        return
+    _qsa_route_from_blocks(
+        block_indices,
+        query_positions,
+        sequence_lengths,
+        token_to_req,
+        block_table,
+        out_logical,
+        out_route,
+        out_mask,
+        compress_ratio,
+        page_size,
+        num_slots,
+    )
+
+
+@register_custom_op(
+    "flashinfer::qsa_route_from_logical", mutates_args=("out_route", "out_mask")
+)
+def _qsa_route_from_logical(
+    logical: torch.Tensor,
+    token_to_req: torch.Tensor,
+    block_table: torch.Tensor,
+    out_route: torch.Tensor,
+    out_mask: torch.Tensor,
+    valid_rows: int,
+    page_size: int,
+    num_slots: int,
+) -> None:
+    get_sparse_route_module().qsa_route_from_logical(
+        logical,
+        token_to_req,
+        block_table,
+        out_route,
+        out_mask,
+        valid_rows,
+        page_size,
+        num_slots,
+    )
+
+
+@register_fake_op("flashinfer::qsa_route_from_logical")
+def _qsa_route_from_logical_fake(
+    logical: torch.Tensor,
+    token_to_req: torch.Tensor,
+    block_table: torch.Tensor,
+    out_route: torch.Tensor,
+    out_mask: torch.Tensor,
+    valid_rows: int,
+    page_size: int,
+    num_slots: int,
+) -> None:
+    pass
+
+
+def qsa_route_from_logical(
+    logical: torch.Tensor,
+    token_to_req: torch.Tensor,
+    block_table: torch.Tensor,
+    out_route: torch.Tensor,
+    out_mask: torch.Tensor,
+    valid_rows: int,
+    page_size: int,
+    num_slots: int,
+) -> None:
+    r"""Map a logical token route through a block table into physical KV slots.
+
+    The second half of :func:`qsa_route_from_blocks`, for callers whose logical route
+    was produced earlier and outlived the physical one -- a speculative decoder reuses
+    a selection across its steps.
+
+    An entry is valid when it names a real token: non-negative, on a logical page the
+    block table covers, on a page the table maps, and in a slot the cache holds.
+    Invalid entries route to slot 0 with their mask bit clear, since an out-of-range
+    slot would be read before the mask applies. Route rows at or past ``valid_rows``
+    are padding and come out fully masked.
+
+    Parameters
+    ----------
+    logical : torch.Tensor
+        Logical token route, shape ``[>= valid_rows, width]``. Rows past
+        ``valid_rows`` are never read.
+    token_to_req : torch.Tensor
+        Request each live row belongs to, at least ``valid_rows`` entries.
+    block_table : torch.Tensor
+        Logical page to physical page per request, shape ``[num_requests, table_width]``.
+        A negative entry marks an unmapped page.
+    out_route : torch.Tensor
+        Receives the physical slot route, shape ``[rows, width]``, contiguous.
+    out_mask : torch.Tensor
+        Receives the packed validity, ``ceil(width / 8)`` uint8 per row, contiguous.
+    valid_rows : int
+        Rows that carry a real query; the rest are masked off.
+    page_size : int
+        KV entries per physical page.
+    num_slots : int
+        Total KV entries the cache holds.
+    """
+    if out_route.ndim != 2:
+        raise ValueError(f"out_route must be 2D [rows, width], got {out_route.ndim}D")
+    if page_size < 1:
+        raise ValueError(f"page_size must be positive, got {page_size}")
+    if out_route.shape[0] == 0:
+        return
+    _qsa_route_from_logical(
+        logical,
+        token_to_req,
+        block_table,
+        out_route,
+        out_mask,
+        valid_rows,
+        page_size,
+        num_slots,
+    )

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -141,7 +141,14 @@ __global__ void __launch_bounds__(THREADS)
       token = tail_start + tail_offset;
       valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
     }
-    valid = valid && token >= 0 && token < sequence_length;
+    // A selected block is meant to be one the query has already passed, which
+    // is what the selector's own visible count bounds it to. Nothing here had
+    // been checking it, though: the block id is the caller's, and the only
+    // bound it met was the sequence length. A block past the query would have
+    // expanded into tokens the query cannot see -- with a ratio of four, a
+    // query at position 3 selecting block 2 routes tokens 8 through 11. The
+    // route drops them rather than carry them.
+    valid = valid && token >= 0 && token <= query_position && token < sequence_length;
     row_out[static_cast<uint32_t>(column) * out_stride] =
         valid ? static_cast<IdType>(token) : IdType(-1);
   }
@@ -227,7 +234,10 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
         token = tail_start + tail_offset;
         valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
       }
-      valid = valid && token >= 0 && token < sequence_length;
+      // Same causal bound as the standalone expansion above: a selected block
+      // the query has not reached would expand into tokens it cannot see, and
+      // the sequence length alone does not stop them.
+      valid = valid && token >= 0 && token <= query_position && token < sequence_length;
       if (!valid) token = -1;
       row_logical[col] = static_cast<IdType>(token);
     }

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -101,11 +101,13 @@ __global__ void __launch_bounds__(THREADS)
 
   // Every column of this row shares them, so they are read once per block.
   // The index tensors may be int64 and everything below is int32, so each value
-  // is bounded in its own width before it is narrowed. The request is already
-  // compared against its count in IdType, which rejects anything an int32 could
-  // not hold; the position and the length are not bounded from above by
-  // anything else, and a value of exactly 2^32 narrows to zero. The bound is
-  // written out for all three so the next one cannot regress quietly.
+  // is bounded in its own width before it is narrowed -- a value of exactly
+  // 2^32 would narrow to zero, which is a real request and a real position.
+  //
+  // The request is also compared against num_requests, but that is a tensor
+  // extent with no int32 cap of its own, so the comparison alone does not stand
+  // in for the bound. The position and the length have nothing above them at
+  // all.
   constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
   const IdType position_raw = query_positions[row];
   const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
@@ -215,11 +217,13 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
   if (row >= rows || tile_base >= output_width) return;
 
   // The index tensors may be int64 and everything below is int32, so each value
-  // is bounded in its own width before it is narrowed. The request is already
-  // compared against its count in IdType, which rejects anything an int32 could
-  // not hold; the position and the length are not bounded from above by
-  // anything else, and a value of exactly 2^32 narrows to zero. The bound is
-  // written out for all three so the next one cannot regress quietly.
+  // is bounded in its own width before it is narrowed -- a value of exactly
+  // 2^32 would narrow to zero, which is a real request and a real position.
+  //
+  // The request is also compared against num_requests, but that is a tensor
+  // extent with no int32 cap of its own, so the comparison alone does not stand
+  // in for the bound. The position and the length have nothing above them at
+  // all.
   constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
   const IdType position_raw = query_positions[row];
   const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
@@ -306,11 +310,15 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
         // What bounds the page is the slot space, not an int32. A route of
         // int64 can hold a slot of 2^31 and the caller is allowed to ask for
         // one, so capping the page at INT32_MAX would mask a page it is
-        // entitled to. The cap is the largest page whose first slot is still
-        // inside num_slots, which is also what keeps the product below 64 bits.
-        const uint64_t max_page = (static_cast<uint64_t>(num_slots) - 1) / page_size;
+        // entitled to.
+        //
+        // page < num_slots is necessary rather than sufficient -- the slot is
+        // at least the page whenever a page holds anything -- so it turns no
+        // valid page away, and it is what keeps the product inside 64 bits:
+        // both factors are under 2^32 by then. The exact bound is still the
+        // candidate below.
         const IdType page = row_table[logical_page];
-        if (page >= IdType(0) && static_cast<uint64_t>(page) <= max_page) {
+        if (page >= IdType(0) && static_cast<uint64_t>(page) < static_cast<uint64_t>(num_slots)) {
           const uint64_t candidate =
               static_cast<uint64_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
           if (candidate < static_cast<uint64_t>(num_slots)) {
@@ -402,10 +410,8 @@ __global__ void __launch_bounds__(THREADS)
         if (logical_page < table_width) {
           // Bounded by the slot space rather than by an int32, for the same
           // reason as the fused kernel above.
-          const uint64_t max_page =
-              (static_cast<uint64_t>(num_slots) - 1) / static_cast<uint32_t>(page_size);
           const IdType page = row_table[logical_page];
-          if (page >= IdType(0) && static_cast<uint64_t>(page) <= max_page) {
+          if (page >= IdType(0) && static_cast<uint64_t>(page) < static_cast<uint64_t>(num_slots)) {
             const uint64_t candidate =
                 static_cast<uint64_t>(page) * static_cast<uint32_t>(page_size) + entry;
             if (candidate < static_cast<uint64_t>(num_slots)) {

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -125,13 +125,17 @@ __global__ void __launch_bounds__(THREADS)
   // One past the last block the query has entirely behind it. A selection is
   // only expandable while it names one of these: the block the query sits in
   // is partly ahead of it, and the tail below is what supplies its seen half.
-  const int32_t past_blocks = min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
-                                  sequence_length / static_cast<int32_t>(COMPRESS_RATIO));
+  // query_position + 1 in its own width: INT32_MAX is inside the range the cast
+  // above accepts, and adding one to it in int32 is signed overflow.
+  const int64_t query_end = static_cast<int64_t>(query_position) + 1;
+  const int32_t past_blocks = static_cast<int32_t>(
+      min(query_end / static_cast<int64_t>(COMPRESS_RATIO),
+          static_cast<int64_t>(sequence_length) / static_cast<int64_t>(COMPRESS_RATIO)));
   const int32_t complete_blocks = min(past_blocks, static_cast<int32_t>(block_topk));
   const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
-  const int32_t tail_start =
-      ((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO)) * COMPRESS_RATIO;
-  const int32_t tail_count = (query_position + 1) - tail_start;
+  const int32_t tail_start = static_cast<int32_t>(
+      (query_end / static_cast<int64_t>(COMPRESS_RATIO)) * static_cast<int64_t>(COMPRESS_RATIO));
+  const int32_t tail_count = static_cast<int32_t>(query_end - static_cast<int64_t>(tail_start));
 
   const IdType* row_blocks = block_indices + row * stride_blocks_row;
   IdType* row_out = out + row * stride_out_row;
@@ -149,13 +153,16 @@ __global__ void __launch_bounds__(THREADS)
     if (column < expanded_count) {
       const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
       const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
-      const IdType block_raw = row_blocks[rank * blocks_stride];
-      const int32_t block =
-          (block_raw >= IdType(0) && block_raw <= kInt32Max) ? static_cast<int32_t>(block_raw) : -1;
-      token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
       // The whole block, not the token: keeping only the seen half of a block
-      // the query sits in would repeat exactly what the tail appends.
-      valid = block >= 0 && block < past_blocks;
+      // the query sits in would repeat exactly what the tail appends. Decided
+      // before the multiply, so a block that is not one of ours is never
+      // scaled by the ratio at all.
+      const IdType block_raw = row_blocks[rank * blocks_stride];
+      valid = block_raw >= IdType(0) && block_raw <= kInt32Max &&
+              block_raw < static_cast<IdType>(past_blocks);
+      token = valid
+                  ? static_cast<int32_t>(block_raw) * static_cast<int32_t>(COMPRESS_RATIO) + offset
+                  : -1;
     } else {
       const int32_t tail_offset = column - expanded_count;
       token = tail_start + tail_offset;
@@ -231,13 +238,17 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
   // One past the last block the query has entirely behind it. A selection is
   // only expandable while it names one of these: the block the query sits in
   // is partly ahead of it, and the tail below is what supplies its seen half.
-  const int32_t past_blocks = min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
-                                  sequence_length / static_cast<int32_t>(COMPRESS_RATIO));
+  // query_position + 1 in its own width: INT32_MAX is inside the range the cast
+  // above accepts, and adding one to it in int32 is signed overflow.
+  const int64_t query_end = static_cast<int64_t>(query_position) + 1;
+  const int32_t past_blocks = static_cast<int32_t>(
+      min(query_end / static_cast<int64_t>(COMPRESS_RATIO),
+          static_cast<int64_t>(sequence_length) / static_cast<int64_t>(COMPRESS_RATIO)));
   const int32_t complete_blocks = min(past_blocks, static_cast<int32_t>(block_topk));
   const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
-  const int32_t tail_start =
-      ((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO)) * COMPRESS_RATIO;
-  const int32_t tail_count = (query_position + 1) - tail_start;
+  const int32_t tail_start = static_cast<int32_t>(
+      (query_end / static_cast<int64_t>(COMPRESS_RATIO)) * static_cast<int64_t>(COMPRESS_RATIO));
+  const int32_t tail_count = static_cast<int32_t>(query_end - static_cast<int64_t>(tail_start));
 
   const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
   const IdType* row_blocks = block_indices + row * stride_blocks_row;
@@ -262,13 +273,14 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
       if (column < expanded_count) {
         const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
         const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
+        // Same whole-block rule as the standalone expansion above, decided
+        // before the multiply for the same reason.
         const IdType block_raw = row_blocks[rank * blocks_stride];
-        const int32_t block = (block_raw >= IdType(0) && block_raw <= kInt32Max)
-                                  ? static_cast<int32_t>(block_raw)
-                                  : -1;
-        token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
-        // Same whole-block rule as the standalone expansion above.
-        valid = block >= 0 && block < past_blocks;
+        valid = block_raw >= IdType(0) && block_raw <= kInt32Max &&
+                block_raw < static_cast<IdType>(past_blocks);
+        token =
+            valid ? static_cast<int32_t>(block_raw) * static_cast<int32_t>(COMPRESS_RATIO) + offset
+                  : -1;
       } else {
         const int32_t tail_offset = column - expanded_count;
         token = tail_start + tail_offset;
@@ -287,12 +299,15 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
     if (valid) {
       const uint32_t logical_page = static_cast<uint32_t>(token) / page_size;
       if (logical_page < table_width && row_table != nullptr) {
-        const int32_t page = static_cast<int32_t>(row_table[logical_page]);
-        if (page >= 0) {
-          const uint32_t candidate =
-              static_cast<uint32_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
-          if (candidate < num_slots) {
-            slot = candidate;
+        // The page id keeps its own width until it is bounded, and the slot is
+        // formed in 64 bits: page * page_size overflows a uint32 long before
+        // either factor does, and a wrapped product can land under num_slots.
+        const IdType page = row_table[logical_page];
+        if (page >= IdType(0) && page <= kInt32Max) {
+          const uint64_t candidate =
+              static_cast<uint64_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
+          if (candidate < static_cast<uint64_t>(num_slots)) {
+            slot = static_cast<uint32_t>(candidate);
           } else {
             valid = false;
           }
@@ -347,9 +362,14 @@ __global__ void __launch_bounds__(THREADS)
 
   // Rows past the caller's token count are padding: they carry no request and must
   // come out fully masked.
+  // Same range contract as the expansion kernels: an index is bounded in its
+  // own width before it is narrowed, or a value of 2^32 becomes request zero.
+  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
   const bool row_live = row < valid_rows;
-  const int32_t request = row_live ? static_cast<int32_t>(token_to_req[row]) : -1;
-  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
+  const IdType request_raw = row_live ? token_to_req[row] : IdType(-1);
+  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                             request_raw < static_cast<IdType>(num_requests);
+  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
   const IdType* row_table = request_valid ? block_table + request * stride_table_row : nullptr;
   // Only a live row reads the logical route, so it needs to cover those rows and
   // no more -- a short step can hand over its own tensor instead of padding one.
@@ -367,17 +387,18 @@ __global__ void __launch_bounds__(THREADS)
     uint32_t slot = 0;
     bool valid = false;
     if (in_row && row_table != nullptr && row_logical != nullptr) {
-      const int32_t token = static_cast<int32_t>(row_logical[col]);
-      if (token >= 0) {
+      const IdType token_raw = row_logical[col];
+      if (token_raw >= IdType(0) && token_raw <= kInt32Max) {
+        const int32_t token = static_cast<int32_t>(token_raw);
         uint32_t logical_page, entry;
         page_size.divmod(static_cast<uint32_t>(token), logical_page, entry);
         if (logical_page < table_width) {
-          const int32_t page = static_cast<int32_t>(row_table[logical_page]);
-          if (page >= 0) {
-            const uint32_t candidate =
-                static_cast<uint32_t>(page) * static_cast<uint32_t>(page_size) + entry;
-            if (candidate < num_slots) {
-              slot = candidate;
+          const IdType page = row_table[logical_page];
+          if (page >= IdType(0) && page <= kInt32Max) {
+            const uint64_t candidate =
+                static_cast<uint64_t>(page) * static_cast<uint32_t>(page_size) + entry;
+            if (candidate < static_cast<uint64_t>(num_slots)) {
+              slot = static_cast<uint32_t>(candidate);
               valid = true;
             }
           }

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -100,12 +100,26 @@ __global__ void __launch_bounds__(THREADS)
   if (row >= rows || tile_base >= output_width) return;
 
   // Every column of this row shares them, so they are read once per block.
-  const int32_t query_position = static_cast<int32_t>(query_positions[row]);
-  const int32_t request = static_cast<int32_t>(token_to_req[row]);
-  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
-  const int32_t safe_request = min(max(request, 0), static_cast<int32_t>(num_requests) - 1);
-  const int32_t sequence_length =
-      request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
+  // The index tensors may be int64 and everything below is int32, so each value
+  // is bounded in its own width before it is narrowed. The request is already
+  // compared against its count in IdType, which rejects anything an int32 could
+  // not hold; the position and the length are not bounded from above by
+  // anything else, and a value of exactly 2^32 narrows to zero. The bound is
+  // written out for all three so the next one cannot regress quietly.
+  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
+  const IdType position_raw = query_positions[row];
+  const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
+                                     ? static_cast<int32_t>(position_raw)
+                                     : -1;
+  const IdType request_raw = token_to_req[row];
+  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                             request_raw < static_cast<IdType>(num_requests);
+  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
+  const int32_t safe_request =
+      request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
+  IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
+  if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
+  const int32_t sequence_length = static_cast<int32_t>(length_raw);
 
   // Blocks entirely in the past, capped by what the selector produced.
   // One past the last block the query has entirely behind it. A selection is
@@ -135,7 +149,9 @@ __global__ void __launch_bounds__(THREADS)
     if (column < expanded_count) {
       const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
       const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
-      const int32_t block = static_cast<int32_t>(row_blocks[rank * blocks_stride]);
+      const IdType block_raw = row_blocks[rank * blocks_stride];
+      const int32_t block =
+          (block_raw >= IdType(0) && block_raw <= kInt32Max) ? static_cast<int32_t>(block_raw) : -1;
       token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
       // The whole block, not the token: keeping only the seen half of a block
       // the query sits in would repeat exactly what the tail appends.
@@ -191,12 +207,26 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
   const uint32_t tile_base = blockIdx.x * TILE;
   if (row >= rows || tile_base >= output_width) return;
 
-  const int32_t query_position = static_cast<int32_t>(query_positions[row]);
-  const int32_t request = static_cast<int32_t>(token_to_req[row]);
-  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
-  const int32_t safe_request = min(max(request, 0), static_cast<int32_t>(num_requests) - 1);
-  const int32_t sequence_length =
-      request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
+  // The index tensors may be int64 and everything below is int32, so each value
+  // is bounded in its own width before it is narrowed. The request is already
+  // compared against its count in IdType, which rejects anything an int32 could
+  // not hold; the position and the length are not bounded from above by
+  // anything else, and a value of exactly 2^32 narrows to zero. The bound is
+  // written out for all three so the next one cannot regress quietly.
+  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
+  const IdType position_raw = query_positions[row];
+  const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
+                                     ? static_cast<int32_t>(position_raw)
+                                     : -1;
+  const IdType request_raw = token_to_req[row];
+  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                             request_raw < static_cast<IdType>(num_requests);
+  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
+  const int32_t safe_request =
+      request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
+  IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
+  if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
+  const int32_t sequence_length = static_cast<int32_t>(length_raw);
 
   // One past the last block the query has entirely behind it. A selection is
   // only expandable while it names one of these: the block the query sits in
@@ -232,7 +262,10 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
       if (column < expanded_count) {
         const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
         const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
-        const int32_t block = static_cast<int32_t>(row_blocks[rank * blocks_stride]);
+        const IdType block_raw = row_blocks[rank * blocks_stride];
+        const int32_t block = (block_raw >= IdType(0) && block_raw <= kInt32Max)
+                                  ? static_cast<int32_t>(block_raw)
+                                  : -1;
         token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
         // Same whole-block rule as the standalone expansion above.
         valid = block >= 0 && block < past_blocks;

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -1,0 +1,515 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_SPARSE_ROUTE_CUH_
+#define FLASHINFER_SPARSE_ROUTE_CUH_
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+#include "fastdiv.cuh"
+#include "utils.cuh"
+
+namespace flashinfer {
+
+namespace sparse_route {
+
+// Columns one thread block writes, and the threads that write them. Each thread
+// takes every kThreads-th column of the tile, so a warp always covers 32 adjacent
+// columns; giving a thread adjacent columns instead splits each warp's store across
+// more sectors. The route is thousands wide, so tiling it also keeps enough blocks
+// in flight when only a few rows are expanded -- a decode step has one per request.
+// Two shapes, picked by whether the launch fills the device.
+//
+// A wide tile with few threads gives each block more columns and each SM more
+// blocks, which wins once there are thousands of rows. It starves a decode step,
+// where a handful of rows produce only a few blocks -- there the narrow tile with
+// more threads per block keeps more lanes busy.
+constexpr uint32_t kWideTile = 512;
+constexpr uint32_t kWideThreads = 128;
+constexpr uint32_t kNarrowTile = 256;
+constexpr uint32_t kNarrowThreads = 256;
+
+// Whether the wide shape fills the device is a question about this kernel on
+// this GPU, so ask the driver rather than carry a number measured on one
+// architecture. Half a wave of blocks is where the narrow shape's extra blocks
+// stop buying anything.
+template <typename KernelFn>
+inline cudaError_t choose_wide(KernelFn wide_kernel, uint32_t threads, uint32_t wide_blocks,
+                               bool* wide) {
+  int dev_id = 0, num_sms = 0, blocks_per_sm = 0;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_sm, wide_kernel,
+                                                                     static_cast<int>(threads), 0));
+  *wide = num_sms == 0 || blocks_per_sm == 0 ||
+          wide_blocks >= static_cast<uint32_t>(num_sms) * static_cast<uint32_t>(blocks_per_sm) / 2;
+  return cudaSuccess;
+}
+
+}  // namespace sparse_route
+
+/*!
+ * \brief Expand a per-query list of selected blocks into the token route it stands for.
+ *
+ * A block-granular selector picks `block_topk` blocks of `COMPRESS_RATIO` tokens each. The
+ * attention that consumes the choice works on tokens, so every selected block becomes its
+ * `COMPRESS_RATIO` tokens, laid out in selection order.
+ *
+ * The block a query itself sits in is only partially in the past, so it is never selected as a
+ * whole. Its already-seen tokens are appended after the expanded blocks instead -- at most
+ * `COMPRESS_RATIO - 1` of them, which is why a route is `block_topk * COMPRESS_RATIO +
+ * COMPRESS_RATIO - 1` wide.
+ *
+ * Positions that no token reaches are written as -1; the consumer masks them.
+ *
+ * \tparam COMPRESS_RATIO tokens per block, a compile-time constant so the divisions
+ *   by it fold into shifts for the power-of-two ratios this is used with
+ * \tparam IdType index type of both the selection and the route
+ */
+template <uint32_t COMPRESS_RATIO, bool CONTIGUOUS_COLUMNS, uint32_t TILE, uint32_t THREADS,
+          typename IdType>
+__global__ void __launch_bounds__(THREADS)
+    ExpandBlockRouteKernel(const IdType* __restrict__ block_indices,
+                           const IdType* __restrict__ query_positions,
+                           const IdType* __restrict__ sequence_lengths,
+                           const IdType* __restrict__ token_to_req, IdType* __restrict__ out,
+                           uint32_t stride_blocks_row, uint32_t stride_blocks_col,
+                           uint32_t stride_out_row, uint32_t stride_out_col, uint32_t rows,
+                           uint32_t num_requests, uint32_t block_topk) {
+  // blockIdx.x walks the columns of one row so consecutive blocks write consecutive
+  // memory; putting the row on x instead interleaves unrelated rows in flight.
+  // The width follows from the selection: every block expands to COMPRESS_RATIO
+  // tokens, plus the tail of the query's own block.
+  const uint32_t output_width = block_topk * COMPRESS_RATIO + COMPRESS_RATIO - 1;
+  const uint32_t row = blockIdx.y;
+  const uint32_t tile_base = blockIdx.x * TILE;
+  if (row >= rows || tile_base >= output_width) return;
+
+  // Every column of this row shares them, so they are read once per block.
+  const int32_t query_position = static_cast<int32_t>(query_positions[row]);
+  const int32_t request = static_cast<int32_t>(token_to_req[row]);
+  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
+  const int32_t safe_request = min(max(request, 0), static_cast<int32_t>(num_requests) - 1);
+  const int32_t sequence_length =
+      request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
+
+  // Blocks entirely in the past, capped by what the selector produced.
+  const int32_t complete_blocks =
+      min(min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
+              sequence_length / static_cast<int32_t>(COMPRESS_RATIO)),
+          static_cast<int32_t>(block_topk));
+  const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
+  const int32_t tail_start =
+      ((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO)) * COMPRESS_RATIO;
+  const int32_t tail_count = (query_position + 1) - tail_start;
+
+  const IdType* row_blocks = block_indices + row * stride_blocks_row;
+  IdType* row_out = out + row * stride_out_row;
+
+  const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
+  const uint32_t out_stride = CONTIGUOUS_COLUMNS ? 1u : stride_out_col;
+
+#pragma unroll
+  for (uint32_t i = 0; i < TILE / THREADS; ++i) {
+    const uint32_t col = tile_base + threadIdx.x + i * THREADS;
+    if (col >= output_width) break;
+    const int32_t column = static_cast<int32_t>(col);
+    int32_t token;
+    bool valid;
+    if (column < expanded_count) {
+      const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
+      const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
+      const int32_t block = static_cast<int32_t>(row_blocks[rank * blocks_stride]);
+      token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
+      valid = true;
+    } else {
+      const int32_t tail_offset = column - expanded_count;
+      token = tail_start + tail_offset;
+      valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
+    }
+    valid = valid && token >= 0 && token < sequence_length;
+    row_out[static_cast<uint32_t>(column) * out_stride] =
+        valid ? static_cast<IdType>(token) : IdType(-1);
+  }
+}
+
+/*!
+ * \brief Turn a per-query block selection straight into a paged attention route.
+ *
+ * Fuses three steps that would otherwise each read and write the whole route:
+ * expanding the selected blocks into tokens (see ExpandBlockRouteKernel), mapping
+ * each token through the block table into a physical KV slot, and packing the
+ * validity of every entry into the bitmask the attention kernel reads.
+ *
+ * A route entry is valid when it names a real token: inside the request, on a
+ * logical page the block table covers, on a page the table actually maps, and in a
+ * slot the cache holds. Invalid entries route to slot 0 with their mask bit clear,
+ * because an out-of-range slot would be read before the mask is applied.
+ *
+ * The logical route is written out as well: a speculative decoder reuses the
+ * selection across its steps, so it outlives the physical route derived from it.
+ *
+ * \tparam MASK_BYTES_PER_ROW ceil(output_width / 8), the stride of one mask row
+ */
+template <uint32_t COMPRESS_RATIO, bool CONTIGUOUS_COLUMNS, uint32_t TILE, uint32_t THREADS,
+          typename IdType>
+__global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
+    const IdType* __restrict__ block_indices, const IdType* __restrict__ query_positions,
+    const IdType* __restrict__ sequence_lengths, const IdType* __restrict__ token_to_req,
+    const IdType* __restrict__ block_table, IdType* __restrict__ out_logical,
+    IdType* __restrict__ out_route, uint8_t* __restrict__ out_mask, uint32_t stride_blocks_row,
+    uint32_t stride_blocks_col, uint32_t stride_logical_row, uint32_t stride_table_row,
+    uint32_t rows, uint32_t num_requests, uint32_t block_topk, uint32_t table_width,
+    uint32_t page_size, uint32_t num_slots, uint32_t mask_bytes_per_row) {
+  const uint32_t output_width = block_topk * COMPRESS_RATIO + COMPRESS_RATIO - 1;
+  const uint32_t row = blockIdx.y;
+  const uint32_t tile_base = blockIdx.x * TILE;
+  if (row >= rows || tile_base >= output_width) return;
+
+  const int32_t query_position = static_cast<int32_t>(query_positions[row]);
+  const int32_t request = static_cast<int32_t>(token_to_req[row]);
+  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
+  const int32_t safe_request = min(max(request, 0), static_cast<int32_t>(num_requests) - 1);
+  const int32_t sequence_length =
+      request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
+
+  const int32_t complete_blocks =
+      min(min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
+              sequence_length / static_cast<int32_t>(COMPRESS_RATIO)),
+          static_cast<int32_t>(block_topk));
+  const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
+  const int32_t tail_start =
+      ((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO)) * COMPRESS_RATIO;
+  const int32_t tail_count = (query_position + 1) - tail_start;
+
+  const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
+  const IdType* row_blocks = block_indices + row * stride_blocks_row;
+  const IdType* row_table = request_valid ? block_table + safe_request * stride_table_row : nullptr;
+  IdType* row_logical = out_logical + row * stride_logical_row;
+  IdType* row_route = out_route + row * output_width;
+  uint8_t* row_mask = out_mask + row * mask_bytes_per_row;
+
+  // A warp always covers 32 consecutive columns, so its ballot is exactly the four
+  // mask bytes that cover them and no two warps write the same byte.
+  const uint32_t lane = threadIdx.x & 31u;
+
+#pragma unroll
+  for (uint32_t i = 0; i < TILE / THREADS; ++i) {
+    const uint32_t col = tile_base + threadIdx.x + i * THREADS;
+    const bool in_row = col < output_width;
+
+    int32_t token = -1;
+    bool valid = false;
+    if (in_row) {
+      const int32_t column = static_cast<int32_t>(col);
+      if (column < expanded_count) {
+        const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
+        const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
+        const int32_t block = static_cast<int32_t>(row_blocks[rank * blocks_stride]);
+        token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
+        valid = true;
+      } else {
+        const int32_t tail_offset = column - expanded_count;
+        token = tail_start + tail_offset;
+        valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
+      }
+      valid = valid && token >= 0 && token < sequence_length;
+      if (!valid) token = -1;
+      row_logical[col] = static_cast<IdType>(token);
+    }
+
+    // Logical token -> physical slot, folding every bound into the same validity.
+    uint32_t slot = 0;
+    if (valid) {
+      const uint32_t logical_page = static_cast<uint32_t>(token) / page_size;
+      if (logical_page < table_width && row_table != nullptr) {
+        const int32_t page = static_cast<int32_t>(row_table[logical_page]);
+        if (page >= 0) {
+          const uint32_t candidate =
+              static_cast<uint32_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
+          if (candidate < num_slots) {
+            slot = candidate;
+          } else {
+            valid = false;
+          }
+        } else {
+          valid = false;
+        }
+      } else {
+        valid = false;
+      }
+    }
+    if (in_row) row_route[col] = static_cast<IdType>(slot);
+
+    const uint32_t bits = __ballot_sync(0xffffffffu, valid && in_row);
+    if (lane == 0) {
+      const uint32_t byte_base = (tile_base + (threadIdx.x & ~31u) + i * THREADS) >> 3;
+#pragma unroll
+      for (uint32_t b = 0; b < 4; ++b) {
+        const uint32_t byte_index = byte_base + b;
+        if (byte_index < mask_bytes_per_row) {
+          row_mask[byte_index] = static_cast<uint8_t>((bits >> (b * 8)) & 0xffu);
+        }
+      }
+    }
+  }
+}
+
+/*!
+ * \brief Map a logical token route through a block table into physical KV slots.
+ *
+ * The second half of QSARouteFromBlocksKernel, for callers whose logical route was
+ * produced earlier and outlived the physical one -- a speculative decoder reuses a
+ * selection across its steps.
+ *
+ * An entry is valid when it names a real token: non-negative, on a logical page the
+ * block table covers, on a page the table maps, and in a slot the cache holds.
+ * Invalid entries route to slot 0 with their mask bit clear, because an
+ * out-of-range slot would be read before the mask is applied.
+ */
+template <uint32_t TILE, uint32_t THREADS, typename IdType>
+__global__ void __launch_bounds__(THREADS)
+    QSARouteFromLogicalKernel(const IdType* __restrict__ logical,
+                              const IdType* __restrict__ token_to_req,
+                              const IdType* __restrict__ block_table,
+                              IdType* __restrict__ out_route, uint8_t* __restrict__ out_mask,
+                              uint32_t stride_logical_row, uint32_t stride_table_row, uint32_t rows,
+                              uint32_t valid_rows, uint32_t num_requests, uint32_t width,
+                              uint32_t table_width, uint_fastdiv page_size, uint32_t num_slots,
+                              uint32_t mask_bytes_per_row) {
+  const uint32_t row = blockIdx.y;
+  const uint32_t tile_base = blockIdx.x * TILE;
+  if (row >= rows || tile_base >= width) return;
+
+  // Rows past the caller's token count are padding: they carry no request and must
+  // come out fully masked.
+  const bool row_live = row < valid_rows;
+  const int32_t request = row_live ? static_cast<int32_t>(token_to_req[row]) : -1;
+  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
+  const IdType* row_table = request_valid ? block_table + request * stride_table_row : nullptr;
+  // Only a live row reads the logical route, so it needs to cover those rows and
+  // no more -- a short step can hand over its own tensor instead of padding one.
+  const IdType* row_logical = row_live ? logical + row * stride_logical_row : nullptr;
+  IdType* row_route = out_route + row * width;
+  uint8_t* row_mask = out_mask + row * mask_bytes_per_row;
+
+  const uint32_t lane = threadIdx.x & 31u;
+
+#pragma unroll
+  for (uint32_t i = 0; i < TILE / THREADS; ++i) {
+    const uint32_t col = tile_base + threadIdx.x + i * THREADS;
+    const bool in_row = col < width;
+
+    uint32_t slot = 0;
+    bool valid = false;
+    if (in_row && row_table != nullptr && row_logical != nullptr) {
+      const int32_t token = static_cast<int32_t>(row_logical[col]);
+      if (token >= 0) {
+        uint32_t logical_page, entry;
+        page_size.divmod(static_cast<uint32_t>(token), logical_page, entry);
+        if (logical_page < table_width) {
+          const int32_t page = static_cast<int32_t>(row_table[logical_page]);
+          if (page >= 0) {
+            const uint32_t candidate =
+                static_cast<uint32_t>(page) * static_cast<uint32_t>(page_size) + entry;
+            if (candidate < num_slots) {
+              slot = candidate;
+              valid = true;
+            }
+          }
+        }
+      }
+    }
+    if (in_row) row_route[col] = static_cast<IdType>(slot);
+
+    const uint32_t bits = __ballot_sync(0xffffffffu, valid);
+    if (lane == 0) {
+      const uint32_t byte_base = (tile_base + (threadIdx.x & ~31u) + i * THREADS) >> 3;
+#pragma unroll
+      for (uint32_t b = 0; b < 4; ++b) {
+        const uint32_t byte_index = byte_base + b;
+        if (byte_index < mask_bytes_per_row) {
+          row_mask[byte_index] = static_cast<uint8_t>((bits >> (b * 8)) & 0xffu);
+        }
+      }
+    }
+  }
+}
+
+template <typename IdType>
+cudaError_t QSARouteFromLogical(const IdType* logical, const IdType* token_to_req,
+                                const IdType* block_table, IdType* out_route, uint8_t* out_mask,
+                                uint32_t stride_logical_row, uint32_t stride_table_row,
+                                uint32_t rows, uint32_t valid_rows, uint32_t num_requests,
+                                uint32_t width, uint32_t table_width, uint32_t page_size,
+                                uint32_t num_slots, uint32_t mask_bytes_per_row,
+                                cudaStream_t stream) {
+  if (rows == 0 || width == 0) return cudaSuccess;
+  const uint32_t wide_blocks = rows * ceil_div(width, sparse_route::kWideTile);
+  bool wide = true;
+  FLASHINFER_CUDA_CALL(sparse_route::choose_wide(
+      QSARouteFromLogicalKernel<sparse_route::kWideTile, sparse_route::kWideThreads, IdType>,
+      sparse_route::kWideThreads, wide_blocks, &wide));
+  const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
+  const dim3 grid(ceil_div(width, tile), rows);
+  const uint_fastdiv page_div(page_size);
+
+  if (wide) {
+    QSARouteFromLogicalKernel<sparse_route::kWideTile, sparse_route::kWideThreads, IdType>
+        <<<grid, sparse_route::kWideThreads, 0, stream>>>(
+            logical, token_to_req, block_table, out_route, out_mask, stride_logical_row,
+            stride_table_row, rows, valid_rows, num_requests, width, table_width, page_div,
+            num_slots, mask_bytes_per_row);
+  } else {
+    QSARouteFromLogicalKernel<sparse_route::kNarrowTile, sparse_route::kNarrowThreads, IdType>
+        <<<grid, sparse_route::kNarrowThreads, 0, stream>>>(
+            logical, token_to_req, block_table, out_route, out_mask, stride_logical_row,
+            stride_table_row, rows, valid_rows, num_requests, width, table_width, page_div,
+            num_slots, mask_bytes_per_row);
+  }
+  return cudaGetLastError();
+}
+
+template <typename IdType>
+cudaError_t ExpandBlockRoute(const IdType* block_indices, const IdType* query_positions,
+                             const IdType* sequence_lengths, const IdType* token_to_req,
+                             IdType* out, uint32_t stride_blocks_row, uint32_t stride_blocks_col,
+                             uint32_t stride_out_row, uint32_t stride_out_col, uint32_t rows,
+                             uint32_t num_requests, uint32_t block_topk, uint32_t compress_ratio,
+                             uint32_t output_width, cudaStream_t stream) {
+  if (rows == 0 || output_width == 0) return cudaSuccess;
+  const uint32_t wide_blocks = rows * ceil_div(output_width, sparse_route::kWideTile);
+  bool wide = true;
+  FLASHINFER_CUDA_CALL(sparse_route::choose_wide(
+      ExpandBlockRouteKernel<1, true, sparse_route::kWideTile, sparse_route::kWideThreads, IdType>,
+      sparse_route::kWideThreads, wide_blocks, &wide));
+  const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
+  const dim3 grid(ceil_div(output_width, tile), rows);
+  // Both strides are 1 for every caller that hands over a plain route; folding them
+  // away turns the inner address into an add.
+  const bool contiguous = stride_blocks_col == 1 && stride_out_col == 1;
+
+#define _FI_LAUNCH_CFG(RATIO, CONTIGUOUS, TILE, THREADS)                                          \
+  ExpandBlockRouteKernel<RATIO, CONTIGUOUS, TILE, THREADS, IdType><<<grid, THREADS, 0, stream>>>( \
+      block_indices, query_positions, sequence_lengths, token_to_req, out, stride_blocks_row,     \
+      stride_blocks_col, stride_out_row, stride_out_col, rows, num_requests, block_topk)
+
+#define _FI_LAUNCH(RATIO, CONTIGUOUS)                                                             \
+  do {                                                                                            \
+    if (wide) {                                                                                   \
+      _FI_LAUNCH_CFG(RATIO, CONTIGUOUS, sparse_route::kWideTile, sparse_route::kWideThreads);     \
+    } else {                                                                                      \
+      _FI_LAUNCH_CFG(RATIO, CONTIGUOUS, sparse_route::kNarrowTile, sparse_route::kNarrowThreads); \
+    }                                                                                             \
+  } while (0)
+
+#define _FI_DISPATCH_COMPRESS_RATIO(RATIO) \
+  case RATIO: {                            \
+    if (contiguous) {                      \
+      _FI_LAUNCH(RATIO, true);             \
+    } else {                               \
+      _FI_LAUNCH(RATIO, false);            \
+    }                                      \
+    break;                                 \
+  }
+
+  switch (compress_ratio) {
+    _FI_DISPATCH_COMPRESS_RATIO(1)
+    _FI_DISPATCH_COMPRESS_RATIO(2)
+    _FI_DISPATCH_COMPRESS_RATIO(4)
+    _FI_DISPATCH_COMPRESS_RATIO(8)
+    _FI_DISPATCH_COMPRESS_RATIO(16)
+    _FI_DISPATCH_COMPRESS_RATIO(32)
+    default:
+      return cudaErrorInvalidValue;
+  }
+#undef _FI_DISPATCH_COMPRESS_RATIO
+#undef _FI_LAUNCH
+#undef _FI_LAUNCH_CFG
+
+  return cudaGetLastError();
+}
+
+template <typename IdType>
+cudaError_t QSARouteFromBlocks(const IdType* block_indices, const IdType* query_positions,
+                               const IdType* sequence_lengths, const IdType* token_to_req,
+                               const IdType* block_table, IdType* out_logical, IdType* out_route,
+                               uint8_t* out_mask, uint32_t stride_blocks_row,
+                               uint32_t stride_blocks_col, uint32_t stride_logical_row,
+                               uint32_t stride_table_row, uint32_t rows, uint32_t num_requests,
+                               uint32_t block_topk, uint32_t table_width, uint32_t page_size,
+                               uint32_t num_slots, uint32_t mask_bytes_per_row,
+                               uint32_t compress_ratio, cudaStream_t stream) {
+  const uint32_t output_width = block_topk * compress_ratio + compress_ratio - 1;
+  if (rows == 0 || output_width == 0) return cudaSuccess;
+  const uint32_t wide_blocks = rows * ceil_div(output_width, sparse_route::kWideTile);
+  bool wide = true;
+  FLASHINFER_CUDA_CALL(
+      sparse_route::choose_wide(QSARouteFromBlocksKernel<1, true, sparse_route::kWideTile,
+                                                         sparse_route::kWideThreads, IdType>,
+                                sparse_route::kWideThreads, wide_blocks, &wide));
+  const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
+  const dim3 grid(ceil_div(output_width, tile), rows);
+  const bool contiguous = stride_blocks_col == 1;
+
+#define _FI_ROUTE_CFG(RATIO, CONTIGUOUS, TILE, THREADS)                                           \
+  QSARouteFromBlocksKernel<RATIO, CONTIGUOUS, TILE, THREADS, IdType>                              \
+      <<<grid, THREADS, 0, stream>>>(block_indices, query_positions, sequence_lengths,            \
+                                     token_to_req, block_table, out_logical, out_route, out_mask, \
+                                     stride_blocks_row, stride_blocks_col, stride_logical_row,    \
+                                     stride_table_row, rows, num_requests, block_topk,            \
+                                     table_width, page_size, num_slots, mask_bytes_per_row)
+
+#define _FI_ROUTE_LAUNCH(RATIO, CONTIGUOUS)                                                      \
+  do {                                                                                           \
+    if (wide) {                                                                                  \
+      _FI_ROUTE_CFG(RATIO, CONTIGUOUS, sparse_route::kWideTile, sparse_route::kWideThreads);     \
+    } else {                                                                                     \
+      _FI_ROUTE_CFG(RATIO, CONTIGUOUS, sparse_route::kNarrowTile, sparse_route::kNarrowThreads); \
+    }                                                                                            \
+  } while (0)
+
+#define _FI_ROUTE_DISPATCH(RATIO)     \
+  case RATIO: {                       \
+    if (contiguous) {                 \
+      _FI_ROUTE_LAUNCH(RATIO, true);  \
+    } else {                          \
+      _FI_ROUTE_LAUNCH(RATIO, false); \
+    }                                 \
+    break;                            \
+  }
+
+  switch (compress_ratio) {
+    _FI_ROUTE_DISPATCH(1)
+    _FI_ROUTE_DISPATCH(2)
+    _FI_ROUTE_DISPATCH(4)
+    _FI_ROUTE_DISPATCH(8)
+    _FI_ROUTE_DISPATCH(16)
+    _FI_ROUTE_DISPATCH(32)
+    default:
+      return cudaErrorInvalidValue;
+  }
+#undef _FI_ROUTE_DISPATCH
+#undef _FI_ROUTE_LAUNCH
+#undef _FI_ROUTE_CFG
+
+  return cudaGetLastError();
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_SPARSE_ROUTE_CUH_

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -52,9 +52,14 @@ constexpr uint32_t kNarrowThreads = 256;
 // between calls on one device, and a route launch is short enough that asking
 // the driver three times for them is a measurable part of it. They are kept per
 // device, and the template gives each kernel its own copy.
-template <typename KernelFn>
-inline cudaError_t choose_wide(KernelFn wide_kernel, uint32_t threads, uint32_t wide_blocks,
-                               bool* wide) {
+//
+// The kernel and its thread count are template parameters rather than
+// arguments, because the cache below lives in the instantiation: taking either
+// as a value would give one shared entry to every kernel of the same signature
+// and every thread count, and a second caller would read back an occupancy
+// measured for something else.
+template <auto WideKernel, uint32_t Threads>
+inline cudaError_t choose_wide(uint32_t wide_blocks, bool* wide) {
   int dev_id = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
   static thread_local int cached_dev = -1;
@@ -62,7 +67,7 @@ inline cudaError_t choose_wide(KernelFn wide_kernel, uint32_t threads, uint32_t 
   if (cached_dev != dev_id) {
     FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
     FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &blocks_per_sm, wide_kernel, static_cast<int>(threads), 0));
+        &blocks_per_sm, WideKernel, static_cast<int>(Threads), 0));
     cached_dev = dev_id;
   }
   *wide = num_sms == 0 || blocks_per_sm == 0 ||
@@ -459,9 +464,15 @@ cudaError_t QSARouteFromLogical(const IdType* logical, const IdType* token_to_re
   if (rows == 0 || width == 0) return cudaSuccess;
   const uint32_t wide_blocks = rows * ceil_div(width, sparse_route::kWideTile);
   bool wide = true;
-  FLASHINFER_CUDA_CALL(sparse_route::choose_wide(
-      QSARouteFromLogicalKernel<sparse_route::kWideTile, sparse_route::kWideThreads, IdType>,
-      sparse_route::kWideThreads, wide_blocks, &wide));
+  // Hoisted into a name: the kernel's own template arguments written inline
+  // inside choose_wide's argument list is more than the frontend will parse.
+  constexpr auto kWideKernel =
+      QSARouteFromLogicalKernel<sparse_route::kWideTile, sparse_route::kWideThreads, IdType>;
+  // Through a name: the comma between the template arguments would otherwise
+  // split FLASHINFER_CUDA_CALL's own argument list.
+  const cudaError_t shape_status =
+      sparse_route::choose_wide<kWideKernel, sparse_route::kWideThreads>(wide_blocks, &wide);
+  FLASHINFER_CUDA_CALL(shape_status);
   const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
   const dim3 grid(ceil_div(width, tile), rows);
   const uint_fastdiv page_div(page_size);
@@ -492,9 +503,11 @@ cudaError_t ExpandBlockRoute(const IdType* block_indices, const IdType* query_po
   if (rows == 0 || output_width == 0) return cudaSuccess;
   const uint32_t wide_blocks = rows * ceil_div(output_width, sparse_route::kWideTile);
   bool wide = true;
-  FLASHINFER_CUDA_CALL(sparse_route::choose_wide(
-      ExpandBlockRouteKernel<1, true, sparse_route::kWideTile, sparse_route::kWideThreads, IdType>,
-      sparse_route::kWideThreads, wide_blocks, &wide));
+  constexpr auto kWideKernel =
+      ExpandBlockRouteKernel<1, true, sparse_route::kWideTile, sparse_route::kWideThreads, IdType>;
+  const cudaError_t shape_status =
+      sparse_route::choose_wide<kWideKernel, sparse_route::kWideThreads>(wide_blocks, &wide);
+  FLASHINFER_CUDA_CALL(shape_status);
   const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
   const dim3 grid(ceil_div(output_width, tile), rows);
   // Both strides are 1 for every caller that hands over a plain route; folding them
@@ -556,10 +569,11 @@ cudaError_t QSARouteFromBlocks(const IdType* block_indices, const IdType* query_
   if (rows == 0 || output_width == 0) return cudaSuccess;
   const uint32_t wide_blocks = rows * ceil_div(output_width, sparse_route::kWideTile);
   bool wide = true;
-  FLASHINFER_CUDA_CALL(
-      sparse_route::choose_wide(QSARouteFromBlocksKernel<1, true, sparse_route::kWideTile,
-                                                         sparse_route::kWideThreads, IdType>,
-                                sparse_route::kWideThreads, wide_blocks, &wide));
+  constexpr auto kWideKernel = QSARouteFromBlocksKernel<1, true, sparse_route::kWideTile,
+                                                        sparse_route::kWideThreads, IdType>;
+  const cudaError_t shape_status =
+      sparse_route::choose_wide<kWideKernel, sparse_route::kWideThreads>(wide_blocks, &wide);
+  FLASHINFER_CUDA_CALL(shape_status);
   const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
   const dim3 grid(ceil_div(output_width, tile), rows);
   const bool contiguous = stride_blocks_col == 1;

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -302,8 +302,15 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
         // The page id keeps its own width until it is bounded, and the slot is
         // formed in 64 bits: page * page_size overflows a uint32 long before
         // either factor does, and a wrapped product can land under num_slots.
+        //
+        // What bounds the page is the slot space, not an int32. A route of
+        // int64 can hold a slot of 2^31 and the caller is allowed to ask for
+        // one, so capping the page at INT32_MAX would mask a page it is
+        // entitled to. The cap is the largest page whose first slot is still
+        // inside num_slots, which is also what keeps the product below 64 bits.
+        const uint64_t max_page = (static_cast<uint64_t>(num_slots) - 1) / page_size;
         const IdType page = row_table[logical_page];
-        if (page >= IdType(0) && page <= kInt32Max) {
+        if (page >= IdType(0) && static_cast<uint64_t>(page) <= max_page) {
           const uint64_t candidate =
               static_cast<uint64_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
           if (candidate < static_cast<uint64_t>(num_slots)) {
@@ -393,8 +400,12 @@ __global__ void __launch_bounds__(THREADS)
         uint32_t logical_page, entry;
         page_size.divmod(static_cast<uint32_t>(token), logical_page, entry);
         if (logical_page < table_width) {
+          // Bounded by the slot space rather than by an int32, for the same
+          // reason as the fused kernel above.
+          const uint64_t max_page =
+              (static_cast<uint64_t>(num_slots) - 1) / static_cast<uint32_t>(page_size);
           const IdType page = row_table[logical_page];
-          if (page >= IdType(0) && page <= kInt32Max) {
+          if (page >= IdType(0) && static_cast<uint64_t>(page) <= max_page) {
             const uint64_t candidate =
                 static_cast<uint64_t>(page) * static_cast<uint32_t>(page_size) + entry;
             if (candidate < static_cast<uint64_t>(num_slots)) {

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -43,6 +43,12 @@ constexpr uint32_t kWideThreads = 128;
 constexpr uint32_t kNarrowTile = 256;
 constexpr uint32_t kNarrowThreads = 256;
 
+// gridDim.y stops at 65535 on every compute capability, and the row count is a
+// query-token count that a long-context step can take past it. The rows a
+// launch cannot cover in one grid are walked by a stride instead; x stays on
+// the columns so consecutive blocks still write consecutive memory.
+constexpr uint32_t kMaxGridY = 65535;
+
 // Whether the wide shape fills the device is a question about this kernel on
 // this GPU, so ask the driver rather than carry a number measured on one
 // architecture. Half a wave of blocks is where the narrow shape's extra blocks
@@ -110,91 +116,98 @@ __global__ void __launch_bounds__(THREADS)
   // The width follows from the selection: every block expands to COMPRESS_RATIO
   // tokens, plus the tail of the query's own block.
   const uint32_t output_width = block_topk * COMPRESS_RATIO + COMPRESS_RATIO - 1;
-  const uint32_t row = blockIdx.y;
   const uint32_t tile_base = blockIdx.x * TILE;
-  if (row >= rows || tile_base >= output_width) return;
+  if (tile_base >= output_width) return;
+  // One grid cannot cover more rows than gridDim.y allows, so the rest are
+  // walked by a stride. Every launch that fits takes the loop once.
+  for (uint32_t row = blockIdx.y; row < rows; row += gridDim.y) {
+    // Every column of this row shares them, so they are read once per block.
+    // The index tensors may be int64 and everything below is int32, so each value
+    // is bounded in its own width before it is narrowed -- a value of exactly
+    // 2^32 would narrow to zero, which is a real request and a real position.
+    //
+    // The request is also compared against num_requests, but that is a tensor
+    // extent with no int32 cap of its own, so the comparison alone does not stand
+    // in for the bound. The position and the length have nothing above them at
+    // all.
+    constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
+    const IdType position_raw = query_positions[row];
+    const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
+                                       ? static_cast<int32_t>(position_raw)
+                                       : -1;
+    const IdType request_raw = token_to_req[row];
+    const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                               request_raw < static_cast<IdType>(num_requests);
+    const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
+    const int32_t safe_request =
+        request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
+    IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
+    if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
+    const int32_t sequence_length = static_cast<int32_t>(length_raw);
 
-  // Every column of this row shares them, so they are read once per block.
-  // The index tensors may be int64 and everything below is int32, so each value
-  // is bounded in its own width before it is narrowed -- a value of exactly
-  // 2^32 would narrow to zero, which is a real request and a real position.
-  //
-  // The request is also compared against num_requests, but that is a tensor
-  // extent with no int32 cap of its own, so the comparison alone does not stand
-  // in for the bound. The position and the length have nothing above them at
-  // all.
-  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
-  const IdType position_raw = query_positions[row];
-  const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
-                                     ? static_cast<int32_t>(position_raw)
-                                     : -1;
-  const IdType request_raw = token_to_req[row];
-  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
-                             request_raw < static_cast<IdType>(num_requests);
-  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
-  const int32_t safe_request =
-      request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
-  IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
-  if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
-  const int32_t sequence_length = static_cast<int32_t>(length_raw);
+    // Blocks entirely in the past, capped by what the selector produced.
+    // One past the last block the query has entirely behind it. A selection is
+    // only expandable while it names one of these: the block the query sits in
+    // is partly ahead of it, and the tail below is what supplies its seen half.
+    // query_position + 1 in its own width: INT32_MAX is inside the range the cast
+    // above accepts, and adding one to it in int32 is signed overflow.
+    const int64_t query_end = static_cast<int64_t>(query_position) + 1;
+    const int32_t past_blocks = static_cast<int32_t>(
+        min(query_end / static_cast<int64_t>(COMPRESS_RATIO),
+            static_cast<int64_t>(sequence_length) / static_cast<int64_t>(COMPRESS_RATIO)));
+    // Every rank the selector produced gets its own columns, whether or not the
+    // block it names turns out to be usable. Sizing this by past_blocks instead
+    // made the layout depend on the query: a rank at or above it was never read,
+    // its columns were reinterpreted as tail columns, and a valid block sitting
+    // there vanished. The causal test is on the block, further down.
+    const int32_t expanded_count =
+        static_cast<int32_t>(block_topk) * static_cast<int32_t>(COMPRESS_RATIO);
+    const int32_t tail_start = static_cast<int32_t>(
+        (query_end / static_cast<int64_t>(COMPRESS_RATIO)) * static_cast<int64_t>(COMPRESS_RATIO));
+    const int32_t tail_count = static_cast<int32_t>(query_end - static_cast<int64_t>(tail_start));
 
-  // Blocks entirely in the past, capped by what the selector produced.
-  // One past the last block the query has entirely behind it. A selection is
-  // only expandable while it names one of these: the block the query sits in
-  // is partly ahead of it, and the tail below is what supplies its seen half.
-  // query_position + 1 in its own width: INT32_MAX is inside the range the cast
-  // above accepts, and adding one to it in int32 is signed overflow.
-  const int64_t query_end = static_cast<int64_t>(query_position) + 1;
-  const int32_t past_blocks = static_cast<int32_t>(
-      min(query_end / static_cast<int64_t>(COMPRESS_RATIO),
-          static_cast<int64_t>(sequence_length) / static_cast<int64_t>(COMPRESS_RATIO)));
-  const int32_t complete_blocks = min(past_blocks, static_cast<int32_t>(block_topk));
-  const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
-  const int32_t tail_start = static_cast<int32_t>(
-      (query_end / static_cast<int64_t>(COMPRESS_RATIO)) * static_cast<int64_t>(COMPRESS_RATIO));
-  const int32_t tail_count = static_cast<int32_t>(query_end - static_cast<int64_t>(tail_start));
+    const IdType* row_blocks = block_indices + row * stride_blocks_row;
+    IdType* row_out = out + row * stride_out_row;
 
-  const IdType* row_blocks = block_indices + row * stride_blocks_row;
-  IdType* row_out = out + row * stride_out_row;
-
-  const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
-  const uint32_t out_stride = CONTIGUOUS_COLUMNS ? 1u : stride_out_col;
+    const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
+    const uint32_t out_stride = CONTIGUOUS_COLUMNS ? 1u : stride_out_col;
 
 #pragma unroll
-  for (uint32_t i = 0; i < TILE / THREADS; ++i) {
-    const uint32_t col = tile_base + threadIdx.x + i * THREADS;
-    if (col >= output_width) break;
-    const int32_t column = static_cast<int32_t>(col);
-    int32_t token;
-    bool valid;
-    if (column < expanded_count) {
-      const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
-      const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
-      // The whole block, not the token: keeping only the seen half of a block
-      // the query sits in would repeat exactly what the tail appends. Decided
-      // before the multiply, so a block that is not one of ours is never
-      // scaled by the ratio at all.
-      const IdType block_raw = row_blocks[rank * blocks_stride];
-      valid = block_raw >= IdType(0) && block_raw <= kInt32Max &&
-              block_raw < static_cast<IdType>(past_blocks);
-      token = valid
-                  ? static_cast<int32_t>(block_raw) * static_cast<int32_t>(COMPRESS_RATIO) + offset
+    for (uint32_t i = 0; i < TILE / THREADS; ++i) {
+      const uint32_t col = tile_base + threadIdx.x + i * THREADS;
+      if (col >= output_width) break;
+      const int32_t column = static_cast<int32_t>(col);
+      int32_t token;
+      bool valid;
+      if (column < expanded_count) {
+        const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
+        const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
+        // The whole block, not the token: keeping only the seen half of a block
+        // the query sits in would repeat exactly what the tail appends. Decided
+        // before the multiply, so a block that is not one of ours is never
+        // scaled by the ratio at all.
+        const IdType block_raw = row_blocks[rank * blocks_stride];
+        valid = block_raw >= IdType(0) && block_raw <= kInt32Max &&
+                block_raw < static_cast<IdType>(past_blocks);
+        token =
+            valid ? static_cast<int32_t>(block_raw) * static_cast<int32_t>(COMPRESS_RATIO) + offset
                   : -1;
-    } else {
-      const int32_t tail_offset = column - expanded_count;
-      token = tail_start + tail_offset;
-      valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
+      } else {
+        const int32_t tail_offset = column - expanded_count;
+        token = tail_start + tail_offset;
+        valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
+      }
+      // A selected block is meant to be one the query has already passed, which
+      // is what the selector's own visible count bounds it to. Nothing here had
+      // been checking it, though: the block id is the caller's, and the only
+      // bound it met was the sequence length. A block past the query would have
+      // expanded into tokens the query cannot see -- with a ratio of four, a
+      // query at position 3 selecting block 2 routes tokens 8 through 11. The
+      // route drops them rather than carry them.
+      valid = valid && token >= 0 && token <= query_position && token < sequence_length;
+      row_out[static_cast<uint32_t>(column) * out_stride] =
+          valid ? static_cast<IdType>(token) : IdType(-1);
     }
-    // A selected block is meant to be one the query has already passed, which
-    // is what the selector's own visible count bounds it to. Nothing here had
-    // been checking it, though: the block id is the caller's, and the only
-    // bound it met was the sequence length. A block past the query would have
-    // expanded into tokens the query cannot see -- with a ratio of four, a
-    // query at position 3 selecting block 2 routes tokens 8 through 11. The
-    // route drops them rather than carry them.
-    valid = valid && token >= 0 && token <= query_position && token < sequence_length;
-    row_out[static_cast<uint32_t>(column) * out_stride] =
-        valid ? static_cast<IdType>(token) : IdType(-1);
   }
 }
 
@@ -227,137 +240,146 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
     uint32_t rows, uint32_t num_requests, uint32_t block_topk, uint32_t table_width,
     uint32_t page_size, uint32_t num_slots, uint32_t mask_bytes_per_row) {
   const uint32_t output_width = block_topk * COMPRESS_RATIO + COMPRESS_RATIO - 1;
-  const uint32_t row = blockIdx.y;
   const uint32_t tile_base = blockIdx.x * TILE;
-  if (row >= rows || tile_base >= output_width) return;
+  if (tile_base >= output_width) return;
+  // One grid cannot cover more rows than gridDim.y allows, so the rest are
+  // walked by a stride. Every launch that fits takes the loop once.
+  for (uint32_t row = blockIdx.y; row < rows; row += gridDim.y) {
+    // The index tensors may be int64 and everything below is int32, so each value
+    // is bounded in its own width before it is narrowed -- a value of exactly
+    // 2^32 would narrow to zero, which is a real request and a real position.
+    //
+    // The request is also compared against num_requests, but that is a tensor
+    // extent with no int32 cap of its own, so the comparison alone does not stand
+    // in for the bound. The position and the length have nothing above them at
+    // all.
+    constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
+    const IdType position_raw = query_positions[row];
+    const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
+                                       ? static_cast<int32_t>(position_raw)
+                                       : -1;
+    const IdType request_raw = token_to_req[row];
+    const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                               request_raw < static_cast<IdType>(num_requests);
+    const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
+    const int32_t safe_request =
+        request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
+    IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
+    if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
+    const int32_t sequence_length = static_cast<int32_t>(length_raw);
 
-  // The index tensors may be int64 and everything below is int32, so each value
-  // is bounded in its own width before it is narrowed -- a value of exactly
-  // 2^32 would narrow to zero, which is a real request and a real position.
-  //
-  // The request is also compared against num_requests, but that is a tensor
-  // extent with no int32 cap of its own, so the comparison alone does not stand
-  // in for the bound. The position and the length have nothing above them at
-  // all.
-  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
-  const IdType position_raw = query_positions[row];
-  const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
-                                     ? static_cast<int32_t>(position_raw)
-                                     : -1;
-  const IdType request_raw = token_to_req[row];
-  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
-                             request_raw < static_cast<IdType>(num_requests);
-  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
-  const int32_t safe_request =
-      request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
-  IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
-  if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
-  const int32_t sequence_length = static_cast<int32_t>(length_raw);
+    // One past the last block the query has entirely behind it. A selection is
+    // only expandable while it names one of these: the block the query sits in
+    // is partly ahead of it, and the tail below is what supplies its seen half.
+    // query_position + 1 in its own width: INT32_MAX is inside the range the cast
+    // above accepts, and adding one to it in int32 is signed overflow.
+    const int64_t query_end = static_cast<int64_t>(query_position) + 1;
+    const int32_t past_blocks = static_cast<int32_t>(
+        min(query_end / static_cast<int64_t>(COMPRESS_RATIO),
+            static_cast<int64_t>(sequence_length) / static_cast<int64_t>(COMPRESS_RATIO)));
+    // Every rank the selector produced gets its own columns, whether or not the
+    // block it names turns out to be usable. Sizing this by past_blocks instead
+    // made the layout depend on the query: a rank at or above it was never read,
+    // its columns were reinterpreted as tail columns, and a valid block sitting
+    // there vanished. The causal test is on the block, further down.
+    const int32_t expanded_count =
+        static_cast<int32_t>(block_topk) * static_cast<int32_t>(COMPRESS_RATIO);
+    const int32_t tail_start = static_cast<int32_t>(
+        (query_end / static_cast<int64_t>(COMPRESS_RATIO)) * static_cast<int64_t>(COMPRESS_RATIO));
+    const int32_t tail_count = static_cast<int32_t>(query_end - static_cast<int64_t>(tail_start));
 
-  // One past the last block the query has entirely behind it. A selection is
-  // only expandable while it names one of these: the block the query sits in
-  // is partly ahead of it, and the tail below is what supplies its seen half.
-  // query_position + 1 in its own width: INT32_MAX is inside the range the cast
-  // above accepts, and adding one to it in int32 is signed overflow.
-  const int64_t query_end = static_cast<int64_t>(query_position) + 1;
-  const int32_t past_blocks = static_cast<int32_t>(
-      min(query_end / static_cast<int64_t>(COMPRESS_RATIO),
-          static_cast<int64_t>(sequence_length) / static_cast<int64_t>(COMPRESS_RATIO)));
-  const int32_t complete_blocks = min(past_blocks, static_cast<int32_t>(block_topk));
-  const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
-  const int32_t tail_start = static_cast<int32_t>(
-      (query_end / static_cast<int64_t>(COMPRESS_RATIO)) * static_cast<int64_t>(COMPRESS_RATIO));
-  const int32_t tail_count = static_cast<int32_t>(query_end - static_cast<int64_t>(tail_start));
+    const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
+    const IdType* row_blocks = block_indices + row * stride_blocks_row;
+    const IdType* row_table =
+        request_valid ? block_table + safe_request * stride_table_row : nullptr;
+    IdType* row_logical = out_logical + row * stride_logical_row;
+    IdType* row_route = out_route + row * output_width;
+    uint8_t* row_mask = out_mask + row * mask_bytes_per_row;
 
-  const uint32_t blocks_stride = CONTIGUOUS_COLUMNS ? 1u : stride_blocks_col;
-  const IdType* row_blocks = block_indices + row * stride_blocks_row;
-  const IdType* row_table = request_valid ? block_table + safe_request * stride_table_row : nullptr;
-  IdType* row_logical = out_logical + row * stride_logical_row;
-  IdType* row_route = out_route + row * output_width;
-  uint8_t* row_mask = out_mask + row * mask_bytes_per_row;
-
-  // A warp always covers 32 consecutive columns, so its ballot is exactly the four
-  // mask bytes that cover them and no two warps write the same byte.
-  const uint32_t lane = threadIdx.x & 31u;
+    // A warp always covers 32 consecutive columns, so its ballot is exactly the four
+    // mask bytes that cover them and no two warps write the same byte.
+    const uint32_t lane = threadIdx.x & 31u;
 
 #pragma unroll
-  for (uint32_t i = 0; i < TILE / THREADS; ++i) {
-    const uint32_t col = tile_base + threadIdx.x + i * THREADS;
-    const bool in_row = col < output_width;
+    for (uint32_t i = 0; i < TILE / THREADS; ++i) {
+      const uint32_t col = tile_base + threadIdx.x + i * THREADS;
+      const bool in_row = col < output_width;
 
-    int32_t token = -1;
-    bool valid = false;
-    if (in_row) {
-      const int32_t column = static_cast<int32_t>(col);
-      if (column < expanded_count) {
-        const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
-        const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
-        // Same whole-block rule as the standalone expansion above, decided
-        // before the multiply for the same reason.
-        const IdType block_raw = row_blocks[rank * blocks_stride];
-        valid = block_raw >= IdType(0) && block_raw <= kInt32Max &&
-                block_raw < static_cast<IdType>(past_blocks);
-        token =
-            valid ? static_cast<int32_t>(block_raw) * static_cast<int32_t>(COMPRESS_RATIO) + offset
-                  : -1;
-      } else {
-        const int32_t tail_offset = column - expanded_count;
-        token = tail_start + tail_offset;
-        valid = tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
+      int32_t token = -1;
+      bool valid = false;
+      if (in_row) {
+        const int32_t column = static_cast<int32_t>(col);
+        if (column < expanded_count) {
+          const int32_t rank = column / static_cast<int32_t>(COMPRESS_RATIO);
+          const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
+          // Same whole-block rule as the standalone expansion above, decided
+          // before the multiply for the same reason.
+          const IdType block_raw = row_blocks[rank * blocks_stride];
+          valid = block_raw >= IdType(0) && block_raw <= kInt32Max &&
+                  block_raw < static_cast<IdType>(past_blocks);
+          token = valid ? static_cast<int32_t>(block_raw) * static_cast<int32_t>(COMPRESS_RATIO) +
+                              offset
+                        : -1;
+        } else {
+          const int32_t tail_offset = column - expanded_count;
+          token = tail_start + tail_offset;
+          valid =
+              tail_offset < tail_count && tail_offset < static_cast<int32_t>(COMPRESS_RATIO) - 1;
+        }
+        // Same causal bound as the standalone expansion above: a selected block
+        // the query has not reached would expand into tokens it cannot see, and
+        // the sequence length alone does not stop them.
+        valid = valid && token >= 0 && token <= query_position && token < sequence_length;
+        if (!valid) token = -1;
+        row_logical[col] = static_cast<IdType>(token);
       }
-      // Same causal bound as the standalone expansion above: a selected block
-      // the query has not reached would expand into tokens it cannot see, and
-      // the sequence length alone does not stop them.
-      valid = valid && token >= 0 && token <= query_position && token < sequence_length;
-      if (!valid) token = -1;
-      row_logical[col] = static_cast<IdType>(token);
-    }
 
-    // Logical token -> physical slot, folding every bound into the same validity.
-    uint32_t slot = 0;
-    if (valid) {
-      const uint32_t logical_page = static_cast<uint32_t>(token) / page_size;
-      if (logical_page < table_width && row_table != nullptr) {
-        // The page id keeps its own width until it is bounded, and the slot is
-        // formed in 64 bits: page * page_size overflows a uint32 long before
-        // either factor does, and a wrapped product can land under num_slots.
-        //
-        // What bounds the page is the slot space, not an int32. A route of
-        // int64 can hold a slot of 2^31 and the caller is allowed to ask for
-        // one, so capping the page at INT32_MAX would mask a page it is
-        // entitled to.
-        //
-        // page < num_slots is necessary rather than sufficient -- the slot is
-        // at least the page whenever a page holds anything -- so it turns no
-        // valid page away, and it is what keeps the product inside 64 bits:
-        // both factors are under 2^32 by then. The exact bound is still the
-        // candidate below.
-        const IdType page = row_table[logical_page];
-        if (page >= IdType(0) && static_cast<uint64_t>(page) < static_cast<uint64_t>(num_slots)) {
-          const uint64_t candidate =
-              static_cast<uint64_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
-          if (candidate < static_cast<uint64_t>(num_slots)) {
-            slot = static_cast<uint32_t>(candidate);
+      // Logical token -> physical slot, folding every bound into the same validity.
+      uint32_t slot = 0;
+      if (valid) {
+        const uint32_t logical_page = static_cast<uint32_t>(token) / page_size;
+        if (logical_page < table_width && row_table != nullptr) {
+          // The page id keeps its own width until it is bounded, and the slot is
+          // formed in 64 bits: page * page_size overflows a uint32 long before
+          // either factor does, and a wrapped product can land under num_slots.
+          //
+          // What bounds the page is the slot space, not an int32. A route of
+          // int64 can hold a slot of 2^31 and the caller is allowed to ask for
+          // one, so capping the page at INT32_MAX would mask a page it is
+          // entitled to.
+          //
+          // page < num_slots is necessary rather than sufficient -- the slot is
+          // at least the page whenever a page holds anything -- so it turns no
+          // valid page away, and it is what keeps the product inside 64 bits:
+          // both factors are under 2^32 by then. The exact bound is still the
+          // candidate below.
+          const IdType page = row_table[logical_page];
+          if (page >= IdType(0) && static_cast<uint64_t>(page) < static_cast<uint64_t>(num_slots)) {
+            const uint64_t candidate =
+                static_cast<uint64_t>(page) * page_size + static_cast<uint32_t>(token) % page_size;
+            if (candidate < static_cast<uint64_t>(num_slots)) {
+              slot = static_cast<uint32_t>(candidate);
+            } else {
+              valid = false;
+            }
           } else {
             valid = false;
           }
         } else {
           valid = false;
         }
-      } else {
-        valid = false;
       }
-    }
-    if (in_row) row_route[col] = static_cast<IdType>(slot);
+      if (in_row) row_route[col] = static_cast<IdType>(slot);
 
-    const uint32_t bits = __ballot_sync(0xffffffffu, valid && in_row);
-    if (lane == 0) {
-      const uint32_t byte_base = (tile_base + (threadIdx.x & ~31u) + i * THREADS) >> 3;
+      const uint32_t bits = __ballot_sync(0xffffffffu, valid && in_row);
+      if (lane == 0) {
+        const uint32_t byte_base = (tile_base + (threadIdx.x & ~31u) + i * THREADS) >> 3;
 #pragma unroll
-      for (uint32_t b = 0; b < 4; ++b) {
-        const uint32_t byte_index = byte_base + b;
-        if (byte_index < mask_bytes_per_row) {
-          row_mask[byte_index] = static_cast<uint8_t>((bits >> (b * 8)) & 0xffu);
+        for (uint32_t b = 0; b < 4; ++b) {
+          const uint32_t byte_index = byte_base + b;
+          if (byte_index < mask_bytes_per_row) {
+            row_mask[byte_index] = static_cast<uint8_t>((bits >> (b * 8)) & 0xffu);
+          }
         }
       }
     }
@@ -386,67 +408,70 @@ __global__ void __launch_bounds__(THREADS)
                               uint32_t valid_rows, uint32_t num_requests, uint32_t width,
                               uint32_t table_width, uint_fastdiv page_size, uint32_t num_slots,
                               uint32_t mask_bytes_per_row) {
-  const uint32_t row = blockIdx.y;
   const uint32_t tile_base = blockIdx.x * TILE;
-  if (row >= rows || tile_base >= width) return;
+  if (tile_base >= width) return;
+  // One grid cannot cover more rows than gridDim.y allows, so the rest are
+  // walked by a stride. Every launch that fits takes the loop once.
+  for (uint32_t row = blockIdx.y; row < rows; row += gridDim.y) {
+    // Rows past the caller's token count are padding: they carry no request and must
+    // come out fully masked.
+    // Same range contract as the expansion kernels: an index is bounded in its
+    // own width before it is narrowed, or a value of 2^32 becomes request zero.
+    constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
+    const bool row_live = row < valid_rows;
+    const IdType request_raw = row_live ? token_to_req[row] : IdType(-1);
+    const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                               request_raw < static_cast<IdType>(num_requests);
+    const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
+    const IdType* row_table = request_valid ? block_table + request * stride_table_row : nullptr;
+    // Only a live row reads the logical route, so it needs to cover those rows and
+    // no more -- a short step can hand over its own tensor instead of padding one.
+    const IdType* row_logical = row_live ? logical + row * stride_logical_row : nullptr;
+    IdType* row_route = out_route + row * width;
+    uint8_t* row_mask = out_mask + row * mask_bytes_per_row;
 
-  // Rows past the caller's token count are padding: they carry no request and must
-  // come out fully masked.
-  // Same range contract as the expansion kernels: an index is bounded in its
-  // own width before it is narrowed, or a value of 2^32 becomes request zero.
-  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
-  const bool row_live = row < valid_rows;
-  const IdType request_raw = row_live ? token_to_req[row] : IdType(-1);
-  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
-                             request_raw < static_cast<IdType>(num_requests);
-  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
-  const IdType* row_table = request_valid ? block_table + request * stride_table_row : nullptr;
-  // Only a live row reads the logical route, so it needs to cover those rows and
-  // no more -- a short step can hand over its own tensor instead of padding one.
-  const IdType* row_logical = row_live ? logical + row * stride_logical_row : nullptr;
-  IdType* row_route = out_route + row * width;
-  uint8_t* row_mask = out_mask + row * mask_bytes_per_row;
-
-  const uint32_t lane = threadIdx.x & 31u;
+    const uint32_t lane = threadIdx.x & 31u;
 
 #pragma unroll
-  for (uint32_t i = 0; i < TILE / THREADS; ++i) {
-    const uint32_t col = tile_base + threadIdx.x + i * THREADS;
-    const bool in_row = col < width;
+    for (uint32_t i = 0; i < TILE / THREADS; ++i) {
+      const uint32_t col = tile_base + threadIdx.x + i * THREADS;
+      const bool in_row = col < width;
 
-    uint32_t slot = 0;
-    bool valid = false;
-    if (in_row && row_table != nullptr && row_logical != nullptr) {
-      const IdType token_raw = row_logical[col];
-      if (token_raw >= IdType(0) && token_raw <= kInt32Max) {
-        const int32_t token = static_cast<int32_t>(token_raw);
-        uint32_t logical_page, entry;
-        page_size.divmod(static_cast<uint32_t>(token), logical_page, entry);
-        if (logical_page < table_width) {
-          // Bounded by the slot space rather than by an int32, for the same
-          // reason as the fused kernel above.
-          const IdType page = row_table[logical_page];
-          if (page >= IdType(0) && static_cast<uint64_t>(page) < static_cast<uint64_t>(num_slots)) {
-            const uint64_t candidate =
-                static_cast<uint64_t>(page) * static_cast<uint32_t>(page_size) + entry;
-            if (candidate < static_cast<uint64_t>(num_slots)) {
-              slot = static_cast<uint32_t>(candidate);
-              valid = true;
+      uint32_t slot = 0;
+      bool valid = false;
+      if (in_row && row_table != nullptr && row_logical != nullptr) {
+        const IdType token_raw = row_logical[col];
+        if (token_raw >= IdType(0) && token_raw <= kInt32Max) {
+          const int32_t token = static_cast<int32_t>(token_raw);
+          uint32_t logical_page, entry;
+          page_size.divmod(static_cast<uint32_t>(token), logical_page, entry);
+          if (logical_page < table_width) {
+            // Bounded by the slot space rather than by an int32, for the same
+            // reason as the fused kernel above.
+            const IdType page = row_table[logical_page];
+            if (page >= IdType(0) &&
+                static_cast<uint64_t>(page) < static_cast<uint64_t>(num_slots)) {
+              const uint64_t candidate =
+                  static_cast<uint64_t>(page) * static_cast<uint32_t>(page_size) + entry;
+              if (candidate < static_cast<uint64_t>(num_slots)) {
+                slot = static_cast<uint32_t>(candidate);
+                valid = true;
+              }
             }
           }
         }
       }
-    }
-    if (in_row) row_route[col] = static_cast<IdType>(slot);
+      if (in_row) row_route[col] = static_cast<IdType>(slot);
 
-    const uint32_t bits = __ballot_sync(0xffffffffu, valid);
-    if (lane == 0) {
-      const uint32_t byte_base = (tile_base + (threadIdx.x & ~31u) + i * THREADS) >> 3;
+      const uint32_t bits = __ballot_sync(0xffffffffu, valid);
+      if (lane == 0) {
+        const uint32_t byte_base = (tile_base + (threadIdx.x & ~31u) + i * THREADS) >> 3;
 #pragma unroll
-      for (uint32_t b = 0; b < 4; ++b) {
-        const uint32_t byte_index = byte_base + b;
-        if (byte_index < mask_bytes_per_row) {
-          row_mask[byte_index] = static_cast<uint8_t>((bits >> (b * 8)) & 0xffu);
+        for (uint32_t b = 0; b < 4; ++b) {
+          const uint32_t byte_index = byte_base + b;
+          if (byte_index < mask_bytes_per_row) {
+            row_mask[byte_index] = static_cast<uint8_t>((bits >> (b * 8)) & 0xffu);
+          }
         }
       }
     }
@@ -474,7 +499,7 @@ cudaError_t QSARouteFromLogical(const IdType* logical, const IdType* token_to_re
       sparse_route::choose_wide<kWideKernel, sparse_route::kWideThreads>(wide_blocks, &wide);
   FLASHINFER_CUDA_CALL(shape_status);
   const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
-  const dim3 grid(ceil_div(width, tile), rows);
+  const dim3 grid(ceil_div(width, tile), min(rows, sparse_route::kMaxGridY));
   const uint_fastdiv page_div(page_size);
 
   if (wide) {
@@ -509,7 +534,7 @@ cudaError_t ExpandBlockRoute(const IdType* block_indices, const IdType* query_po
       sparse_route::choose_wide<kWideKernel, sparse_route::kWideThreads>(wide_blocks, &wide);
   FLASHINFER_CUDA_CALL(shape_status);
   const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
-  const dim3 grid(ceil_div(output_width, tile), rows);
+  const dim3 grid(ceil_div(output_width, tile), min(rows, sparse_route::kMaxGridY));
   // Both strides are 1 for every caller that hands over a plain route; folding them
   // away turns the inner address into an add.
   const bool contiguous = stride_blocks_col == 1 && stride_out_col == 1;
@@ -575,7 +600,7 @@ cudaError_t QSARouteFromBlocks(const IdType* block_indices, const IdType* query_
       sparse_route::choose_wide<kWideKernel, sparse_route::kWideThreads>(wide_blocks, &wide);
   FLASHINFER_CUDA_CALL(shape_status);
   const uint32_t tile = wide ? sparse_route::kWideTile : sparse_route::kNarrowTile;
-  const dim3 grid(ceil_div(output_width, tile), rows);
+  const dim3 grid(ceil_div(output_width, tile), min(rows, sparse_route::kMaxGridY));
   const bool contiguous = stride_blocks_col == 1;
 
 #define _FI_ROUTE_CFG(RATIO, CONTIGUOUS, TILE, THREADS)                                           \

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -47,14 +47,24 @@ constexpr uint32_t kNarrowThreads = 256;
 // this GPU, so ask the driver rather than carry a number measured on one
 // architecture. Half a wave of blocks is where the narrow shape's extra blocks
 // stop buying anything.
+//
+// Neither the multiprocessor count nor the occupancy of a given kernel changes
+// between calls on one device, and a route launch is short enough that asking
+// the driver three times for them is a measurable part of it. They are kept per
+// device, and the template gives each kernel its own copy.
 template <typename KernelFn>
 inline cudaError_t choose_wide(KernelFn wide_kernel, uint32_t threads, uint32_t wide_blocks,
                                bool* wide) {
-  int dev_id = 0, num_sms = 0, blocks_per_sm = 0;
+  int dev_id = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
-  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&blocks_per_sm, wide_kernel,
-                                                                     static_cast<int>(threads), 0));
+  static thread_local int cached_dev = -1;
+  static thread_local int num_sms = 0, blocks_per_sm = 0;
+  if (cached_dev != dev_id) {
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+    FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &blocks_per_sm, wide_kernel, static_cast<int>(threads), 0));
+    cached_dev = dev_id;
+  }
   *wide = num_sms == 0 || blocks_per_sm == 0 ||
           wide_blocks >= static_cast<uint32_t>(num_sms) * static_cast<uint32_t>(blocks_per_sm) / 2;
   return cudaSuccess;

--- a/include/flashinfer/sparse_route.cuh
+++ b/include/flashinfer/sparse_route.cuh
@@ -108,10 +108,12 @@ __global__ void __launch_bounds__(THREADS)
       request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
 
   // Blocks entirely in the past, capped by what the selector produced.
-  const int32_t complete_blocks =
-      min(min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
-              sequence_length / static_cast<int32_t>(COMPRESS_RATIO)),
-          static_cast<int32_t>(block_topk));
+  // One past the last block the query has entirely behind it. A selection is
+  // only expandable while it names one of these: the block the query sits in
+  // is partly ahead of it, and the tail below is what supplies its seen half.
+  const int32_t past_blocks = min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
+                                  sequence_length / static_cast<int32_t>(COMPRESS_RATIO));
+  const int32_t complete_blocks = min(past_blocks, static_cast<int32_t>(block_topk));
   const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
   const int32_t tail_start =
       ((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO)) * COMPRESS_RATIO;
@@ -135,7 +137,9 @@ __global__ void __launch_bounds__(THREADS)
       const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
       const int32_t block = static_cast<int32_t>(row_blocks[rank * blocks_stride]);
       token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
-      valid = true;
+      // The whole block, not the token: keeping only the seen half of a block
+      // the query sits in would repeat exactly what the tail appends.
+      valid = block >= 0 && block < past_blocks;
     } else {
       const int32_t tail_offset = column - expanded_count;
       token = tail_start + tail_offset;
@@ -194,10 +198,12 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
   const int32_t sequence_length =
       request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
 
-  const int32_t complete_blocks =
-      min(min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
-              sequence_length / static_cast<int32_t>(COMPRESS_RATIO)),
-          static_cast<int32_t>(block_topk));
+  // One past the last block the query has entirely behind it. A selection is
+  // only expandable while it names one of these: the block the query sits in
+  // is partly ahead of it, and the tail below is what supplies its seen half.
+  const int32_t past_blocks = min((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO),
+                                  sequence_length / static_cast<int32_t>(COMPRESS_RATIO));
+  const int32_t complete_blocks = min(past_blocks, static_cast<int32_t>(block_topk));
   const int32_t expanded_count = complete_blocks * static_cast<int32_t>(COMPRESS_RATIO);
   const int32_t tail_start =
       ((query_position + 1) / static_cast<int32_t>(COMPRESS_RATIO)) * COMPRESS_RATIO;
@@ -228,7 +234,8 @@ __global__ void __launch_bounds__(THREADS) QSARouteFromBlocksKernel(
         const int32_t offset = column - rank * static_cast<int32_t>(COMPRESS_RATIO);
         const int32_t block = static_cast<int32_t>(row_blocks[rank * blocks_stride]);
         token = block * static_cast<int32_t>(COMPRESS_RATIO) + offset;
-        valid = true;
+        // Same whole-block rule as the standalone expansion above.
+        valid = block >= 0 && block < past_blocks;
       } else {
         const int32_t tail_offset = column - expanded_count;
         token = tail_start + tail_offset;

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -43,21 +43,24 @@ def _expand_reference(
         request = requests[row]
         seq = lengths[request] if 0 <= request < num_requests else 0
         position = positions[row]
-        complete = min(
-            (position + 1) // compress_ratio, seq // compress_ratio, block_topk
-        )
+        past = min((position + 1) // compress_ratio, seq // compress_ratio)
+        complete = min(past, block_topk)
         route = []
         for rank in range(complete):
-            base = blocks[row][rank] * compress_ratio
-            route.extend(base + offset for offset in range(compress_ratio))
+            block = blocks[row][rank]
+            # The whole block or none of it: the block the query sits in is
+            # partly ahead of it, and the tail below appends its seen half, so
+            # expanding it here would route those tokens twice.
+            base = block * compress_ratio if 0 <= block < past else None
+            route.extend(
+                None if base is None else base + offset
+                for offset in range(compress_ratio)
+            )
         tail_start = ((position + 1) // compress_ratio) * compress_ratio
         tail = min((position + 1) - tail_start, compress_ratio - 1)
         route.extend(tail_start + offset for offset in range(tail))
         for column, token in enumerate(route[:width]):
-            # A block the query has not reached expands into tokens it cannot
-            # see. The block ids are the caller's, so the bound is applied here
-            # rather than assumed.
-            if 0 <= token <= position and token < seq:
+            if token is not None and 0 <= token <= position and token < seq:
                 out[row, column] = token
     return out
 
@@ -168,6 +171,28 @@ def test_expand_block_route_drops_a_block_the_query_has_not_reached():
     token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
     out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
     assert int(out.max()) <= 3, f"routed a token past the query: {out.tolist()}"
+    assert out[0, :ratio].tolist() == [-1] * ratio
+    expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_expand_block_route_does_not_repeat_the_block_the_query_sits_in():
+    """The block a query sits in is half behind it, and the tail is what
+    appends that half. Keeping the seen tokens of that block during expansion
+    instead of dropping the block whole would route them twice -- at a ratio of
+    four and a query at position 9, block 2 covers tokens 8 to 11 and the tail
+    already carries 8 and 9."""
+    ratio = 4
+    # One column, so the only expansion is the offending block.
+    blocks = torch.tensor([[2]], dtype=torch.int32, device=DEV)
+    positions = torch.tensor([9], dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([512], dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
+    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
+    routed = [t for t in out[0].tolist() if t >= 0]
+    assert len(routed) == len(set(routed)), f"a token is routed twice: {routed}"
+    assert routed == [8, 9], routed
+    assert out[0, :ratio].tolist() == [-1] * ratio
     expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
 

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -576,13 +576,14 @@ def test_qsa_route_from_blocks_does_not_wrap_an_index_that_is_not_an_int32(field
     every guard, so the same values are injected here and not only into the
     standalone slot kernel.
 
-    Removing those copies does not fail this: in the fused path the request is
-    compared against its count, the block against the past-block bound and the
-    page against num_slots, all in IdType, so a value an int32 could not hold is
-    rejected before the cast either way. The explicit bounds are belt and
-    braces and this is coverage of the path, not a pin on them. What the
-    boundary test above pins is the one value nothing else bounds -- the query
-    position, and the plus one taken from it.
+    Removing those copies does not fail this, for different reasons per guard.
+    The block bound is genuinely redundant: block < past_blocks is applied in
+    IdType and past_blocks is an int32 count. The request bound is not -- it is
+    compared against num_requests, which is a tensor extent with no int32 cap of
+    its own, so a large enough request count would let a wrapped id through.
+    This case cannot show that, since building a request table of two billion
+    rows is not a test. What the boundary test above pins is the query position,
+    which nothing else bounds.
     """
     ratio, page_size, num_slots = 4, 16, 4096
     blocks = torch.tensor([[0, 1, 2, 3]], dtype=torch.int64, device=DEV)
@@ -628,3 +629,50 @@ def test_qsa_route_from_blocks_does_not_wrap_an_index_that_is_not_an_int32(field
         # Only the rank or the page that carried it goes; the rest still route.
         assert all(t <= 31 for t in routed), routed
         assert 0 not in live, f"a wrapped index routed: {route[0].tolist()}"
+
+
+@pytest.mark.parametrize("path", ["logical", "blocks"])
+def test_qsa_route_keeps_a_page_an_int64_route_can_hold(path):
+    """A route of int64 is allowed a slot space past what an int32 holds, so a
+    page that lands inside it is a page the caller is entitled to. Bounding the
+    page id at INT32_MAX instead of at the slot space would mask it: page 2^31
+    at a page size of one is slot 2^31, inside a space of 2^31 + 1."""
+    page_size, num_slots = 1, 2147483649
+    big_page = 2147483648
+    if path == "logical":
+        width = 4
+        logical = torch.zeros(1, width, dtype=torch.int64, device=DEV)
+        token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+        table = torch.full((1, 1), big_page, dtype=torch.int64, device=DEV)
+        route = torch.empty(1, width, dtype=torch.int64, device=DEV)
+        mask = torch.empty(1, dtype=torch.uint8, device=DEV)
+        flashinfer.qsa_route_from_logical(
+            logical, token_to_req, table, route, mask, 1, page_size, num_slots
+        )
+    else:
+        ratio = 1
+        width = 4 * ratio + ratio - 1
+        blocks = torch.zeros(1, 4, dtype=torch.int64, device=DEV)
+        positions = torch.tensor([7], dtype=torch.int64, device=DEV)
+        lengths = torch.tensor([8], dtype=torch.int64, device=DEV)
+        token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+        table = torch.full((1, 8), big_page, dtype=torch.int64, device=DEV)
+        logical = torch.empty(1, width, dtype=torch.int64, device=DEV)
+        route = torch.empty(1, width, dtype=torch.int64, device=DEV)
+        mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
+        flashinfer.qsa_route_from_blocks(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            table,
+            logical,
+            route,
+            mask,
+            ratio,
+            page_size,
+            num_slots,
+        )
+    torch.cuda.synchronize()
+    assert int(mask[0]) & 1, "a page inside the slot space was masked out"
+    assert int(route[0, 0]) == big_page, route[0, 0].item()

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -54,7 +54,10 @@ def _expand_reference(
         tail = min((position + 1) - tail_start, compress_ratio - 1)
         route.extend(tail_start + offset for offset in range(tail))
         for column, token in enumerate(route[:width]):
-            if 0 <= token < seq:
+            # A block the query has not reached expands into tokens it cannot
+            # see. The block ids are the caller's, so the bound is applied here
+            # rather than assumed.
+            if 0 <= token <= position and token < seq:
                 out[row, column] = token
     return out
 
@@ -151,6 +154,22 @@ def test_expand_block_route_empties_a_row_without_a_request():
     out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, 4)
     assert int((out[1] >= 0).sum()) == 0
     assert int((out[0] >= 0).sum()) > 0
+
+
+def test_expand_block_route_drops_a_block_the_query_has_not_reached():
+    """The block ids are the caller's. A block past the query expands into
+    tokens the query cannot see -- at a ratio of four, a query at position 3
+    selecting block 2 would route tokens 8 through 11 -- and the sequence
+    length alone does not bound them."""
+    ratio = 4
+    blocks = torch.tensor([[2, 0, 0, 0]], dtype=torch.int32, device=DEV)
+    positions = torch.tensor([3], dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([512], dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
+    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
+    assert int(out.max()) <= 3, f"routed a token past the query: {out.tolist()}"
+    expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
 @pytest.mark.parametrize("compress_ratio", [2, 4])

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -30,7 +30,17 @@ requires_cuda_sm80 = pytest.mark.skipif(
 def _expand_reference(
     block_indices, query_positions, sequence_lengths, token_to_req, compress_ratio
 ):
-    """Expand the selection one row at a time, in plain Python."""
+    """Expand the selection one row at a time, in plain Python.
+
+    The index tensors may be int64 while the kernel works in int32, so a value
+    outside that range is not an index at all. Python has no such range, so the
+    rule is written out here rather than inherited.
+    """
+    int32_max = 2147483647
+
+    def in_range(value):
+        return 0 <= value <= int32_max
+
     rows, block_topk = block_indices.shape
     width = block_topk * compress_ratio + compress_ratio - 1
     num_requests = sequence_lengths.shape[0]
@@ -41,8 +51,10 @@ def _expand_reference(
     requests = token_to_req.tolist()
     for row in range(rows):
         request = requests[row]
-        seq = lengths[request] if 0 <= request < num_requests else 0
-        position = positions[row]
+        request_ok = in_range(request) and request < num_requests
+        raw_seq = lengths[request] if request_ok else 0
+        seq = raw_seq if in_range(raw_seq) else 0
+        position = positions[row] if in_range(positions[row]) else -1
         past = min((position + 1) // compress_ratio, seq // compress_ratio)
         complete = min(past, block_topk)
         route = []
@@ -51,7 +63,7 @@ def _expand_reference(
             # The whole block or none of it: the block the query sits in is
             # partly ahead of it, and the tail below appends its seen half, so
             # expanding it here would route those tokens twice.
-            base = block * compress_ratio if 0 <= block < past else None
+            base = block * compress_ratio if in_range(block) and block < past else None
             route.extend(
                 None if base is None else base + offset
                 for offset in range(compress_ratio)
@@ -351,3 +363,44 @@ def test_route_ops_reject_bad_arguments():
     # a ratio the dispatch has no kernel for
     with pytest.raises(Exception, match="compress_ratio"):
         flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, 3)
+
+
+# Values that do not fit an int32. The index tensors may be int64 and the
+# kernels narrow, so a wrapped one must not become a valid position, request or
+# block: 2^32 exactly wraps to zero, which is a real block and a real request.
+_PAST_INT32 = [2147483648, 4294967296, 9223372036854775807, -2147483649]
+
+
+@pytest.mark.parametrize("bad", _PAST_INT32)
+@pytest.mark.parametrize("field", ["positions", "token_to_req", "blocks", "lengths"])
+def test_expand_block_route_does_not_wrap_an_index_that_is_not_an_int32(field, bad):
+    ratio = 4
+    # Distinct blocks, so a repeat in the output can only come from the kernel
+    # and not from a selector that named the same block twice.
+    blocks = torch.tensor([[0, 1, 2, 3]], dtype=torch.int64, device=DEV)
+    positions = torch.tensor([31], dtype=torch.int64, device=DEV)
+    lengths = torch.tensor([512], dtype=torch.int64, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+    field_map = {
+        "positions": positions,
+        "token_to_req": token_to_req,
+        "lengths": lengths,
+    }
+    if field == "blocks":
+        blocks[0, 0] = bad  # rank 0; ranks 1..3 stay valid
+    else:
+        field_map[field][0] = bad
+
+    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
+    torch.cuda.synchronize()
+    routed = [t for t in out[0].tolist() if t >= 0]
+    assert len(routed) == len(set(routed)), f"a token is routed twice: {routed}"
+    if field == "blocks":
+        # The rank that named it contributes nothing; the rest still route.
+        assert out[0, :ratio].tolist() == [-1] * ratio
+    else:
+        # No request, no position and no length the row can resolve, so it
+        # routes nothing at all.
+        assert routed == [], routed
+    expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -1,0 +1,273 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+DEV = "cuda:0"
+
+requires_cuda_sm80 = pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] < 8,
+    reason="the FA2 large-head path starts at sm_80",
+)
+
+
+def _expand_reference(
+    block_indices, query_positions, sequence_lengths, token_to_req, compress_ratio
+):
+    """Expand the selection one row at a time, in plain Python."""
+    rows, block_topk = block_indices.shape
+    width = block_topk * compress_ratio + compress_ratio - 1
+    num_requests = sequence_lengths.shape[0]
+    out = torch.full((rows, width), -1, dtype=block_indices.dtype, device=DEV)
+    blocks = block_indices.tolist()
+    positions = query_positions.tolist()
+    lengths = sequence_lengths.tolist()
+    requests = token_to_req.tolist()
+    for row in range(rows):
+        request = requests[row]
+        seq = lengths[request] if 0 <= request < num_requests else 0
+        position = positions[row]
+        complete = min(
+            (position + 1) // compress_ratio, seq // compress_ratio, block_topk
+        )
+        route = []
+        for rank in range(complete):
+            base = blocks[row][rank] * compress_ratio
+            route.extend(base + offset for offset in range(compress_ratio))
+        tail_start = ((position + 1) // compress_ratio) * compress_ratio
+        tail = min((position + 1) - tail_start, compress_ratio - 1)
+        route.extend(tail_start + offset for offset in range(tail))
+        for column, token in enumerate(route[:width]):
+            if 0 <= token < seq:
+                out[row, column] = token
+    return out
+
+
+def _route_reference(
+    logical, token_to_req, block_table, page_size, num_slots, valid_rows
+):
+    """Map the logical route to slots and pack validity, one row at a time."""
+    rows, width = logical.shape
+    nbytes = -(-width // 8)
+    route = torch.zeros((rows, width), dtype=logical.dtype, device=DEV)
+    mask = torch.zeros(rows * nbytes, dtype=torch.uint8, device=DEV)
+    table = block_table.tolist()
+    requests = token_to_req.tolist()
+    tokens = logical.tolist()
+    table_width = block_table.shape[1]
+    for row in range(rows):
+        if row >= valid_rows:
+            continue
+        request = requests[row]
+        if not 0 <= request < block_table.shape[0]:
+            continue
+        for column in range(width):
+            token = tokens[row][column]
+            if token < 0:
+                continue
+            page = token // page_size
+            if page >= table_width:
+                continue
+            mapped = table[request][page]
+            if mapped < 0:
+                continue
+            slot = mapped * page_size + token % page_size
+            if slot >= num_slots:
+                continue
+            route[row, column] = slot
+            mask[row * nbytes + column // 8] |= 1 << (column % 8)
+    return route, mask
+
+
+def _make_case(
+    rows, block_topk, compress_ratio, seq_len, num_requests, page_size, seed
+):
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    blocks = torch.randint(
+        0,
+        max(1, seq_len // compress_ratio),
+        (rows, block_topk),
+        dtype=torch.int32,
+        device=DEV,
+        generator=g,
+    )
+    positions = torch.randint(
+        0, seq_len, (rows,), dtype=torch.int32, device=DEV, generator=g
+    )
+    lengths = torch.full((num_requests,), seq_len, dtype=torch.int32, device=DEV)
+    token_to_req = torch.randint(
+        0, num_requests, (rows,), dtype=torch.int32, device=DEV, generator=g
+    )
+    pages_per_request = (seq_len + page_size - 1) // page_size
+    pages = pages_per_request * num_requests
+    table = (
+        torch.randperm(pages, device=DEV, generator=g)
+        .reshape(num_requests, pages_per_request)
+        .contiguous()
+        .to(torch.int32)
+    )
+    # unmapped pages the validity has to catch
+    table[:, ::7] = -1
+    return blocks, positions, lengths, token_to_req, table, pages * page_size
+
+
+@pytest.mark.parametrize("compress_ratio", [1, 2, 4, 8])
+@pytest.mark.parametrize("rows", [1, 7, 64, 300])
+@pytest.mark.parametrize("block_topk", [1, 16, 128])
+def test_expand_block_route(compress_ratio, rows, block_topk):
+    blocks, positions, lengths, token_to_req, _, _ = _make_case(
+        rows, block_topk, compress_ratio, 512, 4, 64, seed=rows + block_topk
+    )
+    out = flashinfer.expand_block_route(
+        blocks, positions, lengths, token_to_req, compress_ratio
+    )
+    expected = _expand_reference(
+        blocks, positions, lengths, token_to_req, compress_ratio
+    )
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_expand_block_route_empties_a_row_without_a_request():
+    blocks = torch.zeros(2, 4, dtype=torch.int32, device=DEV)
+    positions = torch.tensor([100, 100], dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([512], dtype=torch.int32, device=DEV)
+    token_to_req = torch.tensor([0, -1], dtype=torch.int32, device=DEV)
+    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, 4)
+    assert int((out[1] >= 0).sum()) == 0
+    assert int((out[0] >= 0).sum()) > 0
+
+
+@pytest.mark.parametrize("compress_ratio", [2, 4])
+@pytest.mark.parametrize("rows", [1, 9, 128])
+@pytest.mark.parametrize("page_size", [1, 16, 64])
+def test_qsa_route_from_blocks(compress_ratio, rows, page_size):
+    block_topk = 32
+    blocks, positions, lengths, token_to_req, table, num_slots = _make_case(
+        rows, block_topk, compress_ratio, 1024, 4, page_size, seed=rows + page_size
+    )
+    width = block_topk * compress_ratio + compress_ratio - 1
+    nbytes = -(-width // 8)
+    logical = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
+
+    flashinfer.qsa_route_from_blocks(
+        blocks,
+        positions,
+        lengths,
+        token_to_req,
+        table,
+        logical,
+        route,
+        mask,
+        compress_ratio,
+        page_size,
+        num_slots,
+    )
+
+    expected_logical = _expand_reference(
+        blocks, positions, lengths, token_to_req, compress_ratio
+    )
+    torch.testing.assert_close(logical, expected_logical, rtol=0, atol=0)
+    expected_route, expected_mask = _route_reference(
+        expected_logical, token_to_req, table, page_size, num_slots, rows
+    )
+    torch.testing.assert_close(route, expected_route, rtol=0, atol=0)
+    torch.testing.assert_close(mask, expected_mask, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("rows,valid_rows", [(1, 1), (16, 16), (128, 100), (64, 0)])
+@pytest.mark.parametrize("page_size", [1, 64])
+def test_qsa_route_from_logical(rows, valid_rows, page_size):
+    """Padding rows must come out fully masked, whatever the logical route holds."""
+    block_topk, compress_ratio = 32, 4
+    blocks, positions, lengths, token_to_req, table, num_slots = _make_case(
+        rows, block_topk, compress_ratio, 1024, 4, page_size, seed=rows
+    )
+    logical = _expand_reference(
+        blocks, positions, lengths, token_to_req, compress_ratio
+    )
+    width = logical.shape[1]
+    nbytes = -(-width // 8)
+    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
+
+    flashinfer.qsa_route_from_logical(
+        logical, token_to_req, table, route, mask, valid_rows, page_size, num_slots
+    )
+    expected_route, expected_mask = _route_reference(
+        logical, token_to_req, table, page_size, num_slots, valid_rows
+    )
+    torch.testing.assert_close(route, expected_route, rtol=0, atol=0)
+    torch.testing.assert_close(mask, expected_mask, rtol=0, atol=0)
+
+
+def test_qsa_route_never_points_outside_the_cache():
+    """An entry the mask clears must still hold an in-range slot."""
+    rows, block_topk, compress_ratio, page_size = 32, 16, 4, 16
+    blocks, positions, lengths, token_to_req, table, num_slots = _make_case(
+        rows, block_topk, compress_ratio, 256, 2, page_size, seed=7
+    )
+    # every page unmapped: nothing is valid, and every slot must still be legal
+    table.fill_(-1)
+    width = block_topk * compress_ratio + compress_ratio - 1
+    nbytes = -(-width // 8)
+    logical = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
+    flashinfer.qsa_route_from_blocks(
+        blocks,
+        positions,
+        lengths,
+        token_to_req,
+        table,
+        logical,
+        route,
+        mask,
+        compress_ratio,
+        page_size,
+        num_slots,
+    )
+    assert int(mask.sum()) == 0
+    assert int(route.min()) >= 0
+    assert int(route.max()) < num_slots
+
+
+def test_route_ops_reject_bad_arguments():
+    blocks = torch.zeros(4, 8, dtype=torch.int32, device=DEV)
+    positions = torch.zeros(4, dtype=torch.int32, device=DEV)
+    lengths = torch.full((1,), 64, dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(4, dtype=torch.int32, device=DEV)
+
+    with pytest.raises(ValueError, match="compress_ratio"):
+        flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, 0)
+    with pytest.raises(ValueError, match="2D"):
+        flashinfer.expand_block_route(blocks[0], positions, lengths, token_to_req, 4)
+    with pytest.raises(ValueError, match="shape"):
+        flashinfer.expand_block_route(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            4,
+            out=torch.zeros(4, 8, dtype=torch.int32, device=DEV),
+        )
+    # a ratio the dispatch has no kernel for
+    with pytest.raises(Exception, match="compress_ratio"):
+        flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, 3)

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -404,3 +404,50 @@ def test_expand_block_route_does_not_wrap_an_index_that_is_not_an_int32(field, b
         assert routed == [], routed
     expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("field", ["positions", "lengths"])
+def test_expand_block_route_takes_a_value_at_the_top_of_the_int32_range(field):
+    """INT32_MAX is inside the range the kernels accept, so what it exercises is
+    the arithmetic after the cast: the block bound and the tail both come from
+    position + 1, and adding one to INT32_MAX in int32 is signed overflow."""
+    ratio = 4
+    blocks = torch.tensor([[0, 1, 2, 3]], dtype=torch.int64, device=DEV)
+    positions = torch.tensor([31], dtype=torch.int64, device=DEV)
+    lengths = torch.tensor([512], dtype=torch.int64, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+    if field == "positions":
+        positions[0] = 2147483647
+    else:
+        lengths[0] = 2147483647
+    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
+    torch.cuda.synchronize()
+    routed = [t for t in out[0].tolist() if t >= 0]
+    assert len(routed) == len(set(routed)), routed
+    expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_qsa_route_from_logical_does_not_let_a_slot_wrap_into_range():
+    """The physical slot is page * page_size + entry. Both factors fit a uint32
+    while their product does not, and a product computed in 32 bits wraps to a
+    small number that passes the num_slots bound -- page 65536 of a 65536-entry
+    page is exactly 2^32, which would arrive as slot 0.
+    """
+    page_size, num_slots, width = 65536, 1024, 8
+    rows = 1
+    logical = torch.arange(width, dtype=torch.int32, device=DEV).reshape(rows, width)
+    token_to_req = torch.zeros(rows, dtype=torch.int32, device=DEV)
+    # One page, mapped to a page id whose product with the page size is 2^32.
+    table = torch.tensor([[65536]], dtype=torch.int32, device=DEV)
+    nbytes = -(-width // 8)
+    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
+
+    flashinfer.qsa_route_from_logical(
+        logical, token_to_req, table, route, mask, rows, page_size, num_slots
+    )
+    torch.cuda.synchronize()
+    assert int(mask[0]) == 0, (
+        f"a slot past num_slots was accepted: route={route.tolist()} mask={mask.tolist()}"
+    )

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -433,15 +433,20 @@ def test_qsa_route_from_logical_does_not_let_a_slot_wrap_into_range():
     while their product does not, and a product computed in 32 bits wraps to a
     small number that passes the num_slots bound -- page 65536 of a 65536-entry
     page is exactly 2^32, which would arrive as slot 0.
+
+    The page itself is inside the slot space here, so the bound that precedes
+    the multiply lets it through and the width of the multiply is what decides
+    the case. That needs the largest slot space a route can be given, which is
+    an int64 one.
     """
-    page_size, num_slots, width = 65536, 1024, 8
+    page_size, num_slots, width = 65536, 4294967295, 8
     rows = 1
-    logical = torch.arange(width, dtype=torch.int32, device=DEV).reshape(rows, width)
-    token_to_req = torch.zeros(rows, dtype=torch.int32, device=DEV)
+    logical = torch.arange(width, dtype=torch.int64, device=DEV).reshape(rows, width)
+    token_to_req = torch.zeros(rows, dtype=torch.int64, device=DEV)
     # One page, mapped to a page id whose product with the page size is 2^32.
-    table = torch.tensor([[65536]], dtype=torch.int32, device=DEV)
+    table = torch.tensor([[65536]], dtype=torch.int64, device=DEV)
     nbytes = -(-width // 8)
-    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    route = torch.empty(rows, width, dtype=torch.int64, device=DEV)
     mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
 
     flashinfer.qsa_route_from_logical(
@@ -505,9 +510,11 @@ def test_qsa_route_from_blocks_bounds_the_ratio_before_it_derives_a_width():
 @pytest.mark.parametrize("bad", _PAST_INT32)
 @pytest.mark.parametrize("field", ["token_to_req", "logical", "page_table"])
 def test_qsa_route_from_logical_does_not_wrap_an_index_that_is_not_an_int32(field, bad):
-    """The slot kernel narrows the request, the logical token and the page id
-    just as the expansion does, so the same values must not come back as
-    request, token or page zero."""
+    """The slot kernel narrows the request and the logical token just as the
+    expansion does, so neither may come back as request or token zero. The page
+    id is not narrowed at all -- it is bounded against the slot space in IdType
+    and then widened -- so what this asks of it is that a value it cannot
+    address is refused rather than folded into one it can."""
     width, page_size, num_slots = 8, 16, 4096
     logical = torch.arange(width, dtype=torch.int64, device=DEV).reshape(1, width)
     token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -761,7 +761,12 @@ def test_a_route_covers_more_rows_than_one_grid_can_hold(path):
     """Rows go on the grid's y dimension, which stops at 65535 on every compute
     capability, and a row is a query token. A long-context step goes past that,
     so the rows a grid cannot cover are walked by a stride rather than dropped
-    or refused."""
+    or refused.
+
+    Every output each entry point writes is compared against the reference, not
+    just the first: a stride that loses rows in the physical route or in the
+    packed mask would not show in the logical one.
+    """
     rows, ratio, topk = 70000, 4, 2
     assert rows > 65535
     blocks = torch.zeros(rows, topk, dtype=torch.int32, device=DEV)
@@ -770,44 +775,60 @@ def test_a_route_covers_more_rows_than_one_grid_can_hold(path):
     token_to_req = torch.zeros(rows, dtype=torch.int32, device=DEV)
     width = topk * ratio + ratio - 1
     page_size, pages = 8, 8
+    num_slots = pages * page_size
     table = torch.arange(pages, dtype=torch.int32, device=DEV).reshape(1, pages)
-    logical = flashinfer.expand_block_route(
-        blocks, positions, lengths, token_to_req, ratio
+
+    want_logical = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
+    want_route, want_mask = _route_reference(
+        want_logical, token_to_req, table, page_size, num_slots, rows
     )
+
     if path == "expand":
-        out = logical
+        got = flashinfer.expand_block_route(
+            blocks, positions, lengths, token_to_req, ratio
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(got, want_logical, rtol=0, atol=0)
+        # A row that the stride skipped would be left as -1 rather than routed.
+        assert int((got[-1] >= 0).sum()) > 0, got[-1].tolist()
+        return
+
+    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(rows * (-(-width // 8)), dtype=torch.uint8, device=DEV)
+    if path == "blocks":
+        logical = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+        flashinfer.qsa_route_from_blocks(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            table,
+            logical,
+            route,
+            mask,
+            ratio,
+            page_size,
+            num_slots,
+        )
+        torch.cuda.synchronize()
+        torch.testing.assert_close(logical, want_logical, rtol=0, atol=0)
     else:
-        route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
-        mask = torch.empty(rows * (-(-width // 8)), dtype=torch.uint8, device=DEV)
-        if path == "blocks":
-            fused = torch.empty(rows, width, dtype=torch.int32, device=DEV)
-            flashinfer.qsa_route_from_blocks(
-                blocks,
-                positions,
-                lengths,
-                token_to_req,
-                table,
-                fused,
-                route,
-                mask,
-                ratio,
-                page_size,
-                pages * page_size,
-            )
-            out = fused
-        else:
-            flashinfer.qsa_route_from_logical(
-                logical,
-                token_to_req,
-                table,
-                route,
-                mask,
-                rows,
-                page_size,
-                pages * page_size,
-            )
-            out = route
-    torch.cuda.synchronize()
-    # Every row is the same query, so every row comes out the same.
-    assert bool((out == out[0]).all()), out[-1].tolist()
-    assert int((out[-1] >= 0).sum()) > 0, out[-1].tolist()
+        flashinfer.qsa_route_from_logical(
+            want_logical,
+            token_to_req,
+            table,
+            route,
+            mask,
+            rows,
+            page_size,
+            num_slots,
+        )
+        torch.cuda.synchronize()
+
+    torch.testing.assert_close(route, want_route, rtol=0, atol=0)
+    torch.testing.assert_close(mask, want_mask, rtol=0, atol=0)
+    # The last row really was written: its first mask byte carries the columns
+    # the expansion filled. The byte after it covers columns 8 to 10, which this
+    # selection leaves empty, so it is zero for every row.
+    nbytes = -(-width // 8)
+    assert int(mask[(rows - 1) * nbytes]) != 0, mask[(rows - 1) * nbytes].item()

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -428,7 +428,8 @@ def test_expand_block_route_takes_a_value_at_the_top_of_the_int32_range(field):
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
-def test_qsa_route_from_logical_does_not_let_a_slot_wrap_into_range():
+@pytest.mark.parametrize("path", ["logical", "blocks"])
+def test_qsa_route_does_not_let_a_slot_wrap_into_range(path):
     """The physical slot is page * page_size + entry. Both factors fit a uint32
     while their product does not, and a product computed in 32 bits wraps to a
     small number that passes the num_slots bound -- page 65536 of a 65536-entry
@@ -438,20 +439,46 @@ def test_qsa_route_from_logical_does_not_let_a_slot_wrap_into_range():
     the multiply lets it through and the width of the multiply is what decides
     the case. That needs the largest slot space a route can be given, which is
     an int64 one.
-    """
-    page_size, num_slots, width = 65536, 4294967295, 8
-    rows = 1
-    logical = torch.arange(width, dtype=torch.int64, device=DEV).reshape(rows, width)
-    token_to_req = torch.zeros(rows, dtype=torch.int64, device=DEV)
-    # One page, mapped to a page id whose product with the page size is 2^32.
-    table = torch.tensor([[65536]], dtype=torch.int64, device=DEV)
-    nbytes = -(-width // 8)
-    route = torch.empty(rows, width, dtype=torch.int64, device=DEV)
-    mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
 
-    flashinfer.qsa_route_from_logical(
-        logical, token_to_req, table, route, mask, rows, page_size, num_slots
-    )
+    Both paths, because the fused kernel carries its own copy of the multiply:
+    narrowing one of them is not caught by exercising the other.
+    """
+    page_size, num_slots = 65536, 4294967295
+    big_page = 65536  # times the page size, exactly 2^32
+    if path == "logical":
+        width = 8
+        logical = torch.arange(width, dtype=torch.int64, device=DEV).reshape(1, width)
+        token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+        table = torch.tensor([[big_page]], dtype=torch.int64, device=DEV)
+        route = torch.empty(1, width, dtype=torch.int64, device=DEV)
+        mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
+        flashinfer.qsa_route_from_logical(
+            logical, token_to_req, table, route, mask, 1, page_size, num_slots
+        )
+    else:
+        ratio = 1
+        width = 4 * ratio + ratio - 1
+        blocks = torch.zeros(1, 4, dtype=torch.int64, device=DEV)
+        positions = torch.tensor([7], dtype=torch.int64, device=DEV)
+        lengths = torch.tensor([8], dtype=torch.int64, device=DEV)
+        token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+        table = torch.tensor([[big_page]], dtype=torch.int64, device=DEV)
+        logical = torch.empty(1, width, dtype=torch.int64, device=DEV)
+        route = torch.empty(1, width, dtype=torch.int64, device=DEV)
+        mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
+        flashinfer.qsa_route_from_blocks(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            table,
+            logical,
+            route,
+            mask,
+            ratio,
+            page_size,
+            num_slots,
+        )
     torch.cuda.synchronize()
     assert int(mask[0]) == 0, (
         f"a slot past num_slots was accepted: route={route.tolist()} mask={mask.tolist()}"

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -463,9 +463,14 @@ def test_qsa_route_from_logical_refuses_a_slot_space_its_route_cannot_hold():
     table = torch.zeros(1, 1, dtype=torch.int32, device=DEV)
     route = torch.empty(1, width, dtype=torch.int32, device=DEV)
     mask = torch.empty(1, dtype=torch.uint8, device=DEV)
+    # A count of 2^31 is slots 0 .. INT32_MAX, which the route holds; one more
+    # is not.
+    flashinfer.qsa_route_from_logical(
+        logical, token_to_req, table, route, mask, 1, 65536, 2147483648
+    )
     with pytest.raises(Exception, match="fit the route dtype"):
         flashinfer.qsa_route_from_logical(
-            logical, token_to_req, table, route, mask, 1, 65536, 2147483648
+            logical, token_to_req, table, route, mask, 1, 65536, 2147483649
         )
 
 
@@ -541,7 +546,10 @@ def test_qsa_route_rejects_a_host_scalar_that_is_not_a_uint32(scalar):
     table = torch.zeros(1, 1, dtype=torch.int32, device=DEV)
     args = dict(compress_ratio=1, page_size=16, num_slots=256)
     args[scalar] = 4294967296
-    width = 4 * args["compress_ratio"] + args["compress_ratio"] - 1
+    # Sized for the ratio the binding will accept, not the one under test: a
+    # width derived from 2^32 is 21 billion columns and the allocation is what
+    # would fail rather than the check.
+    width = 4 * 1 + 1 - 1
     logical = torch.empty(1, width, dtype=torch.int32, device=DEV)
     route = torch.empty(1, width, dtype=torch.int32, device=DEV)
     mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
@@ -559,3 +567,64 @@ def test_qsa_route_rejects_a_host_scalar_that_is_not_a_uint32(scalar):
             args["page_size"],
             args["num_slots"],
         )
+
+
+@pytest.mark.parametrize("bad", _PAST_INT32)
+@pytest.mark.parametrize("field", ["token_to_req", "blocks", "page_table"])
+def test_qsa_route_from_blocks_does_not_wrap_an_index_that_is_not_an_int32(field, bad):
+    """The fused kernel expands and resolves in one pass, with its own copy of
+    every guard, so the same values are injected here and not only into the
+    standalone slot kernel.
+
+    Removing those copies does not fail this: in the fused path the request is
+    compared against its count, the block against the past-block bound and the
+    page against num_slots, all in IdType, so a value an int32 could not hold is
+    rejected before the cast either way. The explicit bounds are belt and
+    braces and this is coverage of the path, not a pin on them. What the
+    boundary test above pins is the one value nothing else bounds -- the query
+    position, and the plus one taken from it.
+    """
+    ratio, page_size, num_slots = 4, 16, 4096
+    blocks = torch.tensor([[0, 1, 2, 3]], dtype=torch.int64, device=DEV)
+    positions = torch.tensor([31], dtype=torch.int64, device=DEV)
+    lengths = torch.tensor([512], dtype=torch.int64, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+    table = torch.zeros(1, 32, dtype=torch.int64, device=DEV)
+    if field == "token_to_req":
+        token_to_req[0] = bad
+    elif field == "blocks":
+        blocks[0, 0] = bad
+    else:
+        table[0, 0] = bad
+
+    width = 4 * ratio + ratio - 1
+    logical = torch.empty(1, width, dtype=torch.int64, device=DEV)
+    route = torch.empty(1, width, dtype=torch.int64, device=DEV)
+    mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
+    flashinfer.qsa_route_from_blocks(
+        blocks,
+        positions,
+        lengths,
+        token_to_req,
+        table,
+        logical,
+        route,
+        mask,
+        ratio,
+        page_size,
+        num_slots,
+    )
+    torch.cuda.synchronize()
+    routed = [t for t in logical[0].tolist() if t >= 0]
+    assert len(routed) == len(set(routed)), routed
+    live = [
+        c
+        for c in range(width)
+        if (int(mask[-(-width // 8) * 0 + c // 8]) >> (c % 8)) & 1
+    ]
+    if field == "token_to_req":
+        assert live == [], f"a wrapped request routed: {route[0].tolist()}"
+    else:
+        # Only the rank or the page that carried it goes; the rest still route.
+        assert all(t <= 31 for t in routed), routed
+        assert 0 not in live, f"a wrapped index routed: {route[0].tolist()}"

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -56,9 +56,10 @@ def _expand_reference(
         seq = raw_seq if in_range(raw_seq) else 0
         position = positions[row] if in_range(positions[row]) else -1
         past = min((position + 1) // compress_ratio, seq // compress_ratio)
-        complete = min(past, block_topk)
         route = []
-        for rank in range(complete):
+        # Every rank gets its columns; whether the block it names is usable is
+        # decided per block, not by truncating the rank range.
+        for rank in range(block_topk):
             block = blocks[row][rank]
             # The whole block or none of it: the block the query sits in is
             # partly ahead of it, and the tail below appends its seen half, so
@@ -710,3 +711,64 @@ def test_qsa_route_keeps_a_page_an_int64_route_can_hold(path):
     torch.cuda.synchronize()
     assert int(mask[0]) & 1, "a page inside the slot space was masked out"
     assert int(route[0, 0]) == big_page, route[0, 0].item()
+
+
+@pytest.mark.parametrize("path", ["logical", "blocks"])
+def test_expand_block_route_reads_every_rank_the_selector_filled(path):
+    """The selector's ranks are its own business. A valid block sitting at a
+    rank the query happens to be short of is still a valid block: with a ratio
+    of four and a query at position 7, two blocks are behind the query, and a
+    selection of [-1, -1, 0, 1] has both of them at ranks 2 and 3. Sizing the
+    expanded region by the query rather than by the rank count dropped them and
+    reinterpreted their columns as tail columns."""
+    ratio = 4
+    blocks = torch.tensor([[-1, -1, 0, 1]], dtype=torch.int32, device=DEV)
+    positions = torch.tensor([7], dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([16], dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
+    if path == "logical":
+        out = flashinfer.expand_block_route(
+            blocks, positions, lengths, token_to_req, ratio
+        )
+    else:
+        page_size, width = 4, 4 * ratio + ratio - 1
+        table = torch.arange(4, dtype=torch.int32, device=DEV).reshape(1, 4)
+        out = torch.empty(1, width, dtype=torch.int32, device=DEV)
+        route = torch.empty(1, width, dtype=torch.int32, device=DEV)
+        mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
+        flashinfer.qsa_route_from_blocks(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            table,
+            out,
+            route,
+            mask,
+            ratio,
+            page_size,
+            16,
+        )
+    torch.cuda.synchronize()
+    routed = sorted(t for t in out[0].tolist() if t >= 0)
+    assert routed == [0, 1, 2, 3, 4, 5, 6, 7], routed
+    expected = _expand_reference(blocks, positions, lengths, token_to_req, ratio)
+    torch.testing.assert_close(out, expected, rtol=0, atol=0)
+
+
+def test_expand_block_route_covers_more_rows_than_one_grid_can_hold():
+    """Rows go on the grid's y dimension, which stops at 65535 on every compute
+    capability, and a row is a query token. A long-context step goes past that,
+    so the rows a grid cannot cover are walked by a stride rather than dropped
+    or refused."""
+    rows, ratio, topk = 70000, 4, 2
+    assert rows > 65535
+    blocks = torch.zeros(rows, topk, dtype=torch.int32, device=DEV)
+    positions = torch.full((rows,), 31, dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([64], dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(rows, dtype=torch.int32, device=DEV)
+    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
+    torch.cuda.synchronize()
+    # Every row is the same query, so every row is the same route.
+    assert bool((out == out[0]).all()), out[-1].tolist()
+    assert int((out[-1] >= 0).sum()) > 0, out[-1].tolist()

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -451,3 +451,111 @@ def test_qsa_route_from_logical_does_not_let_a_slot_wrap_into_range():
     assert int(mask[0]) == 0, (
         f"a slot past num_slots was accepted: route={route.tolist()} mask={mask.tolist()}"
     )
+
+
+def test_qsa_route_from_logical_refuses_a_slot_space_its_route_cannot_hold():
+    """A slot is written into the route's own dtype. An int32 route cannot hold
+    2^31, which would come back out as a negative index with its mask bit set,
+    so a slot space that large has to be refused rather than truncated."""
+    width = 8
+    logical = torch.arange(width, dtype=torch.int32, device=DEV).reshape(1, width)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
+    table = torch.zeros(1, 1, dtype=torch.int32, device=DEV)
+    route = torch.empty(1, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(1, dtype=torch.uint8, device=DEV)
+    with pytest.raises(Exception, match="fit the route dtype"):
+        flashinfer.qsa_route_from_logical(
+            logical, token_to_req, table, route, mask, 1, 65536, 2147483648
+        )
+
+
+def test_qsa_route_from_blocks_bounds_the_ratio_before_it_derives_a_width():
+    """The route width is block_topk * compress_ratio + compress_ratio - 1. A
+    ratio near the top of int64 overflows that product before any check on the
+    ratio could reject it, so the bound has to come first."""
+    blocks = torch.zeros(1, 4, dtype=torch.int32, device=DEV)
+    positions = torch.zeros(1, dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([16], dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
+    table = torch.zeros(1, 1, dtype=torch.int32, device=DEV)
+    logical = torch.empty(1, 8, dtype=torch.int32, device=DEV)
+    route = torch.empty(1, 8, dtype=torch.int32, device=DEV)
+    mask = torch.empty(1, dtype=torch.uint8, device=DEV)
+    with pytest.raises(Exception, match="compress_ratio must fit in 32 bits"):
+        flashinfer.qsa_route_from_blocks(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            table,
+            logical,
+            route,
+            mask,
+            9223372036854775807,
+            16,
+            256,
+        )
+
+
+@pytest.mark.parametrize("bad", _PAST_INT32)
+@pytest.mark.parametrize("field", ["token_to_req", "logical", "page_table"])
+def test_qsa_route_from_logical_does_not_wrap_an_index_that_is_not_an_int32(field, bad):
+    """The slot kernel narrows the request, the logical token and the page id
+    just as the expansion does, so the same values must not come back as
+    request, token or page zero."""
+    width, page_size, num_slots = 8, 16, 4096
+    logical = torch.arange(width, dtype=torch.int64, device=DEV).reshape(1, width)
+    token_to_req = torch.zeros(1, dtype=torch.int64, device=DEV)
+    table = torch.zeros(1, 4, dtype=torch.int64, device=DEV)
+    if field == "token_to_req":
+        token_to_req[0] = bad
+    elif field == "logical":
+        logical[0, 0] = bad
+    else:
+        table[0, 0] = bad
+
+    route = torch.empty(1, width, dtype=torch.int64, device=DEV)
+    mask = torch.empty(1, dtype=torch.uint8, device=DEV)
+    flashinfer.qsa_route_from_logical(
+        logical, token_to_req, table, route, mask, 1, page_size, num_slots
+    )
+    torch.cuda.synchronize()
+    live = [c for c in range(width) if (int(mask[0]) >> c) & 1]
+    if field == "logical":
+        # Only that column is unusable; the rest of the row still routes.
+        assert 0 not in live, f"a wrapped token was routed: {route[0].tolist()}"
+    else:
+        # No request, or no page under it, so the whole row is masked.
+        assert live == [], f"a wrapped index was routed: {route[0].tolist()}"
+
+
+@pytest.mark.parametrize("scalar", ["page_size", "num_slots", "compress_ratio"])
+def test_qsa_route_rejects_a_host_scalar_that_is_not_a_uint32(scalar):
+    """page_size, num_slots and compress_ratio are narrowed to uint32 for the
+    kernel, so 2^32 arrives as zero -- a page size or a compression ratio to
+    divide by."""
+    blocks = torch.zeros(1, 4, dtype=torch.int32, device=DEV)
+    positions = torch.zeros(1, dtype=torch.int32, device=DEV)
+    lengths = torch.tensor([16], dtype=torch.int32, device=DEV)
+    token_to_req = torch.zeros(1, dtype=torch.int32, device=DEV)
+    table = torch.zeros(1, 1, dtype=torch.int32, device=DEV)
+    args = dict(compress_ratio=1, page_size=16, num_slots=256)
+    args[scalar] = 4294967296
+    width = 4 * args["compress_ratio"] + args["compress_ratio"] - 1
+    logical = torch.empty(1, width, dtype=torch.int32, device=DEV)
+    route = torch.empty(1, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(-(-width // 8), dtype=torch.uint8, device=DEV)
+    with pytest.raises(Exception, match="must fit in 32 bits"):
+        flashinfer.qsa_route_from_blocks(
+            blocks,
+            positions,
+            lengths,
+            token_to_req,
+            table,
+            logical,
+            route,
+            mask,
+            args["compress_ratio"],
+            args["page_size"],
+            args["num_slots"],
+        )

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -756,7 +756,8 @@ def test_expand_block_route_reads_every_rank_the_selector_filled(path):
     torch.testing.assert_close(out, expected, rtol=0, atol=0)
 
 
-def test_expand_block_route_covers_more_rows_than_one_grid_can_hold():
+@pytest.mark.parametrize("path", ["expand", "logical", "blocks"])
+def test_a_route_covers_more_rows_than_one_grid_can_hold(path):
     """Rows go on the grid's y dimension, which stops at 65535 on every compute
     capability, and a row is a query token. A long-context step goes past that,
     so the rows a grid cannot cover are walked by a stride rather than dropped
@@ -767,8 +768,46 @@ def test_expand_block_route_covers_more_rows_than_one_grid_can_hold():
     positions = torch.full((rows,), 31, dtype=torch.int32, device=DEV)
     lengths = torch.tensor([64], dtype=torch.int32, device=DEV)
     token_to_req = torch.zeros(rows, dtype=torch.int32, device=DEV)
-    out = flashinfer.expand_block_route(blocks, positions, lengths, token_to_req, ratio)
+    width = topk * ratio + ratio - 1
+    page_size, pages = 8, 8
+    table = torch.arange(pages, dtype=torch.int32, device=DEV).reshape(1, pages)
+    logical = flashinfer.expand_block_route(
+        blocks, positions, lengths, token_to_req, ratio
+    )
+    if path == "expand":
+        out = logical
+    else:
+        route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+        mask = torch.empty(rows * (-(-width // 8)), dtype=torch.uint8, device=DEV)
+        if path == "blocks":
+            fused = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+            flashinfer.qsa_route_from_blocks(
+                blocks,
+                positions,
+                lengths,
+                token_to_req,
+                table,
+                fused,
+                route,
+                mask,
+                ratio,
+                page_size,
+                pages * page_size,
+            )
+            out = fused
+        else:
+            flashinfer.qsa_route_from_logical(
+                logical,
+                token_to_req,
+                table,
+                route,
+                mask,
+                rows,
+                page_size,
+                pages * page_size,
+            )
+            out = route
     torch.cuda.synchronize()
-    # Every row is the same query, so every row is the same route.
+    # Every row is the same query, so every row comes out the same.
     assert bool((out == out[0]).all()), out[-1].tolist()
     assert int((out[-1] >= 0).sum()) > 0, out[-1].tolist()

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -249,6 +249,42 @@ def test_qsa_route_never_points_outside_the_cache():
     assert int(route.max()) < num_slots
 
 
+def test_qsa_route_rejects_a_mapped_page_past_the_cache():
+    """An unmapped page is not the only way out of range.
+
+    A page the table maps is trusted for its id but not for where that id
+    lands: a mapping whose first slot is already at the end of the cache has
+    to clear as well, or the route walks past it holding a legal-looking id.
+    """
+    rows, block_topk, compress_ratio, page_size = 32, 16, 4, 16
+    blocks, positions, lengths, token_to_req, table, num_slots = _make_case(
+        rows, block_topk, compress_ratio, 256, 2, page_size, seed=7
+    )
+    # Mapped, and one page past the last the cache holds.
+    table.fill_(num_slots // page_size)
+    width = block_topk * compress_ratio + compress_ratio - 1
+    nbytes = -(-width // 8)
+    logical = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    route = torch.empty(rows, width, dtype=torch.int32, device=DEV)
+    mask = torch.empty(rows * nbytes, dtype=torch.uint8, device=DEV)
+    flashinfer.qsa_route_from_blocks(
+        blocks,
+        positions,
+        lengths,
+        token_to_req,
+        table,
+        logical,
+        route,
+        mask,
+        compress_ratio,
+        page_size,
+        num_slots,
+    )
+    assert int(mask.sum()) == 0
+    assert int(route.min()) >= 0
+    assert int(route.max()) < num_slots
+
+
 def test_route_ops_reject_bad_arguments():
     blocks = torch.zeros(4, 8, dtype=torch.int32, device=DEV)
     positions = torch.zeros(4, dtype=torch.int32, device=DEV)

--- a/tests/attention/test_sparse_route.py
+++ b/tests/attention/test_sparse_route.py
@@ -22,7 +22,7 @@ import flashinfer
 DEV = "cuda:0"
 
 requires_cuda_sm80 = pytest.mark.skipif(
-    torch.cuda.get_device_capability()[0] < 8,
+    not torch.cuda.is_available() or torch.cuda.get_device_capability(DEV)[0] < 8,
     reason="the FA2 large-head path starts at sm_80",
 )
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds the route kernels: they turn a block selection into the physical KV slots a paged attention kernel reads, together with the mask that says which of those slots are real.

A sparse attention step selects blocks, not tokens. Attention reads slots. Something has to expand one into the other, and it cannot be done in a few tensor ops without materializing the intermediate: the expansion is per row, it crosses a block table, and the entries that fall outside the sequence have to be neutralized rather than dropped, because a paged kernel reads its route before it applies a mask.

- `flashinfer.expand_block_route(...)` expands a block selection into a token route.
- `flashinfer.qsa_route_from_blocks(...)` does the expansion and the block-table lookup in one pass, producing the physical route and its packed mask.
- `flashinfer.qsa_route_from_logical(...)` is the second half on its own, for a caller whose logical route was produced earlier and outlived the physical one — a speculative decoder reuses one selection across its steps.
- An entry is valid when it names a real token: non-negative, on a logical page the block table covers, on a page the table maps, and in a slot the cache holds. **Invalid entries route to slot 0 with their mask bit clear**, because an out-of-range slot would be dereferenced before the mask applies. Rows past `valid_rows` come out fully masked.
- `query_positions` may be int32 or int64. A position is bounded by the context length, not by what indexes the cache, and a caller that builds positions beside a slot mapping keeps them in int64; tying the two to one dtype made such a caller copy its positions down before every call. The kernels carry a `PosType` of their own and narrow at the point of use, so int32 callers are unaffected.
- Output goes into buffers the caller owns; nothing is allocated inside a call.

### Scope

This is one of four QSA pieces and is independent of the others. The kernel, the binding, the Python entry points and the tests are new files; the only shared files touched are `flashinfer/__init__.py` and `flashinfer/aot.py`.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/attention/test_sparse_route.py` — 20 tests covering the expansion against a Python reference, every way an entry can be invalid (negative, past the block table, unmapped page, slot past the cache), padding rows, both index dtypes crossed with both position dtypes, and the packed mask's bit layout.

Run on compute capability 8.0.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

## Reviewer Notes

The "invalid routes to slot 0, masked" rule is the part worth a second look. Dropping invalid entries instead would make the route ragged and the attention kernel would need a per-row count; keeping them and masking keeps every row the same width, which is what lets the plan be built once and replayed.
