### PR TITLE
perf(gdn): optimize SM100 CP kernels

### DIFF
--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -2388,6 +2388,12 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         tRT_tCcState = thr_state_r2t.partition_S(cState)
         tRT_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, self.acc_dtype)
         tGR_tCrState = cute.make_rmem_tensor_like(tRT_tCcState, mS_init.element_type)
+        state_g2r_atom = cute.make_copy_atom(
+            cute.nvgpu.CopyG2ROp(),
+            mS_init.element_type,
+            num_bits_per_copy=128,
+            invariant=True,
+        )
 
         if cutlass.const_expr(mS_indices is not None):
             state_idx = mS_indices[batch_idx]
@@ -2401,10 +2407,21 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         kv_acc_handle = kv_acc_producer.acquire_and_advance()
         for sub in cutlass.range(tGR_tCrState.shape[2]):
             # 1. Load S_init state_dtype GMEM -> state_dtype registers
-            cute.autovec_copy(
-                tGR_tCgState[None, 0, sub],
+            state_src = tGR_tCgState[None, 0, sub]
+            state_src_ptr = state_src.iterator
+            state_src_aligned = cute.make_tensor(
+                cute.make_ptr(
+                    state_src_ptr.dtype,
+                    state_src_ptr.toint(),
+                    state_src_ptr.memspace,
+                    assumed_align=16,
+                ),
+                state_src.layout,
+            )
+            cute.copy(
+                state_g2r_atom,
+                state_src_aligned,
                 tGR_tCrState[None, 0, sub],
-                l1c_evict_priority=cute.nvgpu.CacheEvictionPriority.NO_ALLOCATE,
             )
             if cutlass.const_expr(self.acc_dtype != mS_init.element_type):
                 tRT_tCrState[None, 0, sub].store(

--- a/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
+++ b/flashinfer/gdn_kernels/blackwell/gated_delta_net_cp_prefill.py
@@ -1932,19 +1932,50 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         cT = cute.make_identity_tensor((self.b_t, self.b_t))
         tTcT = thr_t_s2r.partition_D(cT)
         tTcT = thr_t_s2r.retile(tTcT)
-        for i in cutlass.range_constexpr(cute.size(tTrT)):
-            t, s = tTcT[i]
-            pred = s >= t
-            if is_final_block:
-                pred = pred and s < valid_tokens and t < valid_tokens
-            gamma = cutlass.Float32(0.0)
-            if pred:
-                gamma = cute.math.exp2(
-                    sCumsumlog[s, 0, gate_handle.index]
-                    - sCumsumlog[t, 0, gate_handle.index],
-                    fastmath=True,
-                )
-            tTrT[i] = self.io_dtype(-gamma * cutlass.Float32(tTrT[i]))
+        # Coordinate semantics:
+        #   tTcT[((s2, t8, s8), s16), _, _] -> (t, s)
+        # where s2 advances s by 1, t8 advances t by 8, s8 advances s by 8,
+        # and s16 advances s by 16. The T register fragment and QK TMEM fragment
+        # enumerate these transposed matrix coordinates in the same order.
+        # Cache the gate values varying along t8 once in tRowLog, and those
+        # varying along (s2, s8) once per s16 tile in tColLog.
+        tQKrScale = cute.make_rmem_tensor_like(tTR_cS, self.acc_dtype)
+        fragment_layout = cute.make_layout(tTcT.shape)
+        tTrT_mn = cute.make_tensor(tTrT.iterator, fragment_layout)
+        tQKrScale_mn = cute.make_tensor(tQKrScale.iterator, fragment_layout)
+
+        tRowLog = cute.make_rmem_tensor((2,), self.acc_dtype)
+        for row in cutlass.range_constexpr(2):
+            t, _ = tTcT[((0, row, 0), 0), 0, 0]
+            tRowLog[row] = sCumsumlog[t, 0, gate_handle.index]
+
+        for tile in cutlass.range_constexpr(4):
+            tColLog = cute.make_rmem_tensor((2, 2), self.acc_dtype)
+            for group in cutlass.range_constexpr(2):
+                for column in cutlass.range_constexpr(2):
+                    _, s = tTcT[((column, 0, group), tile), 0, 0]
+                    tColLog[column, group] = sCumsumlog[s, 0, gate_handle.index]
+
+            for group in cutlass.range_constexpr(2):
+                for row in cutlass.range_constexpr(2):
+                    for column in cutlass.range_constexpr(2):
+                        coord = ((column, row, group), tile), 0, 0
+                        t, s = tTcT[coord]
+                        valid = cutlass.Boolean(True)
+                        if cutlass.const_expr(is_final_block):
+                            valid = s < valid_tokens and t < valid_tokens
+                        gate_delta = tColLog[column, group] - tRowLog[row]
+                        t_gamma = cutlass.Float32(0.0)
+                        qk_gamma = cutlass.Float32(0.0)
+                        if valid:
+                            if s >= t:
+                                t_gamma = cute.math.exp2(gate_delta, fastmath=True)
+                            if t >= s:
+                                qk_gamma = cute.math.exp2(-gate_delta, fastmath=True)
+                        tTrT_mn[coord] = self.io_dtype(
+                            -t_gamma * cutlass.Float32(tTrT_mn[coord])
+                        )
+                        tQKrScale_mn[coord] = qk_gamma
 
         sAinv_t = cute.make_tensor(
             sAinv_mn.iterator,
@@ -1989,18 +2020,9 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
                 tQKrQK[None, 0, sub],
             )
             for i in cutlass.range(32):
-                s, t = tTR_cS[i, 0, sub]
-                pred = s >= t
-                if is_final_block:
-                    pred = pred and s < valid_tokens and t < valid_tokens
-                gamma = cutlass.Float32(0.0)
-                if pred:
-                    gamma = cute.math.exp2(
-                        sCumsumlog[s, 0, gate_handle.index]
-                        - sCumsumlog[t, 0, gate_handle.index],
-                        fastmath=True,
-                    )
-                tQKrQK_out[i, 0, sub] = self.io_dtype(tQKrQK[i, 0, sub] * gamma * scale)
+                tQKrQK_out[i, 0, sub] = self.io_dtype(
+                    tQKrQK[i, 0, sub] * tQKrScale[i] * scale
+                )
             cute.copy(
                 tiled_qk_r2s,
                 tQrQK[None, 0, sub],
@@ -2091,15 +2113,26 @@ class CPDeltaRulePrefillTcgen05Sm100(KeyedCompileMixin):
         for chunk_in_pair in range(2):
             chunk_idx = pair_idx * 2 + chunk_in_pair
             valid_tokens = chunk_len - chunk_idx * self.b_t
-            pipeline_args = self.compute_group_0_cp(
-                tidx,
-                tmem_ptr,
-                scale,
-                mma_args,
-                smem_args,
-                pipeline_args,
-                (chunk_idx >= num_valid_chunks - 1, valid_tokens),
-            )
+            if chunk_idx >= num_valid_chunks - 1:
+                pipeline_args = self.compute_group_0_cp(
+                    tidx,
+                    tmem_ptr,
+                    scale,
+                    mma_args,
+                    smem_args,
+                    pipeline_args,
+                    (True, valid_tokens),
+                )
+            else:
+                pipeline_args = self.compute_group_0_cp(
+                    tidx,
+                    tmem_ptr,
+                    scale,
+                    mma_args,
+                    smem_args,
+                    pipeline_args,
+                    (False, valid_tokens),
+                )
         return pipeline_args
 
     @cute.jit

--- a/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
+++ b/flashinfer/gdn_kernels/delta_rule_dsl/delta_rule_cp_sm120.py
@@ -2567,8 +2567,8 @@ class CPDeltaRuleFixupSimtSm120(KeyedCompileMixin):
         rM: cute.Tensor,
         k: cutlass.Int32,
     ):
-        for i in cutlass.range_constexpr(self.rows_per_cta):
-            for j in cutlass.range_constexpr(16):
+        for j in cutlass.range_constexpr(16):
+            for i in cutlass.range_constexpr(self.rows_per_cta):
                 rAcc[i] = rAcc[i] + sState[i, k + cutlass.Int32(j)] * rM[j]
 
     @cute.jit


### PR DESCRIPTION
## Description

This PR ports the useful SM100 CP kernel optimizations identified while comparing the CuTeDSL implementation with the CAKE-generated kernels in #4539:

- vectorize state loads in the final prefill kernel;
- interleave fixup accumulators to expose instruction-level parallelism;
- reuse gate factors and express their coordinates directly in MN semantics;
- replace runtime integer division in CP work mapping with fast divmod.

The launch-grid heuristic and optional max_seqlen interface change were split into independent PR #4946 so they do not block these kernel-only improvements.

## Tests

- Pre-commit hooks passed for the optimization stack.
- Before the history split, the combined stack passed the GDN prefill selection: 3087 passed, 864 skipped. The split only removes the independent host launch/API commit.
- CUDA-graph capture and replay passed.

## B200 CUDA-graph benchmark

Built-in benchmarks/bench_gdn_prefill.py with CUDA graphs, 10 warmups, and 100 measured iterations. GPU: NVIDIA B200 at a 1000 W power limit.

Only single-sequence cases are retained here because they are independent of the launch-grid change moved to #4946. For one sequence, max_seqlen equals total_seq_len under both launch policies.

```
Heads            Seqlens          h_qk  h_v   Opt graph  TFLOPS  Main graph  Speedup
-----------------------------------------------------------------------------------
397B/122B TP8    1x65536             2    8      0.330ms   104.0      0.353ms    1.07x
397B/122B TP8    1x32768             2    8      0.195ms    88.3      0.218ms    1.12x
397B/122B TP8    1x16384             2    8      0.127ms    67.5      0.150ms    1.18x
397B/122B TP8    1x8192              2    8      0.093ms    46.4      0.114ms    1.23x
397B/122B TP8    1x4096              2    8      0.070ms    30.7      0.087ms    1.24x
397B/122B TP8    1x2048              2    8      0.057ms    19.0      0.072ms    1.26x

397B/122B TP4    1x65536             4   16      0.620ms   110.8      0.635ms    1.02x
397B/122B TP4    1x32768             4   16      0.325ms   105.6      0.337ms    1.04x
397B/122B TP4    1x16384             4   16      0.188ms    91.6      0.201ms    1.07x
397B/122B TP4    1x8192              4   16      0.120ms    71.7      0.133ms    1.11x
397B/122B TP4    1x4096              4   16      0.085ms    50.4      0.097ms    1.14x
397B/122B TP4    1x2048              4   16      0.069ms    31.3      0.080ms    1.16x
```

## Pull Request Checklist

- [x] Pre-commit checks pass.
- [x] Tests have been added or updated as needed.
- [x] GDN prefill tests passed before the scope-only history split.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved processing efficiency for chunked prefill workloads by reducing indexing overhead and optimizing memory transfers on supported hardware.
  - Streamlined state accumulation to improve execution efficiency.

- **Correctness**
  - Updated gating and scaling calculations used during prefill attention processing for more consistent results across grouped operations.
  - Improved handling of final processing blocks and variable-length sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->