### PR TITLE
perf(mla): swap-AB Q tiles for small-M decode and a parallel split-KV merge on SM90

### DIFF
--- a/csrc/batch_mla_binding.cu
+++ b/csrc/batch_mla_binding.cu
@@ -25,7 +25,8 @@ using tvm::ffi::Tuple;
 Tuple<Array<int64_t>, int64_t> BatchMLAPagedAttentionPlan(
     TensorView float_workspace_buffer, TensorView int_workspace_buffer,
     TensorView page_locked_int_workspace_buffer, TensorView qo_indptr, TensorView kv_indptr,
-    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal);
+    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal, int64_t graph_num_blks_x,
+    int64_t graph_cta_tile_q);
 
 void BatchMLAPagedAttentionRun(TensorView float_workspace_buffer, TensorView int_workspace_buffer,
                                Array<int64_t> plan_info_vec, TensorView q_nope, TensorView q_pe,

--- a/csrc/batch_mla_plan.cu
+++ b/csrc/batch_mla_plan.cu
@@ -28,7 +28,8 @@ using tvm::ffi::Tuple;
 Tuple<Array<int64_t>, int64_t> BatchMLAPagedAttentionPlan(
     TensorView float_workspace_buffer, TensorView int_workspace_buffer,
     TensorView page_locked_int_workspace_buffer, TensorView qo_indptr, TensorView kv_indptr,
-    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal) {
+    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal, int64_t graph_num_blks_x,
+    int64_t graph_cta_tile_q) {
   CHECK_INPUT_TYPE(qo_indptr, dl_int32);
   CHECK_INPUT_TYPE(kv_indptr, dl_int32);
   CHECK_INPUT_TYPE(kv_len, dl_int32);
@@ -51,7 +52,8 @@ Tuple<Array<int64_t>, int64_t> BatchMLAPagedAttentionPlan(
       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
       int_workspace_size_in_bytes, plan_info, staged_int_workspace_bytes,
       static_cast<IdType*>(qo_indptr.data_ptr()), static_cast<IdType*>(kv_indptr.data_ptr()),
-      static_cast<IdType*>(kv_len.data_ptr()), batch_size, num_heads, head_dim_o, causal, stream);
+      static_cast<IdType*>(kv_len.data_ptr()), batch_size, num_heads, head_dim_o, causal,
+      /*min_cta_tile_q=*/64, graph_num_blks_x, graph_cta_tile_q, stream);
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "Failed to plan MLA, error: " << cudaGetErrorString(status);
 

--- a/csrc/batch_mla_sm90_binding.cu
+++ b/csrc/batch_mla_sm90_binding.cu
@@ -25,7 +25,8 @@ using tvm::ffi::Tuple;
 Tuple<Array<int64_t>, int64_t> BatchMLAPagedAttentionSM90Plan(
     TensorView float_workspace_buffer, TensorView int_workspace_buffer,
     TensorView page_locked_int_workspace_buffer, TensorView qo_indptr, TensorView kv_indptr,
-    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal);
+    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal, int64_t graph_num_blks_x,
+    int64_t graph_cta_tile_q);
 
 void BatchMLAPagedAttentionSM90Run(TensorView float_workspace_buffer,
                                    TensorView int_workspace_buffer, Array<int64_t> plan_info_vec,

--- a/csrc/batch_mla_sm90_plan.cu
+++ b/csrc/batch_mla_sm90_plan.cu
@@ -28,7 +28,8 @@ using tvm::ffi::Tuple;
 Tuple<Array<int64_t>, int64_t> BatchMLAPagedAttentionSM90Plan(
     TensorView float_workspace_buffer, TensorView int_workspace_buffer,
     TensorView page_locked_int_workspace_buffer, TensorView qo_indptr, TensorView kv_indptr,
-    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal) {
+    TensorView kv_len, int64_t num_heads, int64_t head_dim_o, bool causal, int64_t graph_num_blks_x,
+    int64_t graph_cta_tile_q) {
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * get_element_size(float_workspace_buffer);
   size_t int_workspace_size_in_bytes =
@@ -47,7 +48,8 @@ Tuple<Array<int64_t>, int64_t> BatchMLAPagedAttentionSM90Plan(
       int_workspace_buffer.data_ptr(), page_locked_int_workspace_buffer.data_ptr(),
       int_workspace_size_in_bytes, plan_info, staged_int_workspace_bytes,
       static_cast<IdType*>(qo_indptr.data_ptr()), static_cast<IdType*>(kv_indptr.data_ptr()),
-      static_cast<IdType*>(kv_len.data_ptr()), batch_size, num_heads, head_dim_o, causal, stream);
+      static_cast<IdType*>(kv_len.data_ptr()), batch_size, num_heads, head_dim_o, causal,
+      /*min_cta_tile_q=*/16, graph_num_blks_x, graph_cta_tile_q, stream);
 
   TVM_FFI_ICHECK(status == cudaSuccess)
       << "Failed to plan MLA, error: " << cudaGetErrorString(status);

--- a/csrc/batch_mla_sm90_run.cu
+++ b/csrc/batch_mla_sm90_run.cu
@@ -123,11 +123,15 @@ void BatchMLAPagedAttentionSM90Run(
                 ? static_cast<const float*>(maybe_ckv_scale_arr.value().data_ptr())
                 : nullptr;
 
-        cudaError_t status =
-            mla::BatchMLAPageAttentionHopper<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE>(
-                params, plan_info.num_blks_x, plan_info.num_blks_y, stream);
+        // The planner picks the Q tile from the longest packed query in the
+        // batch; 16 and 32 run the swap-AB layout (see hopper::HopperKernelTraits).
+        DISPATCH_MLA_CTA_TILE_Q(plan_info.cta_tile_q, CTA_TILE_Q, {
+          cudaError_t status =
+              mla::BatchMLAPageAttentionHopper<MASK_MODE, HEAD_DIM_CKV, HEAD_DIM_KPE, CTA_TILE_Q>(
+                  params, plan_info.num_blks_x, plan_info.num_blks_y, stream);
 
-        TVM_FFI_ICHECK(status == cudaSuccess)
-            << "Failed to run MLA, error: " << cudaGetErrorString(status);
+          TVM_FFI_ICHECK(status == cudaSuccess)
+              << "Failed to run MLA, error: " << cudaGetErrorString(status);
+        });
       });
 }

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -167,7 +167,7 @@ def get_batch_mla_uri(
         f"dtype_idx_{filename_safe_dtype_map[dtype_idx]}_"
         f"head_dim_ckv_{head_dim_ckv}_"
         f"head_dim_kpe_{head_dim_kpe}_"
-        f"profiler_{use_profiler}_planabi2"
+        f"profiler_{use_profiler}_planabi3"
     ) + ("_sm90" if backend == "fa3" else "")
 
 

--- a/flashinfer/mla/_batch_mla/_backends/_fa_common.py
+++ b/flashinfer/mla/_batch_mla/_backends/_fa_common.py
@@ -7,7 +7,17 @@ you may not use this file except in compliance with the License.
 
 import functools
 import math
-from typing import Callable, ClassVar, Optional, Protocol, Tuple, TypeVar, Union, cast
+from typing import (
+    Callable,
+    ClassVar,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import torch
 
@@ -125,9 +135,11 @@ class _BatchMLAGeneratedFaMechanics:
         kv_len_arr_buf: Optional[torch.Tensor],
         int_workspace_buffer: Optional[torch.Tensor] = None,
         pin_memory_int_workspace_buffer: Optional[torch.Tensor] = None,
+        graph_plan_info: Optional[Sequence[int]] = None,
     ) -> None:
         self._backend = backend
         self._float_workspace_buffer = float_workspace_buffer
+        self._graph_plan_info = graph_plan_info
         self.device = float_workspace_buffer.device
         if int_workspace_buffer is None:
             int_workspace_buffer = torch.empty(
@@ -303,6 +315,13 @@ class _BatchMLAGeneratedFaMechanics:
         qo_indptr_host = qo_indptr.to("cpu")
         kv_indptr_host = kv_indptr.to("cpu")
         kv_len_arr_host = kv_len_arr.to("cpu")
+        # A CUDA graph replays the kernel and grid of the plan it was captured
+        # with (MLAPlanInfo: num_blks_x first, cta_tile_q last), so a replan
+        # keeps them; 0 lets the planner choose.
+        graph_num_blks_x = graph_cta_tile_q = 0
+        if self._use_cuda_graph and self._graph_plan_info is not None:
+            graph_num_blks_x = int(self._graph_plan_info[0])
+            graph_cta_tile_q = int(self._graph_plan_info[-1])
         plan_args = (
             self._float_workspace_buffer,
             self._int_workspace_buffer,
@@ -313,6 +332,8 @@ class _BatchMLAGeneratedFaMechanics:
             num_heads,
             head_dim_ckv,
             causal,
+            graph_num_blks_x,
+            graph_cta_tile_q,
         )
         if hasattr(cached_module, "plan_with_staged_workspace_bytes"):
             plan_info, staged_int_workspace_bytes = (
@@ -513,6 +534,7 @@ class _BatchMLAPagedAttentionFaBackendBase(_BatchMLAGeneratedFaMechanics):
         kv_split_widths: tuple[int, int],
         int_workspace_buffer: Optional[torch.Tensor] = None,
         pin_memory_int_workspace_buffer: Optional[torch.Tensor] = None,
+        graph_plan_info: Optional[Sequence[int]] = None,
     ) -> None:
         if backend is None:
             if self._plan_capabilities is None:
@@ -528,6 +550,7 @@ class _BatchMLAPagedAttentionFaBackendBase(_BatchMLAGeneratedFaMechanics):
             kv_len_arr_buf=kv_len_arr_buf,
             int_workspace_buffer=int_workspace_buffer,
             pin_memory_int_workspace_buffer=pin_memory_int_workspace_buffer,
+            graph_plan_info=graph_plan_info,
         )
         self._query_split_widths = query_split_widths
         self._kv_split_widths = kv_split_widths
@@ -571,6 +594,7 @@ class _BatchMLAPagedAttentionFaBackendBase(_BatchMLAGeneratedFaMechanics):
             query_split_widths=(args.head_dim_ckv, args.head_dim_kpe),
             kv_split_widths=(args.head_dim_ckv, args.head_dim_kpe),
             int_workspace_buffer=args._graph_plan_int_workspace_buffer,
