### PR TITLE
docs(moe): regenerate the Unified MoE activation matrix (unblocks CI on main)

### DIFF
--- a/docs/design_docs/flashinfer_moe_api.md
+++ b/docs/design_docs/flashinfer_moe_api.md
@@ -754,8 +754,11 @@ python scripts/generate_moe_activation_matrix.py --write
 | --- | --- | --- | --- |
 | `b12x_nvfp4` | `B12xNvfp4Config` | `NVFP4` | `SwiGLU`, `GeGLUTanh`, `ReLU2` |
 | `b12x_w4a16` | `B12xW4A16Config` | `W4A16` | `SwiGLU`, `ReLU2` |
-| `cute_dsl_nvfp4` | `CuteDslConfig` | `NVFP4` | `SwiGLU`, `GeGLUTanh`, `ReLU2`, `SiTU` |
-| `cute_dsl_nvfp4` | `CuteDslConfig` | `W4A16` | `SwiGLU`, `GeGLUTanh`, `ReLU2`, `SiTU` |
+| `cute_dsl` | `CuteDslConfig` | `MXFP4` | `SwiGLU`, `GeGLUTanh`, `ReLU2`, `SiTU` |
+| `cute_dsl` | `CuteDslConfig` | `NVFP4` | `SwiGLU`, `GeGLUTanh`, `ReLU2`, `SiTU` |
+| `cute_dsl` | `CuteDslConfig` | `W4A16` | `SwiGLU`, `GeGLUTanh`, `ReLU2`, `SiTU` |
+| `cutile_bf16` | `CuTileBf16Config` | `BF16` | `SwiGLU`, `ReLU2` |
+| `cutile_nvfp4` | `CuTileNvfp4Config` | `NVFP4` | `SwiGLU`, `ReLU2` |
 | `cutlass_bf16` | `CutlassBf16Config` | `BF16` | `SwiGLU`, `SwiGLUStep`, `GeGLU`, `GeGLUTanh`, `ReLU2`, `SiTU`, `Identity`, `GELU`, `ReLU`, `SiLU` |
 | `cutlass_fp8_block` | `CutlassFp8BlockConfig` | `DeepSeekFp8` | `SwiGLU`, `SwiGLUStep`, `GeGLU`, `GeGLUTanh`, `ReLU2`, `SiTU`, `Identity`, `GELU`, `ReLU`, `SiLU` |
 | `cutlass_fp8_per_tensor` | `CutlassFp8PerTensorConfig` | `FP8PerTensor` | `SwiGLU`, `SwiGLUStep`, `GeGLU`, `GeGLUTanh`, `ReLU2`, `SiTU`, `Identity`, `GELU`, `ReLU`, `SiLU` |


### PR DESCRIPTION
## 📌 Description

`tests/moe/test_unified_moe_activation_matrix.py::test_documented_activation_matrix_matches_runner_registry` is failing on `main`, which blocks CI for **every open PR**:

```
AssertionError: docs/design_docs/flashinfer_moe_api.md is stale;
run: python scripts/generate_moe_activation_matrix.py --write
```

This is a **semantic merge conflict**, not a defect in any single PR. #4805 added the generator, its check test, and a matrix block rendered from `_BACKEND_RUNNERS` as it stood on that PR's base. Two changes landed on `main` in between, and neither could have known to re-render the block:

| Change | Effect on the matrix |
|---|---|
| #4793 (`f7d4b167`) | renamed `CuteDslRunner.backend_key` `cute_dsl_nvfp4` → `cute_dsl` and added `QuantVariant.MXFP4` to its supported variants |
| #4646 (`0cbace05`) | registered `CuTileBf16Runner` / `CuTileNvfp4Runner` in `_BACKEND_RUNNERS` |

Each PR was green on its own base; the merged tree is what is stale. Because the check compares the committed block against the live registry, it has been red for everyone since #4805 merged.

## 🔍 Change

Only the generated block changes — this commit is the mechanical output of the documented regeneration command:

```
python scripts/generate_moe_activation_matrix.py --write
```

- adds `cutile_bf16` (`BF16`) and `cutile_nvfp4` (`NVFP4`), both `SwiGLU`, `ReLU2`
- replaces the two `cute_dsl_nvfp4` rows with three `cute_dsl` rows (`MXFP4`, `NVFP4`, `W4A16`)

No source, test, or prose changes.

## 🧪 Testing

The authoritative check is `test_documented_activation_matrix_matches_runner_registry`, which runs in this PR's own CI.

## 🔗 Related

Surfaced while triaging CI on #4387, whose H100 job ran the full suite with 221,273 passing and this as the sole failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the MoE activation matrix table to document MXFP4, NVFP4, and W4A16 support across additional activation functions.
  * Added documented BF16 and NVFP4 configuration entries for CuTile implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->