### PR TITLE
feat(prims-ts): support decode GQA ratios up to 128

### DIFF
--- a/flashinfer/attention/prims_ts/decode.py
+++ b/flashinfer/attention/prims_ts/decode.py
@@ -170,6 +170,7 @@ def _decode_policy_from_config(
         ),
         ("tile_size_q", int(config.tile_size_q)),
         ("tile_size_kv", int(config.tile_size_kv)),
+        ("num_insts_kv", int(config.num_insts_kv)),
         ("use_split_kv", bool(config.use_split_kv)),
         ("splits_kv", int(config.splits_kv)),
         ("max_splits_kv", int(config.max_splits_kv)),

--- a/flashinfer/attention/prims_ts/decode.py
+++ b/flashinfer/attention/prims_ts/decode.py
@@ -59,6 +59,7 @@ _SUPPORTED_COMPUTE_CAPABILITIES = ((10, 0), (10, 3), (10, 7))
 _COMPILE_OPTIONS = "--enable-tvm-ffi --opt-level 3"
 _WORKSPACE_ALIGNMENT = 256
 _WORKSPACE_DTYPES = (torch.int8, torch.uint8)
+_MAX_HEAD_RATIO = 128
 
 
 @dataclass(frozen=True)
@@ -574,9 +575,10 @@ def _validate_head_geometry(num_qo_heads: int, num_kv_heads: int) -> None:
             f"{num_qo_heads} and {num_kv_heads}"
         )
     head_ratio = num_qo_heads // num_kv_heads
-    if head_ratio > 32:
+    if head_ratio > _MAX_HEAD_RATIO:
         raise ValueError(
-            f"attention-ts decode requires 1 <= Hq/Hkv <= 32, got {head_ratio}"
+            "attention-ts decode requires "
+            f"1 <= Hq/Hkv <= {_MAX_HEAD_RATIO}, got {head_ratio}"
         )
 
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
@@ -50,7 +50,7 @@ graph. This is not a public knob.
 | Head dimension | 64, 128, or 256 |
 | Fixed Q length | Any positive integer representable by the metadata and tensor extents |
 | Packed Q | Positive per-request lengths no greater than a positive static maximum |
-| Head mapping | MHA/GQA; `Hq` must be divisible by `Hkv` and `1 <= Hq/Hkv <= 32` |
+| Head mapping | MHA/GQA; `Hq` must be divisible by `Hkv`, with `1 <= Hq/Hkv <= 128`. Qualified fixed-Q FP8 D256/page-32 profiles use grouped Swaps Q8/Q16/Q32 through ratio 32, Keeps Q64 through ratio 64, and Keeps Q128 through ratio 128. |
 | Q/K/V dtype | Q and K/V must match: `torch.float16`, `torch.bfloat16`, or `torch.float8_e4m3fn` |
 | Output dtype | `torch.float16` for `torch.float16` input; `torch.bfloat16` for `torch.bfloat16` input; `torch.float16` or `torch.float8_e4m3fn` for `torch.float8_e4m3fn` input |
 | K/V layout | HND paged cache, combined or separate K/V tensors |

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/README.md
@@ -50,7 +50,7 @@ graph. This is not a public knob.
 | Head dimension | 64, 128, or 256 |
 | Fixed Q length | Any positive integer representable by the metadata and tensor extents |
 | Packed Q | Positive per-request lengths no greater than a positive static maximum |
