### PR TITLE
feat(attention): score a paged KV cache against a multi-head query

### DIFF
--- a/benchmarks/bench_sparse_paged_scores.py
+++ b/benchmarks/bench_sparse_paged_scores.py
@@ -107,8 +107,10 @@ def main():
 
     # Replayed from a graph. The smallest shapes here run in a few microseconds,
     # which is the same order as a launch, so timing them one launch at a time
-    # measures the launch as much as the kernel.
-    print(f"{'rows':>6} {'heads':>6} {'head_dim':>9} {'columns':>8} {'us':>9}")
+    # measures the launch as much as the kernel. Warm cache: a step scores
+    # several rows against the same pages, which is what the kernel is shaped
+    # for, and the replays leave the cache alone.
+    print(f"{'rows':>6} {'heads':>6} {'head_dim':>9} {'columns':>8} {'warm us':>9}")
     for rows, num_heads, head_dim, columns, num_requests in SHAPES:
         run = build(
             rows,
@@ -124,6 +126,11 @@ def main():
             run,
             use_cuda_graph=True,
             num_iters_within_graph=args.iters_within_graph,
+            # The closure holds its own tensors, so the helper has nothing to
+            # rotate and cannot cold the cache between replays. Said here
+            # rather than left to the default, which would disable itself with
+            # a warning and read as a cold measurement.
+            cold_l2_cache=False,
         )
         print(
             f"{rows:>6} {num_heads:>6} {head_dim:>9} {columns:>8} "

--- a/benchmarks/bench_sparse_paged_scores.py
+++ b/benchmarks/bench_sparse_paged_scores.py
@@ -1,0 +1,135 @@
+"""Time sparse_paged_scores over the shapes a sparse-attention selector asks for.
+
+The kernel scores every visible entry of a paged KV cache against a multi-head
+query, which is the input a top-k ranks. Rows is how many query tokens a step
+scores at once, and columns is how far back the selector looks.
+"""
+
+import argparse
+import math
+
+import numpy as np
+import torch
+
+import flashinfer
+from flashinfer.testing.utils import bench_gpu_time
+
+# rows, num_heads, head_dim, columns, num_requests
+SHAPES = [
+    (1, 4, 128, 1024, 1),
+    (1, 16, 128, 4096, 1),
+    (8, 16, 128, 4096, 1),
+    (16, 16, 128, 4096, 2),
+    (40, 8, 256, 2048, 5),
+    (48, 8, 256, 2048, 6),
+    (64, 4, 128, 1024, 64),
+    (64, 16, 128, 4096, 8),
+    (512, 8, 256, 2048, 2),
+    (2048, 4, 128, 1024, 2),
+    (2048, 16, 128, 4096, 2),
+]
+
+
+def build(rows, num_heads, head_dim, columns, num_requests, page_size, ratio, dtype):
+    device = torch.device("cuda:0")
+    gen = torch.Generator(device=device).manual_seed(0)
+    pages_per_request = (columns + page_size - 1) // page_size
+    pages = pages_per_request * num_requests
+
+    q = torch.randn(
+        rows, num_heads, head_dim, dtype=dtype, device=device, generator=gen
+    )
+    k_cache = torch.randn(
+        pages, page_size, head_dim, dtype=dtype, device=device, generator=gen
+    )
+    # Shuffled so the gather chases pages rather than walking them in order, and
+    # every eleventh entry unmapped so the masked path is exercised too.
+    page_table = (
+        torch.randperm(pages, device=device, generator=gen)
+        .reshape(num_requests, pages_per_request)
+        .contiguous()
+        .to(torch.int32)
+    )
+    page_table[:, ::11] = -1
+
+    per_request = max(1, rows // num_requests)
+    token_to_req = (
+        (torch.arange(rows, device=device, dtype=torch.int32) // per_request)
+        .clamp(max=num_requests - 1)
+        .contiguous()
+    )
+    seqlen = columns * ratio
+    # Spread the rows of a request over its sequence, with the last one seeing
+    # all of it: a row at position zero scores nothing and would time the launch
+    # rather than the kernel.
+    step = max(1, seqlen // max(1, per_request))
+    positions = (
+        (
+            ((torch.arange(rows, device=device, dtype=torch.int32) % per_request) + 1)
+            * step
+            - 1
+        )
+        .clamp(min=0, max=seqlen - 1)
+        .contiguous()
+    )
+    seq_lens = torch.full((num_requests,), seqlen, dtype=torch.int32, device=device)
+
+    logits = torch.empty(rows, columns, dtype=torch.float32, device=device)
+    visible = torch.empty(rows, dtype=torch.int32, device=device)
+
+    def run():
+        flashinfer.sparse_paged_scores(
+            q,
+            k_cache,
+            page_table,
+            token_to_req,
+            positions,
+            seq_lens,
+            ratio,
+            math.sqrt(head_dim),
+            num_columns=columns,
+            logits=logits,
+            visible_blocks=visible,
+        )
+
+    return run
+
+
+@torch.inference_mode()
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--page-size", type=int, default=64)
+    parser.add_argument("--compress-ratio", type=int, default=4)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--iters-within-graph", type=int, default=50)
+    args = parser.parse_args()
+    dtype = getattr(torch, args.dtype)
+
+    # Replayed from a graph. The smallest shapes here run in a few microseconds,
+    # which is the same order as a launch, so timing them one launch at a time
+    # measures the launch as much as the kernel.
+    print(f"{'rows':>6} {'heads':>6} {'head_dim':>9} {'columns':>8} {'us':>9}")
+    for rows, num_heads, head_dim, columns, num_requests in SHAPES:
+        run = build(
+            rows,
+            num_heads,
+            head_dim,
+            columns,
+            num_requests,
+            args.page_size,
+            args.compress_ratio,
+            dtype,
+        )
+        times = bench_gpu_time(
+            run,
+            use_cuda_graph=True,
+            num_iters_within_graph=args.iters_within_graph,
+        )
+        print(
+            f"{rows:>6} {num_heads:>6} {head_dim:>9} {columns:>8} "
+            f"{np.median(times) * 1e3:>9.2f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/sparse_scores.cu
+++ b/csrc/sparse_scores.cu
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <flashinfer/attention/sparse_scores.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using namespace flashinfer;
+
+#define _FI_DISPATCH_HEAD_DIM(DIM, ...) \
+  case DIM: {                           \
+    constexpr uint32_t HEAD_DIM = DIM;  \
+    __VA_ARGS__                         \
+    break;                              \
+  }
+
+void sparse_paged_scores(TensorView q, TensorView k_cache, TensorView page_table,
+                         TensorView token_to_req, TensorView query_positions,
+                         TensorView sequence_lengths, TensorView visible_blocks, TensorView logits,
+                         int64_t compress_ratio, double divisor) {
+  CHECK_DEVICE(q, logits);
+  CHECK_DEVICE(k_cache, logits);
+  CHECK_DEVICE(page_table, logits);
+  CHECK_DEVICE(token_to_req, logits);
+  CHECK_DEVICE(query_positions, logits);
+  CHECK_DEVICE(sequence_lengths, logits);
+  CHECK_DEVICE(visible_blocks, logits);
+  CHECK_DIM(3, q);        // [rows, heads, head_dim]
+  CHECK_DIM(3, k_cache);  // [pages, page_size, head_dim]
+  CHECK_DIM(2, page_table);
+  CHECK_DIM(2, logits);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(q);
+  CHECK_LAST_DIM_CONTIGUOUS_INPUT(k_cache);
+  CHECK_CONTIGUOUS(token_to_req);
+  CHECK_CONTIGUOUS(query_positions);
+  CHECK_CONTIGUOUS(sequence_lengths);
+  CHECK_CONTIGUOUS(visible_blocks);
+  // The kernel walks a row of each of these with a stride of one element.
+  CHECK_LAST_DIM_CONTIGUOUS(page_table);
+  CHECK_LAST_DIM_CONTIGUOUS(logits);
+
+  const int64_t rows = q.size(0);
+  const int64_t num_heads = q.size(1);
+  const int64_t head_dim = q.size(2);
+  const int64_t num_columns = logits.size(1);
+  TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_GT(divisor, 0.0) << "divisor must be positive";
+  TVM_FFI_ICHECK_EQ(k_cache.size(2), head_dim) << "cache and query head_dim must match";
+  TVM_FFI_ICHECK_EQ(logits.size(0), rows);
+  TVM_FFI_ICHECK_EQ(token_to_req.size(0), rows);
+  TVM_FFI_ICHECK_EQ(query_positions.size(0), rows);
+  TVM_FFI_ICHECK_EQ(visible_blocks.size(0), rows);
+  TVM_FFI_ICHECK_EQ(sequence_lengths.size(0), page_table.size(0));
+  TVM_FFI_ICHECK_EQ(logits.dtype(), dl_float32) << "logits must be float32";
+  TVM_FFI_ICHECK_EQ(k_cache.dtype(), q.dtype()) << "cache and query dtype must match";
+  // Every index tensor is read through one pointer type.
+  TVM_FFI_ICHECK_EQ(token_to_req.dtype(), page_table.dtype());
+  TVM_FFI_ICHECK_EQ(query_positions.dtype(), page_table.dtype());
+  TVM_FFI_ICHECK_EQ(sequence_lengths.dtype(), page_table.dtype());
+  TVM_FFI_ICHECK_EQ(visible_blocks.dtype(), page_table.dtype());
+
+  ffi::CUDADeviceGuard device_guard(logits.device().device_id);
+  const cudaStream_t stream = get_stream(logits.device());
+  DISPATCH_DLPACK_IDTYPE_TO_CTYPE(page_table.dtype(), c_idtype, [&] {
+    return DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(q.dtype(), c_type, [&] {
+      cudaError_t status = cudaErrorInvalidValue;
+      auto launch = [&](auto head_dim_tag) {
+        constexpr uint32_t HEAD_DIM = decltype(head_dim_tag)::value;
+        status = SparsePagedScores<HEAD_DIM, c_type, c_idtype>(
+            static_cast<const c_type*>(q.data_ptr()),
+            static_cast<const c_type*>(k_cache.data_ptr()),
+            static_cast<const c_idtype*>(page_table.data_ptr()),
+            static_cast<const c_idtype*>(token_to_req.data_ptr()),
+            static_cast<const c_idtype*>(query_positions.data_ptr()),
+            static_cast<const c_idtype*>(sequence_lengths.data_ptr()),
+            static_cast<c_idtype*>(visible_blocks.data_ptr()),
+            static_cast<float*>(logits.data_ptr()), static_cast<uint32_t>(q.stride(0)),
+            static_cast<uint32_t>(q.stride(1)), static_cast<uint32_t>(k_cache.stride(0)),
+            static_cast<uint32_t>(k_cache.stride(1)), static_cast<uint32_t>(page_table.stride(0)),
+            static_cast<uint32_t>(logits.stride(0)), static_cast<uint32_t>(rows),
+            static_cast<uint32_t>(num_columns), static_cast<uint32_t>(k_cache.size(0)),
+            static_cast<uint32_t>(page_table.size(0)), static_cast<uint32_t>(page_table.size(1)),
+            static_cast<uint32_t>(num_heads), static_cast<uint32_t>(k_cache.size(1)),
+            static_cast<uint32_t>(compress_ratio), static_cast<float>(divisor), stream);
+      };
+      switch (head_dim) {
+        case 64:
+          launch(std::integral_constant<uint32_t, 64>{});
+          break;
+        case 128:
+          launch(std::integral_constant<uint32_t, 128>{});
+          break;
+        case 192:
+          launch(std::integral_constant<uint32_t, 192>{});
+          break;
+        case 256:
+          launch(std::integral_constant<uint32_t, 256>{});
+          break;
+        default:
+          TVM_FFI_ICHECK(false) << "unsupported head_dim " << head_dim
+                                << "; expected 64, 128, 192 or 256";
+      }
+      TVM_FFI_ICHECK(status != cudaErrorInvalidValue)
+          << "unsupported query head count " << num_heads << "; expected at most 16";
+      TVM_FFI_ICHECK(status == cudaSuccess)
+          << "SparsePagedScores failed: " << cudaGetErrorString(status);
+      return true;
+    });
+  });
+}

--- a/csrc/sparse_scores.cu
+++ b/csrc/sparse_scores.cu
@@ -55,7 +55,10 @@ void sparse_paged_scores(TensorView q, TensorView k_cache, TensorView page_table
   const int64_t num_heads = q.size(1);
   const int64_t head_dim = q.size(2);
   const int64_t num_columns = logits.size(1);
+  // Narrowed to uint32 for the kernel, where a value past that wraps: 2^32
+  // would arrive as a compression ratio of zero and divide by it.
   TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
+  TVM_FFI_ICHECK_LE(compress_ratio, 4294967295LL) << "compress_ratio must fit in 32 bits";
   TVM_FFI_ICHECK_GT(divisor, 0.0) << "divisor must be positive";
   TVM_FFI_ICHECK_EQ(k_cache.size(2), head_dim) << "cache and query head_dim must match";
   // A page holds at least one entry: the kernel divides a column by this to

--- a/csrc/sparse_scores.cu
+++ b/csrc/sparse_scores.cu
@@ -58,6 +58,9 @@ void sparse_paged_scores(TensorView q, TensorView k_cache, TensorView page_table
   TVM_FFI_ICHECK_GT(compress_ratio, 0) << "compress_ratio must be positive";
   TVM_FFI_ICHECK_GT(divisor, 0.0) << "divisor must be positive";
   TVM_FFI_ICHECK_EQ(k_cache.size(2), head_dim) << "cache and query head_dim must match";
+  // A page holds at least one entry: the kernel divides a column by this to
+  // reach its page, and a cache with no pages at all is still a page size.
+  TVM_FFI_ICHECK_GT(k_cache.size(1), 0) << "a page holds at least one entry";
   TVM_FFI_ICHECK_EQ(logits.size(0), rows);
   TVM_FFI_ICHECK_EQ(token_to_req.size(0), rows);
   TVM_FFI_ICHECK_EQ(query_positions.size(0), rows);

--- a/csrc/sparse_scores.cu
+++ b/csrc/sparse_scores.cu
@@ -64,6 +64,17 @@ void sparse_paged_scores(TensorView q, TensorView k_cache, TensorView page_table
   // A page holds at least one entry: the kernel divides a column by this to
   // reach its page, and a cache with no pages at all is still a page size.
   TVM_FFI_ICHECK_GT(k_cache.size(1), 0) << "a page holds at least one entry";
+  // Checked here rather than read back out of a cudaErrorInvalidValue: the
+  // launch returns that for a bad grid or a rejected shared-memory size too,
+  // and blaming the head count for those points at the wrong input.
+  TVM_FFI_ICHECK_LE(num_heads, 16)
+      << "unsupported query head count " << num_heads << "; expected at most 16";
+  // A row of each of these is one entry per row, so a second axis would be
+  // read as more rows and score against the wrong request.
+  TVM_FFI_ICHECK_EQ(token_to_req.ndim(), 1) << "token_to_req has one axis";
+  TVM_FFI_ICHECK_EQ(query_positions.ndim(), 1) << "query_positions has one axis";
+  TVM_FFI_ICHECK_EQ(sequence_lengths.ndim(), 1) << "sequence_lengths has one axis";
+  TVM_FFI_ICHECK_EQ(visible_blocks.ndim(), 1) << "visible_blocks has one axis";
   TVM_FFI_ICHECK_EQ(logits.size(0), rows);
   TVM_FFI_ICHECK_EQ(token_to_req.size(0), rows);
   TVM_FFI_ICHECK_EQ(query_positions.size(0), rows);
@@ -118,8 +129,6 @@ void sparse_paged_scores(TensorView q, TensorView k_cache, TensorView page_table
           TVM_FFI_ICHECK(false) << "unsupported head_dim " << head_dim
                                 << "; expected 64, 128, 192 or 256";
       }
-      TVM_FFI_ICHECK(status != cudaErrorInvalidValue)
-          << "unsupported query head count " << num_heads << "; expected at most 16";
       TVM_FFI_ICHECK(status == cudaSuccess)
           << "SparsePagedScores failed: " << cudaGetErrorString(status);
       return true;

--- a/csrc/sparse_scores_jit_binding.cu
+++ b/csrc/sparse_scores_jit_binding.cu
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tvm_ffi_utils.h"
+
+void sparse_paged_scores(TensorView q, TensorView k_cache, TensorView page_table,
+                         TensorView token_to_req, TensorView query_positions,
+                         TensorView sequence_lengths, TensorView visible_blocks, TensorView logits,
+                         int64_t compress_ratio, double divisor);
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_paged_scores, sparse_paged_scores);

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -300,6 +300,7 @@ from .sparse import BlockSparseAttentionWrapper as BlockSparseAttentionWrapper
 from .sparse import (
     VariableBlockSparseAttentionWrapper as VariableBlockSparseAttentionWrapper,
 )
+from .sparse_scores import sparse_paged_scores as sparse_paged_scores
 from .trtllm_low_latency_gemm import (
     prepare_low_latency_gemm_weights as prepare_low_latency_gemm_weights,
 )

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -168,6 +168,7 @@ from .jit.spdlog import gen_spdlog_module
 from .jit.moe_utils import gen_moe_utils_module
 from .jit.hash_topk import gen_hash_topk_module
 from .jit.tllm_utils import gen_trtllm_utils_module
+from .jit.sparse_scores import gen_sparse_scores_module
 from .jit.topk import gen_topk_module
 from .jit.xqa import gen_xqa_module, gen_xqa_module_mla
 
@@ -847,6 +848,10 @@ def gen_all_modules(
             gen_sampling_module(),
             gen_topk_module(),
         ]
+        # The scorer multiplies with m16n8k16, so it is only built where that
+        # exists; without it here an AOT-only install has no artifact to load.
+        if has_sm80:
+            jit_specs.append(gen_sparse_scores_module())
         # Fused RMSNorm+SiLU: pre-compile all LUT configs (SM100+ only)
         if has_sm100:
             for C in _SUPPORTED_C:

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -850,7 +850,13 @@ def gen_all_modules(
         ]
         # The scorer multiplies with m16n8k16, so it is only built where that
         # exists; without it here an AOT-only install has no artifact to load.
-        if has_sm80:
+        # has_sm80 means "an 8.x target is in the build", which is narrower than
+        # what the kernel needs: every 9.x/10.x/12.x target has m16n8k16 too.
+        from .jit.core import current_compilation_context
+
+        if any(
+            major >= 8 for major, _ in current_compilation_context.TARGET_CUDA_ARCHS
+        ):
             jit_specs.append(gen_sparse_scores_module())
         # Fused RMSNorm+SiLU: pre-compile all LUT configs (SM100+ only)
         if has_sm100:

--- a/flashinfer/jit/sparse_scores.py
+++ b/flashinfer/jit/sparse_scores.py
@@ -1,0 +1,31 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from . import env as jit_env
+from .core import JitSpec, gen_jit_spec
+
+
+def gen_sparse_scores_module() -> JitSpec:
+    # The scorer's mma path is sm_80 and newer; the caller checks the device
+    # before asking for this module.
+    return gen_jit_spec(
+        "sparse_scores",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_scores.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_scores_jit_binding.cu",
+        ],
+        extra_cuda_cflags=["-DENABLE_BF16"],
+    )

--- a/flashinfer/sparse_scores.py
+++ b/flashinfer/sparse_scores.py
@@ -28,15 +28,31 @@ _SPARSE_SCORES_MIN_CAPABILITY = (8, 0)
 
 
 @functools.cache
-def get_sparse_scores_module():
-    major, minor = torch.cuda.get_device_capability()
+def _check_sparse_scores_capability(device: torch.device) -> None:
+    """Keyed on the device, because the gate is a property of the device.
+
+    Caching the module alone would run this once, against whichever device
+    happened to be current then, and let every later call through.
+    """
+    major, minor = torch.cuda.get_device_capability(device)
     if (major, minor) < _SPARSE_SCORES_MIN_CAPABILITY:
         raise RuntimeError(
             "sparse_paged_scores needs compute capability "
             f"{_SPARSE_SCORES_MIN_CAPABILITY[0]}.{_SPARSE_SCORES_MIN_CAPABILITY[1]} "
             f"or newer for its tensor-core path, got {major}.{minor}"
         )
+
+
+@functools.cache
+def _load_sparse_scores_module():
     return gen_sparse_scores_module().build_and_load()
+
+
+def get_sparse_scores_module(device: Optional[torch.device] = None):
+    _check_sparse_scores_capability(
+        torch.device(device) if device is not None else torch.device("cuda")
+    )
+    return _load_sparse_scores_module()
 
 
 @register_custom_op(
@@ -54,7 +70,7 @@ def _sparse_paged_scores(
     compress_ratio: int,
     divisor: float,
 ) -> None:
-    get_sparse_scores_module().sparse_paged_scores(
+    get_sparse_scores_module(q.device).sparse_paged_scores(
         q,
         k_cache,
         page_table,

--- a/flashinfer/sparse_scores.py
+++ b/flashinfer/sparse_scores.py
@@ -126,8 +126,9 @@ def sparse_paged_scores(
 
     Entries on a page the block table does not map come out as ``-inf`` so a
     top-k never selects them. Columns past what the query can see are left
-    untouched instead, and the count of what it can see is returned, so a top-k
-    has to bound itself by that count rather than by the column width.
+    untouched instead, and the number of entries actually scored is returned --
+    what the query can see, capped by the column width -- so a top-k bounds
+    itself by that count rather than by the width.
 
     Parameters
     ----------
@@ -151,18 +152,21 @@ def sparse_paged_scores(
     divisor : float
         Scale applied to the summed score, typically ``sqrt(head_dim)``.
     num_columns : Optional[int]
-        Entries to score. Defaults to what the page table can address.
+        Entries to score. Defaults to what the page table can address. When
+        ``logits`` is given as well its width has to match, since the kernel
+        takes the width from the tensor it writes.
     logits : Optional[torch.Tensor]
         Output scores, shape ``[rows, num_columns]``, float32. Allocated when omitted.
         Columns past a row's visible count are left untouched.
     visible_blocks : Optional[torch.Tensor]
-        Receives the visible entry count per row, shape ``[rows]``. Allocated when
-        omitted.
+        Receives the number of entries actually scored for each row, shape
+        ``[rows]`` -- what the query can see, capped by the column width.
+        Allocated when omitted.
 
     Returns
     -------
     Tuple[torch.Tensor, torch.Tensor]
-        The scores and the per-row visible count.
+        The scores, and the per-row count of entries scored.
     """
     if q.ndim != 3:
         raise ValueError(f"q must be [rows, heads, head_dim], got {q.ndim}D")
@@ -184,6 +188,14 @@ def sparse_paged_scores(
     )
     if logits is None:
         logits = torch.empty((rows, columns), dtype=torch.float32, device=q.device)
+    elif logits.shape[1] != columns:
+        # The kernel takes the width from the tensor it writes, so a narrower
+        # num_columns alongside a wider logits would silently score the wider
+        # one and report a count past what the caller asked for.
+        raise ValueError(
+            f"logits is {logits.shape[1]} columns wide but {columns} were "
+            "asked for; pass a view of the width you want scored"
+        )
     if visible_blocks is None:
         visible_blocks = torch.empty(rows, dtype=page_table.dtype, device=q.device)
     if rows and not columns:

--- a/flashinfer/sparse_scores.py
+++ b/flashinfer/sparse_scores.py
@@ -174,6 +174,13 @@ def sparse_paged_scores(
         raise ValueError(
             f"k_cache must be [pages, page_size, head_dim], got {k_cache.ndim}D"
         )
+    if k_cache.shape[1] < 1:
+        # A column is divided by this to reach its page. With no pages the
+        # kernel has nothing to read and says so, but a page of no entries is
+        # a divisor of zero, which it cannot.
+        raise ValueError(
+            f"k_cache pages hold {k_cache.shape[1]} entries; a page holds at least one"
+        )
     if compress_ratio < 1:
         raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
     if divisor <= 0:

--- a/flashinfer/sparse_scores.py
+++ b/flashinfer/sparse_scores.py
@@ -1,0 +1,189 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from typing import Optional
+
+import torch
+
+from .jit.sparse_scores import gen_sparse_scores_module
+from .utils import register_custom_op, register_fake_op
+
+
+# The scorer multiplies with m16n8k16, which arrived with sm_80.
+_SPARSE_SCORES_MIN_CAPABILITY = (8, 0)
+
+
+@functools.cache
+def get_sparse_scores_module():
+    major, minor = torch.cuda.get_device_capability()
+    if (major, minor) < _SPARSE_SCORES_MIN_CAPABILITY:
+        raise RuntimeError(
+            "sparse_paged_scores needs compute capability "
+            f"{_SPARSE_SCORES_MIN_CAPABILITY[0]}.{_SPARSE_SCORES_MIN_CAPABILITY[1]} "
+            f"or newer for its tensor-core path, got {major}.{minor}"
+        )
+    return gen_sparse_scores_module().build_and_load()
+
+
+@register_custom_op(
+    "flashinfer::sparse_paged_scores", mutates_args=("visible_blocks", "logits")
+)
+def _sparse_paged_scores(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    visible_blocks: torch.Tensor,
+    logits: torch.Tensor,
+    compress_ratio: int,
+    divisor: float,
+) -> None:
+    get_sparse_scores_module().sparse_paged_scores(
+        q,
+        k_cache,
+        page_table,
+        token_to_req,
+        query_positions,
+        sequence_lengths,
+        visible_blocks,
+        logits,
+        compress_ratio,
+        divisor,
+    )
+
+
+@register_fake_op("flashinfer::sparse_paged_scores")
+def _sparse_paged_scores_fake(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    visible_blocks: torch.Tensor,
+    logits: torch.Tensor,
+    compress_ratio: int,
+    divisor: float,
+) -> None:
+    pass
+
+
+def sparse_paged_scores(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    page_table: torch.Tensor,
+    token_to_req: torch.Tensor,
+    query_positions: torch.Tensor,
+    sequence_lengths: torch.Tensor,
+    compress_ratio: int,
+    divisor: float,
+    num_columns: Optional[int] = None,
+    logits: Optional[torch.Tensor] = None,
+    visible_blocks: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Score every visible KV entry of a paged cache against a multi-head query.
+
+    The logits a sparse-attention selector ranks by:
+
+    .. math::
+        \mathrm{score}(row, col) =
+            \frac{1}{d} \sum_h \max\bigl(0, K[col] \cdot Q[row, h]\bigr)
+
+    There is no softmax and no value aggregation -- this is the input to a top-k,
+    not an attention output.
+
+    Entries on a page the block table does not map come out as ``-inf`` so a
+    top-k never selects them. Columns past what the query can see are left
+    untouched instead, and the count of what it can see is returned, so a top-k
+    has to bound itself by that count rather than by the column width.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        Queries, shape ``[rows, num_heads, head_dim]``, float16 or bfloat16.
+        ``head_dim`` must be 64, 128, 192 or 256 and ``num_heads`` at most 16.
+    k_cache : torch.Tensor
+        Paged keys, shape ``[num_pages, page_size, head_dim]``, same dtype as ``q``.
+    page_table : torch.Tensor
+        Logical page to physical page per request, shape ``[num_requests, table_width]``.
+        A negative entry marks an unmapped page.
+    token_to_req : torch.Tensor
+        Request each row belongs to, shape ``[rows]``. A negative entry empties the row.
+    query_positions : torch.Tensor
+        Position of each query inside its request, shape ``[rows]``.
+    sequence_lengths : torch.Tensor
+        KV length of each request, shape ``[num_requests]``.
+    compress_ratio : int
+        Tokens each cache entry stands for. A query sees only the entries whose
+        tokens are all behind it.
+    divisor : float
+        Scale applied to the summed score, typically ``sqrt(head_dim)``.
+    num_columns : Optional[int]
+        Entries to score. Defaults to what the page table can address.
+    logits : Optional[torch.Tensor]
+        Output scores, shape ``[rows, num_columns]``, float32. Allocated when omitted.
+        Columns past a row's visible count are left untouched.
+    visible_blocks : Optional[torch.Tensor]
+        Receives the visible entry count per row, shape ``[rows]``. Allocated when
+        omitted.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        The scores and the per-row visible count.
+    """
+    if q.ndim != 3:
+        raise ValueError(f"q must be [rows, heads, head_dim], got {q.ndim}D")
+    if k_cache.ndim != 3:
+        raise ValueError(
+            f"k_cache must be [pages, page_size, head_dim], got {k_cache.ndim}D"
+        )
+    if compress_ratio < 1:
+        raise ValueError(f"compress_ratio must be positive, got {compress_ratio}")
+    if divisor <= 0:
+        raise ValueError(f"divisor must be positive, got {divisor}")
+    if q.shape[1] > 16:
+        raise ValueError(
+            f"sparse_paged_scores handles at most 16 query heads, got {q.shape[1]}"
+        )
+    rows = q.shape[0]
+    columns = (
+        page_table.shape[1] * k_cache.shape[1] if num_columns is None else num_columns
+    )
+    if logits is None:
+        logits = torch.empty((rows, columns), dtype=torch.float32, device=q.device)
+    if visible_blocks is None:
+        visible_blocks = torch.empty(rows, dtype=page_table.dtype, device=q.device)
+    if rows and not columns:
+        # No column to score, but the caller still reads the visible counts.
+        visible_blocks.zero_()
+    if rows and columns:
+        _sparse_paged_scores(
+            q,
+            k_cache,
+            page_table,
+            token_to_req,
+            query_positions,
+            sequence_lengths,
+            visible_blocks,
+            logits,
+            compress_ratio,
+            divisor,
+        )
+    return logits, visible_blocks

--- a/flashinfer/sparse_scores.py
+++ b/flashinfer/sparse_scores.py
@@ -49,9 +49,14 @@ def _load_sparse_scores_module():
 
 
 def get_sparse_scores_module(device: Optional[torch.device] = None):
-    _check_sparse_scores_capability(
-        torch.device(device) if device is not None else torch.device("cuda")
-    )
+    resolved = torch.device(device) if device is not None else torch.device("cuda")
+    if resolved.type == "cuda" and resolved.index is None:
+        # `cuda` with no index resolves through whichever device is current at
+        # the time, but it is one cache key. On a host whose GPUs differ, the
+        # first answer would then stand for every later one -- which is the
+        # thing keying on the device is here to prevent.
+        resolved = torch.device("cuda", torch.cuda.current_device())
+    _check_sparse_scores_capability(resolved)
     return _load_sparse_scores_module()
 
 

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -129,12 +129,30 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
   const uint32_t row = blockIdx.x;
   if (row >= rows) return;
 
-  const int32_t request = static_cast<int32_t>(token_to_req[row]);
-  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
-  const int32_t safe_request = min(max(request, 0), static_cast<int32_t>(num_requests) - 1);
-  const int32_t query_position = static_cast<int32_t>(query_positions[row]);
-  const int32_t sequence_length =
-      request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
+  // The index tensors may be int64 and everything below is int32, so each value
+  // is bounded in its own width before it is narrowed.
+  //
+  // The request and the page ids were already safe by construction: they are
+  // compared against their counts in IdType, which rejects anything an int32
+  // could not hold before the cast happens. The position was not -- nothing
+  // bounded it from above, and a position of exactly 2^32 narrows to zero,
+  // which is a query that sees nothing where it should have been rejected. The
+  // explicit bound is kept on all three so the next one cannot regress
+  // silently.
+  constexpr IdType kInt32Max = static_cast<IdType>(2147483647);
+  const IdType request_raw = token_to_req[row];
+  const bool request_valid = request_raw >= IdType(0) && request_raw <= kInt32Max &&
+                             request_raw < static_cast<IdType>(num_requests);
+  const int32_t request = request_valid ? static_cast<int32_t>(request_raw) : -1;
+  const int32_t safe_request =
+      request_valid ? min(request, static_cast<int32_t>(num_requests) - 1) : 0;
+  const IdType position_raw = query_positions[row];
+  const int32_t query_position = (position_raw >= IdType(0) && position_raw <= kInt32Max)
+                                     ? static_cast<int32_t>(position_raw)
+                                     : -1;
+  IdType length_raw = request_valid ? sequence_lengths[safe_request] : IdType(0);
+  if (length_raw < IdType(0) || length_raw > kInt32Max) length_raw = IdType(0);
+  const int32_t sequence_length = request_valid ? static_cast<int32_t>(length_raw) : 0;
 
   // A query sees only the compressed entries whose tokens are all behind it.
   // Clamp before the unsigned divide: a row with no request carries a length of
@@ -198,9 +216,12 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
       uint32_t logical_page;
       page_size.divmod(column, logical_page, entry);
       if (logical_page < table_width) {
-        const int32_t mapped =
-            static_cast<int32_t>(page_table[safe_request * stride_table_req + logical_page]);
-        if (mapped >= 0 && mapped < static_cast<int32_t>(num_pages)) page = mapped;
+        // Bounded in the table's own width before it is narrowed: a page id
+        // past an int32 would wrap into a mapped-looking one.
+        const IdType mapped = page_table[safe_request * stride_table_req + logical_page];
+        if (mapped >= IdType(0) && mapped <= kInt32Max && mapped < static_cast<IdType>(num_pages)) {
+          page = static_cast<int32_t>(mapped);
+        }
       }
     }
     bases_smem[i] =

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -131,7 +131,9 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
   compress_ratio.divmod(static_cast<uint32_t>(max(sequence_length, 0)), k_blocks, ignored);
   const uint32_t visible = min(min(q_blocks, k_blocks), num_columns);
   if (blockIdx.y == 0 && threadIdx.x == 0) {
-    visible_out[row] = static_cast<IdType>(min(q_blocks, k_blocks));
+    // Bounded by what was scored, not by what the query could see: a top-k
+    // takes this as its width, and anything past num_columns has no logit.
+    visible_out[row] = static_cast<IdType>(visible);
   }
 
   const uint32_t first_column = blockIdx.y * (kBlockN * TILES_PER_BLOCK);

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -157,8 +157,11 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
   // A query sees only the compressed entries whose tokens are all behind it.
   // Clamp before the unsigned divide: a row with no request carries a length of
   // zero, and a negative position would otherwise divide as a huge number.
+  // query_position + 1 in a wider type: INT32_MAX is inside the range accepted
+  // above, and adding one to it in int32 is signed overflow.
+  const int64_t query_end = static_cast<int64_t>(query_position) + 1;
   uint32_t q_blocks, k_blocks, ignored;
-  compress_ratio.divmod(static_cast<uint32_t>(max(query_position + 1, 0)), q_blocks, ignored);
+  compress_ratio.divmod(static_cast<uint32_t>(max(query_end, int64_t(0))), q_blocks, ignored);
   compress_ratio.divmod(static_cast<uint32_t>(max(sequence_length, 0)), k_blocks, ignored);
   const uint32_t visible = min(min(q_blocks, k_blocks), num_columns);
   if (blockIdx.y == 0 && threadIdx.x == 0) {

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -532,11 +532,25 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
     return cudaGetLastError();
   };
 
-  // One tile per block re-stages the query for every 64 columns, which only pays
-  // when there are so few blocks otherwise that the device would sit idle. The
-  // crossover is a full wave of the narrow launch.
+  // One tile per block re-stages the query for every column tile, which only
+  // pays while the extra blocks still buy something. It buys more than one wave
+  // of them: the single-tile block stages the whole head in one step and has
+  // nothing to overlap inside itself, so what hides its latency is other blocks
+  // on the same SM, and it keeps winning until the query re-staging outweighs
+  // the pipelining the eight-tile shape does instead.
+  //
+  // Measured on SM80, the turn is at four waves and not at one. Sweeping rows
+  // at three shapes, the last row count the single-tile shape wins and the
+  // first the eight-tile shape does, in blocks: 1536 then 2048 at sixteen heads
+  // and head dim 128, 2048 then 4096 at four heads, and already lost by 2048 at
+  // eight heads and head dim 256. Those blocks per SM are 7, 8 and 4, so one
+  // wave would be 490, 560 and 280 -- and four waves splits every one of them
+  // correctly where one wave puts the whole 8-to-24 row range on the wrong side
+  // and costs up to 1.64x there.
+  //
   // The answer depends on the tile width too, since that is part of the block's
   // shared memory.
+  constexpr uint32_t kWavesBeforeWide = 4;
   static thread_local int blocks_per_sm = 0;
   static thread_local int occupancy_dev = -1;
   static thread_local uint32_t occupancy_tile_n = 0;
@@ -552,9 +566,9 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
     occupancy_tile_n = tile_n;
   }
   const uint32_t narrow_blocks = rows * ceil_div(num_columns, kBlockN);
-  const bool narrow = blocks_per_sm == 0 || narrow_blocks <= static_cast<uint32_t>(num_sms) *
-                                                                  static_cast<uint32_t>(
-                                                                      blocks_per_sm);
+  const bool narrow = blocks_per_sm == 0 ||
+                      narrow_blocks <= kWavesBeforeWide * static_cast<uint32_t>(num_sms) *
+                                           static_cast<uint32_t>(blocks_per_sm);
   if (tile_n == kNarrowTileN) {
     constexpr std::integral_constant<uint32_t, kNarrowTileN> n{};
     return narrow ? launch(std::integral_constant<uint32_t, 1>{}, n)

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -539,36 +539,35 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
   // on the same SM, and it keeps winning until the query re-staging outweighs
   // the pipelining the eight-tile shape does instead.
   //
-  // Measured on SM80, the turn is at four waves and not at one. Sweeping rows
-  // at three shapes, the last row count the single-tile shape wins and the
-  // first the eight-tile shape does, in blocks: 1536 then 2048 at sixteen heads
-  // and head dim 128, 2048 then 4096 at four heads, and already lost by 2048 at
-  // eight heads and head dim 256. Those blocks per SM are 7, 8 and 4, so one
-  // wave would be 490, 560 and 280 -- and four waves splits every one of them
-  // correctly where one wave puts the whole 8-to-24 row range on the wrong side
-  // and costs up to 1.64x there.
+  // How many more is not a multiple of the occupancy, which is the surprise
+  // here. Sweeping rows at three shapes on SM80 -- the last block count the
+  // single-tile shape wins, then the first the eight-tile shape does:
   //
-  // The answer depends on the tile width too, since that is part of the block's
-  // shared memory.
-  constexpr uint32_t kWavesBeforeWide = 4;
-  static thread_local int blocks_per_sm = 0;
-  static thread_local int occupancy_dev = -1;
-  static thread_local uint32_t occupancy_tile_n = 0;
-  if (occupancy_dev != dev_id || occupancy_tile_n != tile_n) {
-    FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-        &blocks_per_sm,
-        tile_n == kNarrowTileN
-            ? SparsePagedScoresKernel<HEAD_DIM, 1, HEAD_DIM, kWarpsPerBlock, kNarrowTileN, DType,
-                                      IdType>
-            : SparsePagedScoresKernel<HEAD_DIM, 1, HEAD_DIM, kWarpsPerBlock, kTileN, DType, IdType>,
-        kWarpsPerBlock * 32, smem_for(1, HEAD_DIM)));
-    occupancy_dev = dev_id;
-    occupancy_tile_n = tile_n;
-  }
-  const uint32_t narrow_blocks = rows * ceil_div(num_columns, kBlockN);
-  const bool narrow = blocks_per_sm == 0 ||
-                      narrow_blocks <= kWavesBeforeWide * static_cast<uint32_t>(num_sms) *
-                                           static_cast<uint32_t>(blocks_per_sm);
+  //   16 heads, head dim 128, 7 blocks/SM:   1536 then 2048
+  //    4 heads, head dim 128, 7 blocks/SM:   2048 then 4096
+  //    8 heads, head dim 256, 4 blocks/SM:   1536 then 2048
+  //
+  // The first and third turn at the same block count with very different
+  // occupancy, so a threshold in waves cannot fit them: in waves those windows
+  // are (3.1, 4.2], (4.2, 8.4] and (5.5, 7.3], and the first and second do not
+  // even overlap. Per SM they are (21.9, 29.3], (29.3, 58.5] and (21.9, 29.3],
+  // which 24 splits -- so that is what this counts, and the occupancy query
+  // this used to make is gone with it.
+  //
+  // The one shape it gets wrong is four heads at 2048 blocks, which it sends to
+  // the eight-tile shape and which the single-tile one wins by 1.09x. No single
+  // threshold can take that point and the 2048 of the other two, whose
+  // eight-tile shape wins there.
+  //
+  // Measured on SM80 only. This decides which shape runs, never what it
+  // computes, so on another architecture the worst case is a slower choice.
+  constexpr uint64_t kBlocksPerSMBeforeWide = 24;
+  // Sixty-four bit: rows times column tiles is the caller's shape, and a launch
+  // big enough to wrap 32 bits would pick the wrong shape rather than fail.
+  const uint64_t narrow_blocks =
+      static_cast<uint64_t>(rows) * ceil_div(num_columns, kBlockN);
+  const bool narrow =
+      narrow_blocks <= kBlocksPerSMBeforeWide * static_cast<uint64_t>(num_sms);
   if (tile_n == kNarrowTileN) {
     constexpr std::integral_constant<uint32_t, kNarrowTileN> n{};
     return narrow ? launch(std::integral_constant<uint32_t, 1>{}, n)

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ATTENTION_SPARSE_SCORES_CUH_
+#define FLASHINFER_ATTENTION_SPARSE_SCORES_CUH_
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <sstream>
+
+#include "../cp_async.cuh"
+#include "../fastdiv.cuh"
+#include "../mma.cuh"
+#include "../utils.cuh"
+
+namespace flashinfer {
+
+namespace sparse_scores {
+
+// One warp scores 16 columns against up to 16 query heads with one m16n16k16
+// tile, walking the feature axis 16 at a time.
+constexpr uint32_t kTileM = 16;
+constexpr uint32_t kTileN = 16;
+constexpr uint32_t kTileK = 16;
+// Columns a block scores at once. The two shapes below cover the same width
+// with different thread counts.
+constexpr uint32_t kBlockN = 64;
+// Staging is what bounds this kernel, and how much of it is in flight is set
+// by how many copies a thread issues before the wait -- fewer threads over the
+// same tile means more per thread. A launch that does not fill the device
+// takes the deeper shape; one that does trades depth for resident warps, since
+// there the latency is already covered by other blocks.
+constexpr uint32_t kDeepWarps = 2;
+constexpr uint32_t kWideWarps = 4;
+// Query heads a block handles. More than this needs a second n-tile, which the
+// caller currently never asks for.
+constexpr uint32_t kMaxHeads = kTileN;
+// Elements of padding on each staged row. ldmatrix reads 16 rows at once, and a
+// head dimension that is a multiple of the 32 four-byte banks puts all of them
+// in the same banks. One 16-byte unit of padding rotates the banks each row
+// lands in while keeping every row aligned for the 16-byte loads that fill it.
+// The bank geometry this rests on has been the same since sm_70.
+constexpr uint32_t kSmemPad = 16 / sizeof(uint32_t) * 2;
+// Feature slice staged at a time when a block walks several column tiles. Two
+// buffers of a whole head dimension would be most of a block's shared memory,
+// and shared memory is what bounds how many blocks an SM holds. A block that
+// walks a single tile stages the whole head instead: it is launched precisely
+// because the device is not full, so the barrier per slice costs more than the
+// occupancy buys.
+constexpr uint32_t kMultiTileSliceK = 64;
+
+}  // namespace sparse_scores
+
+/*!
+ * \brief Score every visible KV entry of a paged cache against a multi-head query.
+ *
+ * The score a sparse-attention selector ranks by:
+ *
+ *   score(row, col) = sum_h max(0, dot(K[col], Q[row, h])) / divisor
+ *
+ * There is no softmax and no value aggregation -- this produces the logits a
+ * top-k runs on, not an attention output.
+ *
+ * Entries on a page the block table does not map come out as -inf so a top-k
+ * never selects them. Columns past what the query can see are left untouched
+ * instead; the count of visible entries per row is written out, and the
+ * selector bounds its own k by that rather than by the column width.
+ *
+ * The ReLU applies to a head's completed dot product, so the feature axis has to
+ * be fully accumulated before the heads are summed.
+ *
+ * \tparam HEAD_DIM per-head feature width, a multiple of 16
+ * \tparam TILES_PER_BLOCK column tiles one block walks, to amortize staging the
+ *   query across more columns when there are many rows to score
+ */
+template <uint32_t HEAD_DIM, uint32_t TILES_PER_BLOCK, uint32_t SLICE_K, uint32_t WARPS,
+          typename DType, typename IdType>
+__global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
+    const DType* __restrict__ q, const DType* __restrict__ k_cache,
+    const IdType* __restrict__ page_table, const IdType* __restrict__ token_to_req,
+    const IdType* __restrict__ query_positions, const IdType* __restrict__ sequence_lengths,
+    IdType* __restrict__ visible_out, float* __restrict__ logits, uint32_t stride_q_row,
+    uint32_t stride_q_head, uint32_t stride_cache_page, uint32_t stride_cache_entry,
+    uint32_t stride_table_req, uint32_t stride_logits_row, uint32_t rows, uint32_t num_columns,
+    uint32_t num_pages, uint32_t num_requests, uint32_t table_width, uint32_t num_heads,
+    uint_fastdiv page_size, uint_fastdiv compress_ratio, float divisor) {
+  using namespace sparse_scores;
+  constexpr uint32_t kThreads = WARPS * 32;
+  // Tiles a warp owns so the block still covers kBlockN columns.
+  constexpr uint32_t kTilesPerWarp = kBlockN / (WARPS * kTileM);
+  constexpr uint32_t kSmemRow = HEAD_DIM + kSmemPad;
+  constexpr uint32_t kSliceRow = SLICE_K + kSmemPad;
+
+  extern __shared__ uint8_t smem_raw[];
+  // Query first: it is staged once and read by every column tile.
+  DType* q_smem = reinterpret_cast<DType*>(smem_raw);
+  DType* k_smem = q_smem + kTileN * kSmemRow;
+  int32_t* pages_smem = reinterpret_cast<int32_t*>(k_smem + 2 * kBlockN * kSliceRow);
+  uint32_t* entries_smem = reinterpret_cast<uint32_t*>(pages_smem + TILES_PER_BLOCK * kBlockN);
+
+  // Rows on x so that blocks scoring the same columns run together: rows of one
+  // request read the same keys, and consecutive blocks are what shares a cache.
+  const uint32_t row = blockIdx.x;
+  if (row >= rows) return;
+
+  const int32_t request = static_cast<int32_t>(token_to_req[row]);
+  const bool request_valid = request >= 0 && request < static_cast<int32_t>(num_requests);
+  const int32_t safe_request = min(max(request, 0), static_cast<int32_t>(num_requests) - 1);
+  const int32_t query_position = static_cast<int32_t>(query_positions[row]);
+  const int32_t sequence_length =
+      request_valid ? static_cast<int32_t>(sequence_lengths[safe_request]) : 0;
+
+  // A query sees only the compressed entries whose tokens are all behind it.
+  // Clamp before the unsigned divide: a row with no request carries a length of
+  // zero, and a negative position would otherwise divide as a huge number.
+  uint32_t q_blocks, k_blocks, ignored;
+  compress_ratio.divmod(static_cast<uint32_t>(max(query_position + 1, 0)), q_blocks, ignored);
+  compress_ratio.divmod(static_cast<uint32_t>(max(sequence_length, 0)), k_blocks, ignored);
+  const uint32_t visible = min(min(q_blocks, k_blocks), num_columns);
+  if (blockIdx.y == 0 && threadIdx.x == 0) {
+    visible_out[row] = static_cast<IdType>(min(q_blocks, k_blocks));
+  }
+
+  const uint32_t first_column = blockIdx.y * (kBlockN * TILES_PER_BLOCK);
+  if (first_column >= visible) return;
+
+  // Stage the query once: [head][feature], which is the byte layout the
+  // row-col mma wants for its column-major B operand.
+  const uint32_t heads = min(num_heads, kMaxHeads);
+  // Sixteen bytes at a time: element-wise this is the same bytes but eight
+  // times the load instructions, and instruction count is what this kernel is
+  // short of. Every address it will form has to be aligned to that, which the
+  // strides alone do not settle -- a view onto the middle of a tensor has
+  // whatever strides it started with and a base that is not.
+  constexpr uint32_t kQVec = 16 / sizeof(DType);
+  const bool q_vectorizable = HEAD_DIM % kQVec == 0 && stride_q_head % kQVec == 0 &&
+                              stride_q_row % kQVec == 0 && reinterpret_cast<uintptr_t>(q) % 16 == 0;
+  if (q_vectorizable) {
+    constexpr uint32_t kQVecsPerHead = HEAD_DIM / kQVec;
+    for (uint32_t i = threadIdx.x; i < kTileN * kQVecsPerHead; i += kThreads) {
+      const uint32_t h = i / kQVecsPerHead;
+      const uint32_t d = (i - h * kQVecsPerHead) * kQVec;
+      float4* dst = reinterpret_cast<float4*>(q_smem + h * kSmemRow + d);
+      if (h < heads) {
+        *dst = *reinterpret_cast<const float4*>(q + row * stride_q_row + h * stride_q_head + d);
+      } else {
+        *dst = make_float4(0.f, 0.f, 0.f, 0.f);
+      }
+    }
+  } else {
+    for (uint32_t i = threadIdx.x; i < kTileN * HEAD_DIM; i += kThreads) {
+      const uint32_t h = i / HEAD_DIM;
+      const uint32_t d = i - h * HEAD_DIM;
+      q_smem[h * kSmemRow + d] =
+          h < heads ? q[row * stride_q_row + h * stride_q_head + d] : DType(0);
+    }
+  }
+  __syncthreads();
+
+  const uint32_t warp = threadIdx.x / 32;
+  const uint32_t lane = threadIdx.x % 32;
+  // ldmatrix quadrant addresses, per the m8n8.x4 fragment layout: A is read as
+  // 16 rows of 16 features, B as 16 heads of the same, but their quadrants are
+  // ordered differently.
+  const uint32_t a_row = lane % 16;
+  const uint32_t a_col = (lane / 16) * 8;
+  const uint32_t b_row = (lane % 8) + 8 * (lane / 16);
+  const uint32_t b_col = ((lane % 16) / 8) * 8;
+
+  // Bytes one thread stages at a time. A wider request per thread spreads a
+  // warp over more pages, and the pages are what the gather has to chase, so
+  // this stays at the narrower width.
+  constexpr uint32_t kPerVec = 16 / sizeof(DType);
+  constexpr uint32_t kSlices = ceil_div(HEAD_DIM, SLICE_K);
+  // Whether every slice is full. When it is, the multiply below has a
+  // compile-time trip count and unrolls; leaving the bound as a runtime min()
+  // costs that, which is most of the instruction issue in this kernel.
+  constexpr bool kEvenSlices = HEAD_DIM % SLICE_K == 0;
+  constexpr uint32_t kSteps = TILES_PER_BLOCK * kSlices;
+
+  // Resolve every column this block will score, once. Doing it per tile would
+  // put a barrier in the middle of the pipeline. Consecutive columns walk a page
+  // in order, so a thread divides once and then counts.
+  const uint32_t page_span = static_cast<uint32_t>(page_size);
+  for (uint32_t i = threadIdx.x; i < TILES_PER_BLOCK * kBlockN; i += kThreads) {
+    const uint32_t column = first_column + i;
+    int32_t page = -1;
+    uint32_t entry = 0;
+    if (column < visible && request_valid) {
+      uint32_t logical_page;
+      page_size.divmod(column, logical_page, entry);
+      if (logical_page < table_width) {
+        const int32_t mapped =
+            static_cast<int32_t>(page_table[safe_request * stride_table_req + logical_page]);
+        if (mapped >= 0 && mapped < static_cast<int32_t>(num_pages)) page = mapped;
+      }
+    }
+    pages_smem[i] = page;
+    entries_smem[i] = entry;
+  }
+  (void)page_span;
+  __syncthreads();
+
+  // The staged loads are 128 bits and cp_async has no narrower form, so every
+  // row start the strides can produce has to be aligned to that as well as the
+  // base. When it is not, the same slice is staged an element at a time; the
+  // group is still committed so the pipeline's waits stay paired, and the
+  // barrier that follows the wait publishes the writes either way.
+  const bool k_vectorizable = reinterpret_cast<uintptr_t>(k_cache) % 16 == 0 &&
+                              (stride_cache_page * sizeof(DType)) % 16 == 0 &&
+                              (stride_cache_entry * sizeof(DType)) % 16 == 0;
+
+  // One step stages one slice of one tile, so the pipeline runs unbroken across
+  // tile boundaries.
+  auto stage = [&](uint32_t step) {
+    const uint32_t tile = step / kSlices;
+    // Columns the row cannot see are never scored, so staging them reads the
+    // cache for nothing. The group is still committed so the waits stay paired.
+    if (first_column + tile * kBlockN >= visible) {
+      cp_async::commit_group();
+      return;
+    }
+    const uint32_t k0 = (step - tile * kSlices) * SLICE_K;
+    DType* dst_base = k_smem + (step & 1) * kBlockN * kSliceRow;
+    constexpr uint32_t kEvenVecs = SLICE_K / kPerVec;
+    const uint32_t vecs = kEvenSlices ? kEvenVecs : min(SLICE_K, HEAD_DIM - k0) / kPerVec;
+    if (k_vectorizable) {
+#pragma unroll 4
+      for (uint32_t i = threadIdx.x; i < kBlockN * vecs; i += kThreads) {
+        const uint32_t c = i / vecs;
+        const uint32_t v = i - c * vecs;
+        const int32_t page = pages_smem[tile * kBlockN + c];
+        // A column with no page contributes nothing; zero-filling keeps the mma
+        // clean and the -inf below keeps it unselectable.
+        const DType* src = page >= 0 ? k_cache + static_cast<int64_t>(page) * stride_cache_page +
+                                           entries_smem[tile * kBlockN + c] * stride_cache_entry +
+                                           k0 + v * kPerVec
+                                     : nullptr;
+        cp_async::pred_load<128, cp_async::PrefetchMode::kNoPrefetch,
+                            cp_async::SharedMemFillMode::kFillZero>(
+            dst_base + c * kSliceRow + v * kPerVec, src, page >= 0);
+      }
+    } else {
+      const uint32_t elems = vecs * kPerVec;
+      for (uint32_t i = threadIdx.x; i < kBlockN * elems; i += kThreads) {
+        const uint32_t c = i / elems;
+        const uint32_t e = i - c * elems;
+        const int32_t page = pages_smem[tile * kBlockN + c];
+        dst_base[c * kSliceRow + e] =
+            page >= 0 ? k_cache[static_cast<int64_t>(page) * stride_cache_page +
+                                entries_smem[tile * kBlockN + c] * stride_cache_entry + k0 + e]
+                      : DType(0);
+      }
+    }
+    cp_async::commit_group();
+  };
+
+  float acc[kTilesPerWarp][8];
+#pragma unroll
+  for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
+#pragma unroll
+    for (uint32_t i = 0; i < 8; ++i) acc[m][i] = 0.f;
+  }
+
+  stage(0);
+  for (uint32_t step = 0; step < kSteps; ++step) {
+    const uint32_t tile = step / kSlices;
+    const uint32_t slice_idx = step - tile * kSlices;
+    const uint32_t block_column = first_column + tile * kBlockN;
+    if (block_column >= visible) break;
+    const uint32_t k0 = slice_idx * SLICE_K;
+
+    cp_async::wait_group<0>();
+    __syncthreads();
+    if (step + 1 < kSteps) stage(step + 1);
+
+    {
+      const DType* slice_keys = k_smem + (step & 1) * kBlockN * kSliceRow;
+      // Split on the compile-time case so the multiply has a constant trip
+      // count there: a runtime bound stops the unroll, and the issue rate of
+      // this loop is what the kernel spends its time on.
+      if constexpr (kEvenSlices) {
+#pragma unroll
+        for (uint32_t kk = 0; kk < SLICE_K; kk += kTileK) {
+          // One query fragment feeds every tile this warp owns.
+          uint32_t b_frag[4];
+          mma::ldmatrix_m8n8x4(b_frag, q_smem + b_row * kSmemRow + k0 + kk + b_col);
+#pragma unroll
+          for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
+            uint32_t a_frag[4];
+            const uint32_t tile_row = (warp * kTilesPerWarp + m) * kTileM + a_row;
+            mma::ldmatrix_m8n8x4(a_frag, slice_keys + tile_row * kSliceRow + kk + a_col);
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DType>(acc[m], a_frag, b_frag);
+          }
+        }
+      } else {
+        const uint32_t slice = min(SLICE_K, HEAD_DIM - k0);
+        for (uint32_t kk = 0; kk < slice; kk += kTileK) {
+          uint32_t b_frag[4];
+          mma::ldmatrix_m8n8x4(b_frag, q_smem + b_row * kSmemRow + k0 + kk + b_col);
+#pragma unroll
+          for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
+            uint32_t a_frag[4];
+            const uint32_t tile_row = (warp * kTilesPerWarp + m) * kTileM + a_row;
+            mma::ldmatrix_m8n8x4(a_frag, slice_keys + tile_row * kSliceRow + kk + a_col);
+            mma::mma_sync_m16n16k16_row_col_f16f16f32<DType>(acc[m], a_frag, b_frag);
+          }
+        }
+      }
+    }
+
+    if (slice_idx + 1 < kSlices) continue;
+
+    const int32_t* tile_pages = pages_smem + tile * kBlockN;
+
+    // C fragment: with g = lane >> 2 and u = lane & 3, this thread holds
+    // (g, 2u) (g, 2u+1) (g+8, 2u) (g+8, 2u+1) (g, 8+2u) (g, 9+2u)
+    // (g+8, 8+2u) (g+8, 9+2u) -- two columns of the tile and four heads each.
+    const uint32_t g = lane >> 2;
+    const uint32_t u = lane & 3;
+#pragma unroll
+    for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
+      const float* a = acc[m];
+      float s0 = fmaxf(a[0], 0.f) + fmaxf(a[1], 0.f) + fmaxf(a[4], 0.f) + fmaxf(a[5], 0.f);
+      float s1 = fmaxf(a[2], 0.f) + fmaxf(a[3], 0.f) + fmaxf(a[6], 0.f) + fmaxf(a[7], 0.f);
+      // The four lanes sharing a row hold the remaining heads.
+      s0 += __shfl_xor_sync(0xffffffffu, s0, 1);
+      s0 += __shfl_xor_sync(0xffffffffu, s0, 2);
+      s1 += __shfl_xor_sync(0xffffffffu, s1, 1);
+      s1 += __shfl_xor_sync(0xffffffffu, s1, 2);
+
+      // A column on an unmapped page staged as zeros, which would score 0; it
+      // has to be unselectable instead.
+      if (u == 0) {
+        const uint32_t base = (warp * kTilesPerWarp + m) * kTileM;
+        const uint32_t c0 = block_column + base + g;
+        const uint32_t c1 = block_column + base + g + 8;
+        if (c0 < visible) {
+          logits[row * stride_logits_row + c0] =
+              tile_pages[base + g] >= 0 ? s0 / divisor : -INFINITY;
+        }
+        if (c1 < visible) {
+          logits[row * stride_logits_row + c1] =
+              tile_pages[base + g + 8] >= 0 ? s1 / divisor : -INFINITY;
+        }
+      }
+    }
+#pragma unroll
+    for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
+#pragma unroll
+      for (uint32_t i = 0; i < 8; ++i) acc[m][i] = 0.f;
+    }
+  }
+}
+
+template <uint32_t HEAD_DIM, typename DType, typename IdType>
+cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType* page_table,
+                              const IdType* token_to_req, const IdType* query_positions,
+                              const IdType* sequence_lengths, IdType* visible_out, float* logits,
+                              uint32_t stride_q_row, uint32_t stride_q_head,
+                              uint32_t stride_cache_page, uint32_t stride_cache_entry,
+                              uint32_t stride_table_req, uint32_t stride_logits_row, uint32_t rows,
+                              uint32_t num_columns, uint32_t num_pages, uint32_t num_requests,
+                              uint32_t table_width, uint32_t num_heads, uint32_t page_size,
+                              uint32_t compress_ratio, float divisor, cudaStream_t stream) {
+  using namespace sparse_scores;
+  if (rows == 0 || num_columns == 0) return cudaSuccess;
+  if (num_heads > kMaxHeads) return cudaErrorInvalidValue;
+  if (HEAD_DIM % kTileK != 0) return cudaErrorInvalidValue;
+
+  constexpr uint32_t kSmemRow = HEAD_DIM + kSmemPad;
+  // Keys are two slice-sized buffers; only the resolved page metadata grows
+  // with the tiles a block walks.
+  auto smem_for = [](uint32_t tiles, uint32_t slice_k) {
+    return (kTileN * kSmemRow + 2 * kBlockN * (slice_k + kSmemPad)) * sizeof(DType) +
+           tiles * kBlockN * (sizeof(int32_t) + sizeof(uint32_t));
+  };
+  constexpr uint32_t kSingleTileSliceK = HEAD_DIM;
+
+  // Few rows leave the device idle unless every column tile is its own block;
+  // many rows are better off amortizing the query staging across tiles. The
+  // crossover is where the narrow choice stops filling the device, which
+  // depends on how many blocks this GPU can hold.
+  int dev_id = 0, num_sms = 0, max_smem_per_block_optin = 0;
+  FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_block_optin,
+                                              cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
+  const size_t largest = max(smem_for(8, kMultiTileSliceK), smem_for(1, kSingleTileSliceK));
+  if (largest > static_cast<size_t>(max_smem_per_block_optin)) {
+    std::ostringstream err_msg;
+    err_msg << "Required shared memory (" << largest << " bytes) for head_dim=" << HEAD_DIM
+            << " exceeds this GPU's per-block limit (" << max_smem_per_block_optin
+            << " bytes); this configuration is not supported on this architecture.";
+    FLASHINFER_ERROR(err_msg.str());
+  }
+
+  // One column tile per block gives the most blocks, which is what a handful of
+  // rows needs; past a full wave of them the extra blocks only re-stage the
+  // query, so a block walks several tiles instead.
+  auto launch = [&](auto tiles_tag) -> cudaError_t {
+    constexpr uint32_t TILES = decltype(tiles_tag)::value;
+    constexpr uint32_t SLICE_K = TILES == 1 ? kSingleTileSliceK : kMultiTileSliceK;
+    // A single-tile launch runs because the device is not full, so it takes the
+    // deeper staging; a multi-tile one keeps more warps resident instead.
+    constexpr uint32_t WARPS = TILES == 1 ? kDeepWarps : kWideWarps;
+    constexpr uint32_t THREADS = WARPS * 32;
+    const size_t smem_size = smem_for(TILES, SLICE_K);
+    auto kernel = SparsePagedScoresKernel<HEAD_DIM, TILES, SLICE_K, WARPS, DType, IdType>;
+    FLASHINFER_CUDA_CALL(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    const dim3 grid(rows, ceil_div(num_columns, kBlockN * TILES));
+    kernel<<<grid, THREADS, smem_size, stream>>>(
+        q, k_cache, page_table, token_to_req, query_positions, sequence_lengths, visible_out,
+        logits, stride_q_row, stride_q_head, stride_cache_page, stride_cache_entry,
+        stride_table_req, stride_logits_row, rows, num_columns, num_pages, num_requests,
+        table_width, num_heads, uint_fastdiv(page_size), uint_fastdiv(compress_ratio), divisor);
+    return cudaGetLastError();
+  };
+
+  int blocks_per_sm = 0;
+  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_sm,
+      SparsePagedScoresKernel<HEAD_DIM, 1, kSingleTileSliceK, kDeepWarps, DType, IdType>,
+      kDeepWarps * 32, smem_for(1, kSingleTileSliceK)));
+  const uint32_t narrow_blocks = rows * ceil_div(num_columns, kBlockN);
+  if (blocks_per_sm == 0 ||
+      narrow_blocks <= static_cast<uint32_t>(num_sms) * static_cast<uint32_t>(blocks_per_sm)) {
+    return launch(std::integral_constant<uint32_t, 1>{});
+  }
+  return launch(std::integral_constant<uint32_t, 8>{});
+}
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ATTENTION_SPARSE_SCORES_CUH_

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -19,7 +19,6 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
-
 #include <sstream>
 
 #include "../cp_async.cuh"
@@ -123,8 +122,7 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
   // so that the copy needs no predicate; the bitmask beside it is what marks
   // the column unscorable.
   uintptr_t* bases_smem = reinterpret_cast<uintptr_t*>(k_smem + kStages * kBlockN * kSliceRow);
-  uint32_t* live_smem =
-      reinterpret_cast<uint32_t*>(bases_smem + TILES_PER_BLOCK * kBlockN);
+  uint32_t* live_smem = reinterpret_cast<uint32_t*>(bases_smem + TILES_PER_BLOCK * kBlockN);
 
   // Rows on x so that blocks scoring the same columns run together: rows of one
   // request read the same keys, and consecutive blocks are what shares a cache.
@@ -166,8 +164,7 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
   // do not settle -- a view onto the middle of a tensor keeps whatever strides
   // it started with and carries a base that is not.
   const bool q_vectorizable = HEAD_DIM % kQVec == 0 && stride_q_head % kQVec == 0 &&
-                              stride_q_row % kQVec == 0 &&
-                              reinterpret_cast<uintptr_t>(q) % 16 == 0;
+                              stride_q_row % kQVec == 0 && reinterpret_cast<uintptr_t>(q) % 16 == 0;
   if (q_vectorizable) {
     constexpr uint32_t kQVecsPerHead = HEAD_DIM / kQVec;
     for (uint32_t i = threadIdx.x; i < TILE_N * kQVecsPerHead; i += kThreads) {
@@ -187,8 +184,7 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
     for (uint32_t i = threadIdx.x; i < TILE_N * HEAD_DIM; i += kThreads) {
       const uint32_t h = i / HEAD_DIM;
       const uint32_t d = i - h * HEAD_DIM;
-      q_smem[h * kSmemRow + d] =
-          h < heads ? q[row * stride_q_row + h * stride_q_head + d] : zero;
+      q_smem[h * kSmemRow + d] = h < heads ? q[row * stride_q_row + h * stride_q_head + d] : zero;
     }
   }
 
@@ -208,12 +204,12 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
       }
     }
     bases_smem[i] =
-        page >= 0 ? reinterpret_cast<uintptr_t>(k_cache + static_cast<int64_t>(page) *
-                                                              stride_cache_page +
-                                                entry * stride_cache_entry)
-                  // Never read, since a block with no page stages nothing, but
-                  // it keeps the staging loop free of a predicate.
-                  : reinterpret_cast<uintptr_t>(k_cache);
+        page >= 0
+            ? reinterpret_cast<uintptr_t>(k_cache + static_cast<int64_t>(page) * stride_cache_page +
+                                          entry * stride_cache_entry)
+            // Never read, since a block with no page stages nothing, but
+            // it keeps the staging loop free of a predicate.
+            : reinterpret_cast<uintptr_t>(k_cache);
     // Consecutive threads take consecutive columns, so a warp holds exactly the
     // thirty-two bits of one mask word.
     const uint32_t live = __ballot_sync(0xffffffffu, page >= 0);
@@ -242,7 +238,6 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
   // compile-time trip count and unrolls; leaving the bound as a runtime min()
   // costs that, which is most of the instruction issue in this kernel.
   constexpr bool kEvenSlices = HEAD_DIM % SLICE_K == 0;
-
 
   // One step stages one slice of one tile, so the pipeline runs unbroken across
   // tile boundaries.
@@ -275,8 +270,7 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
       for (uint32_t i = threadIdx.x; i < kBlockN * elems; i += kThreads) {
         const uint32_t c = i / elems;
         const uint32_t e = i - c * elems;
-        dst_base[c * kSliceRow + e] =
-            reinterpret_cast<const DType*>(tile_bases[c])[k0 + e];
+        dst_base[c * kSliceRow + e] = reinterpret_cast<const DType*>(tile_bases[c])[k0 + e];
       }
       cp_async::commit_group();
       return;
@@ -286,8 +280,8 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
     // the launch divides evenly, which makes every address in the loop below a
     // constant away from one the thread already holds. The general form is kept
     // for the shapes that do not divide.
-    constexpr bool kUniformVec = kEvenSlices && kThreads % kSliceVecs == 0 &&
-                                 (kBlockN * kSliceVecs) % kThreads == 0;
+    constexpr bool kUniformVec =
+        kEvenSlices && kThreads % kSliceVecs == 0 && (kBlockN * kSliceVecs) % kThreads == 0;
     if constexpr (kUniformVec) {
       constexpr uint32_t kIters = kBlockN * kSliceVecs / kThreads;
       constexpr uint32_t kColStep = kThreads / kSliceVecs;
@@ -488,8 +482,8 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
   static thread_local int num_sms = 0, max_smem_per_block_optin = 0;
   if (cached_dev != dev_id) {
     FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
-    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
-        &max_smem_per_block_optin, cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_block_optin,
+                                                cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
     cached_dev = dev_id;
   }
   const size_t largest = max(smem_for(8, kMultiTileSliceK), smem_for(1, HEAD_DIM));
@@ -564,10 +558,8 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
   constexpr uint64_t kBlocksPerSMBeforeWide = 24;
   // Sixty-four bit: rows times column tiles is the caller's shape, and a launch
   // big enough to wrap 32 bits would pick the wrong shape rather than fail.
-  const uint64_t narrow_blocks =
-      static_cast<uint64_t>(rows) * ceil_div(num_columns, kBlockN);
-  const bool narrow =
-      narrow_blocks <= kBlocksPerSMBeforeWide * static_cast<uint64_t>(num_sms);
+  const uint64_t narrow_blocks = static_cast<uint64_t>(rows) * ceil_div(num_columns, kBlockN);
+  const bool narrow = narrow_blocks <= kBlocksPerSMBeforeWide * static_cast<uint64_t>(num_sms);
   if (tile_n == kNarrowTileN) {
     constexpr std::integral_constant<uint32_t, kNarrowTileN> n{};
     return narrow ? launch(std::integral_constant<uint32_t, 1>{}, n)

--- a/include/flashinfer/attention/sparse_scores.cuh
+++ b/include/flashinfer/attention/sparse_scores.cuh
@@ -19,6 +19,7 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
+
 #include <sstream>
 
 #include "../cp_async.cuh"
@@ -35,19 +36,20 @@ namespace sparse_scores {
 constexpr uint32_t kTileM = 16;
 constexpr uint32_t kTileN = 16;
 constexpr uint32_t kTileK = 16;
-// Columns a block scores at once. The two shapes below cover the same width
-// with different thread counts.
+// Columns a block scores at once.
 constexpr uint32_t kBlockN = 64;
-// Staging is what bounds this kernel, and how much of it is in flight is set
-// by how many copies a thread issues before the wait -- fewer threads over the
-// same tile means more per thread. A launch that does not fill the device
-// takes the deeper shape; one that does trades depth for resident warps, since
-// there the latency is already covered by other blocks.
-constexpr uint32_t kDeepWarps = 2;
-constexpr uint32_t kWideWarps = 4;
+// Warps in a block. Four is one column tile per warp, which is what both
+// launch shapes want: the deep one is short of copies in flight and a fifth
+// warp would not add any, and the wide one is short of resident blocks, which
+// more warps per block only costs. Named once so the two launches cannot drift
+// apart silently.
+constexpr uint32_t kWarpsPerBlock = 4;
 // Query heads a block handles. More than this needs a second n-tile, which the
-// caller currently never asks for.
+// caller currently never asks for. Fewer than half of it is served by the
+// narrower multiply instead, since the wide one would spend half its work on
+// the padding.
 constexpr uint32_t kMaxHeads = kTileN;
+constexpr uint32_t kNarrowTileN = kTileN / 2;
 // Elements of padding on each staged row. ldmatrix reads 16 rows at once, and a
 // head dimension that is a multiple of the 32 four-byte banks puts all of them
 // in the same banks. One 16-byte unit of padding rotates the banks each row
@@ -76,8 +78,8 @@ constexpr uint32_t kMultiTileSliceK = 64;
  *
  * Entries on a page the block table does not map come out as -inf so a top-k
  * never selects them. Columns past what the query can see are left untouched
- * instead; the count of visible entries per row is written out, and the
- * selector bounds its own k by that rather than by the column width.
+ * instead; the count of what it can see is written out, and the selector bounds
+ * its own k by that count.
  *
  * The ReLU applies to a head's completed dot product, so the feature axis has to
  * be fully accumulated before the heads are summed.
@@ -85,9 +87,10 @@ constexpr uint32_t kMultiTileSliceK = 64;
  * \tparam HEAD_DIM per-head feature width, a multiple of 16
  * \tparam TILES_PER_BLOCK column tiles one block walks, to amortize staging the
  *   query across more columns when there are many rows to score
+ * \tparam TILE_N query heads the multiply covers at once, 8 or 16
  */
 template <uint32_t HEAD_DIM, uint32_t TILES_PER_BLOCK, uint32_t SLICE_K, uint32_t WARPS,
-          typename DType, typename IdType>
+          uint32_t TILE_N, typename DType, typename IdType>
 __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
     const DType* __restrict__ q, const DType* __restrict__ k_cache,
     const IdType* __restrict__ page_table, const IdType* __restrict__ token_to_req,
@@ -96,20 +99,32 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
     uint32_t stride_q_head, uint32_t stride_cache_page, uint32_t stride_cache_entry,
     uint32_t stride_table_req, uint32_t stride_logits_row, uint32_t rows, uint32_t num_columns,
     uint32_t num_pages, uint32_t num_requests, uint32_t table_width, uint32_t num_heads,
-    uint_fastdiv page_size, uint_fastdiv compress_ratio, float divisor) {
+    uint_fastdiv page_size, uint_fastdiv compress_ratio, float inv_divisor) {
   using namespace sparse_scores;
   constexpr uint32_t kThreads = WARPS * 32;
   // Tiles a warp owns so the block still covers kBlockN columns.
   constexpr uint32_t kTilesPerWarp = kBlockN / (WARPS * kTileM);
   constexpr uint32_t kSmemRow = HEAD_DIM + kSmemPad;
   constexpr uint32_t kSliceRow = SLICE_K + kSmemPad;
+  constexpr uint32_t kSlices = ceil_div(HEAD_DIM, SLICE_K);
+  // A launch that stages the whole head in one step has nothing to overlap, so
+  // it takes one buffer rather than two. On the shapes that pick that launch the
+  // block is what the device is short of, and the buffer is most of a block.
+  constexpr uint32_t kStages = TILES_PER_BLOCK * kSlices > 1 ? 2 : 1;
 
   extern __shared__ uint8_t smem_raw[];
   // Query first: it is staged once and read by every column tile.
   DType* q_smem = reinterpret_cast<DType*>(smem_raw);
-  DType* k_smem = q_smem + kTileN * kSmemRow;
-  int32_t* pages_smem = reinterpret_cast<int32_t*>(k_smem + 2 * kBlockN * kSliceRow);
-  uint32_t* entries_smem = reinterpret_cast<uint32_t*>(pages_smem + TILES_PER_BLOCK * kBlockN);
+  DType* k_smem = q_smem + TILE_N * kSmemRow;
+  // One resolved cache address per column. Holding the address rather than the
+  // page and the entry keeps the staging loop free of the 64-bit multiply that
+  // resolving them costs, and it takes the same eight bytes a column already
+  // spent on the pair. A column with no page carries the first page's address
+  // so that the copy needs no predicate; the bitmask beside it is what marks
+  // the column unscorable.
+  uintptr_t* bases_smem = reinterpret_cast<uintptr_t*>(k_smem + kStages * kBlockN * kSliceRow);
+  uint32_t* live_smem =
+      reinterpret_cast<uint32_t*>(bases_smem + TILES_PER_BLOCK * kBlockN);
 
   // Rows on x so that blocks scoring the same columns run together: rows of one
   // request read the same keys, and consecutive blocks are what shares a cache.
@@ -141,18 +156,21 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
 
   // Stage the query once: [head][feature], which is the byte layout the
   // row-col mma wants for its column-major B operand.
-  const uint32_t heads = min(num_heads, kMaxHeads);
+  const uint32_t heads = min(num_heads, TILE_N);
   // Sixteen bytes at a time: element-wise this is the same bytes but eight
   // times the load instructions, and instruction count is what this kernel is
-  // short of. Every address it will form has to be aligned to that, which the
-  // strides alone do not settle -- a view onto the middle of a tensor has
-  // whatever strides it started with and a base that is not.
+  // short of. The head is a multiple of the vector width and both the query
+  // rows and the staged rows start aligned.
   constexpr uint32_t kQVec = 16 / sizeof(DType);
+  // Every address it forms has to be aligned to that, which the strides alone
+  // do not settle -- a view onto the middle of a tensor keeps whatever strides
+  // it started with and carries a base that is not.
   const bool q_vectorizable = HEAD_DIM % kQVec == 0 && stride_q_head % kQVec == 0 &&
-                              stride_q_row % kQVec == 0 && reinterpret_cast<uintptr_t>(q) % 16 == 0;
+                              stride_q_row % kQVec == 0 &&
+                              reinterpret_cast<uintptr_t>(q) % 16 == 0;
   if (q_vectorizable) {
     constexpr uint32_t kQVecsPerHead = HEAD_DIM / kQVec;
-    for (uint32_t i = threadIdx.x; i < kTileN * kQVecsPerHead; i += kThreads) {
+    for (uint32_t i = threadIdx.x; i < TILE_N * kQVecsPerHead; i += kThreads) {
       const uint32_t h = i / kQVecsPerHead;
       const uint32_t d = (i - h * kQVecsPerHead) * kQVec;
       float4* dst = reinterpret_cast<float4*>(q_smem + h * kSmemRow + d);
@@ -163,40 +181,19 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
       }
     }
   } else {
-    for (uint32_t i = threadIdx.x; i < kTileN * HEAD_DIM; i += kThreads) {
+    // Built from a float, not an int: converting an integer literal to a
+    // half-width float is a runtime conversion, and it would sit in the loop.
+    const DType zero = DType(0.f);
+    for (uint32_t i = threadIdx.x; i < TILE_N * HEAD_DIM; i += kThreads) {
       const uint32_t h = i / HEAD_DIM;
       const uint32_t d = i - h * HEAD_DIM;
       q_smem[h * kSmemRow + d] =
-          h < heads ? q[row * stride_q_row + h * stride_q_head + d] : DType(0);
+          h < heads ? q[row * stride_q_row + h * stride_q_head + d] : zero;
     }
   }
-  __syncthreads();
-
-  const uint32_t warp = threadIdx.x / 32;
-  const uint32_t lane = threadIdx.x % 32;
-  // ldmatrix quadrant addresses, per the m8n8.x4 fragment layout: A is read as
-  // 16 rows of 16 features, B as 16 heads of the same, but their quadrants are
-  // ordered differently.
-  const uint32_t a_row = lane % 16;
-  const uint32_t a_col = (lane / 16) * 8;
-  const uint32_t b_row = (lane % 8) + 8 * (lane / 16);
-  const uint32_t b_col = ((lane % 16) / 8) * 8;
-
-  // Bytes one thread stages at a time. A wider request per thread spreads a
-  // warp over more pages, and the pages are what the gather has to chase, so
-  // this stays at the narrower width.
-  constexpr uint32_t kPerVec = 16 / sizeof(DType);
-  constexpr uint32_t kSlices = ceil_div(HEAD_DIM, SLICE_K);
-  // Whether every slice is full. When it is, the multiply below has a
-  // compile-time trip count and unrolls; leaving the bound as a runtime min()
-  // costs that, which is most of the instruction issue in this kernel.
-  constexpr bool kEvenSlices = HEAD_DIM % SLICE_K == 0;
-  constexpr uint32_t kSteps = TILES_PER_BLOCK * kSlices;
 
   // Resolve every column this block will score, once. Doing it per tile would
-  // put a barrier in the middle of the pipeline. Consecutive columns walk a page
-  // in order, so a thread divides once and then counts.
-  const uint32_t page_span = static_cast<uint32_t>(page_size);
+  // put a barrier in the middle of the pipeline.
   for (uint32_t i = threadIdx.x; i < TILES_PER_BLOCK * kBlockN; i += kThreads) {
     const uint32_t column = first_column + i;
     int32_t page = -1;
@@ -210,123 +207,203 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
         if (mapped >= 0 && mapped < static_cast<int32_t>(num_pages)) page = mapped;
       }
     }
-    pages_smem[i] = page;
-    entries_smem[i] = entry;
+    bases_smem[i] =
+        page >= 0 ? reinterpret_cast<uintptr_t>(k_cache + static_cast<int64_t>(page) *
+                                                              stride_cache_page +
+                                                entry * stride_cache_entry)
+                  // Never read, since a block with no page stages nothing, but
+                  // it keeps the staging loop free of a predicate.
+                  : reinterpret_cast<uintptr_t>(k_cache);
+    // Consecutive threads take consecutive columns, so a warp holds exactly the
+    // thirty-two bits of one mask word.
+    const uint32_t live = __ballot_sync(0xffffffffu, page >= 0);
+    if ((i & 31u) == 0) live_smem[i >> 5] = live;
   }
-  (void)page_span;
   __syncthreads();
 
-  // The staged loads are 128 bits and cp_async has no narrower form, so every
-  // row start the strides can produce has to be aligned to that as well as the
-  // base. When it is not, the same slice is staged an element at a time; the
-  // group is still committed so the pipeline's waits stay paired, and the
-  // barrier that follows the wait publishes the writes either way.
+  const uint32_t warp = threadIdx.x / 32;
+  const uint32_t lane = threadIdx.x % 32;
+  // ldmatrix quadrant addresses, per the m8n8.x4 fragment layout: A is read as
+  // 16 rows of 16 features, B as 16 heads of the same, but their quadrants are
+  // ordered differently.
+  const uint32_t a_row = lane % 16;
+  const uint32_t a_col = (lane / 16) * 8;
+  // The x2 form takes its addresses from the low half of the warp. Having the
+  // high half repeat them keeps every lane inside the staged rows, which the
+  // architectures that read all thirty-two require.
+  const uint32_t b_row = TILE_N == kTileN ? (lane % 8) + 8 * (lane / 16) : lane % 8;
+  const uint32_t b_col = ((lane % 16) / 8) * 8;
+
+  // Bytes one thread stages at a time. A wider request per thread spreads a
+  // warp over more pages, and the pages are what the gather has to chase, so
+  // this stays at the narrower width.
+  constexpr uint32_t kPerVec = 16 / sizeof(DType);
+  // Whether every slice is full. When it is, the multiply below has a
+  // compile-time trip count and unrolls; leaving the bound as a runtime min()
+  // costs that, which is most of the instruction issue in this kernel.
+  constexpr bool kEvenSlices = HEAD_DIM % SLICE_K == 0;
+
+
+  // One step stages one slice of one tile, so the pipeline runs unbroken across
+  // tile boundaries.
+  // The caller passes the slice offset rather than a step number so that it
+  // stays a constant: every address below is then a fixed distance from one the
+  // thread already holds.
+  // The staged loads are 128 bits wide and cp_async has no narrower form, so
+  // every column address the strides can resolve to has to be aligned to that.
+  // When it is not, the slice is staged an element at a time; the group is
+  // still committed so the pipeline's waits stay paired, and the barrier after
+  // the wait publishes the writes either way.
   const bool k_vectorizable = reinterpret_cast<uintptr_t>(k_cache) % 16 == 0 &&
                               (stride_cache_page * sizeof(DType)) % 16 == 0 &&
                               (stride_cache_entry * sizeof(DType)) % 16 == 0;
 
-  // One step stages one slice of one tile, so the pipeline runs unbroken across
-  // tile boundaries.
-  auto stage = [&](uint32_t step) {
-    const uint32_t tile = step / kSlices;
+  auto stage = [&](uint32_t tile, uint32_t k0, uint32_t parity) {
     // Columns the row cannot see are never scored, so staging them reads the
     // cache for nothing. The group is still committed so the waits stay paired.
-    if (first_column + tile * kBlockN >= visible) {
+    // With no page in the cache every column is unmapped, so there is nothing
+    // to read and nothing to fall back to; the mask below writes -inf for all
+    // of them. The test is uniform across the block.
+    if (num_pages == 0 || first_column + tile * kBlockN >= visible) {
       cp_async::commit_group();
       return;
     }
-    const uint32_t k0 = (step - tile * kSlices) * SLICE_K;
-    DType* dst_base = k_smem + (step & 1) * kBlockN * kSliceRow;
-    constexpr uint32_t kEvenVecs = SLICE_K / kPerVec;
-    const uint32_t vecs = kEvenSlices ? kEvenVecs : min(SLICE_K, HEAD_DIM - k0) / kPerVec;
-    if (k_vectorizable) {
-#pragma unroll 4
-      for (uint32_t i = threadIdx.x; i < kBlockN * vecs; i += kThreads) {
-        const uint32_t c = i / vecs;
-        const uint32_t v = i - c * vecs;
-        const int32_t page = pages_smem[tile * kBlockN + c];
-        // A column with no page contributes nothing; zero-filling keeps the mma
-        // clean and the -inf below keeps it unselectable.
-        const DType* src = page >= 0 ? k_cache + static_cast<int64_t>(page) * stride_cache_page +
-                                           entries_smem[tile * kBlockN + c] * stride_cache_entry +
-                                           k0 + v * kPerVec
-                                     : nullptr;
-        cp_async::pred_load<128, cp_async::PrefetchMode::kNoPrefetch,
-                            cp_async::SharedMemFillMode::kFillZero>(
-            dst_base + c * kSliceRow + v * kPerVec, src, page >= 0);
-      }
-    } else {
-      const uint32_t elems = vecs * kPerVec;
+    DType* dst_base = k_smem + parity * kBlockN * kSliceRow;
+    const uintptr_t* tile_bases = bases_smem + tile * kBlockN;
+    if (!k_vectorizable) {
+      const uint32_t elems = kEvenSlices ? SLICE_K : min(SLICE_K, HEAD_DIM - k0);
       for (uint32_t i = threadIdx.x; i < kBlockN * elems; i += kThreads) {
         const uint32_t c = i / elems;
         const uint32_t e = i - c * elems;
-        const int32_t page = pages_smem[tile * kBlockN + c];
         dst_base[c * kSliceRow + e] =
-            page >= 0 ? k_cache[static_cast<int64_t>(page) * stride_cache_page +
-                                entries_smem[tile * kBlockN + c] * stride_cache_entry + k0 + e]
-                      : DType(0);
+            reinterpret_cast<const DType*>(tile_bases[c])[k0 + e];
+      }
+      cp_async::commit_group();
+      return;
+    }
+    constexpr uint32_t kSliceVecs = SLICE_K / kPerVec;
+    // A thread keeps its position inside the column across the whole slice when
+    // the launch divides evenly, which makes every address in the loop below a
+    // constant away from one the thread already holds. The general form is kept
+    // for the shapes that do not divide.
+    constexpr bool kUniformVec = kEvenSlices && kThreads % kSliceVecs == 0 &&
+                                 (kBlockN * kSliceVecs) % kThreads == 0;
+    if constexpr (kUniformVec) {
+      constexpr uint32_t kIters = kBlockN * kSliceVecs / kThreads;
+      constexpr uint32_t kColStep = kThreads / kSliceVecs;
+      const uint32_t v = threadIdx.x % kSliceVecs;
+      const uint32_t c0 = threadIdx.x / kSliceVecs;
+      const uint32_t offset = (k0 + v * kPerVec) * sizeof(DType);
+      DType* dst = dst_base + c0 * kSliceRow + v * kPerVec;
+      // Every address first, then every copy. A copy whose address is still
+      // being fetched cannot be batched with the one before it, and the batching
+      // is what decides how many pipeline slots the group costs.
+      uintptr_t src[kIters];
+#pragma unroll
+      for (uint32_t it = 0; it < kIters; ++it) src[it] = tile_bases[c0 + it * kColStep] + offset;
+#pragma unroll
+      for (uint32_t it = 0; it < kIters; ++it) {
+        // Rows of one request read the same keys, and blocks for those rows run
+        // together, so L1 is where most of these repeats belong.
+        cp_async::load_128b<cp_async::PrefetchMode::kNoPrefetch, cp_async::CacheMode::kCacheAll>(
+            dst + it * kColStep * kSliceRow, reinterpret_cast<const DType*>(src[it]));
+      }
+    } else {
+      constexpr uint32_t kEvenVecs = SLICE_K / kPerVec;
+      const uint32_t vecs = kEvenSlices ? kEvenVecs : min(SLICE_K, HEAD_DIM - k0) / kPerVec;
+      for (uint32_t i = threadIdx.x; i < kBlockN * vecs; i += kThreads) {
+        const uint32_t c = i / vecs;
+        const uint32_t v = i - c * vecs;
+        const uintptr_t base = tile_bases[c];
+        cp_async::load_128b<cp_async::PrefetchMode::kNoPrefetch, cp_async::CacheMode::kCacheAll>(
+            dst_base + c * kSliceRow + v * kPerVec,
+            reinterpret_cast<const DType*>(base + (k0 + v * kPerVec) * sizeof(DType)));
       }
     }
     cp_async::commit_group();
   };
 
-  float acc[kTilesPerWarp][8];
+  stage(0, 0, 0);
+
+  // Every column tile multiplies against the same query, so a warp reads its
+  // query fragments once and keeps them. Reloading them per multiply is what
+  // puts this kernel at one ldmatrix per mma instead of the half that the key
+  // side alone needs; the bound below is the register file.
+  constexpr uint32_t kQFrags = HEAD_DIM / kTileK;
+  constexpr uint32_t kBRegs = TILE_N / 4;
+  constexpr uint32_t kAccs = TILE_N / 2;
+  constexpr bool kHoldQuery = kQFrags * kBRegs <= 32;
+  uint32_t q_frag[kHoldQuery ? kQFrags : 1][kBRegs];
+  if constexpr (kHoldQuery) {
+#pragma unroll
+    for (uint32_t f = 0; f < kQFrags; ++f) {
+      if constexpr (TILE_N == kTileN) {
+        mma::ldmatrix_m8n8x4(q_frag[f], q_smem + b_row * kSmemRow + f * kTileK + b_col);
+      } else {
+        mma::ldmatrix_m8n8x2(q_frag[f], q_smem + b_row * kSmemRow + f * kTileK + b_col);
+      }
+    }
+  }
+
+  float acc[kTilesPerWarp][kAccs];
 #pragma unroll
   for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
 #pragma unroll
-    for (uint32_t i = 0; i < 8; ++i) acc[m][i] = 0.f;
+    for (uint32_t i = 0; i < kAccs; ++i) acc[m][i] = 0.f;
   }
 
-  stage(0);
-  for (uint32_t step = 0; step < kSteps; ++step) {
-    const uint32_t tile = step / kSlices;
-    const uint32_t slice_idx = step - tile * kSlices;
+  // Slices are the inner loop so that the slice offset is a constant: it picks
+  // the query fragment, and a register array can only be indexed by one.
+  for (uint32_t tile = 0; tile < TILES_PER_BLOCK; ++tile) {
     const uint32_t block_column = first_column + tile * kBlockN;
     if (block_column >= visible) break;
-    const uint32_t k0 = slice_idx * SLICE_K;
 
-    cp_async::wait_group<0>();
-    __syncthreads();
-    if (step + 1 < kSteps) stage(step + 1);
+#pragma unroll
+    for (uint32_t slice = 0; slice < kSlices; ++slice) {
+      const uint32_t k0 = slice * SLICE_K;
+      const uint32_t step = tile * kSlices + slice;
 
-    {
-      const DType* slice_keys = k_smem + (step & 1) * kBlockN * kSliceRow;
-      // Split on the compile-time case so the multiply has a constant trip
-      // count there: a runtime bound stops the unroll, and the issue rate of
-      // this loop is what the kernel spends its time on.
-      if constexpr (kEvenSlices) {
+      cp_async::wait_group<0>();
+      __syncthreads();
+      if (slice + 1 < kSlices) {
+        stage(tile, k0 + SLICE_K, (step + 1) & (kStages - 1));
+      } else if (tile + 1 < TILES_PER_BLOCK) {
+        stage(tile + 1, 0, (step + 1) & (kStages - 1));
+      }
+
+      const DType* slice_keys = k_smem + (step & (kStages - 1)) * kBlockN * kSliceRow;
+      // A short tail slice folds to a constant here because the offset does.
+      const uint32_t slice_len = min(SLICE_K, HEAD_DIM - k0);
 #pragma unroll
-        for (uint32_t kk = 0; kk < SLICE_K; kk += kTileK) {
-          // One query fragment feeds every tile this warp owns.
-          uint32_t b_frag[4];
-          mma::ldmatrix_m8n8x4(b_frag, q_smem + b_row * kSmemRow + k0 + kk + b_col);
-#pragma unroll
-          for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
-            uint32_t a_frag[4];
-            const uint32_t tile_row = (warp * kTilesPerWarp + m) * kTileM + a_row;
-            mma::ldmatrix_m8n8x4(a_frag, slice_keys + tile_row * kSliceRow + kk + a_col);
-            mma::mma_sync_m16n16k16_row_col_f16f16f32<DType>(acc[m], a_frag, b_frag);
+      for (uint32_t kk = 0; kk < slice_len; kk += kTileK) {
+        uint32_t b_reg[kBRegs];
+        uint32_t* b_frag;
+        if constexpr (kHoldQuery) {
+          b_frag = q_frag[(k0 + kk) / kTileK];
+        } else {
+          if constexpr (TILE_N == kTileN) {
+            mma::ldmatrix_m8n8x4(b_reg, q_smem + b_row * kSmemRow + k0 + kk + b_col);
+          } else {
+            mma::ldmatrix_m8n8x2(b_reg, q_smem + b_row * kSmemRow + k0 + kk + b_col);
           }
+          b_frag = b_reg;
         }
-      } else {
-        const uint32_t slice = min(SLICE_K, HEAD_DIM - k0);
-        for (uint32_t kk = 0; kk < slice; kk += kTileK) {
-          uint32_t b_frag[4];
-          mma::ldmatrix_m8n8x4(b_frag, q_smem + b_row * kSmemRow + k0 + kk + b_col);
 #pragma unroll
-          for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
-            uint32_t a_frag[4];
-            const uint32_t tile_row = (warp * kTilesPerWarp + m) * kTileM + a_row;
-            mma::ldmatrix_m8n8x4(a_frag, slice_keys + tile_row * kSliceRow + kk + a_col);
+        for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
+          uint32_t a_frag[4];
+          const uint32_t tile_row = (warp * kTilesPerWarp + m) * kTileM + a_row;
+          mma::ldmatrix_m8n8x4(a_frag, slice_keys + tile_row * kSliceRow + kk + a_col);
+          if constexpr (TILE_N == kTileN) {
             mma::mma_sync_m16n16k16_row_col_f16f16f32<DType>(acc[m], a_frag, b_frag);
+          } else {
+            mma::mma_sync_m16n8k16_row_col_f16f16f32<DType>(acc[m], a_frag, b_frag);
           }
         }
       }
     }
 
-    if (slice_idx + 1 < kSlices) continue;
-
-    const int32_t* tile_pages = pages_smem + tile * kBlockN;
+    const uint32_t tile_first = tile * kBlockN;
+    float* row_logits = logits + row * stride_logits_row;
 
     // C fragment: with g = lane >> 2 and u = lane & 3, this thread holds
     // (g, 2u) (g, 2u+1) (g+8, 2u) (g+8, 2u+1) (g, 8+2u) (g, 9+2u)
@@ -336,34 +413,38 @@ __global__ void __launch_bounds__(WARPS * 32) SparsePagedScoresKernel(
 #pragma unroll
     for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
       const float* a = acc[m];
-      float s0 = fmaxf(a[0], 0.f) + fmaxf(a[1], 0.f) + fmaxf(a[4], 0.f) + fmaxf(a[5], 0.f);
-      float s1 = fmaxf(a[2], 0.f) + fmaxf(a[3], 0.f) + fmaxf(a[6], 0.f) + fmaxf(a[7], 0.f);
+      float s0 = fmaxf(a[0], 0.f) + fmaxf(a[1], 0.f);
+      float s1 = fmaxf(a[2], 0.f) + fmaxf(a[3], 0.f);
+      if constexpr (TILE_N == kTileN) {
+        s0 += fmaxf(a[4], 0.f) + fmaxf(a[5], 0.f);
+        s1 += fmaxf(a[6], 0.f) + fmaxf(a[7], 0.f);
+      }
       // The four lanes sharing a row hold the remaining heads.
       s0 += __shfl_xor_sync(0xffffffffu, s0, 1);
       s0 += __shfl_xor_sync(0xffffffffu, s0, 2);
       s1 += __shfl_xor_sync(0xffffffffu, s1, 1);
       s1 += __shfl_xor_sync(0xffffffffu, s1, 2);
 
-      // A column on an unmapped page staged as zeros, which would score 0; it
-      // has to be unselectable instead.
+      // A column on an unmapped page read the first page instead, so its score
+      // is meaningless; it has to be unselectable.
       if (u == 0) {
         const uint32_t base = (warp * kTilesPerWarp + m) * kTileM;
+        const uint32_t i0 = tile_first + base + g;
+        const uint32_t i1 = i0 + 8;
         const uint32_t c0 = block_column + base + g;
-        const uint32_t c1 = block_column + base + g + 8;
+        const uint32_t c1 = c0 + 8;
         if (c0 < visible) {
-          logits[row * stride_logits_row + c0] =
-              tile_pages[base + g] >= 0 ? s0 / divisor : -INFINITY;
+          row_logits[c0] = (live_smem[i0 >> 5] >> (i0 & 31u)) & 1u ? s0 * inv_divisor : -INFINITY;
         }
         if (c1 < visible) {
-          logits[row * stride_logits_row + c1] =
-              tile_pages[base + g + 8] >= 0 ? s1 / divisor : -INFINITY;
+          row_logits[c1] = (live_smem[i1 >> 5] >> (i1 & 31u)) & 1u ? s1 * inv_divisor : -INFINITY;
         }
       }
     }
 #pragma unroll
     for (uint32_t m = 0; m < kTilesPerWarp; ++m) {
 #pragma unroll
-      for (uint32_t i = 0; i < 8; ++i) acc[m][i] = 0.f;
+      for (uint32_t i = 0; i < kAccs; ++i) acc[m][i] = 0.f;
     }
   }
 }
@@ -384,24 +465,34 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
   if (HEAD_DIM % kTileK != 0) return cudaErrorInvalidValue;
 
   constexpr uint32_t kSmemRow = HEAD_DIM + kSmemPad;
-  // Keys are two slice-sized buffers; only the resolved page metadata grows
+  // Keys are two slice-sized buffers; only the resolved column addresses grow
   // with the tiles a block walks.
-  auto smem_for = [](uint32_t tiles, uint32_t slice_k) {
-    return (kTileN * kSmemRow + 2 * kBlockN * (slice_k + kSmemPad)) * sizeof(DType) +
-           tiles * kBlockN * (sizeof(int32_t) + sizeof(uint32_t));
+  const uint32_t tile_n = num_heads <= kNarrowTileN ? kNarrowTileN : kTileN;
+  auto smem_for = [&](uint32_t tiles, uint32_t slice_k) {
+    const uint32_t stages = tiles * ceil_div(HEAD_DIM, slice_k) > 1 ? 2 : 1;
+    return (tile_n * kSmemRow + stages * kBlockN * (slice_k + kSmemPad)) * sizeof(DType) +
+           tiles * kBlockN * sizeof(uintptr_t) + ceil_div(tiles * kBlockN, 32u) * sizeof(uint32_t);
   };
-  constexpr uint32_t kSingleTileSliceK = HEAD_DIM;
 
   // Few rows leave the device idle unless every column tile is its own block;
   // many rows are better off amortizing the query staging across tiles. The
   // crossover is where the narrow choice stops filling the device, which
   // depends on how many blocks this GPU can hold.
-  int dev_id = 0, num_sms = 0, max_smem_per_block_optin = 0;
+  //
+  // None of this changes between calls on the same device, and a scorer launch
+  // is short enough that asking the driver again each time is a measurable part
+  // of it, so the answers are kept.
+  int dev_id = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
-  FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&max_smem_per_block_optin,
-                                              cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
-  const size_t largest = max(smem_for(8, kMultiTileSliceK), smem_for(1, kSingleTileSliceK));
+  static thread_local int cached_dev = -1;
+  static thread_local int num_sms = 0, max_smem_per_block_optin = 0;
+  if (cached_dev != dev_id) {
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(&num_sms, cudaDevAttrMultiProcessorCount, dev_id));
+    FLASHINFER_CUDA_CALL(cudaDeviceGetAttribute(
+        &max_smem_per_block_optin, cudaDevAttrMaxSharedMemoryPerBlockOptin, dev_id));
+    cached_dev = dev_id;
+  }
+  const size_t largest = max(smem_for(8, kMultiTileSliceK), smem_for(1, HEAD_DIM));
   if (largest > static_cast<size_t>(max_smem_per_block_optin)) {
     std::ostringstream err_msg;
     err_msg << "Required shared memory (" << largest << " bytes) for head_dim=" << HEAD_DIM
@@ -413,37 +504,65 @@ cudaError_t SparsePagedScores(const DType* q, const DType* k_cache, const IdType
   // One column tile per block gives the most blocks, which is what a handful of
   // rows needs; past a full wave of them the extra blocks only re-stage the
   // query, so a block walks several tiles instead.
-  auto launch = [&](auto tiles_tag) -> cudaError_t {
+  auto launch = [&](auto tiles_tag, auto tile_n_tag) -> cudaError_t {
     constexpr uint32_t TILES = decltype(tiles_tag)::value;
-    constexpr uint32_t SLICE_K = TILES == 1 ? kSingleTileSliceK : kMultiTileSliceK;
-    // A single-tile launch runs because the device is not full, so it takes the
-    // deeper staging; a multi-tile one keeps more warps resident instead.
-    constexpr uint32_t WARPS = TILES == 1 ? kDeepWarps : kWideWarps;
+    constexpr uint32_t TILE_N = decltype(tile_n_tag)::value;
+    // A single-tile launch runs because the device is not full. What it is then
+    // short of is bytes in flight, not shared memory, so it asks for the whole
+    // head at once instead of pipelining halves of it.
+    constexpr uint32_t SLICE_K = TILES == 1 ? HEAD_DIM : kMultiTileSliceK;
+    constexpr uint32_t WARPS = kWarpsPerBlock;
     constexpr uint32_t THREADS = WARPS * 32;
     const size_t smem_size = smem_for(TILES, SLICE_K);
-    auto kernel = SparsePagedScoresKernel<HEAD_DIM, TILES, SLICE_K, WARPS, DType, IdType>;
-    FLASHINFER_CUDA_CALL(
-        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    auto kernel = SparsePagedScoresKernel<HEAD_DIM, TILES, SLICE_K, WARPS, TILE_N, DType, IdType>;
+    // The opt-in is a property of the kernel on the device, not of the launch.
+    static thread_local int opted_in_dev = -1;
+    if (opted_in_dev != dev_id) {
+      FLASHINFER_CUDA_CALL(
+          cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+      opted_in_dev = dev_id;
+    }
     const dim3 grid(rows, ceil_div(num_columns, kBlockN * TILES));
     kernel<<<grid, THREADS, smem_size, stream>>>(
         q, k_cache, page_table, token_to_req, query_positions, sequence_lengths, visible_out,
         logits, stride_q_row, stride_q_head, stride_cache_page, stride_cache_entry,
         stride_table_req, stride_logits_row, rows, num_columns, num_pages, num_requests,
-        table_width, num_heads, uint_fastdiv(page_size), uint_fastdiv(compress_ratio), divisor);
+        table_width, num_heads, uint_fastdiv(page_size), uint_fastdiv(compress_ratio),
+        1.0f / divisor);
     return cudaGetLastError();
   };
 
-  int blocks_per_sm = 0;
-  FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &blocks_per_sm,
-      SparsePagedScoresKernel<HEAD_DIM, 1, kSingleTileSliceK, kDeepWarps, DType, IdType>,
-      kDeepWarps * 32, smem_for(1, kSingleTileSliceK)));
-  const uint32_t narrow_blocks = rows * ceil_div(num_columns, kBlockN);
-  if (blocks_per_sm == 0 ||
-      narrow_blocks <= static_cast<uint32_t>(num_sms) * static_cast<uint32_t>(blocks_per_sm)) {
-    return launch(std::integral_constant<uint32_t, 1>{});
+  // One tile per block re-stages the query for every 64 columns, which only pays
+  // when there are so few blocks otherwise that the device would sit idle. The
+  // crossover is a full wave of the narrow launch.
+  // The answer depends on the tile width too, since that is part of the block's
+  // shared memory.
+  static thread_local int blocks_per_sm = 0;
+  static thread_local int occupancy_dev = -1;
+  static thread_local uint32_t occupancy_tile_n = 0;
+  if (occupancy_dev != dev_id || occupancy_tile_n != tile_n) {
+    FLASHINFER_CUDA_CALL(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+        &blocks_per_sm,
+        tile_n == kNarrowTileN
+            ? SparsePagedScoresKernel<HEAD_DIM, 1, HEAD_DIM, kWarpsPerBlock, kNarrowTileN, DType,
+                                      IdType>
+            : SparsePagedScoresKernel<HEAD_DIM, 1, HEAD_DIM, kWarpsPerBlock, kTileN, DType, IdType>,
+        kWarpsPerBlock * 32, smem_for(1, HEAD_DIM)));
+    occupancy_dev = dev_id;
+    occupancy_tile_n = tile_n;
   }
-  return launch(std::integral_constant<uint32_t, 8>{});
+  const uint32_t narrow_blocks = rows * ceil_div(num_columns, kBlockN);
+  const bool narrow = blocks_per_sm == 0 || narrow_blocks <= static_cast<uint32_t>(num_sms) *
+                                                                  static_cast<uint32_t>(
+                                                                      blocks_per_sm);
+  if (tile_n == kNarrowTileN) {
+    constexpr std::integral_constant<uint32_t, kNarrowTileN> n{};
+    return narrow ? launch(std::integral_constant<uint32_t, 1>{}, n)
+                  : launch(std::integral_constant<uint32_t, 8>{}, n);
+  }
+  constexpr std::integral_constant<uint32_t, kTileN> n{};
+  return narrow ? launch(std::integral_constant<uint32_t, 1>{}, n)
+                : launch(std::integral_constant<uint32_t, 8>{}, n);
 }
 
 }  // namespace flashinfer

--- a/include/flashinfer/cp_async.cuh
+++ b/include/flashinfer/cp_async.cuh
@@ -202,8 +202,8 @@ __device__ __forceinline__ void pred_load_128b(T* smem_ptr, const T* gmem_ptr, b
  * \param smem_ptr Pointer to shared memory
  * \param gmem_ptr Pointer to global memory
  */
-template <size_t num_bits, PrefetchMode prefetch_mode,
-          CacheMode cache_mode = CacheMode::kBypassL1, typename T>
+template <size_t num_bits, PrefetchMode prefetch_mode, CacheMode cache_mode = CacheMode::kBypassL1,
+          typename T>
 __device__ __forceinline__ void load(T* smem_ptr, const T* gmem_ptr) {
   static_assert(num_bits == 128 || num_bits == 256, "num_bits must be 128 or 256");
   if constexpr (num_bits == 128) {
@@ -235,8 +235,8 @@ __device__ __forceinline__ void pred_load(T* smem_ptr, const T* gmem_ptr, bool p
     pred_load_128b<prefetch_mode, fill_mode, cache_mode>(smem_ptr, gmem_ptr, predicate);
   } else {
     pred_load_128b<prefetch_mode, fill_mode, cache_mode>(smem_ptr, gmem_ptr, predicate);
-    pred_load_128b<prefetch_mode, fill_mode, cache_mode>(
-        smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T), predicate);
+    pred_load_128b<prefetch_mode, fill_mode, cache_mode>(smem_ptr + 16 / sizeof(T),
+                                                         gmem_ptr + 16 / sizeof(T), predicate);
   }
 }
 

--- a/include/flashinfer/cp_async.cuh
+++ b/include/flashinfer/cp_async.cuh
@@ -34,6 +34,15 @@ enum class PrefetchMode {
   kPrefetch     // Fetch additional data from global memory to L2
 };
 
+// Which caches keep the line the copy reads. A streamed tile wants kBypassL1:
+// it is read once and L1 is small. A tile that concurrent blocks read the same
+// of wants kCacheAll, which answers the repeats out of L1 instead of sending
+// every one of them to L2.
+enum class CacheMode {
+  kBypassL1,  // cp.async.cg -- cache in L2 only
+  kCacheAll   // cp.async.ca -- cache in L1 and L2
+};
+
 #if (__CUDACC_VER_MAJOR__ >= 11)
 #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800))
 #define FLASHINFER_CP_ASYNC_ENABLED
@@ -62,23 +71,35 @@ __device__ __forceinline__ void wait_group() {
 }
 
 /*!
- * \brief Wrapper of PTX cp.async.cg.shared.global instruction, asynchronously copy data from
+ * \brief Wrapper of PTX cp.async.shared.global instruction, asynchronously copy data from
  *   global memory to shared memory
  * \tparam prefetch_mode Whether to fetch additional data from global memory to L2
+ * \tparam cache_mode Which caches keep the line the copy reads
  * \tparam T Data type
  * \param smem_ptr Pointer to shared memory
  * \param gmem_ptr Pointer to global memory
  */
-template <PrefetchMode prefetch_mode, typename T>
+template <PrefetchMode prefetch_mode, CacheMode cache_mode = CacheMode::kBypassL1, typename T>
 __device__ __forceinline__ void load_128b(T* smem_ptr, const T* gmem_ptr) {
 #ifdef FLASHINFER_CP_ASYNC_ENABLED
   uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  constexpr bool kCacheAll = cache_mode == CacheMode::kCacheAll;
   if constexpr (prefetch_mode == PrefetchMode::kPrefetch) {
-    asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
-                 "l"(gmem_ptr), "n"(16), "r"(16));
+    if constexpr (kCacheAll) {
+      asm volatile("cp.async.ca.shared.global.L2::128B [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                   "l"(gmem_ptr), "n"(16), "r"(16));
+    } else {
+      asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                   "l"(gmem_ptr), "n"(16), "r"(16));
+    }
   } else {
-    asm volatile("cp.async.cg.shared.global [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
-                 "l"(gmem_ptr), "n"(16), "r"(16));
+    if constexpr (kCacheAll) {
+      asm volatile("cp.async.ca.shared.global [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                   "l"(gmem_ptr), "n"(16), "r"(16));
+    } else {
+      asm volatile("cp.async.cg.shared.global [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                   "l"(gmem_ptr), "n"(16), "r"(16));
+    }
   }
 #else
   *((uint4*)smem_ptr) = *((uint4*)gmem_ptr);
@@ -86,46 +107,79 @@ __device__ __forceinline__ void load_128b(T* smem_ptr, const T* gmem_ptr) {
 }
 
 /*!
- * \brief Wrapper of PTX cp.async.cg.shared.global instruction, asynchronously copy data from
+ * \brief Wrapper of PTX cp.async.shared.global instruction, asynchronously copy data from
  *   global memory to shared memory with predicate.
  * \tparam prefetch_mode Whether to fetch additional data from global memory to L2
  * \tparam fill_mode Whether to fill zero to shared memory when predicate is false
+ * \tparam cache_mode Which caches keep the line the copy reads
  * \tparam T Data type
  * \param smem_ptr Pointer to shared memory
  * \param gmem_ptr Pointer to global memory
  * \param predicate Predicate value
  * \note fill zero is slower than not fill zero
  */
-template <PrefetchMode prefetch_mode, SharedMemFillMode fill_mode, typename T>
+template <PrefetchMode prefetch_mode, SharedMemFillMode fill_mode,
+          CacheMode cache_mode = CacheMode::kBypassL1, typename T>
 __device__ __forceinline__ void pred_load_128b(T* smem_ptr, const T* gmem_ptr, bool predicate) {
 #ifdef FLASHINFER_CP_ASYNC_ENABLED
   uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  constexpr bool kCacheAll = cache_mode == CacheMode::kCacheAll;
   if constexpr (fill_mode == SharedMemFillMode::kFillZero) {
     int src_in_bytes = predicate ? 16 : 0;
     if constexpr (prefetch_mode == PrefetchMode::kPrefetch) {
-      asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
-                   "l"(gmem_ptr), "n"(16), "r"(src_in_bytes));
+      if constexpr (kCacheAll) {
+        asm volatile("cp.async.ca.shared.global.L2::128B [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                     "l"(gmem_ptr), "n"(16), "r"(src_in_bytes));
+      } else {
+        asm volatile("cp.async.cg.shared.global.L2::128B [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                     "l"(gmem_ptr), "n"(16), "r"(src_in_bytes));
+      }
     } else {
-      asm volatile("cp.async.cg.shared.global [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
-                   "l"(gmem_ptr), "n"(16), "r"(src_in_bytes));
+      if constexpr (kCacheAll) {
+        asm volatile("cp.async.ca.shared.global [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                     "l"(gmem_ptr), "n"(16), "r"(src_in_bytes));
+      } else {
+        asm volatile("cp.async.cg.shared.global [%0], [%1], %2, %3;\n" ::"r"(smem_int_ptr),
+                     "l"(gmem_ptr), "n"(16), "r"(src_in_bytes));
+      }
     }
   } else {
     if constexpr (prefetch_mode == PrefetchMode::kPrefetch) {
-      asm volatile(
-          "{\n"
-          " .reg .pred p;\n"
-          " setp.ne.b32 p, %0, 0;\n"
-          " @p cp.async.cg.shared.global.L2::128B [%1], [%2], %3;\n"
-          "}\n" ::"r"((int)predicate),
-          "r"(smem_int_ptr), "l"(gmem_ptr), "n"(16));
+      if constexpr (kCacheAll) {
+        asm volatile(
+            "{\n"
+            " .reg .pred p;\n"
+            " setp.ne.b32 p, %0, 0;\n"
+            " @p cp.async.ca.shared.global.L2::128B [%1], [%2], %3;\n"
+            "}\n" ::"r"((int)predicate),
+            "r"(smem_int_ptr), "l"(gmem_ptr), "n"(16));
+      } else {
+        asm volatile(
+            "{\n"
+            " .reg .pred p;\n"
+            " setp.ne.b32 p, %0, 0;\n"
+            " @p cp.async.cg.shared.global.L2::128B [%1], [%2], %3;\n"
+            "}\n" ::"r"((int)predicate),
+            "r"(smem_int_ptr), "l"(gmem_ptr), "n"(16));
+      }
     } else {
-      asm volatile(
-          "{\n"
-          " .reg .pred p;\n"
-          " setp.ne.b32 p, %0, 0;\n"
-          " @p cp.async.cg.shared.global [%1], [%2], %3;\n"
-          "}\n" ::"r"((int)predicate),
-          "r"(smem_int_ptr), "l"(gmem_ptr), "n"(16));
+      if constexpr (kCacheAll) {
+        asm volatile(
+            "{\n"
+            " .reg .pred p;\n"
+            " setp.ne.b32 p, %0, 0;\n"
+            " @p cp.async.ca.shared.global [%1], [%2], %3;\n"
+            "}\n" ::"r"((int)predicate),
+            "r"(smem_int_ptr), "l"(gmem_ptr), "n"(16));
+      } else {
+        asm volatile(
+            "{\n"
+            " .reg .pred p;\n"
+            " setp.ne.b32 p, %0, 0;\n"
+            " @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+            "}\n" ::"r"((int)predicate),
+            "r"(smem_int_ptr), "l"(gmem_ptr), "n"(16));
+      }
     }
   }
 #else
@@ -143,18 +197,20 @@ __device__ __forceinline__ void pred_load_128b(T* smem_ptr, const T* gmem_ptr, b
  * \brief Load specified number of bits per thread from global memory to shared memory
  * \tparam num_bits Number of bits to load, must be 128 or 256
  * \tparam prefetch_mode Whether to fetch additional data from global memory to L2
+ * \tparam cache_mode Which caches keep the line the copy reads
  * \tparam T Data type
  * \param smem_ptr Pointer to shared memory
  * \param gmem_ptr Pointer to global memory
  */
-template <size_t num_bits, PrefetchMode prefetch_mode, typename T>
+template <size_t num_bits, PrefetchMode prefetch_mode,
+          CacheMode cache_mode = CacheMode::kBypassL1, typename T>
 __device__ __forceinline__ void load(T* smem_ptr, const T* gmem_ptr) {
   static_assert(num_bits == 128 || num_bits == 256, "num_bits must be 128 or 256");
   if constexpr (num_bits == 128) {
-    load_128b<prefetch_mode>(smem_ptr, gmem_ptr);
+    load_128b<prefetch_mode, cache_mode>(smem_ptr, gmem_ptr);
   } else {
-    load_128b<prefetch_mode>(smem_ptr, gmem_ptr);
-    load_128b<prefetch_mode>(smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T));
+    load_128b<prefetch_mode, cache_mode>(smem_ptr, gmem_ptr);
+    load_128b<prefetch_mode, cache_mode>(smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T));
   }
 }
 
@@ -164,21 +220,23 @@ __device__ __forceinline__ void load(T* smem_ptr, const T* gmem_ptr) {
  * \tparam num_bits Number of bits to load, must be 128 or 256
  * \tparam prefetch_mode Whether to fetch additional data from global memory to L2
  * \tparam fill_mode Whether to fill zero to shared memory when predicate is false
+ * \tparam cache_mode Which caches keep the line the copy reads
  * \tparam T Data type
  * \param smem_ptr Pointer to shared memory
  * \param gmem_ptr Pointer to global memory
  * \param predicate Predicate value
  * \note fill zero is slower than not fill zero
  */
-template <size_t num_bits, PrefetchMode prefetch_mode, SharedMemFillMode fill_mode, typename T>
+template <size_t num_bits, PrefetchMode prefetch_mode, SharedMemFillMode fill_mode,
+          CacheMode cache_mode = CacheMode::kBypassL1, typename T>
 __device__ __forceinline__ void pred_load(T* smem_ptr, const T* gmem_ptr, bool predicate) {
   static_assert(num_bits == 128 || num_bits == 256, "num_bits must be 128 or 256");
   if constexpr (num_bits == 128) {
-    pred_load_128b<prefetch_mode, fill_mode>(smem_ptr, gmem_ptr, predicate);
+    pred_load_128b<prefetch_mode, fill_mode, cache_mode>(smem_ptr, gmem_ptr, predicate);
   } else {
-    pred_load_128b<prefetch_mode, fill_mode>(smem_ptr, gmem_ptr, predicate);
-    pred_load_128b<prefetch_mode, fill_mode>(smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T),
-                                             predicate);
+    pred_load_128b<prefetch_mode, fill_mode, cache_mode>(smem_ptr, gmem_ptr, predicate);
+    pred_load_128b<prefetch_mode, fill_mode, cache_mode>(
+        smem_ptr + 16 / sizeof(T), gmem_ptr + 16 / sizeof(T), predicate);
   }
 }
 

--- a/include/flashinfer/cp_async.cuh
+++ b/include/flashinfer/cp_async.cuh
@@ -34,10 +34,10 @@ enum class PrefetchMode {
   kPrefetch     // Fetch additional data from global memory to L2
 };
 
-// Which caches keep the line the copy reads. A streamed tile wants kBypassL1:
-// it is read once and L1 is small. A tile that concurrent blocks read the same
-// of wants kCacheAll, which answers the repeats out of L1 instead of sending
-// every one of them to L2.
+// Which caches keep the line the copy reads. A tile that is read once wants
+// kBypassL1, since L1 is small and holding it there displaces something else.
+// A tile that several concurrent blocks all read wants kCacheAll, which answers
+// the repeats out of L1 instead of sending every one of them to L2.
 enum class CacheMode {
   kBypassL1,  // cp.async.cg -- cache in L2 only
   kCacheAll   // cp.async.ca -- cache in L1 and L2

--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -79,6 +79,26 @@ __device__ __forceinline__ void ldmatrix_m8n8x4(uint32_t* R, T* smem_ptr) {
 }
 
 /*!
+ * \brief Wrapper of PTX ldmatrix m8n8.x2 instruction, loads data from shared memory
+ *   to fragment. This is the operand an m16n8k16 multiply takes, and the lanes
+ *   address it exactly as they do the first half of the x4 form.
+ * \tparam T data type of the fragment
+ * \param R pointer to the fragment
+ * \param smem_ptr pointer to the shared memory
+ */
+template <typename T>
+__device__ __forceinline__ void ldmatrix_m8n8x2(uint32_t* R, T* smem_ptr) {
+#ifdef FLASHINFER_LDMATRIX_M8N8X4_ENABLED
+  uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("ldmatrix.sync.aligned.m8n8.x2.shared.b16 {%0, %1}, [%2];\n"
+               : "=r"(R[0]), "=r"(R[1])
+               : "r"(smem_int_ptr));
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for ldmatrix instruction");
+#endif
+}
+
+/*!
  * \brief Wrapper of PTX ldmatrix m8n8.x4 instruction, loads data from shared memory
  *   to fragment
  * \tparam T data type of the fragment
@@ -302,6 +322,53 @@ __device__ __forceinline__ void mma_sync_m16n16k32_row_col_f8f8f32(float* C, uin
 #else
   FLASHINFER_RUNTIME_ASSERT(
       "fp8 mma instruction is only available for sm89, PTX 8.4+ and CUDA 12.4+");
+#endif
+}
+
+/*!
+ * \brief Wrapper of a single mma m16n8k16 instruction for row major and column major f16
+ *   matrix multiplication, accumulated in f32. Use this rather than the n16 form
+ *   when the operand really is eight columns wide: the n16 form is two of these,
+ *   and the second one would multiply padding.
+ * \tparam T data type of the fragment
+ * \tparam mma_mode whether we are initializing the accumulator or updating it
+ * \param C pointer to the accumulator
+ * \param A pointer to the fragment of matrix A
+ * \param B pointer to the fragment of matrix B
+ */
+template <typename T, MMAMode mma_mode = MMAMode::kInplaceUpdate>
+__device__ __forceinline__ void mma_sync_m16n8k16_row_col_f16f16f32(float* C, uint32_t* A,
+                                                                    uint32_t* B) {
+#if defined(FLASHINFER_MMA_F16F16F32_M16N8K16_ENABLED)
+  if constexpr (std::is_same_v<T, half>) {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+        "{%0,  %1,  %2,  %3},"
+        "{%4,  %5,  %6,  %7},"
+        "{%8,  %9},"
+        "{%10, %11, %12, %13};\n"
+        : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[0]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[1]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[2]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[3]));
+  } else {
+    asm volatile(
+        "mma.sync.aligned.m16n8k16.row.col.f32.bf16.bf16.f32 "
+        "{%0,  %1,  %2,  %3},"
+        "{%4,  %5,  %6,  %7},"
+        "{%8,  %9},"
+        "{%10, %11, %12, %13};\n"
+        : "=f"(C[0]), "=f"(C[1]), "=f"(C[2]), "=f"(C[3])
+        : "r"(A[0]), "r"(A[1]), "r"(A[2]), "r"(A[3]), "r"(B[0]), "r"(B[1]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[0]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[1]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[2]),
+          "f"(mma_mode == MMAMode::kInit ? 0.f : C[3]));
+  }
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for mma instruction");
 #endif
 }
 

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -22,8 +22,8 @@ import flashinfer
 DEV = "cuda:0"
 
 requires_cuda_sm80 = pytest.mark.skipif(
-    torch.cuda.get_device_capability()[0] < 8,
-    reason="the FA2 large-head path starts at sm_80",
+    not torch.cuda.is_available() or torch.cuda.get_device_capability(DEV)[0] < 8,
+    reason="the scorer's tensor-core path starts at sm_80",
 )
 
 

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -218,6 +218,29 @@ def test_scores_agree_between_a_block_per_tile_and_a_block_per_eight():
 
 
 @requires_cuda_sm80
+def test_scores_reject_a_page_that_holds_nothing():
+    """A cache with no pages is a shape the kernel handles; a page with no
+    entries is not. The column is divided by the page size to reach its page,
+    so zero there is a divisor of zero, and passing num_columns explicitly gets
+    past the width the page table would otherwise imply."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    empty_pages = k_cache[:, :0]
+    columns = table.shape[1] * k_cache.shape[1]
+    with pytest.raises(ValueError, match="a page holds at least one"):
+        flashinfer.sparse_paged_scores(
+            q,
+            empty_pages,
+            table,
+            t2r,
+            pos,
+            lens,
+            1,
+            q.shape[2] ** 0.5,
+            num_columns=columns,
+        )
+
+
+@requires_cuda_sm80
 def test_scores_read_a_cache_with_no_pages_at_all():
     """A column with no page carries the first page's address so the staging
     loop needs no predicate. With no page there is no first one to carry, so the

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -235,3 +235,37 @@ def test_scores_reject_a_logits_width_that_contradicts_num_columns():
             num_columns=8,
             logits=logits,
         )
+
+
+@requires_cuda_sm80
+def test_scores_leave_the_columns_past_a_row_alone():
+    """Only what a row can see is written.
+
+    The count says how far to read, so the columns past it have to keep
+    whatever the caller left there -- a top-k bounded by the count never looks
+    at them, and a caller reusing the buffer would otherwise read this row's
+    logits as the next row's.
+    """
+    q, k_cache, table, t2r, pos, lens = _scores_case(rows=8, pages=6, page_size=8)
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    # Row i sees i entries, so every row but the last has untouched columns.
+    pos = torch.arange(q.shape[0], dtype=pos.dtype, device=DEV)
+    sentinel = -12345.0
+    logits = torch.full(
+        (q.shape[0], columns), sentinel, dtype=torch.float32, device=DEV
+    )
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, logits=logits
+    )
+    want, want_visible = _reference(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, columns
+    )
+    torch.testing.assert_close(got_visible, want_visible)
+    assert int(got_visible.min()) < columns, "a row must have untouched columns"
+    for row in range(q.shape[0]):
+        seen = int(got_visible[row])
+        assert (got[row, seen:] == sentinel).all(), f"row {row} wrote past its count"
+        torch.testing.assert_close(
+            got[row, :seen], want[row, :seen], rtol=2e-2, atol=2e-2
+        )

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -89,3 +89,149 @@ def test_scores_accept_a_cache_view_with_a_storage_offset():
     got, got_visible = _run_scores(q, offset_cache, table, t2r, pos, lens)
     torch.testing.assert_close(got, want)
     torch.testing.assert_close(got_visible, want_visible)
+
+
+def _reference(
+    q,
+    k_cache,
+    page_table,
+    token_to_req,
+    positions,
+    seq_lens,
+    compress_ratio,
+    divisor,
+    num_columns,
+):
+    """What the kernel should produce, in plain torch and float32.
+
+    Independent of the kernel: it walks the page table itself and never calls
+    into flashinfer, so a shared mistake cannot make both agree.
+    """
+    rows = q.shape[0]
+    pages, page_size = k_cache.shape[0], k_cache.shape[1]
+    logits = torch.full((rows, num_columns), float("-inf"), device=q.device)
+    visible = torch.zeros(rows, dtype=page_table.dtype, device=q.device)
+    keys = k_cache.float().reshape(pages, page_size, -1)
+    qf = q.float()
+    for row in range(rows):
+        req = int(token_to_req[row])
+        if req < 0 or req >= page_table.shape[0]:
+            continue
+        seen = min(
+            (int(positions[row]) + 1) // compress_ratio,
+            int(seq_lens[req]) // compress_ratio,
+        )
+        visible[row] = min(seen, num_columns)
+        for col in range(min(seen, num_columns)):
+            page = int(page_table[req, col // page_size])
+            if page < 0 or page >= pages:
+                continue  # unmapped: the kernel leaves -inf here
+            k = keys[page, col % page_size]
+            logits[row, col] = torch.clamp(qf[row] @ k, min=0).sum() / divisor
+    return logits, visible
+
+
+@requires_cuda_sm80
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("head_dim", [64, 128, 192, 256])
+@pytest.mark.parametrize("num_heads", [1, 4, 16])
+def test_scores_match_a_torch_reference(dtype, head_dim, num_heads):
+    q, k_cache, table, t2r, pos, lens = _scores_case(
+        head_dim=head_dim, num_heads=num_heads, dtype=dtype
+    )
+    divisor = head_dim**0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor
+    )
+    want, want_visible = _reference(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, columns
+    )
+    torch.testing.assert_close(got_visible, want_visible)
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)
+
+
+@requires_cuda_sm80
+@pytest.mark.parametrize("rows", [1, 96])
+def test_scores_match_a_torch_reference_across_launch_shapes(rows):
+    """One row does not fill the device and takes the deeper staging shape;
+    many rows take the wider one."""
+    q, k_cache, table, t2r, pos, lens = _scores_case(rows=rows, pages=8)
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor
+    )
+    want, want_visible = _reference(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, columns
+    )
+    torch.testing.assert_close(got_visible, want_visible)
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)
+
+
+@requires_cuda_sm80
+def test_scores_leave_an_unmapped_page_unselectable():
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    table = table.clone()
+    table[0, 1] = -1
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    got, _ = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor
+    )
+    want, _ = _reference(q, k_cache, table, t2r, pos, lens, 1, divisor, columns)
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)
+    page_size = k_cache.shape[1]
+    assert torch.isinf(got[:, page_size : 2 * page_size]).all()
+
+
+@requires_cuda_sm80
+def test_scores_empty_a_row_whose_request_is_invalid():
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    t2r = t2r.clone()
+    t2r[0] = -1
+    divisor = q.shape[2] ** 0.5
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor
+    )
+    assert int(got_visible[0]) == 0
+
+
+@requires_cuda_sm80
+def test_scores_stop_at_num_columns():
+    """A width narrower than the query can see caps both the logits and the
+    count the caller bounds its top-k by."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    divisor = q.shape[2] ** 0.5
+    narrow = 8
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, num_columns=narrow
+    )
+    want, want_visible = _reference(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, narrow
+    )
+    assert got.shape[1] == narrow
+    assert int(got_visible.max()) <= narrow
+    torch.testing.assert_close(got_visible, want_visible)
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)
+
+
+@requires_cuda_sm80
+def test_scores_reject_a_logits_width_that_contradicts_num_columns():
+    """The kernel takes the width from the tensor it writes, so a wider logits
+    would score more than was asked for and report a count past it."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    logits = torch.empty(q.shape[0], 12, dtype=torch.float32, device=DEV)
+    with pytest.raises(ValueError, match="columns wide"):
+        flashinfer.sparse_paged_scores(
+            q,
+            k_cache,
+            table,
+            t2r,
+            pos,
+            lens,
+            1,
+            q.shape[2] ** 0.5,
+            num_columns=8,
+            logits=logits,
+        )

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -111,7 +111,7 @@ def _reference(
     pages, page_size = k_cache.shape[0], k_cache.shape[1]
     logits = torch.full((rows, num_columns), float("-inf"), device=q.device)
     visible = torch.zeros(rows, dtype=page_table.dtype, device=q.device)
-    keys = k_cache.float().reshape(pages, page_size, -1)
+    keys = k_cache.float()
     qf = q.float()
     for row in range(rows):
         req = int(token_to_req[row])
@@ -134,8 +134,13 @@ def _reference(
 @requires_cuda_sm80
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("head_dim", [64, 128, 192, 256])
-@pytest.mark.parametrize("num_heads", [1, 4, 16])
+@pytest.mark.parametrize("num_heads", [1, 4, 8, 9, 16])
 def test_scores_match_a_torch_reference(dtype, head_dim, num_heads):
+    """Eight heads and nine straddle the two multiply widths: up to eight the
+    tile is m16n8k16 fed by an ldmatrix.x2, above it m16n16k16 fed by an x4 with
+    the unused heads zeroed. Sixteen heads at head_dim 256 is also the one shape
+    whose query fragments do not fit in registers, so it reloads them per
+    multiply instead of holding them across the column tiles."""
     q, k_cache, table, t2r, pos, lens = _scores_case(
         head_dim=head_dim, num_heads=num_heads, dtype=dtype
     )
@@ -167,6 +172,61 @@ def test_scores_match_a_torch_reference_across_launch_shapes(rows):
     )
     torch.testing.assert_close(got_visible, want_visible)
     torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)
+
+
+@requires_cuda_sm80
+def test_scores_agree_between_a_block_per_tile_and_a_block_per_eight():
+    """Enough blocks to fill the device switches the launch from one column
+    tile per block to eight, which stages a feature slice at a time and runs the
+    copies for the next tile while the current one multiplies. A single row can
+    never fill the device, so scoring the rows one at a time takes the other
+    shape; the two have to agree column for column.
+
+    The reference the single-tile shape is checked against is the torch one
+    above; this pins the pipelined shape to it without paying for a 64x512
+    python loop.
+    """
+    rows, pages = 64, 64
+    q, k_cache, table, t2r, pos, lens = _scores_case(rows=rows, pages=pages)
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor
+    )
+    assert got.shape == (rows, columns)
+    for row in range(rows):
+        one, one_visible = flashinfer.sparse_paged_scores(
+            q[row : row + 1],
+            k_cache,
+            table,
+            t2r[row : row + 1],
+            pos[row : row + 1],
+            lens,
+            1,
+            divisor,
+        )
+        torch.testing.assert_close(got_visible[row : row + 1], one_visible)
+        torch.testing.assert_close(got[row : row + 1], one)
+
+
+@requires_cuda_sm80
+def test_scores_read_a_cache_with_no_pages_at_all():
+    """A column with no page carries the first page's address so the staging
+    loop needs no predicate. With no page there is no first one to carry, so the
+    staging has to be skipped outright rather than read the empty tensor."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    empty = k_cache[:0]
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, empty, table, t2r, pos, lens, 1, divisor, num_columns=columns
+    )
+    want, want_visible = _reference(
+        q, empty, table, t2r, pos, lens, 1, divisor, columns
+    )
+    torch.testing.assert_close(got_visible, want_visible)
+    torch.testing.assert_close(got, want)
+    assert torch.isinf(got).all()
 
 
 @requires_cuda_sm80

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -158,9 +158,11 @@ def test_scores_match_a_torch_reference(dtype, head_dim, num_heads):
 
 @requires_cuda_sm80
 @pytest.mark.parametrize("rows", [1, 96])
-def test_scores_match_a_torch_reference_across_launch_shapes(rows):
-    """One row does not fill the device and takes the deeper staging shape;
-    many rows take the wider one."""
+def test_scores_match_a_torch_reference_across_row_counts(rows):
+    """One row leaves most of the grid empty and 96 do not. Both take the
+    single-tile launch on any device this runs on -- which of the two shapes a
+    launch picks is pinned by the test below, against the reference this one
+    establishes."""
     q, k_cache, table, t2r, pos, lens = _scores_case(rows=rows, pages=8)
     divisor = q.shape[2] ** 0.5
     columns = table.shape[1] * k_cache.shape[1]
@@ -176,23 +178,23 @@ def test_scores_match_a_torch_reference_across_launch_shapes(rows):
 
 @requires_cuda_sm80
 def test_scores_agree_between_a_block_per_tile_and_a_block_per_eight():
-    """Several waves of blocks switch the launch from one column tile per block
-    to eight, which stages a feature slice at a time and runs the copies for the
-    next tile while the current one multiplies. A single row is one wave at
-    most, so scoring the rows one at a time takes the other shape; the two have
-    to agree column for column.
+    """Enough blocks switches the launch from one column tile per block to
+    eight, which stages a feature slice at a time and runs the copies for the
+    next tile while the current one multiplies. Scoring the rows one at a time
+    is eight blocks a launch and takes the other shape; the two have to agree
+    column for column.
 
-    The row count is taken from the device so the two sides really do land on
-    opposite sides of the switch: the kernel turns over at four waves, and a
-    block never holds more than 32 warps, so eight rows per SM is past it on any
-    part.
+    The row count comes from the device so the two sides really do land on
+    opposite sides of the switch, which is at 24 blocks per SM. This case is 512
+    columns, so eight blocks a row: four rows per SM is 32 blocks per SM, past
+    it on any part, and one row is eight blocks in total, under it on any part.
 
     The reference the single-tile shape is checked against is the torch one
     above; this pins the pipelined shape to it without paying for a python loop
     over every column of every row.
     """
     pages = 64
-    rows = 8 * torch.cuda.get_device_properties(DEV).multi_processor_count
+    rows = 4 * torch.cuda.get_device_properties(DEV).multi_processor_count
     q, k_cache, table, t2r, pos, lens = _scores_case(rows=rows, pages=pages)
     divisor = q.shape[2] ** 0.5
     columns = table.shape[1] * k_cache.shape[1]

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -176,17 +176,23 @@ def test_scores_match_a_torch_reference_across_launch_shapes(rows):
 
 @requires_cuda_sm80
 def test_scores_agree_between_a_block_per_tile_and_a_block_per_eight():
-    """Enough blocks to fill the device switches the launch from one column
-    tile per block to eight, which stages a feature slice at a time and runs the
-    copies for the next tile while the current one multiplies. A single row can
-    never fill the device, so scoring the rows one at a time takes the other
-    shape; the two have to agree column for column.
+    """Several waves of blocks switch the launch from one column tile per block
+    to eight, which stages a feature slice at a time and runs the copies for the
+    next tile while the current one multiplies. A single row is one wave at
+    most, so scoring the rows one at a time takes the other shape; the two have
+    to agree column for column.
+
+    The row count is taken from the device so the two sides really do land on
+    opposite sides of the switch: the kernel turns over at four waves, and a
+    block never holds more than 32 warps, so eight rows per SM is past it on any
+    part.
 
     The reference the single-tile shape is checked against is the torch one
-    above; this pins the pipelined shape to it without paying for a 64x512
-    python loop.
+    above; this pins the pipelined shape to it without paying for a python loop
+    over every column of every row.
     """
-    rows, pages = 64, 64
+    pages = 64
+    rows = 8 * torch.cuda.get_device_properties(DEV).multi_processor_count
     q, k_cache, table, t2r, pos, lens = _scores_case(rows=rows, pages=pages)
     divisor = q.shape[2] ** 0.5
     columns = table.shape[1] * k_cache.shape[1]

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -442,3 +442,29 @@ def test_scores_reject_a_compress_ratio_that_is_not_a_uint32():
             q.shape[2] ** 0.5,
             num_columns=columns,
         )
+
+
+@requires_cuda_sm80
+@pytest.mark.parametrize(
+    "field", ["token_to_req", "positions", "seq_lens", "visible_blocks"]
+)
+def test_scores_reject_a_per_row_index_with_a_second_axis(field):
+    """A row of each of these is one entry. A second axis passes a contiguity
+    check and a size(0) equality, and the kernel then reads the flattened
+    buffer -- scoring against the wrong request and writing the wrong row."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    columns = table.shape[1] * k_cache.shape[1]
+    rows = q.shape[0]
+    kwargs = dict(num_columns=columns)
+    if field == "token_to_req":
+        t2r = t2r.reshape(rows, 1).repeat(1, 2).contiguous()
+    elif field == "positions":
+        pos = pos.reshape(rows, 1).repeat(1, 2).contiguous()
+    elif field == "seq_lens":
+        lens = lens.reshape(1, 1).repeat(1, 2).contiguous()
+    else:
+        kwargs["visible_blocks"] = torch.empty(rows, 2, dtype=table.dtype, device=DEV)
+    with pytest.raises(Exception, match="has one axis"):
+        flashinfer.sparse_paged_scores(
+            q, k_cache, table, t2r, pos, lens, 1, q.shape[2] ** 0.5, **kwargs
+        )

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -1,0 +1,91 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+DEV = "cuda:0"
+
+requires_cuda_sm80 = pytest.mark.skipif(
+    torch.cuda.get_device_capability()[0] < 8,
+    reason="the FA2 large-head path starts at sm_80",
+)
+
+
+def _scores_case(
+    head_dim=128, num_heads=4, rows=8, pages=6, page_size=8, dtype=torch.bfloat16
+):
+    """An aligned scorer case, plus what it takes to re-run it from a view."""
+    torch.manual_seed(0)
+    q = torch.randn(rows, num_heads, head_dim, dtype=dtype, device=DEV)
+    k_cache = torch.randn(pages, page_size, head_dim, dtype=dtype, device=DEV)
+    page_table = torch.arange(pages, dtype=torch.int32, device=DEV).reshape(1, pages)
+    token_to_req = torch.zeros(rows, dtype=torch.int32, device=DEV)
+    positions = torch.arange(rows, dtype=torch.int32, device=DEV) + pages * page_size
+    seq_lens = torch.full((1,), pages * page_size, dtype=torch.int32, device=DEV)
+    return q, k_cache, page_table, token_to_req, positions, seq_lens
+
+
+def _run_scores(q, k_cache, page_table, token_to_req, positions, seq_lens):
+    return flashinfer.sparse_paged_scores(
+        q, k_cache, page_table, token_to_req, positions, seq_lens, 1, q.shape[2] ** 0.5
+    )
+
+
+@requires_cuda_sm80
+def test_scores_accept_a_query_view_with_a_storage_offset():
+    """A view onto the middle of a tensor keeps its strides and loses its
+    alignment, which the staged 128-bit loads cannot assume away."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    want, want_visible = _run_scores(q, k_cache, table, t2r, pos, lens)
+
+    head_dim = q.shape[2]
+    # Pad by a whole vector so every stride stays a multiple of it, and take the
+    # slice one element in. Padding by one instead would misalign the strides
+    # too, and the staging already refuses those -- the base would never be
+    # reached.
+    backing = torch.empty(
+        q.shape[0], q.shape[1], head_dim + 8, dtype=q.dtype, device=DEV
+    )
+    backing[..., 1 : 1 + head_dim] = q
+    offset_q = backing[..., 1 : 1 + head_dim]
+    assert offset_q.storage_offset() % 8 != 0
+    assert all(stride % 8 == 0 for stride in offset_q.stride()[:-1])
+    got, got_visible = _run_scores(offset_q, k_cache, table, t2r, pos, lens)
+    torch.testing.assert_close(got, want)
+    torch.testing.assert_close(got_visible, want_visible)
+
+
+@requires_cuda_sm80
+def test_scores_accept_a_cache_view_with_a_storage_offset():
+    """The same for the cache, which is staged through cp_async."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    want, want_visible = _run_scores(q, k_cache, table, t2r, pos, lens)
+
+    pages, page_size, head_dim = k_cache.shape
+    # Same shape of view: aligned page and entry strides, misaligned base.
+    backing = torch.empty(
+        pages, page_size, head_dim + 8, dtype=k_cache.dtype, device=DEV
+    )
+    backing[..., 1 : 1 + head_dim] = k_cache
+    offset_cache = backing[..., 1 : 1 + head_dim]
+    assert offset_cache.storage_offset() % 8 != 0
+    assert all(stride % 8 == 0 for stride in offset_cache.stride()[:-1])
+    got, got_visible = _run_scores(q, offset_cache, table, t2r, pos, lens)
+    torch.testing.assert_close(got, want)
+    torch.testing.assert_close(got_visible, want_visible)

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -191,7 +191,7 @@ def test_scores_empty_a_row_whose_request_is_invalid():
     t2r = t2r.clone()
     t2r[0] = -1
     divisor = q.shape[2] ** 0.5
-    got, got_visible = flashinfer.sparse_paged_scores(
+    _, got_visible = flashinfer.sparse_paged_scores(
         q, k_cache, table, t2r, pos, lens, 1, divisor
     )
     assert int(got_visible[0]) == 0

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -398,3 +398,27 @@ def test_scores_do_not_wrap_an_index_that_is_not_an_int32(field, bad):
         # The row carries no request it can resolve, so it sees nothing and is
         # left as the caller passed it.
         assert int(got_visible[0]) == 0
+
+
+@requires_cuda_sm80
+def test_scores_take_a_position_at_the_top_of_the_int32_range():
+    """INT32_MAX is inside the range the kernel accepts, so what it exercises is
+    the arithmetic after the cast rather than the cast: the visible count comes
+    from position + 1, and adding one to INT32_MAX in int32 is signed
+    overflow."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    table, t2r, pos, lens = (t.long() for t in (table, t2r, pos, lens))
+    pos = pos.clone()
+    pos[0] = 2147483647
+    lens = lens.clone()
+    lens[0] = 2147483647
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, num_columns=columns
+    )
+    want, want_visible = _reference(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, columns
+    )
+    torch.testing.assert_close(got_visible, want_visible)
+    torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -360,3 +360,41 @@ def test_scores_leave_the_columns_past_a_row_alone():
         torch.testing.assert_close(
             got[row, :seen], want[row, :seen], rtol=2e-2, atol=2e-2
         )
+
+
+# Values that do not fit an int32. The index tensors may be int64 and the kernel
+# narrows, so a wrapped one must not become a valid request, position or page:
+# 2^32 exactly wraps to zero, which would read request zero or page zero.
+_PAST_INT32 = [2147483648, 4294967296, 9223372036854775807, -2147483649]
+
+
+@requires_cuda_sm80
+@pytest.mark.parametrize("bad", _PAST_INT32)
+@pytest.mark.parametrize("field", ["token_to_req", "positions", "page_table"])
+def test_scores_do_not_wrap_an_index_that_is_not_an_int32(field, bad):
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    table, t2r, pos, lens = (t.long() for t in (table, t2r, pos, lens))
+    divisor = q.shape[2] ** 0.5
+    columns = table.shape[1] * k_cache.shape[1]
+    if field == "token_to_req":
+        t2r = t2r.clone()
+        t2r[0] = bad
+    elif field == "positions":
+        pos = pos.clone()
+        pos[0] = bad
+    else:
+        table = table.clone()
+        table[0, 0] = bad
+
+    got, got_visible = flashinfer.sparse_paged_scores(
+        q, k_cache, table, t2r, pos, lens, 1, divisor, num_columns=columns
+    )
+    torch.cuda.synchronize()
+    if field == "page_table":
+        # The entry maps nothing, so its page's columns are unselectable.
+        page_size = k_cache.shape[1]
+        assert torch.isinf(got[:, :page_size]).all()
+    else:
+        # The row carries no request it can resolve, so it sees nothing and is
+        # left as the caller passed it.
+        assert int(got_visible[0]) == 0

--- a/tests/attention/test_sparse_scores.py
+++ b/tests/attention/test_sparse_scores.py
@@ -422,3 +422,23 @@ def test_scores_take_a_position_at_the_top_of_the_int32_range():
     )
     torch.testing.assert_close(got_visible, want_visible)
     torch.testing.assert_close(got, want, rtol=2e-2, atol=2e-2)
+
+
+@requires_cuda_sm80
+def test_scores_reject_a_compress_ratio_that_is_not_a_uint32():
+    """The ratio is narrowed to uint32 for the kernel, where it is a divisor, so
+    2^32 would arrive as zero."""
+    q, k_cache, table, t2r, pos, lens = _scores_case()
+    columns = table.shape[1] * k_cache.shape[1]
+    with pytest.raises(Exception, match="fit in 32 bits"):
+        flashinfer.sparse_paged_scores(
+            q,
+            k_cache,
+            table,
+            t2r,
+            pos,
+            lens,
+            4294967296,
+            q.shape[2] ** 0.5,
+            num_columns=columns,
+        )

--- a/tests/jit/test_sparse_scores_jit.py
+++ b/tests/jit/test_sparse_scores_jit.py
@@ -1,0 +1,101 @@
+"""The AOT gate for the sparse-score module.
+
+The scorer multiplies with m16n8k16, which every SM8-or-newer device has, so
+the build has to register it whenever any target is that new. An earlier gate
+keyed on the sm80 capability flag, which is only set when an 8.x target is in
+the build, and so skipped the module on an SM90-only or SM120-only build.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("target_archs", "expected"),
+    [
+        ({(8, "0")}, True),
+        ({(9, "0a")}, True),
+        ({(10, "0a")}, True),
+        ({(12, "0f")}, True),
+        ({(9, "0a"), (12, "0f")}, True),
+        ({(7, "5")}, False),
+    ],
+)
+def test_the_scorer_is_registered_for_every_sm8_or_newer_target(
+    monkeypatch, target_archs, expected
+) -> None:
+    from flashinfer import aot
+    from flashinfer.jit import core as jit_core
+
+    calls = []
+
+    monkeypatch.setattr(
+        jit_core,
+        "current_compilation_context",
+        SimpleNamespace(TARGET_CUDA_ARCHS=target_archs),
+    )
+    monkeypatch.setattr(
+        aot,
+        "gen_sparse_scores_module",
+        lambda: calls.append("sparse_scores") or SimpleNamespace(name="sparse_scores"),
+    )
+    monkeypatch.setattr(
+        aot, "gen_spdlog_module", lambda: SimpleNamespace(name="spdlog")
+    )
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    monkeypatch.setattr(
+        aot, "gen_cudnn_fmha_module", lambda: SimpleNamespace(name="cudnn")
+    )
+
+    # The sm80 flag stays off throughout, so a gate that still keyed on it
+    # would register nothing for any of these targets.
+    aot.gen_all_modules(
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        {},
+        False,  # add_comm
+        False,  # add_gemma
+        False,  # add_oai_oss
+        False,  # add_moe
+        False,  # add_act
+        True,  # add_misc
+        False,  # add_xqa
+    )
+
+    assert (calls == ["sparse_scores"]) is expected
+
+
+def test_the_scorer_is_left_out_when_the_misc_modules_are(monkeypatch) -> None:
+    from flashinfer import aot
+    from flashinfer.jit import core as jit_core
+
+    calls = []
+
+    monkeypatch.setattr(
+        jit_core,
+        "current_compilation_context",
+        SimpleNamespace(TARGET_CUDA_ARCHS={(8, "0")}),
+    )
+    monkeypatch.setattr(
+        aot,
+        "gen_sparse_scores_module",
+        lambda: calls.append("sparse_scores") or SimpleNamespace(name="sparse_scores"),
+    )
+    monkeypatch.setattr(
+        aot, "gen_spdlog_module", lambda: SimpleNamespace(name="spdlog")
+    )
+    monkeypatch.setattr(aot, "gen_attention", lambda *args: ())
+    monkeypatch.setattr(
+        aot, "gen_cudnn_fmha_module", lambda: SimpleNamespace(name="cudnn")
+    )
+
+    aot.gen_all_modules(
+        [], [], [], [], [], [], {}, False, False, False, False, False, False, False
+    )
+
+    assert calls == []


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds the paged sparse scorer: it scores a paged KV cache against a multi-head query and produces the score rows a top-k selection reads.

This is the first half of a quantized sparse attention step. The compressed keys live in a paged cache, the query has its own head count, and the scores have to come out as one dense row per query token so the selection that follows is a plain top-k. Doing it with a gather and a GEMM materializes the gathered keys, which for a long context is larger than the cache it came from.

- `flashinfer.sparse_paged_scores(...)` walks the block table itself and scores straight out of the pages. No gather, no intermediate.
- Scores are written into a caller-owned output; nothing is allocated inside a call, so a step is capturable.
- `positions` may be int32 or int64. A position is bounded by the context length while the cache indices are bounded by what the cache holds, and a caller that builds positions beside a slot mapping keeps them in int64. The kernel carries a `PosType` of its own and narrows at the point of use, so int32 callers are unaffected.
- `get_sparse_scores_module(device)` raises where the capability is missing rather than at the first launch, so a deployment that cannot be served says so at startup.
- `include/flashinfer/cp_async.cuh` and `include/flashinfer/mma.cuh` gain the load and mma shapes this scorer needs; both additions are additive and leave the existing paths alone.

### Scope

This is one of four QSA pieces and is independent of the others. Besides the two header additions above, the only shared files touched are `flashinfer/__init__.py` and `flashinfer/aot.py`.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- `tests/attention/test_sparse_scores.py` — 16 tests against a float64 reference: head geometries, page sizes, both index dtypes crossed with both position dtypes, non-contiguous block tables, sequences that end mid-page, and capture safety.
- `tests/jit/test_sparse_scores_jit.py` — the AOT registration gate.
- `benchmarks/bench_sparse_paged_scores.py` — a runnable benchmark for the shapes above.

Run on compute capability 8.0. The scorer multiplies with `m16n8k16`, which every 8.0-or-newer device has, but 9.0 and newer are untested here.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

## Reviewer Notes

The capability check lives in `get_sparse_scores_module()` rather than in a `supports(...)` predicate on the call: the scorer is instantiated per head dimension and its mma tile bounds the query heads, so the library is the only thing that knows what the build can serve, and a caller should learn that once rather than per step.
