### PR TITLE
[feat] Add warp level split k bf16 gemm

### DIFF
--- a/flashinfer/autotuner/autotuner.py
+++ b/flashinfer/autotuner/autotuner.py
@@ -476,6 +476,11 @@ class TuningConfig:
         profiling_repeat (int | None): Per-operation profiling repeat override.
             ``None`` uses the autotuner default. This affects measurement
             precision, not tactic compatibility or persisted cache identity.
+        use_cold_l2_graph_replay (bool): Replay the captured graph once untimed
+            (absorbing first-launch initialization), then evict L2 so the timed
+            replay starts from a cold L2, and give every launch in the graph its
+            own input copy. Requires ``use_cuda_graph``; the eviction also
+            requires ``use_cold_l2_cache``.
         tensor_initializers (Tuple[Tuple[int, TensorInitializer]]): Per-input-index
             initializer closures used to synthesize profiling tensors. Each entry
             pairs an input tensor index with the closure that fills that input.
@@ -502,6 +507,7 @@ class TuningConfig:
     use_cold_l2_cache: bool = False
     use_cuda_graph: bool = False
     profiling_repeat: int | None = None
+    use_cold_l2_graph_replay: bool = False
     value_aware_input_indices: tuple[int, ...] = ()
     profile_arena_input_indices: tuple[int, ...] = ()
     # Optional callback invoked once per profile bucket, after dynamic
@@ -1567,6 +1573,7 @@ class AutoTuner:
             use_cold_l2_cache=tuning_config.use_cold_l2_cache,
             use_cuda_graph=tuning_config.use_cuda_graph,
             profiling_repeat=tuning_config.profiling_repeat,
+            use_cold_l2_graph_replay=tuning_config.use_cold_l2_graph_replay,
             value_aware_input_indices=tuning_config.value_aware_input_indices,
             profile_arena_input_indices=tuning_config.profile_arena_input_indices,
             inputs_pre_hook=tuning_config.inputs_pre_hook,
@@ -2094,6 +2101,17 @@ class AutoTuner:
 
         def pure_profile(stream: torch.cuda.Stream, repeat: int) -> float:
             graph = torch.cuda.CUDAGraph()
+            l2_eviction_buffer = None
+            if (
+                tuning_config.use_cold_l2_cache
+                and tuning_config.use_cuda_graph
+                and tuning_config.use_cold_l2_graph_replay
+            ):
+                l2_eviction_buffer = torch.empty(
+                    2 * self._get_l2_cache_size_in_bytes(),
+                    dtype=torch.uint8,
+                    device=stream.device,
+                )
 
             if self._use_global_timer:
                 start_ts = torch.empty(1, dtype=torch.int64, device="cuda")
@@ -2136,6 +2154,16 @@ class AutoTuner:
                         _run_kernels()
 
                 stream.synchronize()
+                if (
+                    tuning_config.use_cuda_graph
+                    and tuning_config.use_cold_l2_graph_replay
+                ):
+                    # Exclude first-replay initialization from the timed sample.
+                    graph.replay()
+                    if l2_eviction_buffer is not None:
+                        # Restore cold-L2 state after graph initialization.
+                        l2_eviction_buffer.zero_()
+                    stream.synchronize()
 
                 # Delay the profiled kernel launch to eliminate affects of host time overhead in profiling.
                 delay_kernel_time_usec = (
@@ -2908,6 +2936,9 @@ class AutoTuner:
 
         num_buffers = self._get_l2_cache_size_in_bytes() * 3 // one_buffer_bytes + 1
         num_buffers = min(num_buffers, profiling_repeat + 1)
+        # Avoid reusing a warmed batch within the timed graph.
+        if tuning_config.use_cuda_graph and tuning_config.use_cold_l2_graph_replay:
+            num_buffers = max(num_buffers, profiling_repeat)
 
         inputs_list = [inputs]
         for _ in range(num_buffers - 1):

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1461,7 +1461,7 @@ def get_mm_bf16_cublaslt_module():
     )
 
 
-_CUTE_DSL_BF16_AUTOTUNE_VERSION = 10
+_CUTE_DSL_BF16_AUTOTUNE_VERSION = 11
 
 
 _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
@@ -1586,6 +1586,37 @@ def _tgv_gemm_runner(dtype: torch.dtype, use_sm_100f: bool):
     return TGVRunner()
 
 
+class _CuteDSLBf16Runner(TunableRunner):
+    """Shared protocol of the CuTe-DSL low-M BF16 runners.
+
+    ``_cute_dsl_bf16_runners`` lists only runners whose ``supports_inputs``
+    holds for the real inputs, so the runner order is purely a preference.
+    ``is_tactic_compatible`` is re-checked after autotuner selection because a
+    cached tactic can come from a bucket profiled at another M; override it
+    when a runner's tactics are not portable across the M values of a bucket.
+    """
+
+    def __init__(self, compute_capability: int) -> None:
+        self.compute_capability = compute_capability
+
+    def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+        a, _, bias, pdl, out, *_ = inputs
+        return (
+            str(a.dtype),
+            str(out.dtype),
+            bias is not None,
+            bool(pdl),
+            self.compute_capability,
+            _CUTE_DSL_BF16_AUTOTUNE_VERSION,
+        )
+
+    def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
+        return True
+
+    def is_tactic_compatible(self, inputs: List[torch.Tensor], tactic: object) -> bool:
+        return True
+
+
 @functools.cache
 def _cute_dsl_splitk_bf16_gemm_runner(
     compute_capability: int,
@@ -1597,18 +1628,10 @@ def _cute_dsl_splitk_bf16_gemm_runner(
         run_splitk_dense,
     )
 
-    class CuteDSLSplitKBf16Runner(TunableRunner):
-        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
-            a, _, bias, pdl, out, *_ = inputs
-            return (
-                str(a.dtype),
-                str(out.dtype),
-                bias is not None,
-                bool(pdl),
-                compute_capability,
-                _CUTE_DSL_BF16_AUTOTUNE_VERSION,
-            )
-
+    # Serves every input the cute-dsl backend requirement admits: it validates
+    # ``default_tactic`` for the real shape, so the inherited ``supports_inputs``
+    # holds.
+    class CuteDSLSplitKBf16Runner(_CuteDSLBf16Runner):
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
@@ -1651,7 +1674,7 @@ def _cute_dsl_splitk_bf16_gemm_runner(
                     ) from error
             return run_splitk_dense(a, b, bias, out, bool(pdl), tactic)
 
-    return CuteDSLSplitKBf16Runner()
+    return CuteDSLSplitKBf16Runner(compute_capability)
 
 
 @functools.cache
@@ -1664,7 +1687,9 @@ def _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability: int):
         validate_inputs,
     )
 
-    class CuteDSLWarpSplitKBf16Runner(TunableRunner):
+    # Every warp Split-K tactic serves every M in [1, _MAX_M], so the inherited
+    # ``is_tactic_compatible`` holds.
+    class CuteDSLWarpSplitKBf16Runner(_CuteDSLBf16Runner):
         def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
             a, b, bias, _, out, *_ = inputs
             try:
@@ -1672,17 +1697,6 @@ def _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability: int):
             except ValueError:
                 return False
             return True
-
-        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
-            a, _, bias, pdl, out, *_ = inputs
-            return (
-                str(a.dtype),
-                str(out.dtype),
-                bias is not None,
-                bool(pdl),
-                compute_capability,
-                _CUTE_DSL_BF16_AUTOTUNE_VERSION,
-            )
 
         def get_valid_tactics(
             self, inputs: List[torch.Tensor], profile: OptimizationProfile
@@ -1718,7 +1732,7 @@ def _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability: int):
                         ) from error
                 return run_warp_splitk_dense(a, b, out, bool(pdl), tactic, bias)
 
-    return CuteDSLWarpSplitKBf16Runner()
+    return CuteDSLWarpSplitKBf16Runner(compute_capability)
 
 
 @functools.cache
@@ -1733,15 +1747,23 @@ def _cute_dsl_direct_bf16_gemm_runner(
         validate_tactic,
     )
 
-    class CuteDSLDirectBf16Runner(TunableRunner):
+    class CuteDSLDirectBf16Runner(_CuteDSLBf16Runner):
+        def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
+            a, b, bias, *_ = inputs
+            if bias is not None:  # the Direct kernel has no bias epilogue
+                return False
+            try:
+                default_tactic(a.shape[0], b.shape[1], a.shape[1])
+            except ValueError:
+                return False
+            return True
+
         def is_tactic_compatible(
             self, inputs: List[torch.Tensor], tactic: object
         ) -> bool:
             if tactic == -1:
                 return True
-            a, b, bias, *_ = inputs
-            if bias is not None:
-                return False
+            a, b, *_ = inputs
             try:
                 if not isinstance(tactic, (DirectTactic, tuple, list)):
                     return False
