### PR TITLE
feat(moe): support independent static scaling for FP4 GEMM2

### DIFF
--- a/csrc/nv_internal/cpp/kernels/quantization.cu
+++ b/csrc/nv_internal/cpp/kernels/quantization.cu
@@ -429,6 +429,60 @@ template void invokeNvfp4QuantAndPerTokenScale<__nv_bfloat16>(
     float* perTokenScaleOutput, QuantizationSFLayout sfLayout, cudaStream_t stream);
 #endif
 
+template <typename T>
+void invokeNvfp4QuantWithStaticScale(uint32_t m, uint32_t n, T const* input,
+                                     float globalEncodeScale, int32_t* expandedIdxToPermutedIdx,
+                                     uint8_t* weightOutput, uint8_t* scaleOutput,
+                                     QuantizationSFLayout sfLayout, cudaStream_t stream) {
+  TLLM_CHECK_WITH_INFO(n % 16 == 0, "n must be a multiple of 16 for NVFP4 quantization");
+  constexpr uint32_t BLOCK_SIZE = 128;
+  dim3 block(BLOCK_SIZE);
+  dim3 grid(m);
+  bool const disableFP4QuantFastMath = tensorrt_llm::common::getEnvDisableFP4QuantFastMath();
+  bool const use4Over6 = tensorrt_llm::common::getEnvNVFP4Use4Over6();
+
+  auto launchKernel = [&](auto sfLayoutTag, auto disableFP4QuantFastMathTag,
+                          auto nvfp4_4over6_config_tag) {
+    constexpr QuantizationSFLayout SF_LAYOUT = decltype(sfLayoutTag)::value;
+    nvfp4QuantWithStaticScaleKernel<T, BLOCK_SIZE, SF_LAYOUT,
+                                    decltype(disableFP4QuantFastMathTag)::value,
+                                    decltype(nvfp4_4over6_config_tag)><<<grid, block, 0, stream>>>(
+        m, n, input, globalEncodeScale, expandedIdxToPermutedIdx, weightOutput, scaleOutput);
+  };
+
+  dispatchSFLayout(sfLayout, [&](auto sfLayoutTag) {
+    auto launchWithLayout = [&](auto disableFP4QuantFastMathTag, auto nvfp4_4over6_config_tag) {
+      launchKernel(sfLayoutTag, disableFP4QuantFastMathTag, nvfp4_4over6_config_tag);
+    };
+    if (use4Over6) {
+      NVFP44Over6ErrMode const errMode = tensorrt_llm::common::getEnvNVFP44Over6ErrMode();
+      bool const errUseFastMath = tensorrt_llm::common::getEnvNVFP44Over6ErrUseFastMath();
+      int e4m3Max = 448;
+      if (tensorrt_llm::common::getEnvNVFP44Over6E4M3Use256()) {
+        e4m3Max = 256;
+      }
+      dispatchNVFP44Over6Config(std::true_type{}, disableFP4QuantFastMath, errMode, errUseFastMath,
+                                e4m3Max, launchWithLayout);
+    } else {
+      dispatchNVFP44Over6Config(std::false_type{}, disableFP4QuantFastMath, NVFP44Over6ErrMode::MAE,
+                                false, 448, launchWithLayout);
+    }
+  });
+}
+
+template void invokeNvfp4QuantWithStaticScale<half>(uint32_t m, uint32_t n, half const* input,
+                                                    float globalEncodeScale,
+                                                    int32_t* expandedIdxToPermutedIdx,
+                                                    uint8_t* weightOutput, uint8_t* scaleOutput,
+                                                    QuantizationSFLayout sfLayout,
+                                                    cudaStream_t stream);
+#ifdef ENABLE_BF16
+template void invokeNvfp4QuantWithStaticScale<__nv_bfloat16>(
+    uint32_t m, uint32_t n, __nv_bfloat16 const* input, float globalEncodeScale,
+    int32_t* expandedIdxToPermutedIdx, uint8_t* weightOutput, uint8_t* scaleOutput,
+    QuantizationSFLayout sfLayout, cudaStream_t stream);
+#endif
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // FP4/MXFP8 Quantization
 

--- a/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
+++ b/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
@@ -873,6 +873,55 @@ __global__ void nvfp4QuantAndPerTokenScaleKernel(
 #endif
 }
 
+template <typename T, uint32_t BLOCK_SIZE, QuantizationSFLayout SF_LAYOUT,
+          bool DISABLE_FP4_QUANT_FAST_MATH = false, typename NVFP4_4OVER6_CONFIG = std::false_type>
+__global__ void nvfp4QuantWithStaticScaleKernel(
+    // input
+    uint32_t m, uint32_t n, T const* input, float globalEncodeScale,
+    int32_t* expandedIdxToPermutedIdx,
+    // output
+    uint8_t* weightOutput, uint8_t* scaleOutput) {
+  constexpr int SF_VEC_SIZE = 16;
+  int rowIdx = blockIdx.x;
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  cudaGridDependencySynchronize();
+#endif
+  if (rowIdx >= m) return;
+  if (expandedIdxToPermutedIdx != nullptr) {
+    rowIdx = expandedIdxToPermutedIdx[rowIdx];
+  }
+  if (rowIdx < 0) return;
+
+  using InType = PackedVec<T, SF_VEC_SIZE>;
+  using PackedFp4Type = uint64_t;
+  uint32_t const numVecsPerRow = n / SF_VEC_SIZE;
+
+  for (uint32_t vecIdx = threadIdx.x; vecIdx < numVecsPerRow; vecIdx += BLOCK_SIZE) {
+    int64_t const vecOffset = static_cast<int64_t>(rowIdx) * numVecsPerRow + vecIdx;
+    InType vecIn;
+    loadPackedVec(vecIn, reinterpret_cast<InType const*>(input) + vecOffset);
+
+    uint8_t fp8Scale;
+    auto const fp4Vals =
+        cvt_warp_fp16_to_fp4<T, SF_VEC_SIZE, SF_VEC_SIZE, false, DISABLE_FP4_QUANT_FAST_MATH,
+                             NVFP4_4OVER6_CONFIG>(vecIn, globalEncodeScale, &fp8Scale);
+    reinterpret_cast<PackedFp4Type*>(weightOutput)[vecOffset] = fp4Vals;
+
+    int64_t sfOffset;
+    if constexpr (SF_LAYOUT == QuantizationSFLayout::LINEAR) {
+      sfOffset = static_cast<int64_t>(rowIdx) * numVecsPerRow + vecIdx;
+    } else if constexpr (SF_LAYOUT == QuantizationSFLayout::SWIZZLED_128x4) {
+      sfOffset = get_sf_out_offset_128x4(rowIdx, vecIdx, numVecsPerRow);
+    } else {
+      sfOffset = get_sf_out_offset_8x4(rowIdx, vecIdx, numVecsPerRow);
+    }
+    scaleOutput[sfOffset] = fp8Scale;
+  }
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+  cudaTriggerProgrammaticLaunchCompletion();
+#endif
+}
+
 // Fast approximation of nvfp4 quantization.
 // This kernel first quantizes the input to fp4 with local amax only,
 // then calculates the e4m3 scales with the global amax and cached local amax.