+            graph_plan_info=args._graph_plan_info,
         )
         if args._use_cuda_graph:
             backend._preflight_graph_metadata_buffers(

--- a/flashinfer/mla/_batch_mla/_backends/fa2_backend.py
+++ b/flashinfer/mla/_batch_mla/_backends/fa2_backend.py
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 """
 
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Sequence
 
 import torch
 
@@ -39,6 +39,7 @@ class _BatchMLAPagedAttentionFa2Backend(_BatchMLAPagedAttentionFaBackendBase):
         kv_split_widths: tuple[int, int],
         int_workspace_buffer: Optional[torch.Tensor] = None,
         pin_memory_int_workspace_buffer: Optional[torch.Tensor] = None,
+        graph_plan_info: Optional[Sequence[int]] = None,
     ) -> None:
         super().__init__(
             backend="fa2",
@@ -52,6 +53,7 @@ class _BatchMLAPagedAttentionFa2Backend(_BatchMLAPagedAttentionFaBackendBase):
             kv_split_widths=kv_split_widths,
             int_workspace_buffer=int_workspace_buffer,
             pin_memory_int_workspace_buffer=pin_memory_int_workspace_buffer,
+            graph_plan_info=graph_plan_info,
         )
 
     def plan(

--- a/flashinfer/mla/_batch_mla/_backends/fa3_backend.py
+++ b/flashinfer/mla/_batch_mla/_backends/fa3_backend.py
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 """
 
-from typing import ClassVar, Optional
+from typing import ClassVar, Optional, Sequence
 
 import torch
 
@@ -39,6 +39,7 @@ class _BatchMLAPagedAttentionFa3Backend(_BatchMLAPagedAttentionFaBackendBase):
         kv_split_widths: tuple[int, int],
         int_workspace_buffer: Optional[torch.Tensor] = None,
         pin_memory_int_workspace_buffer: Optional[torch.Tensor] = None,
+        graph_plan_info: Optional[Sequence[int]] = None,
     ) -> None:
         super().__init__(
             backend="fa3",
@@ -52,6 +53,7 @@ class _BatchMLAPagedAttentionFa3Backend(_BatchMLAPagedAttentionFaBackendBase):
             kv_split_widths=kv_split_widths,
             int_workspace_buffer=int_workspace_buffer,
             pin_memory_int_workspace_buffer=pin_memory_int_workspace_buffer,
+            graph_plan_info=graph_plan_info,
         )
 
     def plan(

--- a/flashinfer/mla/_batch_mla/_planning.py
+++ b/flashinfer/mla/_batch_mla/_planning.py
@@ -6,7 +6,7 @@ you may not use this file except in compliance with the License.
 """
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional
+from typing import Literal, Optional, Sequence
 
 import torch
 
@@ -582,6 +582,11 @@ class _MLAPlanArguments:
     _kv_indices_buf: Optional[torch.Tensor] = field(repr=False, compare=False)
     _kv_len_arr_buf: Optional[torch.Tensor] = field(repr=False, compare=False)
     _graph_plan_int_workspace_buffer: Optional[torch.Tensor] = field(
+        default=None, repr=False, compare=False
+    )
+    # Plan info of the FA2/FA3 plan a CUDA graph was captured with; a replan
+    # keeps the kernel configuration recorded there.
+    _graph_plan_info: Optional[Sequence[int]] = field(
         default=None, repr=False, compare=False
     )
     _metadata_resolver: _MLAPlanMetadataResolver = field(

--- a/flashinfer/mla/_batch_mla/_wrapper.py
+++ b/flashinfer/mla/_batch_mla/_wrapper.py
@@ -527,6 +527,7 @@ class BatchMLAPagedAttentionWrapper:
 
         previous_backend = getattr(self, "_planned_backend", None)
         graph_plan_int_workspace_buffer = None
+        graph_plan_info = None
         if (
             self._use_cuda_graph
             and previous_backend is not None
@@ -534,6 +535,7 @@ class BatchMLAPagedAttentionWrapper:
             and getattr(previous_backend, "_backend", None) in ("fa2", "fa3")
         ):
             graph_plan_int_workspace_buffer = previous_backend._int_workspace_buffer
+            graph_plan_info = getattr(previous_backend, "_plan_info", None)
 
         backend_type = _BACKEND_TYPES[self._backend]
         planned_capabilities = backend_type._plan_capabilities
@@ -589,6 +591,7 @@ class BatchMLAPagedAttentionWrapper:
             _kv_indices_buf=self._kv_indices_buf,
             _kv_len_arr_buf=self._kv_len_arr_buf,
             _graph_plan_int_workspace_buffer=graph_plan_int_workspace_buffer,
+            _graph_plan_info=graph_plan_info,
         )
 
         # ---------------------------------------------------------------------------

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -760,9 +760,16 @@ __device__ __forceinline__ void finalize_m_(typename KTraits::AttentionVariant v
   }
 }
 
+// Split-KV merge, run by every CTA after the grid-wide sync. A CTA owns `len`
+// packed rows; row `i` has one partial state per KV chunk at partial offsets
+// `partial_offset_start + i`, `+ stride`, `+ 2 * stride`, ... The CTA's threads
+// form NUM_GROUPS groups of one HEAD_DIM_CKV row each. When there are fewer
+// rows than groups (decode with few heads), the groups of a row take
+// interleaved partials and combine through shared memory; the merge is bound
+// by L2 latency, so each group keeps MERGE_BATCH partial loads in flight.
 template <typename KTraits>
 __device__ void DevicePersistentMergeStates(
-    typename KTraits::IdType* merge_packed_offset_start,
+    uint8_t* smem, typename KTraits::IdType* merge_packed_offset_start,
     typename KTraits::IdType* merge_packed_offset_end,
     typename KTraits::IdType* merge_partial_packed_offset_start,
     typename KTraits::IdType* merge_partial_packed_offset_end,
@@ -770,40 +777,98 @@ __device__ void DevicePersistentMergeStates(
     float* partial_lse, typename KTraits::DTypeO* final_o, float* final_lse,
     const uint32_t o_stride_n, const uint32_t o_stride_h, const uint_fastdiv& num_heads,
     const bool& return_lse_base_on_e) {
+  constexpr uint32_t HEAD_DIM_CKV = KTraits::HEAD_DIM_CKV;
   constexpr uint32_t VEC_SIZE = 8;  // partial o has data type float
-  constexpr uint32_t NUM_THRS_PER_ROW = KTraits::HEAD_DIM_CKV / VEC_SIZE;
-  constexpr uint32_t ROWS_PER_ITERATION = (KTraits::NUM_THREADS) / NUM_THRS_PER_ROW;
+  constexpr uint32_t NUM_THRS_PER_ROW = HEAD_DIM_CKV / VEC_SIZE;
+  constexpr uint32_t NUM_GROUPS = KTraits::NUM_THREADS / NUM_THRS_PER_ROW;
+  constexpr uint32_t MERGE_BATCH = 8;
+  static_assert(
+      KTraits::NUM_THREADS % NUM_THRS_PER_ROW == 0 && (NUM_GROUPS & (NUM_GROUPS - 1)) == 0,
+      "merge groups must be a power of two");
+  struct GroupState {
+    alignas(16) float o[HEAD_DIM_CKV];
+    float m;
+    float d;
+  };
+  GroupState* group_states = reinterpret_cast<GroupState*>(smem);
+
   const uint32_t cta_idx = (gridDim.x * blockIdx.y + blockIdx.x);
   const uint32_t thread_id = (threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x;
+  const uint32_t group_idx = thread_id / NUM_THRS_PER_ROW;
+  const uint32_t vec_idx = thread_id % NUM_THRS_PER_ROW;
   const uint32_t offset_start = merge_packed_offset_start[cta_idx];
   const uint32_t len = merge_packed_offset_end[cta_idx] - offset_start;
   const uint32_t partial_offset_start = merge_partial_packed_offset_start[cta_idx];
   const uint32_t partial_offset_end = merge_partial_packed_offset_end[cta_idx];
   const uint32_t stride = merge_partial_stride[cta_idx];
+  if (len == 0) return;
+
+  // Rows are merged rows_per_iter at a time (a power of two, at most NUM_GROUPS);
+  // the groups_per_row groups sharing a row split its partials.
+  uint32_t rows_per_iter = 1;
+  while (rows_per_iter * 2 <= min(len, NUM_GROUPS)) rows_per_iter *= 2;
+  const uint32_t groups_per_row = NUM_GROUPS / rows_per_iter;
+  const uint32_t row_in_iter = group_idx / groups_per_row;
+  const uint32_t slice = group_idx % groups_per_row;
+
 #pragma unroll 1
-  for (uint32_t local_packed_offset = thread_id / NUM_THRS_PER_ROW; local_packed_offset < len;
-       local_packed_offset += ROWS_PER_ITERATION) {
-    uint32_t final_packed_offset = offset_start + local_packed_offset;
-    uint32_t q, r;
-    num_heads.divmod(final_packed_offset, q, r);
+  for (uint32_t row_base = 0; row_base < len; row_base += rows_per_iter) {
+    const uint32_t local_row = row_base + row_in_iter;
+    const bool has_row = local_row < len;
     state_t<VEC_SIZE> st;
-#pragma unroll 8
-    for (uint32_t partial_packed_offset = partial_offset_start + local_packed_offset;
-         partial_packed_offset < partial_offset_end; partial_packed_offset += stride) {
-      vec_t<float, VEC_SIZE> o_partial;
-      float lse_partial;
-      o_partial.cast_load(partial_o + partial_packed_offset * KTraits::HEAD_DIM_CKV +
-                          (thread_id % NUM_THRS_PER_ROW) * VEC_SIZE);
-      lse_partial = partial_lse[partial_packed_offset];
-      st.merge(o_partial, lse_partial, 1);
+    if (has_row) {
+      const uint32_t partial_step = groups_per_row * stride;
+#pragma unroll 1
+      for (uint32_t partial_offset = partial_offset_start + local_row + slice * stride;
+           partial_offset < partial_offset_end; partial_offset += MERGE_BATCH * partial_step) {
+        vec_t<float, VEC_SIZE> o_partial[MERGE_BATCH];
+        float lse_partial[MERGE_BATCH];
+#pragma unroll
+        for (uint32_t b = 0; b < MERGE_BATCH; ++b) {
+          const uint32_t p = partial_offset + b * partial_step;
+          if (p < partial_offset_end) {
+            o_partial[b].cast_load(partial_o + p * HEAD_DIM_CKV + vec_idx * VEC_SIZE);
+            lse_partial[b] = partial_lse[p];
+          }
+        }
+#pragma unroll
+        for (uint32_t b = 0; b < MERGE_BATCH; ++b) {
+          if (partial_offset + b * partial_step < partial_offset_end) {
+            st.merge(o_partial[b], lse_partial[b], 1.f);
+          }
+        }
+      }
     }
-    st.normalize();
-    st.o.cast_store(final_o +
-                    (q * o_stride_n + r * o_stride_h + (thread_id % NUM_THRS_PER_ROW) * VEC_SIZE));
-    if (final_lse) {
-      final_lse[q * num_heads + r] = st.get_lse();
-      if (return_lse_base_on_e) {
-        final_lse[q * num_heads + r] *= math::loge2;
+
+    if (groups_per_row > 1) {
+      if (has_row && slice > 0) {
+        st.o.store(group_states[group_idx].o + vec_idx * VEC_SIZE);
+        if (vec_idx == 0) {
+          group_states[group_idx].m = st.m;
+          group_states[group_idx].d = st.d;
+        }
+      }
+      __syncthreads();
+      if (has_row && slice == 0) {
+#pragma unroll 1
+        for (uint32_t other_slice = 1; other_slice < groups_per_row; ++other_slice) {
+          const GroupState& other = group_states[group_idx + other_slice];
+          vec_t<float, VEC_SIZE> other_o;
+          other_o.load(other.o + vec_idx * VEC_SIZE);
+          st.merge(other_o, other.m, other.d);
+        }
+      }
+      __syncthreads();
+    }
+
+    if (has_row && slice == 0) {
+      st.normalize();
+      uint32_t q, r;
+      num_heads.divmod(offset_start + local_row, q, r);
+      st.o.cast_store(final_o + (q * o_stride_n + r * o_stride_h + vec_idx * VEC_SIZE));
+      if (final_lse && vec_idx == 0) {
+        final_lse[q * num_heads + r] =
+            return_lse_base_on_e ? st.get_lse() * math::loge2 : st.get_lse();
       }
     }
   }
@@ -1207,7 +1272,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPagedAttentionKe
 
   // the second stage, merge partial outputs
   DevicePersistentMergeStates<KTraits>(
-      params.merge_packed_offset_start, params.merge_packed_offset_end,
+      smem, params.merge_packed_offset_start, params.merge_packed_offset_end,
       params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
       params.merge_partial_stride, partial_o, partial_lse, final_o, final_lse, o_stride_n,
       o_stride_h, num_heads, params.return_lse_base_on_e);

--- a/include/flashinfer/attention/mla.cuh
+++ b/include/flashinfer/attention/mla.cuh
@@ -790,6 +790,8 @@ __device__ void DevicePersistentMergeStates(
     float m;
     float d;
   };
+  static_assert(NUM_GROUPS * sizeof(GroupState) <= sizeof(typename KTraits::SharedStorage),
+                "merge scratch exceeds the kernel's dynamic shared memory");
   GroupState* group_states = reinterpret_cast<GroupState*>(smem);
 
   const uint32_t cta_idx = (gridDim.x * blockIdx.y + blockIdx.x);

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -55,6 +55,13 @@ enum class NamedBarriers {
   // (consumer arrives after QK -> producer reads BF16 staging in PV).
   kConsumerDequantBegin = 4U,
   kConsumerDequantEnd = 5U,
+  // Swap-AB Q tiles only (see HopperKernelTraits): one 128-thread barrier per
+  // warpgroup. The consumer uses its barrier to exchange per-warp softmax
+  // partials through shared memory; both warpgroups use theirs to wait for
+  // their own transposed O staging before copying rows out. cutlass reserves
+  // the upper half of the 16 hardware barriers, so ids must stay below 8.
+  kConsumerWarpgroup = 6U,
+  kProducerWarpgroup = 7U,
 };
 
 __device__ __forceinline__ void barrier_arrive(int num_threads, NamedBarriers barrier) {
@@ -116,6 +123,9 @@ struct HopperSharedStorageQKVO {
       alignas(16) float o_scale[CTA_TILE_Q];
       alignas(16) float m[CTA_TILE_Q];
       alignas(16) float d[CTA_TILE_Q];
+      // Swap-AB Q tiles reduce softmax statistics across the four warps of the
+      // consumer warpgroup; each warp parks its per-column partials here.
+      alignas(16) float md_partial[4][CTA_TILE_Q];
     };
 
     typename MainloopPipeline::SharedStorage pipeline_q, pipeline_kv;
@@ -131,9 +141,6 @@ struct HopperKernelTraits
   static constexpr uint32_t NUM_THREADS = 256;
   static constexpr uint32_t NUM_COPY_THREADS = 128;
   static constexpr uint32_t NUM_QK_THREADS = 128;
-  static constexpr uint32_t NUM_REGS_S_FRAG = CTA_TILE_KV_ / 2;
-  static constexpr uint32_t NUM_REGS_O_FRAG = HEAD_DIM_CKV_ / 4;
-  static constexpr uint32_t NUM_REGS_P_FRAG = CTA_TILE_KV_ / 4;
   // FP8 KV path: KV stored as FP8 e4m3 in shmem, dequantized to DTypeQ
   // before WGMMA. Match on the exact type (not sizeof==1) — other 1-byte
   // JIT dtypes (e.g. __nv_fp4x2_e2m1) have no compatible vec_cast.
@@ -172,6 +179,52 @@ struct HopperKernelTraits
   using SharedStorage =
       HopperSharedStorageQKVO<MainloopPipeline, NUM_STAGES_, CTA_TILE_Q_, CTA_TILE_KV_,
                               HEAD_DIM_CKV_, HEAD_DIM_KPE_, DTypeQ_, DTypeKV_, DTypeO_>;
+
+  // Q tile layout. CTA_TILE_Q == 64 is the original layout: Q is the WGMMA-M
+  // operand, so a decode work item with 8 or 16 packed query rows pads to 64
+  // rows and wastes most of the tensor-core work. Narrower tiles swap the GEMM
+  // operands (SWAP_AB) so the query rows land on WGMMA-N, whose granularity is 8:
+  //
+  //   S^T[kv, q]  = K[kv, d]   * Q^T[d, q]     A = K   (K-major),  B = Q   (K-major)
+  //   O^T[d, q]  += V^T[d, kv] * P^T[kv, q]    A = V^T (MN-major), B = P^T (K-major)
+  //
+  // Both products read the same shared-memory tiles as the original layout;
+  // only the descriptor roles and the accumulator layout change. A thread then
+  // owns two kv (or d) rows and CTA_TILE_Q / 4 query columns, so the softmax
+  // statistics m/d/o_scale are per column, and the reduction over kv needs one
+  // cross-warp step through shared memory per KV tile.
+  static constexpr bool SWAP_AB = CTA_TILE_Q_ < 64;
+  static_assert(CTA_TILE_Q_ % 16 == 0 && CTA_TILE_Q_ <= 64, "unsupported Q tile");
+  static_assert(!SWAP_AB || HEAD_DIM_CKV_ % 128 == 0,
+                "swap-AB tiles split each warpgroup's half of HEAD_DIM_CKV into 64-row chunks");
+
+  // Accumulator registers per thread. S is [CTA_TILE_Q, CTA_TILE_KV], or its
+  // transpose when swapped. Each warpgroup owns HEAD_DIM_CKV / 2 columns of O;
+  // swapped, that half is NUM_O_CHUNKS independent 64-row WGMMA-M chunks.
+  static constexpr uint32_t NUM_REGS_S_FRAG = (SWAP_AB ? CTA_TILE_Q_ : CTA_TILE_KV_) / 2;
+  static constexpr uint32_t NUM_REGS_P_FRAG = NUM_REGS_S_FRAG / 2;
+  static constexpr uint32_t NUM_O_CHUNKS = SWAP_AB ? HEAD_DIM_CKV_ / 128 : 1;
+  static constexpr uint32_t NUM_REGS_O_CHUNK = SWAP_AB ? CTA_TILE_Q_ / 2 : HEAD_DIM_CKV_ / 4;
+  static constexpr uint32_t NUM_REGS_O_FRAG = NUM_O_CHUNKS * NUM_REGS_O_CHUNK;
+  // Softmax states (m, d, o_scale) per thread: two rows, or CTA_TILE_Q / 4 columns.
+  static constexpr uint32_t NUM_MD = SWAP_AB ? CTA_TILE_Q_ / 4 : 2;
+
+  // Softmax state that accumulator register `reg` belongs to. The WGMMA
+  // accumulator layout is the same for S and for every O chunk: register
+  // 4 * i + 2 * j + c holds (row lane / 4 + 8 * j, column 8 * i + 2 * (lane % 4) + c).
+  static __device__ __forceinline__ uint32_t md_index(uint32_t reg) {
+    if constexpr (SWAP_AB) {
+      const uint32_t r = reg % NUM_REGS_O_CHUNK;
+      return 2 * (r / 4) + r % 2;
+    } else {
+      return (reg % 4) / 2;
+    }
+  }
+
+  // Query column within the tile of softmax state `md` on lane `lane_idx` (swap-AB).
+  static __device__ __forceinline__ uint32_t md_column(uint32_t md, uint32_t lane_idx) {
+    return 8 * (md / 2) + 2 * (lane_idx % 4) + md % 2;
+  }
 };
 
 template <typename KTraits>
@@ -182,7 +235,7 @@ __device__ __forceinline__ void init_states_(float* o_frag, float* m, float* d, 
   }
 
 #pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
+  for (uint32_t j = 0; j < KTraits::NUM_MD; ++j) {
     m[j] = -math::inf;
     d[j] = 1.f;
     o_scale[j] = 1.f;
@@ -198,47 +251,40 @@ __device__ __forceinline__ void load_q(
   using DTypeQ = typename KTraits::DTypeQ;
   constexpr uint32_t UPCAST_STRIDE_Q_NOPE = KTraits::UPCAST_STRIDE_Q_NOPE;
   constexpr uint32_t UPCAST_STRIDE_Q_PE = KTraits::UPCAST_STRIDE_Q_PE;
-  constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
-  constexpr uint32_t NUM_MMA_D_KPE = KTraits::NUM_MMA_D_KPE;
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
-  const uint32_t warp_group_idx = cutlass::canonical_warp_group_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
 
   smem_t<KTraits::SWIZZLE_MODE_Q_NOPE> q_smem_nope(smem_storage->q_smem.nope);
   smem_t<KTraits::SWIZZLE_MODE_Q_PE> q_smem_pe(smem_storage->q_smem.pe);
 
+  // Each pass covers 16 packed rows: 4 rows per warp, 8 lanes per row.
 #pragma unroll
-  for (uint32_t mma_q = 0; mma_q < 2; ++mma_q) {
-#pragma unroll
-    for (uint32_t j = 0; j < 2; ++j) {
-      uint32_t q, r;
-      num_heads.divmod(packed_offset + lane_idx / 8 + (j + mma_q * 2) * 16 + warp_idx_in_wg * 4, q,
-                       r);
-      DTypeQ* q_nope_ptr = q_nope + q * q_nope_stride_n + r * q_nope_stride_h +
-                           (lane_idx % 8) * upcast_size<DTypeQ>();
-      DTypeQ* q_pe_ptr =
-          q_pe + q * q_pe_stride_n + r * q_pe_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
-      uint32_t q_smem_nope_offset_w =
-          get_swizzle_offset<KTraits::SWIZZLE_MODE_Q_NOPE, UPCAST_STRIDE_Q_NOPE>(
-              32 * mma_q + j * 16 + warp_idx_in_wg * 4 + lane_idx / 8, 8 * 0 + lane_idx % 8);
-      uint32_t q_smem_pe_offset_w =
-          get_swizzle_offset<KTraits::SWIZZLE_MODE_Q_PE, UPCAST_STRIDE_Q_PE>(
-              32 * mma_q + j * 16 + warp_idx_in_wg * 4 + lane_idx / 8, 8 * 0 + lane_idx % 8);
+  for (uint32_t pass = 0; pass < KTraits::CTA_TILE_Q / 16; ++pass) {
+    const uint32_t row = pass * 16 + warp_idx_in_wg * 4 + lane_idx / 8;
+    uint32_t q, r;
+    num_heads.divmod(packed_offset + row, q, r);
+    DTypeQ* q_nope_ptr =
+        q_nope + q * q_nope_stride_n + r * q_nope_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
+    DTypeQ* q_pe_ptr =
+        q_pe + q * q_pe_stride_n + r * q_pe_stride_h + (lane_idx % 8) * upcast_size<DTypeQ>();
+    uint32_t q_smem_nope_offset_w =
+        get_swizzle_offset<KTraits::SWIZZLE_MODE_Q_NOPE, UPCAST_STRIDE_Q_NOPE>(row, lane_idx % 8);
+    uint32_t q_smem_pe_offset_w =
+        get_swizzle_offset<KTraits::SWIZZLE_MODE_Q_PE, UPCAST_STRIDE_Q_PE>(row, lane_idx % 8);
 
 #pragma unroll
-      for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 4; ++mma_d) {
-        q_smem_nope.load_128b_async<SharedMemFillMode::kFillZero>(q_smem_nope_offset_w, q_nope_ptr,
-                                                                  q < q_len);
-        q_smem_nope_offset_w += 64;
-        q_nope_ptr += 8 * upcast_size<DTypeQ>();
-      }
-#pragma unroll
-      for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_KPE / 4; ++mma_d) {
-        q_smem_pe.load_128b_async<SharedMemFillMode::kFillZero>(q_smem_pe_offset_w, q_pe_ptr,
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_CKV / 4; ++mma_d) {
+      q_smem_nope.load_128b_async<SharedMemFillMode::kFillZero>(q_smem_nope_offset_w, q_nope_ptr,
                                                                 q < q_len);
-        q_smem_pe_offset_w += 64;
-        q_pe_ptr += 8 * upcast_size<DTypeQ>();
-      }
+      q_smem_nope_offset_w += 64;
+      q_nope_ptr += 8 * upcast_size<DTypeQ>();
+    }
+#pragma unroll
+    for (uint32_t mma_d = 0; mma_d < KTraits::NUM_MMA_D_KPE / 4; ++mma_d) {
+      q_smem_pe.load_128b_async<SharedMemFillMode::kFillZero>(q_smem_pe_offset_w, q_pe_ptr,
+                                                              q < q_len);
+      q_smem_pe_offset_w += 64;
+      q_pe_ptr += 8 * upcast_size<DTypeQ>();
     }
   }
 }
@@ -284,8 +330,6 @@ __device__ __forceinline__ void load_kv(typename KTraits::SharedStorage* smem_st
   using DTypeKV = typename KTraits::DTypeKV;
   constexpr uint32_t UPCAST_STRIDE_CKV = KTraits::UPCAST_STRIDE_CKV;
   constexpr uint32_t UPCAST_STRIDE_KPE = KTraits::UPCAST_STRIDE_KPE;
-  constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
-  constexpr uint32_t NUM_MMA_D_KPE = KTraits::NUM_MMA_D_KPE;
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
 
@@ -438,6 +482,17 @@ __device__ __forceinline__ void repack_fp8_kv_to_bf16(
   }
 }
 
+// One K=16 step of the QK product. Swap-AB tiles issue K as the A operand and Q
+// as the B operand; the descriptors are the same either way.
+template <typename KTraits, typename wgmma, bool init>
+__device__ __forceinline__ void qk_mma(uint64_t desc_q, uint64_t desc_k, float* s_frag) {
+  if constexpr (KTraits::SWAP_AB) {
+    wgmma::template op<init>(desc_k, desc_q, s_frag);
+  } else {
+    wgmma::template op<init>(desc_q, desc_k, s_frag);
+  }
+}
+
 template <typename KTraits>
 __device__ __forceinline__ void compute_mla_qk(typename KTraits::SharedStorage* smem_storage,
                                                const uint32_t stage_idx, float* s_frag) {
@@ -457,17 +512,18 @@ __device__ __forceinline__ void compute_mla_qk(typename KTraits::SharedStorage* 
   auto desc_k_pe =
       make_smem_desc<KTraits::SWIZZLE_MODE_KPE, /*leading_byte_offset=*/16,
                      /*stride_byte_offset=*/KTraits::HEAD_DIM_KPE * 16, KVDescType>(kpe_smem_ptr);
-  using wgmma = WGMMA_ASYNC_SS<KVDescType, float, 64, KTraits::CTA_TILE_KV, 16, Major::K, Major::K,
-                               ScaleIn::One, ScaleIn::One>;
+  using wgmma = WGMMA_ASYNC_SS<KVDescType, float, 64,
+                               KTraits::SWAP_AB ? KTraits::CTA_TILE_Q : KTraits::CTA_TILE_KV, 16,
+                               Major::K, Major::K, ScaleIn::One, ScaleIn::One>;
 
   warpgroup_fence_frag<KTraits::NUM_REGS_S_FRAG>(s_frag);
   warpgroup_arrive();
 #pragma unroll
   for (uint32_t mma_d_pe = 0; mma_d_pe < KTraits::NUM_MMA_D_KPE; ++mma_d_pe) {
     if (mma_d_pe == 0) {
-      wgmma::op</*init=*/true>(desc_q_pe, desc_k_pe, s_frag);
+      qk_mma<KTraits, wgmma, /*init=*/true>(desc_q_pe, desc_k_pe, s_frag);
     } else {
-      wgmma::op</*init=*/false>(desc_q_pe, desc_k_pe, s_frag);
+      qk_mma<KTraits, wgmma, /*init=*/false>(desc_q_pe, desc_k_pe, s_frag);
     }
     if ((mma_d_pe + 1) % 4 == 0) {
       desc_q_pe += 64 - 6;
@@ -487,14 +543,14 @@ __device__ __forceinline__ void compute_mla_qk(typename KTraits::SharedStorage* 
                      /*stride_byte_offset=*/KTraits::HEAD_DIM_CKV * 16, KVDescType>(ckv_smem_ptr);
 
   if constexpr (KTraits::NUM_MMA_D_KPE == 0) {
-    wgmma::op</*init=*/true>(desc_q_nope, desc_ckv, s_frag);
+    qk_mma<KTraits, wgmma, /*init=*/true>(desc_q_nope, desc_ckv, s_frag);
     desc_q_nope += 2;
     desc_ckv += 2;
   }
 #pragma unroll
   for (uint32_t mma_d_ckv = KTraits::NUM_MMA_D_KPE == 0 ? 1 : 0; mma_d_ckv < KTraits::NUM_MMA_D_CKV;
        ++mma_d_ckv) {
-    wgmma::op</*init=*/false>(desc_q_nope, desc_ckv, s_frag);
+    qk_mma<KTraits, wgmma, /*init=*/false>(desc_q_nope, desc_ckv, s_frag);
     if ((mma_d_ckv + 1) % 4 == 0) {
       desc_q_nope += 64 - 6;
       desc_ckv += 64 - 6;
@@ -511,8 +567,6 @@ __device__ __forceinline__ void compute_mla_qk(typename KTraits::SharedStorage* 
 template <typename KTraits>
 __device__ __forceinline__ void compute_mla_pv(typename KTraits::SharedStorage* smem_storage,
                                                const uint32_t stage_idx, float* o_frag) {
-  const uint32_t lane_idx = cutlass::canonical_lane_idx();
-  const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
   const uint32_t warp_group_idx = cutlass::canonical_warp_group_idx();
 
   // P is always DTypeQ-typed; V (= CKV) comes from the BF16 staging buffer on
@@ -527,20 +581,40 @@ __device__ __forceinline__ void compute_mla_pv(typename KTraits::SharedStorage* 
       make_smem_desc<KTraits::SWIZZLE_MODE_P, /*leading_byte_offset=*/16,
                      /*stride_byte_offset=*/KTraits::CTA_TILE_KV * 16, typename KTraits::DTypeQ>(
           smem_storage->kv_o_smem[stage_idx].p);
+  // V is read along d (MN-major): one 128B swizzle atom per 64 d columns, 8 kv
+  // rows apart. Each warpgroup owns the upper or lower half of HEAD_DIM_CKV.
   auto desc_ckv = make_smem_desc<KTraits::SWIZZLE_MODE_CKV,
                                  /*leading_byte_offset=*/KTraits::CTA_TILE_KV * 16,
                                  /*stride_byte_offset=*/KTraits::HEAD_DIM_CKV * 16, KVDescType>(
       ckv_base + warp_group_idx * 8 * (KTraits::HEAD_DIM_CKV / 2));
   warpgroup_fence_frag<KTraits::NUM_REGS_O_FRAG>(o_frag);
   warpgroup_arrive();
-  using wgmma = WGMMA_ASYNC_SS<KVDescType, float, 64, KTraits::HEAD_DIM_CKV / 2, 16, Major::K,
-                               Major::MN, ScaleIn::One, ScaleIn::One>;
 
+  if constexpr (!KTraits::SWAP_AB) {
+    using wgmma = WGMMA_ASYNC_SS<KVDescType, float, 64, KTraits::HEAD_DIM_CKV / 2, 16, Major::K,
+                                 Major::MN, ScaleIn::One, ScaleIn::One>;
 #pragma unroll
-  for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
-    wgmma::op</*init=*/false>(desc_p, desc_ckv, o_frag);
-    desc_p += 2;
-    desc_ckv += 1024;
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+      wgmma::template op</*init=*/false>(desc_p, desc_ckv, o_frag);
+      desc_p += 2;
+      desc_ckv += 1024;
+    }
+  } else {
+    // O^T[d, q] += V^T[d, kv] * P^T[kv, q]: this warpgroup's half of d is
+    // NUM_O_CHUNKS WGMMA-M chunks of 64 rows, each one swizzle atom (1024B)
+    // further along d and accumulating into its own registers.
+    using wgmma = WGMMA_ASYNC_SS<KVDescType, float, 64, KTraits::CTA_TILE_Q, 16, Major::MN,
+                                 Major::K, ScaleIn::One, ScaleIn::One>;
+#pragma unroll
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+#pragma unroll
+      for (uint32_t chunk = 0; chunk < KTraits::NUM_O_CHUNKS; ++chunk) {
+        wgmma::template op</*init=*/false>(desc_ckv + chunk * 64, desc_p,
+                                           o_frag + chunk * KTraits::NUM_REGS_O_CHUNK);
+      }
+      desc_p += 2;
+      desc_ckv += 1024;
+    }
   }
   warpgroup_commit_batch();
   warpgroup_fence_frag<KTraits::NUM_REGS_O_FRAG>(o_frag);
@@ -553,68 +627,126 @@ __device__ __forceinline__ void logits_mask_(const uint32_t qo_packed_idx_base,
                                              const uint_fastdiv num_heads, float* s_frag) {
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
-  constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
-  uint32_t q[2];
-#pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
-    q[j] = (qo_packed_idx_base + warp_idx_in_wg * 16 + lane_idx / 4 + 8 * j) / num_heads;
-  }
 
+  auto keep = [&](uint32_t q_idx, uint32_t kv_idx) {
+    return !(KTraits::CAUSAL ? (kv_idx + qo_len > kv_len + q_idx || (kv_idx >= kv_end))
+                             : kv_idx >= kv_end);
+  };
+
+  if constexpr (!KTraits::SWAP_AB) {
+    uint32_t q[2];
 #pragma unroll
-  for (uint32_t reg_id = 0; reg_id < KTraits::NUM_REGS_S_FRAG; ++reg_id) {
-    const uint32_t q_idx = q[(reg_id % 4) / 2],
-                   kv_idx = kv_idx_base + 2 * (lane_idx % 4) + 8 * (reg_id / 4) + reg_id % 2;
-    const bool mask = (!(KTraits::CAUSAL ? (kv_idx + qo_len > kv_len + q_idx || (kv_idx >= kv_end))
-                                         : kv_idx >= kv_end));
-    s_frag[reg_id] = (mask) ? s_frag[reg_id] : (KTraits::MaskFillValue);
+    for (uint32_t j = 0; j < 2; ++j) {
+      q[j] = (qo_packed_idx_base + warp_idx_in_wg * 16 + lane_idx / 4 + 8 * j) / num_heads;
+    }
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < KTraits::NUM_REGS_S_FRAG; ++reg_id) {
+      const uint32_t q_idx = q[(reg_id % 4) / 2],
+                     kv_idx = kv_idx_base + 2 * (lane_idx % 4) + 8 * (reg_id / 4) + reg_id % 2;
+      s_frag[reg_id] = keep(q_idx, kv_idx) ? s_frag[reg_id] : KTraits::MaskFillValue;
+    }
+  } else {
+    // S^T: rows are kv positions, columns are packed query rows.
+    uint32_t q[KTraits::NUM_MD];
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      q[md] = (qo_packed_idx_base + KTraits::md_column(md, lane_idx)) / num_heads;
+    }
+#pragma unroll
+    for (uint32_t reg_id = 0; reg_id < KTraits::NUM_REGS_S_FRAG; ++reg_id) {
+      const uint32_t q_idx = q[KTraits::md_index(reg_id)],
+                     kv_idx =
+                         kv_idx_base + warp_idx_in_wg * 16 + lane_idx / 4 + 8 * ((reg_id % 4) / 2);
+      s_frag[reg_id] = keep(q_idx, kv_idx) ? s_frag[reg_id] : KTraits::MaskFillValue;
+    }
   }
 }
 
 template <typename KTraits>
 __device__ __forceinline__ void rescale_o_(float* o_scale, float* o_frag) {
-  const uint32_t lane_idx = cutlass::canonical_lane_idx();
-  const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
 #pragma unroll
   for (uint32_t reg_id = 0; reg_id < KTraits::NUM_REGS_O_FRAG; ++reg_id) {
-    o_frag[reg_id] *= o_scale[(reg_id % 4) / 2];
+    o_frag[reg_id] *= o_scale[KTraits::md_index(reg_id)];
   }
 }
 
+// Online-softmax update for one KV tile: folds the tile into the running
+// max/sum, rewrites s_frag as unnormalized probabilities, and leaves the O
+// rescale factor in o_scale. d stays a per-thread partial sum until the end.
 template <typename KTraits>
 __device__ __forceinline__ void update_md_(typename KTraits::SharedStorage* smem_storage,
                                            typename KTraits::AttentionVariant variant,
                                            float* s_frag, float* m, float* d, float* o_scale) {
-  using AttentionVariant = typename KTraits::AttentionVariant;
   const float sm_scale = variant.sm_scale_log2;
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
-  float m_prev[2];
+  // Per-row clamp for fully masked rows (see update_mdo_states in prefill.cuh).
+  auto scaled_max = [&](float m_val) {
+    return max(m_val * sm_scale, -cuda::std::numeric_limits<float>::max());
+  };
+
+  if constexpr (!KTraits::SWAP_AB) {
+    // Rows of S: a thread holds two rows, spread over the four lanes of a quad.
+    float m_prev[2];
 #pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
-    m_prev[j] = m[j];
+    for (uint32_t j = 0; j < 2; ++j) {
+      m_prev[j] = m[j];
 #pragma unroll
-    for (uint32_t k = 0; k < KTraits::NUM_REGS_S_FRAG / 4; ++k) {
-      float m_local = max(s_frag[k * 4 + j * 2 + 0], s_frag[k * 4 + j * 2 + 1]);
-      m[j] = max(m[j], m_local);
+      for (uint32_t k = 0; k < KTraits::NUM_REGS_S_FRAG / 4; ++k) {
+        float m_local = max(s_frag[k * 4 + j * 2 + 0], s_frag[k * 4 + j * 2 + 1]);
+        m[j] = max(m[j], m_local);
+      }
+      m[j] = max(m[j], math::shfl_xor_sync(m[j], 0x2));
+      m[j] = max(m[j], math::shfl_xor_sync(m[j], 0x1));
     }
-    m[j] = max(m[j], math::shfl_xor_sync(m[j], 0x2));
-    m[j] = max(m[j], math::shfl_xor_sync(m[j], 0x1));
-  }
 
 #pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
-    // Per-row clamp for fully masked rows (see update_mdo_states in prefill.cuh).
-    const float m_scaled = max(m[j] * sm_scale, -cuda::std::numeric_limits<float>::max());
-    o_scale[j] = math::ptx_exp2(m_prev[j] * sm_scale - m_scaled);
-    float d_local = 0.f;
+    for (uint32_t j = 0; j < 2; ++j) {
+      const float m_scaled = scaled_max(m[j]);
+      o_scale[j] = math::ptx_exp2(m_prev[j] * sm_scale - m_scaled);
+      float d_local = 0.f;
 #pragma unroll
-    for (uint32_t k = 0; k < KTraits::NUM_REGS_S_FRAG / 4; ++k) {
-      s_frag[k * 4 + j * 2 + 0] = math::ptx_exp2(s_frag[k * 4 + j * 2 + 0] * sm_scale - m_scaled);
-      s_frag[k * 4 + j * 2 + 1] = math::ptx_exp2(s_frag[k * 4 + j * 2 + 1] * sm_scale - m_scaled);
+      for (uint32_t k = 0; k < KTraits::NUM_REGS_S_FRAG / 4; ++k) {
+        s_frag[k * 4 + j * 2 + 0] = math::ptx_exp2(s_frag[k * 4 + j * 2 + 0] * sm_scale - m_scaled);
+        s_frag[k * 4 + j * 2 + 1] = math::ptx_exp2(s_frag[k * 4 + j * 2 + 1] * sm_scale - m_scaled);
 
-      d_local += s_frag[k * 4 + j * 2 + 0] + s_frag[k * 4 + j * 2 + 1];
+        d_local += s_frag[k * 4 + j * 2 + 0] + s_frag[k * 4 + j * 2 + 1];
+      }
+      d[j] = d[j] * o_scale[j] + d_local;
     }
-    d[j] = d[j] * o_scale[j] + d_local;
+  } else {
+    // Columns of S^T: a thread holds two kv rows of each column. The column
+    // max is reduced over the eight lanes that share a column (lane bits 2..4)
+    // and then across the four warps of the warpgroup through shared memory.
+    float m_prev[KTraits::NUM_MD];
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      m_prev[md] = m[md];
+      const uint32_t reg_id = 4 * (md / 2) + md % 2;
+      float m_local = max(s_frag[reg_id], s_frag[reg_id + 2]);
+      m_local = max(m_local, math::shfl_xor_sync(m_local, 0x4));
+      m_local = max(m_local, math::shfl_xor_sync(m_local, 0x8));
+      m_local = max(m_local, math::shfl_xor_sync(m_local, 0x10));
+      if (lane_idx < 4) {
+        smem_storage->md_partial[warp_idx_in_wg][KTraits::md_column(md, lane_idx)] = m_local;
+      }
+    }
+    barrier_sync(KTraits::NUM_QK_THREADS, NamedBarriers::kConsumerWarpgroup);
+
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      const uint32_t col = KTraits::md_column(md, lane_idx);
+      const float m_tile =
+          max(max(smem_storage->md_partial[0][col], smem_storage->md_partial[1][col]),
+              max(smem_storage->md_partial[2][col], smem_storage->md_partial[3][col]));
+      m[md] = max(m[md], m_tile);
+      const float m_scaled = scaled_max(m[md]);
+      o_scale[md] = math::ptx_exp2(m_prev[md] * sm_scale - m_scaled);
+      const uint32_t reg_id = 4 * (md / 2) + md % 2;
+      s_frag[reg_id] = math::ptx_exp2(s_frag[reg_id] * sm_scale - m_scaled);
+      s_frag[reg_id + 2] = math::ptx_exp2(s_frag[reg_id + 2] * sm_scale - m_scaled);
+      d[md] = d[md] * o_scale[md] + s_frag[reg_id] + s_frag[reg_id + 2];
+    }
   }
 }
 
@@ -623,39 +755,62 @@ __device__ __forceinline__ void write_p_rmem_smem(typename KTraits::SharedStorag
                                                   const uint32_t stage_idx, uint32_t* p_frag) {
   // P is DTypeQ-typed, so use UPCAST_STRIDE_P_BF16 (BF16 elements per b128) for
   // the swizzle offset on both the BF16 and FP8 KV paths.
-  static constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
   smem_t<KTraits::SWIZZLE_MODE_P> p_smem(smem_storage->kv_o_smem[stage_idx].p);
+  if constexpr (!KTraits::SWAP_AB) {
 #pragma unroll
-  for (uint32_t mma_kv = 0; mma_kv < NUM_MMA_KV; ++mma_kv) {
-    uint32_t p_smem_offset_w =
-        get_swizzle_offset<KTraits::SWIZZLE_MODE_P, KTraits::UPCAST_STRIDE_P_BF16>(
-            warp_idx_in_wg * 16 + lane_idx % 16, mma_kv * 2 + lane_idx / 16);
-    p_smem.stmatrix_m8n8x4(p_smem_offset_w, p_frag + mma_kv * 4);
+    for (uint32_t mma_kv = 0; mma_kv < KTraits::NUM_MMA_KV; ++mma_kv) {
+      uint32_t p_smem_offset_w =
+          get_swizzle_offset<KTraits::SWIZZLE_MODE_P, KTraits::UPCAST_STRIDE_P_BF16>(
+              warp_idx_in_wg * 16 + lane_idx % 16, mma_kv * 2 + lane_idx / 16);
+      p_smem.stmatrix_m8n8x4(p_smem_offset_w, p_frag + mma_kv * 4);
+    }
+  } else {
+    // The registers hold P^T; a transposed stmatrix lands every 8x8 block as
+    // P[q, kv], the K-major B operand of the PV product. Each x4 store covers
+    // 16 query columns by this warp's 16 kv rows.
+#pragma unroll
+    for (uint32_t i = 0; i < KTraits::CTA_TILE_Q / 16; ++i) {
+      uint32_t p_smem_offset_w =
+          get_swizzle_offset<KTraits::SWIZZLE_MODE_P, KTraits::UPCAST_STRIDE_P_BF16>(
+              i * 16 + 8 * (lane_idx / 16) + lane_idx % 8, warp_idx_in_wg * 2 + (lane_idx / 8) % 2);
+      p_smem.stmatrix_m8n8x4_trans(p_smem_offset_w, p_frag + i * 4);
+    }
   }
 }
 
 template <typename KTraits>
-__device__ __forceinline__ void normalize_d_(typename KTraits::SharedStorage* smem_storage,
-                                             float* o_frag, float* m, float* d) {
-  float d_rcp[2];
+__device__ __forceinline__ void normalize_d_(float* o_frag, float* m, float* d) {
+  float d_rcp[KTraits::NUM_MD];
   // compute reciprocal of d
 #pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
+  for (uint32_t j = 0; j < KTraits::NUM_MD; ++j) {
     d_rcp[j] = (m[j] != -math::inf) ? math::ptx_rcp(d[j]) : 0.f;
   }
 
 #pragma unroll
   for (uint32_t reg_id = 0; reg_id < KTraits::NUM_REGS_O_FRAG; ++reg_id) {
-    o_frag[reg_id] = o_frag[reg_id] * d_rcp[(reg_id % 4) / 2];
+    o_frag[reg_id] = o_frag[reg_id] * d_rcp[KTraits::md_index(reg_id)];
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void scale_m_(typename KTraits::AttentionVariant variant, float* m) {
+  if constexpr (variant.use_softmax) {
+#pragma unroll
+    for (uint32_t j = 0; j < KTraits::NUM_MD; ++j) {
+      if (m[j] != -math::inf) {
+        m[j] *= variant.sm_scale_log2;
+      }
+    }
   }
 }
 
 template <bool write_lse, typename KTraits>
 __device__ __forceinline__ void write_o(
     typename KTraits::SharedStorage* smem_storage, typename KTraits::DTypeO* final_o,
-    float* final_lse, typename KTraits::DTypeO* partial_o, float* partial_lse, float(*o_frag),
+    float* final_lse, typename KTraits::DTypeO* partial_o, float* partial_lse, float* o_frag,
     float* m, float* d, const uint32_t o_stride_n, const uint32_t o_stride_h, const uint32_t q_len,
     const uint32_t packed_offset, const uint_fastdiv& num_heads, const bool& return_lse_base_on_e) {
   using DTypeO = typename KTraits::DTypeO;
@@ -671,89 +826,93 @@ __device__ __forceinline__ void write_o(
   o_smem = smem_storage->o;
 
   // step 0. rmem to smem
+  if constexpr (!KTraits::SWAP_AB) {
 #pragma unroll
-  for (uint32_t k = 0; k < HEAD_DIM_CKV / 32; ++k) {
-    uint32_t o_frag_f16[8 / 2];
-    vec_cast<DTypeO, float>::cast<8>((DTypeO*)o_frag_f16, &o_frag[k * 8]);
-    uint32_t o_smem_offset_w = get_swizzle_offset<KTraits::SWIZZLE_MODE_O, UPCAST_STRIDE_FINAL_O>(
-        warp_idx_in_wg * 16 + lane_idx % 16,
-        warp_group_idx * NUM_MMA_D_CKV + k * 2 + lane_idx / 16);
-    o_smem.template stmatrix_m8n8x4(o_smem_offset_w, o_frag_f16);
-  }
-
-  if (partial_o != nullptr) {
-    // NOTE(Zihao): o_smem is not used if write to partial_o, and we can avoid the barrier
-    // write to partial_o
-
-#pragma unroll
-    for (uint32_t j = 0; j < 4; ++j) {
-      uint32_t q_idx = (packed_offset + warp_idx_in_wg * 16 + 4 * j + lane_idx / 8) / num_heads;
-      DTypeO* o_partial_ptr =
-          partial_o +
-          ((blockIdx.x * 4 + warp_idx_in_wg) * 16 + 4 * j + lane_idx / 8) * HEAD_DIM_CKV +
-          warp_group_idx * (HEAD_DIM_CKV / 2) + (lane_idx % 8) * upcast_size<DTypeO>();
+    for (uint32_t k = 0; k < HEAD_DIM_CKV / 32; ++k) {
+      uint32_t o_frag_f16[8 / 2];
+      vec_cast<DTypeO, float>::cast<8>((DTypeO*)o_frag_f16, &o_frag[k * 8]);
       uint32_t o_smem_offset_w = get_swizzle_offset<KTraits::SWIZZLE_MODE_O, UPCAST_STRIDE_FINAL_O>(
-          warp_idx_in_wg * 16 + 4 * j + lane_idx / 8,
-          warp_group_idx * NUM_MMA_D_CKV + lane_idx % 8);
-#pragma unroll
-      for (uint32_t k = 0; k < HEAD_DIM_CKV / 128; ++k) {
-        if (q_idx < q_len) {
-          o_smem.template store_128b(o_smem_offset_w, o_partial_ptr);
-        }
-        o_partial_ptr += 8 * upcast_size<DTypeO>();
-        o_smem_offset_w += 64;
-      }
-    }
-
-    if constexpr (write_lse) {
-#pragma unroll
-      for (uint32_t j = 0; j < 2; ++j) {
-        uint32_t q_idx = (packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4) / num_heads;
-        if (lane_idx % 4 == 0 && q_idx < q_len) {
-          float lse = (m[j] == -math::inf) ? -cuda::std::numeric_limits<float>::infinity()
-                                           : math::ptx_log2(d[j]) + float(m[j]);
-          partial_lse[(blockIdx.x * 4 + warp_idx_in_wg) * 16 + 8 * j + lane_idx / 4] = lse;
-        }
-      }
+          warp_idx_in_wg * 16 + lane_idx % 16,
+          warp_group_idx * NUM_MMA_D_CKV + k * 2 + lane_idx / 16);
+      o_smem.template stmatrix_m8n8x4(o_smem_offset_w, o_frag_f16);
     }
   } else {
-    // write to final_o
-
-// step 1. smem to gmem
+    // The registers hold O^T; a transposed stmatrix lands every 8x8 block as
+    // O[q, d]. Each x4 store covers 16 query rows by this warp's 16 d columns
+    // of one 64-column chunk.
 #pragma unroll
-    for (uint32_t j = 0; j < 4; ++j) {
-      uint32_t q, r;
-      num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 4 * j + lane_idx / 8, q, r);
-      DTypeO* o_final_ptr = final_o + q * o_stride_n + r * o_stride_h +
-                            warp_group_idx * (HEAD_DIM_CKV / 2) +
-                            (lane_idx % 8) * upcast_size<DTypeO>();
-      uint32_t o_smem_offset_w = get_swizzle_offset<KTraits::SWIZZLE_MODE_O, UPCAST_STRIDE_FINAL_O>(
-          warp_idx_in_wg * 16 + 4 * j + lane_idx / 8,
-          warp_group_idx * NUM_MMA_D_CKV + lane_idx % 8);
+    for (uint32_t chunk = 0; chunk < KTraits::NUM_O_CHUNKS; ++chunk) {
 #pragma unroll
-      for (uint32_t k = 0; k < HEAD_DIM_CKV / 128; ++k) {
-        if (q < q_len) {
-          o_smem.template store_128b(o_smem_offset_w, o_final_ptr);
-        }
-        o_final_ptr += 8 * upcast_size<DTypeO>();
-        o_smem_offset_w += 64;
+      for (uint32_t i = 0; i < KTraits::CTA_TILE_Q / 16; ++i) {
+        uint32_t o_frag_f16[8 / 2];
+        vec_cast<DTypeO, float>::cast<8>((DTypeO*)o_frag_f16,
+                                         &o_frag[chunk * KTraits::NUM_REGS_O_CHUNK + i * 8]);
+        uint32_t o_smem_offset_w =
+            get_swizzle_offset<KTraits::SWIZZLE_MODE_O, UPCAST_STRIDE_FINAL_O>(
+                i * 16 + 8 * (lane_idx / 16) + lane_idx % 8, warp_group_idx * NUM_MMA_D_CKV +
+                                                                 chunk * 8 + warp_idx_in_wg * 2 +
+                                                                 (lane_idx / 8) % 2);
+        o_smem.template stmatrix_m8n8x4_trans(o_smem_offset_w, o_frag_f16);
       }
     }
+    // Every warp of this warpgroup wrote a slice of every row: wait for the
+    // whole half of O before reading rows back.
+    barrier_sync(KTraits::NUM_COPY_THREADS, warp_group_idx == 0
+                                                ? NamedBarriers::kProducerWarpgroup
+                                                : NamedBarriers::kConsumerWarpgroup);
+  }
 
-    if constexpr (write_lse) {
-      if (final_lse) {
+  // step 1. smem to gmem, 16 rows per pass: 4 rows per warp, 8 lanes per row.
+  // In the original layout each warp copies back the 16 rows it staged itself.
+#pragma unroll
+  for (uint32_t pass = 0; pass < KTraits::CTA_TILE_Q / 16; ++pass) {
+    const uint32_t row = KTraits::SWAP_AB ? pass * 16 + warp_idx_in_wg * 4 + lane_idx / 8
+                                          : warp_idx_in_wg * 16 + pass * 4 + lane_idx / 8;
+    uint32_t q, r;
+    num_heads.divmod(packed_offset + row, q, r);
+    DTypeO* o_ptr = (partial_o != nullptr)
+                        ? partial_o + (blockIdx.x * KTraits::CTA_TILE_Q + row) * HEAD_DIM_CKV
+                        : final_o + q * o_stride_n + r * o_stride_h;
+    o_ptr += warp_group_idx * (HEAD_DIM_CKV / 2) + (lane_idx % 8) * upcast_size<DTypeO>();
+    uint32_t o_smem_offset_w = get_swizzle_offset<KTraits::SWIZZLE_MODE_O, UPCAST_STRIDE_FINAL_O>(
+        row, warp_group_idx * NUM_MMA_D_CKV + lane_idx % 8);
+#pragma unroll
+    for (uint32_t k = 0; k < HEAD_DIM_CKV / 128; ++k) {
+      if (q < q_len) {
+        o_smem.template store_128b(o_smem_offset_w, o_ptr);
+      }
+      o_ptr += 8 * upcast_size<DTypeO>();
+      o_smem_offset_w += 64;
+    }
+  }
+
+  if constexpr (write_lse) {
+    auto store_lse = [&](uint32_t row, float m_val, float d_val) {
+      uint32_t q, r;
+      num_heads.divmod(packed_offset + row, q, r);
+      if (q >= q_len) return;
+      const float lse = (m_val == -math::inf) ? -cuda::std::numeric_limits<float>::infinity()
+                                              : math::ptx_log2(d_val) + m_val;
+      if (partial_o != nullptr) {
+        partial_lse[blockIdx.x * KTraits::CTA_TILE_Q + row] = lse;
+      } else if (final_lse) {
+        final_lse[q * num_heads + r] = return_lse_base_on_e ? lse * math::loge2 : lse;
+      }
+    };
+    if constexpr (!KTraits::SWAP_AB) {
+      if (lane_idx % 4 == 0) {
 #pragma unroll
         for (uint32_t j = 0; j < 2; ++j) {
-          uint32_t q, r;
-          num_heads.divmod(packed_offset + warp_idx_in_wg * 16 + 8 * j + lane_idx / 4, q, r);
-          if (lane_idx % 4 == 0 && q < q_len) {
-            final_lse[q * num_heads + r] = (m[j] == -math::inf)
-                                               ? -cuda::std::numeric_limits<float>::infinity()
-                                               : math::ptx_log2(d[j]) + float(m[j]);
-            if (return_lse_base_on_e) {
-              final_lse[q * num_heads + r] *= math::loge2;
-            }
-          }
+          store_lse(warp_idx_in_wg * 16 + 8 * j + lane_idx / 4, m[j], d[j]);
+        }
+      }
+    } else {
+      // Every thread holds the reduced statistics of its columns; warp 0's
+      // first quad covers all CTA_TILE_Q of them.
+      if (warp_idx_in_wg == 0 && lane_idx < 4) {
+#pragma unroll
+        for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+          store_lse(KTraits::md_column(md, lane_idx), m[md], d[md]);
         }
       }
     }
@@ -780,15 +939,25 @@ __device__ __forceinline__ void convert_s_to_p(float* s_frag, uint32_t* p_frag) 
   }
 }
 
+// Consumer -> producer handoff of the per-tile O rescale factors.
 template <typename KTraits>
 __device__ __forceinline__ void write_o_scale_smem(typename KTraits::SharedStorage* smem_storage,
                                                    float* o_scale) {
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
+  if constexpr (!KTraits::SWAP_AB) {
 #pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
-    if (lane_idx % 4 == 0) {
-      smem_storage->o_scale[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = o_scale[j];
+    for (uint32_t j = 0; j < 2; ++j) {
+      if (lane_idx % 4 == 0) {
+        smem_storage->o_scale[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = o_scale[j];
+      }
+    }
+  } else {
+    if (warp_idx_in_wg == 0 && lane_idx < 4) {
+#pragma unroll
+      for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+        smem_storage->o_scale[KTraits::md_column(md, lane_idx)] = o_scale[md];
+      }
     }
   }
 }
@@ -798,67 +967,406 @@ __device__ __forceinline__ void load_o_scale_smem(typename KTraits::SharedStorag
                                                   float* o_scale) {
   const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
+  if constexpr (!KTraits::SWAP_AB) {
 #pragma unroll
-  for (uint32_t j = 0; j < 2; ++j) {
-    o_scale[j] = smem_storage->o_scale[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4];
+    for (uint32_t j = 0; j < 2; ++j) {
+      o_scale[j] = smem_storage->o_scale[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4];
+    }
+  } else {
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      o_scale[md] = smem_storage->o_scale[KTraits::md_column(md, lane_idx)];
+    }
   }
+}
+
+// Consumer, after the last KV tile: complete the row sums d (per-thread partials
+// until now) and publish m/d for the producer warpgroup through shared memory.
+template <typename KTraits>
+__device__ __forceinline__ void finalize_md_(typename KTraits::SharedStorage* smem_storage,
+                                             float* m, float* d) {
+  const uint32_t lane_idx = cutlass::canonical_lane_idx();
+  const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
+  if constexpr (!KTraits::SWAP_AB) {
+#pragma unroll
+    for (uint32_t j = 0; j < 2; ++j) {
+      d[j] += math::shfl_xor_sync(d[j], 0x2);
+      d[j] += math::shfl_xor_sync(d[j], 0x1);
+      if (lane_idx % 4 == 0) {
+        smem_storage->m[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = m[j];
+        smem_storage->d[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = d[j];
+      }
+    }
+  } else {
+    // Sum over the eight lanes sharing a column, then across the four warps.
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      d[md] += math::shfl_xor_sync(d[md], 0x4);
+      d[md] += math::shfl_xor_sync(d[md], 0x8);
+      d[md] += math::shfl_xor_sync(d[md], 0x10);
+      if (lane_idx < 4) {
+        smem_storage->md_partial[warp_idx_in_wg][KTraits::md_column(md, lane_idx)] = d[md];
+      }
+    }
+    barrier_sync(KTraits::NUM_QK_THREADS, NamedBarriers::kConsumerWarpgroup);
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      const uint32_t col = KTraits::md_column(md, lane_idx);
+      d[md] = (smem_storage->md_partial[0][col] + smem_storage->md_partial[1][col]) +
+              (smem_storage->md_partial[2][col] + smem_storage->md_partial[3][col]);
+      if (warp_idx_in_wg == 0 && lane_idx < 4) {
+        smem_storage->m[col] = m[md];
+        smem_storage->d[col] = d[md];
+      }
+    }
+  }
+}
+
+template <typename KTraits>
+__device__ __forceinline__ void load_md_(typename KTraits::SharedStorage* smem_storage, float* m,
+                                         float* d) {
+  const uint32_t lane_idx = cutlass::canonical_lane_idx();
+  const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
+  if constexpr (!KTraits::SWAP_AB) {
+#pragma unroll
+    for (uint32_t j = 0; j < 2; ++j) {
+      m[j] = smem_storage->m[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4];
+      d[j] = smem_storage->d[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4];
+    }
+  } else {
+#pragma unroll
+    for (uint32_t md = 0; md < KTraits::NUM_MD; ++md) {
+      m[md] = smem_storage->m[KTraits::md_column(md, lane_idx)];
+      d[md] = smem_storage->d[KTraits::md_column(md, lane_idx)];
+    }
+  }
+}
+
+template <typename Pipeline, typename PipelineState>
+__device__ __forceinline__ void consumer_wait(Pipeline& pipeline, PipelineState& smem_pipe_read) {
+  auto barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
+  pipeline.consumer_wait(smem_pipe_read, barrier_token);
+}
+
+// Coordinates of one work item, shared by the per-tile steps below.
+struct WorkCoord {
+  uint32_t qo_packed_idx_base;
+  uint32_t q_len;
+  uint32_t kv_len;
+  uint32_t kv_start;
+  uint32_t kv_end;
+  // First packed KV position of this work item and the end of the request's KV.
+  uint32_t kv_block_iter_base;
+  uint32_t packed_kv_bound;
+};
+
+// Producer warpgroup, one KV tile: take the consumer's rescale factors, rescale
+// the running O and run this warpgroup's half of the PV product.
+template <typename KTraits, typename Pipeline, typename PipelineState>
+__device__ __forceinline__ void producer_pv_tile(typename KTraits::SharedStorage& smem_storage,
+                                                 typename KTraits::AttentionVariant& variant,
+                                                 Pipeline& pipeline_kv,
+                                                 PipelineState& smem_pipe_read_kv, float* o_frag,
+                                                 float* o_scale) {
+  if constexpr (KTraits::USE_KV_REPACK) {
+    // d1/d2: pair with the consumer's s1/s2 around its FP8->BF16 dequant. The
+    // producer only passes through; after d2 the BF16 staging buffer holds
+    // the current stage and is safe to read in the PV WGMMA below.
+    __syncthreads();
+    __syncthreads();
+  }
+  barrier_sync(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
+  load_o_scale_smem<KTraits>(&smem_storage, o_scale);
+  PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
+  rescale_o_<KTraits>(o_scale, o_frag);
+  PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
+  consumer_wait(pipeline_kv, smem_pipe_read_kv);
+  __syncthreads();
+  PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
+  compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
+  warpgroup_wait<0>();
+  PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
+  pipeline_kv.consumer_release(smem_pipe_read_kv);
+  ++smem_pipe_read_kv;
+  if constexpr (KTraits::USE_KV_REPACK) {
+    // iter-end sync: both warpgroups must finish this tile's WGMMA reads of
+    // the BF16 staging buffer before the next dequant overwrites it.
+    __syncthreads();
+  }
+}
+
+// Producer warpgroup, one work item: stream Q and the KV tiles into shared
+// memory one tile ahead of the consumer, and own the lower half of O.
+template <typename KTraits, typename Params, typename Pipeline, typename PipelineState>
+__device__ __forceinline__ void producer_work(
+    const Params& params, typename KTraits::SharedStorage& smem_storage,
+    typename KTraits::AttentionVariant& variant, const typename Params::IdType work_idx,
+    Pipeline& pipeline_q, Pipeline& pipeline_kv, PipelineState& smem_pipe_write_q,
+    PipelineState& smem_pipe_write_kv, PipelineState& smem_pipe_read_kv) {
+  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+  constexpr bool CAUSAL = KTraits::CAUSAL;
+  const uint_fastdiv& num_heads = params.num_heads;
+  const uint_fastdiv& block_size = params.block_size;
+
+  auto [q_indptr, kv_indptr, partial_indptr, q_len, kv_len, packed_qo_start, kv_start, kv_end] =
+      get_block_coord(params, work_idx);
+
+  alignas(16) float o_frag[KTraits::NUM_REGS_O_FRAG];
+  float m[KTraits::NUM_MD];
+  float d[KTraits::NUM_MD];
+  float o_scale[KTraits::NUM_MD];
+  init_states_<KTraits>(o_frag, m, d, o_scale);
+
+  const uint32_t cluster_tile_q = gridDim.x * KTraits::CTA_TILE_Q;
+  const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
+  const uint32_t qo_upperbound =
+      min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
+
+  const uint32_t packed_kv_bound = kv_indptr * block_size + kv_len;
+  int kv_tile_idx =
+      ceil_div(
+          (CAUSAL ? min(kv_end, kv_len - q_len + (packed_qo_start + cluster_tile_q) / num_heads)
+                  : kv_end),
+          CTA_TILE_KV) -
+      1 - (kv_start / CTA_TILE_KV);
+  const bool has_kv = kv_tile_idx >= 0;
+  const uint32_t block_iter_base = kv_indptr * block_size + kv_start;
+
+  int64_t ckv_offset[KTraits::NUM_MMA_KV / 2][2];
+  int64_t kpe_offset[KTraits::NUM_MMA_KV / 2][2];
+
+  if (has_kv) {
+    prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
+                             params.ckv_stride_page, params.ckv_stride_n, params.kpe_stride_page,
+                             params.kpe_stride_n, block_size, params.kv_indices, ckv_offset,
+                             kpe_offset);
+    pipeline_kv.producer_acquire(smem_pipe_write_kv);
+    PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadKV);
+    load_kv<true, KTraits>(&smem_storage, params.ckv, params.kpe, packed_kv_bound,
+                           block_iter_base + kv_tile_idx * CTA_TILE_KV, smem_pipe_write_kv.index(),
+                           ckv_offset, kpe_offset);
+    PROFILER_EVENT_END(variant, ProfileEventType::kIssueLoadKV);
+    pipeline_kv.producer_commit(smem_pipe_write_kv, cutlass::arch::cpasync_barrier_arrive);
+    kv_tile_idx -= 1;
+    ++smem_pipe_write_kv;
+    if (kv_tile_idx >= 0) {
+      prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
+                               params.ckv_stride_page, params.ckv_stride_n, params.kpe_stride_page,
+                               params.kpe_stride_n, block_size, params.kv_indices, ckv_offset,
+                               kpe_offset);
+    }
+  }
+
+  pipeline_q.producer_acquire(smem_pipe_write_q);
+  PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadQ);
+  load_q<KTraits>(&smem_storage, params.q_nope + q_indptr * params.q_nope_stride_n,
+                  params.q_pe + q_indptr * params.q_pe_stride_n, params.q_nope_stride_n,
+                  params.q_nope_stride_h, params.q_pe_stride_n, params.q_pe_stride_h, qo_upperbound,
+                  qo_packed_idx_base, num_heads);
+  PROFILER_EVENT_END(variant, ProfileEventType::kIssueLoadQ);
+  pipeline_q.producer_commit(smem_pipe_write_q, cutlass::arch::cpasync_barrier_arrive);
+  ++smem_pipe_write_q;
+
+#pragma unroll 1
+  for (; kv_tile_idx >= 0; --kv_tile_idx) {
+    pipeline_kv.producer_acquire(smem_pipe_write_kv);
+    PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadKV);
+    load_kv<false, KTraits>(&smem_storage, params.ckv, params.kpe, packed_kv_bound,
+                            block_iter_base + kv_tile_idx * CTA_TILE_KV, smem_pipe_write_kv.index(),
+                            ckv_offset, kpe_offset);
+    PROFILER_EVENT_END(variant, ProfileEventType::kIssueLoadKV);
+    if (kv_tile_idx > 0) {
+      prefetch_offset<KTraits>(block_iter_base + (kv_tile_idx - 1) * CTA_TILE_KV, packed_kv_bound,
+                               params.ckv_stride_page, params.ckv_stride_n, params.kpe_stride_page,
+                               params.kpe_stride_n, block_size, params.kv_indices, ckv_offset,
+                               kpe_offset);
+    }
+    pipeline_kv.producer_commit(smem_pipe_write_kv, cutlass::arch::cpasync_barrier_arrive);
+    ++smem_pipe_write_kv;
+
+    producer_pv_tile<KTraits>(smem_storage, variant, pipeline_kv, smem_pipe_read_kv, o_frag,
+                              o_scale);
+  }
+
+  if (has_kv) {
+    producer_pv_tile<KTraits>(smem_storage, variant, pipeline_kv, smem_pipe_read_kv, o_frag,
+                              o_scale);
+  }
+
+  barrier_sync(KTraits::NUM_THREADS, NamedBarriers::kMDReady);
+  load_md_<KTraits>(&smem_storage, m, d);
+  normalize_d_<KTraits>(o_frag, m, d);
+  PROFILER_EVENT_START(variant, ProfileEventType::kWriteO);
+  write_o<false, KTraits>(
+      &smem_storage, params.final_o + q_indptr * params.o_stride_n,
+      params.final_lse ? params.final_lse + q_indptr * num_heads : nullptr,
+      (partial_indptr == -1) ? nullptr : params.partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
+      (partial_indptr == -1) ? nullptr : params.partial_lse + partial_indptr, o_frag, m, d,
+      params.o_stride_n, params.o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads,
+      params.return_lse_base_on_e);
+  PROFILER_EVENT_END(variant, ProfileEventType::kWriteO);
+  __syncthreads();
+}
+
+// Consumer warpgroup, one KV tile: QK, masking (for boundary tiles only),
+// online softmax, P to shared memory, then this warpgroup's half of PV.
+template <typename KTraits, bool MASK, typename Params, typename Pipeline, typename PipelineState>
+__device__ __forceinline__ void consumer_tile(
+    const Params& params, typename KTraits::SharedStorage& smem_storage,
+    typename KTraits::AttentionVariant& variant, Pipeline& pipeline_kv,
+    PipelineState& smem_pipe_read_kv, const WorkCoord& work, const int kv_tile_idx, float* s_frag,
+    uint32_t* p_frag, float* o_frag, float* m, float* d, float* o_scale) {
+  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+
+  consumer_wait(pipeline_kv, smem_pipe_read_kv);
+  if constexpr (KTraits::USE_KV_REPACK) {
+    // s1: pair with producer's d1 (matches per-iter __syncthreads count).
+    __syncthreads();
+    // Only consumer warpgroup (128 threads) dequants FP8 KV -> BF16
+    // staging buffers. Producer wg passes through the d1/d2/d_end syncs.
+    repack_fp8_kv_to_bf16<KTraits>(&smem_storage, smem_pipe_read_kv.index(), variant.ckv_scale,
+                                   variant.kpe_scale, variant.ckv_scale_arr,
+                                   work.kv_block_iter_base + kv_tile_idx * CTA_TILE_KV,
+                                   params.kv_indices, params.block_size, work.packed_kv_bound);
+    // s2: ensures dequant is complete before any wg reads BF16 staging.
+    __syncthreads();
+  }
+  PROFILER_EVENT_START(variant, ProfileEventType::kGemmQK);
+  compute_mla_qk<KTraits>(&smem_storage, smem_pipe_read_kv.index(), s_frag);
+  warpgroup_wait<0>();
+  PROFILER_EVENT_END(variant, ProfileEventType::kGemmQK);
+  if constexpr (MASK) {
+    logits_mask_<KTraits>(work.qo_packed_idx_base, work.kv_start + kv_tile_idx * CTA_TILE_KV,
+                          work.q_len, work.kv_len, work.kv_end, params.num_heads, s_frag);
+  }
+  PROFILER_EVENT_START(variant, ProfileEventType::kSoftmaxUpdate);
+  update_md_<KTraits>(&smem_storage, variant, s_frag, m, d, o_scale);
+  PROFILER_EVENT_END(variant, ProfileEventType::kSoftmaxUpdate);
+  write_o_scale_smem<KTraits>(&smem_storage, o_scale);
+  convert_s_to_p<KTraits>(s_frag, p_frag);
+  write_p_rmem_smem<KTraits>(&smem_storage, smem_pipe_read_kv.index(), p_frag);
+  barrier_arrive(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
+  PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
+  rescale_o_<KTraits>(o_scale, o_frag);
+  PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
+  __syncthreads();
+  PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
+  compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
+  warpgroup_wait<0>();
+  PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
+  pipeline_kv.consumer_release(smem_pipe_read_kv);
+  ++smem_pipe_read_kv;
+  if constexpr (KTraits::USE_KV_REPACK) {
+    // iter-end sync: both warpgroups must finish this tile's WGMMA reads of
+    // the BF16 staging buffer before the next dequant overwrites it.
+    __syncthreads();
+  }
+}
+
+// Consumer warpgroup, one work item: QK and softmax for every KV tile, the
+// upper half of O, and the final statistics / LSE.
+template <typename KTraits, typename Params, typename Pipeline, typename PipelineState>
+__device__ __forceinline__ void consumer_work(const Params& params,
+                                              typename KTraits::SharedStorage& smem_storage,
+                                              typename KTraits::AttentionVariant& variant,
+                                              const typename Params::IdType work_idx,
+                                              Pipeline& pipeline_q, Pipeline& pipeline_kv,
+                                              PipelineState& smem_pipe_read_q,
+                                              PipelineState& smem_pipe_read_kv) {
+  constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
+  constexpr int32_t NUM_STAGES = KTraits::NUM_STAGES;
+  constexpr bool CAUSAL = KTraits::CAUSAL;
+  const uint_fastdiv& num_heads = params.num_heads;
+  const uint_fastdiv& block_size = params.block_size;
+
+  auto [q_indptr, kv_indptr, partial_indptr, q_len, kv_len, packed_qo_start, kv_start, kv_end] =
+      get_block_coord(params, work_idx);
+
+  alignas(16) float o_frag[KTraits::NUM_REGS_O_FRAG];
+  float m[KTraits::NUM_MD];
+  float d[KTraits::NUM_MD];
+  float o_scale[KTraits::NUM_MD];
+  float s_frag[KTraits::NUM_REGS_S_FRAG];
+  uint32_t p_frag[KTraits::NUM_REGS_P_FRAG];
+  init_states_<KTraits>(o_frag, m, d, o_scale);
+
+  const uint32_t cluster_tile_q = gridDim.x * KTraits::CTA_TILE_Q;
+  const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
+  const uint32_t qo_upperbound =
+      min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
+  const WorkCoord work{qo_packed_idx_base,
+                       static_cast<uint32_t>(q_len),
+                       static_cast<uint32_t>(kv_len),
+                       static_cast<uint32_t>(kv_start),
+                       static_cast<uint32_t>(kv_end),
+                       kv_indptr * block_size + kv_start,
+                       kv_indptr * block_size + kv_len};
+
+  int kv_tile_idx =
+      ceil_div(
+          (CAUSAL ? min(kv_end, kv_len - q_len + (packed_qo_start + cluster_tile_q) / num_heads)
+                  : kv_end),
+          CTA_TILE_KV) -
+      1 - (kv_start / CTA_TILE_KV);
+
+  int mask_tile_idx =
+      (CAUSAL ? min(kv_end, kv_len - q_len + static_cast<uint32_t>(packed_qo_start) / num_heads)
+              : kv_end) /
+          CTA_TILE_KV -
+      (kv_start / CTA_TILE_KV);
+
+  consumer_wait(pipeline_q, smem_pipe_read_q);
+  // Tiles crossing the causal / kv_end boundary need masking; the interior
+  // tiles do not. The last NUM_STAGES tiles are handled as boundary tiles.
+#pragma unroll 1
+  for (; kv_tile_idx >= mask_tile_idx && kv_tile_idx > 0; --kv_tile_idx) {
+    consumer_tile<KTraits, /*MASK=*/true>(params, smem_storage, variant, pipeline_kv,
+                                          smem_pipe_read_kv, work, kv_tile_idx, s_frag, p_frag,
+                                          o_frag, m, d, o_scale);
+  }
+#pragma unroll 1
+  for (; kv_tile_idx + 1 > NUM_STAGES; --kv_tile_idx) {
+    consumer_tile<KTraits, /*MASK=*/false>(params, smem_storage, variant, pipeline_kv,
+                                           smem_pipe_read_kv, work, kv_tile_idx, s_frag, p_frag,
+                                           o_frag, m, d, o_scale);
+  }
+#pragma unroll 1
+  for (; kv_tile_idx >= 0; --kv_tile_idx) {
+    consumer_tile<KTraits, /*MASK=*/true>(params, smem_storage, variant, pipeline_kv,
+                                          smem_pipe_read_kv, work, kv_tile_idx, s_frag, p_frag,
+                                          o_frag, m, d, o_scale);
+  }
+
+  pipeline_q.consumer_release(smem_pipe_read_q);
+  ++smem_pipe_read_q;
+
+  finalize_md_<KTraits>(&smem_storage, m, d);
+  normalize_d_<KTraits>(o_frag, m, d);
+  scale_m_<KTraits>(variant, m);
+  barrier_arrive(KTraits::NUM_THREADS, NamedBarriers::kMDReady);
+  PROFILER_EVENT_START(variant, ProfileEventType::kWriteO);
+  write_o<true, KTraits>(
+      &smem_storage, params.final_o + q_indptr * params.o_stride_n,
+      params.final_lse ? params.final_lse + q_indptr * num_heads : nullptr,
+      (partial_indptr == -1) ? nullptr : params.partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
+      (partial_indptr == -1) ? nullptr : params.partial_lse + partial_indptr, o_frag, m, d,
+      params.o_stride_n, params.o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads,
+      params.return_lse_base_on_e);
+  PROFILER_EVENT_END(variant, ProfileEventType::kWriteO);
+  __syncthreads();
 }
 
 template <typename KTraits, typename Params>
 __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHopperKernel(
     const __grid_constant__ Params params) {
-  using DTypeQ = typename Params::DTypeQ;
-  using DTypeKV = typename Params::DTypeKV;
-  using DTypeO = typename Params::DTypeO;
   using IdType = typename Params::IdType;
 
   extern __shared__ __align__(alignof(typename KTraits::SharedStorage)) uint8_t smem[];
   auto& smem_storage = reinterpret_cast<typename KTraits::SharedStorage&>(smem);
 
   typename KTraits::AttentionVariant variant(params, blockIdx.y, smem);
-  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q_NOPE = KTraits::SWIZZLE_MODE_Q_NOPE;
-  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_Q_PE = KTraits::SWIZZLE_MODE_Q_PE;
-  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_CKV = KTraits::SWIZZLE_MODE_CKV;
-  [[maybe_unused]] constexpr SwizzleMode SWIZZLE_MODE_KPE = KTraits::SWIZZLE_MODE_KPE;
-  [[maybe_unused]] constexpr uint32_t NUM_MMA_KV = KTraits::NUM_MMA_KV;
-  [[maybe_unused]] constexpr uint32_t NUM_MMA_D_CKV = KTraits::NUM_MMA_D_CKV;
-  [[maybe_unused]] constexpr uint32_t HEAD_DIM_CKV = KTraits::HEAD_DIM_CKV;
-  [[maybe_unused]] constexpr uint32_t CTA_TILE_Q = KTraits::CTA_TILE_Q;
-  [[maybe_unused]] constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
-  [[maybe_unused]] constexpr int32_t NUM_STAGES = KTraits::NUM_STAGES;
-  [[maybe_unused]] constexpr uint32_t NUM_COPY_THREADS = KTraits::NUM_COPY_THREADS;
-  [[maybe_unused]] constexpr bool CAUSAL = KTraits::CAUSAL;
-
-  DTypeQ* q_nope = params.q_nope;
-  DTypeQ* q_pe = params.q_pe;
-  DTypeKV* ckv = params.ckv;
-  DTypeKV* kpe = params.kpe;
-  IdType* kv_indices = params.kv_indices;
-  DTypeO* partial_o = params.partial_o;
-  float* partial_lse = params.partial_lse;
-  DTypeO* final_o = params.final_o;
-  float* final_lse = params.final_lse;
   IdType* work_indptr = params.work_indptr;
-
-  const uint_fastdiv& num_heads = params.num_heads;
-  const uint_fastdiv& block_size = params.block_size;
-  const uint32_t q_nope_stride_n = params.q_nope_stride_n;
-  const uint32_t q_nope_stride_h = params.q_nope_stride_h;
-  const uint32_t q_pe_stride_n = params.q_pe_stride_n;
-  const uint32_t q_pe_stride_h = params.q_pe_stride_h;
-  const uint32_t ckv_stride_page = params.ckv_stride_page;
-  const uint32_t ckv_stride_n = params.ckv_stride_n;
-  const uint32_t kpe_stride_page = params.kpe_stride_page;
-  const uint32_t kpe_stride_n = params.kpe_stride_n;
-  const uint32_t o_stride_n = params.o_stride_n;
-  const uint32_t o_stride_h = params.o_stride_h;
-  const uint32_t cluster_tile_q = gridDim.x * KTraits::CTA_TILE_Q;
-
-  const uint32_t lane_predicate = cute::elect_one_sync();
-  const uint32_t lane_idx = cutlass::canonical_lane_idx();
   const uint32_t warp_group_idx = cutlass::canonical_warp_group_idx();
-  const uint32_t warp_idx = cutlass::canonical_warp_idx();
-  const uint32_t warp_idx_in_wg = cutlass::canonical_warp_idx() % 4;
 
   PROFILER_INIT(params, smem_storage, variant, warp_group_idx, 2, (threadIdx.x % 128 == 0));
 
@@ -878,14 +1386,6 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
   MainloopPipeline pipeline_kv(smem_storage.pipeline_kv, pipeline_params);
 
   __syncthreads();
-  alignas(16) float o_frag[KTraits::NUM_REGS_O_FRAG];
-  float m[2];
-  float d[2];
-  float o_scale[2];
-  auto consumer_wait = [](auto& pipeline, auto& smem_pipe_read) {
-    auto barrier_token = pipeline.consumer_try_wait(smem_pipe_read);
-    pipeline.consumer_wait(smem_pipe_read, barrier_token);
-  };
 
   if (warp_group_idx == 0) {
     // load q & kv, compute pv1
@@ -893,361 +1393,22 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
     PipelineState smem_pipe_write_kv = cutlass::make_producer_start_state<MainloopPipeline>();
     PipelineState smem_pipe_read_kv;
 
-    int64_t ckv_offset[KTraits::NUM_MMA_KV / 2][2];
-    int64_t kpe_offset[KTraits::NUM_MMA_KV / 2][2];
-
 #pragma unroll 1
     for (IdType work_idx = work_indptr[blockIdx.y]; work_idx < work_indptr[blockIdx.y + 1];
          ++work_idx) {
-      auto [q_indptr, kv_indptr, partial_indptr, q_len, kv_len, packed_qo_start, kv_start, kv_end] =
-          get_block_coord(params, work_idx);
-
-      init_states_<KTraits>(o_frag, m, d, o_scale);
-
-      const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
-      const uint32_t qo_upperbound =
-          min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
-
-      uint32_t packed_kv_bound = kv_indptr * block_size + kv_len;
-      int kv_tile_idx =
-          ceil_div(
-              (CAUSAL ? min(kv_end, kv_len - q_len + (packed_qo_start + cluster_tile_q) / num_heads)
-                      : kv_end),
-              CTA_TILE_KV) -
-          1 - (kv_start / CTA_TILE_KV);
-
-      bool has_kv = kv_tile_idx >= 0;
-
-      const uint32_t block_iter_base = kv_indptr * block_size + kv_start;
-
-      if (has_kv) {
-        prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
-                                 ckv_stride_page, ckv_stride_n, kpe_stride_page, kpe_stride_n,
-                                 block_size, kv_indices, ckv_offset, kpe_offset);
-        pipeline_kv.producer_acquire(smem_pipe_write_kv);
-        PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadKV);
-        load_kv<true, KTraits>(&smem_storage, ckv, kpe, packed_kv_bound,
-                               block_iter_base + kv_tile_idx * CTA_TILE_KV,
-                               smem_pipe_write_kv.index(), ckv_offset, kpe_offset);
-        PROFILER_EVENT_END(variant, ProfileEventType::kIssueLoadKV);
-        pipeline_kv.producer_commit(smem_pipe_write_kv, cutlass::arch::cpasync_barrier_arrive);
-        kv_tile_idx -= 1;
-        ++smem_pipe_write_kv;
-        if (kv_tile_idx >= 0) {
-          prefetch_offset<KTraits>(block_iter_base + kv_tile_idx * CTA_TILE_KV, packed_kv_bound,
-                                   ckv_stride_page, ckv_stride_n, kpe_stride_page, kpe_stride_n,
-                                   block_size, kv_indices, ckv_offset, kpe_offset);
-        }
-      }
-
-      pipeline_q.producer_acquire(smem_pipe_write_q);
-      PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadQ);
-      load_q<KTraits>(&smem_storage, q_nope + q_indptr * q_nope_stride_n,
-                      q_pe + q_indptr * q_pe_stride_n, q_nope_stride_n, q_nope_stride_h,
-                      q_pe_stride_n, q_pe_stride_h, qo_upperbound, qo_packed_idx_base,
-                      params.num_heads);
-      PROFILER_EVENT_END(variant, ProfileEventType::kIssueLoadQ);
-      pipeline_q.producer_commit(smem_pipe_write_q, cutlass::arch::cpasync_barrier_arrive);
-      ++smem_pipe_write_q;
-
-#pragma unroll 1
-      for (; kv_tile_idx >= 0; --kv_tile_idx) {
-        pipeline_kv.producer_acquire(smem_pipe_write_kv);
-        PROFILER_EVENT_START(variant, ProfileEventType::kIssueLoadKV);
-        load_kv<false, KTraits>(&smem_storage, ckv, kpe, packed_kv_bound,
-                                block_iter_base + kv_tile_idx * CTA_TILE_KV,
-                                smem_pipe_write_kv.index(), ckv_offset, kpe_offset);
-        PROFILER_EVENT_END(variant, ProfileEventType::kIssueLoadKV);
-        if (kv_tile_idx > 0) {
-          prefetch_offset<KTraits>(block_iter_base + (kv_tile_idx - 1) * CTA_TILE_KV,
-                                   packed_kv_bound, ckv_stride_page, ckv_stride_n, kpe_stride_page,
-                                   kpe_stride_n, block_size, kv_indices, ckv_offset, kpe_offset);
-        }
-        pipeline_kv.producer_commit(smem_pipe_write_kv, cutlass::arch::cpasync_barrier_arrive);
-        ++smem_pipe_write_kv;
-
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // d1: pair with consumer's s1 (consumer is at __syncthreads_pre_dequant
-          // right after its own consumer_wait). Producer participates as a
-          // pass-through here — only the consumer warpgroup writes the BF16
-          // staging buffer below.
-          __syncthreads();
-          // d2: pair with consumer's s2 (post-dequant). Once we cross this
-          // barrier, the BF16 staging buffer has the current stage's data and
-          // is safe to read in the PV WGMMA below.
-          __syncthreads();
-        }
-        barrier_sync(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
-        load_o_scale_smem<KTraits>(&smem_storage, o_scale);
-        PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
-        rescale_o_<KTraits>(o_scale, o_frag);
-        PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
-        consumer_wait(pipeline_kv, smem_pipe_read_kv);
-        __syncthreads();
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
-        compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
-        pipeline_kv.consumer_release(smem_pipe_read_kv);
-        ++smem_pipe_read_kv;
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // iter-end sync: ensures both wgs finished this iter's WGMMA reads
-          // of the BF16 staging buffer before any wg overwrites it in the
-          // next iter's dequant.
-          __syncthreads();
-        }
-      }
-
-      if (has_kv) {
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // d1: pair with consumer's s1 (consumer is at __syncthreads_pre_dequant
-          // right after its own consumer_wait). Producer participates as a
-          // pass-through here — only the consumer warpgroup writes the BF16
-          // staging buffer below.
-          __syncthreads();
-          // d2: pair with consumer's s2 (post-dequant). Once we cross this
-          // barrier, the BF16 staging buffer has the current stage's data and
-          // is safe to read in the PV WGMMA below.
-          __syncthreads();
-        }
-        barrier_sync(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
-        load_o_scale_smem<KTraits>(&smem_storage, o_scale);
-        PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
-        rescale_o_<KTraits>(o_scale, o_frag);
-        PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
-        consumer_wait(pipeline_kv, smem_pipe_read_kv);
-        __syncthreads();
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
-        compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
-        pipeline_kv.consumer_release(smem_pipe_read_kv);
-        ++smem_pipe_read_kv;
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // iter-end sync: ensures both wgs finished this iter's WGMMA reads
-          // of the BF16 staging buffer before any wg overwrites it in the
-          // next iter's dequant.
-          __syncthreads();
-        }
-      }
-
-      barrier_sync(KTraits::NUM_THREADS, NamedBarriers::kMDReady);
-#pragma unroll
-      for (uint32_t j = 0; j < 2; ++j) {
-        m[j] = smem_storage.m[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4];
-        d[j] = smem_storage.d[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4];
-      }
-      normalize_d_<KTraits>(&smem_storage, o_frag, m, d);
-      finalize_m_<KTraits>(variant, m);
-      PROFILER_EVENT_START(variant, ProfileEventType::kWriteO);
-      write_o<false, KTraits>(
-          &smem_storage, final_o + q_indptr * o_stride_n,
-          final_lse ? final_lse + q_indptr * num_heads : nullptr,
-          (partial_indptr == -1) ? nullptr : partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
-          (partial_indptr == -1) ? nullptr : partial_lse + partial_indptr, o_frag, m, d, o_stride_n,
-          o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads, params.return_lse_base_on_e);
-      PROFILER_EVENT_END(variant, ProfileEventType::kWriteO);
-      __syncthreads();
+      producer_work<KTraits>(params, smem_storage, variant, work_idx, pipeline_q, pipeline_kv,
+                             smem_pipe_write_q, smem_pipe_write_kv, smem_pipe_read_kv);
     }
   } else {
     // compute qk, pv2
     PipelineState smem_pipe_read_q;
     PipelineState smem_pipe_read_kv;
-    float s_frag[KTraits::NUM_REGS_S_FRAG];
-    uint32_t p_frag[KTraits::NUM_REGS_P_FRAG];
 
 #pragma unroll 1
     for (IdType work_idx = work_indptr[blockIdx.y]; work_idx < work_indptr[blockIdx.y + 1];
          ++work_idx) {
-      auto [q_indptr, kv_indptr, partial_indptr, q_len, kv_len, packed_qo_start, kv_start, kv_end] =
-          get_block_coord(params, work_idx);
-      const uint32_t qo_packed_idx_base = packed_qo_start + blockIdx.x * KTraits::CTA_TILE_Q;
-      const uint32_t qo_upperbound =
-          min(q_len, ceil_div(qo_packed_idx_base + KTraits::CTA_TILE_Q, num_heads));
-
-      init_states_<KTraits>(o_frag, m, d, o_scale);
-
-      int kv_tile_idx =
-          ceil_div(
-              (CAUSAL ? min(kv_end, kv_len - q_len + (packed_qo_start + cluster_tile_q) / num_heads)
-                      : kv_end),
-              CTA_TILE_KV) -
-          1 - (kv_start / CTA_TILE_KV);
-
-      int mask_tile_idx =
-          (CAUSAL ? min(kv_end, kv_len - q_len + static_cast<uint32_t>(packed_qo_start) / num_heads)
-                  : kv_end) /
-              CTA_TILE_KV -
-          (kv_start / CTA_TILE_KV);
-
-      consumer_wait(pipeline_q, smem_pipe_read_q);
-#pragma unroll 1
-      for (; kv_tile_idx >= mask_tile_idx && kv_tile_idx > 0; --kv_tile_idx) {
-        consumer_wait(pipeline_kv, smem_pipe_read_kv);
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // s1: pair with producer's d1 (matches per-iter __syncthreads count).
-          __syncthreads();
-          // Only consumer warpgroup (128 threads) dequants FP8 KV -> BF16
-          // staging buffers. Producer wg passes through the d1/d2/d_end syncs.
-          repack_fp8_kv_to_bf16<KTraits>(
-              &smem_storage, smem_pipe_read_kv.index(), variant.ckv_scale, variant.kpe_scale,
-              variant.ckv_scale_arr,
-              kv_indptr * block_size + kv_start +
-                  static_cast<uint32_t>(kv_tile_idx) * KTraits::CTA_TILE_KV,
-              kv_indices, block_size, kv_indptr * block_size + kv_len);
-          // s2: ensures dequant is complete before any wg reads BF16 staging.
-          __syncthreads();
-        }
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmQK);
-        compute_mla_qk<KTraits>(&smem_storage, smem_pipe_read_kv.index(), s_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmQK);
-        logits_mask_<KTraits>(qo_packed_idx_base, kv_start + kv_tile_idx * CTA_TILE_KV, q_len,
-                              kv_len, kv_end, num_heads, s_frag);
-        PROFILER_EVENT_START(variant, ProfileEventType::kSoftmaxUpdate);
-        update_md_<KTraits>(&smem_storage, variant, s_frag, m, d, o_scale);
-        PROFILER_EVENT_END(variant, ProfileEventType::kSoftmaxUpdate);
-        write_o_scale_smem<KTraits>(&smem_storage, o_scale);
-
-        convert_s_to_p<KTraits>(s_frag, p_frag);
-        write_p_rmem_smem<KTraits>(&smem_storage, smem_pipe_read_kv.index(), p_frag);
-        barrier_arrive(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
-        PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
-        rescale_o_<KTraits>(o_scale, o_frag);
-        PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
-        __syncthreads();
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
-        compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
-        pipeline_kv.consumer_release(smem_pipe_read_kv);
-        ++smem_pipe_read_kv;
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // iter-end sync: ensures both wgs finished this iter's WGMMA reads
-          // of the BF16 staging buffer before any wg overwrites it in the
-          // next iter's dequant.
-          __syncthreads();
-        }
-      }
-
-#pragma unroll 1
-      for (; kv_tile_idx + 1 > NUM_STAGES; --kv_tile_idx) {
-        consumer_wait(pipeline_kv, smem_pipe_read_kv);
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // s1: pair with producer's d1 (matches per-iter __syncthreads count).
-          __syncthreads();
-          // Only consumer warpgroup (128 threads) dequants FP8 KV -> BF16
-          // staging buffers. Producer wg passes through the d1/d2/d_end syncs.
-          repack_fp8_kv_to_bf16<KTraits>(
-              &smem_storage, smem_pipe_read_kv.index(), variant.ckv_scale, variant.kpe_scale,
-              variant.ckv_scale_arr,
-              kv_indptr * block_size + kv_start +
-                  static_cast<uint32_t>(kv_tile_idx) * KTraits::CTA_TILE_KV,
-              kv_indices, block_size, kv_indptr * block_size + kv_len);
-          // s2: ensures dequant is complete before any wg reads BF16 staging.
-          __syncthreads();
-        }
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmQK);
-        compute_mla_qk<KTraits>(&smem_storage, smem_pipe_read_kv.index(), s_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmQK);
-        PROFILER_EVENT_START(variant, ProfileEventType::kSoftmaxUpdate);
-        update_md_<KTraits>(&smem_storage, variant, s_frag, m, d, o_scale);
-        PROFILER_EVENT_END(variant, ProfileEventType::kSoftmaxUpdate);
-        write_o_scale_smem<KTraits>(&smem_storage, o_scale);
-        convert_s_to_p<KTraits>(s_frag, p_frag);
-        write_p_rmem_smem<KTraits>(&smem_storage, smem_pipe_read_kv.index(), p_frag);
-        barrier_arrive(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
-        PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
-        rescale_o_<KTraits>(o_scale, o_frag);
-        PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
-        __syncthreads();
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
-        compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
-        pipeline_kv.consumer_release(smem_pipe_read_kv);
-        ++smem_pipe_read_kv;
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // iter-end sync: ensures both wgs finished this iter's WGMMA reads
-          // of the BF16 staging buffer before any wg overwrites it in the
-          // next iter's dequant.
-          __syncthreads();
-        }
-      }
-
-#pragma unroll 1
-      for (; kv_tile_idx >= 0; --kv_tile_idx) {
-        consumer_wait(pipeline_kv, smem_pipe_read_kv);
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // s1: pair with producer's d1 (matches per-iter __syncthreads count).
-          __syncthreads();
-          // Only consumer warpgroup (128 threads) dequants FP8 KV -> BF16
-          // staging buffers. Producer wg passes through the d1/d2/d_end syncs.
-          repack_fp8_kv_to_bf16<KTraits>(
-              &smem_storage, smem_pipe_read_kv.index(), variant.ckv_scale, variant.kpe_scale,
-              variant.ckv_scale_arr,
-              kv_indptr * block_size + kv_start +
-                  static_cast<uint32_t>(kv_tile_idx) * KTraits::CTA_TILE_KV,
-              kv_indices, block_size, kv_indptr * block_size + kv_len);
-          // s2: ensures dequant is complete before any wg reads BF16 staging.
-          __syncthreads();
-        }
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmQK);
-        compute_mla_qk<KTraits>(&smem_storage, smem_pipe_read_kv.index(), s_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmQK);
-        logits_mask_<KTraits>(qo_packed_idx_base, kv_start + kv_tile_idx * CTA_TILE_KV, q_len,
-                              kv_len, kv_end, num_heads, s_frag);
-        PROFILER_EVENT_START(variant, ProfileEventType::kSoftmaxUpdate);
-        update_md_<KTraits>(&smem_storage, variant, s_frag, m, d, o_scale);
-        PROFILER_EVENT_END(variant, ProfileEventType::kSoftmaxUpdate);
-        write_o_scale_smem<KTraits>(&smem_storage, o_scale);
-        convert_s_to_p<KTraits>(s_frag, p_frag);
-        write_p_rmem_smem<KTraits>(&smem_storage, smem_pipe_read_kv.index(), p_frag);
-        barrier_arrive(KTraits::NUM_THREADS, NamedBarriers::kOScaleReady);
-        PROFILER_EVENT_START(variant, ProfileEventType::kRescaleO);
-        rescale_o_<KTraits>(o_scale, o_frag);
-        PROFILER_EVENT_END(variant, ProfileEventType::kRescaleO);
-        __syncthreads();
-        PROFILER_EVENT_START(variant, ProfileEventType::kGemmPV);
-        compute_mla_pv<KTraits>(&smem_storage, smem_pipe_read_kv.index(), o_frag);
-        warpgroup_wait<0>();
-        PROFILER_EVENT_END(variant, ProfileEventType::kGemmPV);
-        pipeline_kv.consumer_release(smem_pipe_read_kv);
-        ++smem_pipe_read_kv;
-        if constexpr (KTraits::USE_KV_REPACK) {
-          // iter-end sync: ensures both wgs finished this iter's WGMMA reads
-          // of the BF16 staging buffer before any wg overwrites it in the
-          // next iter's dequant.
-          __syncthreads();
-        }
-      }
-
-      pipeline_q.consumer_release(smem_pipe_read_q);
-      ++smem_pipe_read_q;
-
-#pragma unroll
-      for (uint32_t j = 0; j < 2; ++j) {
-        d[j] += __shfl_xor_sync(0x11111111, d[j], 0x2);
-        d[j] += __shfl_xor_sync(0x11111111, d[j], 0x1);
-        if (lane_idx % 4 == 0) {
-          smem_storage.m[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = m[j];
-          smem_storage.d[warp_idx_in_wg * 16 + j * 8 + lane_idx / 4] = d[j];
-        }
-      }
-      normalize_d_<KTraits>(&smem_storage, o_frag, m, d);
-      finalize_m_<KTraits>(variant, m);
-      barrier_arrive(KTraits::NUM_THREADS, NamedBarriers::kMDReady);
-      PROFILER_EVENT_START(variant, ProfileEventType::kWriteO);
-      write_o<true, KTraits>(
-          &smem_storage, final_o + q_indptr * o_stride_n,
-          final_lse ? final_lse + q_indptr * num_heads : nullptr,
-          (partial_indptr == -1) ? nullptr : partial_o + partial_indptr * KTraits::HEAD_DIM_CKV,
-          (partial_indptr == -1) ? nullptr : partial_lse + partial_indptr, o_frag, m, d, o_stride_n,
-          o_stride_h, qo_upperbound, qo_packed_idx_base, num_heads, params.return_lse_base_on_e);
-      PROFILER_EVENT_END(variant, ProfileEventType::kWriteO);
-      __syncthreads();
+      consumer_work<KTraits>(params, smem_storage, variant, work_idx, pipeline_q, pipeline_kv,
+                             smem_pipe_read_q, smem_pipe_read_kv);
     }
   }
 
@@ -1261,15 +1422,43 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
   DevicePersistentMergeStates<KTraits>(
       params.merge_packed_offset_start, params.merge_packed_offset_end,
       params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
-      params.merge_partial_stride, partial_o, partial_lse, final_o, final_lse, o_stride_n,
-      o_stride_h, num_heads, params.return_lse_base_on_e);
+      params.merge_partial_stride, params.partial_o, params.partial_lse, params.final_o,
+      params.final_lse, params.o_stride_n, params.o_stride_h, params.num_heads,
+      params.return_lse_base_on_e);
 
   PROFILER_EVENT_END(variant, ProfileEventType::kSplitK);
 }
 
 }  // namespace hopper
 
-template <MaskMode MASK_MODE, uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, typename Params>
+// Q tiles the SM90 kernel is instantiated for; MLAPlan reports the planned one
+// in MLAPlanInfo::cta_tile_q.
+#define DISPATCH_MLA_CTA_TILE_Q(cta_tile_q, CTA_TILE_Q, ...)   \
+  switch (cta_tile_q) {                                        \
+    case 16: {                                                 \
+      constexpr uint32_t CTA_TILE_Q = 16;                      \
+      __VA_ARGS__                                              \
+      break;                                                   \
+    }                                                          \
+    case 32: {                                                 \
+      constexpr uint32_t CTA_TILE_Q = 32;                      \
+      __VA_ARGS__                                              \
+      break;                                                   \
+    }                                                          \
+    case 64: {                                                 \
+      constexpr uint32_t CTA_TILE_Q = 64;                      \
+      __VA_ARGS__                                              \
+      break;                                                   \
+    }                                                          \
+    default: {                                                 \
+      std::ostringstream err_msg;                              \
+      err_msg << "Unsupported MLA cta_tile_q: " << cta_tile_q; \
+      FLASHINFER_ERROR(err_msg.str());                         \
+    }                                                          \
+  }
+
+template <MaskMode MASK_MODE, uint32_t HEAD_DIM_CKV, uint32_t HEAD_DIM_KPE, uint32_t CTA_TILE_Q,
+          typename Params>
 cudaError_t BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint32_t num_blks_y,
                                         cudaStream_t stream) {
   using DTypeQ = typename Params::DTypeQ;
@@ -1292,7 +1481,6 @@ cudaError_t BatchMLAPageAttentionHopper(Params params, uint32_t num_blks_x, uint
   // budget by sharing a single (non-per-stage) `o` writeback overlay across
   // the whole data path, freeing up room for the BF16 dequant staging buffers.
   constexpr uint32_t NUM_STAGES = 2;
-  constexpr uint32_t CTA_TILE_Q = 64;
   constexpr uint32_t CTA_TILE_KV = 64;
 
   using KTraits =

--- a/include/flashinfer/attention/mla_hopper.cuh
+++ b/include/flashinfer/attention/mla_hopper.cuh
@@ -1420,7 +1420,7 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchMLAPageAttentionHop
   __syncthreads();
   // the second stage, merge partial outputs
   DevicePersistentMergeStates<KTraits>(
-      params.merge_packed_offset_start, params.merge_packed_offset_end,
+      smem, params.merge_packed_offset_start, params.merge_packed_offset_end,
       params.merge_partial_packed_offset_start, params.merge_partial_packed_offset_end,
       params.merge_partial_stride, params.partial_o, params.partial_lse, params.final_o,
       params.final_lse, params.o_stride_n, params.o_stride_h, params.num_heads,

--- a/include/flashinfer/attention/scheduler.cuh
+++ b/include/flashinfer/attention/scheduler.cuh
@@ -1527,6 +1527,10 @@ struct MLAPlanInfo {
   int64_t work_indptr_offset;
   int64_t partial_o_offset;
   int64_t partial_lse_offset;
+  // Packed query rows per CTA (16, 32 or 64); the SM90 kernel is instantiated
+  // per tile. Together with num_blks_x this is the kernel configuration a
+  // CUDA graph captures, which later replans keep (see MLAPlan).
+  int64_t cta_tile_q;
 
   std::vector<int64_t> ToVector() const {
     return {num_blks_x,
@@ -1546,13 +1550,14 @@ struct MLAPlanInfo {
             kv_end_offset,
             work_indptr_offset,
             partial_o_offset,
-            partial_lse_offset};
+            partial_lse_offset,
+            cta_tile_q};
   }
 
   void FromVector(const std::vector<int64_t>& vec) {
-    if (vec.size() != 18) {
+    if (vec.size() != 19) {
       std::ostringstream err_msg;
-      err_msg << "MLAPlanInfo::FromVector: vec.size() should be 18, but got " << vec.size();
+      err_msg << "MLAPlanInfo::FromVector: vec.size() should be 19, but got " << vec.size();
       FLASHINFER_ERROR(err_msg.str());
     }
     num_blks_x = vec[0];
@@ -1573,8 +1578,26 @@ struct MLAPlanInfo {
     work_indptr_offset = vec[15];
     partial_o_offset = vec[16];
     partial_lse_offset = vec[17];
+    cta_tile_q = vec[18];
   }
 };
+
+// Q tile for a batch whose longest request packs `max_packed_qo_len` =
+// qo_len * num_heads query rows: the smallest power of two in
+// [min_cta_tile_q, 64] that holds them, so no request needs more Q tiles than
+// it would with the 64-row tile. Narrower tiles only pay off with one CTA per
+// work item; the second CTA of a cluster would stream KV for rows that do not
+// exist.
+inline uint32_t MLASelectCtaTileQ(int max_packed_qo_len, uint32_t min_cta_tile_q,
+                                  int cluster_size) {
+  constexpr uint32_t kMaxCtaTileQ = 64;
+  if (cluster_size != 1) return kMaxCtaTileQ;
+  uint32_t cta_tile_q = min_cta_tile_q;
+  while (cta_tile_q < kMaxCtaTileQ && static_cast<int>(cta_tile_q) < max_packed_qo_len) {
+    cta_tile_q *= 2;
+  }
+  return cta_tile_q;
+}
 
 template <typename IdType>
 inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_bytes,
@@ -1583,7 +1606,20 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
                            size_t& staged_int_workspace_bytes, IdType* qo_indptr_h,
                            IdType* kv_indptr_h, IdType* kv_len_arr_h, uint32_t batch_size,
                            uint32_t num_heads, uint32_t head_dim_o, bool causal,
-                           cudaStream_t stream) {
+                           uint32_t min_cta_tile_q, uint32_t graph_num_blks_x,
+                           uint32_t graph_cta_tile_q, cudaStream_t stream) {
+  // min_cta_tile_q is the narrowest Q tile the kernel can run (16, 32 or 64).
+  // graph_num_blks_x / graph_cta_tile_q are the values of the plan a CUDA
+  // graph was captured with (0 when not replanning under a graph): the graph
+  // replays that kernel and grid, so the plan keeps them. Any tile and cluster
+  // size give correct results; the captured ones may just be less efficient.
+  FLASHINFER_CHECK(min_cta_tile_q == 16 || min_cta_tile_q == 32 || min_cta_tile_q == 64,
+                   "min_cta_tile_q must be 16, 32 or 64");
+  FLASHINFER_CHECK(graph_num_blks_x <= 2, "graph_num_blks_x must be 0, 1 or 2");
+  FLASHINFER_CHECK(graph_cta_tile_q == 0 || (graph_cta_tile_q >= min_cta_tile_q &&
+                                             (graph_cta_tile_q == 16 || graph_cta_tile_q == 32 ||
+                                              graph_cta_tile_q == 64)),
+                   "graph_cta_tile_q must be 0 or a supported Q tile");
   int num_sm = 0;
   int dev_id = 0;
   FLASHINFER_CUDA_CALL(cudaGetDevice(&dev_id));
@@ -1591,6 +1627,7 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
 
   // step 0. determine the number of blocks in x and y dimensions
   int accum_packed_qo_len = 0;
+  int max_packed_qo_len = 0;
   std::vector<std::tuple<int, int, int>> idx_qo_kv_len_vec;
   for (uint32_t i = 0; i < batch_size; ++i) {
     if (qo_indptr_h[i + 1] - qo_indptr_h[i] < 0) {
@@ -1603,6 +1640,7 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
     int qo_len = qo_indptr_h[i + 1] - qo_indptr_h[i];
     int packed_qo_len = qo_len * num_heads;
     accum_packed_qo_len += packed_qo_len;
+    max_packed_qo_len = std::max(max_packed_qo_len, packed_qo_len);
 
     int kv_len = kv_len_arr_h[i];
     idx_qo_kv_len_vec.push_back({i, qo_len, kv_len});
@@ -1610,7 +1648,9 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
   int avg_packed_qo_len = accum_packed_qo_len / batch_size;
 
   int cluster_size;
-  if (avg_packed_qo_len > 64) {
+  if (graph_num_blks_x != 0) {
+    cluster_size = graph_num_blks_x;
+  } else if (avg_packed_qo_len > 64) {
     cluster_size = 2;  // two ctas in a cluster
   } else {
     cluster_size = 1;  // one cta in a cluster
@@ -1618,7 +1658,10 @@ inline cudaError_t MLAPlan(void* float_buffer, size_t float_workspace_size_in_by
   uint32_t num_clusters = num_sm / cluster_size;
   plan_info.num_blks_x = cluster_size;
   plan_info.num_blks_y = num_clusters;
-  const int cta_tile_q = 64;
+  const int cta_tile_q = graph_cta_tile_q != 0
+                             ? graph_cta_tile_q
+                             : MLASelectCtaTileQ(max_packed_qo_len, min_cta_tile_q, cluster_size);
+  plan_info.cta_tile_q = cta_tile_q;
   int cluster_tile_q = cluster_size * cta_tile_q;
 
   int64_t total_kv_lens = 0;

--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -205,6 +205,25 @@ __device__ __forceinline__ void stmatrix_m8n8x4(uint32_t* R, T* smem_ptr) {
 }
 
 /*!
+ * \brief Wrapper of PTX stmatrix m8n8.x4 transposed instruction, stores each 8x8
+ *   fragment to shared memory transposed (fragment rows become shared memory columns)
+ * \tparam T data type of the fragment
+ * \param R pointer to the fragment
+ * \param smem_ptr pointer to the shared memory
+ */
+template <typename T>
+__device__ __forceinline__ void stmatrix_m8n8x4_trans(uint32_t* R, T* smem_ptr) {
+#ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
+  uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile("stmatrix.sync.aligned.trans.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+               :
+               : "r"(smem_int_ptr), "r"(R[0]), "r"(R[1]), "r"(R[2]), "r"(R[3]));
+#else
+  FLASHINFER_RUNTIME_ASSERT("Unsupported CUDA architecture for stmatrix instruction");
+#endif
+}
+
+/*!
  * \brief Wrapper of two mma m16n8k32 instructions for row major and column major f8 matrix
  *   multiplication, accumulated in f32.
  * \tparam T data type of the fragment

--- a/include/flashinfer/mma.cuh
+++ b/include/flashinfer/mma.cuh
@@ -33,10 +33,14 @@ namespace mma {
 #endif
 #endif
 
-#if (__CUDACC_VER_MAJOR__ >= 11)
+// stmatrix needs PTX ISA 7.8 (CUDA 11.8) and sm_90.
+#if (__CUDACC_VER_MAJOR__ * 10000 + __CUDACC_VER_MINOR__ * 100 >= 110800)
 #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 900))
 #define FLASHINFER_STMATRIX_M8N8X4_ENABLED
 #endif
+#endif
+
+#if (__CUDACC_VER_MAJOR__ >= 11)
 #if (!defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 800))
 #define FLASHINFER_MMA_F16F16F32_M16N8K16_ENABLED
 #define FLASHINFER_MMA_F16F16F16_M16N8K16_ENABLED
@@ -215,7 +219,7 @@ template <typename T>
 __device__ __forceinline__ void stmatrix_m8n8x4_trans(uint32_t* R, T* smem_ptr) {
 #ifdef FLASHINFER_STMATRIX_M8N8X4_ENABLED
   uint32_t smem_int_ptr = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
-  asm volatile("stmatrix.sync.aligned.trans.m8n8.x4.shared.b16 [%0], {%1, %2, %3, %4};\n"
+  asm volatile("stmatrix.sync.aligned.m8n8.x4.trans.shared.b16 [%0], {%1, %2, %3, %4};\n"
                :
                : "r"(smem_int_ptr), "r"(R[0]), "r"(R[1]), "r"(R[2]), "r"(R[3]));
 #else

--- a/include/flashinfer/permuted_smem.cuh
+++ b/include/flashinfer/permuted_smem.cuh
@@ -144,6 +144,11 @@ struct smem_t {
     mma::stmatrix_m8n8x4(R, smem_ptr);
   }
 
+  __device__ __forceinline__ void stmatrix_m8n8x4_trans(uint32_t offset, uint32_t* R) {
+    b128_t* smem_ptr = base + offset;
+    mma::stmatrix_m8n8x4_trans(R, smem_ptr);
+  }
+
   __device__ __forceinline__ void ldmatrix_m8n8x4_trans(uint32_t offset, uint32_t* R) {
     b128_t* smem_ptr = base + offset;
     mma::ldmatrix_m8n8x4_trans(R, smem_ptr);

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -796,6 +796,25 @@ def test_batch_mla_narrow_q_tile(
     )
 
 
+# Long-context decode splits the KV cache over every SM (128 partial states per
+# query row here), so the merge runs its batched, multi-group path.
+@pytest.mark.parametrize("num_heads", [8, 16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+def test_batch_mla_long_context_decode(num_heads, causal, backend):
+    test_batch_mla_page_attention(
+        batch_size=1,
+        kv_len=65536,
+        qo_len=1,
+        num_heads=num_heads,
+        causal=causal,
+        page_size=64,
+        backend=backend,
+        use_cuda_graph=False,
+        dtype=torch.bfloat16,
+    )
+
+
 @pytest.mark.parametrize("num_heads", [8, 16])
 @pytest.mark.parametrize("causal", [False, True])
 @pytest.mark.parametrize("page_size", [1, 16])

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -581,7 +581,8 @@ def test_batch_mla_oob_kv_nan(
     q = torch.cat([q_nope, q_pe], dim=-1)
     o_ref, lse_ref = attention_ref(batch_size, q, k, v, causal, sm_scale)
     lse_ref = lse_ref.flatten(0, 1)
-    torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
+    o_tol = 1e-3 if dtype == torch.half else 2e-2
+    torch.testing.assert_close(o, o_ref, rtol=o_tol, atol=o_tol)
     if kv_len != 0:
         torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
 
@@ -737,7 +738,8 @@ def test_batch_mla_page_attention(
     q = torch.cat([q_nope, q_pe], dim=-1)
     o_ref, lse_ref = attention_ref(batch_size, q, k, v, causal, sm_scale)
     lse_ref = lse_ref.flatten(0, 1)
-    torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
+    o_tol = 1e-3 if dtype == torch.half else 2e-2
+    torch.testing.assert_close(o, o_ref, rtol=o_tol, atol=o_tol)
     if kv_len != 0:
         torch.testing.assert_close(lse, lse_ref, rtol=1e-3, atol=1e-3)
 
@@ -767,6 +769,179 @@ def test_batch_mla_page_attention_cuda_graph_replan(backend):
         use_cuda_graph=True,
         dtype=torch.half,
     )
+
+
+# The SM90 kernel runs 16- and 32-row Q tiles (with the GEMM operands swapped)
+# when the longest packed query in the batch fits; 64-row tiles otherwise.
+@pytest.mark.parametrize("batch_size", [1, 3])
+@pytest.mark.parametrize("kv_len", [17, 130, 4096, 8737])
+@pytest.mark.parametrize("qo_len", [1, 2, 4])
+@pytest.mark.parametrize("num_heads", [8, 16, 32])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [1, 64])
+@pytest.mark.parametrize("dtype", [torch.half, torch.bfloat16])
+def test_batch_mla_narrow_q_tile(
+    batch_size, kv_len, qo_len, num_heads, causal, page_size, dtype
+):
+    test_batch_mla_page_attention(
+        batch_size=batch_size,
+        kv_len=kv_len,
+        qo_len=qo_len,
+        num_heads=num_heads,
+        causal=causal,
+        page_size=page_size,
+        backend="fa3",
+        use_cuda_graph=False,
+        dtype=dtype,
+    )
+
+
+@pytest.mark.parametrize("num_heads", [8, 16])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+def test_batch_mla_mixed_qo_len_batch(num_heads, causal, page_size, backend):
+    """Requests with different qo_len share one plan; the Q tile follows the
+    longest packed query in the batch."""
+    device = torch.device("cuda:0")
+    clear_cuda_cache(device)
+    if backend == "fa3" and not is_sm90a_supported(device):
+        pytest.skip("FA3 is not supported on this device")
+    torch.manual_seed(42)
+    dtype = torch.half
+    head_dim_ckv, head_dim_kpe = 512, 64
+    qo_lens = [1, 3, 1, 2, 5, 1]
+    kv_lens = [300, 17, 4096, 130, 64, 2000]
+    batch_size = len(qo_lens)
+    sm_scale = 1.0 / ((128 + 64) ** 0.5)
+    pages = [math.ceil(kv_len / page_size) for kv_len in kv_lens]
+
+    q_nope = torch.randn(
+        sum(qo_lens), num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(
+        sum(qo_lens), num_heads, head_dim_kpe, dtype=dtype, device=device
+    )
+    ckv = torch.randn(sum(pages), page_size, head_dim_ckv, dtype=dtype, device=device)
+    kpe = torch.randn(sum(pages), page_size, head_dim_kpe, dtype=dtype, device=device)
+
+    q_indptr = torch.tensor([0] + qo_lens, dtype=torch.int32, device=device).cumsum(
+        0, dtype=torch.int32
+    )
+    kv_indptr = torch.tensor([0] + pages, dtype=torch.int32, device=device).cumsum(
+        0, dtype=torch.int32
+    )
+    kv_indices = torch.arange(sum(pages), dtype=torch.int32, device=device)
+    kv_len_arr = torch.tensor(kv_lens, dtype=torch.int32, device=device)
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(
+        workspace_buffer, backend=backend
+    )
+    wrapper.plan(
+        metadata=flashinfer.mla.MLAPlanMetadata.csr(
+            q_indptr, kv_indptr, kv_indices, kv_len_arr
+        ),
+        num_heads=num_heads,
+        head_dim_ckv=head_dim_ckv,
+        head_dim_kpe=head_dim_kpe,
+        page_size=page_size,
+        causal=causal,
+        sm_scale=sm_scale,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        query_layout="split",
+        kv_cache_layout="split",
+        lse_mode="base2",
+    )
+    o, lse = wrapper.run(query=(q_nope, q_pe), kv_cache=(ckv, kpe), return_lse=True)
+
+    q = torch.cat([q_nope, q_pe], dim=-1)
+    for i in range(batch_size):
+        q_i = q[q_indptr[i] : q_indptr[i + 1]]
+        k_i, v_i = generate_kv_from_cache(
+            ckv[kv_indptr[i] : kv_indptr[i + 1]],
+            kpe[kv_indptr[i] : kv_indptr[i + 1]],
+            kv_lens[i],
+            1,
+            num_heads,
+        )
+        o_ref, lse_ref = attention_ref(1, q_i, k_i, v_i, causal, sm_scale)
+        torch.testing.assert_close(
+            o[q_indptr[i] : q_indptr[i + 1]], o_ref, rtol=1e-3, atol=2e-3
+        )
+        torch.testing.assert_close(
+            lse[q_indptr[i] : q_indptr[i + 1]],
+            lse_ref.flatten(0, 1),
+            rtol=1e-3,
+            atol=2e-3,
+        )
+
+
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+def test_batch_mla_cuda_graph_replan_keeps_kernel_config(backend):
+    """A CUDA graph replays the kernel and grid it was captured with, so a
+    replan for a batch that would pick another Q tile or cluster size keeps
+    the captured configuration and still computes the right result."""
+    device = torch.device("cuda:0")
+    clear_cuda_cache(device)
+    if backend == "fa3" and not is_sm90a_supported(device):
+        pytest.skip("FA3 is not supported on this device")
+    torch.manual_seed(42)
+    num_heads, head_dim_ckv, head_dim_kpe, page_size = 16, 512, 64, 1
+    kv_len, dtype = 200, torch.half
+    sm_scale = 1.0 / ((128 + 64) ** 0.5)
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
+    wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(
+        workspace_buffer,
+        backend=backend,
+        use_cuda_graph=True,
+        qo_indptr=torch.empty(2, dtype=torch.int32, device=device),
+        kv_indptr=torch.empty(2, dtype=torch.int32, device=device),
+        kv_indices=torch.empty(kv_len, dtype=torch.int32, device=device),
+        kv_len_arr=torch.empty(1, dtype=torch.int32, device=device),
+    )
+    ckv = torch.randn(kv_len, page_size, head_dim_ckv, dtype=dtype, device=device)
+    kpe = torch.randn(kv_len, page_size, head_dim_kpe, dtype=dtype, device=device)
+
+    def plan(qo_len):
+        wrapper.plan(
+            metadata=flashinfer.mla.MLAPlanMetadata.csr(
+                torch.tensor([0, qo_len], dtype=torch.int32, device=device),
+                torch.tensor([0, kv_len], dtype=torch.int32, device=device),
+                torch.arange(kv_len, dtype=torch.int32, device=device),
+                torch.tensor([kv_len], dtype=torch.int32, device=device),
+            ),
+            num_heads=num_heads,
+            head_dim_ckv=head_dim_ckv,
+            head_dim_kpe=head_dim_kpe,
+            page_size=page_size,
+            causal=True,
+            sm_scale=sm_scale,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            query_layout="split",
+            kv_cache_layout="split",
+            lse_mode="base2",
+        )
+        return wrapper._plan_info[0], wrapper._plan_info[-1]
+
+    # Captured with 16 packed rows; the replans would otherwise move to the
+    # 64-row tile (48 rows) and to two-CTA clusters (160 rows).
+    captured = plan(qo_len=1)
+    for qo_len in (3, 10):
+        assert plan(qo_len) == captured
+        q_nope = torch.randn(
+            qo_len, num_heads, head_dim_ckv, dtype=dtype, device=device
+        )
+        q_pe = torch.randn(qo_len, num_heads, head_dim_kpe, dtype=dtype, device=device)
+        o, lse = wrapper.run(query=(q_nope, q_pe), kv_cache=(ckv, kpe), return_lse=True)
+        k, v = generate_kv_from_cache(ckv, kpe, kv_len, 1, num_heads)
+        o_ref, lse_ref = attention_ref(
+            1, torch.cat([q_nope, q_pe], dim=-1), k, v, True, sm_scale
+        )
+        torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(lse, lse_ref.flatten(0, 1), rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 4])
@@ -1032,7 +1207,7 @@ def test_batch_mla_fp8_nope_group_scales_matches_bf16_reference(backend):
 @pytest.mark.parametrize("kv_len", [256, 1024, 4096])
 @pytest.mark.parametrize("qo_len", [1, 16])
 @pytest.mark.parametrize("page_size", [16, 64])
-@pytest.mark.parametrize("num_heads", [16, 128])
+@pytest.mark.parametrize("num_heads", [8, 16, 32, 128])
 @pytest.mark.parametrize("causal", [False, True])
 def test_batch_mla_fp8_kv_matches_bf16_reference(
     batch_size, kv_len, qo_len, page_size, num_heads, causal

--- a/tests/attention/test_deepseek_mla.py
+++ b/tests/attention/test_deepseek_mla.py
@@ -901,14 +901,14 @@ def test_batch_mla_mixed_qo_len_batch(num_heads, causal, page_size, backend):
 def test_batch_mla_cuda_graph_replan_keeps_kernel_config(backend):
     """A CUDA graph replays the kernel and grid it was captured with, so a
     replan for a batch that would pick another Q tile or cluster size keeps
-    the captured configuration and still computes the right result."""
+    the captured configuration, and replaying the graph is still correct."""
     device = torch.device("cuda:0")
     clear_cuda_cache(device)
     if backend == "fa3" and not is_sm90a_supported(device):
         pytest.skip("FA3 is not supported on this device")
     torch.manual_seed(42)
     num_heads, head_dim_ckv, head_dim_kpe, page_size = 16, 512, 64, 1
-    kv_len, dtype = 200, torch.half
+    kv_len, qo_len_max, dtype = 200, 10, torch.half
     sm_scale = 1.0 / ((128 + 64) ** 0.5)
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.int8, device=device)
     wrapper = flashinfer.mla.BatchMLAPagedAttentionWrapper(
@@ -945,22 +945,44 @@ def test_batch_mla_cuda_graph_replan_keeps_kernel_config(backend):
         )
         return wrapper._plan_info[0], wrapper._plan_info[-1]
 
