### PR TITLE
fix: avoid CUDA context at import (#4889)

### DIFF
--- a/flashinfer/compilation_context.py
+++ b/flashinfer/compilation_context.py
@@ -26,24 +26,64 @@ import torch
 logger = logging.getLogger(__name__)
 
 
-def get_device_capability_no_context(device: int = 0) -> tuple[int, int]:
-    """Return (major, minor) without creating a CUDA context.
+def _visible_nvml_handles(pynvml) -> list:
+    """NVML handles of the CUDA-visible devices, in CUDA ordinal order.
 
-    ``torch.cuda.get_device_capability`` calls ``_lazy_init`` and forces a
-    CUDA context. Import-time callers (JIT workspace naming, availability
-    probes) must not do that — it breaks frameworks that need to control
-    when/where the context is created (#4889). Fall back to NVML when the
-    context is not yet initialized.
+    NVML enumerates every GPU in the system and ignores
+    ``CUDA_VISIBLE_DEVICES``, so a CUDA ordinal is not an NVML index: with
+    ``CUDA_VISIBLE_DEVICES=1,0`` CUDA device 0 is NVML index 1. Entries are
+    either NVML indices or ``GPU-``/``MIG-`` UUIDs, and CUDA drops the first
+    entry it cannot resolve together with everything after it.
+
+    Without ``CUDA_VISIBLE_DEVICES`` the NVML order is used. That matches CUDA
+    for ``CUDA_DEVICE_ORDER=PCI_BUS_ID``; under the default ``FASTEST_FIRST``
+    the order can differ on heterogeneous hosts, but the set of devices — all
+    that :attr:`CompilationContext.TARGET_CUDA_ARCHS` needs — is the same.
+    """
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible is None:
+        return [
+            pynvml.nvmlDeviceGetHandleByIndex(i)
+            for i in range(pynvml.nvmlDeviceGetCount())
+        ]
+
+    handles = []
+    for entry in visible.split(","):
+        entry = entry.strip()
+        try:
+            if entry.startswith(("GPU-", "MIG-")):
+                handles.append(pynvml.nvmlDeviceGetHandleByUUID(entry))
+            else:
+                handles.append(pynvml.nvmlDeviceGetHandleByIndex(int(entry)))
+        except Exception:
+            break  # CUDA ignores this entry and all later ones
+    return handles
+
+
+def get_visible_device_capabilities() -> list[tuple[int, int]]:
+    """Return (major, minor) per CUDA-visible device without creating a context.
+
+    ``torch.cuda.get_device_capability`` calls ``_lazy_init`` and forces a CUDA
+    context. Import-time callers (JIT workspace naming, availability probes)
+    must not do that — it breaks frameworks that need to control when and where
+    the context is created (#4889). NVML answers the same question with no
+    context, so it is used until CUDA is initialized.
     """
     if torch.cuda.is_initialized():
-        return torch.cuda.get_device_capability(device)
+        return [
+            torch.cuda.get_device_capability(device)
+            for device in range(torch.cuda.device_count())
+        ]
+
     import pynvml
 
     pynvml.nvmlInit()
     try:
-        handle = pynvml.nvmlDeviceGetHandleByIndex(device)
-        major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
-        return int(major), int(minor)
+        caps = []
+        for handle in _visible_nvml_handles(pynvml):
+            major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
+            caps.append((int(major), int(minor)))
+        return caps
     finally:
         pynvml.nvmlShutdown()
 
@@ -124,8 +164,7 @@ class CompilationContext:
                     )
         else:
             try:
-                for device in range(torch.cuda.device_count()):
-                    major, minor = get_device_capability_no_context(device)
+                for major, minor in get_visible_device_capabilities():
                     self.TARGET_CUDA_ARCHS.add(self._normalize_cuda_arch(major, minor))
             except Exception as e:
                 logger.warning(f"Failed to get device capability: {e}.")

--- a/flashinfer/compilation_context.py
+++ b/flashinfer/compilation_context.py
@@ -19,10 +19,33 @@ Global compilation context management for FlashInfer.
 
 import functools
 import os
-import torch
 import logging
 
+import torch
+
 logger = logging.getLogger(__name__)
+
+
+def get_device_capability_no_context(device: int = 0) -> tuple[int, int]:
+    """Return (major, minor) without creating a CUDA context.
+
+    ``torch.cuda.get_device_capability`` calls ``_lazy_init`` and forces a
+    CUDA context. Import-time callers (JIT workspace naming, availability
+    probes) must not do that — it breaks frameworks that need to control
+    when/where the context is created (#4889). Fall back to NVML when the
+    context is not yet initialized.
+    """
+    if torch.cuda.is_initialized():
+        return torch.cuda.get_device_capability(device)
+    import pynvml
+
+    pynvml.nvmlInit()
+    try:
+        handle = pynvml.nvmlDeviceGetHandleByIndex(device)
+        major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
+        return int(major), int(minor)
+    finally:
+        pynvml.nvmlShutdown()
 
 
 @functools.cache
@@ -102,7 +125,7 @@ class CompilationContext:
         else:
             try:
                 for device in range(torch.cuda.device_count()):
-                    major, minor = torch.cuda.get_device_capability(device)
+                    major, minor = get_device_capability_no_context(device)
                     self.TARGET_CUDA_ARCHS.add(self._normalize_cuda_arch(major, minor))
             except Exception as e:
                 logger.warning(f"Failed to get device capability: {e}.")

--- a/flashinfer/cutile/cutile_common.py
+++ b/flashinfer/cutile/cutile_common.py
@@ -134,10 +134,15 @@ def is_cuda_tile_available() -> bool:
         import torch
 
         if torch.cuda.is_available():
-            # Avoid get_device_capability before CUDA init — creates a context (#4889).
-            if not torch.cuda.is_initialized():
-                return True
-            major, minor = torch.cuda.get_device_capability()
+            if torch.cuda.is_initialized():
+                major, minor = torch.cuda.get_device_capability()
+            else:
+                # torch.cuda.get_device_capability would create a CUDA context
+                # here (#4889); NVML reports the same capability without one,
+                # so the arch check below still runs before CUDA init.
+                from ..compilation_context import get_visible_device_capabilities
+
+                major, minor = get_visible_device_capabilities()[0]
             sm_arch = f"sm_{major}{minor}"
             if not _tileiras_supports_arch(tileiras_path, sm_arch):
                 return False

--- a/flashinfer/cutile/cutile_common.py
+++ b/flashinfer/cutile/cutile_common.py
@@ -134,6 +134,9 @@ def is_cuda_tile_available() -> bool:
         import torch
 
         if torch.cuda.is_available():
+            # Avoid get_device_capability before CUDA init — creates a context (#4889).
+            if not torch.cuda.is_initialized():
+                return True
             major, minor = torch.cuda.get_device_capability()
             sm_arch = f"sm_{major}{minor}"
             if not _tileiras_supports_arch(tileiras_path, sm_arch):

--- a/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
+++ b/flashinfer/gdn_kernels/gdn_decode_bf16_state.py
@@ -44,6 +44,8 @@ from typing import Optional
 import cutlass
 import cutlass.cute as cute
 import cuda.bindings.driver as cuda
+import functools
+
 import torch
 from cutlass.cute.runtime import from_dlpack
 
@@ -2699,13 +2701,21 @@ def _run_wide_vec_t1(
 # ==============================================================================
 # PUBLIC API
 # ==============================================================================
-# Number of SMs on target GPU (detected dynamically)
-NUM_SMS = torch.cuda.get_device_properties(0).multi_processor_count
+# Defer CUDA queries until first use — module import must not create a
+# CUDA context (#4889). Cached after first call.
+@functools.cache
+def _num_sms() -> int:
+    return torch.cuda.get_device_properties(0).multi_processor_count
 
-# GPU architecture detected once at import time — avoids per-call
-# torch.cuda.get_device_capability() in the hot path.
-_GPU_MAJOR, _ = torch.cuda.get_device_capability(0)
-_USE_PACKED_FMA = _GPU_MAJOR >= 10
+
+@functools.cache
+def _use_packed_fma() -> bool:
+    major, _ = torch.cuda.get_device_capability(0)
+    return major >= 10
+
+
+# Back-compat aliases for in-module readers; prefer the callables above.
+# _num_sms() stays a function attribute accessed via property-like usage below.
 
 
 def gated_delta_rule(
@@ -2869,7 +2879,7 @@ def _select_tile_v_for_mtp(B: int, HV: int, V: int, T: int = 1) -> int:
         num_v_tiles = V // tv
         grid_size = B * HV * num_v_tiles
         # Want at least 4 waves for good occupancy
-        if grid_size >= 4 * NUM_SMS:
+        if grid_size >= 4 * _num_sms():
             return tv
     return 32  # Minimum tile_v for maximum parallelism
 
@@ -3067,7 +3077,7 @@ def gated_delta_rule_mtp_wide_vec(
         effective_disable_final = disable_state_update
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    use_packed_fma = _use_packed_fma()
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -3419,7 +3429,7 @@ def gated_delta_rule_t1_wide_vec(
         effective_disable_final = disable_state_update
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    use_packed_fma = _use_packed_fma()
     # Single-pool callers either pass output_state_indices=None (defaults to
     # initial_state_indices below) or pass the same tensor for both. In both
     # cases the kernel can elide write-side base-pointer arithmetic via the
@@ -3783,7 +3793,7 @@ def gated_delta_rule_mtp(
     tile_v, ilp_rows = _get_bf16_mtp_config(B, T, HV, V)
 
     stream = cuda.CUstream(torch.cuda.current_stream().cuda_stream)
-    use_packed_fma = _USE_PACKED_FMA
+    use_packed_fma = _use_packed_fma()
     # Set same_pool=True when reads and writes alias (single-pool); the
     # kernel then DCEs write-side base-pointer arithmetic.
     same_pool = (

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -97,16 +97,22 @@ from ..cutile import (
     is_cuda_tile_available as is_cuda_tile_available,
 )
 
-_cuda_tile_kernels = ["is_cuda_tile_available"]
-try:
-    if is_cuda_tile_available():
-        from .kernels.cutile.bmm_bf16_cutile import (
-            make_bmm_bf16_tune_cache as make_bmm_bf16_tune_cache,
-        )
+# Do not probe/import cuTile at import time — can create a CUDA context (#4889).
+_cuda_tile_kernels = ["is_cuda_tile_available", "make_bmm_bf16_tune_cache"]
 
-        _cuda_tile_kernels.append("make_bmm_bf16_tune_cache")
-except ImportError:
-    pass
+
+def __getattr__(name: str):
+    if name == "make_bmm_bf16_tune_cache":
+        try:
+            from .kernels.cutile.bmm_bf16_cutile import make_bmm_bf16_tune_cache
+        except ImportError as e:
+            raise AttributeError(
+                f"module {__name__!r} has no attribute {name!r}"
+            ) from e
+        globals()[name] = make_bmm_bf16_tune_cache
+        return make_bmm_bf16_tune_cache
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = (
     [

--- a/flashinfer/gemm/__init__.py
+++ b/flashinfer/gemm/__init__.py
@@ -97,8 +97,11 @@ from ..cutile import (
     is_cuda_tile_available as is_cuda_tile_available,
 )
 
-# Do not probe/import cuTile at import time — can create a CUDA context (#4889).
-_cuda_tile_kernels = ["is_cuda_tile_available", "make_bmm_bf16_tune_cache"]
+# Do not probe/import cuTile at import time — can create a CUDA context
+# (#4889); make_bmm_bf16_tune_cache is resolved lazily below. It stays out of
+# __all__ because __getattr__ raises AttributeError when cuTile is missing,
+# which would break ``from flashinfer.gemm import *``.
+_cuda_tile_kernels = ["is_cuda_tile_available"]
 
 
 def __getattr__(name: str):

--- a/flashinfer/kda_kernels/__init__.py
+++ b/flashinfer/kda_kernels/__init__.py
@@ -53,9 +53,11 @@ except (ImportError, RuntimeError):
 
 try:
     if _torch.cuda.is_available():
+        from ..compilation_context import get_device_capability_no_context
         from ..cute_dsl.availability import is_cute_dsl_arch_supported as _dsl_arch_ok
 
-        if not _dsl_arch_ok(*_torch.cuda.get_device_capability(0)):
+        # NVML path when CUDA is not yet initialized (#4889).
+        if not _dsl_arch_ok(*get_device_capability_no_context(0)):
             raise ImportError(
                 "installed CuTe DSL does not support this GPU architecture"
             )

--- a/flashinfer/kda_kernels/__init__.py
+++ b/flashinfer/kda_kernels/__init__.py
@@ -53,11 +53,13 @@ except (ImportError, RuntimeError):
 
 try:
     if _torch.cuda.is_available():
-        from ..compilation_context import get_device_capability_no_context
+        from ..compilation_context import get_visible_device_capabilities
         from ..cute_dsl.availability import is_cute_dsl_arch_supported as _dsl_arch_ok
 
-        # NVML path when CUDA is not yet initialized (#4889).
-        if not _dsl_arch_ok(*get_device_capability_no_context(0)):
+        # NVML path when CUDA is not yet initialized (#4889); [0] keeps the
+        # previous "first visible device" semantics.
+        _caps = get_visible_device_capabilities()
+        if _caps and not _dsl_arch_ok(*_caps[0]):
             raise ImportError(
                 "installed CuTe DSL does not support this GPU architecture"
             )


### PR DESCRIPTION
## Summary
- Use NVML in CompilationContext / KDA cute-dsl arch gate when CUDA is not initialized.
- Defer GDN NUM_SMS / packed-FMA arch probes until first use.
- Skip cuTile SM-arch check in is_cuda_tile_available() before CUDA init.
- Lazily export make_bmm_bf16_tune_cache from flashinfer.gemm.

Fixes #4889

## Test plan
- [x] PYTHONPATH=. python -c "import torch; import flashinfer; import flashinfer.gemm; import flashinfer.comm; print(torch.cuda.is_initialized())" -> False (cuda.tile installed, GB10)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented library imports and capability checks from unnecessarily initializing CUDA contexts.
  * Improved GPU architecture detection when CUDA has not yet been initialized.
  * Added accurate capability detection across all CUDA-visible devices, including devices identified by indices or UUIDs.
  * Deferred certain kernel and device capability checks until they are needed, reducing import-time side effects.
  * Preserved access to supported GEMM tuning functionality through on-demand loading.
  * Improved handling of unsupported cuTile environments during imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->