--- a/csrc/nv_internal/tensorrt_llm/kernels/quantization.h
+++ b/csrc/nv_internal/tensorrt_llm/kernels/quantization.h
@@ -79,6 +79,12 @@ void invokeNvfp4QuantAndPerTokenScale(uint32_t m, uint32_t n, T const* input, fl
                                       QuantizationSFLayout sfLayout, cudaStream_t stream = 0);
 
 template <typename T>
+void invokeNvfp4QuantWithStaticScale(uint32_t m, uint32_t n, T const* input,
+                                     float globalEncodeScale, int32_t* expanded_idx_to_permuted_idx,
+                                     uint8_t* weightOutput, uint8_t* scaleOutput,
+                                     QuantizationSFLayout sfLayout, cudaStream_t stream = 0);
+
+template <typename T>
 void invokeBlockScaleInterleave(int b, int m, int m_padded, int n, int n_padded, T const* SFIn,
                                 T* SFOutput, int multiProcessorCount, cudaStream_t stream = 0);
 

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -3420,26 +3420,27 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
 
     auto const gemm1_output_hidden =
         mDtypeAct == btg::Dtype::E2m1 ? args->intermediate_size / 2 : args->intermediate_size;
+    bool const stage_gemm2_input = mDtypeAct == btg::Dtype::E2m1 && per_token_scales.has_value();
     if (mDtypeAct == btg::Dtype::E2m1 || mDtypeAct == btg::Dtype::MxE4m3) {
       int64_t sf_size = tensorrt_llm::computeSwizzledLayoutSFSize(
           max_num_padded_tokens_gemm1, args->intermediate_size / sf_vec_size);
       gemm1_output_scale = alloc_tensor({sf_size}, dl_uint8, hidden_states.device());
     }
-    if (!gemm2_use_per_token_scaling) {
+    if (!stage_gemm2_input) {
       gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, gemm1_output_hidden},
                                   mDtypeAct == btg::Dtype::Bfloat16 ? dl_bfloat16 : dl_uint8,
                                   hidden_states.device());
-    } else {  // FC1 output is Bfloat16
+    } else {  // FC1 output is Bfloat16 and is explicitly quantized for FC2.
       TVM_FFI_ICHECK(mDtypeAct == btg::Dtype::E2m1)
-          << "NvFP4 MoE: currently only support NvFP4 x NvFP4 when using per-token scaling.";
-      // When per-token scales are used, the FC1 output is always BF16 and will be quantized
+          << "NvFP4 MoE: explicit FC2 quantization requires NvFP4 activation.";
       gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, args->intermediate_size},
                                   dl_bfloat16, hidden_states.device());
-      // The per-token NvFP4 quant needs to stage the output for running the explicit quant kernel
       activation_output = alloc_tensor({max_num_padded_tokens_gemm1, gemm1_output_hidden}, dl_uint8,
                                        hidden_states.device());
-      per_token_scales_fc2 =
-          alloc_tensor({max_num_padded_tokens_gemm1}, dl_float32, hidden_states.device());
+      if (gemm2_use_per_token_scaling) {
+        per_token_scales_fc2 =
+            alloc_tensor({max_num_padded_tokens_gemm1}, dl_float32, hidden_states.device());
+      }
     }
 
     // Allocate gemm2_output
@@ -3455,9 +3456,11 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
     if (per_token_scales.has_value()) {
       workspace.token_scales = per_token_scales.value().data_ptr();
     }
