### PR TITLE
feat(mla): expose DSv4 TRTLLM-GEN RopeQuant

### DIFF
--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cuda_fp8.h>
 #include <cuda_runtime_api.h>
 #include <float.h>
 
@@ -31,8 +32,53 @@ namespace kernels {
 
 #define NumThreadsPerCta 512
 
+// DSv4 output epilogue: inverse RoPE, UE8M0 block scales, and E4M3 values. This matches the
+// fused-cubin output contract when a BF16 split-KV kernel needs a separate reduction.
+namespace dsv4 {
+
+constexpr int kHeadDim = 512;
+constexpr int kRopeDim = 64;
+constexpr int kQuantBlock = 128;
+constexpr int kHeadsPerGroup = 8;
+constexpr float kE4m3Max = 448.f;
+constexpr float kAmaxFloor = 1e-10f;
+
+__device__ __forceinline__ void inverseRopePair(float& even, float& odd, float cosVal,
+                                                float sinVal) {
+  float const e = even;
+  float const o = odd;
+  even = e * cosVal + o * sinVal;
+  odd = o * cosVal - e * sinVal;
+}
+
+__device__ __forceinline__ int32_t ue8m0ExponentFromAmax(float amax) {
+  amax = fmaxf(amax, kAmaxFloor);
+  int32_t exponent = ilogbf(amax) - 8;
+  if (ldexpf(kE4m3Max, exponent) < amax) {
+    ++exponent;
+  }
+  return min(max(exponent + 127, 0), 255);
+}
+
+__device__ __forceinline__ int64_t valueOffset(int32_t group, int32_t token, int32_t headInGroup,
+                                               int32_t dim, int32_t numTokens) {
+  return (((static_cast<int64_t>(group) * numTokens + token) * kHeadsPerGroup) + headInGroup) *
+             kHeadDim +
+         dim;
+}
+
+__device__ __forceinline__ int64_t scaleByteOffset(int32_t group, int32_t headInGroup,
+                                                   int32_t token, int32_t block,
+                                                   int64_t scaleBufM) {
+  return ((static_cast<int64_t>(group) * kHeadsPerGroup + headInGroup) * scaleBufM + token) *
+             sizeof(int32_t) +
+         block;
+}
+
+}  // namespace dsv4
+
 template <int32_t TileSizePerCtaQ, int32_t HeadDimPerCta, bool IsE4m3Bmm, typename DtypeO,
-          typename DtypePartialO>
+          typename DtypePartialO, bool Dsv4OutputEpilogue = false>
 __global__ void __launch_bounds__(NumThreadsPerCta, 2)
     fmhaReductionKernel(KernelParams const params, bool isTokenSparse, bool groupsTokensHeadsQ,
                         bool supportsVarSparseMlaTopKLens, int32_t numCtasForReduction,
@@ -284,6 +330,65 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
       mul(f2, f2, normalizedScale2);
     }
 
+    if constexpr (Dsv4OutputEpilogue) {
+      static_assert(
+          HeadDimPerCta % dsv4::kQuantBlock == 0 && dsv4::kQuantBlock % NumEltsPer16BVec == 0,
+          "A quant block must be owned by whole lanes of one CTA");
+      static_assert(NumEltsPer16BVec * sizeof(__nv_fp8_e4m3) == sizeof(uint2),
+                    "The E4M3 vector store assumes 8 elements");
+
+      int64_t const absRowIdx{softmaxStatsOffset + softmaxStatsRowIdx};
+      int32_t const tokenIdx{static_cast<int32_t>(absRowIdx / params.mNumHeadsQ)};
+      int32_t const headIdx{static_cast<int32_t>(absRowIdx % params.mNumHeadsQ)};
+      int32_t const dimIdx{headDimCtaIdxV * HeadDimPerCta + headDimIdx};
+
+      int32_t constexpr RopeStart{dsv4::kHeadDim - dsv4::kRopeDim};
+      if (dimIdx >= RopeStart) {
+        int32_t const position{params.ptrSeqLensKv[batchIdx] - seqLenQ + tokenIdx - seqOffsetQ};
+        float const* cosSin{params.ptrDsv4InvRopeCosSinCache +
+                            static_cast<int64_t>(position) * dsv4::kRopeDim};
+#pragma unroll
+        for (int32_t ii = 0; ii < NumEltsPer16BVec; ii += 2) {
+          int32_t const pairIdx{(dimIdx + ii - RopeStart) >> 1};
+          dsv4::inverseRopePair(outputVals[ii], outputVals[ii + 1], cosSin[pairIdx],
+                                cosSin[dsv4::kRopeDim / 2 + pairIdx]);
+        }
+      }
+
+      float amax{0.f};
+#pragma unroll
+      for (int32_t ii = 0; ii < NumEltsPer16BVec; ++ii) {
+        amax = fmaxf(amax, fabsf(outputVals[ii]));
+      }
+#pragma unroll
+      for (int32_t offset = 1; offset < dsv4::kQuantBlock / NumEltsPer16BVec; offset <<= 1) {
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, offset));
+      }
+      int32_t const biasedExp{dsv4::ue8m0ExponentFromAmax(amax)};
+
+      if (isValidRow) {
+        int32_t const group{headIdx / dsv4::kHeadsPerGroup};
+        int32_t const headInGroup{headIdx % dsv4::kHeadsPerGroup};
+        float const invScale{__frcp_rn(__int_as_float(biasedExp << 23))};
+        __nv_fp8_e4m3 quantized[NumEltsPer16BVec];
+#pragma unroll
+        for (int32_t ii = 0; ii < NumEltsPer16BVec; ++ii) {
+          quantized[ii] = static_cast<__nv_fp8_e4m3>(
+              fminf(fmaxf(outputVals[ii] * invScale, -dsv4::kE4m3Max), dsv4::kE4m3Max));
+        }
+        *reinterpret_cast<uint2*>(
+            reinterpret_cast<__nv_fp8_e4m3*>(params.ptrO) +
+            dsv4::valueOffset(group, tokenIdx, headInGroup, dimIdx, params.mSumOfSeqLensQ)) =
+            *reinterpret_cast<uint2 const*>(quantized);
+        if (dimIdx % dsv4::kQuantBlock == 0) {
+          reinterpret_cast<uint8_t*>(params.ptrDsv4OScale)[dsv4::scaleByteOffset(
+              group, headInGroup, tokenIdx, dimIdx / dsv4::kQuantBlock, params.mDsv4ScaleBufM)] =
+              static_cast<uint8_t>(biasedExp);
+        }
+      }
+      continue;
+    }
+
     // Convert the float values to DtypeO, and Store it to global memory.
     if (isValidRow) {
       convertAndStoreToGmem<DtypeO>(reinterpret_cast<char*>(oPtr + gmemStoreOffset), outputVals);
@@ -340,6 +445,8 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
           static_cast<MultiCtasKvMode>(kernelMeta.mMultiCtasKvMode))) {
     return;
   }
+
+  bool const dsv4OutputEpilogue = params.ptrDsv4OScale != nullptr;
 
   // This should only be enabled when using keepsMmaAbForGeneration kernel.
   FLASHINFER_CHECK(
@@ -404,7 +511,19 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
   // Select the kernel function pointer.
   void (*kernel)(KernelParams const, bool, bool, bool, int32_t, int32_t, int32_t, int32_t) =
       nullptr;
-  if (headDimPerCtaV == 64) {
+  if (dsv4OutputEpilogue) {
+    FLASHINFER_CHECK(kernelMeta.mGroupsHeadsQ && !kernelMeta.mGroupsTokensHeadsQ &&
+                         kernelMeta.mTileSizeQ == 64 && headDimPerCtaV >= 128 &&
+                         params.mNumHeadsQ % numHeadsPerCta == 0,
+                     "Not implemented");
+    if (headDimPerCtaV == 128) {
+      kernel = &fmhaReductionKernel<64, 128, true, __nv_bfloat16, __nv_bfloat16, true>;
+    } else if (headDimPerCtaV == 256) {
+      kernel = &fmhaReductionKernel<64, 256, true, __nv_bfloat16, __nv_bfloat16, true>;
+    } else {
+      kernel = &fmhaReductionKernel<64, 512, true, __nv_bfloat16, __nv_bfloat16, true>;
+    }
+  } else if (headDimPerCtaV == 64) {
     SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(64);
   } else if (headDimPerCtaV == 128) {
     SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(128);

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -1080,13 +1080,9 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
 
     TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), dl_float32)
         << "dsv4_inv_rope_cos_sin_cache must be float32";
-    TVM_FFI_ICHECK_EQ(cos_sin_cache.ndim(), 2)
-        << "dsv4_inv_rope_cos_sin_cache must have shape [max_position, 64]";
-    TVM_FFI_ICHECK_EQ(cos_sin_cache.size(1), 64);
-    TVM_FFI_ICHECK(cos_sin_cache.IsContiguous())
-        << "dsv4_inv_rope_cos_sin_cache must be contiguous";
-    TVM_FFI_ICHECK_EQ(cos_sin_cache.device().device_type, query.device().device_type);
-    TVM_FFI_ICHECK_EQ(cos_sin_cache.device().device_id, query.device().device_id);
+    TVM_FFI_ICHECK(cos_sin_cache.ndim() == 2 && cos_sin_cache.size(1) == 64 &&
+                   cos_sin_cache.IsContiguous())
+        << "dsv4_inv_rope_cos_sin_cache must be contiguous [max_position, 64]";
 
     TVM_FFI_ICHECK_EQ(output_scale.dtype(), dl_int32)
         << "dsv4_output_scale must contain packed UE8M0 values in int32 storage";
@@ -1101,8 +1097,12 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
                    dsv4_scale_buf_m % 4 == 0)
         << "dsv4_output_scale token stride must be a multiple of 4 and cover sum_q";
     TVM_FFI_ICHECK_EQ(output_scale.stride(1), heads_per_group * dsv4_scale_buf_m);
