### PR TITLE
fix(jit): fail clearly when runtime cubins are unavailable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -540,6 +540,12 @@ match what the code uses today; values are strings unless noted.
 
 ##### Cubin / Artifact Loader
 
+Runtime artifact loads raise `RuntimeError` when a download fails or the
+downloaded file does not match its checksum. The error identifies the artifact
+and recommends installing the matching `flashinfer-cubin` package. The ctypes
+handoff clears its previous result before every callback, and the native loader
+rejects an empty result, so a failed callback cannot reuse a stale cubin.
+
 | Variable | Default | Read in | Effect |
 |----------|---------|---------|--------|
 | `FLASHINFER_CUBIN_DIR` | `<FLASHINFER_WORKSPACE_BASE>/.cache/flashinfer/cubins` | `flashinfer/jit/env.py` (exposed via `flashinfer/__main__.py show-config`) | Local directory used to cache downloaded cubins. Override to share a cache between users. |

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -229,8 +229,19 @@ def get_artifact(file_name: str, sha256: str, session=None) -> bytes:
     os.makedirs(os.path.dirname(local_path), exist_ok=True)
     uri = safe_urljoin(FLASHINFER_CUBINS_REPOSITORY, file_name)
     logger.info(f"Fetching {file_name} from {uri}")
-    download_file(uri, local_path, session=session)
-    return load_cubin(local_path, sha256)
+    download_succeeded = download_file(uri, local_path, session=session)
+    data = load_cubin(local_path, sha256)
+    if data:
+        return data
+
+    status = "download completed but checksum validation failed"
+    if not download_succeeded:
+        status = "download failed"
+    raise RuntimeError(
+        f"Failed to load FlashInfer artifact '{file_name}' from {uri}: {status}. "
+        f"The local cache path is {local_path}. Install the matching "
+        "flashinfer-cubin package or make the artifact repository reachable."
+    )
 
 
 # Backward-compatible alias
@@ -313,7 +324,16 @@ def setup_cubin_loader(dll_path: str) -> None:
 
     def get_cubin_callback(name: bytes, sha256: bytes):
         # Both name and sha256 are bytes (c_char_p)
-        cubin = get_artifact(name.decode("utf-8"), sha256.decode("utf-8"))
+        artifact_name = name.decode("utf-8")
+        try:
+            cubin = get_artifact(artifact_name, sha256.decode("utf-8"))
+        except Exception:
+            # ctypes callbacks cannot propagate Python exceptions to the native
+            # caller. Explicitly clear the native handoff so it cannot reuse a
+            # cubin from a previous callback, and preserve the real download
+            # failure in the logs.
+            logger.exception(f"Failed to provide FlashInfer cubin {artifact_name}")
+            cubin = b""
         _LIB.FlashInferSetCurrentCubin(
             convert_to_ctypes_char_p(cubin), ctypes.c_int(len(cubin))
         )

--- a/flashinfer/jit/cubin_loader.py
+++ b/flashinfer/jit/cubin_loader.py
@@ -211,7 +211,11 @@ def get_artifact(file_name: str, sha256: str, session=None) -> bytes:
     or its SHA-256 doesn't match, it is downloaded from
     ``FLASHINFER_CUBINS_REPOSITORY``.
 
