### PR TITLE
fix(jit): canonicalize cuda_home with realpath (#4884)

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -46,6 +46,16 @@ def _get_glibcxx_abi_build_flags() -> List[str]:
 
 @functools.cache
 def get_cuda_path() -> str:
+    """Return the canonical path of the CUDA toolkit to build against.
+
+    Resolution order: ``CUDA_HOME``, ``CUDA_PATH``, the parent of ``which
+    nvcc``, then ``/usr/local/cuda``. The result is passed through
+    :func:`os.path.realpath` because it is embedded verbatim as ``cuda_home``
+    in the generated ``build.ninja``: without canonicalization, two processes
+    that reach the same toolkit through different paths (``/usr/local/cuda``
+    vs its ``/usr/local/cuda-X.Y`` symlink target, or a different ``PATH``
+    order) write different ninja files and ninja rebuilds every object.
+    """
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
     if cuda_home is None:
         # get output of "which nvcc"
@@ -60,8 +70,6 @@ def get_cuda_path() -> str:
                 raise RuntimeError(
                     f"Could not find nvcc and default {cuda_home=} doesn't exist"
                 )
-    # realpath so /usr/local/cuda vs /usr/local/cuda-X.Y (symlink) and
-    # PATH-order differences converge to one string in build.ninja (#4884).
     return os.path.realpath(cuda_home)
 
 

--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -47,21 +47,22 @@ def _get_glibcxx_abi_build_flags() -> List[str]:
 @functools.cache
 def get_cuda_path() -> str:
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
-    if cuda_home is not None:
-        return cuda_home
-    # get output of "which nvcc"
-    nvcc_path = subprocess.run(["which", "nvcc"], capture_output=True)
-    if nvcc_path.returncode == 0:
-        cuda_home = os.path.dirname(
-            os.path.dirname(nvcc_path.stdout.decode("utf-8").strip())
-        )
-    else:
-        cuda_home = "/usr/local/cuda"  # This default value is from: https://github.com/pytorch/pytorch/blob/ceb11a584d6b3fdc600358577d9bf2644f88def9/torch/utils/cpp_extension.py#L115
-        if not os.path.exists(cuda_home):
-            raise RuntimeError(
-                f"Could not find nvcc and default {cuda_home=} doesn't exist"
+    if cuda_home is None:
+        # get output of "which nvcc"
+        nvcc_path = subprocess.run(["which", "nvcc"], capture_output=True)
+        if nvcc_path.returncode == 0:
+            cuda_home = os.path.dirname(
+                os.path.dirname(nvcc_path.stdout.decode("utf-8").strip())
             )
-    return cuda_home
+        else:
+            cuda_home = "/usr/local/cuda"  # This default value is from: https://github.com/pytorch/pytorch/blob/ceb11a584d6b3fdc600358577d9bf2644f88def9/torch/utils/cpp_extension.py#L115
+            if not os.path.exists(cuda_home):
+                raise RuntimeError(
+                    f"Could not find nvcc and default {cuda_home=} doesn't exist"
+                )
+    # realpath so /usr/local/cuda vs /usr/local/cuda-X.Y (symlink) and
+    # PATH-order differences converge to one string in build.ninja (#4884).
+    return os.path.realpath(cuda_home)
 
 
 @functools.cache


### PR DESCRIPTION
## Summary
- `get_cuda_path()` returns `os.path.realpath(...)`, so symlinked toolkits
  (`/usr/local/cuda` -> `/usr/local/cuda-X.Y`) and PATH-order differences
  produce an identical `cuda_home` line in the generated `build.ninja`
  instead of rewriting it and forcing a full ninja rebuild.
- Added a docstring on `get_cuda_path()` recording the resolution order and
  why the result is canonicalized.

## Scope
Partial fix for #4884, which reports two independent cache-invalidation
triggers. This PR implements suggestion 1 (canonicalize `cuda_home`) only.
The mtime/content-stamp half (suggestion 2) touches the staleness model in
`jit/core.py` and is deliberately left to a separate PR.

Refs #4884

## Test plan
- [x] DGX Spark (GB10, sm_121a), CUDA 13.0: `get_cuda_path()` returns
      `/usr/local/cuda-13.0` and equals `os.path.realpath` of itself
      (`/usr/local/cuda` symlink resolved).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CUDA installation paths are now consistently resolved to a canonical location, including symlinked installations and PATH-based variants.
  * Improved build reliability by ensuring equivalent CUDA paths are represented consistently during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->