### PR TITLE
perf(xqa): size the SM90 fp8 split-KV grid from occupancy

### DIFF
--- a/csrc/flashinfer_xqa_binding.cu
+++ b/csrc/flashinfer_xqa_binding.cu
@@ -34,8 +34,8 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
                  tvm::ffi::Optional<TensorView> attentionSinks, TensorView kCacheVLLM,
                  TensorView vCacheVLLM, tvm::ffi::Optional<TensorView> kSfCacheVLLM,
                  tvm::ffi::Optional<TensorView> vSfCacheVLLM, TensorView kvCachePageList,
-                 int64_t maxSeqLen, TensorView seqLen, int64_t batchSize, double kvCacheScale,
-                 tvm::ffi::Optional<TensorView> kvScaleTensor, int64_t qSeqLen,
+                 int64_t maxSeqLen, int64_t maxKvLen, TensorView seqLen, int64_t batchSize,
+                 double kvCacheScale, tvm::ffi::Optional<TensorView> kvScaleTensor, int64_t qSeqLen,
                  tvm::ffi::Optional<TensorView> qCuSeqLens, tvm::ffi::Optional<TensorView> mask,
                  TensorView semaphores, TensorView scratch, bool enable_pdl);
 

--- a/csrc/xqa/mha.h
+++ b/csrc/xqa/mha.h
@@ -206,20 +206,23 @@ void launchHopperF8MHA(
 #endif
     uint32_t* semaphores, void* scratch, bool enable_pdl, cudaStream_t stream);
 
