### PR TITLE
Add option to skip checking active rows in TRTLLM ragged prefill

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5142,7 +5142,7 @@ def trtllm_ragged_attention_deepseek(
     kv_seq_lens_cpu: Optional[torch.Tensor] = None,
     use_fp16_softmax: Optional[bool] = None,
     uses_spcompress: Optional[bool] = None,
-    assume_all_rows_active: bool = False,
+    skip_all_rows_active_check: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Parameters
@@ -5232,7 +5232,7 @@ def trtllm_ragged_attention_deepseek(
     kv_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row KV lengths. Currently only
         consulted by the ``trtllm-gen`` backend.
-    assume_all_rows_active : bool
+    skip_all_rows_active_check : bool
         Skip empty-row detection when the caller guarantees that every row has
         positive query and KV lengths. Mutually exclusive with CPU length
         mirrors. Currently only consulted by the ``trtllm-gen`` backend.
@@ -5404,10 +5404,11 @@ def trtllm_ragged_attention_deepseek(
         has_inactive_rows = False
         has_active_rows = True
 
-        if assume_all_rows_active:
+        if skip_all_rows_active_check:
             if q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
                 raise ValueError(
-                    "assume_all_rows_active cannot be combined with CPU length mirrors"
+                    "skip_all_rows_active_check cannot be combined with CPU length "
+                    "mirrors"
                 )
         elif q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
             if q_seq_lens_cpu is None or kv_seq_lens_cpu is None:

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5142,6 +5142,7 @@ def trtllm_ragged_attention_deepseek(
     kv_seq_lens_cpu: Optional[torch.Tensor] = None,
     use_fp16_softmax: Optional[bool] = None,
     uses_spcompress: Optional[bool] = None,
+    assume_all_rows_active: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Parameters
@@ -5231,6 +5232,10 @@ def trtllm_ragged_attention_deepseek(
     kv_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row KV lengths. Currently only
         consulted by the ``trtllm-gen`` backend.
+    assume_all_rows_active : bool
+        Skip empty-row detection when the caller guarantees that every row has
+        positive query and KV lengths. Mutually exclusive with CPU length
+        mirrors. Currently only consulted by the ``trtllm-gen`` backend.
 
     Returns
     -------
@@ -5399,7 +5404,12 @@ def trtllm_ragged_attention_deepseek(
         has_inactive_rows = False
         has_active_rows = True
 
-        if q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
+        if assume_all_rows_active:
+            if q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
+                raise ValueError(
+                    "assume_all_rows_active cannot be combined with CPU length mirrors"
+                )
+        elif q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
             if q_seq_lens_cpu is None or kv_seq_lens_cpu is None:
                 raise ValueError(
                     "q_seq_lens_cpu and kv_seq_lens_cpu must be provided together"

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -2122,7 +2122,7 @@ trtllm_ragged_attention_deepseek_trace = TraceTemplate(
         "return_lse": Scalar("bool"),
         "enable_pdl": Scalar("bool", optional=True),
         "skip_softmax_threshold_scale_factor": Scalar("float32", optional=True),
-        "assume_all_rows_active": Scalar("bool", optional=True),
+        "skip_all_rows_active_check": Scalar("bool", optional=True),
     },
     outputs={
         "output": Tensor(

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -2122,6 +2122,7 @@ trtllm_ragged_attention_deepseek_trace = TraceTemplate(
         "return_lse": Scalar("bool"),
         "enable_pdl": Scalar("bool", optional=True),
         "skip_softmax_threshold_scale_factor": Scalar("float32", optional=True),
+        "assume_all_rows_active": Scalar("bool", optional=True),
     },
     outputs={
         "output": Tensor(

--- a/tests/attention/test_trtllm_ragged_kv_stride.py
+++ b/tests/attention/test_trtllm_ragged_kv_stride.py
@@ -48,7 +48,7 @@ def _run_trtllm_ragged(
     lse: torch.Tensor | None = None,
     q_lens_cpu: torch.Tensor | None = None,
     kv_lens_cpu: torch.Tensor | None = None,
-    assume_all_rows_active: bool = False,
+    skip_all_rows_active_check: bool = False,
 ):
     head_dim_qk = q.shape[2]
     return flashinfer.prefill.trtllm_ragged_attention_deepseek(
@@ -79,7 +79,7 @@ def _run_trtllm_ragged(
         lse=lse,
         q_seq_lens_cpu=q_lens_cpu,
         kv_seq_lens_cpu=kv_lens_cpu,
-        assume_all_rows_active=assume_all_rows_active,
+        skip_all_rows_active_check=skip_all_rows_active_check,
     )
 
 
@@ -361,7 +361,7 @@ def test_trtllm_ragged_empty_kv_rows_direct_fallback_matches_cpu_mirror_path():
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_assumed_active_matches_checked_path(monkeypatch):
+def test_trtllm_ragged_skipped_active_check_matches_checked_path(monkeypatch):
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     torch.manual_seed(42)
@@ -389,7 +389,7 @@ def test_trtllm_ragged_assumed_active_matches_checked_path(monkeypatch):
         q_indptr,
         kv_indptr,
         kv_lens,
-        assume_all_rows_active=True,
+        skip_all_rows_active_check=True,
     )
     checked_output, checked_lse = _run_trtllm_ragged(
         q,
@@ -407,7 +407,7 @@ def test_trtllm_ragged_assumed_active_matches_checked_path(monkeypatch):
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_assumed_active_rejects_cpu_mirrors():
+def test_trtllm_ragged_skipped_active_check_rejects_cpu_mirrors():
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     q, k, v, q_lens, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
@@ -422,7 +422,7 @@ def test_trtllm_ragged_assumed_active_rejects_cpu_mirrors():
             kv_lens,
             q_lens_cpu=q_lens.cpu(),
             kv_lens_cpu=kv_lens.cpu(),
-            assume_all_rows_active=True,
+            skip_all_rows_active_check=True,
         )
 
 
@@ -636,7 +636,7 @@ def test_trtllm_ragged_all_active_cuda_graph_capture_replay(row_activity_mode):
     row_activity_kwargs = (
         {"q_lens_cpu": q_lens_cpu, "kv_lens_cpu": kv_lens_cpu}
         if row_activity_mode == "cpu_mirrors"
-        else {"assume_all_rows_active": True}
+        else {"skip_all_rows_active_check": True}
     )
 
     def _call():

--- a/tests/attention/test_trtllm_ragged_kv_stride.py
+++ b/tests/attention/test_trtllm_ragged_kv_stride.py
@@ -48,6 +48,7 @@ def _run_trtllm_ragged(
     lse: torch.Tensor | None = None,
     q_lens_cpu: torch.Tensor | None = None,
     kv_lens_cpu: torch.Tensor | None = None,
+    assume_all_rows_active: bool = False,
 ):
     head_dim_qk = q.shape[2]
     return flashinfer.prefill.trtllm_ragged_attention_deepseek(
@@ -78,6 +79,7 @@ def _run_trtllm_ragged(
         lse=lse,
         q_seq_lens_cpu=q_lens_cpu,
         kv_seq_lens_cpu=kv_lens_cpu,
+        assume_all_rows_active=assume_all_rows_active,
     )
 
 
@@ -358,6 +360,72 @@ def test_trtllm_ragged_empty_kv_rows_direct_fallback_matches_cpu_mirror_path():
     torch.testing.assert_close(fallback_lse, mirror_lse, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.cuda
+def test_trtllm_ragged_assumed_active_matches_checked_path(monkeypatch):
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    torch.manual_seed(42)
+
+    q_lens = torch.tensor([4, 2, 3, 1], device=device, dtype=torch.int32)
+    kv_lens = torch.tensor([7, 5, 3, 2], device=device, dtype=torch.int32)
+    q_indptr = _indptr(q_lens)
+    kv_indptr = _indptr(kv_lens)
+    q = torch.randn(
+        int(q_indptr[-1].item()), 16, 128, device=device, dtype=torch.bfloat16
+    )
+    k = torch.randn(
+        int(kv_indptr[-1].item()), 16, 128, device=device, dtype=torch.bfloat16
+    )
+    v = torch.randn_like(k)
+
+    monkeypatch.setattr(
+        torch.cuda, "is_current_stream_capturing", lambda: True, raising=False
+    )
+
+    assumed_output, assumed_lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        assume_all_rows_active=True,
+    )
+    checked_output, checked_lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        q_lens_cpu=q_lens.cpu(),
+        kv_lens_cpu=kv_lens.cpu(),
+    )
+
+    torch.testing.assert_close(assumed_output, checked_output, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(assumed_lse, checked_lse, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.cuda
+def test_trtllm_ragged_assumed_active_rejects_cpu_mirrors():
+    device = torch.device("cuda")
+    _require_trtllm_ragged(device)
+    q, k, v, q_lens, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
+
+    with pytest.raises(ValueError, match="cannot be combined"):
+        _run_trtllm_ragged(
+            q,
+            k,
+            v,
+            q_indptr,
+            kv_indptr,
+            kv_lens,
+            q_lens_cpu=q_lens.cpu(),
+            kv_lens_cpu=kv_lens.cpu(),
+            assume_all_rows_active=True,
+        )
+
+
 @pytest.mark.parametrize("use_cpu_lens", [True, False])
 @pytest.mark.cuda
 def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
@@ -517,15 +585,15 @@ def test_trtllm_ragged_capture_q_empty_row_needs_cpu_mirrors(monkeypatch):
         _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens, return_lse=False)
 
 
+@pytest.mark.parametrize("row_activity_mode", ["cpu_mirrors", "assumed_active"])
 @pytest.mark.cuda
-def test_trtllm_ragged_all_active_cuda_graph_capture_replay():
-    """CPU mirrors let an all-active batch capture and replay under torch.cuda.graph().
+def test_trtllm_ragged_all_active_cuda_graph_capture_replay(row_activity_mode):
+    """Trusted row metadata lets an active batch capture and replay.
 
-    Companion to the raise paths above: when both mirrors are supplied,
-    the wrapper skips ``.item()`` reads and the call can be captured
-    into a CUDA graph and replayed. ``max_q_len`` / ``max_kv_len`` are
-    passed explicitly so the helper does not itself do a device sync
-    inside the capture region.
+    Companion to the raise paths above: CPU mirrors and the all-active
+    guarantee both skip ``.item()`` reads, so the call can be captured and
+    replayed. ``max_q_len`` / ``max_kv_len`` are passed explicitly so the
+    helper does not itself synchronize inside the capture region.
     """
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
@@ -565,6 +633,11 @@ def test_trtllm_ragged_all_active_cuda_graph_capture_replay():
     out = torch.empty(
         (q.shape[0], num_heads, head_dim_vo), device=device, dtype=torch.bfloat16
     )
+    row_activity_kwargs = (
+        {"q_lens_cpu": q_lens_cpu, "kv_lens_cpu": kv_lens_cpu}
+        if row_activity_mode == "cpu_mirrors"
+        else {"assume_all_rows_active": True}
+    )
 
     def _call():
         _run_trtllm_ragged(
@@ -578,8 +651,7 @@ def test_trtllm_ragged_all_active_cuda_graph_capture_replay():
             max_kv_len=7,
             return_lse=False,
             out=out,
-            q_lens_cpu=q_lens_cpu,
-            kv_lens_cpu=kv_lens_cpu,
+            **row_activity_kwargs,
         )
 
     # Warm up outside capture so JIT / autotune / workspace allocations


### PR DESCRIPTION
## 📌 Description

Fix performance regression mentioned in issue https://github.com/flashinfer-ai/flashinfer/issues/4928 in TRTLLM MLA ragged prefill caused by CUDA synchronization for checking active rows in query_lens and kv_lens by adding option to skip the checks so that the guarantee can be handled outside the kernel API. The flag is by default False and thus will have no impact on existing behavior.

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to skip empty-row activity checks for ragged attention operations.
  * Added support for configuring this option in trace-based workflows.
  * Added validation to prevent combining the skip option with CPU sequence-length mirrors.

* **Tests**
  * Added coverage for skipped activity checks, CUDA graph capture and replay, output consistency, and invalid option combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->