-    TVM_FFI_ICHECK_EQ(output_scale.device().device_type, query.device().device_type);
-    TVM_FFI_ICHECK_EQ(output_scale.device().device_id, query.device().device_id);
+
+    for (auto const& tensor : {out, output_scale, cos_sin_cache}) {
+      TVM_FFI_ICHECK(tensor.device().device_type == query.device().device_type &&
+                     tensor.device().device_id == query.device().device_id)
+          << "RopeQuant outputs and cos/sin cache must be on the same device as query";
+    }
 
     dsv4_inv_rope_cos_sin_cache_ptr = static_cast<float const*>(cos_sin_cache.data_ptr());
     dsv4_output_scale_ptr = static_cast<float*>(output_scale.data_ptr());

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -181,7 +181,8 @@ void trtllm_paged_attention_launcher(
     bool enable_pdl, int64_t workspace_size, int64_t k_sf_stride_heads, int64_t k_sf_stride_batch,
     int64_t v_sf_stride_heads, int64_t v_sf_stride_batch, bool is_causal, int64_t lse_stride_tokens,
     int64_t lse_stride_heads, int64_t bf16q_fp8kv_transform_mode, bool use_fp16_softmax,
-    bool uses_spcompress, cudaStream_t stream) {
+    bool uses_spcompress, float const* dsv4_inv_rope_cos_sin_cache, float* dsv4_output_scale,
+    int64_t dsv4_scale_buf_m, cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads must be a multiple of num_kv_heads, got num_kv_heads: " << num_kv_heads
@@ -249,6 +250,10 @@ void trtllm_paged_attention_launcher(
   runner_params.scaleSoftmaxLog2 = bmm1_scale * M_LOG2E;
   runner_params.scaleSoftmaxLog2Ptr = bmm1_scale_log2_ptr;
   runner_params.oSfPtr = out_scale_factor;
+  runner_params.dsv4InvRopeCosSinCachePtr = dsv4_inv_rope_cos_sin_cache;
+  runner_params.dsv4OScalePtr = dsv4_output_scale;
+  runner_params.mDsv4ScaleBufM = static_cast<int>(dsv4_scale_buf_m);
+  runner_params.mFusesDsv4InvRopeFp8Quant = dsv4_inv_rope_cos_sin_cache != nullptr;
   runner_params.mSfStartTokenIdx = o_sf_start_index;
   runner_params.mScaleSfO = o_sf_scale;
   TVM_FFI_ICHECK(o_sf_vec_size == 16 || o_sf_vec_size == -1)
@@ -592,7 +597,8 @@ void trtllm_paged_attention_decode(
       enable_block_sparse_attention, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
       k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, /*is_causal=*/true,
       lse_stride_tokens, lse_stride_heads, bf16q_fp8kv_transform_mode, use_fp16_softmax_value,
-      uses_spcompress_value, stream);
+      uses_spcompress_value, /*dsv4_inv_rope_cos_sin_cache=*/nullptr,
+      /*dsv4_output_scale=*/nullptr, /*dsv4_scale_buf_m=*/0, stream);
 }
 
 void trtllm_paged_attention_context(
@@ -736,7 +742,8 @@ void trtllm_paged_attention_context(
       /*enable_block_sparse_attention=*/false, sm_count, enable_pdl, workspace_size,
       k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, is_causal,
       lse_stride_tokens, lse_stride_heads, /*bf16q_fp8kv_transform_mode=*/0, use_fp16_softmax_value,
-      uses_spcompress_value, stream);
+      uses_spcompress_value, /*dsv4_inv_rope_cos_sin_cache=*/nullptr,
+      /*dsv4_output_scale=*/nullptr, /*dsv4_scale_buf_m=*/0, stream);
 }
 
 void trtllm_ragged_attention_launcher(
@@ -973,10 +980,14 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
     TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
     Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
     int64_t sm_count, bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
-    Optional<TensorView> cum_seq_lens_q) {
+    Optional<TensorView> cum_seq_lens_q, Optional<TensorView> dsv4_inv_rope_cos_sin_cache,
+    Optional<TensorView> dsv4_output_scale) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(primary_kv_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
+  bool const fuses_dsv4_inv_rope_fp8_quant = dsv4_inv_rope_cos_sin_cache.has_value();
+  TVM_FFI_ICHECK_EQ(fuses_dsv4_inv_rope_fp8_quant, dsv4_output_scale.has_value())
+      << "dsv4_inv_rope_cos_sin_cache and dsv4_output_scale must be provided together";
 
   TVM_FFI_ICHECK(query.ndim() == 3) << "query must have shape [B*Q, H, D]";
   TVM_FFI_ICHECK(primary_kv_cache.ndim() == 4)
@@ -996,8 +1007,15 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   TVM_FFI_ICHECK_EQ(kv_data_type, q_data_type) << "primary_kv_cache dtype must match query dtype";
   TVM_FFI_ICHECK_EQ(dl_dtype_to_tllm_data_type(sliding_window_kv_cache.dtype()), q_data_type)
       << "sliding_window_kv_cache dtype must match query dtype";
-  TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_BF16)
-      << "DeepSeek V4 sparse MLA output must be BF16";
+  if (fuses_dsv4_inv_rope_fp8_quant) {
+    TVM_FFI_ICHECK_EQ(q_data_type, Data_type::DATA_TYPE_E4M3)
+        << "DeepSeek V4 RopeQuant requires FP8 E4M3 query and KV inputs";
+    TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_E4M3)
+        << "DeepSeek V4 RopeQuant output must be FP8 E4M3";
+  } else {
+    TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_BF16)
+        << "DeepSeek V4 sparse MLA output must be BF16";
+  }
 
   int const sum_seq_q = query.size(0);
   int const num_qo_heads = query.size(1);
@@ -1006,6 +1024,9 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   int* cum_seq_lens_q_ptr =
       is_varlen_q ? static_cast<int*>(cum_seq_lens_q.value().data_ptr()) : nullptr;
   TVM_FFI_ICHECK_EQ(num_kv_heads, 1) << "DeepSeek V4 sparse MLA expects one KV head";
+  if (fuses_dsv4_inv_rope_fp8_quant) {
+    TVM_FFI_ICHECK_EQ(num_qo_heads, 128) << "DeepSeek V4 RopeQuant requires 128 query heads";
+  }
   TVM_FFI_ICHECK_EQ(sliding_window_kv_cache.size(-3), 1)
       << "sliding_window_kv_cache must have one KV head";
   TVM_FFI_ICHECK_EQ(seq_lens.size(0), batch_size);
@@ -1030,11 +1051,62 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       is_4bit(kv_data_type) ? primary_kv_cache.size(-1) * 2 : primary_kv_cache.size(-1);
   int const head_dim_sw = is_4bit(kv_data_type) ? sliding_window_kv_cache.size(-1) * 2
                                                 : sliding_window_kv_cache.size(-1);
-  int const head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
+  int const head_dim_o = fuses_dsv4_inv_rope_fp8_quant
+                             ? 512
+                             : (is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1));
   TVM_FFI_ICHECK_EQ(head_dim_q, 512);
   TVM_FFI_ICHECK_EQ(head_dim_k, 512);
   TVM_FFI_ICHECK_EQ(head_dim_sw, 512);
   TVM_FFI_ICHECK_EQ(head_dim_o, 512);
+
+  float const* dsv4_inv_rope_cos_sin_cache_ptr = nullptr;
+  float* dsv4_output_scale_ptr = nullptr;
+  int64_t dsv4_scale_buf_m = 0;
+  if (fuses_dsv4_inv_rope_fp8_quant) {
+    auto const& cos_sin_cache = dsv4_inv_rope_cos_sin_cache.value();
+    auto const& output_scale = dsv4_output_scale.value();
+    int64_t constexpr heads_per_group = 8;
+    int64_t const num_groups = num_qo_heads / heads_per_group;
+    int64_t const group_width = heads_per_group * head_dim_o;
+
+    TVM_FFI_ICHECK_EQ(out.ndim(), 3)
+        << "RopeQuant out must have shape [sum_q, num_head_groups, group_width]";
+    TVM_FFI_ICHECK_EQ(out.size(0), sum_seq_q);
+    TVM_FFI_ICHECK_EQ(out.size(1), num_groups);
+    TVM_FFI_ICHECK_EQ(out.size(2), group_width);
+    TVM_FFI_ICHECK_EQ(out.stride(0), group_width);
+    TVM_FFI_ICHECK_EQ(out.stride(1), sum_seq_q * group_width);
+    TVM_FFI_ICHECK_EQ(out.stride(2), 1);
+
+    TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), dl_float32)
+        << "dsv4_inv_rope_cos_sin_cache must be float32";
+    TVM_FFI_ICHECK_EQ(cos_sin_cache.ndim(), 2)
+        << "dsv4_inv_rope_cos_sin_cache must have shape [max_position, 64]";
+    TVM_FFI_ICHECK_EQ(cos_sin_cache.size(1), 64);
+    TVM_FFI_ICHECK(cos_sin_cache.IsContiguous())
+        << "dsv4_inv_rope_cos_sin_cache must be contiguous";
+    TVM_FFI_ICHECK_EQ(cos_sin_cache.device().device_type, query.device().device_type);
+    TVM_FFI_ICHECK_EQ(cos_sin_cache.device().device_id, query.device().device_id);
+
+    TVM_FFI_ICHECK_EQ(output_scale.dtype(), dl_int32)
+        << "dsv4_output_scale must contain packed UE8M0 values in int32 storage";
+    TVM_FFI_ICHECK_EQ(output_scale.ndim(), 3)
+        << "dsv4_output_scale must have shape [sum_q, num_head_groups, 8]";
+    TVM_FFI_ICHECK_EQ(output_scale.size(0), sum_seq_q);
+    TVM_FFI_ICHECK_EQ(output_scale.size(1), num_groups);
+    TVM_FFI_ICHECK_EQ(output_scale.size(2), heads_per_group);
+    TVM_FFI_ICHECK_EQ(output_scale.stride(0), 1);
+    dsv4_scale_buf_m = output_scale.stride(2);
+    TVM_FFI_ICHECK(dsv4_scale_buf_m >= sum_seq_q && dsv4_scale_buf_m <= INT_MAX &&
+                   dsv4_scale_buf_m % 4 == 0)
+        << "dsv4_output_scale token stride must be a multiple of 4 and cover sum_q";
+    TVM_FFI_ICHECK_EQ(output_scale.stride(1), heads_per_group * dsv4_scale_buf_m);
+    TVM_FFI_ICHECK_EQ(output_scale.device().device_type, query.device().device_type);
+    TVM_FFI_ICHECK_EQ(output_scale.device().device_id, query.device().device_id);
+
+    dsv4_inv_rope_cos_sin_cache_ptr = static_cast<float const*>(cos_sin_cache.data_ptr());
+    dsv4_output_scale_ptr = static_cast<float*>(output_scale.data_ptr());
+  }
 
   int const sparse_mla_top_k = sparse_indices.size(-1);
   TVM_FFI_ICHECK(sparse_mla_top_k >= kDsv4SparseMlaSlidingWindowTopK)
@@ -1155,7 +1227,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       /*k_sf_stride_heads=*/0, /*k_sf_stride_batch=*/0, /*v_sf_stride_heads=*/0,
       /*v_sf_stride_batch=*/0, /*is_causal=*/true, /*lse_stride_tokens=*/0,
       /*lse_stride_heads=*/0, /*bf16q_fp8kv_transform_mode=*/0, /*use_fp16_softmax=*/false,