-void launchHopperF8MHAFlashInfer(
-    uint32_t multiProcessorCount, uint32_t nbKHeads, uint32_t slidingWinSize, float qScale,
-    float const* qScalePtr, OutputHead* output,
+void launchHopperF8MHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads,
+                                 uint32_t slidingWinSize, float qScale, float const* qScalePtr,
+                                 OutputHead* output,
 #if LOW_PREC_OUTPUT
-    float rcpOutScale,
+                                 float rcpOutScale,
 #endif
-    InputHead const* q, float const* attentionSinks, GMemCacheHead* kCacheVLLM,
-    GMemCacheHead* vCacheVLLM, KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
-    uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale, float const* kvScalePtr,
+                                 InputHead const* q, float const* attentionSinks,
+                                 GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+                                 KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
+                                 uint32_t maxKvLen, uint32_t const* seqLen, uint32_t batchSize,
+                                 float kvCacheScale, float const* kvScalePtr,
 #if SPEC_DEC
-    uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
+                                 uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
 #endif
-    uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
-    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream);
+                                 uint32_t* semaphores, void* scratch, uint64_t scratchBytes,
+                                 bool enable_pdl, uint64_t kv_stride_page, uint64_t kv_stride_token,
+                                 uint64_t kv_stride_head, cudaStream_t stream);
 
 void launchMLA(
     cudaDeviceProp const& prop,

--- a/csrc/xqa/mha_sm90.cu
+++ b/csrc/xqa/mha_sm90.cu
@@ -513,6 +513,14 @@ class ScratchMem {
     return makePtr<Vec<IOHead, ctaNbValidQHeads>>(mTokens);
   }
 
+  // Number of chunks whose partial results fit in scratchBytes (offsets are uint32_t).
+  static HOST_DEVICE_FUNC uint32_t maxNbChunks(uint64_t scratchBytes) {
+    constexpr uint64_t alignment = sizeof(Vec<IOHead, ctaNbValidQHeads>);
+    constexpr uint64_t chunkBytes = sizeof(ColWiseVec) + sizeof(Vec<IOHead, ctaNbValidQHeads>);
+    scratchBytes = mha::min<uint64_t>(scratchBytes, 0xFFFFFFFFu);
+    return scratchBytes > alignment ? uint32_t((scratchBytes - alignment) / chunkBytes) : 0U;
+  }
+
  private:
   template <typename T>
   HOST_DEVICE_FUNC TinyPtr<T> makePtr(uint32_t offset) const {
@@ -3042,34 +3050,74 @@ static uint32_t configureKernel() {
 
 static uint32_t const hostSmemSize = configureKernel();
 
-void launchHopperF8MHAFlashInfer(
-    uint32_t multiProcessorCount, uint32_t nbKHeads, uint32_t slidingWinSize, float qScale,
-    float const* qScalePtr, OutputHead* output,
-#if LOW_PREC_OUTPUT
-    float rcpOutScale,
-#endif
-    InputHead const* q, float const* attentionSinks, GMemCacheHead* kCacheVLLM,
-    GMemCacheHead* vCacheVLLM, KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
-    uint32_t const* seqLen, uint32_t batchSize, float kvCacheScale, float const* kvScalePtr,
-#if SPEC_DEC
-    uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
-#endif
-    uint32_t* semaphores, void* scratch, bool enable_pdl, uint64_t kv_stride_page,
-    uint64_t kv_stride_token, uint64_t kv_stride_head, cudaStream_t stream) {
-  uint32_t const nbSubSeqPerSeq = [&]() -> uint32_t {
-    float const factor = 0.25f;
-    return mha::min<uint32_t>(
-        mha::max<uint32_t>(
-            1U, (uint32_t)round(multiProcessorCount * 3 / (batchSize * nbKHeads) * factor)),
-        divUp(maxSeqLen, gemm0CtaTileNbTokens));
+// Per-CTA fixed cost (prologue, epilogue, semaphore) and per-partial merge cost, in units of one
+// tile of per-CTA streaming time. Measured on GH200; only used to pick the split count.
+constexpr float kCtaOverheadTiles = 10.f;
+constexpr float kMergeCostPerSubSeqTiles = 0.22f;
+constexpr uint32_t kMaxNbSubSeqPerSeq = 256;
+
+// gridDim.y: the split count minimizing waves * (tiles / split + overhead) + merge * split, so the
+// grid fills every resident CTA slot with little wave quantization while short sequences are not
+// split into CTAs dominated by fixed cost. Capped at 2 tiles per CTA and by the scratch capacity.
+static uint32_t computeNbSubSeqPerSeq(uint32_t multiProcessorCount, uint32_t nbSeq,
+                                      uint32_t nbInputSeqSplit, uint32_t maxSeqLen,
+                                      uint32_t maxKvLen, uint64_t scratchBytes) {
+  static uint32_t const maxCtasPerSm = [] {
+    int nbCtas = 0;
+    checkCuda(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&nbCtas, kernel_mha,
+                                                            warp_size * nbWarps, hostSmemSize));
+    return mha::max<uint32_t>(1U, nbCtas);
   }();
+  uint32_t const nbTiles = divUp(mha::min(maxKvLen, maxSeqLen), gemm0CtaTileNbTokens);
+  uint32_t const nbCtaSlots = maxCtasPerSm * multiProcessorCount;
+  uint32_t const nbChunksPerSubSeq = nbSeq * nbInputSeqSplit;
+  uint32_t const maxNbSubSeq = mha::min(mha::min(nbTiles / 2, kMaxNbSubSeqPerSeq),
+                                        ScratchMem::maxNbChunks(scratchBytes) / nbChunksPerSubSeq);
+  auto const cost = [&](uint32_t nbSubSeq) {
+    float const nbWaves = divUp(nbChunksPerSubSeq * nbSubSeq, nbCtaSlots);
+    return nbWaves * (float(nbTiles) / nbSubSeq + kCtaOverheadTiles) +
+           kMergeCostPerSubSeqTiles * nbSubSeq;
+  };
+  uint32_t best = 1;
+  float bestCost = cost(1);
+  for (uint32_t nbSubSeq = 2; nbSubSeq <= maxNbSubSeq; nbSubSeq++) {
+    float const c = cost(nbSubSeq);
+    if (c < bestCost) {
+      best = nbSubSeq;
+      bestCost = c;
+    }
+  }
+  return best;
+}
+
+void launchHopperF8MHAFlashInfer(uint32_t multiProcessorCount, uint32_t nbKHeads,
+                                 uint32_t slidingWinSize, float qScale, float const* qScalePtr,
+                                 OutputHead* output,
+#if LOW_PREC_OUTPUT
+                                 float rcpOutScale,
+#endif
+                                 InputHead const* q, float const* attentionSinks,
+                                 GMemCacheHead* kCacheVLLM, GMemCacheHead* vCacheVLLM,
+                                 KVCachePageIndex const* kvCachePageList, uint32_t maxSeqLen,
+                                 uint32_t maxKvLen, uint32_t const* seqLen, uint32_t batchSize,
+                                 float kvCacheScale, float const* kvScalePtr,
+#if SPEC_DEC
+                                 uint32_t qSeqLen, uint32_t const* qCuSeqLens, MaskType const* mask,
+#endif
+                                 uint32_t* semaphores, void* scratch, uint64_t scratchBytes,
+                                 bool enable_pdl, uint64_t kv_stride_page, uint64_t kv_stride_token,
+                                 uint64_t kv_stride_head, cudaStream_t stream) {
 #if SPEC_DEC
   auto specDecParams = SpecDecParams{qSeqLen, qCuSeqLens, mask};
   uint32_t const qLen = qSeqLen;
 #else
   uint32_t const qLen = 1;
 #endif
-  dim3 const dimGrid{divUp(qLen, inputTokensPerCta), nbSubSeqPerSeq, nbKHeads * batchSize};
+  uint32_t const nbInputSeqSplit = divUp(qLen, inputTokensPerCta);
+  uint32_t const nbSubSeqPerSeq =
+      computeNbSubSeqPerSeq(multiProcessorCount, nbKHeads * batchSize, nbInputSeqSplit, maxSeqLen,
+                            maxKvLen, scratchBytes);
+  dim3 const dimGrid{nbInputSeqSplit, nbSubSeqPerSeq, nbKHeads * batchSize};
   dim3 const dimCta{warp_size * gmmaWarpsPerGrp, 1, 3};
   auto const launchCfg = makeLaunchConfig(dimGrid, dimCta, hostSmemSize, stream, enable_pdl);
   uint32_t const maxNbPagesPerSeq = exactDiv(maxSeqLen, tokensPerPage);

--- a/csrc/xqa/xqa_wrapper.cu
+++ b/csrc/xqa/xqa_wrapper.cu
@@ -55,7 +55,7 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
                  TensorView output, double rcpOutScale, TensorView q,
                  Optional<TensorView> attentionSinks, TensorView kCacheVLLM, TensorView vCacheVLLM,
                  Optional<TensorView> kSfCacheVLLM, Optional<TensorView> vSfCacheVLLM,
-                 TensorView kvCachePageList, int64_t maxSeqLen, TensorView seqLen,
+                 TensorView kvCachePageList, int64_t maxSeqLen, int64_t maxKvLen, TensorView seqLen,
                  int64_t batchSize, double kvCacheScale, Optional<TensorView> kvScaleTensor,
                  int64_t qSeqLen, Optional<TensorView> qCuSeqLens, Optional<TensorView> mask,
                  TensorView semaphores, TensorView scratch, bool enable_pdl) {
@@ -114,14 +114,14 @@ void xqa_wrapper(bool run_sm90_fp8_mha, int64_t multiProcessorCount, int64_t nbK
         reinterpret_cast<InputHead const*>(q.data_ptr()), attentionSinksPtr,
         reinterpret_cast<GMemCacheHead*>(kCacheVLLM.data_ptr()),
         reinterpret_cast<GMemCacheHead*>(vCacheVLLM.data_ptr()),
-        reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()), maxSeqLen,
+        reinterpret_cast<KVCachePageIndex const*>(kvCachePageList.data_ptr()), maxSeqLen, maxKvLen,
         reinterpret_cast<uint32_t const*>(seqLen.data_ptr()), batchSize, kvCacheScale, kvScalePtr,
 #if SPEC_DEC
         qSeqLen, qCuSeqLensPtr, maskPtr,
 #endif
         reinterpret_cast<uint32_t*>(semaphores.data_ptr()),
-        reinterpret_cast<void*>(scratch.data_ptr()), enable_pdl, kv_stride_page, kv_stride_token,
-        kv_stride_head, stream);
+        reinterpret_cast<void*>(scratch.data_ptr()), scratch.numel() * get_element_size(scratch),
+        enable_pdl, kv_stride_page, kv_stride_token, kv_stride_head, stream);
     return;
   }
 #endif

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3931,7 +3931,8 @@ def xqa_batch_decode_with_kv_cache(
         A uint32 1D tensor indicating the kv sequence length of each prompt. shape: ``[batch_size]``
 
     max_seq_len : int
-        max sequence length for kv_cache
+        max sequence length for kv_cache; also sizes the multi-block split, so
+        pass the batch's actual maximum rather than the page-table capacity
 
     bmm1_scale : Union[float, torch.Tensor]
         fused scale for bmm1 input.
@@ -4086,6 +4087,7 @@ def xqa_batch_decode_with_kv_cache(
         q_seq_len=q_len_per_req,
         q_cu_seq_lens=q_cu_seq_lens,
         mask=mask,
+        max_kv_len=max_seq_len,
     )
 
     return out

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -111,6 +111,7 @@ def _get_xqa_module_cached(
         v_sf_cache: Optional[torch.Tensor],
         page_table: torch.Tensor,
         max_seq_len: int,
+        max_kv_len: int,
         seq_lens: torch.Tensor,
         batch_size: int,
         kv_scale: Union[float, torch.Tensor],
@@ -138,6 +139,7 @@ def _get_xqa_module_cached(
             v_sf_cache,
             page_table,
             max_seq_len,
+            max_kv_len,
             seq_lens,
             batch_size,
             1.0 if isinstance(kv_scale, torch.Tensor) else kv_scale,
@@ -167,6 +169,7 @@ def _get_xqa_module_cached(
         v_sf_cache: Optional[torch.Tensor],
         page_table: torch.Tensor,
         max_seq_len: int,
+        max_kv_len: int,
         seq_lens: torch.Tensor,
         batch_size: int,
         kv_scale: Union[float, torch.Tensor],
@@ -210,6 +213,7 @@ def xqa(
     q_cu_seq_lens: Optional[torch.Tensor] = None,
     k_sf_cache: Optional[torch.Tensor] = None,
     v_sf_cache: Optional[torch.Tensor] = None,
+    max_kv_len: Optional[int] = None,
 ) -> None:
     r"""Apply attention with paged KV cache using XQA kernel.
     Parameters
@@ -298,6 +302,11 @@ def xqa(
         ``[total_q_tokens, num_q_heads, head_dim]``, ``q_seq_len`` must be
         the maximum draft length, and ``mask`` rows are packed by the same
         cumulative offsets.
+    max_kv_len : Optional[int], default=None
+        Upper bound on the KV lengths in ``seq_lens``. It only steers how many
+        CTAs each sequence is split across, so a tight bound gives the best
+        split. Defaults to the page-table capacity
+        ``page_table.shape[-1] * page_size``.
 
     Note
     ----
@@ -361,6 +370,9 @@ def xqa(
     # Calculate max_seq_len from page_table and page_size
     num_pages_per_seq = page_table.shape[-1]
     max_seq_len = num_pages_per_seq * page_size
+    max_kv_len = (
+        max_seq_len if max_kv_len is None else max(1, min(max_kv_len, max_seq_len))
+    )
 
     # Determine if sliding window is used
     use_sliding_window = sliding_win_size > 0
@@ -444,6 +456,7 @@ def xqa(
         v_sf_cache,
         page_table,
         max_seq_len,
+        max_kv_len,
         seq_lens,
         batch_size,
         kv_scale,

--- a/flashinfer/xqa.py
+++ b/flashinfer/xqa.py
@@ -304,9 +304,9 @@ def xqa(
         cumulative offsets.
     max_kv_len : Optional[int], default=None
         Upper bound on the KV lengths in ``seq_lens``. It only steers how many
-        CTAs each sequence is split across, so a tight bound gives the best
-        split. Defaults to the page-table capacity
-        ``page_table.shape[-1] * page_size``.
+        CTAs each sequence is split across: a tight bound gives the best split
+        and a too-small value only costs performance. Defaults to the
+        page-table capacity ``page_table.shape[-1] * page_size``.
 
     Note
     ----

--- a/tests/attention/test_xqa.py
+++ b/tests/attention/test_xqa.py
@@ -693,3 +693,234 @@ def test_xqa_mla(
         f"Total {total_elements} elements, only {passing_elements} ({pass_ratio:.1%}) meet tolerance criteria, "
         f"require at least {required_ratio:.1%}"
     )
+
+
+def ref_attention_varlen(
+    q, k_cache, v_cache, seq_lens, q_scale, kv_scale, attention_sinks, sliding_win_size
+):
+    """Reference for per-request KV lengths.
+
+    q: [batch_size, nb_k_heads, head_grp_size, head_dim]
+    k_cache, v_cache: [batch_size, nb_k_heads, capacity, head_dim]
+    seq_lens: [batch_size]
+    """
+    head_dim = q.shape[-1]
+    capacity = k_cache.shape[2]
+    lens = seq_lens.to(device=q.device, dtype=torch.int64)
+    pos = torch.arange(capacity, device=q.device)
+    valid = pos[None, :] < lens[:, None]
+    if sliding_win_size > 0:
+        valid &= pos[None, :] >= lens[:, None] - sliding_win_size
+    qk_scale = q_scale * kv_scale / math.sqrt(head_dim)
+    logits = torch.matmul(q.float(), k_cache.float().transpose(-2, -1)) * qk_scale
+    logits = logits.masked_fill(~valid[:, None, None, :], float("-inf"))
+    row_max = logits.amax(dim=-1, keepdim=True)
+    x = torch.exp(logits - row_max)
+    row_sum = x.sum(dim=-1, keepdim=True)
+    if attention_sinks is not None:
+        row_sum = row_sum + torch.exp(attention_sinks[None, :, :, None] - row_max)
+    return torch.matmul(x, v_cache.float()) * kv_scale / row_sum
+
+
+def assert_close_ratio(ref, out, atol, rtol, required_ratio=0.98):
+    diff_abs = torch.abs(ref - out)
+    diff_rel = diff_abs / (torch.abs(ref) + 1e-8)
+    pass_ratio = ((diff_abs <= atol) | (diff_rel <= rtol)).float().mean().item()
+    assert pass_ratio >= required_ratio, (
+        f"only {pass_ratio:.1%} of elements within tolerance, need {required_ratio:.1%}"
+    )
+
+
+def make_paged_kv(
+    batch_size, nb_k_heads, head_dim, tokens_per_page, capacity, dtype, seed=42
+):
+    """Random NHD paged K/V, a shuffled page table and the gathered per-request caches."""
+    nb_pages_per_seq = capacity // tokens_per_page
+    total_pages = nb_pages_per_seq * batch_size
+    k_cache = torch.randn(
+        total_pages, tokens_per_page, nb_k_heads, head_dim, dtype=dtype, device="cuda"
+    )
+    v_cache = torch.randn(
+        total_pages, tokens_per_page, nb_k_heads, head_dim, dtype=dtype, device="cuda"
+    )
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(seed)
+    page_table = torch.randperm(
+        total_pages, generator=generator, device="cuda", dtype=torch.int32
+    ).view(batch_size, nb_pages_per_seq)
+
+    def gather(cache):
+        # [batch, pages, tokens, heads, dim] -> [batch, heads, capacity, dim]
+        return (
+            cache[page_table.long()]
+            .reshape(batch_size, capacity, nb_k_heads, head_dim)
+            .permute(0, 2, 1, 3)
+        )
+
+    return k_cache, v_cache, page_table, gather
+
+
+@pytest.mark.skipif(
+    get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12],
+    reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
+)
+@pytest.mark.parametrize(
+    "fp8_kv_cache,use_fp8_output", [(False, False), (True, False), (True, True)]
+)
+@pytest.mark.parametrize("use_attention_sinks", [False, True])
+@pytest.mark.parametrize("use_sliding_window", [False, True])
+@pytest.mark.parametrize("max_kv_len", [None, 256])
+def test_xqa_multi_block_mixed_seq_lens(
+    fp8_kv_cache, use_fp8_output, use_attention_sinks, use_sliding_window, max_kv_len
+):
+    """Large batch with one KV head: every long sequence is split across several
+    CTAs, while short ones fall back to fewer splits or a single CTA."""
+    set_random_seed(0)
+    batch_size, nb_k_heads, head_grp_size, head_dim, tokens_per_page = 64, 1, 8, 128, 64
+    longest = 4096
+    capacity = 2 * longest  # page table wider than any sequence
+    input_type = torch.bfloat16
+    nb_q_heads = nb_k_heads * head_grp_size
+
+    seq_lens = torch.randint(1, longest + 1, (batch_size,), dtype=torch.int64)
+    pinned = torch.tensor([1, 63, 64, 65, 127, 128, 129, 255, 511, 512, 513, longest])
+    seq_lens[: pinned.numel()] = pinned
+    seq_lens_arg = seq_lens.to(torch.uint32).view(batch_size, 1).cuda()
+
+    q = torch.randn(
+        batch_size, 1, nb_q_heads, head_dim, dtype=input_type, device="cuda"
+    )
+    k_cache, v_cache, page_table, gather = make_paged_kv(
+        batch_size, nb_k_heads, head_dim, tokens_per_page, capacity, input_type
+    )
+    if fp8_kv_cache:
+        k_cache = (k_cache / 4).to(torch.float8_e4m3fn)
+        v_cache = (v_cache / 4).to(torch.float8_e4m3fn)
+    attention_sinks = (
+        (2.0 + torch.arange(head_grp_size, device="cuda") % 4)
+        .float()
+        .expand(nb_k_heads, head_grp_size)
+        .contiguous()
+        if use_attention_sinks
+        else None
+    )
+    sliding_win_size = 256 if use_sliding_window else 0
+    q_scale, kv_scale = 0.5, 1.0
+    rcp_out_scale = 4.0 if use_fp8_output else 1.0
+    output = torch.full(
+        (batch_size, 1, nb_q_heads, head_dim),
+        float("nan"),
+        dtype=torch.float8_e4m3fn if use_fp8_output else input_type,
+        device="cuda",
+    )
+    nb_seq = nb_k_heads * batch_size
+    semaphores = torch.zeros(
+        round_up(nb_seq, 2) + 2 + nb_seq + 2, dtype=torch.uint32, device="cuda"
+    )
+    scratch = torch.zeros(64 << 20, dtype=torch.uint8, device="cuda")
+
+    xqa(
+        q,
+        k_cache,
+        v_cache,
+        page_table,
+        seq_lens_arg,
+        output,
+        scratch,
+        semaphores,
+        nb_k_heads,
+        tokens_per_page,
+        sinks=attention_sinks,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+        sliding_win_size=sliding_win_size,
+        sm_count=sm_count,
+        rcp_out_scale=rcp_out_scale,
+        max_kv_len=max_kv_len,
+    )
+
+    ref = ref_attention_varlen(
+        q.view(batch_size, nb_k_heads, head_grp_size, head_dim),
+        gather(k_cache),
+        gather(v_cache),
+        seq_lens,
+        q_scale,
+        kv_scale,
+        attention_sinks,
+        sliding_win_size,
+    )
+    out = output.view(batch_size, nb_k_heads, head_grp_size, head_dim).float()
+    if use_fp8_output:
+        ref = ref * rcp_out_scale
+        atol = rtol = 0.15
+    elif fp8_kv_cache:
+        atol = rtol = 0.05
+    else:
+        atol = rtol = 0.01
+    assert_close_ratio(ref, out, atol, rtol)
+
+
+@pytest.mark.skipif(
+    get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12],
+    reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
+)
+@pytest.mark.parametrize("scratch_bytes", [0, 4096, 200 << 10, 300 << 10, 1 << 20])
+def test_xqa_multi_block_scratch_bound(scratch_bytes):
+    """The split count shrinks to what the scratch holds; nothing is written past it."""
+    set_random_seed(0)
+    batch_size, nb_k_heads, head_grp_size, head_dim, tokens_per_page = 64, 1, 8, 128, 64
+    seq_len = 4096
+    input_type = torch.bfloat16
+    nb_q_heads = nb_k_heads * head_grp_size
+
+    q = torch.randn(
+        batch_size, 1, nb_q_heads, head_dim, dtype=input_type, device="cuda"
+    )
+    k_cache, v_cache, page_table, gather = make_paged_kv(
+        batch_size, nb_k_heads, head_dim, tokens_per_page, seq_len, input_type
+    )
+    k_cache = (k_cache / 4).to(torch.float8_e4m3fn)
+    v_cache = (v_cache / 4).to(torch.float8_e4m3fn)
+    seq_lens = torch.full((batch_size, 1), seq_len, dtype=torch.uint32, device="cuda")
+    output = torch.empty(
+        batch_size, 1, nb_q_heads, head_dim, dtype=input_type, device="cuda"
+    )
+    nb_seq = nb_k_heads * batch_size
+    semaphores = torch.zeros(
+        round_up(nb_seq, 2) + 2 + nb_seq + 2, dtype=torch.uint32, device="cuda"
+    )
+    guard = 1 << 20
+    workspace = torch.full(
+        (guard + scratch_bytes + guard,), 0xA5, dtype=torch.uint8, device="cuda"
+    )
+    scratch = workspace[guard : guard + scratch_bytes]
+
+    xqa(
+        q,
+        k_cache,
+        v_cache,
+        page_table,
+        seq_lens,
+        output,
+        scratch,
+        semaphores,
+        nb_k_heads,
+        tokens_per_page,
+        sm_count=sm_count,
+    )
+
+    assert torch.all(workspace[:guard] == 0xA5) and torch.all(
+        workspace[guard + scratch_bytes :] == 0xA5
+    ), "kernel wrote outside its scratch buffer"
+    ref = ref_attention_varlen(
+        q.view(batch_size, nb_k_heads, head_grp_size, head_dim),
+        gather(k_cache),
+        gather(v_cache),
+        seq_lens.view(-1),
+        1.0,
+        1.0,
+        None,
+        0,
+    )
+    out = output.view(batch_size, nb_k_heads, head_grp_size, head_dim).float()
+    assert_close_ratio(ref, out, 0.05, 0.05)

--- a/tests/attention/test_xqa.py
+++ b/tests/attention/test_xqa.py
@@ -723,6 +723,7 @@ def ref_attention_varlen(
 
 
 def assert_close_ratio(ref, out, atol, rtol, required_ratio=0.98):
+    """Require at least required_ratio of elements within atol or rtol."""
     diff_abs = torch.abs(ref - out)
     diff_rel = diff_abs / (torch.abs(ref) + 1e-8)
     pass_ratio = ((diff_abs <= atol) | (diff_rel <= rtol)).float().mean().item()
@@ -769,7 +770,9 @@ def make_paged_kv(
 )
 @pytest.mark.parametrize("use_attention_sinks", [False, True])
 @pytest.mark.parametrize("use_sliding_window", [False, True])
-@pytest.mark.parametrize("max_kv_len", [None, 256])
+# None: page-table capacity (2x the longest sequence); 4096: exact bound;
+# 256: too small, which may only change the split, never the result.
+@pytest.mark.parametrize("max_kv_len", [None, 4096, 256])
 def test_xqa_multi_block_mixed_seq_lens(
     fp8_kv_cache, use_fp8_output, use_attention_sinks, use_sliding_window, max_kv_len
 ):

--- a/tests/attention/test_xqa_batch_decode.py
+++ b/tests/attention/test_xqa_batch_decode.py
@@ -1189,3 +1189,72 @@ if __name__ == "__main__":
         max_in_kv_len=110,
         kv_layout="NHD",
     )
+
+
+@pytest.mark.skipif(
+    get_compute_capability(torch.device(device="cuda"))[0] not in [9, 10, 12],
+    reason="XQA is only supported on SM90, SM100, SM120/SM121 GPUs",
+)
+@pytest.mark.parametrize("kv_dtype", ["bf16", "fp8"])
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+def test_xqa_batch_decode_long_context_multi_block(kv_dtype, kv_layout):
+    """Large batch, one KV head, mixed lengths up to 8K: each sequence is split
+    across several CTAs and merged."""
+    torch.manual_seed(0)
+    batch_size, page_size, num_kv_heads, head_grp_size, head_dim = 64, 64, 1, 8, 128
+    num_qo_heads = num_kv_heads * head_grp_size
+    q_dtype = "bf16"
+
+    q_lens, in_kv_lens, seq_lens = generate_seq_lens_decode(batch_size, 1, 8191)
+    q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
+    kv_cache, k_scale, v_scale, _, _, ref_kv_cache = create_kv_cache(
+        batch_size,
+        seq_lens,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_dtype,
+        q_dtype,
+        kv_layout,
+    )
+    page_table, all_page_ids, page_per_seq = create_page_table(
+        batch_size, seq_lens, page_size
+    )
+    kv_indptr = generate_cumsum_lens(page_per_seq)
+    kv_last_page_len = get_last_page_len(seq_lens, page_size)
+    workspace_buffer, workspace_buffer_ref = create_workspace_buffers(GPU_DEVICE)
+    out, o_scale = create_output(q, q_dtype)
+    sm_scale = float(1.0 / (head_dim**0.5))
+
+    wrapper_ref = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer_ref, kv_layout, use_tensor_cores=True
+    )
+    wrapper_ref.plan(
+        kv_indptr,
+        all_page_ids,
+        kv_last_page_len.to(GPU_DEVICE),
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        pos_encoding_mode="NONE",
+        kv_data_type=ref_kv_cache.dtype,
+        q_data_type=ref_q.dtype,
+    )
+    output_ref = wrapper_ref.run(ref_q, ref_kv_cache)
+
+    output = flashinfer.decode.xqa_batch_decode_with_kv_cache(
+        q.contiguous(),
+        kv_cache,
+        workspace_buffer,
+        page_table,
+        seq_lens.to(GPU_DEVICE),
+        torch.max(seq_lens).item(),
+        q_scale * k_scale * sm_scale,
+        v_scale / o_scale,
+        out=out,
+        kv_layout=kv_layout,
+    )
+
+    tol = 1e-1 if kv_dtype == "fp8" else 1e-2
+    torch.testing.assert_close(output.float(), output_ref.float(), rtol=tol, atol=tol)


### PR DESCRIPTION
## Description

The SM90 fp8 XQA launcher chose the split-KV count as `round(SMs * 3 / (batch * kv_heads) * 0.25)`. Integer division collapses it to 1 once `batch * kv_heads` exceeds ~50, and below that it targets 0.75 CTAs per SM although the kernel fits 3 (44 registers, 35 KB smem). One CTA per SM cannot cover HBM latency, so large-batch long-context decode with few KV heads ran at 60-75% of bandwidth (#2766).

The launcher now picks the split count from the kernel's occupancy by minimizing `ceil(waves) * (tiles / split + overhead) + merge * split` (constants fit on GH200: ~10 tiles per CTA, ~0.22 tiles per merged partial), and clamps it so the partial results fit the scratch buffer. `xqa()` takes an optional `max_kv_len` hint, which `xqa_batch_decode_with_kv_cache` fills from `max_seq_len`, so a page table wider than the longest sequence does not distort the choice. Kernel code is unchanged.

Benchmark: `benchmarks/flashinfer_benchmark.py --routine BatchDecodeWithPagedKVCacheWrapper --backends trtllm-native`, GH200 (132 SMs), bf16 q, fp8 KV, head_dim 128, page 64, CUDA graph, median of 30. q/kv = num_qo_heads/num_kv_heads.

| q/kv heads | batch | kv_len | lengths | before (us) | after (us) | speedup |
|---|---|---|---|---|---|---|
| 8/1 | 32 | 32768 | uniform | 111.9 | 81.3 | 1.38x |
| 8/1 | 64 | 32768 | uniform | 176.8 | 153.2 | 1.15x |
| 8/1 | 128 | 32768 | uniform | 343.5 | 295.3 | 1.16x |
| 8/1 | 64 | 4096 | uniform | 28.9 | 26.0 | 1.11x |
| 8/1 | 128 | 4096 | uniform | 48.7 | 44.0 | 1.11x |
| 8/1 | 1 | 32768 | uniform | 21.4 | 18.1 | 1.18x |
| 8/1 | 64 | 65536 | uniform | 345.1 | 295.9 | 1.17x |
| 8/1 | 128 | 512 | uniform | 10.7 | 11.6 | 0.92x |
| 8/1 | 64 | 1024 | uniform | 11.9 | 12.0 | 0.99x |
| 64/8 | 32 | 32768 | uniform | 570.4 | 574.3 | 0.99x |
| 64/8 | 64 | 32768 | uniform | 1313.4 | 1134.7 | 1.16x |
| 64/8 | 128 | 32768 | uniform | 2288.1 | 2255.6 | 1.01x |
| 64/8 | 64 | 4096 | uniform | 170.0 | 155.9 | 1.09x |
| 64/8 | 128 | 4096 | uniform | 292.3 | 292.5 | 1.00x |
| 64/8 | 1 | 32768 | uniform | 34.5 | 31.1 | 1.11x |
| 64/8 | 64 | 65536 | uniform | 2625.3 | 2260.3 | 1.16x |
| 64/8 | 128 | 512 | uniform | 45.8 | 45.8 | 1.00x |
| 64/8 | 64 | 1024 | uniform | 49.0 | 49.0 | 1.00x |
| 8/1 | 64 | 32768 | random | 160.7 | 90.2 | 1.78x |
| 64/8 | 128 | 4096 | random | 150.1 | 149.7 | 1.00x |
| 8/1 | 256 | 8192 | random | 102.0 | 91.1 | 1.12x |

hpc-ops `attention_decode_fp8` (the kernel the issue compares against), same GPU, 8/1 heads, 32K context: 80 / 152 / 295 us at batch 32 / 64 / 128.

## Related Issues

Closes #2766

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

- `mha.cu` (bf16 KV on SM90, everything on SM100/SM12x) keeps its heuristic; on GH200 it already streams at 3.5-3.75 TB/s. Only SM90 was measured.
- The one slower row (512-token sequences, batch 128, PDL off as in the harness) splits 8-tile sequences three ways: +0.2-0.9 us without PDL, 9.7 to 7.1 us with PDL, the Hopper default.
- The cost-model constants are host-only knobs at the top of the launcher.

Developed in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional KV-length limit for XQA attention, with validation and automatic defaults.
  * Improved multi-block attention splitting based on workload and available scratch-buffer capacity.
  * Added support for variable-length sequences, mixed contexts, attention sinks, sliding windows, and FP8 modes.

* **Bug Fixes**
  * Improved long-context batch decoding and scratch-buffer boundary handling.

* **Tests**
  * Added coverage for configurable KV limits, multi-block execution, long contexts, and varied cache layouts and data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->