+    # Graph-static buffers sized for the longest replanned query.
+    q_nope = torch.randn(
+        qo_len_max, num_heads, head_dim_ckv, dtype=dtype, device=device
+    )
+    q_pe = torch.randn(qo_len_max, num_heads, head_dim_kpe, dtype=dtype, device=device)
+    o_buf = torch.zeros(qo_len_max, num_heads, head_dim_ckv, dtype=dtype, device=device)
+    lse_buf = torch.zeros(qo_len_max, num_heads, dtype=torch.float32, device=device)
+
+    def run():
+        wrapper.run(query=(q_nope, q_pe), kv_cache=(ckv, kpe), out=o_buf, lse=lse_buf)
+
     # Captured with 16 packed rows; the replans would otherwise move to the
     # 64-row tile (48 rows) and to two-CTA clusters (160 rows).
     captured = plan(qo_len=1)
-    for qo_len in (3, 10):
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s):
+        for _ in range(3):
+            run()
+    torch.cuda.current_stream().wait_stream(s)
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        run()
+
+    k, v = generate_kv_from_cache(ckv, kpe, kv_len, 1, num_heads)
+    for qo_len in (1, 3, 10):
         assert plan(qo_len) == captured
-        q_nope = torch.randn(
-            qo_len, num_heads, head_dim_ckv, dtype=dtype, device=device
+        q_nope.normal_()
+        q_pe.normal_()
+        o_buf.zero_()
+        lse_buf.zero_()
+        g.replay()
+        q = torch.cat([q_nope[:qo_len], q_pe[:qo_len]], dim=-1)
+        o_ref, lse_ref = attention_ref(1, q, k, v, True, sm_scale)
+        torch.testing.assert_close(o_buf[:qo_len], o_ref, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(
+            lse_buf[:qo_len], lse_ref.flatten(0, 1), rtol=1e-3, atol=1e-3
         )
-        q_pe = torch.randn(qo_len, num_heads, head_dim_kpe, dtype=dtype, device=device)
-        o, lse = wrapper.run(query=(q_nope, q_pe), kv_cache=(ckv, kpe), return_lse=True)
-        k, v = generate_kv_from_cache(ckv, kpe, kv_len, 1, num_heads)
-        o_ref, lse_ref = attention_ref(
-            1, torch.cat([q_nope, q_pe], dim=-1), k, v, True, sm_scale
-        )
-        torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
-        torch.testing.assert_close(lse, lse_ref.flatten(0, 1), rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 4])


### PR DESCRIPTION
## Description

MLA decode on Hopper (`BatchMLAPagedAttentionWrapper`, `fa3` backend) runs `qo_len * num_heads` packed query rows per work item. Under tensor parallelism a decode step has 8, 16 or 32 rows, which the kernel padded to its fixed 64-row WGMMA-M tile (issue #2995). This PR fixes that and the merge bottleneck it exposed. Two commits.

### Swap-AB Q tiles

`hopper::HopperKernelTraits` takes the Q tile as a parameter. The 16- and 32-row tiles swap the GEMM operands so the query rows land on WGMMA-N (granularity 8):

```
S^T[kv, q]  = K[kv, d]   * Q^T[d, q]     A = K   (K-major),  B = Q   (K-major)
O^T[d, q]  += V^T[d, kv] * P^T[kv, q]    A = V^T (MN-major), B = P^T (K-major)
```

The products read the same shared-memory tiles and descriptors as before; only the operand roles and the accumulator layout change, with each warpgroup's half of `HEAD_DIM_CKV` split into 64-row WGMMA-M chunks. Softmax statistics are per column, reduced over the eight lanes of a column and once across the four warps through shared memory. P and O are staged with `stmatrix.trans`. The 64-row tile keeps the original layout, and both layouts share the same producer and consumer bodies.

`MLAPlan` picks the tile from the longest packed query in the batch (`MLAPlanInfo::cta_tile_q`), one kernel instantiation per tile, only when a work item runs on a single CTA. FA2 keeps the 64-row tile. A CUDA graph replays the kernel and grid it was captured with, so a replan under a graph now keeps the captured cluster size and tile; any tile is correct (a narrower one only means more Q tiles per request), and this also covers the pre-existing cluster-size hazard.

### Parallel split-KV merge

With the tiles in place the tensor pipe went from 29% to 9% busy but decode time barely moved: long-context decode was bound by the split-KV merge, which walked up to 128 partial states per row one at a time at L2 latency with 64 of 256 threads active (29 us of a 77 us kernel at 128K tokens). `DevicePersistentMergeStates` (shared with FA2) now splits a row's partials over the four 64-thread groups of a CTA, keeps eight loads in flight per group, and combines the groups through shared memory. A CTA that owns several rows still gives each group its own row.

### Results

Kernel time (CUPTI median) on a GH200, BF16, `head_dim_ckv=512`, `head_dim_kpe=64`; `qo_len=2` is causal. Before is `main` at 61f9b29d.

| batch | qo_len | heads | kv_len | page_size | before (us) | after (us) | speedup |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 8 | 4096 | 64 | 16.2 | 9.4 | 1.72x |
| 1 | 1 | 8 | 16384 | 64 | 27.2 | 13.6 | 2.00x |
| 1 | 1 | 8 | 65536 | 64 | 57.0 | 32.7 | 1.74x |
| 1 | 1 | 8 | 131072 | 64 | 77.5 | 52.7 | 1.47x |
| 1 | 1 | 16 | 16384 | 64 | 27.7 | 13.7 | 2.02x |
| 1 | 1 | 16 | 131072 | 64 | 79.2 | 53.6 | 1.48x |
| 1 | 1 | 32 | 16384 | 64 | 27.8 | 15.7 | 1.77x |
| 1 | 1 | 32 | 131072 | 64 | 80.2 | 55.7 | 1.44x |
| 1 | 1 | 64 | 16384 | 64 | 29.5 | 18.2 | 1.62x |
| 1 | 1 | 64 | 131072 | 64 | 83.7 | 58.6 | 1.43x |
| 1 | 1 | 128 | 131072 | 64 | 85.7 | 72.5 | 1.18x |
| 1 | 2 | 16 | 65536 | 64 | 59.9 | 34.8 | 1.72x |
| 1 | 1 | 16 | 65536 | 1 | 60.0 | 33.7 | 1.78x |
| 8 | 1 | 16 | 8192 | 64 | 33.8 | 29.8 | 1.13x |
| 32 | 1 | 16 | 32768 | 64 | 332.9 | 329.5 | 1.01x |

At batch 1 with 8 or 16 heads the main loop now runs at the HBM streaming rate of this device (3.56 TB/s in a `cp.async` microbenchmark); at 128K tokens the kernel spends 42 us streaming 151 MB and about 10 us on launch, grid sync and merge. Larger batches were already bandwidth-bound. The 64- and 128-head rows keep the original tile and gain from the merge only.

## Related Issues

Closes #2995.

## Pull Request Checklist

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New tests in `tests/attention/test_deepseek_mla.py`: narrow tiles (8, 16, 32 heads; `qo_len` 1, 2, 4; FP16 and BF16; page sizes 1 and 64; causal), long-context split-KV decode, mixed-`qo_len` batches, graph replans that keep the captured configuration, and FP8 KV with 8 and 32 heads. Existing FA2 and FA3 MLA tests pass, including out-of-bounds KV, no-KPE and FP8. Outputs were also checked against an fp32 PyTorch reference over 416 configurations with FA3 errors at or below FA2's.

## Reviewer Notes

- The 64-row kernel keeps its register budget (234 registers, no spills); the 16- and 32-row kernels use 102 and 174.
- `MLAPlan` gained `min_cta_tile_q` (FA2 passes 64) and the captured `graph_num_blks_x` / `graph_cta_tile_q` of a graph replan; `MLAPlanInfo` gained `cta_tile_q` (last entry), so the JIT URI tag moves to `planabi3`.
- Named barriers 6 and 7 are the per-warpgroup barriers of the swap-AB tiles; CUTLASS reserves hardware barriers 8 to 15.
- The merge commit stands on its own and also speeds up FA2 split-KV decode.

Designed in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added adaptive query-tile selection for Hopper-based MLA attention, supporting tile sizes of 16, 32, and 64.
  * Improved CUDA Graph planning and replanning by preserving captured execution settings.
  * Enhanced long-context and split-KV attention merging for more flexible workloads.
* **Performance**
  * Optimized SM90 MLA execution for narrow query batches and mixed query lengths.
* **Bug Fixes**
  * Improved numerical handling and output validation across supported data types.
  * Corrected transposed matrix shared-memory operations on supported CUDA architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->