-    if (gemm2_use_per_token_scaling) {
+    if (stage_gemm2_input) {
       workspace.activation_output = activation_output.data_ptr();
       workspace.activation_output_scale = workspace.gemm1_output_scale;
+    }
+    if (gemm2_use_per_token_scaling) {
       workspace.token_scales_fc2 = per_token_scales_fc2.data_ptr();
     }
     workspace.gemm2_output = gemm2_output.data_ptr();
@@ -4203,14 +4206,14 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
     TensorView gemm2_weights, TensorView gemm2_weights_scale, Optional<TensorView> gemm2_bias,
     Optional<TensorView> output1_scales_scalar, Optional<TensorView> output1_scales_gate_scalar,
     Optional<TensorView> output2_scales_scalar, Optional<TensorView> per_token_scales,
-    bool gemm2_use_per_token_scaling,
-    int64_t num_experts, int64_t top_k, Optional<int64_t> num_fused_shared_experts,
-    Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
-    int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
-    int64_t routing_method_type, bool do_finalize, bool enable_pdl, int64_t act_type,
-    TensorView output, Array<int64_t> config_index, bool norm_topk_prob,
-    Optional<TensorView> routing_replay_out, Array<Tensor> da_routing_metadata,
-    Array<Tensor> da_body_workspace, bool is_da_body_preparation) {
+    bool gemm2_use_per_token_scaling, int64_t num_experts, int64_t top_k,
+    Optional<int64_t> num_fused_shared_experts, Optional<int64_t> n_group,
+    Optional<int64_t> topk_group, int64_t intermediate_size, int64_t local_expert_offset,
+    int64_t local_num_experts, Optional<double> routed_scaling_factor, int64_t routing_method_type,
+    bool do_finalize, bool enable_pdl, int64_t act_type, TensorView output,
+    Array<int64_t> config_index, bool norm_topk_prob, Optional<TensorView> routing_replay_out,
+    Array<Tensor> da_routing_metadata, Array<Tensor> da_body_workspace,
+    bool is_da_body_preparation) {
   auto const gemm1_bias_type_enum = gemm1_lora_delta.has_value()
                                         ? batchedGemm::gemm::BiasType::Mn
                                         : batchedGemm::gemm::BiasType::None;
@@ -4511,8 +4514,7 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
     Fp8QuantizationType fp8_quantization_type, int64_t const top_k, int64_t const hidden_size,
     int64_t const intermediate_size, int64_t const num_local_experts, int64_t const act_type,
     bool const use_shuffled_weight, int64_t const weight_layout, bool const use_per_token_scaling,
-    bool const gemm2_use_per_token_scaling,
-    int64_t const num_tokens, bool has_gemm1_lora_delta) {
+    bool const gemm2_use_per_token_scaling, int64_t const num_tokens, bool has_gemm1_lora_delta) {
   auto activation_type = validateAndCastActivationType(act_type);
   auto dtype_act = static_cast<btg::Dtype>(dtype_act_);
   auto dtype_weights = static_cast<btg::Dtype>(dtype_weights_);
@@ -4580,8 +4582,7 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
     // FP4 block scale
     return FP4BlockScaleLauncher::getValidConfigs(
         top_k, hidden_size, intermediate_size, num_local_experts, num_tokens, act_type, dtype_act,
-        dtype_weights, use_per_token_scaling, gemm2_use_per_token_scaling,
-        gemm1_bias_type_enum);
+        dtype_weights, use_per_token_scaling, gemm2_use_per_token_scaling, gemm1_bias_type_enum);
   }
 
   TVM_FFI_LOG_AND_THROW(NotImplementedError)
@@ -4599,8 +4600,7 @@ Array<Array<int64_t>> trtllm_get_valid_moe_factorizations(
     Fp8QuantizationType fp8_quantization_type, int64_t const top_k, int64_t const hidden_size,
     int64_t const intermediate_size, int64_t const num_local_experts, int64_t const act_type,
     bool const use_shuffled_weight, int64_t const weight_layout, bool const use_per_token_scaling,
-    bool const gemm2_use_per_token_scaling,
-    int64_t const num_tokens, bool has_gemm1_lora_delta) {
+    bool const gemm2_use_per_token_scaling, int64_t const num_tokens, bool has_gemm1_lora_delta) {
   // Start from complete valid tactics so every factorized coordinate remains executable.
   auto const completeTactics = trtllm_get_valid_moe_configs(
       dtype_act_, dtype_weights_, fp8_quantization_type, top_k, hidden_size, intermediate_size,

--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -1062,6 +1062,7 @@ class FusedMoeLauncher {
   Optional<TensorView> output2_scales_scalar;
   Optional<TensorView> per_token_scales;
   Tensor per_token_scales_fc2;
+  bool gemm2_use_per_token_scaling{};
   bool use_per_channel_scaling_gemm1{false};
   bool use_per_channel_scaling_gemm2{false};
 
@@ -1098,7 +1099,8 @@ class FusedMoeLauncher {
                    const TensorView& gemm2_weights,
                    const Optional<TensorView>& output2_scales_scalar,
                    const Optional<TensorView>& per_token_scales,
-                   RoutingInputMode routing_input_mode = RoutingInputMode::FromLogits)
+                   RoutingInputMode routing_input_mode = RoutingInputMode::FromLogits,
+                   bool gemm2_use_per_token_scaling = false)
       : routing_input_mode_(routing_input_mode),
         routing_logits(routing_logits),
         routing_bias(routing_bias),
@@ -1110,6 +1112,7 @@ class FusedMoeLauncher {
         gemm2_weights(gemm2_weights),
         output2_scales_scalar(output2_scales_scalar),
         per_token_scales(per_token_scales),
+        gemm2_use_per_token_scaling(gemm2_use_per_token_scaling),
         tile_tokens_dim{},
         routing_method_type{},
         use_shuffled_weight{},
@@ -1375,8 +1378,7 @@ class FusedMoeLauncher {
   void prepare_moe_runner(int64_t& moe_tactic) {
     using RunnerType = tensorrt_llm::kernels::trtllmgen_moe::MoE::Runner;
     bool usePerTokenScalingGemm1 = per_token_scales.has_value() || args->mUseRoutingScalesOnInput;
-    // FIXME(siyuan): currently only nvfp4 x nvfp4 uses per-token scaling in both FC1 and FC2
-    bool usePerTokenScalingGemm2 = per_token_scales.has_value() && mDtypeAct == btg::Dtype::E2m1;
+    bool usePerTokenScalingGemm2 = gemm2_use_per_token_scaling;
     // For FP8 block-scale (E4m3 activations, E4m3 weights) with DeepSeek FP8 and no
     // gemm1 bias, use the weights-only Runner constructor to match the original kernel
     // path and numerics. DSFp8 + biasMn routes through the unified constructor below
@@ -3217,11 +3219,12 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
       Optional<TensorView> const& output1_scales_scalar,
       Optional<TensorView> const& output1_scales_gate_scalar,
       Optional<TensorView> const& output2_scales_scalar,
-      Optional<TensorView> const& per_token_scales, TensorView const& topk_ids,
-      TensorView const& topk_weights)
+      Optional<TensorView> const& per_token_scales, bool gemm2_use_per_token_scaling,
+      TensorView const& topk_ids, TensorView const& topk_weights)
       : FusedMoeLauncher(routing_logits, routing_bias, hidden_states, gemm1_weights, gemm1_bias,
                          output1_scales_scalar, output1_scales_gate_scalar, gemm2_weights,
-                         output2_scales_scalar, per_token_scales, routing_input_mode),
+                         output2_scales_scalar, per_token_scales, routing_input_mode,
+                         gemm2_use_per_token_scaling),
         hidden_states_scale(hidden_states_scale),
         gemm1_weights_scale(gemm1_weights_scale),
         gemm1_alpha(gemm1_alpha),
@@ -3314,6 +3317,10 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
           << "Only MxE2m1 weights are supported by block scale MoE with Bfloat16, E4m3 or "
              "MxE4m3 activation";
     }
+
+    TVM_FFI_ICHECK(!gemm2_use_per_token_scaling ||
+                   (mDtypeAct == btg::Dtype::E2m1 && per_token_scales.has_value()))
+        << "FP4 GEMM2 per-token scaling requires E2m1 activation and per_token_scales.";
 
     if (mDtypeAct == btg::Dtype::E4m3) {
       TVM_FFI_ICHECK(output1_scales_scalar.has_value())
@@ -3418,7 +3425,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
           max_num_padded_tokens_gemm1, args->intermediate_size / sf_vec_size);
       gemm1_output_scale = alloc_tensor({sf_size}, dl_uint8, hidden_states.device());
     }