@@ -1755,27 +1777,18 @@ def _cute_dsl_direct_bf16_gemm_runner(
                 return False
             return True
 
-        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
-            a, _, _, pdl, out, *_ = inputs
-            return (
-                str(a.dtype),
-                str(out.dtype),
-                bool(pdl),
-                compute_capability,
-                _CUTE_DSL_BF16_AUTOTUNE_VERSION,
-            )
-
         def get_valid_tactics(
             self,
             inputs: List[torch.Tensor],
             profile: OptimizationProfile,
         ) -> list[tuple[int, int, int]]:
-            a, b, bias, *_ = inputs
-            if bias is not None:
+            if not self.supports_inputs(inputs):
                 return []
-            m, k = a.shape
-            n = b.shape[1]
-            return [astuple(config) for config in autotune_tactics(m, n, k)]
+            a, b, *_ = inputs
+            return [
+                astuple(config)
+                for config in autotune_tactics(a.shape[0], b.shape[1], a.shape[1])
+            ]
 
         def forward(
             self,
@@ -1799,7 +1812,36 @@ def _cute_dsl_direct_bf16_gemm_runner(
                     ) from error
             return run_direct_dense(a, b, out, bool(pdl), tactic)
 
-    return CuteDSLDirectBf16Runner()
+    return CuteDSLDirectBf16Runner(compute_capability)
+
+
+def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
+    """Return the CuTe-DSL low-M runners able to serve ``inputs``, best first.
+
+    ``[0]`` is the no-autotune default and the autotuner's fallback. The Direct
+    kernel leads only where its measured shape heuristic applies. Otherwise the
+    warp Split-K kernel leads whenever it is eligible (M <= 32, N % 16 == 0,
+    K % 128 == 0 with at most 64 K tiles), as it wins nearly every tuned
+    M <= 32 cell on B300, and cluster Split-K comes next.
+    """
+    from .kernels.dense_bf16_gemm_direct import prefer_direct_bf16_gemm_sm100
+
+    a, b, *_ = inputs
+    major, minor = torch.cuda.get_device_capability(a.device)
+    compute_capability = major * 10 + minor
+    direct = _cute_dsl_direct_bf16_gemm_runner(compute_capability)
+    warp_splitk = _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability)
+    cluster_splitk = _cute_dsl_splitk_bf16_gemm_runner(compute_capability)
+
+    prefer_direct = direct.supports_inputs(inputs) and prefer_direct_bf16_gemm_sm100(
+        a.shape[0], b.shape[1], a.shape[1]
+    )
+    order = (
+        (direct, warp_splitk, cluster_splitk)
+        if prefer_direct
+        else (warp_splitk, cluster_splitk, direct)
+    )
+    return [runner for runner in order if runner.supports_inputs(inputs)]
 
 
 def bf16_gemm_sm100(
@@ -1822,9 +1864,6 @@ def bf16_gemm_sm100(
 
     inputs = [a, b, bias, pdl, out, workspace_buffer]
     runners = []
-    direct_runner = None
-    warp_splitk_runner = None
-    warp_splitk_supported = True
     if "cudnn" in runner_names:
         runners.append(
             _cudnn_gemm_bf16_runner(
@@ -1843,56 +1882,7 @@ def bf16_gemm_sm100(
     if "tinygemm" in runner_names:
         runners.append(_tinygemm_bf16_gemm_runner())
     if "cute-dsl" in runner_names:
-        compute_capability = torch.cuda.get_device_capability(a.device)
-        compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
-        splitk_runner = _cute_dsl_splitk_bf16_gemm_runner(compute_capability_number)
-        from .kernels.dense_bf16_gemm_warp_splitk import (
-            _MAX_M as warp_splitk_max_m,
-        )
-
-        warp_splitk_runner = _cute_dsl_warp_splitk_bf16_gemm_runner(
-            compute_capability_number
-        )
-        prefer_direct = False
-        if bias is None:  # the Direct kernel has no bias epilogue
-            from .kernels.dense_bf16_gemm_direct import (
-                prefer_direct_bf16_gemm_sm100,
-            )
-
-            direct_runner = _cute_dsl_direct_bf16_gemm_runner(compute_capability_number)
-            prefer_direct = prefer_direct_bf16_gemm_sm100(
-                a.shape[0], b.shape[1], a.shape[1]
-            )
-        warp_splitk_supported = warp_splitk_runner.supports_inputs(inputs)
-        profile_m = min(a.shape[0], warp_splitk_max_m)
-        warp_splitk_profile_supported = warp_splitk_runner.supports_inputs(
-            [a[:profile_m], b, bias, pdl, out[:profile_m], workspace_buffer]
-        )
-        base_runners = tuple(
-            runner
-            for runner in (
-                (direct_runner, splitk_runner)
-                if prefer_direct
-                else (splitk_runner, direct_runner)
-            )
-            if runner is not None
-        )
-        if not warp_splitk_profile_supported:
-            ordered_runners = base_runners
-        elif not warp_splitk_supported:
-            ordered_runners = (*base_runners, warp_splitk_runner)
-        elif prefer_direct:
-            ordered_runners = (direct_runner, warp_splitk_runner, splitk_runner)
-        else:
-            # runners[0] is the no-autotune default and the fallback for an
-            # incompatible cached Direct tactic; the warp Split-K kernel wins
-            # nearly every tuned M <= 16 cell on B300.
-            ordered_runners = tuple(
-                runner
-                for runner in (warp_splitk_runner, splitk_runner, direct_runner)
-                if runner is not None
-            )
-        runners.extend(ordered_runners)
+        runners.extend(_cute_dsl_bf16_runners(inputs))
     assert runners, "No suitable runners found"
 
     runner, tactic = tuner.choose_one(
@@ -1902,20 +1892,13 @@ def bf16_gemm_sm100(
         inputs,
     )
 
-    # A cached entry can come from a bucket profiled at another M (e.g. the warp
-    # kernel tuned at M=16 for a real M=25, or a Direct tactic illegal for this
-    # M); run the first runner that supports the real inputs with its default.
-    if (runner is warp_splitk_runner and not warp_splitk_supported) or (
-        direct_runner is not None
-        and runner is direct_runner
-        and not direct_runner.is_tactic_compatible(inputs, tactic)
+    # A cached CuTe-DSL tactic can come from a bucket profiled at another M and
+    # be illegal here (e.g. a Direct rows_per_block that does not divide M);
+    # fall back to the default runner and tactic, as the autotuner itself does.
+    if isinstance(runner, _CuteDSLBf16Runner) and not runner.is_tactic_compatible(
+        inputs, tactic
     ):
-        runner = next(
-            candidate
-            for candidate in runners
-            if candidate is not warp_splitk_runner or warp_splitk_supported
-        )
-        tactic = -1
+        runner, tactic = runners[0], -1
 
     runner(inputs=inputs, tactic=tactic)
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -498,15 +498,17 @@ def _cute_dsl_mm_bf16_requirement(
         raise ValueError(
             f"Bias must be contiguous on A's device with shape {(b.shape[1],)}."
         )
-    if a.shape[0] > 32:
-        return _cublaslt_mm_bf16_requirement(
-            a, b, out, out_dtype, bias, False, "cublaslt"
-        )
-
     from flashinfer.cute_dsl.availability import is_cute_dsl_available
 
     if not is_cute_dsl_available():
         raise LibraryError("The CuTeDSL low-M backend requires nvidia-cutlass-dsl.")
+
+    if a.shape[0] > _CUTE_DSL_BF16_MAX_M:
+        # Served by the cuBLASLt fallback runner of the cute-dsl runner set;
+        # pdl is ignored there because cuBLASLt has no PDL API.
+        return _cublaslt_mm_bf16_requirement(
+            a, b, out, out_dtype, bias, False, "cublaslt"
+        )
 
     from .kernels.dense_bf16_gemm_sm100_splitk import default_tactic
 
@@ -727,15 +729,17 @@ def mm_bf16(
         ``"cutile"`` uses the cuTile (cuda.tile Python) backend. Pure-Python
             persistent-scheduled GEMM with per-shape exhaustive autotune; ignores
             ``bias`` / ``pdl``. Requires SM >= 90.
-        ``"cute-dsl"`` uses standalone Blackwell low-M direct and cluster
-        Split-K kernels for M <= 32, plus a warp Split-K kernel (also
-        M <= 32), and falls back to cuBLASLt for larger M. It is never
-        auto-selected; serving frameworks must select it explicitly. Without
-        autotuning, the direct kernel runs where its shape heuristic applies,
-        otherwise the warp Split-K kernel whenever it is eligible (M <= 32,
-        N % 16 == 0, K % 128 == 0 with at most 64 K tiles), and cluster
-        Split-K otherwise. With autotuning, all three tactic spaces are
-        profiled; with bias the Direct kernel is excluded.
+        ``"cute-dsl"`` uses standalone Blackwell low-M kernels for M <= 32
+        (direct, cluster Split-K and warp Split-K) and cuBLASLt above that.
+        It is never auto-selected; serving frameworks must select it
+        explicitly. Without autotuning, M > 32 runs cuBLASLt; below, the
+        direct kernel runs where its shape heuristic applies, otherwise the
+        warp Split-K kernel whenever it is eligible (N % 16 == 0, K % 128 == 0
+        with at most 64 K tiles), and cluster Split-K otherwise. With
+        autotuning, one call profiles the low-M kernels on the M <= 32
+        buckets and the cuBLASLt fallback on the larger ones, so a single
+        large-M warm-up tunes both ranges; with bias the direct kernel is
+        excluded.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -820,9 +824,9 @@ def mm_bf16(
             ["tinygemm"], a, b, bias, pdl, out, out_dtype, backend
         )
     elif backend == "cute-dsl":
-        # The low-M kernels cap M at 32. Use cuBLASLt above that range;
-        # pdl is intentionally ignored because cuBLASLt has no PDL API.
-        backends = ["cute-dsl"] if a.shape[0] <= 32 else ["cublaslt"]
+        # One runner set covers both M ranges (cuBLASLt above 32, ignoring
+        # pdl), so one autotune call profiles both; see _cute_dsl_bf16_runners.
+        backends = ["cute-dsl"]
     else:
         backends = [backend]
 
@@ -1462,6 +1466,8 @@ def get_mm_bf16_cublaslt_module():
 
 
 _CUTE_DSL_BF16_AUTOTUNE_VERSION = 11
+# M bound of the CuTe-DSL low-M kernels; larger M runs the cuBLASLt fallback.
+_CUTE_DSL_BF16_MAX_M = 32
 
 
 _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
@@ -1587,17 +1593,27 @@ def _tgv_gemm_runner(dtype: torch.dtype, use_sm_100f: bool):
 
 
 class _CuteDSLBf16Runner(TunableRunner):
-    """Shared protocol of the CuTe-DSL low-M BF16 runners.
+    """Base of the runners behind ``backend="cute-dsl"``.
 
-    ``_cute_dsl_bf16_runners`` lists only runners whose ``supports_inputs``
-    holds for the real inputs, so the runner order is purely a preference.
-    ``is_tactic_compatible`` is re-checked after autotuner selection because a
-    cached tactic can come from a bucket profiled at another M; override it
-    when a runner's tactics are not portable across the M values of a bucket.
+    ``_cute_dsl_bf16_runners`` lists every runner of the backend so that one
+    autotune call profiles each of them on the buckets it owns; a runner
+    returns no tactics for a profile whose M it does not serve. The defaults
+    here describe the CuTe-DSL kernels (M <= ``_CUTE_DSL_BF16_MAX_M``, one
+    cache-key layout); the cuBLASLt fallback overrides them. After autotuner
+    selection, ``supports_inputs`` and ``is_tactic_compatible`` are re-checked
+    against the real inputs because a cached entry can come from a bucket on
+    the other side of ``_CUTE_DSL_BF16_MAX_M`` or from another M.
     """
 
     def __init__(self, compute_capability: int) -> None:
         self.compute_capability = compute_capability
+
+    def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
+        a, *_ = inputs
+        return 1 <= a.shape[0] <= _CUTE_DSL_BF16_MAX_M
+
+    def is_tactic_compatible(self, inputs: List[torch.Tensor], tactic: object) -> bool:
+        return True
 
     def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
         a, _, bias, pdl, out, *_ = inputs
@@ -1609,12 +1625,6 @@ class _CuteDSLBf16Runner(TunableRunner):
             self.compute_capability,
             _CUTE_DSL_BF16_AUTOTUNE_VERSION,
         )
-
-    def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
-        return True
-
-    def is_tactic_compatible(self, inputs: List[torch.Tensor], tactic: object) -> bool:
-        return True
 
 
 @functools.cache
@@ -1628,9 +1638,9 @@ def _cute_dsl_splitk_bf16_gemm_runner(
         run_splitk_dense,
     )
 
-    # Serves every input the cute-dsl backend requirement admits: it validates
-    # ``default_tactic`` for the real shape, so the inherited ``supports_inputs``
-    # holds.
+    # Serves every M <= 32 input the cute-dsl backend requirement admits (it
+    # validates ``default_tactic`` for the real shape), so the inherited
+    # ``supports_inputs`` holds.
     class CuteDSLSplitKBf16Runner(_CuteDSLBf16Runner):
         def get_valid_tactics(
             self,
@@ -1815,33 +1825,84 @@ def _cute_dsl_direct_bf16_gemm_runner(
     return CuteDSLDirectBf16Runner(compute_capability)
 
 
-def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
-    """Return the CuTe-DSL low-M runners able to serve ``inputs``, best first.
+@functools.cache
+def _cute_dsl_cublaslt_fallback_bf16_gemm_runner(compute_capability: int):
+    cublaslt_runner = get_mm_bf16_cublaslt_module().cublaslt_bf16_gemm_runner()
 
-    ``[0]`` is the no-autotune default and the autotuner's fallback. The Direct
-    kernel leads only where its measured shape heuristic applies. Otherwise the
-    warp Split-K kernel leads whenever it is eligible (M <= 32, N % 16 == 0,
-    K % 128 == 0 with at most 64 K tiles), as it wins nearly every tuned
-    M <= 32 cell on B300, and cluster Split-K comes next.
+    class CuteDSLCublasltFallbackBf16Runner(_CuteDSLBf16Runner):
+        """cuBLASLt for M > _CUTE_DSL_BF16_MAX_M inside ``backend="cute-dsl"``.
+
+        A distinct class, so its records never mix with ``backend="cublaslt"``
+        tuning. The cache-key extras stay cuBLASLt's (exact shape, compute
+        dtype, bias alignment) because a tactic indexes the heuristic's
+        algorithm list for that exact shape; pdl is ignored, as in cuBLASLt.
+        """
+
+        def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
+            a, *_ = inputs
+            return a.shape[0] > _CUTE_DSL_BF16_MAX_M
+
+        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            return cublaslt_runner.get_cache_key_extras(inputs)
+
+        def get_valid_tactics(
+            self, inputs: List[torch.Tensor], profile: OptimizationProfile
+        ) -> List[int]:
+            if not self.supports_inputs(inputs):
+                return []
+            return cublaslt_runner.get_valid_tactics(inputs, profile)
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic: int = -1,
+            do_preparation: bool = False,
+            **kwargs,
+        ) -> torch.Tensor:
+            return cublaslt_runner.forward(
+                inputs, tactic=tactic, do_preparation=do_preparation, **kwargs
+            )
+
+    return CuteDSLCublasltFallbackBf16Runner(compute_capability)
+
+
+def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
+    """Return the runners of ``backend="cute-dsl"`` for ``inputs``, best first.
+
+    Every runner is listed whatever the real M, so that one autotune call
+    profiles the low-M kernels on the buckets M <= 32 and the cuBLASLt
+    fallback on the buckets above (custom ``tuning_buckets`` are assigned the
+    same way). ``[0]`` is the no-autotune default and the autotuner's
+    fallback, so it must serve the real inputs: cuBLASLt above 32; below, the
+    direct kernel where its measured shape heuristic applies, otherwise the
+    warp Split-K kernel whenever eligible (it wins nearly every tuned M <= 32
+    cell on B300), otherwise cluster Split-K. For M <= 32, low-M kernels that
+    cannot serve the real inputs (bias, N, K) are dropped: they serve no
+    bucket either.
     """
     from .kernels.dense_bf16_gemm_direct import prefer_direct_bf16_gemm_sm100
 
     a, b, *_ = inputs
+    m, k = a.shape
+    n = b.shape[1]
     major, minor = torch.cuda.get_device_capability(a.device)
     compute_capability = major * 10 + minor
     direct = _cute_dsl_direct_bf16_gemm_runner(compute_capability)
     warp_splitk = _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability)
     cluster_splitk = _cute_dsl_splitk_bf16_gemm_runner(compute_capability)
+    fallback = _cute_dsl_cublaslt_fallback_bf16_gemm_runner(compute_capability)
 
+    if m > _CUTE_DSL_BF16_MAX_M:
+        return [fallback, warp_splitk, cluster_splitk, direct]
     prefer_direct = direct.supports_inputs(inputs) and prefer_direct_bf16_gemm_sm100(
-        a.shape[0], b.shape[1], a.shape[1]
+        m, n, k
     )
-    order = (
+    kernels = (
         (direct, warp_splitk, cluster_splitk)
         if prefer_direct
         else (warp_splitk, cluster_splitk, direct)
     )
-    return [runner for runner in order if runner.supports_inputs(inputs)]
+    return [runner for runner in kernels if runner.supports_inputs(inputs)] + [fallback]
 
 
 def bf16_gemm_sm100(
@@ -1892,11 +1953,12 @@ def bf16_gemm_sm100(
         inputs,
     )
 
-    # A cached CuTe-DSL tactic can come from a bucket profiled at another M and
-    # be illegal here (e.g. a Direct rows_per_block that does not divide M);
-    # fall back to the default runner and tactic, as the autotuner itself does.
-    if isinstance(runner, _CuteDSLBf16Runner) and not runner.is_tactic_compatible(
-        inputs, tactic
+    # A cached cute-dsl entry can come from a bucket on the other side of M=32
+    # (custom tuning buckets, rounding) or carry a tactic illegal for this M
+    # (e.g. a Direct rows_per_block that does not divide M); fall back to the
+    # default runner and tactic, as the autotuner itself does.
+    if isinstance(runner, _CuteDSLBf16Runner) and not (
+        runner.supports_inputs(inputs) and runner.is_tactic_compatible(inputs, tactic)
     ):
         runner, tactic = runners[0], -1
 

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -727,12 +727,15 @@ def mm_bf16(
         ``"cutile"`` uses the cuTile (cuda.tile Python) backend. Pure-Python
             persistent-scheduled GEMM with per-shape exhaustive autotune; ignores
             ``bias`` / ``pdl``. Requires SM >= 90.
-        ``"cute-dsl"`` uses standalone Blackwell low-M direct and split-K
-        kernels for M <= 32 and falls back to cuBLASLt for larger M. It is
-        never auto-selected; serving frameworks must select it explicitly.
-        Without autotuning, a measured shape
-        heuristic chooses between the algorithms. With autotuning, both tactic
-        spaces are profiled when bias is disabled; bias uses split-K only.
+        ``"cute-dsl"`` uses standalone Blackwell low-M direct and cluster
+        Split-K kernels for M <= 32, plus a warp Split-K kernel (also
+        M <= 32), and falls back to cuBLASLt for larger M. It is never
+        auto-selected; serving frameworks must select it explicitly. Without
+        autotuning, the direct kernel runs where its shape heuristic applies,
+        otherwise the warp Split-K kernel whenever it is eligible (M <= 32,
+        N % 16 == 0, K % 128 == 0 with at most 64 K tiles), and cluster
+        Split-K otherwise. With autotuning, all three tactic spaces are
+        profiled; with bias the Direct kernel is excluded.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -1458,8 +1461,12 @@ def get_mm_bf16_cublaslt_module():
     )
 
 
+_CUTE_DSL_BF16_AUTOTUNE_VERSION = 10
+
+
 _BF16_GEMM_SM100_TUNING_CONFIG = TuningConfig(
     use_cuda_graph=True,
+    use_cold_l2_graph_replay=True,
     use_cold_l2_cache=True,
     dynamic_tensor_specs=(
         DynamicTensorSpec(
@@ -1599,6 +1606,7 @@ def _cute_dsl_splitk_bf16_gemm_runner(
                 bias is not None,
                 bool(pdl),
                 compute_capability,
+                _CUTE_DSL_BF16_AUTOTUNE_VERSION,
             )
 
         def get_valid_tactics(
@@ -1647,6 +1655,73 @@ def _cute_dsl_splitk_bf16_gemm_runner(
 
 
 @functools.cache
+def _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability: int):
+    from .kernels.dense_bf16_gemm_warp_splitk import (
+        WarpSplitKTactic,
+        autotune_tactics,
+        default_tactic,
+        run_warp_splitk_dense,
+        validate_inputs,
+    )
+
+    class CuteDSLWarpSplitKBf16Runner(TunableRunner):
+        def supports_inputs(self, inputs: List[torch.Tensor]) -> bool:
+            a, b, bias, _, out, *_ = inputs
+            try:
+                validate_inputs(a, b, out, bias)
+            except ValueError:
+                return False
+            return True
+
+        def get_cache_key_extras(self, inputs: List[torch.Tensor]) -> tuple:
+            a, _, bias, pdl, out, *_ = inputs
+            return (
+                str(a.dtype),
+                str(out.dtype),
+                bias is not None,
+                bool(pdl),
+                compute_capability,
+                _CUTE_DSL_BF16_AUTOTUNE_VERSION,
+            )
+
+        def get_valid_tactics(
+            self, inputs: List[torch.Tensor], profile: OptimizationProfile
+        ) -> list[tuple[int, int, int, int, int]]:
+            if not self.supports_inputs(inputs):
+                return []
+            a, b, *_ = inputs
+            with torch.cuda.device(a.device):
+                return [
+                    astuple(config)
+                    for config in autotune_tactics(a.shape[0], b.shape[1], a.shape[1])
+                ]
+
+        def forward(
+            self,
+            inputs: List[torch.Tensor],
+            tactic=-1,
+            do_preparation: bool = False,
+            **kwargs,
+        ) -> torch.Tensor:
+            a, b, bias, pdl, out, *_ = inputs
+            with torch.cuda.device(a.device):
+                if tactic == -1:
+                    tactic = default_tactic(a.shape[0], b.shape[1], a.shape[1])
+                else:
+                    try:
+                        tactic = WarpSplitKTactic(*tactic)
+                    except TypeError as error:
+                        raise ValueError(
+                            "CuTeDSL warp split-K tactics must be "
+                            "(output_tile, token_tile, k_tile, stages, "
+                            "b_loader_warps)."
+                        ) from error
+                return run_warp_splitk_dense(a, b, out, bool(pdl), tactic, bias)
+
+    return CuteDSLWarpSplitKBf16Runner()
+
+
+@functools.cache
 def _cute_dsl_direct_bf16_gemm_runner(
     compute_capability: int,
 ):
@@ -1687,6 +1762,7 @@ def _cute_dsl_direct_bf16_gemm_runner(
                 str(out.dtype),
                 bool(pdl),
                 compute_capability,
+                _CUTE_DSL_BF16_AUTOTUNE_VERSION,
             )
 
         def get_valid_tactics(
@@ -1744,8 +1820,11 @@ def bf16_gemm_sm100(
     is_a_k_major = a.stride(-1) == 1
     is_b_k_major = b.stride(-2) == 1
 
+    inputs = [a, b, bias, pdl, out, workspace_buffer]
     runners = []
     direct_runner = None
+    warp_splitk_runner = None
+    warp_splitk_supported = True
     if "cudnn" in runner_names:
         runners.append(
             _cudnn_gemm_bf16_runner(
@@ -1767,7 +1846,15 @@ def bf16_gemm_sm100(
         compute_capability = torch.cuda.get_device_capability(a.device)
         compute_capability_number = compute_capability[0] * 10 + compute_capability[1]
         splitk_runner = _cute_dsl_splitk_bf16_gemm_runner(compute_capability_number)
-        if bias is None:
+        from .kernels.dense_bf16_gemm_warp_splitk import (
+            _MAX_M as warp_splitk_max_m,
+        )
+
+        warp_splitk_runner = _cute_dsl_warp_splitk_bf16_gemm_runner(
+            compute_capability_number
+        )
+        prefer_direct = False
+        if bias is None:  # the Direct kernel has no bias epilogue
             from .kernels.dense_bf16_gemm_direct import (
                 prefer_direct_bf16_gemm_sm100,
             )
@@ -1776,16 +1863,38 @@ def bf16_gemm_sm100(
             prefer_direct = prefer_direct_bf16_gemm_sm100(
                 a.shape[0], b.shape[1], a.shape[1]
             )
-            runners.extend(
+        warp_splitk_supported = warp_splitk_runner.supports_inputs(inputs)
+        profile_m = min(a.shape[0], warp_splitk_max_m)
+        warp_splitk_profile_supported = warp_splitk_runner.supports_inputs(
+            [a[:profile_m], b, bias, pdl, out[:profile_m], workspace_buffer]
+        )
+        base_runners = tuple(
+            runner
+            for runner in (
                 (direct_runner, splitk_runner)
                 if prefer_direct
                 else (splitk_runner, direct_runner)
             )
+            if runner is not None
+        )
+        if not warp_splitk_profile_supported:
+            ordered_runners = base_runners
+        elif not warp_splitk_supported:
+            ordered_runners = (*base_runners, warp_splitk_runner)
+        elif prefer_direct:
+            ordered_runners = (direct_runner, warp_splitk_runner, splitk_runner)
         else:
-            runners.append(splitk_runner)
+            # runners[0] is the no-autotune default and the fallback for an
+            # incompatible cached Direct tactic; the warp Split-K kernel wins
+            # nearly every tuned M <= 16 cell on B300.
+            ordered_runners = tuple(
+                runner
+                for runner in (warp_splitk_runner, splitk_runner, direct_runner)
+                if runner is not None
+            )
+        runners.extend(ordered_runners)
     assert runners, "No suitable runners found"
 
-    inputs = [a, b, bias, pdl, out, workspace_buffer]
     runner, tactic = tuner.choose_one(
         "bf16_gemm",
         runners,
@@ -1793,12 +1902,20 @@ def bf16_gemm_sm100(
         inputs,
     )
 
-    if (
+    # A cached entry can come from a bucket profiled at another M (e.g. the warp
+    # kernel tuned at M=16 for a real M=25, or a Direct tactic illegal for this
+    # M); run the first runner that supports the real inputs with its default.
+    if (runner is warp_splitk_runner and not warp_splitk_supported) or (
         direct_runner is not None
         and runner is direct_runner
         and not direct_runner.is_tactic_compatible(inputs, tactic)
     ):
-        runner, tactic = runners[0], -1
+        runner = next(
+            candidate
+            for candidate in runners
+            if candidate is not warp_splitk_runner or warp_splitk_supported
+        )
+        tactic = -1
 
     runner(inputs=inputs, tactic=tactic)
 

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py
@@ -1,0 +1,823 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+"""cp.async-pipelined BF16 GEMM whose four compute warps hold split-K partials (warp split-K)."""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import math
+
+import cuda.bindings.driver as _cuda
+import cutlass
+import cutlass.cute as cute
+from cutlass.experimental import primitives as prims
+import torch as _torch
+from cutlass import const_expr
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass._mlir.dialects import llvm
+from cutlass.cute import experimental as cute_ext
+from cutlass.cute.nvgpu import warp
+from cutlass.cute.runtime import from_dlpack
+
+
+_MMA_SHAPE = (16, 8, 16)
+_COMPUTE_WARPS = 4
+_A_LOADER_WARPS = 2
+_A_LOADER_THREADS = _A_LOADER_WARPS * 32
+_MAX_M = 32
+# Ring depth cap: cold-read bandwidth saturates around 12 stages (96 KB in
+# flight), so deeper rings only enlarge the tactic space.
+_MAX_STAGES = 16
+# The consumer's K loop is fully unrolled; bound the tile count so JIT time and
+# code size stay proportionate (64 tiles of 256 elements = K 16384).
+_MAX_K_TILES = 64
+_SUPPORTED_OUTPUT_TILES = (16, 32)
+_SUPPORTED_TOKEN_TILES = (8, 16, 32)
+_SUPPORTED_K_TILES = (128, 256)
+_SUPPORTED_B_LOADER_WARPS = (1, 2)
+_SMEM_CAPACITY = cutlass.utils.get_smem_capacity_in_bytes("sm_100")
+# Per-SM shared memory is the per-CTA maximum plus the 1 KB the driver reserves
+# for every resident CTA; residency estimates must include that reservation.
+_CTA_RESERVED_SMEM = 1024
+_SM_SMEM_BYTES = _SMEM_CAPACITY + _CTA_RESERVED_SMEM
+_MAILBOX_GROUP_VALUES = 32
+_MAILBOX_PADDED_GROUP_VALUES = 34
+
+
+# Pad each mailbox group by two FP32 words to reduce bank conflicts.
+def _partial_offset(feature, token, token_tile: int):
+    group_rows = _MAILBOX_GROUP_VALUES // token_tile
+    return (
+        (feature % group_rows) * token_tile
+        + (feature // group_rows) * _MAILBOX_PADDED_GROUP_VALUES
+        + token
+    )
+
+
+def _a_fragment_offset(lane, compute_warp, m_iter, phase, k_tile):
+    """Element offset of one lane's A ``ldmatrix.x4`` address within a stage."""
+    linear = lane % 16 + (lane // 16) * 128 + phase * 256
+    row = linear % _MMA_SHAPE[0] + m_iter * _MMA_SHAPE[0]
+    col = linear // _MMA_SHAPE[0] + compute_warp * (k_tile // _COMPUTE_WARPS)
+    return row * k_tile + (col ^ ((row % 8) * 8))
+
+
+def _b_pair_offset(lane, compute_warp, n_iter, pair, token_tile, k_tile):
+    """Element offset of one lane's B ``ldmatrix.x4`` address within a stage."""
+    b_atom = lane % 8 + ((lane % 32) // 8) * (token_tile * 8)
+    linear = b_atom + pair * 2 * token_tile * 16 + n_iter * 8
+    row = linear % token_tile
+    col = linear // token_tile + compute_warp * (k_tile // _COMPUTE_WARPS)
+    return row * k_tile + (col ^ ((row % 8) * 8))
+
+
+@dsl_user_op
+def _ldmatrix_x4(smem, offset, *, loc=None, ip=None):
+    """``ldmatrix.x4`` of the 16-bit fragment ``offset`` elements into ``smem``."""
+    return prims.ldmatrix(
+        smem.iterator.raw_ptr() + offset,
+        num=4,
+        layout=prims.MMALayout.ROW,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _l2_policy_evict_first(*, loc=None, ip=None):
+    """64-bit L2 evict_first policy (fraction 1.0).
+
+    Must stay a runtime ``createpolicy``: with the equivalent constant, ptxas
+    13.0 emits the invalid ``LDGSTS ... [R+UR], desc[UR1]`` encoding.
+    """
+    return cutlass.Int64(
+        llvm.inline_asm(
+            cutlass.Int64.mlir_type,
+            [],
+            "createpolicy.fractional.L2::evict_first.b64 $0, 1.0;",
+            "=l",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+        )
+    )
+
+
+@dsl_user_op
+def _cp_async_16_with_policy(dst, src, policy, *, loc=None, ip=None):
+    """16-byte cp.async.cg global->shared carrying an L2 cache-policy hint."""
+    llvm.inline_asm(
+        None,
+        [
+            dst.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            src.toint(loc=loc, ip=ip).ir_value(loc=loc, ip=ip),
+            policy.ir_value(loc=loc, ip=ip),
+        ],
+        "cp.async.cg.shared.global.L2::cache_hint [$0], [$1], 16, $2;",
+        "r,l,l",
+        has_side_effects=True,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+    )
+
+
+@dsl_user_op
+def _issue_weight_tile(
+    smem,
+    weight,
+    tidx,
+    output_tile_idx,
+    k_tile,
+    stage,
+    policy,
+    output_tile,
+    k_tile_size,
+    with_policy,
+    *,
+    loc=None,
+    ip=None,
+):
+    """Issue one A-loader thread's cp.async copies for weight K tile ``k_tile``.
+
+    Plain Python control flow only: this helper is not preprocessed by the DSL.
+    ``with_policy`` selects the ``.L2::cache_hint`` form; the pre-barrier
+    prologue tile must use the plain form because ptxas 13.0 mis-encodes the
+    hinted copy in that position (``LDGSTS ... [R+UR], desc[UR<odd>]``).
+    """
+    copy_count = output_tile * k_tile_size // (8 * _A_LOADER_THREADS)
+    for copy_idx in range(copy_count):
+        linear = tidx * 8 + copy_idx * _A_LOADER_THREADS * 8
+        row = linear // k_tile_size
+        col = linear % k_tile_size
+        dst_offset = (
+            stage * output_tile * k_tile_size
+            + row * k_tile_size
+            + (col ^ ((row % 8) * 8))
+        )
+        src_offset = weight.layout(
+            (
+                output_tile_idx * output_tile + row,
+                k_tile * k_tile_size + col,
+            )
+        )
+        if with_policy:
+            # CuTe pointers: ``toint()`` yields the 32-bit shared address for
+            # SMEM and the 64-bit global address for GMEM, as the PTX expects.
+            _cp_async_16_with_policy(
+                smem.iterator + dst_offset,
+                weight.iterator + src_offset,
+                policy,
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            prims.cp_async_shared_global(
+                smem.iterator.raw_ptr() + dst_offset,
+                weight.iterator.raw_ptr() + src_offset,
+                16,
+                "cg",
+                loc=loc,
+                ip=ip,
+            )
+
+
+@dataclasses.dataclass(frozen=True)
+class WarpSplitKTactic:
+    output_tile: int
+    token_tile: int
+    k_tile: int
+    stages: int
+    b_loader_warps: int
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _smem_bytes(tactic: WarpSplitKTactic) -> int:
+    cursor = tactic.output_tile * tactic.k_tile * 2 * tactic.stages
+    cursor = _align_up(cursor, 1024)
+    cursor += tactic.token_tile * tactic.k_tile * 2 * tactic.stages
+    cursor = _align_up(cursor, 16)
+    partial_stride = (
+        tactic.output_tile * tactic.token_tile // _MAILBOX_GROUP_VALUES
+    ) * _MAILBOX_PADDED_GROUP_VALUES
+    cursor += _COMPUTE_WARPS * partial_stride * 4
+    cursor = _align_up(cursor, 8)
+    cursor += tactic.stages * 8
+    cursor = _align_up(cursor, 8)
+    return cursor + tactic.stages * 8
+
+
+def _legal_stages(
+    output_tile: int,
+    token_tile: int,
+    k_tile: int,
+    k: int,
+    b_loader_warps: int,
+) -> tuple[int, ...]:
+    # A single-stage ring only makes sense when K is one tile; with ring reuse it
+    # cannot overlap anything, and ptxas mis-encodes its hinted LDGSTS.
+    if k // k_tile > _MAX_K_TILES:
+        return ()
+    min_stages = _min_stages(k, k_tile)
+    return tuple(
+        stages
+        for stages in range(min_stages, min(_MAX_STAGES, k // k_tile) + 1)
+        if _smem_bytes(
+            WarpSplitKTactic(output_tile, token_tile, k_tile, stages, b_loader_warps)
+        )
+        <= _SMEM_CAPACITY
+    )
+
+
+def _min_stages(k: int, k_tile: int) -> int:
+    return 1 if k // k_tile <= 1 else 2
+
+
+def _k_supported(k: int) -> bool:
+    return k > 0 and any(
+        k % k_tile == 0 and k // k_tile <= _MAX_K_TILES for k_tile in _SUPPORTED_K_TILES
+    )
+
+
+def validate_tactic(tactic: WarpSplitKTactic, m: int, n: int, k: int) -> None:
+    if tactic.output_tile not in _SUPPORTED_OUTPUT_TILES:
+        raise ValueError(f"unsupported output_tile={tactic.output_tile}")
+    if tactic.token_tile not in _SUPPORTED_TOKEN_TILES:
+        raise ValueError(f"unsupported token_tile={tactic.token_tile}")
+    if tactic.k_tile not in _SUPPORTED_K_TILES:
+        raise ValueError(f"unsupported k_tile={tactic.k_tile}")
+    if tactic.b_loader_warps not in _SUPPORTED_B_LOADER_WARPS:
+        raise ValueError(f"unsupported b_loader_warps={tactic.b_loader_warps}")
+    if not 1 <= m <= _MAX_M or n <= 0 or n % tactic.output_tile:
+        raise ValueError(f"unsupported shape {(m, n, k)}")
+    if k <= 0 or k % tactic.k_tile:
+        raise ValueError(f"K={k} must be divisible by k_tile={tactic.k_tile}")
+    if k // tactic.k_tile > _MAX_K_TILES:
+        raise ValueError(
+            f"K={k} spans more than {_MAX_K_TILES} tiles of {tactic.k_tile}"
+        )
+    if not (
+        _min_stages(k, tactic.k_tile)
+        <= tactic.stages
+        <= min(_MAX_STAGES, k // tactic.k_tile)
+    ):
+        raise ValueError(f"invalid stages={tactic.stages}")
+    required_smem = _smem_bytes(tactic)
+    if required_smem > _SMEM_CAPACITY:
+        raise ValueError(f"tactic requires {required_smem} bytes of shared memory")
+
+
+def validate_inputs(
+    a: _torch.Tensor,
+    b: _torch.Tensor,
+    out: _torch.Tensor,
+    bias: _torch.Tensor | None = None,
+) -> tuple[int, int, int]:
+    tensors = (a, b, out) + ((bias,) if bias is not None else ())
+    if any(not isinstance(tensor, _torch.Tensor) for tensor in tensors):
+        raise ValueError("a, b, out, and bias must be torch tensors")
+    if any(tensor.ndim != 2 for tensor in (a, b, out)):
+        raise ValueError("a, b, and out must be 2D tensors")
+    if a.device.type != "cuda" or any(tensor.device != a.device for tensor in tensors):
+        raise ValueError("a, b, out, and bias must be CUDA tensors on the same device")
+    if any(tensor.dtype != _torch.bfloat16 for tensor in tensors):
+        raise ValueError("a, b, out, and bias must have bfloat16 dtype")
+
+    m, k = a.shape
+    if b.shape[0] != k:
+        raise ValueError(
+            f"incompatible shapes: a is {tuple(a.shape)}, b is {tuple(b.shape)}"
+        )
+    n = b.shape[1]
+    if out.shape != (m, n):
+        raise ValueError(f"out must have shape {(m, n)}, got {tuple(out.shape)}")
+    if bias is not None and (bias.shape != (n,) or not bias.is_contiguous()):
+        raise ValueError(f"bias must be a contiguous ({n},) vector")
+    if not 1 <= m <= _MAX_M:
+        raise ValueError(f"M must be in [1, {_MAX_M}], got {m}")
+    if n <= 0 or n % 16:
+        raise ValueError(f"N={n} must be a positive multiple of 16")
+    if not _k_supported(k):
+        raise ValueError(
+            f"K={k} must be a positive multiple of 128 spanning at most "
+            f"{_MAX_K_TILES} tiles of 256 (or 128) elements"
+        )
+
+    if a.stride() != (k, 1):
+        raise ValueError(f"a must be packed row-major, got stride {a.stride()}")
+    if b.stride() != (1, k):
+        raise ValueError(f"b must be packed column-major, got stride {b.stride()}")
+    if out.stride() != (n, 1):
+        raise ValueError(f"out must be packed row-major, got stride {out.stride()}")
+    if any(tensor.data_ptr() % 32 for tensor in tensors):
+        raise ValueError("a, b, and out must be 32-byte aligned")
+    return m, n, k
+
+
+def default_tactic(m: int, n: int, k: int) -> WarpSplitKTactic:
+    k_tile = 128 if k <= 512 or k % 256 else 256
+    k_tile_count = k // k_tile
+    sm_count = _torch.cuda.get_device_properties(
+        _torch.cuda.current_device()
+    ).multi_processor_count
+    output_tiles = tuple(tile for tile in _SUPPORTED_OUTPUT_TILES if n % tile == 0)
+    if not output_tiles:
+        raise ValueError(f"N={n} must be divisible by a supported output tile")
+    # Minimize scheduled wave work; prefer the wider tile on ties.
+    output_tile = min(
+        output_tiles,
+        key=lambda tile: (
+            ((n // tile + sm_count - 1) // sm_count) * tile,
+            -tile,
+        ),
+    )
+    # Splitting M over two half-size token tiles doubles the CTA count at the
+    # cost of a second pass over each weight tile; that only pays while the
+    # doubled grid still fits in one wave.
+    token_tile = 8 if m <= 8 else 16 if m <= 16 else 32
+    if token_tile > 8 and 2 * (n // output_tile) <= sm_count:
+        token_tile //= 2
+    # Two B-loader warps pay off once the ring is reused (long K); for a handful
+    # of K tiles the extra loader threads only add barrier arrivals.
+    b_loader_warps = 2 if token_tile >= 16 or k_tile_count >= 8 else 1
+    legal_stages = _legal_stages(output_tile, token_tile, k_tile, k, b_loader_warps)
+    if not legal_stages:
+        raise ValueError(f"no legal tactic for shape {(m, n, k)}")
+    cta_count = (n // output_tile) * ((m + token_tile - 1) // token_tile)
+    target_residency = 2 if cta_count > sm_count else 1
+    resident_stages = tuple(
+        stages
+        for stages in legal_stages
+        if target_residency
+        * (
+            _smem_bytes(
+                WarpSplitKTactic(
+                    output_tile, token_tile, k_tile, stages, b_loader_warps
+                )
+            )
+            + _CTA_RESERVED_SMEM
+        )
+        <= _SM_SMEM_BYTES
+    )
+    stages = max(resident_stages or legal_stages)
+    tactic = WarpSplitKTactic(output_tile, token_tile, k_tile, stages, b_loader_warps)
+    validate_tactic(tactic, m, n, k)
+    return tactic
+
+
+def autotune_tactics(m: int, n: int, k: int) -> list[WarpSplitKTactic]:
+    if not 1 <= m <= _MAX_M or n <= 0 or n % 16 or not _k_supported(k):
+        return []
+    tactics: list[WarpSplitKTactic] = []
+    for output_tile in _SUPPORTED_OUTPUT_TILES:
+        if n % output_tile:
+            continue
+        for token_tile in _SUPPORTED_TOKEN_TILES:
+            if token_tile > 16 and m <= 16:
+                continue  # a 32-token tile only pays for M > 16
+            for k_tile in _SUPPORTED_K_TILES:
+                if k % k_tile:
+                    continue
+                for b_loader_warps in _SUPPORTED_B_LOADER_WARPS:
+                    tactics.extend(
+                        WarpSplitKTactic(
+                            output_tile,
+                            token_tile,
+                            k_tile,
+                            stages,
+                            b_loader_warps,
+                        )
+                        for stages in _legal_stages(
+                            output_tile,
+                            token_tile,
+                            k_tile,
+                            k,
+                            b_loader_warps,
+                        )
+                    )
+    default = default_tactic(m, n, k)
+    return [default, *(tactic for tactic in tactics if tactic != default)]
+
+
+def _make_smem_layout(dtype, rows: int, cols: int, stages: int):
+    copy_elems = 128 // dtype.width
+    major_size = min(cols, 128 * 8 // dtype.width)
+    outer = cute.tile_to_shape(
+        cute.make_layout((8, major_size), stride=(major_size, 1)),
+        (rows, cols, stages),
+        (0, 1, 2),
+    )
+    return cute.make_composed_layout(
+        cute.make_swizzle(
+            min(int(math.log2(major_size // copy_elems)), 3),
+            4,
+            int(math.log2(copy_elems)),
+        ),
+        0,
+        outer,
+    )
+
+
+class CpAsyncWarpSplitKKernel:
+    def __init__(self, tactic: WarpSplitKTactic, use_pdl: bool, has_bias: bool) -> None:
+        self.output_tile = tactic.output_tile
+        self.token_tile = tactic.token_tile
+        self.k_tile = tactic.k_tile
+        self.stages = tactic.stages
+        self.b_loader_warps = tactic.b_loader_warps
+        self.compute_warp_base = _A_LOADER_WARPS + self.b_loader_warps
+        self.threads = (self.compute_warp_base + _COMPUTE_WARPS) * 32
+        self.load_threads = self.compute_warp_base * 32
+        self.use_pdl = use_pdl
+        self.has_bias = has_bias
+        self.smem_bytes = _smem_bytes(tactic)
+
+    @cute.experimental.jit
+    def __call__(self, weight, activation, bias, output, stream: _cuda.CUstream):
+        sA_layout = _make_smem_layout(
+            weight.element_type, self.output_tile, self.k_tile, self.stages
+        )
+        sB_layout = _make_smem_layout(
+            activation.element_type, self.token_tile, self.k_tile, self.stages
+        )
+        tiled_mma = cute.make_tiled_mma(
+            warp.MmaF16BF16Op(weight.element_type, cutlass.Float32, _MMA_SHAPE),
+            cute.make_layout((1, 1, _COMPUTE_WARPS)),
+            permutation_mnk=(self.output_tile, self.token_tile, self.k_tile),
+        )
+        self.kernel(
+            weight, activation, bias, output, sA_layout, sB_layout, tiled_mma
+        ).launch(
+            grid=(
+                cute.ceil_div(weight.shape[0], self.output_tile),
+                cute.ceil_div(activation.shape[0], self.token_tile),
+                1,
+            ),
+            block=(self.threads, 1, 1),
+            smem=cute.Int64(self.smem_bytes),
+            stream=stream,
+            use_pdl=self.use_pdl,
+        )
+
+    @cute.experimental.kernel
+    def kernel(
+        self,
+        weight: cute.Tensor,
+        activation: cute.Tensor,
+        bias: cute.Tensor,  # (N,) broadcast bias; unread when has_bias is False
+        output: cute.Tensor,
+        sA_layout: cute.ComposedLayout,
+        sB_layout: cute.ComposedLayout,
+        tiled_mma: cute.TiledMma,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        output_tile_idx, token_tile_idx, _ = cute.arch.block_idx()
+        warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
+        lane_idx = tidx % cute.arch.WARP_SIZE
+        reuse_stages = cute.size(weight, mode=[1]) > self.stages * self.k_tile
+
+        sA = cute_ext.allocate(
+            weight.element_type,
+            cute.AddressSpace.smem,
+            sA_layout,
+            alignment=1024,
+        )
+        sB = cute_ext.allocate(
+            activation.element_type,
+            cute.AddressSpace.smem,
+            sB_layout,
+            alignment=1024,
+        )
+        values_per_lane = self.output_tile * self.token_tile // cute.arch.WARP_SIZE
+        partial_stride = (
+            self.output_tile * self.token_tile // _MAILBOX_GROUP_VALUES
+        ) * _MAILBOX_PADDED_GROUP_VALUES
+        partials = cute_ext.allocate(
+            cutlass.Float32,
+            cute.AddressSpace.smem,
+            cute.make_layout(_COMPUTE_WARPS * partial_stride),
+            alignment=16,
+        )
+        bar_full_arr = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(self.stages),
+            alignment=8,
+        )
+        bar_empty_arr = cute_ext.allocate(
+            cutlass.Int64,
+            cute.AddressSpace.smem,
+            cute.make_layout(self.stages),
+            alignment=8,
+        )
+        bar_full = bar_full_arr.iterator
+        bar_empty = bar_empty_arr.iterator
+
+        k_tile_count = cute.size(weight, mode=[1]) // self.k_tile
+
+        if warp_idx < _A_LOADER_WARPS:
+            # Tile 0 has no mbarrier dependency: issue it before the init handshake
+            # so its DRAM latency overlaps init and the CTA barrier.
+            _issue_weight_tile(
+                sA,
+                weight,
+                tidx,
+                output_tile_idx,
+                0,
+                0,
+                cutlass.Int64(0),
+                self.output_tile,
+                self.k_tile,
+                False,
+            )
+        bias_value = cutlass.Float32(0.0)
+        if warp_idx == self.compute_warp_base:
+            # The first compute warp is idle here; it initializes the mbarriers so
+            # the loader warps are never held behind the init.
+            if lane_idx < self.stages:
+                cute.arch.mbarrier_init(bar_full + lane_idx, self.load_threads)
+                if const_expr(reuse_stages):
+                    cute.arch.mbarrier_init(bar_empty + lane_idx, _COMPUTE_WARPS)
+        cute.arch.mbarrier_init_fence()
+        cute.arch.barrier()
+
+        if warp_idx < _A_LOADER_WARPS:
+            # Weights stream through L2 evict_first so the activation rows every
+            # CTA re-reads stay resident. Only tile 0's arrive may follow the init.
+            weight_policy = _l2_policy_evict_first()
+            empty_phase = cutlass.Int32(1)
+            prims.cp_async_mbarrier_arrive(bar_full.llvm_ptr, noinc=True)
+            for k_tile in cutlass.range(1, k_tile_count, unroll=1):
+                stage = k_tile % self.stages
+                if const_expr(reuse_stages):
+                    cute.arch.mbarrier_wait(bar_empty + stage, empty_phase)
+                _issue_weight_tile(
+                    sA,
+                    weight,
+                    tidx,
+                    output_tile_idx,
+                    k_tile,
+                    stage,
+                    weight_policy,
+                    self.output_tile,
+                    self.k_tile,
+                    True,
+                )
+                prims.cp_async_mbarrier_arrive((bar_full + stage).llvm_ptr, noinc=True)
+                if stage == self.stages - 1:
+                    empty_phase = empty_phase ^ 1
+        elif warp_idx < self.compute_warp_base:
+            if const_expr(self.use_pdl):
+                cute.arch.griddepcontrol_wait()
+            b_loader_threads = self.b_loader_warps * 32
+            local_tid = tidx - _A_LOADER_WARPS * 32
+            copy_count = self.token_tile * self.k_tile // (8 * b_loader_threads)
+            empty_phase = cutlass.Int32(1)
+            for k_tile in cutlass.range(k_tile_count, unroll=1):
+                stage = k_tile % self.stages
+                if const_expr(reuse_stages):
+                    cute.arch.mbarrier_wait(bar_empty + stage, empty_phase)
+                for copy_idx in cutlass.range_constexpr(copy_count):
+                    linear = local_tid * 8 + copy_idx * b_loader_threads * 8
+                    row = linear // self.k_tile
+                    col = linear % self.k_tile
+                    global_row = token_tile_idx * self.token_tile + row
+                    # Out-of-range token rows are discarded by the output predicate.
+                    if global_row < cute.size(activation, mode=[0]):
+                        dst = (
+                            sB.iterator.raw_ptr()
+                            + stage * self.token_tile * self.k_tile
+                            + row * self.k_tile
+                            + (col ^ ((row % 8) * 8))
+                        )
+                        src = activation.iterator.raw_ptr() + activation.layout(
+                            (
+                                global_row,
+                                k_tile * self.k_tile + col,
+                            )
+                        )
+                        prims.cp_async_shared_global(dst, src, 16, "cg")
+                prims.cp_async_mbarrier_arrive((bar_full + stage).llvm_ptr, noinc=True)
+                if stage == self.stages - 1:
+                    empty_phase = empty_phase ^ 1
+            if const_expr(self.use_pdl):
+                # This grid-level hint is idempotent across B-loader warps.
+                cute.arch.griddepcontrol_launch_dependents()
+        else:
+            if const_expr(self.has_bias):
+                # Each reduce lane owns one output feature (32 % output_tile == 0).
+                # Issue the load here, after the CTA barrier: waiting on the first
+                # full stage hides its latency, whereas a load before the barrier
+                # would hold the loader warps behind a cold DRAM read.
+                bias_value = bias[
+                    output_tile_idx * self.output_tile + lane_idx % self.output_tile
+                ].to(cutlass.Float32)
+            mma_tid = tidx - self.compute_warp_base * cute.arch.WARP_SIZE
+            compute_warp = warp_idx - self.compute_warp_base
+            thr_mma = tiled_mma.get_slice(mma_tid)
+            acc = cute.make_rmem_tensor(
+                thr_mma.partition_shape_C((self.output_tile, self.token_tile)),
+                cutlass.Float32,
+            )
+            acc.fill(0.0)
+            k_phases = self.k_tile // (_COMPUTE_WARPS * _MMA_SHAPE[2])
+            m_iters = self.output_tile // _MMA_SHAPE[0]
+            n_iters = self.token_tile // _MMA_SHAPE[1]
+            # Fragment addresses are loop-invariant per lane apart from the stage
+            # base; hoist them so the K loop issues ldmatrix from one add each.
+            a_offsets = tuple(
+                tuple(
+                    _a_fragment_offset(
+                        lane_idx, compute_warp, m_iter, phase, self.k_tile
+                    )
+                    for phase in range(k_phases)
+                )
+                for m_iter in range(m_iters)
+            )
+            b_offsets = tuple(
+                tuple(
+                    _b_pair_offset(
+                        lane_idx,
+                        compute_warp,
+                        n_iter,
+                        pair,
+                        self.token_tile,
+                        self.k_tile,
+                    )
+                    for pair in range(k_phases // 2)
+                )
+                for n_iter in range(n_iters)
+            )
+            a_stage_elems = self.output_tile * self.k_tile
+            b_stage_elems = self.token_tile * self.k_tile
+            full_phase = cutlass.Int32(0)
+            # The K-tile count is static: unrolling fully folds `stage`, barrier
+            # addresses and phases to constants, so every ldmatrix is
+            # `[R_lane + imm]` (a rolled loop costs 3-16% on K=7168).
+            for k_tile in cutlass.range(k_tile_count, unroll_full=True):
+                stage = k_tile % self.stages
+                cute.arch.mbarrier_wait(bar_full + stage, full_phase)
+                a_base = stage * a_stage_elems
+                b_base = stage * b_stage_elems
+                a_registers = tuple(
+                    tuple(
+                        _ldmatrix_x4(sA, a_base + a_offsets[m_iter][phase])
+                        for phase in range(k_phases)
+                    )
+                    for m_iter in range(m_iters)
+                )
+                b_registers = tuple(
+                    tuple(
+                        _ldmatrix_x4(sB, b_base + b_offsets[n_iter][pair])
+                        for pair in range(k_phases // 2)
+                    )
+                    for n_iter in range(n_iters)
+                )
+                for phase in cutlass.range_constexpr(k_phases):
+                    for n_iter in cutlass.range_constexpr(n_iters):
+                        packed_b = b_registers[n_iter][phase // 2]
+                        b_offset = (phase % 2) * 2
+                        for m_iter in cutlass.range_constexpr(m_iters):
+                            acc_base = (m_iter * n_iters + n_iter) * 4
+                            result = prims.mma_sync(
+                                llvm.StructType.get_literal(
+                                    [cutlass.Float32.mlir_type] * 4
+                                ),
+                                shape=_MMA_SHAPE,
+                                layout_a=prims.MMALayout.ROW,
+                                layout_b=prims.MMALayout.COL,
+                                operand_a=[
+                                    a_registers[m_iter][phase][i].ir_value()
+                                    for i in range(4)
+                                ],
+                                operand_b=[
+                                    packed_b[b_offset + i].ir_value() for i in range(2)
+                                ],
+                                operand_c=[
+                                    acc[acc_base + i].ir_value() for i in range(4)
+                                ],
+                                multiplicand_a_ptx_type=prims.MMAType.BF16,
+                                multiplicand_b_ptx_type=prims.MMAType.BF16,
+                            )
+                            for i in cutlass.range_constexpr(4):
+                                acc[acc_base + i] = cutlass.Float32(
+                                    llvm.extractvalue(
+                                        cutlass.Float32.mlir_type,
+                                        result,
+                                        [i],
+                                    )
+                                )
+                if const_expr(reuse_stages):
+                    with cute.arch.elect_one():
+                        cute.arch.mbarrier_arrive(bar_empty + stage)
+                if stage == self.stages - 1:
+                    full_phase = full_phase ^ 1
+            for value in cutlass.range_constexpr(values_per_lane):
+                atom = value % 4
+                fragment = value // 4
+                m_iter = fragment // n_iters
+                n_iter = fragment % n_iters
+                feature = lane_idx // 4 + 8 * (atom // 2) + m_iter * _MMA_SHAPE[0]
+                token = 8 * n_iter + 2 * (lane_idx % 4) + atom % 2
+                partials[
+                    compute_warp * partial_stride
+                    + _partial_offset(feature, token, self.token_tile)
+                ] = acc[value]
+            prims.barrier_cta_sync(1, thread_count=_COMPUTE_WARPS * 32)
+
+        if warp_idx == self.compute_warp_base:
+            final_acc = cute.make_rmem_tensor(
+                cute.make_layout(values_per_lane), cutlass.Float32
+            )
+            for value in cutlass.range_constexpr(values_per_lane):
+                linear = value * cute.arch.WARP_SIZE + lane_idx
+                feature = linear % self.output_tile
+                token = linear // self.output_tile
+                total = cutlass.Float32(0)
+                for peer in cutlass.range_constexpr(_COMPUTE_WARPS):
+                    total = (
+                        total
+                        + partials[
+                            peer * partial_stride
+                            + _partial_offset(feature, token, self.token_tile)
+                        ]
+                    )
+                if const_expr(self.has_bias):
+                    total = total + bias_value
+                final_acc[value] = total
+
+            output_base = output_tile_idx * self.output_tile
+            token_base = token_tile_idx * self.token_tile
+            for value in cutlass.range_constexpr(values_per_lane):
+                linear = value * cute.arch.WARP_SIZE + lane_idx
+                feature = linear % self.output_tile
+                token = linear // self.output_tile
+                if token_base + token < cute.size(output, mode=[0]):
+                    output[token_base + token, output_base + feature] = final_acc[
+                        value
+                    ].to(output.element_type)
+
+
+def _from_dlpack(tensor: _torch.Tensor):
+    return from_dlpack(tensor, assumed_align=32)
+
+
+@functools.cache
+def _compile(
+    device_index: int,
+    dtype,
+    m: int,
+    n: int,
+    k: int,
+    tactic: WarpSplitKTactic,
+    use_pdl: bool,
+    has_bias: bool,
+):
+    device = _torch.device("cuda", device_index)
+    with _torch.cuda.device(device):
+        kernel = CpAsyncWarpSplitKKernel(tactic, use_pdl, has_bias)
+        tensors = tuple(
+            _from_dlpack(tensor)
+            for tensor in (
+                _torch.empty((n, k), device=device, dtype=dtype),
+                _torch.empty((m, k), device=device, dtype=dtype),
+                _torch.empty((n,), device=device, dtype=dtype),
+                _torch.empty((m, n), device=device, dtype=dtype),
+            )
+        )
+        stream = _cuda.CUstream(_torch.cuda.current_stream(device).cuda_stream)
+        return cute_ext.compile(kernel, *tensors, stream)
+
+
+def run_warp_splitk_dense(a, b, out, pdl: bool, tactic: WarpSplitKTactic, bias=None):
+    m, n, k = validate_inputs(a, b, out, bias)
+    validate_tactic(tactic, m, n, k)
+    device_index = a.device.index
+    assert device_index is not None
+    with _torch.cuda.device(a.device):
+        compiled = _compile(
+            device_index, a.dtype, m, n, k, tactic, pdl, bias is not None
+        )
+        stream = _cuda.CUstream(_torch.cuda.current_stream(a.device).cuda_stream)
+        # Without bias the kernel never reads its bias argument; pass a row of
+        # ``out`` so the launch signature stays fixed.
+        compiled(
+            _from_dlpack(b.T),
+            _from_dlpack(a),
+            _from_dlpack(bias if bias is not None else out[0]),
+            _from_dlpack(out),
+            stream,
+        )
+    return out
+
+
+__all__ = [
+    "WarpSplitKTactic",
+    "autotune_tactics",
+    "default_tactic",
+    "run_warp_splitk_dense",
+    "validate_inputs",
+]

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -84,11 +84,10 @@ def test_mm_bf16(
         if not is_sm100a_supported(torch.device("cuda")):
             pytest.skip("CuTeDSL low-M backend requires SM100/SM103 with CUDA 12.8+.")
 
-        if m <= 32:
-            from flashinfer.cute_dsl.utils import is_cute_dsl_available
+        from flashinfer.cute_dsl.utils import is_cute_dsl_available
 
-            if not is_cute_dsl_available():
-                pytest.skip("nvidia-cutlass-dsl is not available.")
+        if not is_cute_dsl_available():
+            pytest.skip("nvidia-cutlass-dsl is not available.")
         if res_dtype != torch.bfloat16:
             pytest.skip("CuTeDSL low-M backend requires BF16 output.")
 

--- a/tests/gemm/test_mm_bf16.py
+++ b/tests/gemm/test_mm_bf16.py
@@ -33,6 +33,11 @@ _SMOKE_CASES = [
     (1, 1024, 3072, torch.bfloat16, True, False, "tinygemm", False),
     (32, 1024, 1024, torch.bfloat16, False, False, "cutile", False),
     (25, 2048, 1024, torch.bfloat16, False, False, "cute-dsl", False),
+    # Warp Split-K: tuned low-M with bias and PDL; M > 16 (32-token tile, tail rows)
+    # on the default tactic; K above its tile bound (served by the other runners).
+    (8, 768, 7168, torch.bfloat16, True, True, "cute-dsl", True),
+    (17, 2304, 1536, torch.bfloat16, False, False, "cute-dsl", False),
+    (8, 768, 8320, torch.bfloat16, False, False, "cute-dsl", False),
     (33, 256, 512, torch.bfloat16, True, True, "cute-dsl", False),
     (64, 256, 512, torch.bfloat16, True, True, "cute-dsl", False),
     (64, 4096, 2048, torch.bfloat16, False, False, "auto", True),
@@ -133,6 +138,11 @@ def test_mm_bf16(
 
     cos_sim = F.cosine_similarity(reference.reshape(-1), out.reshape(-1), dim=0)
     assert cos_sim > 0.99
+    if backend == "cute-dsl":
+        fp32_reference = F.linear(
+            input.float(), mat2.float(), bias.float() if bias is not None else None
+        ).to(res_dtype)
+        torch.testing.assert_close(out, fp32_reference, rtol=2e-2, atol=5e-2)
 
 
 def test_mm_bf16_cutile_rejects_bias_and_pdl():


### PR DESCRIPTION
## 📌 Description

Three changes on the `cute-dsl` BF16 GEMM path for decode-sized M on SM100/SM103, targeting the low-M shapes vLLM routes to `dsv3_fused_a_gemm` (vllm-project/vllm#54524), where the existing direct / cluster split-K kernels were behind fused-A on most cells.

### 1. Warp split-K kernel (`flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py`)

- The four compute warps of a CTA each own one K quarter of every tile and reduce through a shared-memory mailbox; the kernel is the first `cute-dsl` runner whenever it is eligible (M <= 32, N % 16 == 0, K % 128 == 0, <= 64 K tiles).
- 2 weight-loader warps stream the [N, K] weight through a `cp.async` ring with an `L2::evict_first` hint (the activation rows every CTA re-reads stay L2-resident); 1-2 activation-loader warps; 4 compute warps (`mma.sync` m16n8k16 BF16 -> FP32), each on its own K quarter of every stage; the first compute warp reduces the four partials and stores BF16 (plus an optional bias, added in FP32).
- The first weight tile is issued before the mbarrier init/CTA barrier, and the consumer K loop is fully unrolled (the K-tile count is static) so every `ldmatrix` is `[R_lane + imm]` — a rolled loop kept the stage index in a vector register and cost 3-16% on K=7168.
- Tactic space: `(output_tile 16|32, token_tile 8|16|32, k_tile 128|256, stages <= 16, b_loader_warps 1|2)`, bounded to 64 K tiles; `default_tactic` picks by wave count and CTA residency (counting the 1 KB per-CTA reservation).
- Two ptxas 13.0 workarounds are documented in the source: the pre-barrier tile stays unhinted and single-stage rings are excluded when K spans several tiles, because the hinted `LDGSTS` is otherwise mis-encoded (`[R+UR], desc[UR<odd>]`, illegal instruction).

### 2. `cute-dsl` runner selection refactor (`flashinfer/gemm/gemm_base.py`)

- One base class, `_CuteDSLBf16Runner`, for the backend's runners: shared cache-key extras plus `supports_inputs` / `is_tactic_compatible`, so no runner is special-cased by name.
- `_cute_dsl_bf16_runners(inputs)` owns the ordering: direct where its measured k=8192 heuristic applies, otherwise warp split-K when eligible, otherwise cluster split-K; direct is excluded with bias.
- `bf16_gemm_sm100` is now: build the runner list -> `choose_one` -> check the cached runner and tactic against the real inputs -> fall back to `runners[0]` with the default tactic. No behavior change for M <= 32; the CuTe-DSL BF16 autotune cache version is bumped.

### 3. Autotuner

- `TuningConfig.use_cold_l2_graph_replay` (opt-in, set only by the BF16 GEMM config): an untimed warm-up replay and an L2 eviction before the timed replay, with one input copy per launch, so tactics are ranked from the cold-L2 state the harness measures. Without it the tuner picks cluster split-K over the warp kernel at M=9-16 N=1536 K=7168 (8 cells of the table below).
- One autotune call covers both M ranges: `mm_bf16(backend="cute-dsl")` no longer pre-dispatches M > 32 to `backend="cublaslt"`. `_cute_dsl_bf16_runners` lists every runner whatever the real M, the three CuTe-DSL kernels (M <= 32) plus a fallback-only cuBLASLt runner (`CuteDSLCublasltFallbackBf16Runner`: M > 32, own cache identity, cuBLASLt's exact-shape key, pdl ignored), and each returns no tactics for a profile outside its range. A single large-M warm-up therefore tunes the low-M kernels on the M <= 32 buckets and cuBLASLt above them, custom `tuning_buckets` go to the runner owning their range, `runners[0]` follows the real M, and a cached entry from across the boundary (or with a tactic illegal for the real M) falls back to it. vLLM can drop the dedicated 32-token warm-up it added in vllm-project/vllm#50572.


## 🔍 Related Issues

- vllm-project/vllm#54524 — the fused-A vs FlashInfer benchmark and the Kimi-K3 / GLM-5.2 shape tables this kernel targets.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`tests/gemm/test_mm_bf16.py`: 26 passed, 1 skipped on B300 / SM103, nvidia-cutlass-dsl 4.7.0, CUDA 13.0, torch 2.13).

```
pytest tests/gemm/test_mm_bf16.py -q   # 26 passed, 1 skipped
```

Three new `cute-dsl` smoke cases: tuned low-M with bias and PDL (M=8 N=768 K=7168), M=17 on the default tactic (32-token tile with tail rows, N=2304 K=1536), and K above the warp kernel's tile bound (K=8320, served by the other runners). Every `cute-dsl` case is also checked elementwise against an FP32 reference. The M=33 and M=64 `cute-dsl` cases (bias + PDL) run through the cuBLASLt fallback runner of the same runner set. Not yet run on SM100/B200.

## 📊 Kernel benchmark

Same method as vllm-project/vllm#54524's `benchmark_fused_a_vs_flashinfer_bf16.py`: every `(N, K, M)` of the Kimi-K3 / GLM-5.2 fused-A tables, CUPTI kernel time under CUDA graph replay with a cold L2 (memset 2x L2 before each launch), PDL enabled, FP32 reference check on every cell. B300 SXM6 (148 SMs), fused-A from vLLM at c0cab8ca30. FlashInfer = `mm_bf16(..., backend="cute-dsl")` after an autotuning pass over the direct, cluster split-K and warp split-K tactic spaces.

Over 210 measured cases (autotuned): **FlashInfer faster in 209, tie in 1, fused-A faster in 0**. Median fused-A/FlashInfer speedup 1.08x (range 1.00x–1.37x).

| N | K | projection | M | cuBLAS µs | fused-A µs | FlashInfer µs | FlashInfer vs fused-A | winner |
|---:|---:|:---|:---:|---:|---:|---:|:---:|:---|
| 768 | 128 | f_b_proj (TP16) | 1-16 | 2.91 | 2.32 | 2.14 | 1.02-1.14x | **FlashInfer** |
| 1536 | 128 | f_b_proj | 1-16 | 3.01 | 2.42 | 2.24 | 1.04-1.10x | **FlashInfer** |
| 3072 | 128 | f_b_proj | 1-16 | 2.85 | 2.62 | 2.45 | 1.05-1.11x | **FlashInfer** |
| 7168 | 384 | shared_down_proj (TP16) | 1-8 | 4.13 | 4.14 | 3.62 | 1.12-1.18x | **FlashInfer** |
| 7168 | 768 | shared_down_proj | 1-16 | 5.44 | 5.41 | 5.04 | 1.05-1.09x | **FlashInfer** |
| 1152 | 1536 | q_b_proj (TP16) | 2-16 | 4.93 | 3.97 | 3.78 | 1.04-1.10x | **FlashInfer** |
| 2304 | 1536 | q_b_proj | 1-16 | 6.08 | 4.43 | 4.34 | 1.00-1.07x | FlashInfer |
| 4608 | 1536 | q_b_proj | 1-16 | 6.24 | 5.81 | 5.58 | 1.02-1.08x | **FlashInfer** |
| 2048 | 2048 | GLM-5.2 q_b_proj | 3-16 | 5.98 | 5.22 | 4.75 | 1.07-1.11x | **FlashInfer** |
| 2624 | 6144 | GLM-5.2 qkv_a_proj | 3-16 | 12.03 | 9.97 | 9.14 | 1.07-1.09x | **FlashInfer** |
| 768 | 7168 | mla_g_proj / shared_gate_up_proj (TP16) | 5-16 | 8.90 | 7.17 | 6.08 | 1.11-1.19x | **FlashInfer** |
| 1536 | 7168 | shared_gate_up_proj / mla_g_proj | 1-16 | 10.03 | 8.08 | 7.46 | 1.06-1.10x | **FlashInfer** |
| 2112 | 7168 | fused_qkv_a_proj | 1-16 | 11.38 | 9.33 | 8.54 | 1.08-1.10x | **FlashInfer** |
| 3216 | 7168 | in_proj_qkvgfab (TP16) | 9-15 | 16.26 | 15.39 | 11.58 | 1.32-1.34x | **FlashInfer** |
| 3584 | 7168 | routed_expert_down_proj | 2-8 | 15.68 | 15.62 | 11.65 | 1.33-1.37x | **FlashInfer** |
| 4224 | 7168 | dense_gate_up_proj (TP16) | 4-8 | 17.41 | 16.99 | 13.02 | 1.30-1.32x | **FlashInfer** |

Medians over the M range per shape; the one tie is N=2304 K=1536 M=11 (4.480 µs both). Five cells are within 1%; the rest win by more than 1%. The largest gains are the K=7168 shapes (1.08-1.37x) where the kernel runs within ~6% of the measured cold-read floor of the weight stream.


## Reviewer Notes

- All measurements are from B300 (SM103); SM100/B200 has not been validated yet, although the runner ordering applies to both.
- The warp kernel is BF16-in / BF16-out only; other dtypes keep their existing runners.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable profiling repetition counts for individual operations.
  * Added an optional cold-L2 CUDA Graph replay mode for more consistent profiling.
  * Added a warp Split-K BF16 GEMM execution path with autotuned tactics and optional bias support.
  * Improved BF16 GEMM runner selection and fallback handling across supported workloads.

* **Bug Fixes**
  * Improved profiling behavior to avoid first-launch initialization and warmed input batches affecting results.

* **Tests**
  * Expanded BF16 GEMM coverage for warp Split-K tuning, tail-row workloads, larger K dimensions, and strict numerical accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
