### PR TITLE
feat(comm): add fused decode CP A2A + LSE reduce

### DIFF
--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -1,0 +1,173 @@
+"""Benchmark decode-CP A2A + LSE reduce under torchrun.
+
+Example:
+  torchrun --standalone --nproc-per-node=4 \
+    benchmarks/bench_dcp_lse_reduce.py --label fused
+"""
+
+import argparse
+import json
+import os
+import statistics
+from typing import Callable
+
+import torch
+import torch.distributed as dist
+
+from flashinfer.comm import (
+    decode_cp_a2a_lse_reduce,
+    decode_cp_a2a_lse_reduce_create_workspace,
+)
+
+
+def _measure(
+    fn: Callable[[], None],
+    *,
+    warmup: int,
+    samples: int,
+    launches_per_sample: int,
+) -> list[float]:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+
+    times = []
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    for _ in range(samples):
+        start.record()
+        for _ in range(launches_per_sample):
+            fn()
+        end.record()
+        end.synchronize()
+        times.append(start.elapsed_time(end) * 1000 / launches_per_sample)
+    return times
+
+
+def _max_rank_median(times_us: list[float], world_size: int) -> float:
+    local = torch.tensor(times_us, dtype=torch.float64, device="cuda")
+    gathered = [torch.empty_like(local) for _ in range(world_size)]
+    dist.all_gather(gathered, local)
+    per_rank_medians = [statistics.median(tensor.cpu().tolist()) for tensor in gathered]
+    return max(per_rank_medians)
+
+
+def _benchmark_case(
+    *,
+    label: str,
+    batch: int,
+    local_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    samples: int,
+    launches_per_sample: int,
+) -> None:
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    torch.manual_seed(2026 + rank)
+
+    partial_o = torch.randn(
+        batch,
+        local_heads,
+        world_size,
+        head_dim,
+        dtype=dtype,
+        device="cuda",
+    )
+    partial_lse = torch.randn(
+        batch,
+        local_heads,
+        world_size,
+        dtype=torch.float32,
+        device="cuda",
+    )
+    workspace = decode_cp_a2a_lse_reduce_create_workspace(
+        max_tokens=batch,
+        local_heads=local_heads,
+        cp_size=world_size,
+        head_dim=head_dim,
+        dtype=dtype,
+        group=dist.group.WORLD,
+    )
+
+    def eager_call() -> None:
+        decode_cp_a2a_lse_reduce(
+            partial_o,
+            partial_lse,
+            workspace,
+            cp_rank=rank,
+            cp_size=world_size,
+        )
+
+    dist.barrier()
+    eager_us = _measure(
+        eager_call,
+        warmup=10,
+        samples=samples,
+        launches_per_sample=launches_per_sample,
+    )
+
+    dist.barrier()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        _graph_output = decode_cp_a2a_lse_reduce(
+            partial_o,
+            partial_lse,
+            workspace,
+            cp_rank=rank,
+            cp_size=world_size,
+        )
+    graph_us = _measure(
+        graph.replay,
+        warmup=10,
+        samples=samples,
+        launches_per_sample=launches_per_sample,
+    )
+
+    result = {
+        "label": label,
+        "world_size": world_size,
+        "batch": batch,
+        "local_heads": local_heads,
+        "head_dim": head_dim,
+        "dtype": str(dtype).removeprefix("torch."),
+        "eager_max_rank_median_us": _max_rank_median(eager_us, world_size),
+        "graph_max_rank_median_us": _max_rank_median(graph_us, world_size),
+    }
+    if rank == 0:
+        print("DCP_LSE_BENCH " + json.dumps(result, sort_keys=True), flush=True)
+    dist.barrier()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--samples", type=int, default=30)
+    parser.add_argument("--launches-per-sample", type=int, default=50)
+    args = parser.parse_args()
+
+    dist.init_process_group("nccl")
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    try:
+        for batch, local_heads, head_dim in [
+            (1, 2, 64),
+            (1, 8, 128),
+            (4, 8, 128),
+            (16, 8, 128),
+        ]:
+            _benchmark_case(
+                label=args.label,
+                batch=batch,
+                local_heads=local_heads,
+                head_dim=head_dim,
+                dtype=torch.bfloat16,
+                samples=args.samples,
+                launches_per_sample=args.launches_per_sample,
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -52,6 +52,34 @@ def _max_rank_median(times_us: list[float], world_size: int) -> float:
     return max(per_rank_medians)
 
 
+def _reference_a2a_lse_reduce(
+    partial_o: torch.Tensor,
+    partial_lse: torch.Tensor,
+    *,
+    cp_rank: int,
+    cp_size: int,
+) -> torch.Tensor:
+    """All-gather reference for the unfused A2A + LSE-reduction baseline."""
+    all_o = [torch.empty_like(partial_o) for _ in range(cp_size)]
+    all_lse = [torch.empty_like(partial_lse) for _ in range(cp_size)]
+    dist.all_gather(all_o, partial_o)
+    dist.all_gather(all_lse, partial_lse)
+    recv_o = torch.stack([tensor[..., cp_rank, :] for tensor in all_o], dim=-2)
+    recv_lse = torch.stack([tensor[..., cp_rank] for tensor in all_lse], dim=-1)
+    recv_lse = torch.where(
+        torch.isnan(recv_lse) | torch.isposinf(recv_lse),
+        torch.full_like(recv_lse, float("-inf")),
+        recv_lse,
+    )
+    lse_max = recv_lse.max(dim=-1, keepdim=True).values
+    lse_max = torch.where(torch.isneginf(lse_max), torch.zeros_like(lse_max), lse_max)
+    weights = torch.exp2(recv_lse - lse_max)
+    denom = weights.sum(dim=-1, keepdim=True)
+    output = (recv_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(1e-20)
+    output = torch.where(denom == 0, torch.zeros_like(output), output)
+    return output.to(partial_o.dtype)
+
+
 def _benchmark_case(
     *,
     label: str,
@@ -99,9 +127,25 @@ def _benchmark_case(
             cp_size=world_size,
         )
 
+    def baseline_call() -> None:
+        _reference_a2a_lse_reduce(
+            partial_o,
+            partial_lse,
+            cp_rank=rank,
+            cp_size=world_size,
+        )
+
     dist.barrier()
     eager_us = _measure(
         eager_call,
+        warmup=10,
+        samples=samples,
+        launches_per_sample=launches_per_sample,
+    )
+
+    dist.barrier()
+    baseline_us = _measure(
+        baseline_call,
         warmup=10,
         samples=samples,
         launches_per_sample=launches_per_sample,
@@ -132,6 +176,7 @@ def _benchmark_case(
         "head_dim": head_dim,
         "dtype": str(dtype).removeprefix("torch."),
         "eager_max_rank_median_us": _max_rank_median(eager_us, world_size),
+        "baseline_max_rank_median_us": _max_rank_median(baseline_us, world_size),
         "graph_max_rank_median_us": _max_rank_median(graph_us, world_size),
     }
     if rank == 0:
@@ -146,9 +191,15 @@ def main() -> None:
     parser.add_argument("--launches-per-sample", type=int, default=50)
     args = parser.parse_args()
 
-    dist.init_process_group("nccl")
     local_rank = int(os.environ["LOCAL_RANK"])
-    torch.cuda.set_device(local_rank)
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    # Eagerly create the NCCL communicator before the symmetric-memory
+    # rendezvous. This registers the group's host communicator for this
+    # concrete CUDA device on released PyTorch builds.
+    dist.init_process_group("nccl", device_id=device)
+    warmup = torch.zeros(1, device=device)
+    dist.all_reduce(warmup)
     try:
         for batch, local_heads, head_dim in [
             (1, 2, 64),

--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -169,20 +169,20 @@ def _benchmark_case(
         launches_per_sample=launches_per_sample,
     )
 
-    graph_50 = torch.cuda.CUDAGraph()
-    with torch.cuda.graph(graph_50):
+    graph_multi = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph_multi):
         for _ in range(graph_launches_per_replay):
-            graph_50_output = decode_cp_a2a_lse_reduce(
+            graph_multi_output = decode_cp_a2a_lse_reduce(
                 partial_o,
                 partial_lse,
                 workspace,
                 cp_rank=rank,
                 cp_size=world_size,
             )
-    graph_50_us = [
+    graph_multi_us = [
         value / graph_launches_per_replay
         for value in _measure(
-            graph_50.replay,
+            graph_multi.replay,
             warmup=10,
             samples=samples,
             launches_per_sample=1,
@@ -201,10 +201,10 @@ def _benchmark_case(
     torch.testing.assert_close(
         eager_call(), nccl_baseline_call(), rtol=1e-2, atol=1e-3
     )
-    graph_50.replay()
+    graph_multi.replay()
     torch.cuda.synchronize()
     torch.testing.assert_close(
-        graph_50_output, nccl_baseline_call(), rtol=1e-2, atol=1e-3
+        graph_multi_output, nccl_baseline_call(), rtol=1e-2, atol=1e-3
     )
 
     result = {
@@ -219,7 +219,10 @@ def _benchmark_case(
             nccl_baseline_us, world_size
         ),
         "graph_max_rank_median_us": _max_rank_median(graph_us, world_size),
-        "graph_50_max_rank_median_us": _max_rank_median(graph_50_us, world_size),
+        "graph_launches_per_replay": graph_launches_per_replay,
+        "graph_multi_launch_max_rank_median_us": _max_rank_median(
+            graph_multi_us, world_size
+        ),
     }
     if rank == 0:
         print("DCP_LSE_BENCH " + json.dumps(result, sort_keys=True), flush=True)
@@ -233,6 +236,8 @@ def main() -> None:
     parser.add_argument("--launches-per-sample", type=int, default=50)
     parser.add_argument("--graph-launches-per-replay", type=int, default=50)
     args = parser.parse_args()
+    if args.graph_launches_per_replay <= 0:
+        parser.error("--graph-launches-per-replay must be greater than zero")
 
     local_rank = int(os.environ["LOCAL_RANK"])
     device = torch.device("cuda", local_rank)

--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -90,6 +90,7 @@ def _benchmark_case(
     dtype: torch.dtype,
     samples: int,
     launches_per_sample: int,
+    graph_launches_per_replay: int,
 ) -> None:
     rank = dist.get_rank()
     world_size = dist.get_world_size()
@@ -168,6 +169,26 @@ def _benchmark_case(
         launches_per_sample=launches_per_sample,
     )
 
+    graph_50 = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph_50):
+        for _ in range(graph_launches_per_replay):
+            graph_50_output = decode_cp_a2a_lse_reduce(
+                partial_o,
+                partial_lse,
+                workspace,
+                cp_rank=rank,
+                cp_size=world_size,
+            )
+    graph_50_us = [
+        value / graph_launches_per_replay
+        for value in _measure(
+            graph_50.replay,
+            warmup=10,
+            samples=samples,
+            launches_per_sample=1,
+        )
+    ]
+
     dist.barrier()
     nccl_baseline_us = _measure(
         nccl_baseline_call,
@@ -179,6 +200,11 @@ def _benchmark_case(
     # Verify the communication permutation and merge outside the timed loops.
     torch.testing.assert_close(
         eager_call(), nccl_baseline_call(), rtol=1e-2, atol=1e-3
+    )
+    graph_50.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        graph_50_output, nccl_baseline_call(), rtol=1e-2, atol=1e-3
     )
 
     result = {
@@ -193,6 +219,7 @@ def _benchmark_case(
             nccl_baseline_us, world_size
         ),
         "graph_max_rank_median_us": _max_rank_median(graph_us, world_size),
+        "graph_50_max_rank_median_us": _max_rank_median(graph_50_us, world_size),
     }
     if rank == 0:
         print("DCP_LSE_BENCH " + json.dumps(result, sort_keys=True), flush=True)
@@ -204,6 +231,7 @@ def main() -> None:
     parser.add_argument("--label", required=True)
     parser.add_argument("--samples", type=int, default=30)
     parser.add_argument("--launches-per-sample", type=int, default=50)
+    parser.add_argument("--graph-launches-per-replay", type=int, default=50)
     args = parser.parse_args()
 
     local_rank = int(os.environ["LOCAL_RANK"])
@@ -230,6 +258,7 @@ def main() -> None:
                 dtype=torch.bfloat16,
                 samples=args.samples,
                 launches_per_sample=args.launches_per_sample,
+                graph_launches_per_replay=args.graph_launches_per_replay,
             )
     finally:
         dist.destroy_process_group()

--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -155,12 +155,25 @@ def _benchmark_case(
     )
 
     dist.barrier()
+    # CUDA graph capture uses a distinct stream. Each graph therefore needs a
+    # separately rendezvoused workspace under the one-stream workspace
+    # contract.
+    graph_workspace = decode_cp_a2a_lse_reduce_create_workspace(
+        max_tokens=batch,
+        local_heads=local_heads,
+        cp_size=world_size,
+        head_dim=head_dim,
+        dtype=dtype,
+        group=dist.group.WORLD,
+    )
+    # One-op replay isolates the CUDA graph replay overhead for one decode
+    # layer. Use a dedicated workspace because capture uses a distinct stream.
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         _graph_output = decode_cp_a2a_lse_reduce(
             partial_o,
             partial_lse,
-            workspace,
+            graph_workspace,
             cp_rank=rank,
             cp_size=world_size,
         )
@@ -171,13 +184,24 @@ def _benchmark_case(
         launches_per_sample=launches_per_sample,
     )
 
+    # Multi-op replay models one decode step containing many layers. Report
+    # its replay time per fused operation, and use another capture-specific
+    # workspace because this graph has its own stream.
+    graph_multi_workspace = decode_cp_a2a_lse_reduce_create_workspace(
+        max_tokens=batch,
+        local_heads=local_heads,
+        cp_size=world_size,
+        head_dim=head_dim,
+        dtype=dtype,
+        group=dist.group.WORLD,
+    )
     graph_multi = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph_multi):
         for _ in range(graph_launches_per_replay):
             graph_multi_output = decode_cp_a2a_lse_reduce(
                 partial_o,
                 partial_lse,
-                workspace,
+                graph_multi_workspace,
                 cp_rank=rank,
                 cp_size=world_size,
             )

--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -52,30 +52,31 @@ def _max_rank_median(times_us: list[float], world_size: int) -> float:
     return max(per_rank_medians)
 
 
-def _reference_a2a_lse_reduce(
+def _nccl_a2a_lse_reduce(
     partial_o: torch.Tensor,
     partial_lse: torch.Tensor,
-    *,
-    cp_rank: int,
-    cp_size: int,
+    send_o: torch.Tensor,
+    send_lse: torch.Tensor,
+    recv_o: torch.Tensor,
+    recv_lse: torch.Tensor,
 ) -> torch.Tensor:
-    """All-gather reference for the unfused A2A + LSE-reduction baseline."""
-    all_o = [torch.empty_like(partial_o) for _ in range(cp_size)]
-    all_lse = [torch.empty_like(partial_lse) for _ in range(cp_size)]
-    dist.all_gather(all_o, partial_o)
-    dist.all_gather(all_lse, partial_lse)
-    recv_o = torch.stack([tensor[..., cp_rank, :] for tensor in all_o], dim=-2)
-    recv_lse = torch.stack([tensor[..., cp_rank] for tensor in all_lse], dim=-1)
-    recv_lse = torch.where(
-        torch.isnan(recv_lse) | torch.isposinf(recv_lse),
-        torch.full_like(recv_lse, float("-inf")),
-        recv_lse,
+    """Unfused NCCL all-to-all plus the LSE-weighted merge."""
+    send_o.copy_(partial_o.permute(2, 0, 1, 3))
+    send_lse.copy_(partial_lse.permute(2, 0, 1))
+    dist.all_to_all_single(recv_o, send_o)
+    dist.all_to_all_single(recv_lse, send_lse)
+    peer_o = recv_o.permute(1, 2, 0, 3)
+    peer_lse = recv_lse.permute(1, 2, 0)
+    peer_lse = torch.where(
+        torch.isnan(peer_lse) | torch.isposinf(peer_lse),
+        torch.full_like(peer_lse, float("-inf")),
+        peer_lse,
     )
-    lse_max = recv_lse.max(dim=-1, keepdim=True).values
+    lse_max = peer_lse.max(dim=-1, keepdim=True).values
     lse_max = torch.where(torch.isneginf(lse_max), torch.zeros_like(lse_max), lse_max)
-    weights = torch.exp2(recv_lse - lse_max)
+    weights = torch.exp2(peer_lse - lse_max)
     denom = weights.sum(dim=-1, keepdim=True)
-    output = (recv_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(1e-20)
+    output = (peer_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(1e-20)
     output = torch.where(denom == 0, torch.zeros_like(output), output)
     return output.to(partial_o.dtype)
 
@@ -118,8 +119,8 @@ def _benchmark_case(
         group=dist.group.WORLD,
     )
 
-    def eager_call() -> None:
-        decode_cp_a2a_lse_reduce(
+    def eager_call() -> torch.Tensor:
+        return decode_cp_a2a_lse_reduce(
             partial_o,
             partial_lse,
             workspace,
@@ -127,25 +128,24 @@ def _benchmark_case(
             cp_size=world_size,
         )
 
-    def baseline_call() -> None:
-        _reference_a2a_lse_reduce(
+    nccl_send_o = torch.empty_like(partial_o.permute(2, 0, 1, 3).contiguous())
+    nccl_recv_o = torch.empty_like(nccl_send_o)
+    nccl_send_lse = torch.empty_like(partial_lse.permute(2, 0, 1).contiguous())
+    nccl_recv_lse = torch.empty_like(nccl_send_lse)
+
+    def nccl_baseline_call() -> torch.Tensor:
+        return _nccl_a2a_lse_reduce(
             partial_o,
             partial_lse,
-            cp_rank=rank,
-            cp_size=world_size,
+            nccl_send_o,
+            nccl_send_lse,
+            nccl_recv_o,
+            nccl_recv_lse,
         )
 
     dist.barrier()
     eager_us = _measure(
         eager_call,
-        warmup=10,
-        samples=samples,
-        launches_per_sample=launches_per_sample,
-    )
-
-    dist.barrier()
-    baseline_us = _measure(
-        baseline_call,
         warmup=10,
         samples=samples,
         launches_per_sample=launches_per_sample,
@@ -168,6 +168,19 @@ def _benchmark_case(
         launches_per_sample=launches_per_sample,
     )
 
+    dist.barrier()
+    nccl_baseline_us = _measure(
+        nccl_baseline_call,
+        warmup=10,
+        samples=samples,
+        launches_per_sample=launches_per_sample,
+    )
+
+    # Verify the communication permutation and merge outside the timed loops.
+    torch.testing.assert_close(
+        eager_call(), nccl_baseline_call(), rtol=1e-2, atol=1e-3
+    )
+
     result = {
         "label": label,
         "world_size": world_size,
@@ -176,7 +189,9 @@ def _benchmark_case(
         "head_dim": head_dim,
         "dtype": str(dtype).removeprefix("torch."),
         "eager_max_rank_median_us": _max_rank_median(eager_us, world_size),
-        "baseline_max_rank_median_us": _max_rank_median(baseline_us, world_size),
+        "nccl_baseline_max_rank_median_us": _max_rank_median(
+            nccl_baseline_us, world_size
+        ),
         "graph_max_rank_median_us": _max_rank_median(graph_us, world_size),
     }
     if rank == 0:

--- a/benchmarks/bench_dcp_lse_reduce.py
+++ b/benchmarks/bench_dcp_lse_reduce.py
@@ -76,7 +76,9 @@ def _nccl_a2a_lse_reduce(
     lse_max = torch.where(torch.isneginf(lse_max), torch.zeros_like(lse_max), lse_max)
     weights = torch.exp2(peer_lse - lse_max)
     denom = weights.sum(dim=-1, keepdim=True)
-    output = (peer_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(1e-20)
+    output = (peer_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(
+        1e-20
+    )
     output = torch.where(denom == 0, torch.zeros_like(output), output)
     return output.to(partial_o.dtype)
 
@@ -198,9 +200,7 @@ def _benchmark_case(
     )
 
     # Verify the communication permutation and merge outside the timed loops.
-    torch.testing.assert_close(
-        eager_call(), nccl_baseline_call(), rtol=1e-2, atol=1e-3
-    )
+    torch.testing.assert_close(eager_call(), nccl_baseline_call(), rtol=1e-2, atol=1e-3)
     graph_multi.replay()
     torch.cuda.synchronize()
     torch.testing.assert_close(

--- a/csrc/dcp_lse_reduce.cu
+++ b/csrc/dcp_lse_reduce.cu
@@ -1,22 +1,22 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAException.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <torch/library.h>
 
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+#include <flashinfer/comm/dcp_lse_reduce.cuh>
+#include <string>
 #include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
 #include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
-
-#include <flashinfer/comm/dcp_lse_reduce.cuh>
-#include "tvm_ffi_utils.h"
-
-#include <climits>
-#include <cstdint>
-#include <string>
 #include <vector>
+
+#include "tvm_ffi_utils.h"
 
 namespace flashinfer::comm::dcp {
 
@@ -26,16 +26,47 @@ using c10d::symmetric_memory::NCCLSymmetricMemory;
 namespace {
 
 template <typename T, bool BaseE>
-void launch_merge(const unsigned char* workspace, size_t out_region_offset, size_t slot_out_bytes,
-                  size_t lse_region_offset, size_t slot_lse_bytes, const uint32_t* state,
-                  at::Tensor& output, int cp_size, int num_tokens, int max_tokens, int local_heads,
-                  int head_dim, cudaStream_t stream) {
-  const dim3 grid(static_cast<unsigned int>(num_tokens), static_cast<unsigned int>(local_heads));
+void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* workspace,
+                  ncclWindow_t window, size_t signal_window_offset, size_t out_region_window_offset,
+                  size_t out_region_local_offset, size_t slot_out_bytes,
+                  size_t lse_region_window_offset, size_t lse_region_local_offset,
+                  size_t slot_lse_bytes, at::Tensor& output, int rank, int cp_size, int num_tokens,
+                  int max_tokens, int local_heads, int head_dim, cudaStream_t stream) {
   const size_t smem = static_cast<size_t>(cp_size) * sizeof(float);
-  MergeKernel<T, BaseE><<<grid, kMergeBlockSize, smem, stream>>>(
-      workspace, out_region_offset, slot_out_bytes, lse_region_offset, slot_lse_bytes, state,
-      reinterpret_cast<T*>(output.data_ptr()), cp_size, num_tokens, max_tokens, local_heads,
-      head_dim);
+  int blocks_per_sm = 0;
+  C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+      &blocks_per_sm, FusedKernel<T, BaseE>, kFusedBlockSize, smem));
+  const cudaDeviceProp* props = at::cuda::getCurrentDeviceProperties();
+  TORCH_CHECK(props->cooperativeLaunch, "decode_cp_a2a_lse_reduce requires cooperative launch");
+  const int max_cooperative_blocks = blocks_per_sm * props->multiProcessorCount;
+  TORCH_CHECK(max_cooperative_blocks > 0,
+              "decode_cp_a2a_lse_reduce has no cooperative launch capacity");
+  const int desired_blocks = std::max(num_tokens * local_heads, cp_size);
+  const int grid_blocks = std::min(desired_blocks, max_cooperative_blocks);
+  T* output_ptr = reinterpret_cast<T*>(output.data_ptr());
+  void* args[] = {
+      &partial_o,
+      &partial_lse,
+      &workspace,
+      &window,
+      &signal_window_offset,
+      &out_region_window_offset,
+      &out_region_local_offset,
+      &slot_out_bytes,
+      &lse_region_window_offset,
+      &lse_region_local_offset,
+      &slot_lse_bytes,
+      &output_ptr,
+      &rank,
+      &cp_size,
+      &num_tokens,
+      &max_tokens,
+      &local_heads,
+      &head_dim,
+  };
+  C10_CUDA_CHECK(cudaLaunchCooperativeKernel(reinterpret_cast<void*>(FusedKernel<T, BaseE>),
+                                             dim3(grid_blocks), dim3(kFusedBlockSize), args, smem,
+                                             stream));
 }
 
 }  // namespace
@@ -50,23 +81,21 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
   TORCH_CHECK(partial_o.is_contiguous(), "partial_o must be contiguous");
   TORCH_CHECK(partial_lse.is_contiguous(), "partial_lse must be contiguous");
   TORCH_CHECK(workspace.is_contiguous(), "workspace must be contiguous");
-  TORCH_CHECK(partial_o.dim() >= 3,
-              "partial_o must be at least 3-D [..., cp_size, head_dim]");
+  TORCH_CHECK(partial_o.dim() >= 3, "partial_o must be at least 3-D [..., cp_size, head_dim]");
   TORCH_CHECK(partial_lse.dim() == partial_o.dim() - 1,
               "partial_lse must have one fewer dimension than partial_o");
   TORCH_CHECK(partial_o.scalar_type() == at::kHalf || partial_o.scalar_type() == at::kBFloat16,
               "partial_o must be float16 or bfloat16");
   TORCH_CHECK(partial_lse.scalar_type() == at::kFloat, "partial_lse must be float32");
   TORCH_CHECK(workspace.scalar_type() == at::kByte, "workspace must be a uint8 tensor");
-  TORCH_CHECK(partial_o.device() == partial_lse.device() &&
-                  partial_o.device() == workspace.device(),
-              "partial_o, partial_lse, and workspace must be on the same device");
+  TORCH_CHECK(
+      partial_o.device() == partial_lse.device() && partial_o.device() == workspace.device(),
+      "partial_o, partial_lse, and workspace must be on the same device");
   TORCH_CHECK(cp_size > 0 && cp_size <= kMaxRanks, "cp_size must be in [1, ", kMaxRanks, "]");
   TORCH_CHECK(cp_rank >= 0 && cp_rank < cp_size, "cp_rank must be in [0, cp_size)");
   TORCH_CHECK(partial_o.size(-2) == cp_size,
               "partial_o second-to-last dimension must equal cp_size");
-  TORCH_CHECK(partial_lse.size(-1) == cp_size,
-              "partial_lse last dimension must equal cp_size");
+  TORCH_CHECK(partial_lse.size(-1) == cp_size, "partial_lse last dimension must equal cp_size");
   for (int64_t i = 0; i < partial_lse.dim() - 1; ++i) {
     TORCH_CHECK(partial_o.size(i) == partial_lse.size(i),
                 "partial_o and partial_lse leading dimensions must match");
@@ -90,8 +119,7 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
   TORCH_CHECK(symm_mem != nullptr,
               "workspace must be allocated via torch symmetric memory and rendezvoused first");
   auto* nccl_hdl = dynamic_cast<NCCLSymmetricMemory*>(symm_mem.get());
-  TORCH_CHECK(nccl_hdl != nullptr,
-              "workspace requires the NCCL torch symmetric-memory backend");
+  TORCH_CHECK(nccl_hdl != nullptr, "workspace requires the NCCL torch symmetric-memory backend");
 
   c10::cuda::CUDAGuard guard(partial_o.device());
   const auto stream = at::cuda::getCurrentCUDAStream();
@@ -104,7 +132,6 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
   auto devcomm_opt = manager.get_devcomm(group_name, kDevcommKey);
   if (!devcomm_opt) {
     ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
-    reqs.lsaBarrierCount = 1;
     ncclDevComm devcomm;
     C10D_NCCL_CHECK(ncclDevCommCreate(comm, &reqs, &devcomm),
                     "ncclDevCommCreate failed in decode_cp_a2a_lse_reduce");
@@ -122,22 +149,23 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
               "workspace must be the base symmetric-memory tensor, not a view");
   TORCH_CHECK(reinterpret_cast<uintptr_t>(workspace.data_ptr()) % 16 == 0,
               "workspace must be 16-byte aligned");
-  TORCH_CHECK((nccl_hdl->get_window_offset() + kMetadataBytes) % 16 == 0,
+  const size_t payload_offset = PayloadOffset(cp_size);
+  TORCH_CHECK((nccl_hdl->get_window_offset() + payload_offset) % 16 == 0,
               "payload offset within the NCCL symmetric window must be 16-byte aligned");
 
   const size_t workspace_bytes = static_cast<size_t>(workspace.numel());
   const size_t bytes_per_token =
       kNumSlots * static_cast<size_t>(cp_size) * static_cast<size_t>(local_heads_i64) *
       (static_cast<size_t>(head_dim_i64) * partial_o.element_size() + sizeof(float));
-  TORCH_CHECK(workspace_bytes >= kMetadataBytes &&
-                  (workspace_bytes - kMetadataBytes) % bytes_per_token == 0,
+  TORCH_CHECK(workspace_bytes >= payload_offset &&
+                  (workspace_bytes - payload_offset) % bytes_per_token == 0,
               "workspace has an invalid size for this tensor geometry");
   const int64_t max_tokens_i64 =
-      static_cast<int64_t>((workspace_bytes - kMetadataBytes) / bytes_per_token);
+      static_cast<int64_t>((workspace_bytes - payload_offset) / bytes_per_token);
   TORCH_CHECK(num_tokens_i64 <= max_tokens_i64, "input token count exceeds workspace capacity");
 
-  TORCH_CHECK(num_tokens_i64 <= INT_MAX && local_heads_i64 <= INT_MAX &&
-                  head_dim_i64 <= INT_MAX && max_tokens_i64 <= INT_MAX,
+  TORCH_CHECK(num_tokens_i64 <= INT_MAX && local_heads_i64 <= INT_MAX && head_dim_i64 <= INT_MAX &&
+                  max_tokens_i64 <= INT_MAX,
               "tensor geometry exceeds kernel integer limits");
   const int num_tokens = static_cast<int>(num_tokens_i64);
   const int local_heads = static_cast<int>(local_heads_i64);
@@ -148,62 +176,48 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
   const size_t slot_out_bytes = rows_per_slot * head_dim * partial_o.element_size();
   const size_t slot_lse_bytes = rows_per_slot * sizeof(float);
   const size_t window_base_offset = nccl_hdl->get_window_offset();
-  const size_t out_region_window_offset = window_base_offset + kMetadataBytes;
-  const size_t lse_region_window_offset =
-      out_region_window_offset + kNumSlots * slot_out_bytes;
+  const size_t signal_window_offset = window_base_offset + kMetadataBytes;
+  const size_t out_region_window_offset = window_base_offset + payload_offset;
+  const size_t lse_region_window_offset = out_region_window_offset + kNumSlots * slot_out_bytes;
   auto* workspace_ptr = static_cast<unsigned char*>(workspace.data_ptr());
-  auto* state = reinterpret_cast<uint32_t*>(workspace_ptr);
+  const size_t out_region_local_offset = payload_offset;
+  const size_t lse_region_local_offset = out_region_local_offset + kNumSlots * slot_out_bytes;
 
   std::vector<int64_t> output_shape(partial_o.sizes().begin(), partial_o.sizes().end() - 2);
   output_shape.push_back(head_dim_i64);
   at::Tensor output = at::empty(output_shape, partial_o.options());
 
-  SelectSlotKernel<<<1, 1, 0, stream>>>(state);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-  const dim3 put_grid(static_cast<unsigned int>(num_tokens * local_heads),
-                      static_cast<unsigned int>(cp_size));
-  if (partial_o.scalar_type() == at::kHalf) {
-    PutPackedKernel<__half><<<put_grid, kPutBlockSize, 0, stream>>>(
-        reinterpret_cast<const __half*>(partial_o.data_ptr()),
-        partial_lse.data_ptr<float>(), window, out_region_window_offset, slot_out_bytes,
-        lse_region_window_offset, slot_lse_bytes, state, cp_rank, cp_size, num_tokens,
-        max_tokens, local_heads, head_dim);
-  } else {
-    PutPackedKernel<__nv_bfloat16><<<put_grid, kPutBlockSize, 0, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(partial_o.data_ptr()),
-        partial_lse.data_ptr<float>(), window, out_region_window_offset, slot_out_bytes,
-        lse_region_window_offset, slot_lse_bytes, state, cp_rank, cp_size, num_tokens,
-        max_tokens, local_heads, head_dim);
-  }
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  BarrierKernel<<<1, 32, 0, stream>>>(devcomm);
-  C10_CUDA_KERNEL_LAUNCH_CHECK();
-
-  const size_t out_region_local_offset = kMetadataBytes;
-  const size_t lse_region_local_offset =
-      out_region_local_offset + kNumSlots * slot_out_bytes;
   if (partial_o.scalar_type() == at::kHalf) {
     if (is_lse_base_on_e) {
-      launch_merge<__half, true>(workspace_ptr, out_region_local_offset, slot_out_bytes,
-                                 lse_region_local_offset, slot_lse_bytes, state, output, cp_size,
+      launch_fused<__half, true>(reinterpret_cast<const __half*>(partial_o.data_ptr()),
+                                 partial_lse.data_ptr<float>(), workspace_ptr, window,
+                                 signal_window_offset, out_region_window_offset,
+                                 out_region_local_offset, slot_out_bytes, lse_region_window_offset,
+                                 lse_region_local_offset, slot_lse_bytes, output, cp_rank, cp_size,
                                  num_tokens, max_tokens, local_heads, head_dim, stream);
     } else {
-      launch_merge<__half, false>(workspace_ptr, out_region_local_offset, slot_out_bytes,
-                                  lse_region_local_offset, slot_lse_bytes, state, output, cp_size,
+      launch_fused<__half, false>(reinterpret_cast<const __half*>(partial_o.data_ptr()),
+                                  partial_lse.data_ptr<float>(), workspace_ptr, window,
+                                  signal_window_offset, out_region_window_offset,
+                                  out_region_local_offset, slot_out_bytes, lse_region_window_offset,
+                                  lse_region_local_offset, slot_lse_bytes, output, cp_rank, cp_size,
                                   num_tokens, max_tokens, local_heads, head_dim, stream);
     }
   } else {
     if (is_lse_base_on_e) {
-      launch_merge<__nv_bfloat16, true>(
-          workspace_ptr, out_region_local_offset, slot_out_bytes, lse_region_local_offset,
-          slot_lse_bytes, state, output, cp_size, num_tokens, max_tokens, local_heads, head_dim,
-          stream);
+      launch_fused<__nv_bfloat16, true>(
+          reinterpret_cast<const __nv_bfloat16*>(partial_o.data_ptr()),
+          partial_lse.data_ptr<float>(), workspace_ptr, window, signal_window_offset,
+          out_region_window_offset, out_region_local_offset, slot_out_bytes,
+          lse_region_window_offset, lse_region_local_offset, slot_lse_bytes, output, cp_rank,
+          cp_size, num_tokens, max_tokens, local_heads, head_dim, stream);
     } else {
-      launch_merge<__nv_bfloat16, false>(
-          workspace_ptr, out_region_local_offset, slot_out_bytes, lse_region_local_offset,
-          slot_lse_bytes, state, output, cp_size, num_tokens, max_tokens, local_heads, head_dim,
-          stream);
+      launch_fused<__nv_bfloat16, false>(
+          reinterpret_cast<const __nv_bfloat16*>(partial_o.data_ptr()),
+          partial_lse.data_ptr<float>(), workspace_ptr, window, signal_window_offset,
+          out_region_window_offset, out_region_local_offset, slot_out_bytes,
+          lse_region_window_offset, lse_region_local_offset, slot_lse_bytes, output, cp_rank,
+          cp_size, num_tokens, max_tokens, local_heads, head_dim, stream);
     }
   }
   C10_CUDA_KERNEL_LAUNCH_CHECK();
@@ -217,8 +231,9 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
 }  // namespace flashinfer::comm::dcp
 
 TORCH_LIBRARY_FRAGMENT(flashinfer, m) {
-  m.def("decode_cp_a2a_lse_reduce(Tensor partial_o, Tensor partial_lse, Tensor(a!) workspace, "
-        "int cp_rank, int cp_size, bool is_lse_base_on_e, str group_name) -> Tensor");
+  m.def(
+      "decode_cp_a2a_lse_reduce(Tensor partial_o, Tensor partial_lse, Tensor(a!) workspace, "
+      "int cp_rank, int cp_size, bool is_lse_base_on_e, str group_name) -> Tensor");
 }
 
 TORCH_LIBRARY_IMPL(flashinfer, CUDA, m) {
@@ -228,8 +243,6 @@ TORCH_LIBRARY_IMPL(flashinfer, CUDA, m) {
 // Give FlashInfer's TVM-FFI JIT loader an exported symbol; loading this module
 // also runs the TORCH_LIBRARY static initializers above.
 namespace {
-bool isDcpLseReduceLoaded() {
-  return true;
-}
+bool isDcpLseReduceLoaded() { return true; }
 }  // namespace
 TVM_FFI_DLL_EXPORT_TYPED_FUNC(dcp_lse_reduce_loaded, isDcpLseReduceLoaded);

--- a/csrc/dcp_lse_reduce.cu
+++ b/csrc/dcp_lse_reduce.cu
@@ -1,0 +1,235 @@
+#include <ATen/ATen.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/library.h>
+
+#include <torch/csrc/distributed/c10d/NCCLUtils.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/NCCLSymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/SymmetricMemory.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_dev_cap.hpp>
+#include <torch/csrc/distributed/c10d/symm_mem/nccl_devcomm_manager.hpp>
+
+#include <flashinfer/comm/dcp_lse_reduce.cuh>
+#include "tvm_ffi_utils.h"
+
+#include <climits>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace flashinfer::comm::dcp {
+
+using c10d::symmetric_memory::NCCLDevCommManager;
+using c10d::symmetric_memory::NCCLSymmetricMemory;
+
+namespace {
+
+template <typename T, bool BaseE>
+void launch_merge(const unsigned char* workspace, size_t out_region_offset, size_t slot_out_bytes,
+                  size_t lse_region_offset, size_t slot_lse_bytes, const uint32_t* state,
+                  at::Tensor& output, int cp_size, int num_tokens, int max_tokens, int local_heads,
+                  int head_dim, cudaStream_t stream) {
+  const dim3 grid(static_cast<unsigned int>(num_tokens), static_cast<unsigned int>(local_heads));
+  const size_t smem = static_cast<size_t>(cp_size) * sizeof(float);
+  MergeKernel<T, BaseE><<<grid, kMergeBlockSize, smem, stream>>>(
+      workspace, out_region_offset, slot_out_bytes, lse_region_offset, slot_lse_bytes, state,
+      reinterpret_cast<T*>(output.data_ptr()), cp_size, num_tokens, max_tokens, local_heads,
+      head_dim);
+}
+
+}  // namespace
+
+at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial_lse,
+                          const at::Tensor& workspace, int64_t cp_rank, int64_t cp_size,
+                          bool is_lse_base_on_e, const std::string& group_name) {
+#ifdef NCCL_HAS_DEVCOMM
+  TORCH_CHECK(partial_o.is_cuda(), "partial_o must be a CUDA tensor");
+  TORCH_CHECK(partial_lse.is_cuda(), "partial_lse must be a CUDA tensor");
+  TORCH_CHECK(workspace.is_cuda(), "workspace must be a CUDA tensor");
+  TORCH_CHECK(partial_o.is_contiguous(), "partial_o must be contiguous");
+  TORCH_CHECK(partial_lse.is_contiguous(), "partial_lse must be contiguous");
+  TORCH_CHECK(workspace.is_contiguous(), "workspace must be contiguous");
+  TORCH_CHECK(partial_o.dim() >= 3,
+              "partial_o must be at least 3-D [..., cp_size, head_dim]");
+  TORCH_CHECK(partial_lse.dim() == partial_o.dim() - 1,
+              "partial_lse must have one fewer dimension than partial_o");
+  TORCH_CHECK(partial_o.scalar_type() == at::kHalf || partial_o.scalar_type() == at::kBFloat16,
+              "partial_o must be float16 or bfloat16");
+  TORCH_CHECK(partial_lse.scalar_type() == at::kFloat, "partial_lse must be float32");
+  TORCH_CHECK(workspace.scalar_type() == at::kByte, "workspace must be a uint8 tensor");
+  TORCH_CHECK(partial_o.device() == partial_lse.device() &&
+                  partial_o.device() == workspace.device(),
+              "partial_o, partial_lse, and workspace must be on the same device");
+  TORCH_CHECK(cp_size > 0 && cp_size <= kMaxRanks, "cp_size must be in [1, ", kMaxRanks, "]");
+  TORCH_CHECK(cp_rank >= 0 && cp_rank < cp_size, "cp_rank must be in [0, cp_size)");
+  TORCH_CHECK(partial_o.size(-2) == cp_size,
+              "partial_o second-to-last dimension must equal cp_size");
+  TORCH_CHECK(partial_lse.size(-1) == cp_size,
+              "partial_lse last dimension must equal cp_size");
+  for (int64_t i = 0; i < partial_lse.dim() - 1; ++i) {
+    TORCH_CHECK(partial_o.size(i) == partial_lse.size(i),
+                "partial_o and partial_lse leading dimensions must match");
+  }
+
+  const int64_t head_dim_i64 = partial_o.size(-1);
+  TORCH_CHECK(head_dim_i64 * partial_o.element_size() % 16 == 0,
+              "partial_o rows must be 16-byte aligned");
+
+  // Every point in the leading shape is an independent reduction entry. This
+  // handles [batch, heads, cp, dim], [rows, cp, dim], and additional batch
+  // dimensions without assigning semantics to any one leading axis.
+  constexpr int64_t local_heads_i64 = 1;
+  int64_t num_tokens_i64 = 1;
+  for (int64_t i = 0; i < partial_o.dim() - 2; ++i) {
+    num_tokens_i64 *= partial_o.size(i);
+  }
+  TORCH_CHECK(num_tokens_i64 > 0, "zero-token inputs are not supported");
+
+  auto symm_mem = c10d::symmetric_memory::rendezvous(workspace, group_name);
+  TORCH_CHECK(symm_mem != nullptr,
+              "workspace must be allocated via torch symmetric memory and rendezvoused first");
+  auto* nccl_hdl = dynamic_cast<NCCLSymmetricMemory*>(symm_mem.get());
+  TORCH_CHECK(nccl_hdl != nullptr,
+              "workspace requires the NCCL torch symmetric-memory backend");
+
+  c10::cuda::CUDAGuard guard(partial_o.device());
+  const auto stream = at::cuda::getCurrentCUDAStream();
+  TORCH_CHECK(nccl_hdl->get_group_name() == group_name,
+              "workspace was rendezvoused with a different process group");
+  auto& manager = NCCLDevCommManager::get(partial_o.device());
+  ncclComm_t comm = manager.get_comm(group_name);
+
+  static constexpr char kDevcommKey[] = "flashinfer_decode_cp_a2a_lse_reduce";
+  auto devcomm_opt = manager.get_devcomm(group_name, kDevcommKey);
+  if (!devcomm_opt) {
+    ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
+    reqs.lsaBarrierCount = 1;
+    ncclDevComm devcomm;
+    C10D_NCCL_CHECK(ncclDevCommCreate(comm, &reqs, &devcomm),
+                    "ncclDevCommCreate failed in decode_cp_a2a_lse_reduce");
+    devcomm_opt = manager.register_devcomm(group_name, devcomm, kDevcommKey);
+  }
+  ncclDevComm& devcomm = devcomm_opt->get();
+  TORCH_CHECK(devcomm.nRanks == cp_size, "cp_size does not match the workspace group");
+  TORCH_CHECK(devcomm.rank == cp_rank, "cp_rank does not match the workspace group");
+  TORCH_CHECK(devcomm.lsaSize == cp_size,
+              "decode_cp_a2a_lse_reduce requires one NCCL LSA/NVLink domain");
+
+  ncclWindow_t window = nccl_hdl->get_window();
+  TORCH_CHECK(window != nullptr, "NCCL symmetric-memory window is null");
+  TORCH_CHECK(workspace.storage_offset() == 0,
+              "workspace must be the base symmetric-memory tensor, not a view");
+  TORCH_CHECK(reinterpret_cast<uintptr_t>(workspace.data_ptr()) % 16 == 0,
+              "workspace must be 16-byte aligned");
+  TORCH_CHECK((nccl_hdl->get_window_offset() + kMetadataBytes) % 16 == 0,
+              "payload offset within the NCCL symmetric window must be 16-byte aligned");
+
+  const size_t workspace_bytes = static_cast<size_t>(workspace.numel());
+  const size_t bytes_per_token =
+      kNumSlots * static_cast<size_t>(cp_size) * static_cast<size_t>(local_heads_i64) *
+      (static_cast<size_t>(head_dim_i64) * partial_o.element_size() + sizeof(float));
+  TORCH_CHECK(workspace_bytes >= kMetadataBytes &&
+                  (workspace_bytes - kMetadataBytes) % bytes_per_token == 0,
+              "workspace has an invalid size for this tensor geometry");
+  const int64_t max_tokens_i64 =
+      static_cast<int64_t>((workspace_bytes - kMetadataBytes) / bytes_per_token);
+  TORCH_CHECK(num_tokens_i64 <= max_tokens_i64, "input token count exceeds workspace capacity");
+
+  TORCH_CHECK(num_tokens_i64 <= INT_MAX && local_heads_i64 <= INT_MAX &&
+                  head_dim_i64 <= INT_MAX && max_tokens_i64 <= INT_MAX,
+              "tensor geometry exceeds kernel integer limits");
+  const int num_tokens = static_cast<int>(num_tokens_i64);
+  const int local_heads = static_cast<int>(local_heads_i64);
+  const int head_dim = static_cast<int>(head_dim_i64);
+  const int max_tokens = static_cast<int>(max_tokens_i64);
+
+  const size_t rows_per_slot = static_cast<size_t>(cp_size) * max_tokens * local_heads;
+  const size_t slot_out_bytes = rows_per_slot * head_dim * partial_o.element_size();
+  const size_t slot_lse_bytes = rows_per_slot * sizeof(float);
+  const size_t window_base_offset = nccl_hdl->get_window_offset();
+  const size_t out_region_window_offset = window_base_offset + kMetadataBytes;
+  const size_t lse_region_window_offset =
+      out_region_window_offset + kNumSlots * slot_out_bytes;
+  auto* workspace_ptr = static_cast<unsigned char*>(workspace.data_ptr());
+  auto* state = reinterpret_cast<uint32_t*>(workspace_ptr);
+
+  std::vector<int64_t> output_shape(partial_o.sizes().begin(), partial_o.sizes().end() - 2);
+  output_shape.push_back(head_dim_i64);
+  at::Tensor output = at::empty(output_shape, partial_o.options());
+
+  SelectSlotKernel<<<1, 1, 0, stream>>>(state);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  const dim3 put_grid(static_cast<unsigned int>(num_tokens * local_heads),
+                      static_cast<unsigned int>(cp_size));
+  if (partial_o.scalar_type() == at::kHalf) {
+    PutPackedKernel<__half><<<put_grid, kPutBlockSize, 0, stream>>>(
+        reinterpret_cast<const __half*>(partial_o.data_ptr()),
+        partial_lse.data_ptr<float>(), window, out_region_window_offset, slot_out_bytes,
+        lse_region_window_offset, slot_lse_bytes, state, cp_rank, cp_size, num_tokens,
+        max_tokens, local_heads, head_dim);
+  } else {
+    PutPackedKernel<__nv_bfloat16><<<put_grid, kPutBlockSize, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(partial_o.data_ptr()),
+        partial_lse.data_ptr<float>(), window, out_region_window_offset, slot_out_bytes,
+        lse_region_window_offset, slot_lse_bytes, state, cp_rank, cp_size, num_tokens,
+        max_tokens, local_heads, head_dim);
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  BarrierKernel<<<1, 32, 0, stream>>>(devcomm);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  const size_t out_region_local_offset = kMetadataBytes;
+  const size_t lse_region_local_offset =
+      out_region_local_offset + kNumSlots * slot_out_bytes;
+  if (partial_o.scalar_type() == at::kHalf) {
+    if (is_lse_base_on_e) {
+      launch_merge<__half, true>(workspace_ptr, out_region_local_offset, slot_out_bytes,
+                                 lse_region_local_offset, slot_lse_bytes, state, output, cp_size,
+                                 num_tokens, max_tokens, local_heads, head_dim, stream);
+    } else {
+      launch_merge<__half, false>(workspace_ptr, out_region_local_offset, slot_out_bytes,
+                                  lse_region_local_offset, slot_lse_bytes, state, output, cp_size,
+                                  num_tokens, max_tokens, local_heads, head_dim, stream);
+    }
+  } else {
+    if (is_lse_base_on_e) {
+      launch_merge<__nv_bfloat16, true>(
+          workspace_ptr, out_region_local_offset, slot_out_bytes, lse_region_local_offset,
+          slot_lse_bytes, state, output, cp_size, num_tokens, max_tokens, local_heads, head_dim,
+          stream);
+    } else {
+      launch_merge<__nv_bfloat16, false>(
+          workspace_ptr, out_region_local_offset, slot_out_bytes, lse_region_local_offset,
+          slot_lse_bytes, state, output, cp_size, num_tokens, max_tokens, local_heads, head_dim,
+          stream);
+    }
+  }
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+  return output;
+#else
+  TORCH_CHECK(false,
+              "decode_cp_a2a_lse_reduce requires NCCL >= 2.29 with device communicator support");
+#endif
+}
+
+}  // namespace flashinfer::comm::dcp
+
+TORCH_LIBRARY_FRAGMENT(flashinfer, m) {
+  m.def("decode_cp_a2a_lse_reduce(Tensor partial_o, Tensor partial_lse, Tensor(a!) workspace, "
+        "int cp_rank, int cp_size, bool is_lse_base_on_e, str group_name) -> Tensor");
+}
+
+TORCH_LIBRARY_IMPL(flashinfer, CUDA, m) {
+  m.impl("decode_cp_a2a_lse_reduce", TORCH_FN(flashinfer::comm::dcp::dcp_lse_reduce));
+}
+
+// Give FlashInfer's TVM-FFI JIT loader an exported symbol; loading this module
+// also runs the TORCH_LIBRARY static initializers above.
+namespace {
+bool isDcpLseReduceLoaded() {
+  return true;
+}
+}  // namespace
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(dcp_lse_reduce_loaded, isDcpLseReduceLoaded);

--- a/csrc/dcp_lse_reduce.cu
+++ b/csrc/dcp_lse_reduce.cu
@@ -71,9 +71,9 @@ void launch_fused_impl(const T* partial_o, const float* partial_lse, unsigned ch
       &local_heads,
       &head_dim,
   };
-  C10_CUDA_CHECK(cudaLaunchCooperativeKernel(
-      reinterpret_cast<void*>(FusedKernel<T, BaseE, RowDistributed>), dim3(grid_blocks),
-      dim3(kFusedBlockSize), args, smem, stream));
+  C10_CUDA_CHECK(
+      cudaLaunchCooperativeKernel(reinterpret_cast<void*>(FusedKernel<T, BaseE, RowDistributed>),
+                                  dim3(grid_blocks), dim3(kFusedBlockSize), args, smem, stream));
 }
 
 template <typename T, bool BaseE>
@@ -88,19 +88,17 @@ void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* w
   // rows to occupy the cooperative grid, distribute (destination, row) pairs
   // across blocks so multiple blocks can serve the same destination.
   if (num_tokens * local_heads >= kRowDistributedMinEntries) {
-    launch_fused_impl<T, BaseE, true>(partial_o, partial_lse, workspace, window,
-                                      signal_window_offset, out_region_window_offset,
-                                      out_region_local_offset, slot_out_bytes,
-                                      lse_region_window_offset, lse_region_local_offset,
-                                      slot_lse_bytes, output, rank, cp_size, num_tokens, max_tokens,
-                                      local_heads, head_dim, stream);
+    launch_fused_impl<T, BaseE, true>(
+        partial_o, partial_lse, workspace, window, signal_window_offset, out_region_window_offset,
+        out_region_local_offset, slot_out_bytes, lse_region_window_offset, lse_region_local_offset,
+        slot_lse_bytes, output, rank, cp_size, num_tokens, max_tokens, local_heads, head_dim,
+        stream);
   } else {
-    launch_fused_impl<T, BaseE, false>(partial_o, partial_lse, workspace, window,
-                                       signal_window_offset, out_region_window_offset,
-                                       out_region_local_offset, slot_out_bytes,
-                                       lse_region_window_offset, lse_region_local_offset,
-                                       slot_lse_bytes, output, rank, cp_size, num_tokens, max_tokens,
-                                       local_heads, head_dim, stream);
+    launch_fused_impl<T, BaseE, false>(
+        partial_o, partial_lse, workspace, window, signal_window_offset, out_region_window_offset,
+        out_region_local_offset, slot_out_bytes, lse_region_window_offset, lse_region_local_offset,
+        slot_lse_bytes, output, rank, cp_size, num_tokens, max_tokens, local_heads, head_dim,
+        stream);
   }
 }
 

--- a/csrc/dcp_lse_reduce.cu
+++ b/csrc/dcp_lse_reduce.cu
@@ -25,6 +25,8 @@ using c10d::symmetric_memory::NCCLSymmetricMemory;
 
 namespace {
 
+constexpr int kRowDistributedMinEntries = 16;
+
 void CheckNccl(ncclResult_t result, const char* operation) {
   TORCH_CHECK(result == ncclSuccess, operation, ": ", ncclGetErrorString(result));
 }
@@ -81,7 +83,11 @@ void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* w
                   size_t lse_region_window_offset, size_t lse_region_local_offset,
                   size_t slot_lse_bytes, at::Tensor& output, int rank, int cp_size, int num_tokens,
                   int max_tokens, int local_heads, int head_dim, cudaStream_t stream) {
-  if (num_tokens * local_heads >= 16) {
+  // Small decode batches keep all rows for one destination in its owning
+  // block, avoiding an extra grid synchronization. Once there are enough
+  // rows to occupy the cooperative grid, distribute (destination, row) pairs
+  // across blocks so multiple blocks can serve the same destination.
+  if (num_tokens * local_heads >= kRowDistributedMinEntries) {
     launch_fused_impl<T, BaseE, true>(partial_o, partial_lse, workspace, window,
                                       signal_window_offset, out_region_window_offset,
                                       out_region_local_offset, slot_out_bytes,

--- a/csrc/dcp_lse_reduce.cu
+++ b/csrc/dcp_lse_reduce.cu
@@ -29,17 +29,18 @@ void CheckNccl(ncclResult_t result, const char* operation) {
   TORCH_CHECK(result == ncclSuccess, operation, ": ", ncclGetErrorString(result));
 }
 
-template <typename T, bool BaseE>
-void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* workspace,
-                  ncclWindow_t window, size_t signal_window_offset, size_t out_region_window_offset,
-                  size_t out_region_local_offset, size_t slot_out_bytes,
-                  size_t lse_region_window_offset, size_t lse_region_local_offset,
-                  size_t slot_lse_bytes, at::Tensor& output, int rank, int cp_size, int num_tokens,
-                  int max_tokens, int local_heads, int head_dim, cudaStream_t stream) {
+template <typename T, bool BaseE, bool RowDistributed>
+void launch_fused_impl(const T* partial_o, const float* partial_lse, unsigned char* workspace,
+                       ncclWindow_t window, size_t signal_window_offset,
+                       size_t out_region_window_offset, size_t out_region_local_offset,
+                       size_t slot_out_bytes, size_t lse_region_window_offset,
+                       size_t lse_region_local_offset, size_t slot_lse_bytes, at::Tensor& output,
+                       int rank, int cp_size, int num_tokens, int max_tokens, int local_heads,
+                       int head_dim, cudaStream_t stream) {
   const size_t smem = static_cast<size_t>(cp_size) * sizeof(float);
   int blocks_per_sm = 0;
   C10_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
-      &blocks_per_sm, FusedKernel<T, BaseE>, kFusedBlockSize, smem));
+      &blocks_per_sm, FusedKernel<T, BaseE, RowDistributed>, kFusedBlockSize, smem));
   const cudaDeviceProp* props = at::cuda::getCurrentDeviceProperties();
   TORCH_CHECK(props->cooperativeLaunch, "decode_cp_a2a_lse_reduce requires cooperative launch");
   const int max_cooperative_blocks = blocks_per_sm * props->multiProcessorCount;
@@ -68,9 +69,33 @@ void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* w
       &local_heads,
       &head_dim,
   };
-  C10_CUDA_CHECK(cudaLaunchCooperativeKernel(reinterpret_cast<void*>(FusedKernel<T, BaseE>),
-                                             dim3(grid_blocks), dim3(kFusedBlockSize), args, smem,
-                                             stream));
+  C10_CUDA_CHECK(cudaLaunchCooperativeKernel(
+      reinterpret_cast<void*>(FusedKernel<T, BaseE, RowDistributed>), dim3(grid_blocks),
+      dim3(kFusedBlockSize), args, smem, stream));
+}
+
+template <typename T, bool BaseE>
+void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* workspace,
+                  ncclWindow_t window, size_t signal_window_offset, size_t out_region_window_offset,
+                  size_t out_region_local_offset, size_t slot_out_bytes,
+                  size_t lse_region_window_offset, size_t lse_region_local_offset,
+                  size_t slot_lse_bytes, at::Tensor& output, int rank, int cp_size, int num_tokens,
+                  int max_tokens, int local_heads, int head_dim, cudaStream_t stream) {
+  if (num_tokens * local_heads >= 16) {
+    launch_fused_impl<T, BaseE, true>(partial_o, partial_lse, workspace, window,
+                                      signal_window_offset, out_region_window_offset,
+                                      out_region_local_offset, slot_out_bytes,
+                                      lse_region_window_offset, lse_region_local_offset,
+                                      slot_lse_bytes, output, rank, cp_size, num_tokens, max_tokens,
+                                      local_heads, head_dim, stream);
+  } else {
+    launch_fused_impl<T, BaseE, false>(partial_o, partial_lse, workspace, window,
+                                       signal_window_offset, out_region_window_offset,
+                                       out_region_local_offset, slot_out_bytes,
+                                       lse_region_window_offset, lse_region_local_offset,
+                                       slot_lse_bytes, output, rank, cp_size, num_tokens, max_tokens,
+                                       local_heads, head_dim, stream);
+  }
 }
 
 }  // namespace

--- a/csrc/dcp_lse_reduce.cu
+++ b/csrc/dcp_lse_reduce.cu
@@ -25,6 +25,10 @@ using c10d::symmetric_memory::NCCLSymmetricMemory;
 
 namespace {
 
+void CheckNccl(ncclResult_t result, const char* operation) {
+  TORCH_CHECK(result == ncclSuccess, operation, ": ", ncclGetErrorString(result));
+}
+
 template <typename T, bool BaseE>
 void launch_fused(const T* partial_o, const float* partial_lse, unsigned char* workspace,
                   ncclWindow_t window, size_t signal_window_offset, size_t out_region_window_offset,
@@ -133,8 +137,8 @@ at::Tensor dcp_lse_reduce(const at::Tensor& partial_o, const at::Tensor& partial
   if (!devcomm_opt) {
     ncclDevCommRequirements reqs = NCCL_DEV_COMM_REQUIREMENTS_INITIALIZER;
     ncclDevComm devcomm;
-    C10D_NCCL_CHECK(ncclDevCommCreate(comm, &reqs, &devcomm),
-                    "ncclDevCommCreate failed in decode_cp_a2a_lse_reduce");
+    CheckNccl(ncclDevCommCreate(comm, &reqs, &devcomm),
+              "ncclDevCommCreate failed in decode_cp_a2a_lse_reduce");
     devcomm_opt = manager.register_devcomm(group_name, devcomm, kDevcommKey);
   }
   ncclDevComm& devcomm = devcomm_opt->get();

--- a/docs/api/comm.rst
+++ b/docs/api/comm.rst
@@ -440,6 +440,20 @@ DCP All-to-All (Context-Parallel Attention Reduction)
     decode_cp_a2a_init_workspace
     decode_cp_a2a_alltoall
 
+NCCL LSA DCP All-to-All + LSE Reduce
+-------------------------------------
+
+The fused path uses PyTorch NCCL symmetric memory and requires every context-
+parallel rank to be in one load/store-accessible NVLink domain. It does not use
+the MNNVL workspace accepted by ``decode_cp_a2a_alltoall``.
+
+.. autosummary::
+    :toctree: ../generated
+
+    decode_cp_a2a_lse_reduce_workspace_size
+    decode_cp_a2a_lse_reduce_create_workspace
+    decode_cp_a2a_lse_reduce
+
 Mixed Communication
 -------------------
 

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -813,6 +813,7 @@ def gen_all_modules(
         from .jit.comm import (
             gen_comm_alltoall_module,
             gen_dcp_alltoall_module,
+            gen_dcp_lse_reduce_module,
             gen_moe_alltoall_module,
             gen_pcie_ipc_comm_module,
             gen_trtllm_comm_module,
@@ -839,6 +840,7 @@ def gen_all_modules(
             # compilation. has_sm100 implies CUDA >= 12.8, which avoids the bug.
             # SM90/SM12x users still get this via JIT.
             jit_specs.append(gen_dcp_alltoall_module())
+        jit_specs.append(gen_dcp_lse_reduce_module())
         jit_specs.append(gen_vllm_comm_module())
         # No architecture gate: the kernels use only plain PTX loads/stores
         # and CUDA IPC, and target PCIe machines without NVLink, which is

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -840,7 +840,18 @@ def gen_all_modules(
             # compilation. has_sm100 implies CUDA >= 12.8, which avoids the bug.
             # SM90/SM12x users still get this via JIT.
             jit_specs.append(gen_dcp_alltoall_module())
-        jit_specs.append(gen_dcp_lse_reduce_module())
+        if (
+            has_sm90
+            or has_sm100
+            or has_sm100f
+            or has_sm103
+            or has_sm107
+            or has_sm110
+            or has_sm120
+            or has_sm120f
+            or has_sm121
+        ):
+            jit_specs.append(gen_dcp_lse_reduce_module())
         jit_specs.append(gen_vllm_comm_module())
         # No architecture gate: the kernels use only plain PTX loads/stores
         # and CUDA IPC, and target PCIe machines without NVLink, which is

--- a/flashinfer/comm/__init__.py
+++ b/flashinfer/comm/__init__.py
@@ -106,6 +106,13 @@ from .dcp_alltoall import (
 )
 from .dcp_alltoall import decode_cp_a2a_init_workspace as decode_cp_a2a_init_workspace
 from .dcp_alltoall import decode_cp_a2a_workspace_size as decode_cp_a2a_workspace_size
+from .dcp_lse_reduce import decode_cp_a2a_lse_reduce as decode_cp_a2a_lse_reduce
+from .dcp_lse_reduce import (
+    decode_cp_a2a_lse_reduce_create_workspace as decode_cp_a2a_lse_reduce_create_workspace,
+)
+from .dcp_lse_reduce import (
+    decode_cp_a2a_lse_reduce_workspace_size as decode_cp_a2a_lse_reduce_workspace_size,
+)
 
 # from .mnnvl import MnnvlMemory, MnnvlMoe, MoEAlltoallInfo
 

--- a/flashinfer/comm/dcp_lse_reduce.py
+++ b/flashinfer/comm/dcp_lse_reduce.py
@@ -29,11 +29,18 @@ import torch.distributed._symmetric_memory as symm_mem
 
 from ..api_logging import flashinfer_api
 from ..jit.comm import gen_dcp_lse_reduce_module
+from ..trace.templates.comm import decode_cp_a2a_lse_reduce_trace
 
 # Keep the rendezvous handle alive and remember the group name needed by the
 # C++ rendezvous lookup. The public hot-path signature remains the issue-4575
 # signature: callers pass only the workspace tensor, rank, and size.
 _workspace_keepalive: Dict[int, Tuple[Any, str]] = {}
+
+
+def _dcp_lse_reduce_payload_offset(cp_size: int) -> int:
+    # 16-byte epoch metadata plus two uint32 readiness arrays, rounded so the
+    # vectorized payload remains 16-byte aligned.
+    return (16 + 2 * cp_size * 4 + 15) // 16 * 16
 
 
 @functools.cache
@@ -57,8 +64,10 @@ def decode_cp_a2a_lse_reduce_workspace_size(
     if dtype not in (torch.float16, torch.bfloat16):
         raise TypeError("dtype must be torch.float16 or torch.bfloat16")
     itemsize = torch.empty((), dtype=dtype).element_size()
-    # 16-byte device epoch/slot metadata followed by two alternating slots.
-    return 16 + 2 * cp_size * max_tokens * local_heads * (
+    if head_dim * itemsize % 16 != 0:
+        raise ValueError("head_dim rows must be 16-byte aligned")
+    payload_offset = _dcp_lse_reduce_payload_offset(cp_size)
+    return payload_offset + 2 * cp_size * max_tokens * local_heads * (
         head_dim * itemsize + 4
     )
 
@@ -73,6 +82,11 @@ def decode_cp_a2a_lse_reduce_create_workspace(
     group: Any,
 ) -> torch.Tensor:
     """Create and rendezvous the fused op's NCCL symmetric workspace.
+
+    All ranks in ``group`` must call this function collectively. The group must
+    fit in one NCCL load/store-accessible (LSA) NVLink domain; multi-node groups
+    spanning LSA domains are not supported. Allocate one workspace per group
+    and reuse it for every invocation and CUDA graph replay.
 
     Parameters
     ----------
@@ -104,14 +118,19 @@ def decode_cp_a2a_lse_reduce_create_workspace(
     )
     symm_mem.set_backend("NCCL")
     workspace = symm_mem.empty(size_bytes, dtype=torch.uint8, device="cuda")
-    workspace.zero_()
+    # Initialize the local epoch and readiness words. The payload is fully
+    # overwritten before every read; clearing it could race a peer's first put.
+    workspace[: _dcp_lse_reduce_payload_offset(cp_size)].zero_()
+    # Initialization must complete before rendezvous; afterwards any peer may
+    # enter the first fused kernel and publish a remote readiness value.
+    torch.cuda.current_stream().synchronize()
     handle = symm_mem.rendezvous(workspace, group)
     group_name = group if isinstance(group, str) else group.group_name
     _workspace_keepalive[workspace.data_ptr()] = (handle, group_name)
     return workspace
 
 
-@flashinfer_api
+@flashinfer_api(trace=decode_cp_a2a_lse_reduce_trace)
 def decode_cp_a2a_lse_reduce(
     partial_o: torch.Tensor,
     partial_lse: torch.Tensor,
@@ -121,7 +140,14 @@ def decode_cp_a2a_lse_reduce(
     is_lse_base_on_e: bool = False,
     enable_pdl: Optional[bool] = None,
 ) -> torch.Tensor:
-    """Fuse the DCP A2A exchange with the LSE-weighted reduce.
+    """Fuse an NCCL LSA DCP A2A exchange with the LSE-weighted reduce.
+
+    Send, receive synchronization, and reduction execute in one cooperative
+    CUDA kernel.
+
+    This is a collective operation. Every rank must invoke it in the same order
+    and the same number of times, including CUDA graph replays. All ranks must
+    belong to one NCCL LSA/NVLink domain.
 
     Parameters
     ----------
@@ -154,8 +180,7 @@ def decode_cp_a2a_lse_reduce(
     workspace_meta = _workspace_keepalive.get(workspace.data_ptr())
     if workspace_meta is None:
         raise ValueError(
-            "workspace was not created by "
-            "decode_cp_a2a_lse_reduce_create_workspace"
+            "workspace was not created by decode_cp_a2a_lse_reduce_create_workspace"
         )
     _, group_name = workspace_meta
     get_dcp_lse_reduce_module()

--- a/flashinfer/comm/dcp_lse_reduce.py
+++ b/flashinfer/comm/dcp_lse_reduce.py
@@ -1,0 +1,177 @@
+"""Fused decode-CP all-to-all + LSE-weighted reduce.
+
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Public names follow https://github.com/flashinfer-ai/flashinfer/issues/4575.
+
+The implementation is self-contained in FlashInfer and uses NCCL's device-side
+LSA APIs over a tensor allocated by torch's NCCL symmetric-memory backend. It
+does not call ``libnccl_longseq`` and does not use the Helix/MNNVL A2A kernel.
+"""
+
+import functools
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+import torch.distributed._symmetric_memory as symm_mem
+
+from ..api_logging import flashinfer_api
+from ..jit.comm import gen_dcp_lse_reduce_module
+
+# Keep the rendezvous handle alive and remember the group name needed by the
+# C++ rendezvous lookup. The public hot-path signature remains the issue-4575
+# signature: callers pass only the workspace tensor, rank, and size.
+_workspace_keepalive: Dict[int, Tuple[Any, str]] = {}
+
+
+@functools.cache
+def get_dcp_lse_reduce_module():
+    """Build and load the torch custom op once."""
+    return gen_dcp_lse_reduce_module().build_and_load()
+
+
+def decode_cp_a2a_lse_reduce_workspace_size(
+    max_tokens: int,
+    local_heads: int,
+    cp_size: int,
+    head_dim: int,
+    dtype: torch.dtype,
+) -> int:
+    """Return the required NCCL symmetric workspace size in bytes."""
+    if min(max_tokens, local_heads, cp_size, head_dim) <= 0:
+        raise ValueError("workspace geometry must be positive")
+    if cp_size > 64:
+        raise ValueError("cp_size must not exceed 64")
+    if dtype not in (torch.float16, torch.bfloat16):
+        raise TypeError("dtype must be torch.float16 or torch.bfloat16")
+    itemsize = torch.empty((), dtype=dtype).element_size()
+    # 16-byte device epoch/slot metadata followed by two alternating slots.
+    return 16 + 2 * cp_size * max_tokens * local_heads * (
+        head_dim * itemsize + 4
+    )
+
+
+@flashinfer_api
+def decode_cp_a2a_lse_reduce_create_workspace(
+    max_tokens: int,
+    local_heads: int,
+    cp_size: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    group: Any,
+) -> torch.Tensor:
+    """Create and rendezvous the fused op's NCCL symmetric workspace.
+
+    Parameters
+    ----------
+    max_tokens : int
+        Upper bound on the token/batch dimension of later calls.
+    local_heads : int
+        Number of heads this rank keeps after the reduce-scatter.
+    cp_size : int
+        Context-parallel group size.
+    head_dim : int
+        Elements per head.
+    dtype : torch.dtype
+        Storage type of ``partial_o`` / ``output`` (fp16 or bf16).
+    group :
+        ``torch.distributed`` process group (or group name) for the CP team.
+
+    Returns
+    -------
+    torch.Tensor
+        A rendezvoused NCCL symmetric-memory ``uint8`` tensor. Allocate it once
+        before CUDA graph capture and reuse it.
+    """
+    # Build/load on every rank before entering either NCCL collective below.
+    # The JIT cache lock may otherwise leave one rank creating the devcomm
+    # while another rank is still compiling.
+    get_dcp_lse_reduce_module()
+    size_bytes = decode_cp_a2a_lse_reduce_workspace_size(
+        max_tokens, local_heads, cp_size, head_dim, dtype
+    )
+    symm_mem.set_backend("NCCL")
+    workspace = symm_mem.empty(size_bytes, dtype=torch.uint8, device="cuda")
+    workspace.zero_()
+    handle = symm_mem.rendezvous(workspace, group)
+    group_name = group if isinstance(group, str) else group.group_name
+    _workspace_keepalive[workspace.data_ptr()] = (handle, group_name)
+    return workspace
+
+
+@flashinfer_api
+def decode_cp_a2a_lse_reduce(
+    partial_o: torch.Tensor,
+    partial_lse: torch.Tensor,
+    workspace: torch.Tensor,
+    cp_rank: int,
+    cp_size: int,
+    is_lse_base_on_e: bool = False,
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    """Fuse the DCP A2A exchange with the LSE-weighted reduce.
+
+    Parameters
+    ----------
+    partial_o : torch.Tensor
+        ``[..., cp_size, head_dim]`` CUDA tensor (fp16 or bf16).
+        Typical layout: ``[batch, local_heads, cp_size, head_dim]``.
+        ``partial_o[..., peer, :]`` is the slice destined for that CP rank.
+    partial_lse : torch.Tensor
+        ``[..., cp_size]`` CUDA float32 tensor. Leading dims must match
+        ``partial_o``.
+    workspace : torch.Tensor
+        Rendezvoused NCCL symmetric-memory tensor from
+        :func:`decode_cp_a2a_lse_reduce_create_workspace`.
+    cp_rank : int
+        This rank's index in the CP group.
+    cp_size : int
+        Context-parallel group size.
+    is_lse_base_on_e : bool
+        ``True`` for natural-log LSE, ``False`` for base-2 (FlashInfer MLA).
+    enable_pdl : bool, optional
+        Accepted for API compatibility. The ported NCCL device kernels do not
+        use programmatic dependent launch.
+
+    Returns
+    -------
+    torch.Tensor
+        ``[..., head_dim]`` in the same dtype as ``partial_o``.
+    """
+    del enable_pdl
+    workspace_meta = _workspace_keepalive.get(workspace.data_ptr())
+    if workspace_meta is None:
+        raise ValueError(
+            "workspace was not created by "
+            "decode_cp_a2a_lse_reduce_create_workspace"
+        )
+    _, group_name = workspace_meta
+    get_dcp_lse_reduce_module()
+    return torch.ops.flashinfer.decode_cp_a2a_lse_reduce(
+        partial_o,
+        partial_lse,
+        workspace,
+        cp_rank,
+        cp_size,
+        is_lse_base_on_e,
+        group_name,
+    )
+
+
+__all__ = [
+    "decode_cp_a2a_lse_reduce_workspace_size",
+    "decode_cp_a2a_lse_reduce_create_workspace",
+    "decode_cp_a2a_lse_reduce",
+]

--- a/flashinfer/comm/dcp_lse_reduce.py
+++ b/flashinfer/comm/dcp_lse_reduce.py
@@ -22,7 +22,9 @@ does not call ``libnccl_longseq`` and does not use the Helix/MNNVL A2A kernel.
 """
 
 import functools
-from typing import Any, Dict, Optional, Tuple
+import weakref
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
 
 import torch
 import torch.distributed._symmetric_memory as symm_mem
@@ -31,10 +33,54 @@ from ..api_logging import flashinfer_api
 from ..jit.comm import gen_dcp_lse_reduce_module
 from ..trace.templates.comm import decode_cp_a2a_lse_reduce_trace
 
+
+@dataclass
+class _WorkspaceState:
+    """Python-owned state associated with one symmetric-memory workspace."""
+
+    handle: Any
+    group_name: str
+    device: torch.device
+    stream_id: Optional[int] = None
+
+
 # Keep the rendezvous handle alive and remember the group name needed by the
 # C++ rendezvous lookup. The public hot-path signature remains the issue-4575
 # signature: callers pass only the workspace tensor, rank, and size.
-_workspace_keepalive: Dict[int, Tuple[Any, str]] = {}
+_workspace_keepalive: Dict[int, _WorkspaceState] = {}
+
+
+def _release_workspace(data_ptr: int, state: _WorkspaceState) -> None:
+    """Release workspace state after its queued CUDA work has completed."""
+    if _workspace_keepalive.get(data_ptr) is not state:
+        return
+    try:
+        torch.cuda.synchronize(state.device)
+    except (AttributeError, RuntimeError):
+        # Finalizers may run while CUDA is shutting down. Removing the matching
+        # entry still avoids retaining a stale rendezvous handle indefinitely.
+        pass
+    finally:
+        if _workspace_keepalive.get(data_ptr) is state:
+            del _workspace_keepalive[data_ptr]
+
+
+def _get_workspace_state(workspace: torch.Tensor) -> _WorkspaceState:
+    state = _workspace_keepalive.get(workspace.data_ptr())
+    if state is None:
+        raise ValueError(
+            "workspace was not created by decode_cp_a2a_lse_reduce_create_workspace"
+        )
+
+    stream_id = int(torch.cuda.current_stream(workspace.device).cuda_stream)
+    if state.stream_id is None:
+        state.stream_id = stream_id
+    elif state.stream_id != stream_id:
+        raise RuntimeError(
+            "a DCP LSE reduce workspace may only be used from one ordered CUDA "
+            "stream; allocate a separate workspace for each concurrent stream"
+        )
+    return state
 
 
 def _dcp_lse_reduce_payload_offset(cp_size: int) -> int:
@@ -86,7 +132,9 @@ def decode_cp_a2a_lse_reduce_create_workspace(
     All ranks in ``group`` must call this function collectively. The group must
     fit in one NCCL load/store-accessible (LSA) NVLink domain; multi-node groups
     spanning LSA domains are not supported. Allocate one workspace per group
-    and reuse it for every invocation and CUDA graph replay.
+    and reuse it for every invocation and CUDA graph replay. A workspace may
+    only be used from one ordered CUDA stream; allocate a workspace per
+    concurrent stream.
 
     Parameters
     ----------
@@ -100,8 +148,8 @@ def decode_cp_a2a_lse_reduce_create_workspace(
         Elements per head.
     dtype : torch.dtype
         Storage type of ``partial_o`` / ``output`` (fp16 or bf16).
-    group :
-        ``torch.distributed`` process group (or group name) for the CP team.
+    group : torch.distributed.ProcessGroup or str
+        Process group (or group name) for the CP team.
 
     Returns
     -------
@@ -131,7 +179,10 @@ def decode_cp_a2a_lse_reduce_create_workspace(
     # enter the first fused kernel and publish a remote readiness value.
     torch.cuda.current_stream().synchronize()
     handle = symm_mem.rendezvous(workspace, group)
-    _workspace_keepalive[workspace.data_ptr()] = (handle, group_name)
+    state = _WorkspaceState(handle=handle, group_name=group_name, device=device)
+    data_ptr = workspace.data_ptr()
+    _workspace_keepalive[data_ptr] = state
+    weakref.finalize(workspace, _release_workspace, data_ptr, state)
     return workspace
 
 
@@ -165,7 +216,8 @@ def decode_cp_a2a_lse_reduce(
         ``partial_o``.
     workspace : torch.Tensor
         Rendezvoused NCCL symmetric-memory tensor from
-        :func:`decode_cp_a2a_lse_reduce_create_workspace`.
+        :func:`decode_cp_a2a_lse_reduce_create_workspace`. Reuse it only from
+        one ordered CUDA stream.
     cp_rank : int
         This rank's index in the CP group.
     cp_size : int
@@ -182,12 +234,7 @@ def decode_cp_a2a_lse_reduce(
         ``[..., head_dim]`` in the same dtype as ``partial_o``.
     """
     del enable_pdl
-    workspace_meta = _workspace_keepalive.get(workspace.data_ptr())
-    if workspace_meta is None:
-        raise ValueError(
-            "workspace was not created by decode_cp_a2a_lse_reduce_create_workspace"
-        )
-    _, group_name = workspace_meta
+    group_name = _get_workspace_state(workspace).group_name
     get_dcp_lse_reduce_module()
     return torch.ops.flashinfer.decode_cp_a2a_lse_reduce(
         partial_o,

--- a/flashinfer/comm/dcp_lse_reduce.py
+++ b/flashinfer/comm/dcp_lse_reduce.py
@@ -116,8 +116,14 @@ def decode_cp_a2a_lse_reduce_create_workspace(
     size_bytes = decode_cp_a2a_lse_reduce_workspace_size(
         max_tokens, local_heads, cp_size, head_dim, dtype
     )
+    group_name = group if isinstance(group, str) else group.group_name
     symm_mem.set_backend("NCCL")
-    workspace = symm_mem.empty(size_bytes, dtype=torch.uint8, device="cuda")
+    # PyTorch's NCCL symmetric-memory communicator registry is keyed by the
+    # concrete CUDA device. Do not use the unindexed ``"cuda"`` device here:
+    # it would rendezvous through a separate registry entry from the process
+    # group's ``cuda:<local_rank>`` communicator.
+    device = torch.device("cuda", torch.cuda.current_device())
+    workspace = symm_mem.empty(size_bytes, dtype=torch.uint8, device=device)
     # Initialize the local epoch and readiness words. The payload is fully
     # overwritten before every read; clearing it could race a peer's first put.
     workspace[: _dcp_lse_reduce_payload_offset(cp_size)].zero_()
@@ -125,7 +131,6 @@ def decode_cp_a2a_lse_reduce_create_workspace(
     # enter the first fused kernel and publish a remote readiness value.
     torch.cuda.current_stream().synchronize()
     handle = symm_mem.rendezvous(workspace, group)
-    group_name = group if isinstance(group, str) else group.group_name
     _workspace_keepalive[workspace.data_ptr()] = (handle, group_name)
     return workspace
 

--- a/flashinfer/jit/comm.py
+++ b/flashinfer/jit/comm.py
@@ -352,3 +352,40 @@ def gen_dcp_alltoall_module() -> JitSpec:
         ],
         extra_cuda_cflags=nvcc_flags,
     )
+
+
+def gen_dcp_lse_reduce_module() -> JitSpec:
+    """Build the NCCL-symmetric-memory DCP A2A + LSE-reduce op."""
+    from torch.utils.cpp_extension import include_paths, library_paths
+
+    nvcc_flags = current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[9, 10, 11, 12]
+    )
+    extra_includes = [pathlib.Path(path) for path in include_paths(device_type="cuda")]
+    extra_ldflags = [f"-L{path}" for path in library_paths(device_type="cuda")]
+    extra_ldflags += [
+        "-ltorch",
+        "-ltorch_cpu",
+        "-ltorch_cuda",
+        "-lc10",
+        "-lc10_cuda",
+        "-lnccl",
+    ]
+
+    nccl_home = os.environ.get("NCCL_HOME")
+    if nccl_home:
+        extra_includes.extend(
+            [
+                pathlib.Path(nccl_home) / "include",
+                pathlib.Path(nccl_home) / "include" / "nccl_device",
+            ]
+        )
+        extra_ldflags.insert(0, f"-L{pathlib.Path(nccl_home) / 'lib'}")
+
+    return gen_jit_spec(
+        "dcp_lse_reduce",
+        [jit_env.FLASHINFER_CSRC_DIR / "dcp_lse_reduce.cu"],
+        extra_include_paths=extra_includes,
+        extra_cuda_cflags=["-DUSE_NCCL"] + nvcc_flags,
+        extra_ldflags=extra_ldflags,
+    )

--- a/flashinfer/jit/comm.py
+++ b/flashinfer/jit/comm.py
@@ -376,7 +376,9 @@ def gen_dcp_lse_reduce_module() -> JitSpec:
         # PyTorch < 2.6 uses the legacy ``cuda`` boolean argument.
         cuda_include_paths = include_paths(cuda=True)
         cuda_library_paths = library_paths(cuda=True)
-    extra_includes = [pathlib.Path(path) for path in cuda_include_paths]
+    extra_includes: list[str | pathlib.Path] = [
+        pathlib.Path(path) for path in cuda_include_paths
+    ]
     extra_ldflags = [f"-L{path}" for path in cuda_library_paths]
     nccl_ldflag = "-lnccl"
 

--- a/flashinfer/jit/comm.py
+++ b/flashinfer/jit/comm.py
@@ -369,8 +369,15 @@ def gen_dcp_lse_reduce_module() -> JitSpec:
         flag.replace("compute_90a,code=sm_90a", "compute_90,code=sm_90")
         for flag in nvcc_flags
     ]
-    extra_includes = [pathlib.Path(path) for path in include_paths(device_type="cuda")]
-    extra_ldflags = [f"-L{path}" for path in library_paths(device_type="cuda")]
+    try:
+        cuda_include_paths = include_paths(device_type="cuda")
+        cuda_library_paths = library_paths(device_type="cuda")
+    except TypeError:
+        # PyTorch < 2.6 uses the legacy ``cuda`` boolean argument.
+        cuda_include_paths = include_paths(cuda=True)
+        cuda_library_paths = library_paths(cuda=True)
+    extra_includes = [pathlib.Path(path) for path in cuda_include_paths]
+    extra_ldflags = [f"-L{path}" for path in cuda_library_paths]
     nccl_ldflag = "-lnccl"
 
     nccl_home = os.environ.get("NCCL_HOME")

--- a/flashinfer/jit/comm.py
+++ b/flashinfer/jit/comm.py
@@ -361,31 +361,49 @@ def gen_dcp_lse_reduce_module() -> JitSpec:
     nvcc_flags = current_compilation_context.get_nvcc_flags_list(
         supported_major_versions=[9, 10, 11, 12]
     )
+    # This kernel uses cooperative groups and NCCL's device API, neither of
+    # which requires Hopper's architecture-specific ``90a`` ISA. Compile a
+    # generic SM90 image so it also loads on H100 installations that expose
+    # compute capability 9.0 without the ``a`` feature set.
+    nvcc_flags = [
+        flag.replace("compute_90a,code=sm_90a", "compute_90,code=sm_90")
+        for flag in nvcc_flags
+    ]
     extra_includes = [pathlib.Path(path) for path in include_paths(device_type="cuda")]
     extra_ldflags = [f"-L{path}" for path in library_paths(device_type="cuda")]
+    nccl_ldflag = "-lnccl"
+
+    nccl_home = os.environ.get("NCCL_HOME")
+    if nccl_home:
+        nccl_home_path = pathlib.Path(nccl_home)
+        nccl_lib_dir = nccl_home_path / "lib"
+        extra_includes.extend(
+            [
+                nccl_home_path / "include",
+                nccl_home_path / "include" / "nccl_device",
+            ]
+        )
+        extra_ldflags.insert(0, f"-L{nccl_lib_dir}")
+        # PyTorch's pip wheels include only the versioned NCCL shared object,
+        # whereas system installations also provide libnccl.so for -lnccl.
+        if not (nccl_lib_dir / "libnccl.so").exists():
+            versioned_libraries = sorted(nccl_lib_dir.glob("libnccl.so.*"))
+            if versioned_libraries:
+                nccl_ldflag = str(versioned_libraries[-1])
+
     extra_ldflags += [
         "-ltorch",
         "-ltorch_cpu",
         "-ltorch_cuda",
         "-lc10",
         "-lc10_cuda",
-        "-lnccl",
+        nccl_ldflag,
     ]
-
-    nccl_home = os.environ.get("NCCL_HOME")
-    if nccl_home:
-        extra_includes.extend(
-            [
-                pathlib.Path(nccl_home) / "include",
-                pathlib.Path(nccl_home) / "include" / "nccl_device",
-            ]
-        )
-        extra_ldflags.insert(0, f"-L{pathlib.Path(nccl_home) / 'lib'}")
 
     return gen_jit_spec(
         "dcp_lse_reduce",
         [jit_env.FLASHINFER_CSRC_DIR / "dcp_lse_reduce.cu"],
         extra_include_paths=extra_includes,
-        extra_cuda_cflags=["-DUSE_NCCL"] + nvcc_flags,
+        extra_cuda_cflags=["-std=c++20", "-DUSE_NCCL"] + nvcc_flags,
         extra_ldflags=extra_ldflags,
     )

--- a/flashinfer/trace/templates/comm.py
+++ b/flashinfer/trace/templates/comm.py
@@ -360,3 +360,100 @@ pcie_ipc_all_reduce_trace = TraceTemplate(
     reference=_pcie_ipc_all_reduce_reference,
     init=_pcie_ipc_all_reduce_init,
 )
+
+
+# ── Fused NCCL-LSA DCP all-to-all + LSE reduce ───────────────────────────────
+
+
+@torch.no_grad()
+def _decode_cp_a2a_lse_reduce_reference(
+    partial_o: torch.Tensor,
+    partial_lse: torch.Tensor,
+    workspace,
+    cp_rank: int,
+    cp_size: int,
+    is_lse_base_on_e: bool = False,
+    enable_pdl=None,
+    **_unused,
+):
+    """Local LSE merge reference; multi-rank exchange is tested under tests/comm."""
+    lse = torch.where(
+        torch.isnan(partial_lse) | torch.isposinf(partial_lse),
+        torch.full_like(partial_lse, float("-inf")),
+        partial_lse,
+    )
+    lse_max = lse.amax(dim=-1, keepdim=True)
+    lse_max = torch.where(torch.isneginf(lse_max), 0, lse_max)
+    weights = (
+        torch.exp(lse - lse_max) if is_lse_base_on_e else torch.exp2(lse - lse_max)
+    )
+    denom = weights.sum(dim=-1, keepdim=True)
+    output = (partial_o.float() * weights.unsqueeze(-1)).sum(dim=-2)
+    output = output / denom.clamp_min(1e-20)
+    output = torch.where(denom == 0, torch.zeros_like(output), output)
+    return output.to(partial_o.dtype)
+
+
+def _decode_cp_a2a_lse_reduce_init(
+    *,
+    batch_dim: int,
+    cp_size: int,
+    head_dim: int = 128,
+    workspace_bytes: int = 16,
+    cp_rank: int = 0,
+    is_lse_base_on_e: bool = False,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build schema inputs; the real workspace must be rendezvoused collectively."""
+    torch.manual_seed(seed)
+    return {
+        "partial_o": torch.randn(
+            batch_dim, cp_size, head_dim, dtype=torch.bfloat16, device=device
+        ),
+        "partial_lse": torch.randn(
+            batch_dim, cp_size, dtype=torch.float32, device=device
+        ),
+        "workspace": torch.zeros(workspace_bytes, dtype=torch.uint8, device=device),
+        "cp_rank": int(cp_rank),
+        "cp_size": int(cp_size),
+        "is_lse_base_on_e": bool(is_lse_base_on_e),
+    }
+
+
+decode_cp_a2a_lse_reduce_trace = TraceTemplate(
+    op_type="comm",
+    name_prefix="decode_cp_a2a_lse_reduce",
+    description=(
+        "Fused context-parallel NCCL-LSA all-to-all and LSE-weighted "
+        "attention-output reduction. The trace reference models the local "
+        "LSE merge; multi-rank exchange correctness is exercised by tests/comm."
+    ),
+    axes={
+        "batch_dim": Var(description="Flattened leading batch/head dimensions."),
+        "cp_size": Var(description="Context-parallel group size."),
+        "head_dim": Const(abbrev="d"),
+        "workspace_bytes": Var(),
+    },
+    inputs={
+        "partial_o": Tensor(
+            ["batch_dim", "cp_size", "head_dim"],
+            description="Per-rank partial attention outputs [..., cp_size, D].",
+        ),
+        "partial_lse": Tensor(
+            ["batch_dim", "cp_size"],
+            dtype="float32",
+            description="Per-rank log-sum-exp values [..., cp_size].",
+        ),
+        "workspace": Tensor(["workspace_bytes"], dtype="uint8"),
+        "cp_rank": Scalar("int32"),
+        "cp_size": Scalar("int32"),
+        "is_lse_base_on_e": Scalar("bool"),
+    },
+    outputs={
+        "output": Tensor(["batch_dim", "head_dim"], dtype_from="partial_o"),
+    },
+    tags=["status:experimental", "stage:comm"],
+    reference=_decode_cp_a2a_lse_reduce_reference,
+    init=_decode_cp_a2a_lse_reduce_init,
+)

--- a/include/flashinfer/comm/dcp_lse_reduce.cuh
+++ b/include/flashinfer/comm/dcp_lse_reduce.cuh
@@ -33,8 +33,8 @@
 //
 // The one deviation from softmax proper: if every shard reports -inf for a head
 // (an empty KV range everywhere) softmax would be 0/0, so that case is defined
-// to produce a zero output and a -inf combined LSE rather than NaN. NaN and
-// +inf inputs fold to -inf before the softmax.
+// to produce a zero output rather than NaN. NaN and +inf inputs fold to -inf
+// before the softmax.
 //
 // The reduction is associative and commutative, so the order is free. This is
 // the same merge flash-attention uses to combine its splits, with the splits
@@ -42,54 +42,62 @@
 //
 // Data movement uses the NCCL device API: each rank stores its per-destination
 // slice straight into the destination's registered symmetric window
-// (ncclGetLsaPointer), an LSA barrier makes those stores visible, then every
-// rank merges locally. That requires a single load/store-accessible (NVLink)
-// domain; a team spanning several LSA domains needs a hierarchical algorithm
-// which is not implemented here.
+// (ncclGetLsaPointer), then publishes a system-scope release flag. Receivers
+// acquire-wait on every source flag and use an unconditional cooperative-grid
+// sync before blocks are reassigned to merge locally. That requires a single
+// load/store-accessible (NVLink) domain; a team spanning several LSA domains
+// needs a hierarchical algorithm which is not implemented here.
 
 #ifndef FLASHINFER_COMM_DCP_LSE_REDUCE_CUH_
 #define FLASHINFER_COMM_DCP_LSE_REDUCE_CUH_
 
+#include <cooperative_groups.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <math.h>
 #include <nccl_device.h>
 
+namespace cg = cooperative_groups;
+
 namespace flashinfer {
 namespace comm {
 namespace dcp {
 
-// Two workspace slots, used alternately, so one barrier per call is enough.
+// Two workspace slots are used alternately. A call cannot enter its receive
+// phase until every rank has completed its sends, so by the time slot i is
+// reused all ranks have completed the receive phase from two calls earlier.
 //
-// With a single slot: rank r issues its put for call i+1 as soon as it clears
-// barrier i, but peer p only issues its merge for call i *after* that same
-// barrier -- r would overwrite data p has not read. Alternating puts the
-// previous reader two calls back, and on p's stream that read is ordered
-// before the barrier r had to clear to reach call i+2.
-//
-// The alternative, two barriers per call, costs about as much as the fused
-// path saves.
+// Each slot also has one readiness word per source rank. The sender publishes
+// epoch + 1 with a system-scope release store after its payload is visible; the
+// receiver waits with system-scope acquire loads before entering the merge.
 constexpr int kNumSlots = 2;
 
 // Merging more than this many ranks per block would blow the shared-memory LSE
 // staging area; workspace creation rejects larger teams.
 constexpr int kMaxRanks = 64;
 
-constexpr int kPutBlockSize = 128;
-constexpr int kMergeBlockSize = 128;
+constexpr int kFusedBlockSize = 128;
 constexpr size_t kMetadataBytes = 16;
+constexpr size_t kWorkspaceAlignment = 16;
 
-// Select the alternating workspace slot on device so CUDA graph replay
-// advances the epoch rather than baking a host-side slot value into the graph.
-// state[0] is the monotonically increasing epoch and state[1] is the slot used
-// by the kernels in this invocation.
-__global__ void SelectSlotKernel(uint32_t* state) {
-  if (threadIdx.x == 0) {
-    const uint32_t epoch = state[0];
-    state[1] = epoch % kNumSlots;
-    state[0] = epoch + 1;
-  }
+inline constexpr size_t SignalRegionBytes(int nranks) {
+  return kNumSlots * static_cast<size_t>(nranks) * sizeof(uint32_t);
+}
+
+inline constexpr size_t PayloadOffset(int nranks) {
+  return (kMetadataBytes + SignalRegionBytes(nranks) + kWorkspaceAlignment - 1) /
+         kWorkspaceAlignment * kWorkspaceAlignment;
+}
+
+__device__ __forceinline__ void store_release_sys(uint32_t* ptr, uint32_t value) {
+  asm volatile("st.release.sys.global.u32 [%0], %1;" : : "l"(ptr), "r"(value) : "memory");
+}
+
+__device__ __forceinline__ uint32_t load_acquire_sys(const uint32_t* ptr) {
+  uint32_t value;
+  asm volatile("ld.acquire.sys.global.u32 %0, [%1];" : "=r"(value) : "l"(ptr) : "memory");
+  return value;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,9 +133,7 @@ __device__ static inline float sanitize_lse(float l) {
   return (isnan(l) || l == INFINITY) ? -INFINITY : l;
 }
 
-// ---------------------------------------------------------------------------
-// Put: publish this rank's partial for every destination directly into that
-// destination's workspace slot.
+// Cooperative fused send, receive synchronization, and LSE merge.
 //
 // The source is already sliced per destination, which is the layout the DCP
 // all-to-all convention uses:
@@ -136,136 +142,136 @@ __device__ static inline float sanitize_lse(float l) {
 // The destination layout inside the peer's slot is
 //   [src_rank][token][local_head][*]
 //
-// Grid  (num_tokens * local_heads, nranks)
-// Block 128 threads, each striding over head_dim.
-// ---------------------------------------------------------------------------
-template <typename T>
-__global__ void PutPackedKernel(const T* __restrict__ partial_o,
-                                const float* __restrict__ partial_lse, ncclWindow_t window,
-                                size_t out_region_byte_offset, size_t slot_out_bytes,
-                                size_t lse_region_byte_offset, size_t slot_lse_bytes,
-                                const uint32_t* state, int rank, int nranks, int num_tokens,
-                                int max_tokens, int local_heads, int head_dim) {
-  const int tile = blockIdx.x;  // token * local_heads + local head
-  const int dst = blockIdx.y;
-  const int token = tile / local_heads;
-  const int local_head = tile - token * local_heads;
-  if (token >= num_tokens || dst >= nranks) return;
-
-  const size_t src_base =
-      ((((size_t)token * local_heads + local_head) * nranks + dst) * head_dim);
-  const unsigned int slot = state[1];
-  const size_t slot_out_byte_offset = out_region_byte_offset + slot * slot_out_bytes;
-  const size_t slot_lse_byte_offset = lse_region_byte_offset + slot * slot_lse_bytes;
-  const size_t dst_row = (((size_t)rank * max_tokens + token) * local_heads + local_head);
-
-  T* dst_out =
-      (T*)ncclGetLsaPointer(window, slot_out_byte_offset + dst_row * head_dim * sizeof(T), dst);
-  float* dst_lse =
-      (float*)ncclGetLsaPointer(window, slot_lse_byte_offset + dst_row * sizeof(float), dst);
-
-  // Widen to 16-byte stores when the row allows it. These go over NVLink, so
-  // the difference between 2-byte and 16-byte transactions is large. Rows are
-  // head_dim*sizeof(T) bytes and both bases are at least 16-byte aligned, so
-  // divisibility of the row is the only condition to check.
-  constexpr int kVec = (int)(sizeof(int4) / sizeof(T));
-  if (head_dim % kVec == 0) {
-    const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
-    int4* dst4 = reinterpret_cast<int4*>(dst_out);
-    const int n4 = head_dim / kVec;
-    for (int d = threadIdx.x; d < n4; d += blockDim.x) {
-      dst4[d] = src4[d];
-    }
-  } else {
-    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
-      dst_out[d] = partial_o[src_base + d];
-    }
-  }
-  if (threadIdx.x == 0) {
-    *dst_lse = partial_lse[((size_t)token * local_heads + local_head) * nranks + dst];
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Barrier: make every peer's puts visible before anyone merges.
-//
-// A single CTA. Kernel boundaries give the intra-rank ordering (all put CTAs
-// have retired), and the LSA barrier with acq_rel gives the inter-rank
-// ordering. Keeping it separate rather than fusing a signal into the put and a
-// spin into the merge costs one launch; it is also the version whose
-// correctness does not depend on getting a hand-rolled protocol right.
-// ---------------------------------------------------------------------------
-__global__ void BarrierKernel(ncclDevComm dev_comm) {
-  ncclLsaBarrierSession<ncclCoopCta> bar(ncclCoopCta(), dev_comm, ncclTeamLsa(dev_comm),
-                                         dev_comm.lsaBarrier, /*index=*/0);
-  bar.sync(ncclCoopCta(), cuda::memory_order_acq_rel);
-}
-
-// ---------------------------------------------------------------------------
-// Merge: softmax-weighted reduction of the nranks partials this rank received.
-//
-// Grid  (num_tokens, local_heads)
-// Block 128 threads.
-//
-// One pass over the payload. The LSEs are staged in shared memory and the
-// weights derived once per block, rather than re-read per pass.
-// ---------------------------------------------------------------------------
+// The grid is persistent and cooperatively launched:
+//   1. block 0 selects the graph-safe device epoch; grid sync;
+//   2. blocks publish complete destination payloads and release-store flags;
+//   3. block 0 acquire-waits for every source flag; unconditional grid sync;
+//   4. blocks are reassigned to output rows and perform the LSE merge.
 template <typename T, bool BASE_E>
-__global__ void MergeKernel(const unsigned char* __restrict__ workspace,
-                            size_t out_region_byte_offset, size_t slot_out_bytes,
-                            size_t lse_region_byte_offset, size_t slot_lse_bytes,
-                            const uint32_t* state, T* __restrict__ combined_out, int nranks,
-                            int num_tokens, int max_tokens, int local_heads, int head_dim) {
+__global__ void FusedKernel(const T* __restrict__ partial_o, const float* __restrict__ partial_lse,
+                            unsigned char* __restrict__ workspace, ncclWindow_t window,
+                            size_t signal_window_offset, size_t out_region_window_offset,
+                            size_t out_region_local_offset, size_t slot_out_bytes,
+                            size_t lse_region_window_offset, size_t lse_region_local_offset,
+                            size_t slot_lse_bytes, T* __restrict__ combined_out, int rank,
+                            int nranks, int num_tokens, int max_tokens, int local_heads,
+                            int head_dim) {
   extern __shared__ float smem[];  // [nranks] merge weights
+  cg::grid_group grid = cg::this_grid();
+  auto* state = reinterpret_cast<uint32_t*>(workspace);
+  auto* ready = reinterpret_cast<uint32_t*>(workspace + kMetadataBytes);
 
-  const int token = blockIdx.x;
-  const int head = blockIdx.y;
-  const unsigned int slot = state[1];
-  const T* recv_out = reinterpret_cast<const T*>(
-      workspace + out_region_byte_offset + slot * slot_out_bytes);
-  const float* recv_lse = reinterpret_cast<const float*>(
-      workspace + lse_region_byte_offset + slot * slot_lse_bytes);
-
-  // Stage the LSEs, then let one thread reduce them. nranks is small (<= 64),
-  // so a single-threaded reduction over shared memory is cheaper than a tree
-  // and keeps the ordering deterministic across launches.
-  for (int r = threadIdx.x; r < nranks; r += blockDim.x) {
-    const size_t idx = (((size_t)r * max_tokens + token) * local_heads + head);
-    smem[r] = sanitize_lse(recv_lse[idx]);
+  // Keep epoch selection on device so CUDA graph replay advances the slot.
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    const uint32_t epoch = state[0];
+    state[1] = epoch;
+    state[0] = epoch + 1;
   }
-  __syncthreads();
+  grid.sync();
+
+  const uint32_t epoch = state[1];
+  const uint32_t signal_value = epoch + 1;
+  const uint32_t slot = epoch % kNumSlots;
+  const int num_entries = num_tokens * local_heads;
+  const size_t slot_out_window_offset = out_region_window_offset + slot * slot_out_bytes;
+  const size_t slot_lse_window_offset = lse_region_window_offset + slot * slot_lse_bytes;
+
+  // Each destination is owned by one block. That block writes every row before
+  // publishing this source rank's readiness flag to the destination.
+  for (int dst = blockIdx.x; dst < nranks; dst += gridDim.x) {
+    for (int tile = 0; tile < num_entries; ++tile) {
+      const int token = tile / local_heads;
+      const int local_head = tile - token * local_heads;
+      const size_t src_base = (((static_cast<size_t>(tile) * nranks + dst) * head_dim));
+      const size_t dst_row =
+          ((static_cast<size_t>(rank) * max_tokens + token) * local_heads + local_head);
+      T* dst_out = reinterpret_cast<T*>(
+          ncclGetLsaPointer(window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
+      float* dst_lse = reinterpret_cast<float*>(
+          ncclGetLsaPointer(window, slot_lse_window_offset + dst_row * sizeof(float), dst));
+
+      constexpr int kVec = static_cast<int>(sizeof(int4) / sizeof(T));
+      const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
+      int4* dst4 = reinterpret_cast<int4*>(dst_out);
+      const int n4 = head_dim / kVec;
+      for (int d = threadIdx.x; d < n4; d += blockDim.x) {
+        dst4[d] = src4[d];
+      }
+      if (threadIdx.x == 0) {
+        *dst_lse = partial_lse[static_cast<size_t>(tile) * nranks + dst];
+      }
+      __syncthreads();
+    }
+
+    // Conservatively flush every writer before the signaling thread publishes
+    // readiness. This can be relaxed after compute-sanitizer and perf testing.
+    __threadfence_system();
+    __syncthreads();
+    if (threadIdx.x == 0) {
+      auto* dst_ready = reinterpret_cast<uint32_t*>(ncclGetLsaPointer(
+          window, signal_window_offset + (slot * nranks + rank) * sizeof(uint32_t), dst));
+      store_release_sys(dst_ready, signal_value);
+    }
+    __syncthreads();
+  }
+
+  // Different threads wait for different source ranks. The grid sync must be
+  // unconditional: after it, blocks are reassigned to merge work, so every
+  // block must observe that all source payloads are ready. This is the same
+  // invariant as NCCL EP's staged LL combine receive path.
+  if (blockIdx.x == 0) {
+    for (int src = threadIdx.x; src < nranks; src += blockDim.x) {
+      const uint32_t* src_ready = ready + slot * nranks + src;
+      while (load_acquire_sys(src_ready) != signal_value) {
+        __nanosleep(64);
+      }
+    }
+  }
+  grid.sync();
+
+  const T* recv_out =
+      reinterpret_cast<const T*>(workspace + out_region_local_offset + slot * slot_out_bytes);
+  const float* recv_lse =
+      reinterpret_cast<const float*>(workspace + lse_region_local_offset + slot * slot_lse_bytes);
 
   __shared__ float s_denom;
-  if (threadIdx.x == 0) {
-    float m = -INFINITY;
-    for (int r = 0; r < nranks; ++r) m = fmaxf(m, smem[r]);
-    // Every shard was empty: emit zeros and a -inf LSE, matching what a single
-    // shard with no contribution would produce.
-    if (m == -INFINITY) m = 0.0f;
-    float denom = 0.0f;
-    for (int r = 0; r < nranks; ++r) {
-      const float e = BASE_E ? __expf(smem[r] - m) : exp2f(smem[r] - m);
-      smem[r] = e;
-      denom += e;
+  for (int entry = blockIdx.x; entry < num_entries; entry += gridDim.x) {
+    const int token = entry / local_heads;
+    const int head = entry - token * local_heads;
+    if (threadIdx.x < nranks) {
+      const int r = threadIdx.x;
+      const size_t idx = ((static_cast<size_t>(r) * max_tokens + token) * local_heads + head);
+      smem[r] = sanitize_lse(recv_lse[idx]);
     }
-    s_denom = denom;
-  }
-  __syncthreads();
+    __syncthreads();
 
-  const float denom = s_denom;
-  const float inv = (denom == 0.0f) ? 0.0f : (1.0f / denom);
-
-  const size_t out_base = ((size_t)token * local_heads + head) * head_dim;
-  for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
-    float acc = 0.0f;
-    for (int r = 0; r < nranks; ++r) {
-      const size_t idx =
-          ((((size_t)r * max_tokens + token) * local_heads + head) * head_dim + d);
-      acc += Conv<T>::to_f32(recv_out[idx]) * (smem[r] * inv);
+    if (threadIdx.x == 0) {
+      float m = -INFINITY;
+      for (int r = 0; r < nranks; ++r) m = fmaxf(m, smem[r]);
+      if (m == -INFINITY) m = 0.0f;
+      float denom = 0.0f;
+      for (int r = 0; r < nranks; ++r) {
+        const float e = BASE_E ? __expf(smem[r] - m) : exp2f(smem[r] - m);
+        smem[r] = e;
+        denom += e;
+      }
+      s_denom = denom;
     }
-    combined_out[out_base + d] = Conv<T>::from_f32(acc);
-  }
+    __syncthreads();
 
+    const float inv = (s_denom == 0.0f) ? 0.0f : (1.0f / s_denom);
+    const size_t out_base = static_cast<size_t>(entry) * head_dim;
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      float acc = 0.0f;
+      for (int r = 0; r < nranks; ++r) {
+        const size_t idx =
+            (((static_cast<size_t>(r) * max_tokens + token) * local_heads + head) * head_dim + d);
+        acc += Conv<T>::to_f32(recv_out[idx]) * (smem[r] * inv);
+      }
+      combined_out[out_base + d] = Conv<T>::from_f32(acc);
+    }
+    __syncthreads();
+  }
 }
 
 }  // namespace dcp

--- a/include/flashinfer/comm/dcp_lse_reduce.cuh
+++ b/include/flashinfer/comm/dcp_lse_reduce.cuh
@@ -1,0 +1,275 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Fused decode context-parallel all-to-all + LSE-weighted reduce.
+//
+// Under decode context parallelism the KV cache is sharded across a team. Every
+// rank attends the query heads against its own KV shard and produces a partial
+// output plus the log-sum-exp of the softmax denominator over that shard. The
+// merge is a standard softmax-weighted reduction: gathering the per-rank LSEs
+// for one (token, head) into a vector l,
+//
+//   out = sum_r softmax(l)_r * o_r
+//   lse = logsumexp(l)
+//
+// i.e. the LSEs act as the logits and the softmax is over the *rank* axis, not
+// the key axis. It is evaluated in the max-shifted stable form, which is
+// identical to softmax(l) because softmax is shift invariant. With base-2 LSE
+// (FlashInfer MLA) the exponentials are base 2, giving softmax(l*ln2).
+//
+// The one deviation from softmax proper: if every shard reports -inf for a head
+// (an empty KV range everywhere) softmax would be 0/0, so that case is defined
+// to produce a zero output and a -inf combined LSE rather than NaN. NaN and
+// +inf inputs fold to -inf before the softmax.
+//
+// The reduction is associative and commutative, so the order is free. This is
+// the same merge flash-attention uses to combine its splits, with the splits
+// being ranks rather than key blocks.
+//
+// Data movement uses the NCCL device API: each rank stores its per-destination
+// slice straight into the destination's registered symmetric window
+// (ncclGetLsaPointer), an LSA barrier makes those stores visible, then every
+// rank merges locally. That requires a single load/store-accessible (NVLink)
+// domain; a team spanning several LSA domains needs a hierarchical algorithm
+// which is not implemented here.
+
+#ifndef FLASHINFER_COMM_DCP_LSE_REDUCE_CUH_
+#define FLASHINFER_COMM_DCP_LSE_REDUCE_CUH_
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <math.h>
+#include <nccl_device.h>
+
+namespace flashinfer {
+namespace comm {
+namespace dcp {
+
+// Two workspace slots, used alternately, so one barrier per call is enough.
+//
+// With a single slot: rank r issues its put for call i+1 as soon as it clears
+// barrier i, but peer p only issues its merge for call i *after* that same
+// barrier -- r would overwrite data p has not read. Alternating puts the
+// previous reader two calls back, and on p's stream that read is ordered
+// before the barrier r had to clear to reach call i+2.
+//
+// The alternative, two barriers per call, costs about as much as the fused
+// path saves.
+constexpr int kNumSlots = 2;
+
+// Merging more than this many ranks per block would blow the shared-memory LSE
+// staging area; workspace creation rejects larger teams.
+constexpr int kMaxRanks = 64;
+
+constexpr int kPutBlockSize = 128;
+constexpr int kMergeBlockSize = 128;
+constexpr size_t kMetadataBytes = 16;
+
+// Select the alternating workspace slot on device so CUDA graph replay
+// advances the epoch rather than baking a host-side slot value into the graph.
+// state[0] is the monotonically increasing epoch and state[1] is the slot used
+// by the kernels in this invocation.
+__global__ void SelectSlotKernel(uint32_t* state) {
+  if (threadIdx.x == 0) {
+    const uint32_t epoch = state[0];
+    state[1] = epoch % kNumSlots;
+    state[0] = epoch + 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Element conversion. Accumulation is always fp32 regardless of storage type;
+// the partials are pre-normalisation, so reducing in fp16 would lose more than
+// the final rounding.
+// ---------------------------------------------------------------------------
+template <typename T>
+struct Conv;
+
+template <>
+struct Conv<float> {
+  __device__ static inline float to_f32(float v) { return v; }
+  __device__ static inline float from_f32(float v) { return v; }
+};
+
+template <>
+struct Conv<__half> {
+  __device__ static inline float to_f32(__half v) { return __half2float(v); }
+  __device__ static inline __half from_f32(float v) { return __float2half(v); }
+};
+
+template <>
+struct Conv<__nv_bfloat16> {
+  __device__ static inline float to_f32(__nv_bfloat16 v) { return __bfloat162float(v); }
+  __device__ static inline __nv_bfloat16 from_f32(float v) { return __float2bfloat16(v); }
+};
+
+// Sanitise an incoming LSE. A shard that contributed nothing reports -inf; some
+// backends emit NaN or +inf instead, and both must fold to "no weight" rather
+// than poisoning the whole merge.
+__device__ static inline float sanitize_lse(float l) {
+  return (isnan(l) || l == INFINITY) ? -INFINITY : l;
+}
+
+// ---------------------------------------------------------------------------
+// Put: publish this rank's partial for every destination directly into that
+// destination's workspace slot.
+//
+// The source is already sliced per destination, which is the layout the DCP
+// all-to-all convention uses:
+//   partial_o   [num_tokens, local_heads, nranks, head_dim]
+//   partial_lse [num_tokens, local_heads, nranks]
+// The destination layout inside the peer's slot is
+//   [src_rank][token][local_head][*]
+//
+// Grid  (num_tokens * local_heads, nranks)
+// Block 128 threads, each striding over head_dim.
+// ---------------------------------------------------------------------------
+template <typename T>
+__global__ void PutPackedKernel(const T* __restrict__ partial_o,
+                                const float* __restrict__ partial_lse, ncclWindow_t window,
+                                size_t out_region_byte_offset, size_t slot_out_bytes,
+                                size_t lse_region_byte_offset, size_t slot_lse_bytes,
+                                const uint32_t* state, int rank, int nranks, int num_tokens,
+                                int max_tokens, int local_heads, int head_dim) {
+  const int tile = blockIdx.x;  // token * local_heads + local head
+  const int dst = blockIdx.y;
+  const int token = tile / local_heads;
+  const int local_head = tile - token * local_heads;
+  if (token >= num_tokens || dst >= nranks) return;
+
+  const size_t src_base =
+      ((((size_t)token * local_heads + local_head) * nranks + dst) * head_dim);
+  const unsigned int slot = state[1];
+  const size_t slot_out_byte_offset = out_region_byte_offset + slot * slot_out_bytes;
+  const size_t slot_lse_byte_offset = lse_region_byte_offset + slot * slot_lse_bytes;
+  const size_t dst_row = (((size_t)rank * max_tokens + token) * local_heads + local_head);
+
+  T* dst_out =
+      (T*)ncclGetLsaPointer(window, slot_out_byte_offset + dst_row * head_dim * sizeof(T), dst);
+  float* dst_lse =
+      (float*)ncclGetLsaPointer(window, slot_lse_byte_offset + dst_row * sizeof(float), dst);
+
+  // Widen to 16-byte stores when the row allows it. These go over NVLink, so
+  // the difference between 2-byte and 16-byte transactions is large. Rows are
+  // head_dim*sizeof(T) bytes and both bases are at least 16-byte aligned, so
+  // divisibility of the row is the only condition to check.
+  constexpr int kVec = (int)(sizeof(int4) / sizeof(T));
+  if (head_dim % kVec == 0) {
+    const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
+    int4* dst4 = reinterpret_cast<int4*>(dst_out);
+    const int n4 = head_dim / kVec;
+    for (int d = threadIdx.x; d < n4; d += blockDim.x) {
+      dst4[d] = src4[d];
+    }
+  } else {
+    for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+      dst_out[d] = partial_o[src_base + d];
+    }
+  }
+  if (threadIdx.x == 0) {
+    *dst_lse = partial_lse[((size_t)token * local_heads + local_head) * nranks + dst];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Barrier: make every peer's puts visible before anyone merges.
+//
+// A single CTA. Kernel boundaries give the intra-rank ordering (all put CTAs
+// have retired), and the LSA barrier with acq_rel gives the inter-rank
+// ordering. Keeping it separate rather than fusing a signal into the put and a
+// spin into the merge costs one launch; it is also the version whose
+// correctness does not depend on getting a hand-rolled protocol right.
+// ---------------------------------------------------------------------------
+__global__ void BarrierKernel(ncclDevComm dev_comm) {
+  ncclLsaBarrierSession<ncclCoopCta> bar(ncclCoopCta(), dev_comm, ncclTeamLsa(dev_comm),
+                                         dev_comm.lsaBarrier, /*index=*/0);
+  bar.sync(ncclCoopCta(), cuda::memory_order_acq_rel);
+}
+
+// ---------------------------------------------------------------------------
+// Merge: softmax-weighted reduction of the nranks partials this rank received.
+//
+// Grid  (num_tokens, local_heads)
+// Block 128 threads.
+//
+// One pass over the payload. The LSEs are staged in shared memory and the
+// weights derived once per block, rather than re-read per pass.
+// ---------------------------------------------------------------------------
+template <typename T, bool BASE_E>
+__global__ void MergeKernel(const unsigned char* __restrict__ workspace,
+                            size_t out_region_byte_offset, size_t slot_out_bytes,
+                            size_t lse_region_byte_offset, size_t slot_lse_bytes,
+                            const uint32_t* state, T* __restrict__ combined_out, int nranks,
+                            int num_tokens, int max_tokens, int local_heads, int head_dim) {
+  extern __shared__ float smem[];  // [nranks] merge weights
+
+  const int token = blockIdx.x;
+  const int head = blockIdx.y;
+  const unsigned int slot = state[1];
+  const T* recv_out = reinterpret_cast<const T*>(
+      workspace + out_region_byte_offset + slot * slot_out_bytes);
+  const float* recv_lse = reinterpret_cast<const float*>(
+      workspace + lse_region_byte_offset + slot * slot_lse_bytes);
+
+  // Stage the LSEs, then let one thread reduce them. nranks is small (<= 64),
+  // so a single-threaded reduction over shared memory is cheaper than a tree
+  // and keeps the ordering deterministic across launches.
+  for (int r = threadIdx.x; r < nranks; r += blockDim.x) {
+    const size_t idx = (((size_t)r * max_tokens + token) * local_heads + head);
+    smem[r] = sanitize_lse(recv_lse[idx]);
+  }
+  __syncthreads();
+
+  __shared__ float s_denom;
+  if (threadIdx.x == 0) {
+    float m = -INFINITY;
+    for (int r = 0; r < nranks; ++r) m = fmaxf(m, smem[r]);
+    // Every shard was empty: emit zeros and a -inf LSE, matching what a single
+    // shard with no contribution would produce.
+    if (m == -INFINITY) m = 0.0f;
+    float denom = 0.0f;
+    for (int r = 0; r < nranks; ++r) {
+      const float e = BASE_E ? __expf(smem[r] - m) : exp2f(smem[r] - m);
+      smem[r] = e;
+      denom += e;
+    }
+    s_denom = denom;
+  }
+  __syncthreads();
+
+  const float denom = s_denom;
+  const float inv = (denom == 0.0f) ? 0.0f : (1.0f / denom);
+
+  const size_t out_base = ((size_t)token * local_heads + head) * head_dim;
+  for (int d = threadIdx.x; d < head_dim; d += blockDim.x) {
+    float acc = 0.0f;
+    for (int r = 0; r < nranks; ++r) {
+      const size_t idx =
+          ((((size_t)r * max_tokens + token) * local_heads + head) * head_dim + d);
+      acc += Conv<T>::to_f32(recv_out[idx]) * (smem[r] * inv);
+    }
+    combined_out[out_base + d] = Conv<T>::from_f32(acc);
+  }
+
+}
+
+}  // namespace dcp
+}  // namespace comm
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_COMM_DCP_LSE_REDUCE_CUH_

--- a/include/flashinfer/comm/dcp_lse_reduce.cuh
+++ b/include/flashinfer/comm/dcp_lse_reduce.cuh
@@ -188,10 +188,10 @@ __global__ void FusedKernel(const T* __restrict__ partial_o, const float* __rest
       const size_t src_base = ((static_cast<size_t>(tile) * nranks + dst) * head_dim);
       const size_t dst_row =
           ((static_cast<size_t>(rank) * max_tokens + token) * local_heads + local_head);
-      T* dst_out = reinterpret_cast<T*>(ncclGetLsaPointer(
-          window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
-      float* dst_lse = reinterpret_cast<float*>(ncclGetLsaPointer(
-          window, slot_lse_window_offset + dst_row * sizeof(float), dst));
+      T* dst_out = reinterpret_cast<T*>(
+          ncclGetLsaPointer(window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
+      float* dst_lse = reinterpret_cast<float*>(
+          ncclGetLsaPointer(window, slot_lse_window_offset + dst_row * sizeof(float), dst));
       constexpr int kVec = static_cast<int>(sizeof(int4) / sizeof(T));
       const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
       int4* dst4 = reinterpret_cast<int4*>(dst_out);
@@ -218,8 +218,8 @@ __global__ void FusedKernel(const T* __restrict__ partial_o, const float* __rest
             ((static_cast<size_t>(rank) * max_tokens + token) * local_heads + local_head);
         T* dst_out = reinterpret_cast<T*>(ncclGetLsaPointer(
             window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
-        float* dst_lse = reinterpret_cast<float*>(ncclGetLsaPointer(
-            window, slot_lse_window_offset + dst_row * sizeof(float), dst));
+        float* dst_lse = reinterpret_cast<float*>(
+            ncclGetLsaPointer(window, slot_lse_window_offset + dst_row * sizeof(float), dst));
         constexpr int kVec = static_cast<int>(sizeof(int4) / sizeof(T));
         const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
         int4* dst4 = reinterpret_cast<int4*>(dst_out);

--- a/include/flashinfer/comm/dcp_lse_reduce.cuh
+++ b/include/flashinfer/comm/dcp_lse_reduce.cuh
@@ -147,7 +147,7 @@ __device__ static inline float sanitize_lse(float l) {
 //   2. blocks publish complete destination payloads and release-store flags;
 //   3. block 0 acquire-waits for every source flag; unconditional grid sync;
 //   4. blocks are reassigned to output rows and perform the LSE merge.
-template <typename T, bool BASE_E>
+template <typename T, bool BASE_E, bool ROW_DISTRIBUTED>
 __global__ void FusedKernel(const T* __restrict__ partial_o, const float* __restrict__ partial_lse,
                             unsigned char* __restrict__ workspace, ncclWindow_t window,
                             size_t signal_window_offset, size_t out_region_window_offset,
@@ -176,43 +176,66 @@ __global__ void FusedKernel(const T* __restrict__ partial_o, const float* __rest
   const size_t slot_out_window_offset = out_region_window_offset + slot * slot_out_bytes;
   const size_t slot_lse_window_offset = lse_region_window_offset + slot * slot_lse_bytes;
 
-  // Each destination is owned by one block. That block writes every row before
-  // publishing this source rank's readiness flag to the destination.
-  for (int dst = blockIdx.x; dst < nranks; dst += gridDim.x) {
-    for (int tile = 0; tile < num_entries; ++tile) {
+  if constexpr (ROW_DISTRIBUTED) {
+    // Split the (destination, row) work across the whole cooperative grid. At
+    // CP=4, one-block-per-destination leaves blocks idle once entries exceed
+    // the number of ranks. Publish only after all producers have flushed.
+    for (int work = blockIdx.x; work < nranks * num_entries; work += gridDim.x) {
+      const int dst = work / num_entries;
+      const int tile = work - dst * num_entries;
       const int token = tile / local_heads;
       const int local_head = tile - token * local_heads;
-      const size_t src_base = (((static_cast<size_t>(tile) * nranks + dst) * head_dim));
+      const size_t src_base = ((static_cast<size_t>(tile) * nranks + dst) * head_dim);
       const size_t dst_row =
           ((static_cast<size_t>(rank) * max_tokens + token) * local_heads + local_head);
-      T* dst_out = reinterpret_cast<T*>(
-          ncclGetLsaPointer(window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
-      float* dst_lse = reinterpret_cast<float*>(
-          ncclGetLsaPointer(window, slot_lse_window_offset + dst_row * sizeof(float), dst));
-
+      T* dst_out = reinterpret_cast<T*>(ncclGetLsaPointer(
+          window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
+      float* dst_lse = reinterpret_cast<float*>(ncclGetLsaPointer(
+          window, slot_lse_window_offset + dst_row * sizeof(float), dst));
       constexpr int kVec = static_cast<int>(sizeof(int4) / sizeof(T));
       const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
       int4* dst4 = reinterpret_cast<int4*>(dst_out);
-      const int n4 = head_dim / kVec;
-      for (int d = threadIdx.x; d < n4; d += blockDim.x) {
-        dst4[d] = src4[d];
-      }
-      if (threadIdx.x == 0) {
-        *dst_lse = partial_lse[static_cast<size_t>(tile) * nranks + dst];
-      }
-      __syncthreads();
+      for (int d = threadIdx.x; d < head_dim / kVec; d += blockDim.x) dst4[d] = src4[d];
+      if (threadIdx.x == 0) *dst_lse = partial_lse[static_cast<size_t>(tile) * nranks + dst];
     }
-
-    // Conservatively flush every writer before the signaling thread publishes
-    // readiness. This can be relaxed after compute-sanitizer and perf testing.
     __threadfence_system();
-    __syncthreads();
-    if (threadIdx.x == 0) {
+    grid.sync();
+    if (blockIdx.x < nranks && threadIdx.x == 0) {
+      const int dst = blockIdx.x;
       auto* dst_ready = reinterpret_cast<uint32_t*>(ncclGetLsaPointer(
           window, signal_window_offset + (slot * nranks + rank) * sizeof(uint32_t), dst));
       store_release_sys(dst_ready, signal_value);
     }
-    __syncthreads();
+  } else {
+    // For small row counts, a destination-owning block avoids the extra grid
+    // synchronization needed by the fully distributed send schedule.
+    for (int dst = blockIdx.x; dst < nranks; dst += gridDim.x) {
+      for (int tile = 0; tile < num_entries; ++tile) {
+        const int token = tile / local_heads;
+        const int local_head = tile - token * local_heads;
+        const size_t src_base = ((static_cast<size_t>(tile) * nranks + dst) * head_dim);
+        const size_t dst_row =
+            ((static_cast<size_t>(rank) * max_tokens + token) * local_heads + local_head);
+        T* dst_out = reinterpret_cast<T*>(ncclGetLsaPointer(
+            window, slot_out_window_offset + dst_row * head_dim * sizeof(T), dst));
+        float* dst_lse = reinterpret_cast<float*>(ncclGetLsaPointer(
+            window, slot_lse_window_offset + dst_row * sizeof(float), dst));
+        constexpr int kVec = static_cast<int>(sizeof(int4) / sizeof(T));
+        const int4* src4 = reinterpret_cast<const int4*>(partial_o + src_base);
+        int4* dst4 = reinterpret_cast<int4*>(dst_out);
+        for (int d = threadIdx.x; d < head_dim / kVec; d += blockDim.x) dst4[d] = src4[d];
+        if (threadIdx.x == 0) *dst_lse = partial_lse[static_cast<size_t>(tile) * nranks + dst];
+        __syncthreads();
+      }
+      __threadfence_system();
+      __syncthreads();
+      if (threadIdx.x == 0) {
+        auto* dst_ready = reinterpret_cast<uint32_t*>(ncclGetLsaPointer(
+            window, signal_window_offset + (slot * nranks + rank) * sizeof(uint32_t), dst));
+        store_release_sys(dst_ready, signal_value);
+      }
+      __syncthreads();
+    }
   }
 
   // Different threads wait for different source ranks. The grid sync must be

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -44,14 +44,12 @@ def _backend_available() -> bool:
         return False
 
 
-pytestmark = pytest.mark.skipif(
-    not _backend_available(),
-    reason="Requires torchrun, CUDA, and torch's NCCL symmetric-memory backend",
-)
-
-
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def process_group():
+    if not _backend_available():
+        pytest.skip(
+            "Requires torchrun, CUDA, and torch's NCCL symmetric-memory backend"
+        )
     created = False
     if not dist.is_initialized():
         torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
@@ -82,15 +80,16 @@ def _reference_lse_reduce(
         else torch.exp2(recv_lse - lse_max)
     )
     denom = weights.sum(dim=-1, keepdim=True)
-    expected = (
-        (recv_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(1e-20)
+    expected = (recv_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(
+        1e-20
     )
     expected = torch.where(denom == 0, torch.zeros_like(expected), expected)
     return expected.to(partial_o.dtype)
 
 
 def test_workspace_size():
-    expected = 16 + 2 * 4 * 8 * 2 * (128 * 2 + 4)
+    payload_offset = (16 + 2 * 4 * 4 + 15) // 16 * 16
+    expected = payload_offset + 2 * 4 * 8 * 2 * (128 * 2 + 4)
     assert (
         decode_cp_a2a_lse_reduce_workspace_size(
             max_tokens=8,
@@ -103,9 +102,42 @@ def test_workspace_size():
     )
 
 
+@pytest.mark.parametrize(
+    "kwargs, error",
+    [
+        ({"max_tokens": 0}, ValueError),
+        ({"local_heads": 0}, ValueError),
+        ({"cp_size": 65}, ValueError),
+        ({"head_dim": 0}, ValueError),
+        ({"head_dim": 7}, ValueError),
+        ({"dtype": torch.float32}, TypeError),
+    ],
+)
+def test_workspace_size_validation(kwargs, error):
+    params = {
+        "max_tokens": 8,
+        "local_heads": 2,
+        "cp_size": 4,
+        "head_dim": 128,
+        "dtype": torch.bfloat16,
+    }
+    params.update(kwargs)
+    with pytest.raises(error):
+        decode_cp_a2a_lse_reduce_workspace_size(**params)
+
+
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("is_lse_base_on_e", [True, False])
-def test_lse_reduce(dtype, is_lse_base_on_e):
+def test_single_rank_reference_is_identity(dtype, is_lse_base_on_e):
+    partial_o = torch.randn(3, 1, 16, dtype=dtype)
+    partial_lse = torch.randn(3, 1)
+    actual = _reference_lse_reduce(partial_o, partial_lse, is_lse_base_on_e)
+    torch.testing.assert_close(actual, partial_o[:, 0])
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("is_lse_base_on_e", [True, False])
+def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
     torch.manual_seed(0)
     group = dist.group.WORLD
     cp_rank = dist.get_rank(group)
@@ -141,6 +173,10 @@ def test_lse_reduce(dtype, is_lse_base_on_e):
         dtype=dtype,
         group=group,
     )
+    recv_o = torch.stack([tensor[..., cp_rank, :] for tensor in all_o], dim=-2)
+    recv_lse = torch.stack([tensor[..., cp_rank] for tensor in all_lse], dim=-1)
+    expected = _reference_lse_reduce(recv_o, recv_lse, is_lse_base_on_e)
+
     # Three calls exercise slot 0, slot 1, and slot 0 reuse without re-init.
     for _ in range(3):
         actual = decode_cp_a2a_lse_reduce(
@@ -152,14 +188,12 @@ def test_lse_reduce(dtype, is_lse_base_on_e):
             is_lse_base_on_e=is_lse_base_on_e,
             enable_pdl=None,
         )
+        torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-3)
 
-    recv_o = torch.stack([tensor[..., cp_rank, :] for tensor in all_o], dim=-2)
-    recv_lse = torch.stack([tensor[..., cp_rank] for tensor in all_lse], dim=-1)
-    expected = _reference_lse_reduce(recv_o, recv_lse, is_lse_base_on_e)
     assert actual.shape == (batch, local_heads, head_dim)
-    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-3)
 
-    # Capture one invocation on every rank, then replay collectively.
+    # Capture one invocation on every rank, then replay enough times to exercise
+    # both slots and slot reuse inside a graph.
     dist.barrier(group=group)
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
@@ -172,6 +206,7 @@ def test_lse_reduce(dtype, is_lse_base_on_e):
             is_lse_base_on_e=is_lse_base_on_e,
         )
     dist.barrier(group=group)
-    graph.replay()
-    torch.cuda.synchronize()
-    torch.testing.assert_close(graph_out, expected, rtol=1e-2, atol=1e-3)
+    for _ in range(4):
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(graph_out, expected, rtol=1e-2, atol=1e-3)

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -1,0 +1,177 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-rank tests for flashinfer.comm.decode_cp_a2a_lse_reduce.
+
+Run with one process per GPU:
+
+  torchrun --standalone --nproc-per-node=4 \
+    -m pytest tests/comm/test_dcp_lse_reduce.py -v -s
+"""
+
+import os
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.distributed._symmetric_memory as symm_mem
+
+from flashinfer.comm import (
+    decode_cp_a2a_lse_reduce,
+    decode_cp_a2a_lse_reduce_create_workspace,
+    decode_cp_a2a_lse_reduce_workspace_size,
+)
+
+
+def _backend_available() -> bool:
+    if not torch.cuda.is_available() or "RANK" not in os.environ:
+        return False
+    try:
+        symm_mem.set_backend("NCCL")
+        return symm_mem.get_backend(torch.device("cuda")) == "NCCL"
+    except (RuntimeError, AttributeError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _backend_available(),
+    reason="Requires torchrun, CUDA, and torch's NCCL symmetric-memory backend",
+)
+
+
+@pytest.fixture(scope="module", autouse=True)
+def process_group():
+    created = False
+    if not dist.is_initialized():
+        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+        dist.init_process_group("nccl")
+        created = True
+    yield
+    if created:
+        dist.destroy_process_group()
+
+
+def _reference_lse_reduce(
+    partial_o: torch.Tensor,
+    partial_lse: torch.Tensor,
+    is_lse_base_on_e: bool,
+) -> torch.Tensor:
+    recv_o = partial_o
+    recv_lse = partial_lse.clone()
+    recv_lse = torch.where(
+        torch.isnan(recv_lse) | torch.isposinf(recv_lse),
+        torch.full_like(recv_lse, float("-inf")),
+        recv_lse,
+    )
+    lse_max = recv_lse.max(dim=-1, keepdim=True).values
+    lse_max = torch.where(torch.isneginf(lse_max), torch.zeros_like(lse_max), lse_max)
+    weights = (
+        torch.exp(recv_lse - lse_max)
+        if is_lse_base_on_e
+        else torch.exp2(recv_lse - lse_max)
+    )
+    denom = weights.sum(dim=-1, keepdim=True)
+    expected = (
+        (recv_o.float() * weights.unsqueeze(-1)).sum(dim=-2) / denom.clamp_min(1e-20)
+    )
+    expected = torch.where(denom == 0, torch.zeros_like(expected), expected)
+    return expected.to(partial_o.dtype)
+
+
+def test_workspace_size():
+    expected = 16 + 2 * 4 * 8 * 2 * (128 * 2 + 4)
+    assert (
+        decode_cp_a2a_lse_reduce_workspace_size(
+            max_tokens=8,
+            local_heads=2,
+            cp_size=4,
+            head_dim=128,
+            dtype=torch.bfloat16,
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("is_lse_base_on_e", [True, False])
+def test_lse_reduce(dtype, is_lse_base_on_e):
+    torch.manual_seed(0)
+    group = dist.group.WORLD
+    cp_rank = dist.get_rank(group)
+    cp_size = dist.get_world_size(group)
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+
+    batch, local_heads, head_dim = 4, 2, 64
+    device = torch.device("cuda", local_rank)
+    partial_o = torch.randn(
+        batch, local_heads, cp_size, head_dim, dtype=dtype, device=device
+    )
+    partial_lse = torch.randn(
+        batch, local_heads, cp_size, dtype=torch.float32, device=device
+    )
+    # One globally empty head: output row must be zeros after sanitise.
+    partial_lse[0, 0, :] = float("-inf")
+    if cp_rank == 0:
+        partial_lse[1, 0, :] = float("nan")
+    if cp_rank == min(1, cp_size - 1):
+        partial_lse[1, 1, :] = float("inf")
+
+    all_o = [torch.empty_like(partial_o) for _ in range(cp_size)]
+    all_lse = [torch.empty_like(partial_lse) for _ in range(cp_size)]
+    dist.all_gather(all_o, partial_o, group=group)
+    dist.all_gather(all_lse, partial_lse, group=group)
+
+    ws = decode_cp_a2a_lse_reduce_create_workspace(
+        max_tokens=batch + 1,
+        local_heads=local_heads,
+        cp_size=cp_size,
+        head_dim=head_dim,
+        dtype=dtype,
+        group=group,
+    )
+    # Three calls exercise slot 0, slot 1, and slot 0 reuse without re-init.
+    for _ in range(3):
+        actual = decode_cp_a2a_lse_reduce(
+            partial_o,
+            partial_lse,
+            ws,
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            is_lse_base_on_e=is_lse_base_on_e,
+            enable_pdl=None,
+        )
+
+    recv_o = torch.stack([tensor[..., cp_rank, :] for tensor in all_o], dim=-2)
+    recv_lse = torch.stack([tensor[..., cp_rank] for tensor in all_lse], dim=-1)
+    expected = _reference_lse_reduce(recv_o, recv_lse, is_lse_base_on_e)
+    assert actual.shape == (batch, local_heads, head_dim)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-3)
+
+    # Capture one invocation on every rank, then replay collectively.
+    dist.barrier(group=group)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = decode_cp_a2a_lse_reduce(
+            partial_o,
+            partial_lse,
+            ws,
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            is_lse_base_on_e=is_lse_base_on_e,
+        )
+    dist.barrier(group=group)
+    graph.replay()
+    torch.cuda.synchronize()
+    torch.testing.assert_close(graph_out, expected, rtol=1e-2, atol=1e-3)

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -143,10 +143,10 @@ def test_single_rank_reference_is_identity(dtype, is_lse_base_on_e):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("is_lse_base_on_e", [True, False])
 def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
-    torch.manual_seed(0)
     group = dist.group.WORLD
     cp_rank = dist.get_rank(group)
     cp_size = dist.get_world_size(group)
+    torch.manual_seed(cp_rank)
     local_rank = int(os.environ["LOCAL_RANK"])
     torch.cuda.set_device(local_rank)
 
@@ -196,6 +196,19 @@ def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
         torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-3)
 
     assert actual.shape == (batch, local_heads, head_dim)
+
+    # The workspace uses two shared slots and must stay on one ordered stream.
+    other_stream = torch.cuda.Stream(device=device)
+    with torch.cuda.stream(other_stream):
+        with pytest.raises(RuntimeError, match="one ordered CUDA stream"):
+            decode_cp_a2a_lse_reduce(
+                partial_o,
+                partial_lse,
+                ws,
+                cp_rank=cp_rank,
+                cp_size=cp_size,
+                is_lse_base_on_e=is_lse_base_on_e,
+            )
 
     # Capture one invocation on every rank, then replay enough times to exercise
     # both slots and slot reuse inside a graph.

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -199,8 +199,9 @@ def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
 
     # The workspace uses two shared slots and must stay on one ordered stream.
     other_stream = torch.cuda.Stream(device=device)
-    with torch.cuda.stream(other_stream), pytest.raises(
-        RuntimeError, match="one ordered CUDA stream"
+    with (
+        torch.cuda.stream(other_stream),
+        pytest.raises(RuntimeError, match="one ordered CUDA stream"),
     ):
         decode_cp_a2a_lse_reduce(
             partial_o,

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -212,6 +212,16 @@ def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
             is_lse_base_on_e=is_lse_base_on_e,
         )
 
+    # CUDA graph capture uses a distinct stream, so it needs a separately
+    # rendezvoused workspace under the one-ordered-stream workspace contract.
+    graph_ws = decode_cp_a2a_lse_reduce_create_workspace(
+        max_tokens=batch + 1,
+        local_heads=local_heads,
+        cp_size=cp_size,
+        head_dim=head_dim,
+        dtype=dtype,
+        group=group,
+    )
     # Capture one invocation on every rank, then replay enough times to exercise
     # both slots and slot reuse inside a graph.
     dist.barrier(group=group)
@@ -220,7 +230,7 @@ def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
         graph_out = decode_cp_a2a_lse_reduce(
             partial_o,
             partial_lse,
-            ws,
+            graph_ws,
             cp_rank=cp_rank,
             cp_size=cp_size,
             is_lse_base_on_e=is_lse_base_on_e,

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -52,8 +52,13 @@ def process_group():
         )
     created = False
     if not dist.is_initialized():
-        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
-        dist.init_process_group("nccl")
+        device = torch.device(f"cuda:{os.environ['LOCAL_RANK']}")
+        torch.cuda.set_device(device)
+        dist.init_process_group("nccl", device_id=device)
+        # Symmetric memory needs the process group's NCCL host communicator,
+        # which is created by the first eager collective in released PyTorch.
+        warmup = torch.zeros(1, device=device)
+        dist.all_reduce(warmup)
         created = True
     yield
     if created:

--- a/tests/comm/test_dcp_lse_reduce.py
+++ b/tests/comm/test_dcp_lse_reduce.py
@@ -199,16 +199,17 @@ def test_lse_reduce(process_group, dtype, is_lse_base_on_e):
 
     # The workspace uses two shared slots and must stay on one ordered stream.
     other_stream = torch.cuda.Stream(device=device)
-    with torch.cuda.stream(other_stream):
-        with pytest.raises(RuntimeError, match="one ordered CUDA stream"):
-            decode_cp_a2a_lse_reduce(
-                partial_o,
-                partial_lse,
-                ws,
-                cp_rank=cp_rank,
-                cp_size=cp_size,
-                is_lse_base_on_e=is_lse_base_on_e,
-            )
+    with torch.cuda.stream(other_stream), pytest.raises(
+        RuntimeError, match="one ordered CUDA stream"
+    ):
+        decode_cp_a2a_lse_reduce(
+            partial_o,
+            partial_lse,
+            ws,
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            is_lse_base_on_e=is_lse_base_on_e,
+        )
 
     # Capture one invocation on every rank, then replay enough times to exercise
     # both slots and slot reuse inside a graph.

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -44,6 +44,7 @@ _TRACE_REGISTRATION_MODULES = (
     "flashinfer.cascade",
     "flashinfer.comm.allreduce",
     "flashinfer.comm.dcp_alltoall",
+    "flashinfer.comm.dcp_lse_reduce",
     "flashinfer.comm.pcie_ipc_ar",
     "flashinfer.concat_ops",
     "flashinfer.cudnn.decode",


### PR DESCRIPTION
## 📌 Description

### Why this is needed

In context-parallel decode, the KV cache is sharded by sequence across ranks. Each rank runs attention against
its local KV shard and produces, for every query token and head:

- `o_r`: a partial attention output
- `lse_r`: the log-sum-exp that records that shard's softmax normalization

The `o_r` values cannot be summed directly: each was normalized over a different KV shard. To reconstruct
full-context attention, the partial outputs must be exchanged and merged with weights derived from all ranks'
LSEs:

`out = Σ_r softmax(lse)_r * o_r`

Each rank's input carries a `cp_size` axis containing the slices destined for the CP ranks. The `heads` axis may
contain either local or total heads: this op treats every batch/head entry independently and does not shard or
otherwise reinterpret the head axis.

### What this PR adds

Adds experimental `decode_cp_a2a_lse_reduce`, which fuses that all-to-all exchange and LSE-weighted merge into one
cooperative CUDA kernel.

```python
decode_cp_a2a_lse_reduce(
    partial_o: torch.Tensor,
    partial_lse: torch.Tensor,
    workspace: torch.Tensor,
    cp_rank: int,
    cp_size: int,
    lse_mode: Literal["base2", "basee"] = "base2",
) -> torch.Tensor
```

Input and output shapes:

- `partial_o`: `[batch, heads, cp_size, head_dim]` (`float16` or `bfloat16`)
- `partial_lse`: `[batch, heads, cp_size]` (`float32`)
- output: `[batch, heads, head_dim]`, with the same dtype as `partial_o`

More generally, arbitrary matching leading dimensions are supported:
`[..., cp_size, head_dim]` + `[..., cp_size]` → `[..., head_dim]`.

`lse_mode="base2"` accepts the base-2 LSE produced by FlashInfer MLA; `lse_mode="basee"` accepts natural-log
LSE. The op does not expose `enable_pdl` because its NCCL device kernel does not use programmatic dependent launch.

- Sends each peer's partial output and LSE together, then merges received contributions in the same kernel.
- Uses NCCL device load/store-accessible (LSA) symmetric memory rather than composing separate framework collectives.
- Supports eager execution and CUDA Graph replay with a collectively created, rendezvoused workspace.
- Requires all CP ranks to be in one NCCL LSA/NVLink domain. A workspace is single-stream; concurrent streams or
  graph-capture streams need separate workspaces.

This implements the NCCL-LSA scope of #4575.

## 🔍 Related Issues

- Implements the NCCL-LSA scope of #4575.
- Related design RFC: https://github.com/NVIDIA/nccl-extensions/issues/10

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items
are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Focused validation:

- ✅ Distributed DCP LSE-reduce test: `15 passed` per rank with 4 processes
- ✅ CPU-safe DCP API/reference tests: `12 passed`
- ✅ DCP trace signature, axes, and completeness checks: `3 passed`
- ✅ All configured pre-commit hooks on the modified PR files
- ✅ Python syntax compilation for modified Python sources
- ✅ `git diff --check`
- ✅ Four-process BF16 benchmark on four H100 80 GB GPUs in one NVLink-connected LSA domain versus unfused legacy
  A2A plus LSE merge (max-rank median; 10 warm-ups, 30 samples, 50 launches/sample):

| Shape | Fused eager | Fused + graph* | Legacy A2A + merge | Speedup |
|---|---:|---:|---:|---:|
| batch 1, heads 2, dim 64 | 12.14 µs | 10.15 µs | 178.91 µs | 14.7× |
| batch 1, heads 8, dim 128 | 15.04 µs | 13.24 µs | 179.22 µs | 11.9× |
| batch 4, heads 8, dim 128 | 18.04 µs | 16.40 µs | 178.73 µs | 9.9× |
| batch 16, heads 8, dim 128 | 18.96 µs | 17.02 µs | 180.88 µs | 9.5× |

* Fused + graph: groups 50 ops in one graph, reporting per-op average.

The largely flat legacy baseline shows that these decode-sized cases are dominated by fixed launch/collective
overhead; the speedup primarily reflects eliminating that overhead rather than a bandwidth improvement.

## Reviewer Notes

- This is the first FlashInfer op that directly uses NCCL device APIs. The new public API, AOT registration,
  trace template, documentation, tests, and benchmark are included in this PR.
- The restricted LSA/NVLink scope and the one-workspace-per-ordered-stream contract are intentional.

## Fused-kernel algorithm

For each token and attention head, every rank starts with a partial attention output $O_r$ and log-sum-exp $L_r$
from its local KV shard. The cooperative kernel completes the exchange and merge in one launch:

1. Block 0 advances a device-side epoch and selects one of two workspace slots, allowing safe slot rotation during
   CUDA Graph replay.
2. Each source rank writes its destination-specific output and LSE directly into the destination's NCCL
   symmetric-memory window using LSA/NVLink stores.
3. Sources publish system-scope release flags after their payloads are visible. Each destination acquire-waits for
   every source, then the cooperative grid synchronizes.
4. One block processes each token/head row. It computes stable rank-axis softmax weights:

$$
m = \max_r L_r, \qquad
w_r = \frac{\exp(L_r-m)}{\sum_j \exp(L_j-m)}.
$$

It then accumulates the combined output in FP32:

$$
O_{\mathrm{combined}}[d] = \sum_r w_r O_r[d].
$$

Base-2 LSE mode uses $2^{L_r-m}$. NaN and $+\infty$ LSEs are treated as $-\infty$; if every shard is empty, the
output is zero. The result is converted back to FP16 or BF16.

This removes the separate NCCL all-to-all and reduction launches by fusing peer transfer, readiness synchronization,
and the LSE-weighted merge. The implementation supports up to 64 ranks, requires one NCCL LSA/NVLink domain, and
requires each workspace to stay on one ordered CUDA stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an experimental context-parallel communication API that combines all-to-all exchange with
    log-sum-exp-weighted attention-output reduction.
  - Added workspace sizing and creation utilities for supported NCCL-based distributed workloads.
  - Supports natural-log and base-2 log-sum-exp calculations, including robust handling of special values.
  - Added CUDA graph and tracing support for the new operation.

- **Documentation**
  - Added API documentation covering the new communication functions and workspace requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