-    if (!per_token_scales.has_value()) {
+    if (!gemm2_use_per_token_scaling) {
       gemm1_output = alloc_tensor({max_num_padded_tokens_gemm1, gemm1_output_hidden},
                                   mDtypeAct == btg::Dtype::Bfloat16 ? dl_bfloat16 : dl_uint8,
                                   hidden_states.device());
@@ -3447,6 +3454,8 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
                                        : nullptr;
     if (per_token_scales.has_value()) {
       workspace.token_scales = per_token_scales.value().data_ptr();
+    }
+    if (gemm2_use_per_token_scaling) {
       workspace.activation_output = activation_output.data_ptr();
       workspace.activation_output_scale = workspace.gemm1_output_scale;
       workspace.token_scales_fc2 = per_token_scales_fc2.data_ptr();
@@ -3592,6 +3601,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
                                                int64_t num_tokens, int64_t act_type,
                                                btg::Dtype dtype_act, btg::Dtype dtype_weights,
                                                bool use_per_token_scaling,
+                                               bool gemm2_use_per_token_scaling,
                                                batchedGemm::gemm::BiasType gemm1_bias_type) {
     Array<Array<int64_t>> valid_configs;
 
@@ -3608,10 +3618,7 @@ class FP4BlockScaleLauncher : public FusedMoeLauncher {
           /*weight_layout*/ batchedGemm::gemm::MatrixLayout::MajorK,
           /*gemm1BiasType*/ gemm1_bias_type,
           /*usePerTokenScalingGemm1*/ use_per_token_scaling,
-          // Match prepare_moe_common(): only NVFP4 uses the explicit
-          // per-token scale operand for FC2.
-          /*usePerTokenScalingGemm2*/
-          use_per_token_scaling && dtype_act == btg::Dtype::E2m1, false, false);
+          /*usePerTokenScalingGemm2*/ gemm2_use_per_token_scaling, false, false);
 
       auto cfgs = moe_runner->getValidConfigIndices(top_k, hidden_size, intermediate_size,
                                                     num_local_experts, num_tokens);
@@ -4196,6 +4203,7 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
     TensorView gemm2_weights, TensorView gemm2_weights_scale, Optional<TensorView> gemm2_bias,
     Optional<TensorView> output1_scales_scalar, Optional<TensorView> output1_scales_gate_scalar,
     Optional<TensorView> output2_scales_scalar, Optional<TensorView> per_token_scales,
+    bool gemm2_use_per_token_scaling,
     int64_t num_experts, int64_t top_k, Optional<int64_t> num_fused_shared_experts,
     Optional<int64_t> n_group, Optional<int64_t> topk_group, int64_t intermediate_size,
     int64_t local_expert_offset, int64_t local_num_experts, Optional<double> routed_scaling_factor,
@@ -4289,6 +4297,10 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
     }
   }
 
+  TVM_FFI_ICHECK(!gemm2_use_per_token_scaling ||
+                 (per_token_scales.has_value() && mDtypeAct == btg::Dtype::E2m1))
+      << "gemm2_use_per_token_scaling requires E2m1 activation and per_token_scales.";
+
   // Determine supported tile sizes
   std::vector<int32_t> mSupportedTileN =
       FP4BlockScaleLauncher::getSupportedTileNums(mDtypeAct, mDtypeWeights);
@@ -4326,7 +4338,8 @@ Array<Tensor> trtllm_fp4_block_scale_moe(
         hidden_states, hidden_states_scale, gemm1_weights, gemm1_weights_scale,
         gemm1_bias_effective, gemm1_alpha, gemm1_beta, gemm1_clamp_limit, gemm2_weights,
         gemm2_weights_scale, gemm2_bias, output1_scales_scalar, output1_scales_gate_scalar,
-        output2_scales_scalar, per_token_scales, topk_ids, topk_weights);
+        output2_scales_scalar, per_token_scales, gemm2_use_per_token_scaling, topk_ids,
+        topk_weights);
     launcher->init(std::move(args), curr_tile_N, routing_method_type, /*use_shuffled_weight=*/true,
                    /*weight_layout=*/0, static_cast<ActivationType>(act_type), mDtypeAct,
                    mDtypeWeights, static_cast<int64_t>(gemm1_bias_type_enum), norm_topk_prob);
@@ -4498,6 +4511,7 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
     Fp8QuantizationType fp8_quantization_type, int64_t const top_k, int64_t const hidden_size,
     int64_t const intermediate_size, int64_t const num_local_experts, int64_t const act_type,
     bool const use_shuffled_weight, int64_t const weight_layout, bool const use_per_token_scaling,