-    Returns the file contents as bytes, or empty bytes on failure.
+    Returns the file contents as bytes.
+
+    Raises:
+        RuntimeError: If the artifact cannot be downloaded or fails checksum
+            validation after downloading.
     """
     local_path = str(FLASHINFER_CUBIN_DIR / file_name)
     data = load_cubin(local_path, sha256)

--- a/include/flashinfer/cubin_loader.h
+++ b/include/flashinfer/cubin_loader.h
@@ -53,6 +53,12 @@ std::string getCubin(const std::string& name, const std::string& sha256) {
   if (!callbackGetCubin) {
     throw std::runtime_error("FlashInferSetCubinCallback not set");
   }
+  // A callback can fail without propagating an exception through ctypes. Do
+  // not let that failure reuse the bytes from a previously loaded kernel.
+  current_cubin.clear();
   callbackGetCubin(name.c_str(), sha256.c_str());
+  if (current_cubin.empty()) {
+    throw std::runtime_error("Failed to load FlashInfer cubin artifact: " + name);
+  }
   return current_cubin;
 }

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -323,6 +323,24 @@ def test_get_checksums_falls_back_to_cached_manifest(monkeypatch, tmp_path):
     }
 
 
+def test_get_artifact_download_failure_raises(monkeypatch, tmp_path):
+    """A missing runtime cubin must not become an empty native kernel image."""
+    from flashinfer.jit import cubin_loader
+
+    monkeypatch.setattr(cubin_loader, "FLASHINFER_CUBIN_DIR", tmp_path / "cubins")
+    monkeypatch.setattr(
+        cubin_loader, "FLASHINFER_CUBINS_REPOSITORY", "https://artifacts.invalid/"
+    )
+    monkeypatch.setattr(
+        cubin_loader, "download_file", lambda *args, **kwargs: False
+    )
+
+    with pytest.raises(RuntimeError, match="missing.cubin") as excinfo:
+        cubin_loader.get_artifact("test-pin/missing.cubin", "0" * 64)
+
+    assert "Install the matching flashinfer-cubin package" in str(excinfo.value)
+
+
 @responses.activate
 def test_get_subdir_file_list(monkeypatch, tmp_path):
     _mock_file_index_responses()

--- a/tests/test_artifacts.py
+++ b/tests/test_artifacts.py
@@ -1,3 +1,9 @@
+import ctypes
+from pathlib import Path
+import shutil
+import subprocess
+import textwrap
+
 from flashinfer.artifacts import (
     ArtifactPath,
     get_available_cubin_files,
@@ -331,14 +337,98 @@ def test_get_artifact_download_failure_raises(monkeypatch, tmp_path):
     monkeypatch.setattr(
         cubin_loader, "FLASHINFER_CUBINS_REPOSITORY", "https://artifacts.invalid/"
     )
-    monkeypatch.setattr(
-        cubin_loader, "download_file", lambda *args, **kwargs: False
-    )
+    monkeypatch.setattr(cubin_loader, "download_file", lambda *args, **kwargs: False)
 
     with pytest.raises(RuntimeError, match="missing.cubin") as excinfo:
         cubin_loader.get_artifact("test-pin/missing.cubin", "0" * 64)
 
     assert "Install the matching flashinfer-cubin package" in str(excinfo.value)
+
+
+def test_get_artifact_download_checksum_failure_raises(monkeypatch, tmp_path):
+    """A successful download with invalid contents must fail explicitly."""
+    from flashinfer.jit import cubin_loader
+
+    monkeypatch.setattr(cubin_loader, "FLASHINFER_CUBIN_DIR", tmp_path / "cubins")
+    monkeypatch.setattr(
+        cubin_loader, "FLASHINFER_CUBINS_REPOSITORY", "https://artifacts.invalid/"
+    )
+
+    def download_corrupt_file(_source, destination, **_kwargs):
+        Path(destination).write_bytes(b"corrupt cubin")
+        return True
+
+    monkeypatch.setattr(cubin_loader, "download_file", download_corrupt_file)
+
+    with pytest.raises(RuntimeError, match="missing.cubin") as excinfo:
+        cubin_loader.get_artifact("test-pin/missing.cubin", "0" * 64)
+
+    message = str(excinfo.value)
+    assert "checksum validation failed" in message
+    assert "Install the matching flashinfer-cubin package" in message
+
+
+def test_cpp_loader_rejects_empty_callback_result(tmp_path):
+    """The native loader must not reuse a cubin after a callback failure."""
+    compiler = shutil.which("c++")
+    if compiler is None:
+        pytest.skip("A C++ compiler is required for the native cubin loader test")
+
+    source = tmp_path / "test_cubin_loader.cc"
+    library = tmp_path / "test_cubin_loader.so"
+    source.write_text(
+        textwrap.dedent(
+            r"""
+            #include <stdexcept>
+            #include <string>
+
+            #include "flashinfer/cubin_loader.h"
+
+            void provide_first_cubin(const char* path, const char*) {
+              if (std::string(path) == "first.cubin") {
+                const std::string cubin = "first cubin contents";
+                FlashInferSetCurrentCubin(cubin.data(), cubin.size());
+              }
+            }
+
+            extern "C" int check_callback_failure() {
+              FlashInferSetCubinCallback(provide_first_cubin);
+              if (getCubin("first.cubin", "unused") != "first cubin contents") {
+                return 1;
+              }
+
+              try {
+                (void)getCubin("missing.cubin", "unused");
+              } catch (const std::runtime_error& error) {
+                return std::string(error.what()).find("missing.cubin") == std::string::npos;
+              }
+              return 2;
+            }
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    include_dir = Path(__file__).resolve().parents[1] / "include"
+    subprocess.run(
+        [
+            compiler,
+            "-std=c++17",
+            "-shared",
+            "-fPIC",
+            "-I",
+            str(include_dir),
+            str(source),
+            "-o",
+            str(library),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    native_test = ctypes.CDLL(str(library))
+    native_test.check_callback_failure.restype = ctypes.c_int
+    assert native_test.check_callback_failure() == 0
 
 
 @responses.activate


### PR DESCRIPTION
## Summary

- raise a descriptive `RuntimeError` when an artifact download fails or the downloaded content fails checksum validation
- clear the native cubin handoff before every callback and reject empty callback results
- direct users to install the matching `flashinfer-cubin` package when runtime artifacts are unavailable
- cover download failure, checksum mismatch, and stale native cubin reuse regressions

## Why

The ctypes callback boundary cannot propagate Python exceptions to C++. Previously, a failed artifact load could therefore return empty bytes or leave the previous cubin in thread-local storage, allowing native code to consume an invalid or stale kernel image.

## Testing

- `uvx ruff check flashinfer/jit/cubin_loader.py tests/test_artifacts.py`
- `uvx ruff format --check flashinfer/jit/cubin_loader.py tests/test_artifacts.py`
- `python -m compileall -q flashinfer/jit/cubin_loader.py tests/test_artifacts.py`
- `python -m pytest tests/test_artifacts.py -q` (10 passed)