-| Head mapping | MHA/GQA; `Hq` must be divisible by `Hkv`, with `1 <= Hq/Hkv <= 128`. Qualified fixed-Q FP8 D256/page-32 profiles use grouped Swaps Q8/Q16/Q32 through ratio 32, Keeps Q64 through ratio 64, and Keeps Q128 through ratio 128. |
+| Head mapping | MHA/GQA; `Hq` must be divisible by `Hkv`, with `1 <= Hq/Hkv <= 128`. Qualified fixed-Q FP8 D64/D128/D256 page-32 profiles use grouped Swaps Q8/Q16/Q32 through ratio 32, Keeps Q64 through ratio 64, and Keeps Q128 through ratio 128. |
 | Q/K/V dtype | Q and K/V must match: `torch.float16`, `torch.bfloat16`, or `torch.float8_e4m3fn` |
 | Output dtype | `torch.float16` for `torch.float16` input; `torch.bfloat16` for `torch.bfloat16` input; `torch.float16` or `torch.float8_e4m3fn` for `torch.float8_e4m3fn` input |
 | K/V layout | HND paged cache, combined or separate K/V tensors |

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1836,8 +1836,7 @@ class FmhaDecodeConfig:
 
         if profile in _GROUPED_KEEPS_PAGED_FP8_PROFILES:
             fixed_q1 = (
-                self.max_seq_len_q == 1
-                and 1 <= self.heads_q_per_kv <= self.tile_size_q
+                self.max_seq_len_q == 1 and 1 <= self.heads_q_per_kv <= self.tile_size_q
             )
             fixed_grouped_q = self.max_seq_len_q > 1
             return (

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -140,15 +140,15 @@ _KV_TILE_256_TASK_TOPOLOGY_DEFAULTS: Mapping[str, int] = {
 
 _KV_TILE_256_TUNABLE_FIELDS = frozenset(("kv_stages",))
 
-# Public cost-model collection uses the FP8 proxy for every source dtype.  The
-# original fixed-Q1 ratio-32 requests exercise a partial grouped-Q tile; the
-# shape-aware path also admits complete fixed multi-Q tiles at any legal head
-# ratio. These are profile families rather than shape exceptions: batch size,
-# KV length, tile choice, and legal GMEM split fanout remain unrestricted by
-# this declaration.
+# Public cost-model collection uses the FP8 proxy for every source dtype. The
+# fixed-Q1 path admits every head ratio covered by its Q64/Q128 tile, while the
+# shape-aware path also admits complete fixed multi-Q tiles. These are profile
+# families rather than shape exceptions: batch size, KV length, tile choice,
+# and legal GMEM split fanout remain unrestricted by this declaration.
 _GROUPED_KEEPS_PAGED_FP8_PROFILES = {
     (Float8E4M3FN, Float8E4M3FN, Float8E4M3FN, 64, 0, 2, 2),
     (Float8E4M3FN, Float8E4M3FN, Float8E4M3FN, 128, 0, 2, 2),
+    (Float8E4M3FN, Float8E4M3FN, Float8E4M3FN, 256, 128, 1, 1),
     (Float8E4M3FN, Float8E4M3FN, Float16, 256, 128, 1, 1),
 }
 
@@ -1835,14 +1835,17 @@ class FmhaDecodeConfig:
         direct = not (self.use_split_kv or self.use_separate_reduction_kernel)
 
         if profile in _GROUPED_KEEPS_PAGED_FP8_PROFILES:
-            fixed_q1_ratio32 = self.max_seq_len_q == 1 and self.heads_q_per_kv == 32
+            fixed_q1 = (
+                self.max_seq_len_q == 1
+                and 1 <= self.heads_q_per_kv <= self.tile_size_q
+            )
             fixed_grouped_q = self.max_seq_len_q > 1
             return (
-                (fixed_q1_ratio32 or fixed_grouped_q)
+                (fixed_q1 or fixed_grouped_q)
                 and not self.use_variable_seqlens_q
                 and self.use_paged_kv
                 and self.num_tokens_per_page == 32
-                and self.mask_type == CAUSAL
+                and self.mask_type in (DENSE, CAUSAL)
                 and not any(
                     (
                         self.use_cluster_smem_reduction,
@@ -2836,6 +2839,70 @@ _LAUNCH_SELECTION_FIELDS = {
 }
 
 
+def _try_apply_default_wide_keeps_config(
+    cfg: FmhaDecodeConfig,
+    *,
+    explicit_fields: set[str],
+    seq_len_q: int,
+    num_heads_q: int,
+    num_heads_kv: int,
+) -> bool:
+    """Select Q64/Q128 Keeps for an unpinned head ratio above 32.
+
+    Prefer a grouped tile so a partial GQA group can occupy the next supported
+    MMA width. If that profile family is not qualified, an exact 64- or
+    128-head group may still use the established ungrouped Keeps path. The
+    caller falls back to ungrouped Q16 Swaps head bands for other profiles.
+    """
+
+    heads_q_per_kv = num_heads_q // num_heads_kv
+    if (
+        heads_q_per_kv <= 32
+        or heads_q_per_kv > 128
+        or bool(_MMA_SELECTION_FIELDS & explicit_fields)
+    ):
+        return False
+
+    tile_size_q = 64 if heads_q_per_kv <= 64 else 128
+    grouping_was_explicit = "groups_tokens_heads_q" in explicit_fields
+    grouping_candidates = (cfg.groups_tokens_heads_q,)
+    if (
+        not grouping_was_explicit
+        and cfg.groups_tokens_heads_q
+        and heads_q_per_kv == tile_size_q
+    ):
+        grouping_candidates += (False,)
+
+    for groups_tokens_heads_q in grouping_candidates:
+        probe = deepcopy(cfg)
+        probe.groups_tokens_heads_q = groups_tokens_heads_q
+        probe.use_keeps_mma_ab = True
+        probe.tile_size_q = tile_size_q
+        try:
+            _finalize_static_decode_config(
+                probe,
+                explicit_fields | {"tile_size_q"},
+            )
+            _validate_profile_support(
+                cfg=probe,
+                seq_len_q=seq_len_q,
+                num_heads_q=num_heads_q,
+                num_heads_kv=num_heads_kv,
+                split_kv_mode="disabled",
+            )
+        except ValueError:
+            continue
+
+        cfg.groups_tokens_heads_q = groups_tokens_heads_q
+        cfg.use_keeps_mma_ab = True
+        cfg.tile_size_q = tile_size_q
+        # Keeps finalization otherwise canonicalizes an implicit tile to Q64.
+        explicit_fields.add("tile_size_q")
+        return True
+
+    return False
+
+
 def _try_apply_auto_kv256_profile(
     cfg: FmhaDecodeConfig,
     *,
@@ -3110,10 +3177,11 @@ def _apply_default_q_grouping(
     cfg: FmhaDecodeConfig,
     *,
     explicit_fields: set[str],
+    heads_q_per_kv: int,
 ) -> None:
-    """Enable token/head grouping unless the caller explicitly opts out."""
+    """Group complete head sets when they fit one supported Q tile."""
     if "groups_tokens_heads_q" not in explicit_fields:
-        cfg.groups_tokens_heads_q = True
+        cfg.groups_tokens_heads_q = heads_q_per_kv <= 128
 
 
 def _apply_layout_config(
@@ -3770,7 +3838,9 @@ def make_decode_config(
        KV128. The final KV width re-derives launch policy instead of reusing a
        fanout scored for KV128. Explicit policies remain caller-controlled.
        TileQ128 remains automatic over TileQ64 only for staged D256. SQ1 is
-       outside this grouped-Q cost model and therefore remains KV128.
+       outside this cost model and remains KV128, but ratios above 32 select
+       the smallest qualified Q64/Q128 Keeps tile. Other profile families use
+       exact-width ungrouped Keeps or ungrouped Swaps head bands as a fallback.
     3. Shapes outside that qualified Q/launch selector retain the general launch
        policy: under-filled fixed-Q long-sequence grids use split-KV GMEM
        reduction, direct grids above one resident wave use persistent
@@ -3833,6 +3903,7 @@ def make_decode_config(
     _apply_default_q_grouping(
         cfg,
         explicit_fields=explicit_fields,
+        heads_q_per_kv=num_heads_q // num_heads_kv,
     )
     cfg.q_dtype = qkv_dtype
     cfg.kv_dtype = qkv_dtype
@@ -3876,12 +3947,29 @@ def make_decode_config(
         max_splits_kv=max_splits_kv,
     )
     if selected_grouped_q_recipe is None:
-        _apply_swaps_tile_config(
+        selected_wide_keeps = _try_apply_default_wide_keeps_config(
             cfg,
             explicit_fields=explicit_fields,
+            seq_len_q=seq_len_q,
             num_heads_q=num_heads_q,
             num_heads_kv=num_heads_kv,
         )
+        if not selected_wide_keeps:
+            heads_q_per_kv = num_heads_q // num_heads_kv
+            if (
+                heads_q_per_kv > 32
+                and "groups_tokens_heads_q" not in explicit_fields
+                and not (_MMA_SELECTION_FIELDS & auto_selection_explicit_fields)
+            ):
+                # Profiles outside the grouped-Keeps matrix remain valid via
+                # the established ungrouped Swaps head bands.
+                cfg.groups_tokens_heads_q = False
+            _apply_swaps_tile_config(
+                cfg,
+                explicit_fields=explicit_fields,
+                num_heads_q=num_heads_q,
+                num_heads_kv=num_heads_kv,
+            )
     kv_tile_was_promoted = _try_apply_auto_kv256_profile(
         cfg,
         q_candidate=(

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -51,6 +51,7 @@ from flashinfer.attention.prims_ts.decode import (
     _validate_decode_query_head_extent,
     _validate_decode_output_aliasing,
     _validate_decode_policy_kv_tile_size,
+    _validate_head_geometry,
     _validate_max_kv_len,
 )
 from flashinfer.attention.prims_ts._tensor_aliasing import (
@@ -1445,7 +1446,7 @@ def test_attention_ts_decode_alias_guard_covers_every_live_allocation() -> None:
 
 
 def test_attention_ts_decode_public_query_geometry_guards() -> None:
-    """Reject unsupported public Q/head geometry before device probing."""
+    """Reject unsafe Q extents and head ratios above 128."""
 
     int32_max = 2**31 - 1
     _validate_decode_query_head_extent(
@@ -1480,41 +1481,73 @@ def test_attention_ts_decode_public_query_geometry_guards() -> None:
             device="cuda:0",
         )
 
-    with pytest.raises(ValueError, match=r"Hq/Hkv <= 32"):
-        get_prims_ts_batch_decode_workspace_size(
-            batch_size=1,
-            num_qo_heads=33,
-            num_kv_heads=1,
-            head_dim=128,
-            page_size=32,
-            max_seq_len=128,
-            device="cuda:0",
-        )
+    for supported_ratio in range(1, 129):
+        _validate_head_geometry(supported_ratio, 1)
+    with pytest.raises(ValueError, match="must be divisible"):
+        _validate_head_geometry(127, 2)
+    with pytest.raises(ValueError, match=r"1 <= Hq/Hkv <= 128"):
+        _validate_head_geometry(129, 1)
 
+
+@pytest.mark.parametrize(
+    ("head_ratio", "expected_mma", "expected_tile_q"),
+    (
+        (1, "swaps_mma_ab", 8),
+        (8, "swaps_mma_ab", 8),
+        (9, "swaps_mma_ab", 16),
+        (16, "swaps_mma_ab", 16),
+        (17, "swaps_mma_ab", 32),
+        (32, "swaps_mma_ab", 32),
+        (33, "keeps_mma_ab", 64),
+        (64, "keeps_mma_ab", 64),
+        (65, "keeps_mma_ab", 128),
+        (128, "keeps_mma_ab", 128),
+    ),
+)
+def test_attention_ts_decode_fp8_d256_head_ratio_buckets(
+    monkeypatch: pytest.MonkeyPatch,
+    head_ratio: int,
+    expected_mma: str,
+    expected_tile_q: int,
+) -> None:
+    """Dispatch each supported ratio range to its smallest qualified Q tile."""
+
+    from contextlib import nullcontext
     from flashinfer.attention.prims_ts import decode as decode_module
+    from flashinfer.attention.prims_ts.kernels.fmha_decode import fmha_decode_config
 
+    monkeypatch.setattr(torch.cuda, "device", lambda *_args, **_kwargs: nullcontext())
+    monkeypatch.setattr(
+        fmha_decode_config,
+        "get_max_active_clusters_for_cluster_size",
+        lambda cluster_size: 152 // cluster_size,
+    )
     decode_module._resolve_decode_launch_spec.cache_clear()
     try:
-        with pytest.raises(ValueError, match=r"Hq/Hkv <= 32"):
-            decode_module._resolve_decode_launch_spec(
-                0,
-                1,
-                33,
-                1,
-                128,
-                32,
-                128,
-                1,
-                "float16",
-                "float16",
-                "float16",
-                "HND",
-                "dense",
-                False,
-                -1,
-            )
+        spec = decode_module._resolve_decode_launch_spec(
+            0,
+            256,
+            head_ratio,
+            1,
+            256,
+            32,
+            4096,
+            1,
+            "float8_e4m3fn",
+            "float8_e4m3fn",
+            "float8_e4m3fn",
+            "HND",
+            "dense",
+            False,
+            -1,
+        )
     finally:
         decode_module._resolve_decode_launch_spec.cache_clear()
+
+    policy = dict(spec.policy)
+    assert policy["mma_variant"] == expected_mma
+    assert policy["tile_size_q"] == expected_tile_q
+    assert policy["groups_tokens_heads_q"] is True
 
 
 def test_attention_ts_decode_reserves_int32_kv_tile_padding() -> None:

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -1156,10 +1156,12 @@ def _exercise_public_paths(
     """Always check eager; reserve standalone/graph parity for anchor rows."""
 
     if case.q.dtype == _FP8:
+        policy = dict(wrapper._policy)
         case = _with_reference(
             case,
             qo_indptr=qo_indptr,
-            splits_kv=int(dict(wrapper._policy)["splits_kv"]),
+            splits_kv=int(policy["splits_kv"]),
+            num_insts_kv=int(policy["num_insts_kv"]),
         )
     eager = _run_case(wrapper, case)
     _assert_case_correct(eager, case)
@@ -1195,6 +1197,7 @@ def _with_reference(
     q: Optional[torch.Tensor] = None,
     qo_indptr: Optional[torch.Tensor] = None,
     splits_kv: int = 1,
+    num_insts_kv: int = _FP8_NUM_KV_INSTANCES,
 ):
     """Return a case whose oracle reflects its current mutable Q/K/V data."""
 
@@ -1215,6 +1218,7 @@ def _with_reference(
             window_left=case.window_left,
             qo_indptr=qo_indptr,
             splits_kv=splits_kv,
+            num_insts_kv=num_insts_kv,
         )
     else:
         reference = _decode_reference(
@@ -4417,7 +4421,7 @@ def test_attention_ts_decode_head_dim_gqa_product(
     )
 
 
-@pytest.mark.parametrize("head_dim", (64, 128), ids=lambda value: f"d{value}")
+@pytest.mark.parametrize("head_dim", (64, 128, 256), ids=lambda value: f"d{value}")
 @pytest.mark.parametrize("head_ratio", (33, 65), ids=lambda value: f"gqa{value}")
 @pytest.mark.arch_blackwell
 @_REQUIRES_PRIMTS_GPU

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -1504,11 +1504,13 @@ def test_attention_ts_decode_public_query_geometry_guards() -> None:
         (128, "keeps_mma_ab", 128),
     ),
 )
-def test_attention_ts_decode_fp8_d256_head_ratio_buckets(
+@pytest.mark.parametrize("head_dim", (64, 128, 256), ids=lambda value: f"d{value}")
+def test_attention_ts_decode_fp8_head_ratio_buckets(
     monkeypatch: pytest.MonkeyPatch,
     head_ratio: int,
     expected_mma: str,
     expected_tile_q: int,
+    head_dim: int,
 ) -> None:
     """Dispatch each supported ratio range to its smallest qualified Q tile."""
 
@@ -1529,7 +1531,7 @@ def test_attention_ts_decode_fp8_d256_head_ratio_buckets(
             256,
             head_ratio,
             1,
-            256,
+            head_dim,
             32,
             4096,
             1,
@@ -4413,6 +4415,37 @@ def test_attention_ts_decode_head_dim_gqa_product(
         max_kv_len=max_kv_len,
         exercise_all_paths=False,
     )
+
+
+@pytest.mark.parametrize("head_dim", (64, 128), ids=lambda value: f"d{value}")
+@pytest.mark.parametrize("head_ratio", (33, 65), ids=lambda value: f"gqa{value}")
+@pytest.mark.arch_blackwell
+@_REQUIRES_PRIMTS_GPU
+def test_attention_ts_decode_wide_fp8_gqa_accuracy(
+    head_dim: int,
+    head_ratio: int,
+):
+    """Check partial Q64/Q128 Keeps tiles against the FP8 reference."""
+
+    case = _make_decode_case(
+        kv_lens=(257, 193),
+        num_qo_heads=head_ratio,
+        num_kv_heads=1,
+        head_dim=head_dim,
+        seq_len_q=1,
+        page_size=32,
+        qkv_dtype=_FP8,
+        output_dtype=_FP8,
+        cache_form="combined",
+        mask_type="dense",
+        device="cuda",
+        seed=33500 + head_dim + head_ratio,
+    )
+    policy = _exercise_auto_case(case)
+
+    assert policy["mma_variant"] == "keeps_mma_ab"
+    assert policy["tile_size_q"] == (64 if head_ratio <= 64 else 128)
+    assert policy["groups_tokens_heads_q"] is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Support `1 <= num_qo_heads / num_kv_heads <= 128` in PrimTS decode.
- Dispatch qualified fixed-Q FP8 D64/D128/D256 profiles to grouped Keeps Q64 for ratios 33–64 and Q128 for ratios 65–128.
- Retain ungrouped head-band fallback for other profiles.

## Testing
- `pytest -q tests/attention/test_attention_ts_decode.py` (120 passed, 92 skipped)
- GB300 FP8 accuracy: D64/D128/D256 at ratios 33 and 65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded FP8 grouped-query attention support for query-to-KV head ratios up to 128.
  - Added support for wider FP8 decode configurations, including KV256 and Q64/Q128 tile profiles.
  - Improved automatic selection of optimized grouped or ungrouped attention strategies across supported head-ratio ranges.

- **Bug Fixes**
  - Improved FP8 decode accuracy and configuration handling for wide GQA layouts.
  - Added coverage for supported head-ratio limits, divisibility, masking modes, and dispatch choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->