+    bool const gemm2_use_per_token_scaling,
     int64_t const num_tokens, bool has_gemm1_lora_delta) {
   auto activation_type = validateAndCastActivationType(act_type);
   auto dtype_act = static_cast<btg::Dtype>(dtype_act_);
@@ -4566,7 +4580,8 @@ Array<Array<int64_t>> trtllm_get_valid_moe_configs(
     // FP4 block scale
     return FP4BlockScaleLauncher::getValidConfigs(
         top_k, hidden_size, intermediate_size, num_local_experts, num_tokens, act_type, dtype_act,
-        dtype_weights, use_per_token_scaling, gemm1_bias_type_enum);
+        dtype_weights, use_per_token_scaling, gemm2_use_per_token_scaling,
+        gemm1_bias_type_enum);
   }
 
   TVM_FFI_LOG_AND_THROW(NotImplementedError)
@@ -4584,12 +4599,13 @@ Array<Array<int64_t>> trtllm_get_valid_moe_factorizations(
     Fp8QuantizationType fp8_quantization_type, int64_t const top_k, int64_t const hidden_size,
     int64_t const intermediate_size, int64_t const num_local_experts, int64_t const act_type,
     bool const use_shuffled_weight, int64_t const weight_layout, bool const use_per_token_scaling,
+    bool const gemm2_use_per_token_scaling,
     int64_t const num_tokens, bool has_gemm1_lora_delta) {
   // Start from complete valid tactics so every factorized coordinate remains executable.
   auto const completeTactics = trtllm_get_valid_moe_configs(
       dtype_act_, dtype_weights_, fp8_quantization_type, top_k, hidden_size, intermediate_size,
       num_local_experts, act_type, use_shuffled_weight, weight_layout, use_per_token_scaling,
-      num_tokens, has_gemm1_lora_delta);
+      gemm2_use_per_token_scaling, num_tokens, has_gemm1_lora_delta);
   auto const dtypeAct = static_cast<btg::Dtype>(dtype_act_);
   auto const dtypeWeights = static_cast<btg::Dtype>(dtype_weights_);
   auto const activationType = validateAndCastActivationType(act_type);
@@ -4597,7 +4613,7 @@ Array<Array<int64_t>> trtllm_get_valid_moe_factorizations(
   auto const gemm1BiasType =
       has_gemm1_lora_delta ? batchedGemm::gemm::BiasType::Mn : batchedGemm::gemm::BiasType::None;
   bool const useDeepSeekFp8 = fp8_quantization_type == Fp8QuantizationType::DeepSeekFp8;
-  bool const usePerTokenScalingGemm2 = use_per_token_scaling && dtypeAct == btg::Dtype::E2m1;
+  bool const usePerTokenScalingGemm2 = gemm2_use_per_token_scaling;
   bool const useWeightsOnlyConstructor = dtypeAct == btg::Dtype::E4m3 &&
                                          dtypeWeights == btg::Dtype::E4m3 && useDeepSeekFp8 &&
                                          gemm1BiasType == batchedGemm::gemm::BiasType::None;

--- a/csrc/trtllm_fused_moe_runner.cu
+++ b/csrc/trtllm_fused_moe_runner.cu
@@ -352,7 +352,8 @@ Runner::Runner(btg::Dtype dtypeAct, btg::Dtype dtypeWeights, bool useDeepSeekFp8
       mUsePerChannelScalingGemm1(usePerChannelScalingGemm1),
       mUsePerChannelScalingGemm2(usePerChannelScalingGemm2),
       mPermuteGemm1(PermuteGemm1::Runner(
-          dtypeAct, dtypeWeights, usePerTokenScalingGemm2 ? btg::Dtype::Bfloat16 : dtypeAct,
+          dtypeAct, dtypeWeights,
+          dtypeAct == btg::Dtype::E2m1 && usePerTokenScalingGemm1 ? btg::Dtype::Bfloat16 : dtypeAct,
           useDeepSeekFp8, tileTokensDim, activationType, useShuffledMatrix, weightLayout,
           gemm1BiasType, usePerTokenScalingGemm1, usePerChannelScalingGemm1)),
       mGemm2(Gemm2::Runner(dtypeAct, dtypeWeights, btg::Dtype::Bfloat16, useDeepSeekFp8,
@@ -613,6 +614,28 @@ void Runner::run(MoERunnerArgs const& args, MoEWorkspace const& workspace, int d
         reinterpret_cast<uint8_t*>(workspace.activation_output),
         reinterpret_cast<uint8_t*>(workspace.activation_output_scale),
         reinterpret_cast<float*>(workspace.token_scales_fc2), sfLayout, stream);
+
+    gemm2_input = workspace.activation_output;
+    gemm2_input_scale = workspace.activation_output_scale;
+  } else if (mUsePerTokenScalingGemm1 && mGemm2.mDtypeAct == btg::Dtype::E2m1) {
+    FLASHINFER_CHECK(mPermuteGemm1.mDtypeOutput == btg::Dtype::Bfloat16,
+                     "Static-scale NVFP4 GEMM2 requires PermuteGemm1 to output Bfloat16.");
+    FLASHINFER_CHECK(workspace.activation_output != nullptr,
+                     "Static-scale NVFP4 GEMM2 requires an activation output buffer.");
+    FLASHINFER_CHECK(workspace.activation_output_scale != nullptr,
+                     "Static-scale NVFP4 GEMM2 requires an activation scale buffer.");
+
+    // The static GEMM2 input quantization scale is supplied through the GEMM1 output scalar.
+    // Generate only the per-block E4M3 factors here; no row-wise outer scale is calculated or
+    // passed to GEMM2.
+    auto sfLayout = mGemm2.mTileTokensDim >= 128 ? QuantizationSFLayout::SWIZZLED_128x4
+                                                 : QuantizationSFLayout::SWIZZLED_8x4;
+    invokeNvfp4QuantWithStaticScale<__nv_bfloat16>(
+        args.num_tokens * totalExpertsPerToken, args.intermediate_size,
+        reinterpret_cast<__nv_bfloat16 const*>(workspace.gemm1_output), 1.0f,
+        workspace.expanded_idx_to_permuted_idx,
+        reinterpret_cast<uint8_t*>(workspace.activation_output),
+        reinterpret_cast<uint8_t*>(workspace.activation_output_scale), sfLayout, stream);
 
     gemm2_input = workspace.activation_output;
     gemm2_input_scale = workspace.activation_output_scale;

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -1857,6 +1857,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             weight_layout: int = WeightLayout.MajorK,
             use_packed_weights: bool = False,
             use_per_token_scaling: bool = False,
+            gemm2_use_per_token_scaling: Optional[bool] = None,
             num_experts: Optional[int] = None,
             num_fused_shared_experts: int = 0,
         ):
@@ -1877,6 +1878,15 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             self.weight_layout = WeightLayout(weight_layout)
             self.use_packed_weights = use_packed_weights
             self.use_per_token_scaling = use_per_token_scaling
+            self.gemm2_use_per_token_scaling = (
+                use_per_token_scaling and dtype_act == DtypeTrtllmGen.E2m1
+                if gemm2_use_per_token_scaling is None
+                else gemm2_use_per_token_scaling
+            )
+            if self.gemm2_use_per_token_scaling and not use_per_token_scaling:
+                raise ValueError(
+                    "GEMM2 per-token scaling requires GEMM1 per-token scaling."
+                )
             self.num_experts = (
                 num_experts if num_experts is not None else num_local_experts
             )
@@ -1995,6 +2005,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 self.use_shuffled_weight,
                 self.weight_layout,
                 self.use_per_token_scaling,
+                self.gemm2_use_per_token_scaling,
                 num_tokens,
                 has_gemm1_lora_delta,
             )
@@ -2032,6 +2043,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 self.use_shuffled_weight,
                 self.weight_layout,
                 self.use_per_token_scaling,
+                self.gemm2_use_per_token_scaling,
                 moe_inputs.hidden_states.shape[0],
                 moe_inputs.gemm1_lora_delta is not None,
             )
@@ -2381,6 +2393,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                     kwargs["output1_scale_gate_scalar"],
                     kwargs["output2_scale_scalar"],
                     moe_inputs.per_token_scale,
+                    self.gemm2_use_per_token_scaling,
                     kwargs["num_experts"],
                     self.top_k,
                     kwargs.get("num_fused_shared_experts", 0),
@@ -3992,6 +4005,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         output1_scale_gate_scalar: Optional[torch.Tensor],
         output2_scale_scalar: Optional[torch.Tensor],
         per_token_scale: Optional[torch.Tensor],
+        gemm2_use_per_token_scaling: bool,
         num_experts: int,
         top_k: int,
         n_group: Optional[int],
@@ -4101,6 +4115,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             weight_layout=WeightLayout.MajorK,
             use_shuffled_weight=True,
             use_per_token_scaling=per_token_scale is not None,
+            gemm2_use_per_token_scaling=gemm2_use_per_token_scaling,
             num_experts=num_experts,
             num_fused_shared_experts=num_fused_shared_experts,
         )