-      /*uses_spcompress=*/false, stream);
+      /*uses_spcompress=*/false, dsv4_inv_rope_cos_sin_cache_ptr, dsv4_output_scale_ptr,
+      dsv4_scale_buf_m, stream);
 }
 
 namespace trtllm_cubin_loader {

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -252,7 +252,7 @@ void trtllm_paged_attention_launcher(
   runner_params.oSfPtr = out_scale_factor;
   runner_params.dsv4InvRopeCosSinCachePtr = dsv4_inv_rope_cos_sin_cache;
   runner_params.dsv4OScalePtr = dsv4_output_scale;
-  runner_params.mDsv4ScaleBufM = static_cast<int>(dsv4_scale_buf_m);
+  runner_params.mDsv4ScaleBufM = dsv4_scale_buf_m;
   runner_params.mFusesDsv4InvRopeFp8Quant = dsv4_inv_rope_cos_sin_cache != nullptr;
   runner_params.mSfStartTokenIdx = o_sf_start_index;
   runner_params.mScaleSfO = o_sf_scale;
@@ -377,6 +377,14 @@ void trtllm_paged_attention_launcher(
   runner_params.mUsesSpcompress = uses_spcompress;
 
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
+  if (!foundKernels && runner_params.mFusesDsv4InvRopeFp8Quant) {
+    // If the normal sparse-MLA heuristic has no matching fused cubin, run its BF16 split-KV
+    // carrier and let the separate reduction kernel apply the same output epilogue.
+    fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type,
+                                              Data_type::DATA_TYPE_BF16);
+    runner_params.mFusesDsv4InvRopeFp8Quant = false;
+    std::tie(foundKernels, kinfo) = fmha_runner->isSupportedWithInfo(runner_params);
+  }
   if (!foundKernels) {
     std::ostringstream err_msg;
     err_msg << "Missing TRTLLM-GEN kernel ("

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -377,14 +377,6 @@ void trtllm_paged_attention_launcher(
   runner_params.mUsesSpcompress = uses_spcompress;
 
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
-  if (!foundKernels && runner_params.mFusesDsv4InvRopeFp8Quant) {
-    // If the normal sparse-MLA heuristic has no matching fused cubin, run its BF16 split-KV
-    // carrier and let the separate reduction kernel apply the same output epilogue.
-    fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type,
-                                              Data_type::DATA_TYPE_BF16);
-    runner_params.mFusesDsv4InvRopeFp8Quant = false;
-    std::tie(foundKernels, kinfo) = fmha_runner->isSupportedWithInfo(runner_params);
-  }
   if (!foundKernels) {
     std::ostringstream err_msg;
     err_msg << "Missing TRTLLM-GEN kernel ("

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1994,10 +1994,20 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         q_lens = seq_lens.new_full((batch_size,), q_len_per_request)
     else:
         q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-    if _validate_dsv4_sync_checks(query.device) and torch.any(seq_lens < q_lens).item():
+    validate_sync_inputs = _validate_dsv4_sync_checks(query.device)
+    if validate_sync_inputs and torch.any(seq_lens < q_lens).item():
         raise ValueError(
             "seq_lens must be greater than or equal to the per-request query "
             "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
+        )
+    if (
+        validate_sync_inputs
+        and dsv4_inv_rope_cos_sin_cache is not None
+        and dsv4_inv_rope_cos_sin_cache.ndim == 2
+        and torch.any(seq_lens > dsv4_inv_rope_cos_sin_cache.size(0)).item()
+    ):
+        raise ValueError(
+            "dsv4_inv_rope_cos_sin_cache does not cover all derived query positions"
         )
 
     primary_kv_cache = compressed_kv_cache

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -721,6 +721,100 @@ def _normalize_dsv4_sparse_mla_kv_cache(
     raise ValueError(f"kv_layout must be either 'HND' or 'NHD', got {kv_layout}")
 
 
+_DSV4_ROPE_QUANT_HEADS_PER_GROUP = 8
+_DSV4_ROPE_QUANT_HEAD_DIM = 512
+_DSV4_ROPE_QUANT_SCALE_ALIGNMENT = 4
+
+
+def _allocate_dsv4_rope_quant_outputs(
+    num_tokens: int, num_heads: int, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Allocate the group-major output layouts consumed by DSv4 DeepGEMM."""
+    if num_heads != 128:
+        raise ValueError(f"DSv4 RopeQuant requires 128 query heads, got {num_heads}")
+    heads_per_group = _DSV4_ROPE_QUANT_HEADS_PER_GROUP
+    num_groups = num_heads // heads_per_group
+    group_width = heads_per_group * _DSV4_ROPE_QUANT_HEAD_DIM
+    scale_buf_m = (
+        (num_tokens + _DSV4_ROPE_QUANT_SCALE_ALIGNMENT - 1)
+        // _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
+        * _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
+    )
+
+    # Physical O is [group, token, flattened-head]; expose [token, group, K].
+    out = torch.empty(
+        (num_groups, num_tokens, group_width),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    ).transpose(0, 1)
+    # Physical SF is [group, head-in-group, padded-token]. Each INT32 packs the
+    # four UE8M0 exponent bytes for one 512-wide head.
+    out_scale = torch.zeros(
+        (num_groups, heads_per_group, scale_buf_m),
+        dtype=torch.int32,
+        device=device,
+    ).permute(2, 0, 1)[:num_tokens]
+    return out, out_scale
+
+
+def _check_dsv4_rope_quant_outputs(
+    out: torch.Tensor,
+    out_scale: torch.Tensor,
+    *,
+    num_tokens: int,
+    num_heads: int,
+    device: torch.device,
+) -> None:
+    heads_per_group = _DSV4_ROPE_QUANT_HEADS_PER_GROUP
+    if num_heads != 128:
+        raise ValueError(f"DSv4 RopeQuant requires 128 query heads, got {num_heads}")
+    num_groups = num_heads // heads_per_group
+    group_width = heads_per_group * _DSV4_ROPE_QUANT_HEAD_DIM
+    check_shape_dtype_device(
+        out,
+        (num_tokens, num_groups, group_width),
+        torch.float8_e4m3fn,
+        device,
+        "out",
+    )
+    expected_out_strides = (group_width, num_tokens * group_width, 1)
+    if out.stride() != expected_out_strides:
+        raise ValueError(
+            "DSv4 RopeQuant out must have group-major strides "
+            f"{expected_out_strides}, got {out.stride()}"
+        )
+
+    check_shape_dtype_device(
+        out_scale,
+        (num_tokens, num_groups, heads_per_group),
+        torch.int32,
+        device,
+        "dsv4_output_scale",
+    )
+    scale_buf_m = out_scale.stride(2)
+    if (
+        out_scale.stride(0) != 1
+        or scale_buf_m < num_tokens
+        or scale_buf_m % _DSV4_ROPE_QUANT_SCALE_ALIGNMENT != 0
+        or out_scale.stride(1) != heads_per_group * scale_buf_m
+    ):
+        raise ValueError(
+            "dsv4_output_scale must use packed UE8M0 group-major strides "
+            "(1, 8 * scale_buf_m, scale_buf_m), with scale_buf_m a multiple "
+            f"of 4 covering {num_tokens} tokens; got {out_scale.stride()}"
+        )
+    required_scale_elements = num_groups * heads_per_group * scale_buf_m
+    available_scale_bytes = (
+        out_scale.untyped_storage().nbytes()
+        - out_scale.storage_offset() * out_scale.element_size()
+    )
+    if available_scale_bytes < required_scale_elements * out_scale.element_size():
+        raise ValueError(
+            "dsv4_output_scale storage must include the full padded physical "
+            f"layout of {required_scale_elements} int32 values"
+        )
+
+
 def _check_sm120_dsv4_kv_cache_layout(
     kv_cache: torch.Tensor,
     kv_layout: Literal["HND", "NHD"],
@@ -1485,14 +1579,19 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     hca_sparse_indices_format: Optional[Literal["compressed-page-aligned"]] = None,
     remapped_sparse_indices_buffer: Optional[torch.Tensor] = None,
     sparse_indices_are_storage_offsets: Optional[bool] = None,
-) -> torch.Tensor:
+    dsv4_inv_rope_cos_sin_cache: Optional[torch.Tensor] = None,
+    dsv4_output_scale: Optional[torch.Tensor] = None,
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode DeepSeek V4 sparse MLA.
 
     The implementation is selected from the query device architecture.
 
     On SM100/SM103, this calls the TRTLLM-GEN DeepSeek V4 sparse MLA kernels.
     The query and both KV pools use head dim 512. The query may be BF16 or
-    per-tensor FP8 E4M3 and the output is BF16. The first 128 columns of
+    per-tensor FP8 E4M3 and the default output is BF16. When
+    ``dsv4_inv_rope_cos_sin_cache`` is provided, the fixed TRTLLM-GEN
+    RopeQuant epilogue instead writes group-major FP8 E4M3 values and packed
+    UE8M0 scales. The first 128 columns of
     ``sparse_indices`` are SWA entries into ``swa_kv_cache``; remaining columns
     are compressed entries into ``compressed_kv_cache``. ``sparse_topk_lens``
     gives the total active sparse length for each query token and must include
@@ -1547,6 +1646,12 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         Original KV sequence lengths, shape ``[batch_size]`` INT32. Required
         by ``trtllm-gen`` and by compressed-page-aligned HCA metadata
         conversion.
+    out : Optional[torch.Tensor]
+        Optional preallocated output. The default path expects the same shape
+        as ``query`` and BF16 dtype. RopeQuant expects FP8 E4M3 shape
+        ``[sum_q, 16, 4096]`` with strides
+        ``(4096, sum_q * 4096, 1)``. If omitted, FlashInfer allocates the
+        appropriate layout.
     bmm1_scale : Union[float, torch.Tensor]
         Fused per-tensor scale for QK and softmax. Tensor form must be FP32.
         HCA currently accepts only a Python float.
@@ -1626,8 +1731,42 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         ``False`` for logical flattened token indices or ``True`` for indices
         already adjusted to storage-row offsets. Strided pools require an
         explicit value to prevent accidental double remapping.
+    dsv4_inv_rope_cos_sin_cache : Optional[torch.Tensor]
+        Enables the TRTLLM-GEN DSv4 RopeQuant epilogue. Must be a contiguous
+        FP32 tensor shaped ``[max_position, 64]`` with each row laid out as
+        ``[cos(32), sin(32)]`` for interleaved RoPE. The kernel derives each
+        query position as ``seq_len - q_len + local_query_index``. This mode
+        requires FP8 E4M3 Q/K/V, 128 query heads, and
+        ``backend="trtllm-gen"``.
+    dsv4_output_scale : Optional[torch.Tensor]
+        Optional preallocated packed UE8M0 scale output. Shape must be
+        ``[sum_q, 16, 8]`` with strides
+        ``(1, 8 * scale_buf_m, scale_buf_m)``; ``scale_buf_m`` must be a
+        multiple of four and at least ``sum_q``. If omitted in RopeQuant mode,
+        FlashInfer allocates it with zeroed physical padding. A caller-provided
+        buffer must also have its padded token rows zero-initialized before
+        first use; the cubin intentionally leaves those rows unwritten.
+        Supplying this tensor together with ``out`` avoids RopeQuant output
+        allocations. CUDA Graph use still requires normal JIT warmup and stable
+        caller-controlled temporary buffers; the existing DSV4 path allocates
+        its internal counter buffer per invocation.
+
+    Returns
+    -------
+    torch.Tensor or tuple[torch.Tensor, torch.Tensor]
+        The existing BF16 output when RopeQuant is disabled. With RopeQuant,
+        returns ``(out_fp8, out_scale)``. ``out_fp8`` has shape
+        ``[sum_q, 16, 4096]`` and group-major strides
+        ``(4096, sum_q * 4096, 1)``; ``out_scale`` uses the packed UE8M0
+        layout described above.
     """
     backend = _resolve_dsv4_sparse_mla_backend(query.device, backend)
+
+    rope_quant = dsv4_inv_rope_cos_sin_cache is not None
+    if dsv4_output_scale is not None and not rope_quant:
+        raise ValueError("dsv4_output_scale requires dsv4_inv_rope_cos_sin_cache")
+    if rope_quant and backend != "trtllm-gen":
+        raise ValueError("DSv4 RopeQuant requires backend='trtllm-gen'")
 
     if backend != "trtllm-gen" and (
         remapped_sparse_indices_buffer is not None
@@ -1865,7 +2004,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         sparse_indices,
         compressed_kv_cache,
         sparse_topk_lens,
-        out,
+        None if rope_quant else out,
         sinks,
         kv_layout,
         cum_seq_lens_q,
@@ -1873,7 +2012,66 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         allow_sm120_packed_kv=False,
     )
 
-    if out is None:
+    if rope_quant:
+        if query.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                "DSv4 RopeQuant requires FP8 E4M3 query and KV inputs, "
+                f"got {query.dtype}"
+            )
+        assert dsv4_inv_rope_cos_sin_cache is not None
+        if (
+            dsv4_inv_rope_cos_sin_cache.ndim != 2
+            or dsv4_inv_rope_cos_sin_cache.shape[1] != 64
+        ):
+            raise ValueError(
+                "dsv4_inv_rope_cos_sin_cache must have shape [max_position, 64], "
+                f"got {tuple(dsv4_inv_rope_cos_sin_cache.shape)}"
+            )
+        check_shape_dtype_device(
+            dsv4_inv_rope_cos_sin_cache,
+            None,
+            torch.float32,
+            query.device,
+            "dsv4_inv_rope_cos_sin_cache",
+        )
+        if not dsv4_inv_rope_cos_sin_cache.is_contiguous():
+            raise ValueError("dsv4_inv_rope_cos_sin_cache must be contiguous")
+
+        num_tokens, num_heads = query_flat.shape[:2]
+        if out is None and dsv4_output_scale is None:
+            out, dsv4_output_scale = _allocate_dsv4_rope_quant_outputs(
+                num_tokens, num_heads, query.device
+            )
+        else:
+            heads_per_group = _DSV4_ROPE_QUANT_HEADS_PER_GROUP
+            num_groups = num_heads // heads_per_group
+            group_width = heads_per_group * _DSV4_ROPE_QUANT_HEAD_DIM
+            if out is None:
+                out = torch.empty(
+                    (num_groups, num_tokens, group_width),
+                    dtype=torch.float8_e4m3fn,
+                    device=query.device,
+                ).transpose(0, 1)
+            if dsv4_output_scale is None:
+                scale_buf_m = (
+                    (num_tokens + _DSV4_ROPE_QUANT_SCALE_ALIGNMENT - 1)
+                    // _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
+                    * _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
+                )
+                dsv4_output_scale = torch.zeros(
+                    (num_groups, heads_per_group, scale_buf_m),
+                    dtype=torch.int32,
+                    device=query.device,
+                ).permute(2, 0, 1)[:num_tokens]
+        assert out is not None and dsv4_output_scale is not None
+        _check_dsv4_rope_quant_outputs(
+            out,
+            dsv4_output_scale,
+            num_tokens=num_tokens,
+            num_heads=num_heads,
+            device=query.device,
+        )
+    elif out is None:
         out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
 
     check_shape_dtype_device(
@@ -1883,11 +2081,29 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         q_lens = seq_lens.new_full((batch_size,), q_len_per_request)
     else:
         q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-    if _validate_dsv4_sync_checks(query.device) and torch.any(seq_lens < q_lens).item():
-        raise ValueError(
-            "seq_lens must be greater than or equal to the per-request query "
-            "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
-        )
+    if _validate_dsv4_sync_checks(query.device):
+        if torch.any(seq_lens < q_lens).item():
+            raise ValueError(
+                "seq_lens must be greater than or equal to the per-request query "
+                "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
+            )
+        if rope_quant:
+            assert dsv4_inv_rope_cos_sin_cache is not None
+            assert dsv4_output_scale is not None
+            if torch.any(seq_lens > dsv4_inv_rope_cos_sin_cache.shape[0]).item():
+                raise ValueError(
+                    "dsv4_inv_rope_cos_sin_cache does not cover all derived query "
+                    "positions"
+                )
+            scale_buf_m = dsv4_output_scale.stride(2)
+            if scale_buf_m > query_flat.size(0):
+                scale_storage = dsv4_output_scale.as_strided(
+                    (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
+                )
+                if torch.any(scale_storage[..., query_flat.size(0) :] != 0).item():
+                    raise ValueError(
+                        "dsv4_output_scale padded token rows must be zero-initialized"
+                    )
 
     primary_kv_cache = compressed_kv_cache
     sparse_indices = sparse_indices.reshape(query_flat.size(0), -1).contiguous()
@@ -1961,7 +2177,12 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         workspace_buffer.numel() * workspace_buffer.element_size(),
         sinks,
         cum_seq_lens_q.contiguous() if cum_seq_lens_q is not None else None,
+        dsv4_inv_rope_cos_sin_cache,
+        dsv4_output_scale,
     )
+    if rope_quant:
+        assert dsv4_output_scale is not None
+        return out, dsv4_output_scale
     return out
 
 

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -778,61 +778,6 @@ def _allocate_dsv4_rope_quant_outputs(
     )
 
 
-def _check_dsv4_rope_quant_outputs(
-    out: torch.Tensor,
-    out_scale: torch.Tensor,
-    *,
-    num_tokens: int,
-    num_heads: int,
-    device: torch.device,
-) -> None:
-    """Validate the two fixed-layout output views required by the cubin ABI."""
-    num_groups, heads_per_group, group_width = _dsv4_rope_quant_group_layout(num_heads)
-    check_shape_dtype_device(
-        out,
-        (num_tokens, num_groups, group_width),
-        torch.float8_e4m3fn,
-        device,
-        "out",
-    )
-    expected_out_strides = (group_width, num_tokens * group_width, 1)
-    if out.stride() != expected_out_strides:
-        raise ValueError(
-            "DSv4 RopeQuant out must have group-major strides "
-            f"{expected_out_strides}, got {out.stride()}"
-        )
-
-    check_shape_dtype_device(
-        out_scale,
-        (num_tokens, num_groups, heads_per_group),
-        torch.int32,
-        device,
-        "dsv4_output_scale",
-    )
-    scale_buf_m = out_scale.stride(2)
-    if (
-        out_scale.stride(0) != 1
-        or scale_buf_m < num_tokens
-        or scale_buf_m % _DSV4_ROPE_QUANT_SCALE_ALIGNMENT != 0
-        or out_scale.stride(1) != heads_per_group * scale_buf_m
-    ):
-        raise ValueError(
-            "dsv4_output_scale must use packed UE8M0 group-major strides "
-            "(1, 8 * scale_buf_m, scale_buf_m), with scale_buf_m a multiple "
-            f"of 4 covering {num_tokens} tokens; got {out_scale.stride()}"
-        )
-    required_scale_elements = num_groups * heads_per_group * scale_buf_m
-    available_scale_bytes = (
-        out_scale.untyped_storage().nbytes()
-        - out_scale.storage_offset() * out_scale.element_size()
-    )
-    if available_scale_bytes < required_scale_elements * out_scale.element_size():
-        raise ValueError(
-            "dsv4_output_scale storage must include the full padded physical "
-            f"layout of {required_scale_elements} int32 values"
-        )
-
-
 def _check_sm120_dsv4_kv_cache_layout(
     kv_cache: torch.Tensor,
     kv_layout: Literal["HND", "NHD"],
@@ -1753,8 +1698,9 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         Enables the TRTLLM-GEN DSv4 RopeQuant epilogue. Must be a contiguous
         FP32 tensor shaped ``[max_position, 64]`` with each row laid out as
         ``[cos(32), sin(32)]`` for interleaved RoPE. The kernel derives each
-        query position as ``seq_len - q_len + local_query_index``. This mode
-        requires FP8 E4M3 Q/K/V, 128 query heads, and
+        query position as ``seq_len - q_len + local_query_index``; the cache
+        must cover every derived position. This mode requires FP8 E4M3 Q/K/V,
+        128 query heads, and
         ``backend="trtllm-gen"``.
     dsv4_output_scale : Optional[torch.Tensor]
         Optional preallocated packed UE8M0 scale output. Shape must be
@@ -2031,52 +1977,13 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     )
 
     if rope_quant:
-        if query.dtype != torch.float8_e4m3fn:
-            raise ValueError(
-                "DSv4 RopeQuant requires FP8 E4M3 query and KV inputs, "
-                f"got {query.dtype}"
-            )
-        assert dsv4_inv_rope_cos_sin_cache is not None
-        if (
-            dsv4_inv_rope_cos_sin_cache.ndim != 2
-            or dsv4_inv_rope_cos_sin_cache.shape[1] != 64
-        ):
-            raise ValueError(
-                "dsv4_inv_rope_cos_sin_cache must have shape [max_position, 64], "
-                f"got {tuple(dsv4_inv_rope_cos_sin_cache.shape)}"
-            )
-        check_shape_dtype_device(
-            dsv4_inv_rope_cos_sin_cache,
-            None,
-            torch.float32,
-            query.device,
-            "dsv4_inv_rope_cos_sin_cache",
-        )
-        if not dsv4_inv_rope_cos_sin_cache.is_contiguous():
-            raise ValueError("dsv4_inv_rope_cos_sin_cache must be contiguous")
-
         num_tokens, num_heads = query_flat.shape[:2]
-        if out is None and dsv4_output_scale is None:
-            out, dsv4_output_scale = _allocate_dsv4_rope_quant_outputs(
+        if out is None:
+            out = _allocate_dsv4_rope_quant_output(num_tokens, num_heads, query.device)
+        if dsv4_output_scale is None:
+            dsv4_output_scale = _allocate_dsv4_rope_quant_output_scale(
                 num_tokens, num_heads, query.device
             )
-        else:
-            if out is None:
-                out = _allocate_dsv4_rope_quant_output(
-                    num_tokens, num_heads, query.device
-                )
-            if dsv4_output_scale is None:
-                dsv4_output_scale = _allocate_dsv4_rope_quant_output_scale(
-                    num_tokens, num_heads, query.device
-                )
-        assert out is not None and dsv4_output_scale is not None
-        _check_dsv4_rope_quant_outputs(
-            out,
-            dsv4_output_scale,
-            num_tokens=num_tokens,
-            num_heads=num_heads,
-            device=query.device,
-        )
     elif out is None:
         out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
 
@@ -2087,32 +1994,11 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         q_lens = seq_lens.new_full((batch_size,), q_len_per_request)
     else:
         q_lens = cum_seq_lens_q[1:] - cum_seq_lens_q[:-1]
-    if _validate_dsv4_sync_checks(query.device):
-        if torch.any(seq_lens < q_lens).item():
-            raise ValueError(
-                "seq_lens must be greater than or equal to the per-request query "
-                "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
-            )
-        if rope_quant:
-            assert dsv4_inv_rope_cos_sin_cache is not None
-            assert dsv4_output_scale is not None
-            if torch.any(seq_lens > dsv4_inv_rope_cos_sin_cache.shape[0]).item():
-                raise ValueError(
-                    "dsv4_inv_rope_cos_sin_cache does not cover all derived query "
-                    "positions"
-                )
-            scale_buf_m = dsv4_output_scale.stride(2)
-            if scale_buf_m > query_flat.size(0):
-                num_groups = dsv4_output_scale.size(1)
-                heads_per_group = dsv4_output_scale.size(2)
-                scale_storage = dsv4_output_scale.as_strided(
-                    (num_groups, heads_per_group, scale_buf_m),
-                    (heads_per_group * scale_buf_m, scale_buf_m, 1),
-                )
-                if torch.any(scale_storage[..., query_flat.size(0) :] != 0).item():
-                    raise ValueError(
-                        "dsv4_output_scale padded token rows must be zero-initialized"
-                    )
+    if _validate_dsv4_sync_checks(query.device) and torch.any(seq_lens < q_lens).item():
+        raise ValueError(
+            "seq_lens must be greater than or equal to the per-request query "
+            "lengths so TRTLLM-GEN can derive the SWA-128 valid window"
+        )
 
     primary_kv_cache = compressed_kv_cache
     sparse_indices = sparse_indices.reshape(query_flat.size(0), -1).contiguous()

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -726,35 +726,56 @@ _DSV4_ROPE_QUANT_HEAD_DIM = 512
 _DSV4_ROPE_QUANT_SCALE_ALIGNMENT = 4
 
 
-def _allocate_dsv4_rope_quant_outputs(
-    num_tokens: int, num_heads: int, device: torch.device
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Allocate the group-major output layouts consumed by DSv4 DeepGEMM."""
+def _dsv4_rope_quant_group_layout(num_heads: int) -> Tuple[int, int, int]:
+    """Return ``(num_groups, heads_per_group, flattened_group_width)``."""
     if num_heads != 128:
         raise ValueError(f"DSv4 RopeQuant requires 128 query heads, got {num_heads}")
     heads_per_group = _DSV4_ROPE_QUANT_HEADS_PER_GROUP
     num_groups = num_heads // heads_per_group
     group_width = heads_per_group * _DSV4_ROPE_QUANT_HEAD_DIM
+    return num_groups, heads_per_group, group_width
+
+
+def _allocate_dsv4_rope_quant_output(
+    num_tokens: int, num_heads: int, device: torch.device
+) -> torch.Tensor:
+    """Allocate the group-major FP8 RopeQuant output view."""
+    num_groups, _, group_width = _dsv4_rope_quant_group_layout(num_heads)
+    # Physical O is [group, token, flattened-head]; expose [token, group, K].
+    return torch.empty(
+        (num_groups, num_tokens, group_width),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    ).transpose(0, 1)
+
+
+def _allocate_dsv4_rope_quant_output_scale(
+    num_tokens: int, num_heads: int, device: torch.device
+) -> torch.Tensor:
+    """Allocate the padded, group-major packed UE8M0 scale view."""
+    num_groups, heads_per_group, _ = _dsv4_rope_quant_group_layout(num_heads)
     scale_buf_m = (
         (num_tokens + _DSV4_ROPE_QUANT_SCALE_ALIGNMENT - 1)
         // _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
         * _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
     )
-
-    # Physical O is [group, token, flattened-head]; expose [token, group, K].
-    out = torch.empty(
-        (num_groups, num_tokens, group_width),
-        dtype=torch.float8_e4m3fn,
-        device=device,
-    ).transpose(0, 1)
     # Physical SF is [group, head-in-group, padded-token]. Each INT32 packs the
     # four UE8M0 exponent bytes for one 512-wide head.
-    out_scale = torch.zeros(
+    return torch.zeros(
         (num_groups, heads_per_group, scale_buf_m),
         dtype=torch.int32,
         device=device,
     ).permute(2, 0, 1)[:num_tokens]
-    return out, out_scale
+
+
+def _allocate_dsv4_rope_quant_outputs(
+    num_tokens: int, num_heads: int, device: torch.device
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Allocate the group-major output layouts consumed by DSv4 DeepGEMM."""
+    return (
+        _allocate_dsv4_rope_quant_output(num_tokens, num_heads, device),
+        _allocate_dsv4_rope_quant_output_scale(num_tokens, num_heads, device),
+    )
 
 
 def _check_dsv4_rope_quant_outputs(
@@ -765,11 +786,8 @@ def _check_dsv4_rope_quant_outputs(
     num_heads: int,
     device: torch.device,
 ) -> None:
-    heads_per_group = _DSV4_ROPE_QUANT_HEADS_PER_GROUP
-    if num_heads != 128:
-        raise ValueError(f"DSv4 RopeQuant requires 128 query heads, got {num_heads}")
-    num_groups = num_heads // heads_per_group
-    group_width = heads_per_group * _DSV4_ROPE_QUANT_HEAD_DIM
+    """Validate the two fixed-layout output views required by the cubin ABI."""
+    num_groups, heads_per_group, group_width = _dsv4_rope_quant_group_layout(num_heads)
     check_shape_dtype_device(
         out,
         (num_tokens, num_groups, group_width),
@@ -2043,26 +2061,14 @@ def trtllm_batch_decode_sparse_mla_dsv4(
                 num_tokens, num_heads, query.device
             )
         else:
-            heads_per_group = _DSV4_ROPE_QUANT_HEADS_PER_GROUP
-            num_groups = num_heads // heads_per_group
-            group_width = heads_per_group * _DSV4_ROPE_QUANT_HEAD_DIM
             if out is None:
-                out = torch.empty(
-                    (num_groups, num_tokens, group_width),
-                    dtype=torch.float8_e4m3fn,
-                    device=query.device,
-                ).transpose(0, 1)
-            if dsv4_output_scale is None:
-                scale_buf_m = (
-                    (num_tokens + _DSV4_ROPE_QUANT_SCALE_ALIGNMENT - 1)
-                    // _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
-                    * _DSV4_ROPE_QUANT_SCALE_ALIGNMENT
+                out = _allocate_dsv4_rope_quant_output(
+                    num_tokens, num_heads, query.device
                 )
-                dsv4_output_scale = torch.zeros(
-                    (num_groups, heads_per_group, scale_buf_m),
-                    dtype=torch.int32,
-                    device=query.device,
-                ).permute(2, 0, 1)[:num_tokens]
+            if dsv4_output_scale is None:
+                dsv4_output_scale = _allocate_dsv4_rope_quant_output_scale(
+                    num_tokens, num_heads, query.device
+                )
         assert out is not None and dsv4_output_scale is not None
         _check_dsv4_rope_quant_outputs(
             out,
@@ -2097,8 +2103,11 @@ def trtllm_batch_decode_sparse_mla_dsv4(
                 )
             scale_buf_m = dsv4_output_scale.stride(2)
             if scale_buf_m > query_flat.size(0):
+                num_groups = dsv4_output_scale.size(1)
+                heads_per_group = dsv4_output_scale.size(2)
                 scale_storage = dsv4_output_scale.as_strided(
-                    (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
+                    (num_groups, heads_per_group, scale_buf_m),
+                    (heads_per_group * scale_buf_m, scale_buf_m, 1),
                 )
                 if torch.any(scale_storage[..., query_flat.size(0) :] != 0).item():
                     raise ValueError(

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -664,11 +664,6 @@ class TllmGenFmhaKernel {
       numCtasPerSeqKv = std::min(
           tunedMaxNumCtasPerSeqKv,
           std::max(1, int32_t(params.mMultiProcessorCount / (numCtasX * numCtasY * numCtasZ))));
-      // If no fused cubin matched, the BF16 carrier must produce at least two partials so the
-      // separate reduction kernel can apply the requested DSv4 output epilogue.
-      if (params.dsv4OScalePtr != nullptr && !params.mFusesDsv4InvRopeFp8Quant) {
-        numCtasPerSeqKv = std::max(numCtasPerSeqKv, 2);
-      }
       // Update the numCtasX.
       numCtasX *= numCtasPerSeqKv;
       // The current total number of CTAs.
@@ -931,6 +926,24 @@ class TllmGenFmhaKernel {
   // Select the MLA generation kernel.
   void selectMlaGenerationKernel(RunnerParams const& params,
                                  SelectKernelParams& selectKernelParams) const {
+    if (params.mFusesDsv4InvRopeFp8Quant) {
+      FLASHINFER_CHECK(params.isSparseMla() && params.mHeadDimQk == 512 &&
+                           params.mHeadDimV == 512 && params.mNumHeadsQPerKv == 128,
+                       "DSv4 RopeQuant requires dynamic sparse MLA with 128 query heads and "
+                       "head dimension 512.");
+      selectKernelParams.mKernelType = FmhaKernelType::KeepsMmaAbForGeneration;
+      selectKernelParams.mTileScheduler = TileScheduler::Persistent;
+      selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::Disabled;
+      selectKernelParams.mForceGmemReduction = true;
+      selectKernelParams.mHeadDimPerCtaV = 256;
+      selectKernelParams.mTileSizeQ = 64;
+      selectKernelParams.mTileSizeKv = 128;
+      selectKernelParams.mReuseSmemKForV = false;
+      selectKernelParams.mGroupsTokensHeadsQ = false;
+      selectKernelParams.mUses2CtaMma = true;
+      return;
+    }
+
     if (usesGroupedMlaGenerationKernel(params)) {
       selectGroupedMlaGenerationKernel(params, selectKernelParams);
       return;

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -246,7 +246,8 @@ class TllmGenFmhaKernel {
                          bool dynamicNumTokensPerPage, bool reuseSmemKForV, bool uses2CtaMma,
                          bool groupsTokensHeadsQ, int sparseMlaType, bool skipsSoftmax,
                          int bf16QFp8KvTransformMode, bool uses2QSlidingWindowKernel,
-                         bool fp16Softmax, bool usesSpcompress) const {
+                         bool fp16Softmax, bool usesSpcompress, bool fusesDsv4InvRopeFp8Quant,
+                         bool usesDsv4Ue8m0ScaleO) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -264,6 +265,8 @@ class TllmGenFmhaKernel {
                      "The sparse MLA type must fit in 2 bits.");
     FLASHINFER_CHECK(bf16QFp8KvTransformMode >= 0 && bf16QFp8KvTransformMode <= 2,
                      "The BF16Q FP8KV transform mode must fit in 2 bits.");
+    FLASHINFER_CHECK(!usesDsv4Ue8m0ScaleO || fusesDsv4InvRopeFp8Quant,
+                     "DSv4 UE8M0 output scales require the fused inverse-RoPE FP8 epilogue.");
     // The enum fields are packed tightly, so an out-of-range value would alias onto its neighbour
     // instead of producing a distinct key. Check them rather than trusting the exporter.
     uint64_t const numTokensPerPageLog2 =
@@ -303,7 +306,9 @@ class TllmGenFmhaKernel {
     // Bit 54 - 54: uses2QSlidingWindowKernel (Keeps generation 2Qx1KV SlidingWindowCustom).
     // Bit 55 - 55: fp16Softmax.
     // Bit 56 - 56: usesSpcompress.
-    // Bit 57 - 63: unused.
+    // Bit 57 - 57: fusesDsv4InvRopeFp8Quant.
+    // Bit 58 - 58: usesDsv4Ue8m0ScaleO.
+    // Bit 59 - 63: unused.
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 2) |
            (static_cast<uint64_t>(kernelType) << 5) | (static_cast<uint64_t>(scheduler) << 8) |
            (static_cast<uint64_t>(multiCtasKvMode) << 10) |
@@ -321,7 +326,9 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(groupsTokensHeadsQ) << 53) |
            (static_cast<uint64_t>(uses2QSlidingWindowKernel) << 54) |
            (static_cast<uint64_t>(fp16Softmax) << 55) |
-           (static_cast<uint64_t>(usesSpcompress) << 56);
+           (static_cast<uint64_t>(usesSpcompress) << 56) |
+           (static_cast<uint64_t>(fusesDsv4InvRopeFp8Quant) << 57) |
+           (static_cast<uint64_t>(usesDsv4Ue8m0ScaleO) << 58);
   }
 
   inline bool is2QSlidingWindowKernel(KernelMeta const& kernelMeta) const {
@@ -344,7 +351,8 @@ class TllmGenFmhaKernel {
         kernelMeta.mSparseAttn, kernelMeta.mSkipsSoftmaxWhenPossible,
         getBf16QFp8KvTransformMode(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform,
                                    kernelMeta.mSeparateTransformedKv),
-        is2QSlidingWindowKernel(kernelMeta), kernelMeta.mFp16Softmax, kernelMeta.mUsesSpcompress);
+        is2QSlidingWindowKernel(kernelMeta), kernelMeta.mFp16Softmax, kernelMeta.mUsesSpcompress,
+        kernelMeta.mFusesDsv4InvRopeFp8Quant, kernelMeta.mUsesDsv4Ue8m0ScaleO);
   }
 
   std::pair<bool, std::string> checkIfKernelExist(RunnerParams const& params) const {
@@ -918,6 +926,24 @@ class TllmGenFmhaKernel {
   // Select the MLA generation kernel.
   void selectMlaGenerationKernel(RunnerParams const& params,
                                  SelectKernelParams& selectKernelParams) const {
+    if (params.mFusesDsv4InvRopeFp8Quant) {
+      FLASHINFER_CHECK(params.isSparseMla() && params.mHeadDimQk == 512 &&
+                           params.mHeadDimV == 512 && params.mNumHeadsQPerKv == 128,
+                       "DSv4 RopeQuant requires dynamic sparse MLA with 128 query heads and "
+                       "head dimension 512.");
+      selectKernelParams.mKernelType = FmhaKernelType::KeepsMmaAbForGeneration;
+      selectKernelParams.mTileScheduler = TileScheduler::Persistent;
+      selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::Disabled;
+      selectKernelParams.mForceGmemReduction = true;
+      selectKernelParams.mHeadDimPerCtaV = 256;
+      selectKernelParams.mTileSizeQ = 64;
+      selectKernelParams.mTileSizeKv = 128;
+      selectKernelParams.mReuseSmemKForV = false;
+      selectKernelParams.mGroupsTokensHeadsQ = false;
+      selectKernelParams.mUses2CtaMma = true;
+      return;
+    }
+
     if (usesGroupedMlaGenerationKernel(params)) {
       selectGroupedMlaGenerationKernel(params, selectKernelParams);
       return;
@@ -1228,7 +1254,9 @@ class TllmGenFmhaKernel {
         ", bf16QFp8KvTransformMode=" +
         std::to_string(static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)) +
         ", fp16Softmax=" + std::to_string(selectKernelParams.mUseFp16Softmax) +
-        ", usesSpcompress=" + std::to_string(selectKernelParams.mUsesSpcompress);
+        ", usesSpcompress=" + std::to_string(selectKernelParams.mUsesSpcompress) +
+        ", fusesDsv4InvRopeFp8Quant=" + std::to_string(params.mFusesDsv4InvRopeFp8Quant) +
+        ", usesDsv4Ue8m0ScaleO=" + std::to_string(params.mFusesDsv4InvRopeFp8Quant);
     IKL_LOG_DEBUG(
         "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
         getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut),
@@ -1247,7 +1275,8 @@ class TllmGenFmhaKernel {
                selectKernelParams.mSkipsSoftmaxWhenPossible,
                static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode),
                /*uses2QSlidingWindowKernel=*/false, selectKernelParams.mUseFp16Softmax,
-               selectKernelParams.mUsesSpcompress),
+               selectKernelParams.mUsesSpcompress, params.mFusesDsv4InvRopeFp8Quant,
+               /*usesDsv4Ue8m0ScaleO=*/params.mFusesDsv4InvRopeFp8Quant),
         info);
   }
 

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -664,6 +664,11 @@ class TllmGenFmhaKernel {
       numCtasPerSeqKv = std::min(
           tunedMaxNumCtasPerSeqKv,
           std::max(1, int32_t(params.mMultiProcessorCount / (numCtasX * numCtasY * numCtasZ))));
+      // If no fused cubin matched, the BF16 carrier must produce at least two partials so the
+      // separate reduction kernel can apply the requested DSv4 output epilogue.
+      if (params.dsv4OScalePtr != nullptr && !params.mFusesDsv4InvRopeFp8Quant) {
+        numCtasPerSeqKv = std::max(numCtasPerSeqKv, 2);
+      }
       // Update the numCtasX.
       numCtasX *= numCtasPerSeqKv;
       // The current total number of CTAs.
@@ -926,24 +931,6 @@ class TllmGenFmhaKernel {
   // Select the MLA generation kernel.
   void selectMlaGenerationKernel(RunnerParams const& params,
                                  SelectKernelParams& selectKernelParams) const {
-    if (params.mFusesDsv4InvRopeFp8Quant) {
-      FLASHINFER_CHECK(params.isSparseMla() && params.mHeadDimQk == 512 &&
-                           params.mHeadDimV == 512 && params.mNumHeadsQPerKv == 128,
-                       "DSv4 RopeQuant requires dynamic sparse MLA with 128 query heads and "
-                       "head dimension 512.");
-      selectKernelParams.mKernelType = FmhaKernelType::KeepsMmaAbForGeneration;
-      selectKernelParams.mTileScheduler = TileScheduler::Persistent;
-      selectKernelParams.mMultiCtasKvMode = MultiCtasKvMode::Disabled;
-      selectKernelParams.mForceGmemReduction = true;
-      selectKernelParams.mHeadDimPerCtaV = 256;
-      selectKernelParams.mTileSizeQ = 64;
-      selectKernelParams.mTileSizeKv = 128;
-      selectKernelParams.mReuseSmemKForV = false;
-      selectKernelParams.mGroupsTokensHeadsQ = false;
-      selectKernelParams.mUses2CtaMma = true;
-      return;
-    }
-
     if (usesGroupedMlaGenerationKernel(params)) {
       selectGroupedMlaGenerationKernel(params, selectKernelParams);
       return;
@@ -1255,8 +1242,9 @@ class TllmGenFmhaKernel {
         std::to_string(static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)) +
         ", fp16Softmax=" + std::to_string(selectKernelParams.mUseFp16Softmax) +
         ", usesSpcompress=" + std::to_string(selectKernelParams.mUsesSpcompress) +
-        ", fusesDsv4InvRopeFp8Quant=" + std::to_string(params.mFusesDsv4InvRopeFp8Quant) +
-        ", usesDsv4Ue8m0ScaleO=" + std::to_string(params.mFusesDsv4InvRopeFp8Quant);
+        ", fusesDsv4InvRopeFp8Quant=" +
+        std::to_string(selectKernelParams.mFusesDsv4InvRopeFp8Quant) +
+        ", usesDsv4Ue8m0ScaleO=" + std::to_string(selectKernelParams.mFusesDsv4InvRopeFp8Quant);
     IKL_LOG_DEBUG(
         "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
         getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut),
@@ -1275,8 +1263,8 @@ class TllmGenFmhaKernel {
                selectKernelParams.mSkipsSoftmaxWhenPossible,
                static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode),
                /*uses2QSlidingWindowKernel=*/false, selectKernelParams.mUseFp16Softmax,
-               selectKernelParams.mUsesSpcompress, params.mFusesDsv4InvRopeFp8Quant,
-               /*usesDsv4Ue8m0ScaleO=*/params.mFusesDsv4InvRopeFp8Quant),
+               selectKernelParams.mUsesSpcompress, selectKernelParams.mFusesDsv4InvRopeFp8Quant,
+               /*usesDsv4Ue8m0ScaleO=*/selectKernelParams.mFusesDsv4InvRopeFp8Quant),
         info);
   }
 

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -264,6 +264,9 @@ struct TllmGenFmhaRunnerParams {
   void* oPtr;
   // The output scaling factor buffer.
   void* oSfPtr;
+  // DSv4 fused inverse-RoPE + FP8 quantization inputs/outputs.
+  float const* dsv4InvRopeCosSinCachePtr;
+  float* dsv4OScalePtr;
 
   // The stride between different tokens for Q.
   int qStrideTokens;
@@ -346,8 +349,12 @@ struct TllmGenFmhaRunnerParams {
   TrtllmGenSparseMlaType mSparseMlaType;
   // The top k value for sparse MLA.
   int mSparseMlaTopK;
+  // Padded token dimension of the DSv4 packed UE8M0 output-scale tensor.
+  int mDsv4ScaleBufM;
   // Whether DSv4 sparse MLA should read tile 0 from slidingWindowKvPoolPtr.
   bool mHasSlidingWindowKvPool;
+  // Whether the fixed DSv4 inverse-RoPE + FP8 quant epilogue is selected.
+  bool mFusesDsv4InvRopeFp8Quant;
   // Transform mode for BF16 query + FP8 KV generation kernels.
   Bf16QFp8KvTransformMode mBf16QFp8KvTransformMode;
   // Whether the indices for K & V pages are shared as unified index.

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -350,7 +350,7 @@ struct TllmGenFmhaRunnerParams {
   // The top k value for sparse MLA.
   int mSparseMlaTopK;
   // Padded token dimension of the DSv4 packed UE8M0 output-scale tensor.
-  int mDsv4ScaleBufM;
+  int64_t mDsv4ScaleBufM;
   // Whether DSv4 sparse MLA should read tile 0 from slidingWindowKvPoolPtr.
   bool mHasSlidingWindowKvPool;
   // Whether the fixed DSv4 inverse-RoPE + FP8 quant epilogue is selected.
@@ -433,6 +433,8 @@ struct TllmGenSelectKernelParams {
   bool mUseFp16Softmax;
   // Use spcompress or not.
   bool mUsesSpcompress;
+  // Select the DSv4 inverse-RoPE + E4M3/UE8M0 fused cubin when its exact key exists.
+  bool mFusesDsv4InvRopeFp8Quant;
   // The tile scheduler.
   TileScheduler mTileScheduler;
   // The tile size for Q.
@@ -452,8 +454,9 @@ struct TllmGenSelectKernelParams {
         mHeadDimPerCtaV(params.mHeadDimV)
         // Note the CgaSmemReduction will be enabled based on the heuristic.
         ,
-        mMultiCtasKvMode(params.mMultiCtasKvMode ? MultiCtasKvMode::GmemReduction
-                                                 : MultiCtasKvMode::Disabled),
+        mMultiCtasKvMode((params.mMultiCtasKvMode && !params.mFusesDsv4InvRopeFp8Quant)
+                             ? MultiCtasKvMode::GmemReduction
+                             : MultiCtasKvMode::Disabled),
         mForceGmemReduction(false),
         mMaskType(params.mMaskType),
         mNumTokensPerPage(params.mNumTokensPerPage),
@@ -463,7 +466,9 @@ struct TllmGenSelectKernelParams {
         mSkipsSoftmaxWhenPossible(params.mSkipsSoftmaxWhenPossible),
         mUseFp16Softmax(params.mUseFp16Softmax),
         mUsesSpcompress(params.mUsesSpcompress),
-        mTileScheduler(params.mTileScheduler),
+        mFusesDsv4InvRopeFp8Quant(params.mFusesDsv4InvRopeFp8Quant),
+        mTileScheduler(params.mFusesDsv4InvRopeFp8Quant ? TileScheduler::Persistent
+                                                        : params.mTileScheduler),
         mTileSizeQ(128),
         mTileSizeKv(128),
         mUses2CtaMma(false),

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -454,9 +454,8 @@ struct TllmGenSelectKernelParams {
         mHeadDimPerCtaV(params.mHeadDimV)
         // Note the CgaSmemReduction will be enabled based on the heuristic.
         ,
-        mMultiCtasKvMode((params.mMultiCtasKvMode && !params.mFusesDsv4InvRopeFp8Quant)
-                             ? MultiCtasKvMode::GmemReduction
-                             : MultiCtasKvMode::Disabled),
+        mMultiCtasKvMode(params.mMultiCtasKvMode ? MultiCtasKvMode::GmemReduction
+                                                 : MultiCtasKvMode::Disabled),
         mForceGmemReduction(false),
         mMaskType(params.mMaskType),
         mNumTokensPerPage(params.mNumTokensPerPage),
@@ -467,8 +466,7 @@ struct TllmGenSelectKernelParams {
         mUseFp16Softmax(params.mUseFp16Softmax),
         mUsesSpcompress(params.mUsesSpcompress),
         mFusesDsv4InvRopeFp8Quant(params.mFusesDsv4InvRopeFp8Quant),
-        mTileScheduler(params.mFusesDsv4InvRopeFp8Quant ? TileScheduler::Persistent
-                                                        : params.mTileScheduler),
+        mTileScheduler(params.mTileScheduler),
         mTileSizeQ(128),
         mTileSizeKv(128),
         mUses2CtaMma(false),

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -79,12 +79,11 @@ struct KernelParams {
   int64_t const* ptrCustomMaskOffsets;
   // The debug output matrix O
   float* ptrDebugO;
-  // DSv4 inverse-RoPE + FP8 quant fusion metadata and output scale tensor, only for epilogue
-  // fusion. Unused by FlashInfer but part of the kernel-side KernelParams ABI; the field order
-  // must stay in sync with the kernels or every later field is misread by the cubins.
+  // DSv4 inverse-RoPE + FP8 quant fusion metadata and output scale tensor. The field order must
+  // stay in sync with the kernels or every later field is misread by the cubins.
   float const* ptrDsv4InvRopeCosSinCache;
-  // Dsv4 output block-scaled tensor, only for epilogue fusion
-  float* ptrDsv4OScaleFp32;
+  // DSv4 output scales. RopeQuant cubins interpret this as packed UE8M0 bytes in INT32 storage.
+  float* ptrDsv4OScale;
   // The first sparseMask offsets in the Kv sequence dimension.
   int32_t const* ptrFirstSparseMaskOffsetsKv;
   // The counter for the multiCtasKv mode.
@@ -136,8 +135,7 @@ struct KernelParams {
   int32_t mBatchSize;
   // The chunked attention size in log2.
   int32_t mChunkedAttentionSizeLog2;
-  // Padded token dimension for the DSv4 fused FP32 scale layout. Unused by FlashInfer; kept for
-  // the KernelParams ABI (see the DSv4 pointer fields above).
+  // Padded token dimension for the DSv4 fused packed UE8M0 scale layout.
   int64_t mDsv4ScaleBufM;
   // The factor to add to the maximum value to increase the probability
   //   of skip correction during next iterations.
@@ -845,6 +843,8 @@ struct KernelParams {
     params.ptrO = options.oPtr;
     // The output scaling factor buffer.
     params.ptrSfO = options.oSfPtr;
+    params.ptrDsv4InvRopeCosSinCache = options.dsv4InvRopeCosSinCachePtr;
+    params.ptrDsv4OScale = options.dsv4OScalePtr;
 
     // TRT-LLM restrictions: the quantization scales must be on the device.
     params.ptrOutputScale = options.outputScalePtr;
@@ -907,6 +907,7 @@ struct KernelParams {
     params.mNumHiddenEltsO = options.mNumHeadsQ * options.mHeadDimQk;
     params.mNumTokensPerCtaQ = numTokensPerCtaQ;
     params.mOutputScale = options.outputScale;
+    params.mDsv4ScaleBufM = options.mDsv4ScaleBufM;
     params.mScaleSoftmaxLog2 = options.scaleSoftmaxLog2;
     params.mSkipSoftmaxThresholdScaleFactor = options.mSkipSoftmaxThresholdScaleFactor;
     params.mStartTokenIdxSfO = options.mSfStartTokenIdx;

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -1,14 +1,15 @@
 import dataclasses
+import math
 import random
 from typing import Literal
 
 import pytest
 import torch
 
+import flashinfer.mla._core as mla_core
 from flashinfer.mla import trtllm_batch_decode_sparse_mla_dsv4
 from flashinfer.mla._core import get_trtllm_gen_fmha_module
 from flashinfer.utils import get_compute_capability
-
 
 WORKSPACE_SIZE = 128 * 1024 * 1024
 DSV4_HEAD_DIM = 512
@@ -930,6 +931,8 @@ def test_trtllm_gen_sparse_mla_rejects_remap_buffer_on_other_device() -> None:
             1,
             None,
             None,
+            None,
+            None,
         )
 
 
@@ -1196,3 +1199,259 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph(monkeypatch) -> Non
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
     out_ref = out_ref[testcase.valid_q]
     _assert_close(out_ans, out_ref, p.dtype)
+
+
+@pytest.mark.parametrize("num_tokens", (1, 3, 4, 5))
+def test_dsv4_rope_quant_output_layout(num_tokens):
+    out, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
+        num_tokens, 128, torch.device("cpu")
+    )
+    scale_buf_m = _round_up(num_tokens, 4)
+
+    assert out.shape == (num_tokens, 16, 4096)
+    assert out.dtype == torch.float8_e4m3fn
+    assert out.stride() == (4096, num_tokens * 4096, 1)
+    assert out_scale.shape == (num_tokens, 16, 8)
+    assert out_scale.dtype == torch.int32
+    assert out_scale.stride() == (1, 8 * scale_buf_m, scale_buf_m)
+    scale_storage = out_scale.as_strided(
+        (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
+    )
+    assert torch.all(scale_storage[..., num_tokens:] == 0)
+    mla_core._check_dsv4_rope_quant_outputs(
+        out,
+        out_scale,
+        num_tokens=num_tokens,
+        num_heads=128,
+        device=torch.device("cpu"),
+    )
+
+
+def test_dsv4_rope_quant_rejects_contiguous_output_layout():
+    out = torch.empty((3, 16, 4096), dtype=torch.float8_e4m3fn)
+    _, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
+        3, 128, torch.device("cpu")
+    )
+    with pytest.raises(ValueError, match="group-major strides"):
+        mla_core._check_dsv4_rope_quant_outputs(
+            out,
+            out_scale,
+            num_tokens=3,
+            num_heads=128,
+            device=torch.device("cpu"),
+        )
+
+
+def test_dsv4_output_scale_does_not_enable_rope_quant(monkeypatch):
+    monkeypatch.setattr(mla_core, "get_compute_capability", lambda _device: (10, 0))
+    with pytest.raises(ValueError, match="requires dsv4_inv_rope_cos_sin_cache"):
+        trtllm_batch_decode_sparse_mla_dsv4(
+            query=torch.empty((1, 1, 128, 512), dtype=torch.float8_e4m3fn),
+            swa_kv_cache=torch.empty((1, 1, 1, 512), dtype=torch.float8_e4m3fn),
+            workspace_buffer=torch.empty(1, dtype=torch.uint8),
+            backend="trtllm-gen",
+            dsv4_output_scale=torch.empty((1, 16, 8), dtype=torch.int32),
+        )
+
+
+def _dsv4_rope_quant_cpu_inputs(num_tokens=3, cache_rows=4):
+    out, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
+        num_tokens, 128, torch.device("cpu")
+    )
+    return {
+        "query": torch.empty((1, num_tokens, 128, 512), dtype=torch.float8_e4m3fn),
+        "swa_kv_cache": torch.empty((1, 1, 128, 512), dtype=torch.float8_e4m3fn),
+        "workspace_buffer": torch.empty(1, dtype=torch.uint8),
+        "sparse_indices": torch.zeros((num_tokens, 128), dtype=torch.int32),
+        "compressed_kv_cache": torch.empty((1, 1, 1, 512), dtype=torch.float8_e4m3fn),
+        "sparse_topk_lens": torch.full((num_tokens,), 128, dtype=torch.int32),
+        "seq_lens": torch.tensor([num_tokens + 1], dtype=torch.int32),
+        "out": out,
+        "backend": "trtllm-gen",
+        "enable_pdl": False,
+        "dsv4_inv_rope_cos_sin_cache": torch.empty(
+            (cache_rows, 64), dtype=torch.float32
+        ),
+        "dsv4_output_scale": out_scale,
+    }
+
+
+def test_dsv4_rope_quant_validates_cos_sin_cache_bounds(monkeypatch):
+    args = _dsv4_rope_quant_cpu_inputs(cache_rows=3)
+    monkeypatch.setattr(mla_core, "get_compute_capability", lambda _device: (10, 0))
+    monkeypatch.setattr(mla_core, "_validate_dsv4_sync_checks", lambda _device: True)
+    with pytest.raises(ValueError, match="does not cover all derived query positions"):
+        trtllm_batch_decode_sparse_mla_dsv4(**args)
+
+
+def test_dsv4_rope_quant_validates_zero_scale_padding(monkeypatch):
+    args = _dsv4_rope_quant_cpu_inputs()
+    out_scale = args["dsv4_output_scale"]
+    scale_buf_m = out_scale.stride(2)
+    scale_storage = out_scale.as_strided(
+        (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
+    )
+    scale_storage[..., 3:].fill_(1)
+    monkeypatch.setattr(mla_core, "get_compute_capability", lambda _device: (10, 0))
+    monkeypatch.setattr(mla_core, "_validate_dsv4_sync_checks", lambda _device: True)
+    with pytest.raises(ValueError, match="padded token rows must be zero-initialized"):
+        trtllm_batch_decode_sparse_mla_dsv4(**args)
+
+
+def _unpack_ue8m0_scales(packed: torch.Tensor) -> torch.Tensor:
+    shifts = torch.arange(4, dtype=torch.int32, device=packed.device) * 8
+    exponent_bytes = (packed.unsqueeze(-1) >> shifts) & 0xFF
+    return torch.exp2(exponent_bytes.float() - 127.0)
+
+
+def _inverse_rope_reference(
+    output: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    positions: torch.Tensor,
+) -> torch.Tensor:
+    reference = output.float().reshape(output.shape[0], 16, 8, 512).clone()
+    rope = reference[..., 448:].reshape(*reference.shape[:-1], 32, 2)
+    first = rope[..., 0].clone()
+    second = rope[..., 1].clone()
+    cos_sin = cos_sin_cache.index_select(0, positions)
+    cos = cos_sin[:, :32].reshape(output.shape[0], 1, 1, 32)
+    sin = cos_sin[:, 32:].reshape(output.shape[0], 1, 1, 32)
+    rope[..., 0] = first * cos + second * sin
+    rope[..., 1] = second * cos - first * sin
+    return reference
+
+
+@pytest.mark.arch_blackwell
+def test_trtllm_gen_dsv4_rope_quant_correctness():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if get_compute_capability(torch.device("cuda")) not in ((10, 0), (10, 3)):
+        pytest.skip("TRTLLM-GEN DSv4 RopeQuant requires SM100/SM103")
+
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    batch_size, q_len, num_heads, head_dim = 2, 3, 128, 512
+    num_tokens = batch_size * q_len
+    page_size = 32
+    topk = 128
+
+    query = torch.randn((batch_size, q_len, num_heads, head_dim), device=device).clamp_(
+        -1.0, 1.0
+    )
+    query = query.to(torch.float8_e4m3fn)
+    swa_cache = torch.randn(
+        (topk // page_size, 1, page_size, head_dim), device=device
+    ).clamp_(-1.0, 1.0)
+    swa_cache = swa_cache.to(torch.float8_e4m3fn)
+    compressed_cache = torch.zeros(
+        (1, 1, 1, head_dim), dtype=torch.float8_e4m3fn, device=device
+    )
+    sparse_indices = torch.arange(topk, dtype=torch.int32, device=device).repeat(
+        num_tokens, 1
+    )
+    sparse_topk_lens = torch.full((num_tokens,), topk, dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([topk, topk - 8], dtype=torch.int32, device=device)
+    workspace = torch.empty(64 << 20, dtype=torch.uint8, device=device)
+    softmax_scale = 1.0 / math.sqrt(head_dim)
+
+    baseline = trtllm_batch_decode_sparse_mla_dsv4(
+        query=query,
+        swa_kv_cache=swa_cache,
+        workspace_buffer=workspace,
+        sparse_indices=sparse_indices,
+        compressed_kv_cache=compressed_cache,
+        sparse_topk_lens=sparse_topk_lens,
+        seq_lens=seq_lens,
+        bmm1_scale=softmax_scale,
+        backend="trtllm-gen",
+        enable_pdl=False,
+    )
+
+    cache_positions = torch.arange(topk, dtype=torch.float32, device=device)[:, None]
+    rope_dims = torch.arange(32, dtype=torch.float32, device=device)[None, :]
+    angles = cache_positions * 0.07 + rope_dims * 0.03
+    cos_sin_cache = torch.cat((torch.cos(angles), torch.sin(angles)), dim=-1)
+    out, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
+        num_tokens, num_heads, device
+    )
+    scale_buf_m = out_scale.stride(2)
+    scale_storage = out_scale.as_strided(
+        (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
+    )
+    scale_storage.zero_()
+    out_scale.fill_(0x5A5A5A5A)
+
+    result = trtllm_batch_decode_sparse_mla_dsv4(
+        query=query,
+        swa_kv_cache=swa_cache,
+        workspace_buffer=workspace,
+        sparse_indices=sparse_indices,
+        compressed_kv_cache=compressed_cache,
+        sparse_topk_lens=sparse_topk_lens,
+        seq_lens=seq_lens,
+        out=out,
+        bmm1_scale=softmax_scale,
+        backend="trtllm-gen",
+        enable_pdl=False,
+        dsv4_inv_rope_cos_sin_cache=cos_sin_cache,
+        dsv4_output_scale=out_scale,
+    )
+    result_out, result_scale = result
+    torch.cuda.synchronize()
+
+    assert result_out is out
+    assert result_scale is out_scale
+    assert torch.all(scale_storage[..., num_tokens:] == 0)
+
+    scales = _unpack_ue8m0_scales(out_scale)
+    dequant = out.reshape(num_tokens, 16, 8, 4, 128).float()
+    dequant = dequant * scales.unsqueeze(-1)
+    positions = torch.cat(
+        tuple(
+            torch.arange(seq_len - q_len, seq_len, dtype=torch.int64, device=device)
+            for seq_len in seq_lens.tolist()
+        )
+    )
+    reference = _inverse_rope_reference(
+        baseline.reshape(num_tokens, 128, 512), cos_sin_cache, positions
+    )
+    reference_blocks = reference.reshape(num_tokens, 16, 8, 4, 128)
+
+    reference_amax = reference_blocks.abs().amax(dim=-1).clamp_min(1.0e-10)
+    reference_scales = torch.exp2(torch.ceil(torch.log2(reference_amax / 448.0)))
+    # The fused path quantizes the FP32 attention accumulator, whereas the
+    # comparison path first stores BF16. A block exactly at a power-of-two
+    # boundary may therefore select either neighboring exponent.
+    assert torch.all((torch.log2(scales) - torch.log2(reference_scales)).abs() <= 1)
+
+    # FP8 E4M3 contributes at most 16 * scale at the largest bin. Include a
+    # small allowance for the BF16 store in the non-fused attention reference.
+    error_bound = 16.0 * scales.unsqueeze(-1) + 2.0e-3
+    assert torch.all((dequant - reference_blocks).abs() <= error_bound)
+
+    expected_out = out.clone()
+    expected_scale = out_scale.clone()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_result = trtllm_batch_decode_sparse_mla_dsv4(
+            query=query,
+            swa_kv_cache=swa_cache,
+            workspace_buffer=workspace,
+            sparse_indices=sparse_indices,
+            compressed_kv_cache=compressed_cache,
+            sparse_topk_lens=sparse_topk_lens,
+            seq_lens=seq_lens,
+            out=out,
+            bmm1_scale=softmax_scale,
+            backend="trtllm-gen",
+            enable_pdl=False,
+            dsv4_inv_rope_cos_sin_cache=cos_sin_cache,
+            dsv4_output_scale=out_scale,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+    assert graph_result[0] is out
+    assert graph_result[1] is out_scale
+    torch.testing.assert_close(out, expected_out, atol=0, rtol=0)
+    torch.testing.assert_close(out_scale, expected_scale, atol=0, rtol=0)
+    assert torch.all(scale_storage[..., num_tokens:] == 0)

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -1218,28 +1218,6 @@ def test_dsv4_rope_quant_output_layout(num_tokens):
         (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
     )
     assert torch.all(scale_storage[..., num_tokens:] == 0)
-    mla_core._check_dsv4_rope_quant_outputs(
-        out,
-        out_scale,
-        num_tokens=num_tokens,
-        num_heads=128,
-        device=torch.device("cpu"),
-    )
-
-
-def test_dsv4_rope_quant_rejects_contiguous_output_layout():
-    out = torch.empty((3, 16, 4096), dtype=torch.float8_e4m3fn)
-    _, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
-        3, 128, torch.device("cpu")
-    )
-    with pytest.raises(ValueError, match="group-major strides"):
-        mla_core._check_dsv4_rope_quant_outputs(
-            out,
-            out_scale,
-            num_tokens=3,
-            num_heads=128,
-            device=torch.device("cpu"),
-        )
 
 
 def test_dsv4_output_scale_does_not_enable_rope_quant(monkeypatch):
@@ -1252,50 +1230,6 @@ def test_dsv4_output_scale_does_not_enable_rope_quant(monkeypatch):
             backend="trtllm-gen",
             dsv4_output_scale=torch.empty((1, 16, 8), dtype=torch.int32),
         )
-
-
-def _dsv4_rope_quant_cpu_inputs(num_tokens=3, cache_rows=4):
-    out, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
-        num_tokens, 128, torch.device("cpu")
-    )
-    return {
-        "query": torch.empty((1, num_tokens, 128, 512), dtype=torch.float8_e4m3fn),
-        "swa_kv_cache": torch.empty((1, 1, 128, 512), dtype=torch.float8_e4m3fn),
-        "workspace_buffer": torch.empty(1, dtype=torch.uint8),
-        "sparse_indices": torch.zeros((num_tokens, 128), dtype=torch.int32),
-        "compressed_kv_cache": torch.empty((1, 1, 1, 512), dtype=torch.float8_e4m3fn),
-        "sparse_topk_lens": torch.full((num_tokens,), 128, dtype=torch.int32),
-        "seq_lens": torch.tensor([num_tokens + 1], dtype=torch.int32),
-        "out": out,
-        "backend": "trtllm-gen",
-        "enable_pdl": False,
-        "dsv4_inv_rope_cos_sin_cache": torch.empty(
-            (cache_rows, 64), dtype=torch.float32
-        ),
-        "dsv4_output_scale": out_scale,
-    }
-
-
-def test_dsv4_rope_quant_validates_cos_sin_cache_bounds(monkeypatch):
-    args = _dsv4_rope_quant_cpu_inputs(cache_rows=3)
-    monkeypatch.setattr(mla_core, "get_compute_capability", lambda _device: (10, 0))
-    monkeypatch.setattr(mla_core, "_validate_dsv4_sync_checks", lambda _device: True)
-    with pytest.raises(ValueError, match="does not cover all derived query positions"):
-        trtllm_batch_decode_sparse_mla_dsv4(**args)
-
-
-def test_dsv4_rope_quant_validates_zero_scale_padding(monkeypatch):
-    args = _dsv4_rope_quant_cpu_inputs()
-    out_scale = args["dsv4_output_scale"]
-    scale_buf_m = out_scale.stride(2)
-    scale_storage = out_scale.as_strided(
-        (16, 8, scale_buf_m), (8 * scale_buf_m, scale_buf_m, 1)
-    )
-    scale_storage[..., 3:].fill_(1)
-    monkeypatch.setattr(mla_core, "get_compute_capability", lambda _device: (10, 0))
-    monkeypatch.setattr(mla_core, "_validate_dsv4_sync_checks", lambda _device: True)
-    with pytest.raises(ValueError, match="padded token rows must be zero-initialized"):
-        trtllm_batch_decode_sparse_mla_dsv4(**args)
 
 
 def _unpack_ue8m0_scales(packed: torch.Tensor) -> torch.Tensor:
@@ -1321,7 +1255,7 @@ def _inverse_rope_reference(
     return reference
 
 
-# q=1 batches 1/4/8 cover reduction spans 128/256/512; batch 16 and q>1 use the fused cubin.
+# Cover the fixed 128-head fused schedule across decode shapes, top-k values, and varlen input.
 @pytest.mark.arch_blackwell
 @pytest.mark.parametrize(
     ("batch_size", "q_len", "topk", "is_varlen"),
@@ -1470,8 +1404,6 @@ def test_trtllm_gen_dsv4_rope_quant_correctness(batch_size, q_len, topk, is_varl
     # boundary may therefore select either neighboring exponent.
     assert torch.all((torch.log2(scales) - torch.log2(reference_scales)).abs() <= 1)
 
-    # The fallback intentionally changes the attention reduction topology by
-    # forcing a KV split; use the established FP8 attention tolerance.
     torch.testing.assert_close(dequant, reference_blocks, rtol=0.1, atol=0.1)
 
     if (batch_size, q_len, topk, is_varlen) != (2, 3, 128, False):

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -1232,6 +1232,33 @@ def test_dsv4_output_scale_does_not_enable_rope_quant(monkeypatch):
         )
 
 
+def test_dsv4_rope_quant_rejects_undersized_cos_sin_cache(monkeypatch):
+    num_tokens = 3
+    out, out_scale = mla_core._allocate_dsv4_rope_quant_outputs(
+        num_tokens, 128, torch.device("cpu")
+    )
+    monkeypatch.setattr(mla_core, "get_compute_capability", lambda _device: (10, 0))
+    monkeypatch.setenv("FLASHINFER_VALIDATE_INPUTS", "1")
+
+    with pytest.raises(ValueError, match="does not cover all derived query positions"):
+        trtllm_batch_decode_sparse_mla_dsv4(
+            query=torch.empty((1, num_tokens, 128, 512), dtype=torch.float8_e4m3fn),
+            swa_kv_cache=torch.empty((1, 1, 128, 512), dtype=torch.float8_e4m3fn),
+            workspace_buffer=torch.empty(1, dtype=torch.uint8),
+            sparse_indices=torch.zeros((num_tokens, 128), dtype=torch.int32),
+            compressed_kv_cache=torch.empty((1, 1, 1, 512), dtype=torch.float8_e4m3fn),
+            sparse_topk_lens=torch.full((num_tokens,), 128, dtype=torch.int32),
+            seq_lens=torch.tensor([num_tokens + 1], dtype=torch.int32),
+            out=out,
+            backend="trtllm-gen",
+            enable_pdl=False,
+            dsv4_inv_rope_cos_sin_cache=torch.empty(
+                (num_tokens, 64), dtype=torch.float32
+            ),
+            dsv4_output_scale=out_scale,
+        )
+
+
 def _unpack_ue8m0_scales(packed: torch.Tensor) -> torch.Tensor:
     shifts = torch.arange(4, dtype=torch.int32, device=packed.device) * 8
     exponent_bytes = (packed.unsqueeze(-1) >> shifts) & 0xFF

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -1321,8 +1321,21 @@ def _inverse_rope_reference(
     return reference
 
 
+# q=1 batches 1/4/8 cover reduction spans 128/256/512; batch 16 and q>1 use the fused cubin.
 @pytest.mark.arch_blackwell
-def test_trtllm_gen_dsv4_rope_quant_correctness():
+@pytest.mark.parametrize(
+    ("batch_size", "q_len", "topk", "is_varlen"),
+    (
+        (1, 1, 2048, False),
+        (4, 1, 2048, False),
+        (8, 1, 2048, False),
+        (16, 1, 2048, False),
+        (4, 1, 256, False),
+        (2, 3, 128, False),
+        (16, 4, 2048, True),
+    ),
+)
+def test_trtllm_gen_dsv4_rope_quant_correctness(batch_size, q_len, topk, is_varlen):
     if not torch.cuda.is_available():
         pytest.skip("CUDA is required")
     if get_compute_capability(torch.device("cuda")) not in ((10, 0), (10, 3)):
@@ -1330,29 +1343,54 @@ def test_trtllm_gen_dsv4_rope_quant_correctness():
 
     torch.manual_seed(7)
     device = torch.device("cuda")
-    batch_size, q_len, num_heads, head_dim = 2, 3, 128, 512
-    num_tokens = batch_size * q_len
+    num_heads, head_dim = 128, 512
     page_size = 32
-    topk = 128
-
-    query = torch.randn((batch_size, q_len, num_heads, head_dim), device=device).clamp_(
-        -1.0, 1.0
+    q_lens = (
+        [max(1, q_len - batch_idx % q_len) for batch_idx in range(batch_size)]
+        if is_varlen
+        else [q_len] * batch_size
     )
+    num_tokens = sum(q_lens)
+    query_shape = (
+        (num_tokens, num_heads, head_dim)
+        if is_varlen
+        else (batch_size, q_len, num_heads, head_dim)
+    )
+    query = torch.randn(query_shape, device=device).clamp_(-1.0, 1.0)
     query = query.to(torch.float8_e4m3fn)
     swa_cache = torch.randn(
-        (topk // page_size, 1, page_size, head_dim), device=device
+        (128 // page_size, 1, page_size, head_dim), device=device
     ).clamp_(-1.0, 1.0)
     swa_cache = swa_cache.to(torch.float8_e4m3fn)
-    compressed_cache = torch.zeros(
-        (1, 1, 1, head_dim), dtype=torch.float8_e4m3fn, device=device
+    compressed_tokens = max(topk - 128, 1)
+    compressed_pages = (compressed_tokens + page_size - 1) // page_size
+    compressed_cache = torch.randn(
+        (compressed_pages, 1, page_size, head_dim), device=device
+    ).clamp_(-1.0, 1.0)
+    compressed_cache = compressed_cache.to(torch.float8_e4m3fn)
+    sparse_row = torch.cat(
+        (
+            torch.arange(128, dtype=torch.int32, device=device),
+            torch.arange(topk - 128, dtype=torch.int32, device=device),
+        )
     )
-    sparse_indices = torch.arange(topk, dtype=torch.int32, device=device).repeat(
-        num_tokens, 1
-    )
+    sparse_indices = sparse_row.repeat(num_tokens, 1)
     sparse_topk_lens = torch.full((num_tokens,), topk, dtype=torch.int32, device=device)
-    seq_lens = torch.tensor([topk, topk - 8], dtype=torch.int32, device=device)
-    workspace = torch.empty(64 << 20, dtype=torch.uint8, device=device)
+    seq_lens = torch.tensor(
+        [topk - (batch_idx % 4) * 8 for batch_idx in range(batch_size)],
+        dtype=torch.int32,
+        device=device,
+    )
+    cum_seq_lens_q = None
+    if is_varlen:
+        cum_seq_lens_q = torch.tensor(
+            [0, *torch.tensor(q_lens).cumsum(0).tolist()],
+            dtype=torch.int32,
+            device=device,
+        )
+    workspace = torch.empty(WORKSPACE_SIZE, dtype=torch.uint8, device=device)
     softmax_scale = 1.0 / math.sqrt(head_dim)
+    sinks = torch.linspace(2.0, 3.0, num_heads, dtype=torch.float32, device=device)
 
     baseline = trtllm_batch_decode_sparse_mla_dsv4(
         query=query,
@@ -1363,8 +1401,11 @@ def test_trtllm_gen_dsv4_rope_quant_correctness():
         sparse_topk_lens=sparse_topk_lens,
         seq_lens=seq_lens,
         bmm1_scale=softmax_scale,
+        sinks=sinks,
         backend="trtllm-gen",
         enable_pdl=False,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=q_len if is_varlen else None,
     )
 
     cache_positions = torch.arange(topk, dtype=torch.float32, device=device)[:, None]
@@ -1391,8 +1432,11 @@ def test_trtllm_gen_dsv4_rope_quant_correctness():
         seq_lens=seq_lens,
         out=out,
         bmm1_scale=softmax_scale,
+        sinks=sinks,
         backend="trtllm-gen",
         enable_pdl=False,
+        cum_seq_lens_q=cum_seq_lens_q,
+        max_q_len=q_len if is_varlen else None,
         dsv4_inv_rope_cos_sin_cache=cos_sin_cache,
         dsv4_output_scale=out_scale,
     )
@@ -1408,8 +1452,10 @@ def test_trtllm_gen_dsv4_rope_quant_correctness():
     dequant = dequant * scales.unsqueeze(-1)
     positions = torch.cat(
         tuple(
-            torch.arange(seq_len - q_len, seq_len, dtype=torch.int64, device=device)
-            for seq_len in seq_lens.tolist()
+            torch.arange(
+                seq_len - request_q_len, seq_len, dtype=torch.int64, device=device
+            )
+            for seq_len, request_q_len in zip(seq_lens.tolist(), q_lens, strict=True)
         )
     )
     reference = _inverse_rope_reference(
@@ -1424,10 +1470,12 @@ def test_trtllm_gen_dsv4_rope_quant_correctness():
     # boundary may therefore select either neighboring exponent.
     assert torch.all((torch.log2(scales) - torch.log2(reference_scales)).abs() <= 1)
 
-    # FP8 E4M3 contributes at most 16 * scale at the largest bin. Include a
-    # small allowance for the BF16 store in the non-fused attention reference.
-    error_bound = 16.0 * scales.unsqueeze(-1) + 2.0e-3
-    assert torch.all((dequant - reference_blocks).abs() <= error_bound)
+    # The fallback intentionally changes the attention reduction topology by
+    # forcing a KV split; use the established FP8 attention tolerance.
+    torch.testing.assert_close(dequant, reference_blocks, rtol=0.1, atol=0.1)
+
+    if (batch_size, q_len, topk, is_varlen) != (2, 3, 128, False):
+        return
 
     expected_out = out.clone()
     expected_scale = out_scale.clone()
@@ -1443,8 +1491,11 @@ def test_trtllm_gen_dsv4_rope_quant_correctness():
             seq_lens=seq_lens,
             out=out,
             bmm1_scale=softmax_scale,
+            sinks=sinks,
             backend="trtllm-gen",
             enable_pdl=False,
+            cum_seq_lens_q=cum_seq_lens_q,
+            max_q_len=q_len if is_varlen else None,
             dsv4_inv_rope_cos_sin_cache=cos_sin_cache,
             dsv4_output_scale=out_scale,
         )


### PR DESCRIPTION
## Summary

Expose TRTLLM-GEN DeepSeek V4 sparse-MLA RopeQuant through `trtllm_batch_decode_sparse_mla_dsv4`.

- Use the published fixed 128-head fused-cubin schedule.
- Apply inverse RoPE and return group-major FP8 E4M3 output with packed UE8M0 scales.
- Carry `dsv4_scale_buf_m` through cubin and reduction plumbing.
- Preserve the existing BF16 path and CUDA Graph replay.

## Validation

PyTorch 26.08 on GB300/SM103:

- `pytest -q tests/attention/test_trtllm_gen_sparse_mla_dsv4.py` — 119 passed
- `pytest -q tests/jit/test_trtllm_gen_metainfo.py` — 11 passed
- Ruff 0.12.8 and ClangFormat 19.1.1 passed