@@ -4138,6 +4153,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
             "output1_scale_scalar": output1_scale_scalar,
             "output1_scale_gate_scalar": output1_scale_gate_scalar,
             "output2_scale_scalar": output2_scale_scalar,
+            "gemm2_use_per_token_scaling": gemm2_use_per_token_scaling,
             "n_group": n_group,
             "topk_group": topk_group,
             "local_expert_offset": local_expert_offset,
@@ -4182,6 +4198,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
                 output1_scale_gate_scalar,
                 output2_scale_scalar,
                 per_token_scale,
+                gemm2_use_per_token_scaling,
                 num_experts,
                 top_k,
                 num_fused_shared_experts,
@@ -4292,6 +4309,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         output1_scale_gate_scalar: Optional[torch.Tensor],
         output2_scale_scalar: Optional[torch.Tensor],
         per_token_scale: Optional[torch.Tensor],
+        gemm2_use_per_token_scaling: bool,
         num_experts: int,
         top_k: int,
         n_group: Optional[int],
@@ -4311,7 +4329,7 @@ def _get_trtllm_moe_sm100_module_impl(enable_rubin: bool):
         num_fused_shared_experts: int = 0,
     ):
         # Acknowledge mutation-only and fallback-only controls without executing the native op.
-        _ = routing_replay_out
+        _ = routing_replay_out, gemm2_use_per_token_scaling
         return _fake_trtllm_moe_output(
             hidden_states,
             hidden_size=gemm2_weights.shape[1],
@@ -5171,6 +5189,18 @@ def _validate_routing_replay_out(
         )
     if not routing_replay_out.is_contiguous():
         raise ValueError("routing_replay_out must be contiguous (packed row-major)")
+
+
+def _resolve_fp4_gemm2_per_token_scaling(
+    per_token_scale: Optional[torch.Tensor],
+    gemm2_use_per_token_scaling: Optional[bool],
+) -> bool:
+    """Resolve the FC2 activation quantization mode while preserving legacy behavior."""
+    if gemm2_use_per_token_scaling is None:
+        return per_token_scale is not None
+    if gemm2_use_per_token_scaling and per_token_scale is None:
+        raise ValueError("gemm2_use_per_token_scaling=True requires per_token_scale.")
+    return gemm2_use_per_token_scaling
 
 
 def _validate_fp8_block_scale_gemm1_activation_params(
@@ -6662,6 +6692,7 @@ def trtllm_fp4_block_scale_moe(
     norm_topk_prob: bool = True,
     routing_replay_out: Optional[torch.Tensor] = None,
     num_fused_shared_experts: Optional[int] = None,
+    gemm2_use_per_token_scaling: Optional[bool] = None,
 ) -> List[torch.Tensor]:
     r"""FP4 block-scaled MoE operation.
 
@@ -6766,6 +6797,12 @@ def trtllm_fp4_block_scale_moe(
         ``10`` SiTU uses ``beta*tanh(x0/beta) * alpha*tanh(x1/alpha)*sigmoid(x1)``.
     per_token_scale : Optional[torch.Tensor]
         ``[seq_len]`` per-token scaling factors, ``float32``.
+    gemm2_use_per_token_scaling : Optional[bool]
+        Whether FC2 dynamically quantizes its activation with per-token outer
+        scales. ``None`` preserves the legacy behavior, which enables it when
+        ``per_token_scale`` is provided. Set to ``False`` to keep FC1 input
+        per-token scaling while using ``output1_scale_scalar`` as FC2's static
+        activation scale.
     output : Optional[torch.Tensor]
         Optional in-place ``[seq_len, hidden_size]`` output tensor.
     tune_max_num_tokens : int
@@ -6822,6 +6859,9 @@ def trtllm_fp4_block_scale_moe(
             f"with DeepSeekV3 routing; got routing_method_type={routing_method_type}."
         )
     _validate_routing_replay_out(routing_replay_out, top_k, nsfe)
+    gemm2_use_per_token_scaling = _resolve_fp4_gemm2_per_token_scaling(
+        per_token_scale, gemm2_use_per_token_scaling
+    )
     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
         RoutingInputMode.FromLogits,
         routing_logits,
@@ -6844,6 +6884,7 @@ def trtllm_fp4_block_scale_moe(
         output1_scale_gate_scalar,
         output2_scale_scalar,
         per_token_scale,
+        gemm2_use_per_token_scaling,
         num_experts,
         top_k,
         n_group,
@@ -6898,6 +6939,7 @@ def trtllm_fp4_block_scale_routed_moe(
     output: Optional[torch.Tensor] = None,
     tune_max_num_tokens: int = 8192,
     gemm1_lora_delta: Optional[torch.Tensor] = None,
+    gemm2_use_per_token_scaling: Optional[bool] = None,
 ) -> List[torch.Tensor]:
     """FP4 block scale MoE operation with pre-computed routing.
 
@@ -7027,6 +7069,9 @@ def trtllm_fp4_block_scale_routed_moe(
         see :func:`trtllm_bf16_routed_moe` for the table.
     """
     topk_ids_tensor, topk_weights, routing_mode = _split_precomputed_routing(topk_ids)
+    gemm2_use_per_token_scaling = _resolve_fp4_gemm2_per_token_scaling(
+        per_token_scale, gemm2_use_per_token_scaling
+    )
 
     # The kernel folds dequantScaleAb into scaleC and applies it to the bias
     # when the input is Fp8 or NvFp4 and DeepSeekFp8 is not used (see trtllm-gen
@@ -7072,6 +7117,7 @@ def trtllm_fp4_block_scale_routed_moe(
         output1_scale_gate_scalar,
         output2_scale_scalar,
         per_token_scale,
+        gemm2_use_per_token_scaling,
         num_experts,
         top_k,
         n_group,

--- a/tests/moe/test_fp4_gemm2_scaling_mode.py
+++ b/tests/moe/test_fp4_gemm2_scaling_mode.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from flashinfer.fused_moe.core import _resolve_fp4_gemm2_per_token_scaling
+
+
+def test_fp4_gemm2_scaling_mode_preserves_legacy_behavior():
+    per_token_scale = torch.ones(2, dtype=torch.float32)
+
+    assert _resolve_fp4_gemm2_per_token_scaling(None, None) is False
+    assert _resolve_fp4_gemm2_per_token_scaling(per_token_scale, None) is True
+
+
+def test_fp4_gemm2_scaling_mode_allows_static_fc2_with_per_token_fc1():
+    per_token_scale = torch.ones(2, dtype=torch.float32)
+
+    assert _resolve_fp4_gemm2_per_token_scaling(per_token_scale, False) is False
+
+
+def test_fp4_gemm2_scaling_mode_rejects_missing_token_scales():
+    with pytest.raises(ValueError, match="requires per_token_scale"):
+        _resolve_fp4_gemm2_per_token_scaling(None, True)

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -321,6 +321,7 @@ def _enumerate_valid_tactics(
     num_experts: int,
     num_tokens: int,
     use_per_token_scaling: bool = False,
+    gemm2_use_per_token_scaling: bool | None = None,
     activation_type: ActivationType = ActivationType.Swiglu,
 ) -> list[list[int]]:
     """Enumerate every (tile_N, config) tactic the autotuner may select for
@@ -328,6 +329,10 @@ def _enumerate_valid_tactics(
     from flashinfer.tllm_enums import Fp8QuantizationType
 
     cfg = _quant_mode_config(quant_mode)
+    if gemm2_use_per_token_scaling is None:
+        gemm2_use_per_token_scaling = (
+            quant_mode == "NvFP4xNvFP4" and use_per_token_scaling
+        )
     return list(
         moe_op.trtllm_get_valid_moe_configs(
             cfg["dtype_act"],
@@ -341,6 +346,7 @@ def _enumerate_valid_tactics(
             True,  # use_shuffled_weight
             WeightLayout.MajorK.value,
             use_per_token_scaling,
+            gemm2_use_per_token_scaling,
             num_tokens,
             False,  # has_gemm1_lora_delta
         )
@@ -405,6 +411,7 @@ def test_nvfp4_per_token_all_tactics_are_correct(
                     use_4over6=True,
                     weights_use_4over6=True,
                     activation_type=activation_type,
+                    gemm2_use_per_token_scaling=True,
                 )
         except Exception as err:
             raise AssertionError(
@@ -412,6 +419,27 @@ def test_nvfp4_per_token_all_tactics_are_correct(
                 f"for {activation_type.name}"
             ) from err
         torch.cuda.empty_cache()
+
+
+def test_nvfp4_static_gemm2_has_valid_tactics():
+    """Per-token FC1 with static-scale FC2 must select the BF16 staging path."""
+    if get_compute_capability(torch.device(device="cuda"))[0] not in [10]:
+        pytest.skip("Only work on SM100 / SM103.")
+
+    moe_op = gen_trtllm_gen_fused_moe_sm100_module().build_and_load()
+    valid_tactics = _enumerate_valid_tactics(
+        moe_op,
+        "NvFP4xNvFP4",
+        top_k=8,
+        hidden_size=2048,
+        intermediate_size=768,
+        num_experts=128,
+        num_tokens=4096,
+        use_per_token_scaling=True,
+        gemm2_use_per_token_scaling=False,
+        activation_type=ActivationType.Relu2,
+    )
+    assert valid_tactics
 
 
 def test_nvfp4_per_tensor_small_shape_all_tactics_are_correct():
@@ -858,6 +886,7 @@ def _enumerate_fp8_valid_tactics(
             cfg["use_shuffled_weight"],
             cfg["weight_layout"],
             False,  # use_per_token_scaling
+            False,  # gemm2_use_per_token_scaling
             num_tokens,
             False,  # has_gemm1_lora_delta
         )

--- a/tests/moe/test_trtllm_gen_per_token_moe.py
+++ b/tests/moe/test_trtllm_gen_per_token_moe.py
@@ -67,10 +67,11 @@ cache_permute_indices: Dict[tuple, torch.Tensor] = {}
 @pytest.mark.parametrize("use_4over6", [False, True])
 @pytest.mark.parametrize("weights_use_4over6", [False, True])
 @pytest.mark.parametrize(
-    "activation_type",
+    "activation_type,gemm2_use_per_token_scaling",
     [
-        pytest.param(ActivationType.Swiglu, id="Swiglu"),
-        pytest.param(ActivationType.Relu2, id="Relu2"),
+        pytest.param(ActivationType.Swiglu, True, id="Swiglu-dynamic-fc2"),
+        pytest.param(ActivationType.Relu2, True, id="Relu2-dynamic-fc2"),
+        pytest.param(ActivationType.Relu2, False, id="Relu2-static-fc2"),
     ],
 )
 def test_routed_fused_moe(
@@ -82,6 +83,7 @@ def test_routed_fused_moe(
     use_4over6: bool,
     weights_use_4over6: bool,
     activation_type: ActivationType,
+    gemm2_use_per_token_scaling: bool,
 ):
     device = torch.device("cuda:0")
     compute_capability = get_compute_capability(torch.device(device="cuda"))
@@ -131,6 +133,9 @@ def test_routed_fused_moe(
     expert_weights = expert_weights.view(num_tokens, num_experts)[
         torch.arange(num_tokens).unsqueeze(1), topk_ids
     ].to(torch.bfloat16)
+    if not gemm2_use_per_token_scaling:
+        # Expert-choice routing marks inactive token/expert assignments with -1.
+        topk_ids[0, 0] = -1
 
     # ======== Quantize =======
     nvfp4_4over6_config = NVFP44Over6Config() if use_4over6 else None
@@ -302,16 +307,26 @@ def test_routed_fused_moe(
 
     # For a non-linear elementwise activation (Relu2) the kernel applies the gate scalar
     # *before* the activation and the c scalar *after*, so the dequantization factor must
-    # ride on the gate scalar only -- s * relu(x)^2 != relu(s * x)^2.  The c scalar then
-    # carries just the output quantization factor, which is 1 here because FC1 emits bf16
-    # under per-token scaling.  Gated activations take the dequant on both.
+    # ride on the gate scalar only -- s * relu(x)^2 != relu(s * x)^2. Static FC2 scales
+    # the BF16 activation before block quantization and compensates in the FC2 epilogue.
     # Mirrors scale_c_fc1 / scale_gate_fc1 in tests/moe/trtllm_gen_fused_moe_utils.py.
+    fc2_input_quant_scale = torch.tensor(
+        1.0 if gemm2_use_per_token_scaling else 1.0 / 16.0,
+        device=device,
+        dtype=torch.float32,
+    )
     output1_scale_scalar = torch.stack(
-        [w13_global_scale_inv if is_gated else torch.ones_like(w13_global_scale_inv)]
+        [
+            w13_global_scale_inv * fc2_input_quant_scale
+            if is_gated
+            else fc2_input_quant_scale
+        ]
         * num_experts
     )
     output1_scale_gate_scalar = torch.stack([w13_global_scale_inv] * num_experts)
-    output2_scale_scalar = torch.stack([w2_global_scale_inv] * num_experts)
+    output2_scale_scalar = torch.stack(
+        [w2_global_scale_inv / fc2_input_quant_scale] * num_experts
+    )
 
     packed_tensor = (topk_ids.to(torch.int32) << 16) | expert_weights.to(
         torch.bfloat16
@@ -352,6 +367,7 @@ def test_routed_fused_moe(
         activation_type.value,  # act_type
         per_token_scale_inv,
         None,
+        gemm2_use_per_token_scaling=gemm2_use_per_token_scaling,
     )
 
     from flashinfer.autotuner import autotune


### PR DESCRIPTION
## Summary

- decouple GEMM1 and GEMM2 per-token activation scaling while preserving the existing default behavior
- add a static-scale NVFP4 GEMM2 staging path that quantizes BF16 activations with per-block E4M3 scale factors
- propagate the GEMM2 scaling mode through tactic selection and cache keys
- add API, tactic availability, and numerical coverage for both dynamic and static GEMM2 scaling

## Motivation

Some FP4 MoE configurations use per-token activation scaling for GEMM1 while supplying a model-level static activation scale for GEMM2. Previously, GEMM2 implicitly followed the GEMM1 mode, so this combination could not be represented.

The new optional `gemm2_use_per_token_scaling` argument defaults to the legacy behavior when omitted, keeping existing callers backward compatible.

## Testing

- `uvx ruff check` and `uvx ruff format --check` on the modified Python files
- `python -m pytest tests/moe/test_fp4_gemm2_scaling_mode.py -q` (3 passed)
- `python -m pytest tests/moe/test_trtllm_gen_moe_autotune_tactics.py::test_nvfp4_static_gemm2_has_valid_tactics -q -s` on SM103 (1 passed)
- representative 1-token and 1024-token static GEMM2 numerical cases from `tests/moe/test_trtllm_gen_per_token_moe.py` on SM103 (2 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added static-scale NVFP4 quantization for FP4 MoE GEMM2 activations.
  * Added explicit control over GEMM2 per-token scaling, independently from GEMM1 scaling.
  * Preserved legacy scaling behavior when the new option is unspecified.
  * Added validation for compatible activation types and required token-scale inputs.
  * Improved support for scale layouts and activation routing during FP4 MoE execution.

* **Tests**
  * Added coverage for dynamic and static GEMM2 scaling modes, defaults, validation, tactic selection, and routed execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->