### PR TITLE
feat(MLA): Enable DSv4 sparse-MLA fused epilogue output mode (E4M3 + UE8M0 scales)

### DIFF
--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <cuda_fp8.h>
 #include <cuda_runtime_api.h>
 #include <float.h>
 
@@ -31,8 +32,67 @@ namespace kernels {
 
 #define NumThreadsPerCta 512
 
+// DSv4 fused output epilogue: inverse RoPE, UE8M0 block scales, E4M3 values (matches the fused
+// cubin).
+namespace dsv4 {
+
+static constexpr int kHeadDim = 512;
+static constexpr int kRopeDim = 64;  // trailing interleaved pairs
+static constexpr int kQuantBlock = 128;
+static constexpr int kHeadsPerGroup = 8;
+static constexpr int kCosSinRowWidth = 64;  // cos(32) || sin(32)
+static constexpr float kE4m3Max = 448.f;
+static constexpr float kAmaxFloor = 1e-10f;
+
+// Plain multiply-add so nvcc contracts to FMA.
+__device__ __forceinline__ void inverseRopePair(float& even, float& odd, float cosVal,
+                                                float sinVal) {
+  float const e = even;
+  float const o = odd;
+  even = e * cosVal + o * sinVal;
+  odd = o * cosVal - e * sinVal;
+}
+
+// ceil(log2(max(amax, floor) / 448)) + 127. Not ceilf(log2f(amax * (1/448))): 1/448 is inexact
+// in binary32, so exact power-of-two quotients (e.g. amax 3.5) would round one exponent high.
+__device__ __forceinline__ int32_t ue8m0ExponentFromAmax(float amax) {
+  amax = fmaxf(amax, kAmaxFloor);
+  int32_t e = ilogbf(amax) - 8;  // 448 = 1.75 * 2^8: never high, at most one low
+  if (ldexpf(kE4m3Max, e) < amax) {
+    ++e;
+  }
+  return min(max(e + 127, 0), 255);
+}
+
+__device__ __forceinline__ float reciprocalScaleFromExponent(int32_t biasedExp) {
+  return __frcp_rn(__int_as_float(biasedExp << 23));
+}
+
+__device__ __forceinline__ __nv_fp8_e4m3 quantizeToE4m3(float scaled) {
+  return static_cast<__nv_fp8_e4m3>(fminf(fmaxf(scaled, -kE4m3Max), kE4m3Max));
+}
+
+// Element offset into E4M3 values [numGroups, numTokens, 8, kHeadDim].
+__device__ __forceinline__ int64_t valueOffset(int32_t group, int32_t token, int32_t headInGroup,
+                                               int32_t dim, int32_t numTokens) {
+  return (((static_cast<int64_t>(group) * numTokens + token) * kHeadsPerGroup) + headInGroup) *
+             kHeadDim +
+         dim;
+}
+
+// Byte offset of a block's exponent in INT32 scales [numGroups, 8, scaleBufM]; block 0 is the LSB.
+__device__ __forceinline__ int64_t scaleByteOffset(int32_t group, int32_t headInGroup,
+                                                   int32_t token, int32_t block,
+                                                   int64_t scaleBufM) {
+  return ((static_cast<int64_t>(group) * kHeadsPerGroup + headInGroup) * scaleBufM + token) *
+             sizeof(int32_t) +
+         block;
+}
+
+}  // namespace dsv4
+
 template <int32_t TileSizePerCtaQ, int32_t HeadDimPerCta, bool IsE4m3Bmm, typename DtypeO,
-          typename DtypePartialO>
+          typename DtypePartialO, bool Dsv4FusedEpilogue = false>
 __global__ void __launch_bounds__(NumThreadsPerCta, 2)
     fmhaReductionKernel(KernelParams const params, bool isTokenSparse, bool groupsTokensHeadsQ,
                         bool supportsVarSparseMlaTopKLens, int32_t numCtasForReduction,
@@ -284,6 +344,69 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
       mul(f2, f2, normalizedScale2);
     }
 
+    // DSv4 fused epilogue: quantize the merged FP32 values, as the fused cubin does.
+    if constexpr (Dsv4FusedEpilogue) {
+      static_assert(
+          HeadDimPerCta % dsv4::kQuantBlock == 0 && dsv4::kQuantBlock % NumEltsPer16BVec == 0,
+          "A quant block must be owned by whole lanes of one CTA");
+      static_assert(NumEltsPer16BVec * sizeof(__nv_fp8_e4m3) == sizeof(uint2),
+                    "The E4M3 vector store assumes 8 elements");
+
+      // softmaxStats rows are a flat [token, headQ] index over all tokens.
+      int64_t const absRowIdx{softmaxStatsOffset + softmaxStatsRowIdx};
+      int32_t const tokenIdx{static_cast<int32_t>(absRowIdx / params.mNumHeadsQ)};
+      int32_t const headIdx{static_cast<int32_t>(absRowIdx % params.mNumHeadsQ)};
+      int32_t const dimIdx{headDimCtaIdxV * HeadDimPerCta + headDimIdx};
+
+      // Interleaved RoPE partners share this thread's vector; no shuffle needed.
+      int32_t constexpr RopeStart{dsv4::kHeadDim - dsv4::kRopeDim};
+      if (dimIdx >= RopeStart) {
+        int32_t const position{params.ptrSeqLensKv[batchIdx] - seqLenQ + tokenIdx - seqOffsetQ};
+        float const* cosSin{params.ptrDsv4InvRopeCosSinCache +
+                            static_cast<int64_t>(position) * dsv4::kCosSinRowWidth};
+#pragma unroll
+        for (int32_t ii = 0; ii < NumEltsPer16BVec; ii += 2) {
+          int32_t const pairIdx{(dimIdx + ii - RopeStart) >> 1};
+          dsv4::inverseRopePair(outputVals[ii], outputVals[ii + 1], cosSin[pairIdx],
+                                cosSin[dsv4::kRopeDim / 2 + pairIdx]);
+        }
+      }
+
+      // A quant block is a warp-aligned lane group of one row.
+      float amax{0.f};
+#pragma unroll
+      for (int32_t ii = 0; ii < NumEltsPer16BVec; ++ii) {
+        amax = fmaxf(amax, fabsf(outputVals[ii]));
+      }
+#pragma unroll
+      for (int32_t offset = 1; offset < dsv4::kQuantBlock / NumEltsPer16BVec; offset <<= 1) {
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, offset));
+      }
+      int32_t const biasedExp{dsv4::ue8m0ExponentFromAmax(amax)};
+
+      if (isValidRow) {
+        int32_t const group{headIdx / dsv4::kHeadsPerGroup};
+        int32_t const headInGroup{headIdx % dsv4::kHeadsPerGroup};
+        float const invScale{dsv4::reciprocalScaleFromExponent(biasedExp)};
+        __nv_fp8_e4m3 quantized[NumEltsPer16BVec];
+#pragma unroll
+        for (int32_t ii = 0; ii < NumEltsPer16BVec; ++ii) {
+          quantized[ii] = dsv4::quantizeToE4m3(outputVals[ii] * invScale);
+        }
+        *reinterpret_cast<uint2*>(
+            reinterpret_cast<__nv_fp8_e4m3*>(params.ptrO) +
+            dsv4::valueOffset(group, tokenIdx, headInGroup, dimIdx, params.mSumOfSeqLensQ)) =
+            *reinterpret_cast<uint2 const*>(quantized);
+        // One byte per block: a head's four blocks may live in four CTAs.
+        if (dimIdx % dsv4::kQuantBlock == 0) {
+          reinterpret_cast<uint8_t*>(params.ptrDsv4OScaleFp32)[dsv4::scaleByteOffset(
+              group, headInGroup, tokenIdx, dimIdx / dsv4::kQuantBlock, params.mDsv4ScaleBufM)] =
+              static_cast<uint8_t>(biasedExp);
+        }
+      }
+      continue;
+    }
+
     // Convert the float values to DtypeO, and Store it to global memory.
     if (isValidRow) {
       convertAndStoreToGmem<DtypeO>(reinterpret_cast<char*>(oPtr + gmemStoreOffset), outputVals);
@@ -340,6 +463,8 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
           static_cast<MultiCtasKvMode>(kernelMeta.mMultiCtasKvMode))) {
     return;
   }
+
+  bool const dsv4FusedEpilogue = params.ptrDsv4OScaleFp32 != nullptr;
 
   // This should only be enabled when using keepsMmaAbForGeneration kernel.
   FLASHINFER_CHECK(
@@ -404,7 +529,21 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
   // Select the kernel function pointer.
   void (*kernel)(KernelParams const, bool, bool, bool, int32_t, int32_t, int32_t, int32_t) =
       nullptr;
-  if (headDimPerCtaV == 64) {
+  if (dsv4FusedEpilogue) {
+    // The instantiations below: flat [token, headQ] rows, tileSizeQ 64, a whole quant block per
+    // CTA, whole head groups.
+    FLASHINFER_CHECK(kernelMeta.mGroupsHeadsQ && kernelMeta.mTileSizeQ == 64 &&
+                         headDimPerCtaV >= 128 &&
+                         numCtasForAllHeads * numHeadsPerCta == params.mNumHeadsQ,
+                     "Not implemented");
+    if (headDimPerCtaV == 128) {
+      kernel = &fmhaReductionKernel<64, 128, true, __nv_bfloat16, __nv_bfloat16, true>;
+    } else if (headDimPerCtaV == 256) {
+      kernel = &fmhaReductionKernel<64, 256, true, __nv_bfloat16, __nv_bfloat16, true>;
+    } else {
+      kernel = &fmhaReductionKernel<64, 512, true, __nv_bfloat16, __nv_bfloat16, true>;
+    }
+  } else if (headDimPerCtaV == 64) {
     SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(64);
   } else if (headDimPerCtaV == 128) {
     SELECT_FMHA_REDUCTION_KERNEL_WITH_HEAD_DIM_PER_CTA(128);

--- a/csrc/fmhaReduction.cu
+++ b/csrc/fmhaReduction.cu
@@ -36,13 +36,12 @@ namespace kernels {
 // cubin).
 namespace dsv4 {
 
-static constexpr int kHeadDim = 512;
-static constexpr int kRopeDim = 64;  // trailing interleaved pairs
-static constexpr int kQuantBlock = 128;
-static constexpr int kHeadsPerGroup = 8;
-static constexpr int kCosSinRowWidth = 64;  // cos(32) || sin(32)
+constexpr int kHeadDim = 512;
+constexpr int kRopeDim = 64;  // trailing interleaved pairs; cos/sin rows are cos(32) || sin(32)
+constexpr int kQuantBlock = 128;
+constexpr int kHeadsPerGroup = 8;
 static constexpr float kE4m3Max = 448.f;
-static constexpr float kAmaxFloor = 1e-10f;
+constexpr float kAmaxFloor = 1e-10f;
 
 // Plain multiply-add so nvcc contracts to FMA.
 __device__ __forceinline__ void inverseRopePair(float& even, float& odd, float cosVal,
@@ -53,8 +52,7 @@ __device__ __forceinline__ void inverseRopePair(float& even, float& odd, float c
   odd = o * cosVal - e * sinVal;
 }
 
-// ceil(log2(max(amax, floor) / 448)) + 127. Not ceilf(log2f(amax * (1/448))): 1/448 is inexact
-// in binary32, so exact power-of-two quotients (e.g. amax 3.5) would round one exponent high.
+// ceil(log2(max(amax, floor) / 448)) + 127, exact at power-of-two quotients where log2f rounds up.
 __device__ __forceinline__ int32_t ue8m0ExponentFromAmax(float amax) {
   amax = fmaxf(amax, kAmaxFloor);
   int32_t e = ilogbf(amax) - 8;  // 448 = 1.75 * 2^8: never high, at most one low
@@ -62,14 +60,6 @@ __device__ __forceinline__ int32_t ue8m0ExponentFromAmax(float amax) {
     ++e;
   }
   return min(max(e + 127, 0), 255);
-}
-
-__device__ __forceinline__ float reciprocalScaleFromExponent(int32_t biasedExp) {
-  return __frcp_rn(__int_as_float(biasedExp << 23));
-}
-
-__device__ __forceinline__ __nv_fp8_e4m3 quantizeToE4m3(float scaled) {
-  return static_cast<__nv_fp8_e4m3>(fminf(fmaxf(scaled, -kE4m3Max), kE4m3Max));
 }
 
 // Element offset into E4M3 values [numGroups, numTokens, 8, kHeadDim].
@@ -363,7 +353,7 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
       if (dimIdx >= RopeStart) {
         int32_t const position{params.ptrSeqLensKv[batchIdx] - seqLenQ + tokenIdx - seqOffsetQ};
         float const* cosSin{params.ptrDsv4InvRopeCosSinCache +
-                            static_cast<int64_t>(position) * dsv4::kCosSinRowWidth};
+                            static_cast<int64_t>(position) * dsv4::kRopeDim};
 #pragma unroll
         for (int32_t ii = 0; ii < NumEltsPer16BVec; ii += 2) {
           int32_t const pairIdx{(dimIdx + ii - RopeStart) >> 1};
@@ -387,11 +377,12 @@ __global__ void __launch_bounds__(NumThreadsPerCta, 2)
       if (isValidRow) {
         int32_t const group{headIdx / dsv4::kHeadsPerGroup};
         int32_t const headInGroup{headIdx % dsv4::kHeadsPerGroup};
-        float const invScale{dsv4::reciprocalScaleFromExponent(biasedExp)};
+        float const invScale{__frcp_rn(__int_as_float(biasedExp << 23))};  // exact: power of two
         __nv_fp8_e4m3 quantized[NumEltsPer16BVec];
 #pragma unroll
         for (int32_t ii = 0; ii < NumEltsPer16BVec; ++ii) {
-          quantized[ii] = dsv4::quantizeToE4m3(outputVals[ii] * invScale);
+          quantized[ii] = static_cast<__nv_fp8_e4m3>(
+              fminf(fmaxf(outputVals[ii] * invScale, -dsv4::kE4m3Max), dsv4::kE4m3Max));
         }
         *reinterpret_cast<uint2*>(
             reinterpret_cast<__nv_fp8_e4m3*>(params.ptrO) +
@@ -533,8 +524,7 @@ void runFmhaReduction(TllmGenFmhaKernelMetaInfo const& kernelMeta, KernelParams 
     // The instantiations below: flat [token, headQ] rows, tileSizeQ 64, a whole quant block per
     // CTA, whole head groups.
     FLASHINFER_CHECK(kernelMeta.mGroupsHeadsQ && kernelMeta.mTileSizeQ == 64 &&
-                         headDimPerCtaV >= 128 &&
-                         numCtasForAllHeads * numHeadsPerCta == params.mNumHeadsQ,
+                         headDimPerCtaV >= 128 && params.mNumHeadsQ % numHeadsPerCta == 0,
                      "Not implemented");
     if (headDimPerCtaV == 128) {
       kernel = &fmhaReductionKernel<64, 128, true, __nv_bfloat16, __nv_bfloat16, true>;

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -181,7 +181,8 @@ void trtllm_paged_attention_launcher(
     bool enable_pdl, int64_t workspace_size, int64_t k_sf_stride_heads, int64_t k_sf_stride_batch,
     int64_t v_sf_stride_heads, int64_t v_sf_stride_batch, bool is_causal, int64_t lse_stride_tokens,
     int64_t lse_stride_heads, int64_t bf16q_fp8kv_transform_mode, bool use_fp16_softmax,
-    bool uses_spcompress, cudaStream_t stream) {
+    bool uses_spcompress, float const* dsv4_inv_rope_cos_sin_cache, void* dsv4_o_scale,
+    int64_t dsv4_scale_buf_m, cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
     err_msg << "num_qo_heads must be a multiple of num_kv_heads, got num_kv_heads: " << num_kv_heads
@@ -370,8 +371,20 @@ void trtllm_paged_attention_launcher(
   // Cubin-variant selectors (FP16 softmax accumulator, sparse compression).
   runner_params.mUseFp16Softmax = use_fp16_softmax;
   runner_params.mUsesSpcompress = uses_spcompress;
+  runner_params.mUsesDsv4Ue8m0ScaleO =
+      dsv4_o_scale != nullptr && o_data_type == Data_type::DATA_TYPE_E4M3;
+  runner_params.dsv4InvRopeCosSinCachePtr = dsv4_inv_rope_cos_sin_cache;
+  runner_params.dsv4OScalePtr = dsv4_o_scale;
+  runner_params.mDsv4ScaleBufM = dsv4_scale_buf_m;
 
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
+  if (!foundKernels && runner_params.mUsesDsv4Ue8m0ScaleO) {
+    // No fused kernel: run the BF16 split-KV pair and quantize in its reduction kernel.
+    fmha_runner = TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type,
+                                              Data_type::DATA_TYPE_BF16);
+    runner_params.mUsesDsv4Ue8m0ScaleO = false;
+    std::tie(foundKernels, kinfo) = fmha_runner->isSupportedWithInfo(runner_params);
+  }
   if (!foundKernels) {
     std::ostringstream err_msg;
     err_msg << "Missing TRTLLM-GEN kernel ("
@@ -592,7 +605,8 @@ void trtllm_paged_attention_decode(
       enable_block_sparse_attention, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
       k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, /*is_causal=*/true,
       lse_stride_tokens, lse_stride_heads, bf16q_fp8kv_transform_mode, use_fp16_softmax_value,
-      uses_spcompress_value, stream);
+      uses_spcompress_value, /*dsv4_inv_rope_cos_sin_cache=*/nullptr, /*dsv4_o_scale=*/nullptr,
+      /*dsv4_scale_buf_m=*/0, stream);
 }
 
 void trtllm_paged_attention_context(
@@ -736,7 +750,8 @@ void trtllm_paged_attention_context(
       /*enable_block_sparse_attention=*/false, sm_count, enable_pdl, workspace_size,
       k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, is_causal,
       lse_stride_tokens, lse_stride_heads, /*bf16q_fp8kv_transform_mode=*/0, use_fp16_softmax_value,
-      uses_spcompress_value, stream);
+      uses_spcompress_value, /*dsv4_inv_rope_cos_sin_cache=*/nullptr, /*dsv4_o_scale=*/nullptr,
+      /*dsv4_scale_buf_m=*/0, stream);
 }
 
 void trtllm_ragged_attention_launcher(
@@ -973,7 +988,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
     TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
     Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
     int64_t sm_count, bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
-    Optional<TensorView> cum_seq_lens_q) {
+    Optional<TensorView> cum_seq_lens_q, Optional<TensorView> dsv4_o_scales,
+    Optional<TensorView> dsv4_cos_sin_cache) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(primary_kv_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
@@ -996,11 +1012,45 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
   TVM_FFI_ICHECK_EQ(kv_data_type, q_data_type) << "primary_kv_cache dtype must match query dtype";
   TVM_FFI_ICHECK_EQ(dl_dtype_to_tllm_data_type(sliding_window_kv_cache.dtype()), q_data_type)
       << "sliding_window_kv_cache dtype must match query dtype";
-  TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_BF16)
-      << "DeepSeek V4 sparse MLA output must be BF16";
 
   int const sum_seq_q = query.size(0);
   int const num_qo_heads = query.size(1);
+  float const* dsv4_cos_sin_cache_ptr = nullptr;
+  void* dsv4_o_scale_ptr = nullptr;
+  int64_t dsv4_scale_buf_m = 0;
+  if (dsv4_o_scales.has_value()) {
+    // Fused DSv4 output epilogue: E4M3 values and packed UE8M0 block-128 scales.
+    auto const& o_scales = dsv4_o_scales.value();
+    TVM_FFI_ICHECK(dsv4_cos_sin_cache.has_value()) << "dsv4_o_scales requires dsv4_cos_sin_cache";
+    auto const& cos_sin_cache = dsv4_cos_sin_cache.value();
+    dsv4_scale_buf_m = round_up(static_cast<int64_t>(sum_seq_q), int64_t{4});
+    TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_E4M3)
+        << "out must be float8_e4m3fn when dsv4_o_scales is given";
+    // Fused cubins and the split-KV reduction kernels both exist for this schedule only.
+    TVM_FFI_ICHECK_EQ(num_qo_heads, 128) << "the fused epilogue needs all 128 query heads";
+    TVM_FFI_ICHECK(out.ndim() == 4 && out.size(0) == num_qo_heads / 8 && out.size(1) == sum_seq_q &&
+                   out.size(2) == 8 && out.IsContiguous())
+        << "out must be contiguous [num_qo_heads / 8, sum_seq_q, 8, 512]";
+    TVM_FFI_ICHECK_EQ(o_scales.dtype(), dl_int32) << "dsv4_o_scales must be int32";
+    TVM_FFI_ICHECK(o_scales.ndim() == 3 && o_scales.size(0) == num_qo_heads / 8 &&
+                   o_scales.size(1) == 8 && o_scales.size(2) == dsv4_scale_buf_m &&
+                   o_scales.IsContiguous())
+        << "dsv4_o_scales must be contiguous [num_qo_heads / 8, 8, round_up(sum_seq_q, 4)]";
+    TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), dl_float32) << "dsv4_cos_sin_cache must be float32";
+    TVM_FFI_ICHECK(cos_sin_cache.ndim() == 2 && cos_sin_cache.size(1) == 64 &&
+                   cos_sin_cache.IsContiguous())
+        << "dsv4_cos_sin_cache must be contiguous [max_position, 64]";
+    for (auto const& t : {out, o_scales, cos_sin_cache}) {
+      TVM_FFI_ICHECK(t.device().device_type == query.device().device_type &&
+                     t.device().device_id == query.device().device_id)
+          << "out, dsv4_o_scales and dsv4_cos_sin_cache must be on the same device as query";
+    }
+    dsv4_cos_sin_cache_ptr = static_cast<float const*>(cos_sin_cache.data_ptr());
+    dsv4_o_scale_ptr = o_scales.data_ptr();
+  } else {
+    TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_BF16)
+        << "DeepSeek V4 sparse MLA output must be BF16";
+  }
   int const num_kv_heads = primary_kv_cache.size(-3);
   bool const is_varlen_q = cum_seq_lens_q.has_value();
   int* cum_seq_lens_q_ptr =
@@ -1155,7 +1205,8 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       /*k_sf_stride_heads=*/0, /*k_sf_stride_batch=*/0, /*v_sf_stride_heads=*/0,
       /*v_sf_stride_batch=*/0, /*is_causal=*/true, /*lse_stride_tokens=*/0,
       /*lse_stride_heads=*/0, /*bf16q_fp8kv_transform_mode=*/0, /*use_fp16_softmax=*/false,
-      /*uses_spcompress=*/false, stream);
+      /*uses_spcompress=*/false, dsv4_cos_sin_cache_ptr, dsv4_o_scale_ptr, dsv4_scale_buf_m,
+      stream);
 }
 
 namespace trtllm_cubin_loader {

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -181,7 +181,7 @@ void trtllm_paged_attention_launcher(
     bool enable_pdl, int64_t workspace_size, int64_t k_sf_stride_heads, int64_t k_sf_stride_batch,
     int64_t v_sf_stride_heads, int64_t v_sf_stride_batch, bool is_causal, int64_t lse_stride_tokens,
     int64_t lse_stride_heads, int64_t bf16q_fp8kv_transform_mode, bool use_fp16_softmax,
-    bool uses_spcompress, float const* dsv4_inv_rope_cos_sin_cache, void* dsv4_o_scale,
+    bool uses_spcompress, float const* dsv4_cos_sin_cache, void* dsv4_out_scales,
     int64_t dsv4_scale_buf_m, cudaStream_t stream) {
   if (num_qo_heads % num_kv_heads != 0) {
     std::ostringstream err_msg;
@@ -371,10 +371,9 @@ void trtllm_paged_attention_launcher(
   // Cubin-variant selectors (FP16 softmax accumulator, sparse compression).
   runner_params.mUseFp16Softmax = use_fp16_softmax;
   runner_params.mUsesSpcompress = uses_spcompress;
-  runner_params.mUsesDsv4Ue8m0ScaleO =
-      dsv4_o_scale != nullptr && o_data_type == Data_type::DATA_TYPE_E4M3;
-  runner_params.dsv4InvRopeCosSinCachePtr = dsv4_inv_rope_cos_sin_cache;
-  runner_params.dsv4OScalePtr = dsv4_o_scale;
+  runner_params.mUsesDsv4Ue8m0ScaleO = dsv4_out_scales != nullptr;
+  runner_params.dsv4InvRopeCosSinCachePtr = dsv4_cos_sin_cache;
+  runner_params.dsv4OScalePtr = dsv4_out_scales;
   runner_params.mDsv4ScaleBufM = dsv4_scale_buf_m;
 
   auto [foundKernels, kinfo] = fmha_runner->isSupportedWithInfo(runner_params);
@@ -605,7 +604,7 @@ void trtllm_paged_attention_decode(
       enable_block_sparse_attention, sm_count, enable_pdl, workspace_size, k_sf_stride_heads,
       k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, /*is_causal=*/true,
       lse_stride_tokens, lse_stride_heads, bf16q_fp8kv_transform_mode, use_fp16_softmax_value,
-      uses_spcompress_value, /*dsv4_inv_rope_cos_sin_cache=*/nullptr, /*dsv4_o_scale=*/nullptr,
+      uses_spcompress_value, /*dsv4_cos_sin_cache=*/nullptr, /*dsv4_out_scales=*/nullptr,
       /*dsv4_scale_buf_m=*/0, stream);
 }
 
@@ -750,7 +749,7 @@ void trtllm_paged_attention_context(
       /*enable_block_sparse_attention=*/false, sm_count, enable_pdl, workspace_size,
       k_sf_stride_heads, k_sf_stride_batch, v_sf_stride_heads, v_sf_stride_batch, is_causal,
       lse_stride_tokens, lse_stride_heads, /*bf16q_fp8kv_transform_mode=*/0, use_fp16_softmax_value,
-      uses_spcompress_value, /*dsv4_inv_rope_cos_sin_cache=*/nullptr, /*dsv4_o_scale=*/nullptr,
+      uses_spcompress_value, /*dsv4_cos_sin_cache=*/nullptr, /*dsv4_out_scales=*/nullptr,
       /*dsv4_scale_buf_m=*/0, stream);
 }
 
@@ -988,7 +987,7 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
     TensorView seq_lens, TensorView sparse_mla_top_k_lens, Variant<double, ffi::Tensor> bmm1_scale,
     Variant<double, ffi::Tensor> bmm2_scale, int64_t batch_size, int64_t max_q_len,
     int64_t sm_count, bool enable_pdl, int64_t workspace_size, Optional<TensorView> attention_sinks,
-    Optional<TensorView> cum_seq_lens_q, Optional<TensorView> dsv4_o_scales,
+    Optional<TensorView> cum_seq_lens_q, Optional<TensorView> dsv4_out_scales,
     Optional<TensorView> dsv4_cos_sin_cache) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
   auto kv_data_type = dl_dtype_to_tllm_data_type(primary_kv_cache.dtype());
@@ -1015,27 +1014,30 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
 
   int const sum_seq_q = query.size(0);
   int const num_qo_heads = query.size(1);
+  int const num_kv_heads = primary_kv_cache.size(-3);
   float const* dsv4_cos_sin_cache_ptr = nullptr;
-  void* dsv4_o_scale_ptr = nullptr;
+  void* dsv4_out_scales_ptr = nullptr;
   int64_t dsv4_scale_buf_m = 0;
-  if (dsv4_o_scales.has_value()) {
+  if (dsv4_out_scales.has_value()) {
     // Fused DSv4 output epilogue: E4M3 values and packed UE8M0 block-128 scales.
-    auto const& o_scales = dsv4_o_scales.value();
-    TVM_FFI_ICHECK(dsv4_cos_sin_cache.has_value()) << "dsv4_o_scales requires dsv4_cos_sin_cache";
+    auto const& o_scales = dsv4_out_scales.value();
+    TVM_FFI_ICHECK(dsv4_cos_sin_cache.has_value()) << "dsv4_out_scales requires dsv4_cos_sin_cache";
     auto const& cos_sin_cache = dsv4_cos_sin_cache.value();
     dsv4_scale_buf_m = round_up(static_cast<int64_t>(sum_seq_q), int64_t{4});
+    TVM_FFI_ICHECK_EQ(q_data_type, Data_type::DATA_TYPE_E4M3)
+        << "the fused epilogue kernels take a float8_e4m3fn query and KV";
     TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_E4M3)
-        << "out must be float8_e4m3fn when dsv4_o_scales is given";
+        << "out must be float8_e4m3fn when dsv4_out_scales is given";
     // Fused cubins and the split-KV reduction kernels both exist for this schedule only.
     TVM_FFI_ICHECK_EQ(num_qo_heads, 128) << "the fused epilogue needs all 128 query heads";
     TVM_FFI_ICHECK(out.ndim() == 4 && out.size(0) == num_qo_heads / 8 && out.size(1) == sum_seq_q &&
                    out.size(2) == 8 && out.IsContiguous())
         << "out must be contiguous [num_qo_heads / 8, sum_seq_q, 8, 512]";
-    TVM_FFI_ICHECK_EQ(o_scales.dtype(), dl_int32) << "dsv4_o_scales must be int32";
+    TVM_FFI_ICHECK_EQ(o_scales.dtype(), dl_int32) << "dsv4_out_scales must be int32";
     TVM_FFI_ICHECK(o_scales.ndim() == 3 && o_scales.size(0) == num_qo_heads / 8 &&
                    o_scales.size(1) == 8 && o_scales.size(2) == dsv4_scale_buf_m &&
                    o_scales.IsContiguous())
-        << "dsv4_o_scales must be contiguous [num_qo_heads / 8, 8, round_up(sum_seq_q, 4)]";
+        << "dsv4_out_scales must be contiguous [num_qo_heads / 8, 8, round_up(sum_seq_q, 4)]";
     TVM_FFI_ICHECK_EQ(cos_sin_cache.dtype(), dl_float32) << "dsv4_cos_sin_cache must be float32";
     TVM_FFI_ICHECK(cos_sin_cache.ndim() == 2 && cos_sin_cache.size(1) == 64 &&
                    cos_sin_cache.IsContiguous())
@@ -1043,15 +1045,14 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
     for (auto const& t : {out, o_scales, cos_sin_cache}) {
       TVM_FFI_ICHECK(t.device().device_type == query.device().device_type &&
                      t.device().device_id == query.device().device_id)
-          << "out, dsv4_o_scales and dsv4_cos_sin_cache must be on the same device as query";
+          << "out, dsv4_out_scales and dsv4_cos_sin_cache must be on the same device as query";
     }
     dsv4_cos_sin_cache_ptr = static_cast<float const*>(cos_sin_cache.data_ptr());
-    dsv4_o_scale_ptr = o_scales.data_ptr();
+    dsv4_out_scales_ptr = o_scales.data_ptr();
   } else {
     TVM_FFI_ICHECK_EQ(o_data_type, Data_type::DATA_TYPE_BF16)
         << "DeepSeek V4 sparse MLA output must be BF16";
   }
-  int const num_kv_heads = primary_kv_cache.size(-3);
   bool const is_varlen_q = cum_seq_lens_q.has_value();
   int* cum_seq_lens_q_ptr =
       is_varlen_q ? static_cast<int*>(cum_seq_lens_q.value().data_ptr()) : nullptr;
@@ -1205,7 +1206,7 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       /*k_sf_stride_heads=*/0, /*k_sf_stride_batch=*/0, /*v_sf_stride_heads=*/0,
       /*v_sf_stride_batch=*/0, /*is_causal=*/true, /*lse_stride_tokens=*/0,
       /*lse_stride_heads=*/0, /*bf16q_fp8kv_transform_mode=*/0, /*use_fp16_softmax=*/false,
-      /*uses_spcompress=*/false, dsv4_cos_sin_cache_ptr, dsv4_o_scale_ptr, dsv4_scale_buf_m,
+      /*uses_spcompress=*/false, dsv4_cos_sin_cache_ptr, dsv4_out_scales_ptr, dsv4_scale_buf_m,
       stream);
 }
 

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -259,7 +259,7 @@ PageAttention for MLA
 
     trtllm_batch_decode_with_kv_cache_mla
     trtllm_batch_decode_sparse_mla_dsv4
-    dsv4_fused_epilogue_scale_buf_m
+    dsv4_fused_epilogue_scale_tokens
     convert_compressed_page_aligned_sparse_indices_to_hca_metadata
     DSV4HCAMetadata
     xqa_batch_decode_with_kv_cache_mla

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -259,6 +259,7 @@ PageAttention for MLA
 
     trtllm_batch_decode_with_kv_cache_mla
     trtllm_batch_decode_sparse_mla_dsv4
+    dsv4_fused_epilogue_scale_buf_m
     convert_compressed_page_aligned_sparse_indices_to_hca_metadata
     DSV4HCAMetadata
     xqa_batch_decode_with_kv_cache_mla

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1457,6 +1457,11 @@ def convert_compressed_page_aligned_sparse_indices_to_hca_metadata(
     )
 
 
+def dsv4_fused_epilogue_scale_tokens(sum_seq_q: int) -> int:
+    """Token extent of the fused-epilogue scale layout: ``sum_seq_q`` rounded up to 4."""
+    return (sum_seq_q + 3) // 4 * 4
+
+
 def trtllm_batch_decode_sparse_mla_dsv4(
     query: torch.Tensor,
     swa_kv_cache: torch.Tensor,
@@ -1631,14 +1636,15 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     out_scales : Optional[torch.Tensor]
         Selects the TRTLLM-GEN fused DSv4 output epilogue (inverse RoPE of the
         trailing 64 lanes, block-128 UE8M0 scales, FP8 E4M3 values). INT32
-        ``[num_heads // 8, 8, dsv4_fused_epilogue_scale_buf_m(sum_q)]``,
+        ``[num_heads // 8, 8, dsv4_fused_epilogue_scale_tokens(sum_q)]``,
         contiguous; each word packs one head's four exponents, block 0 in the
         least significant byte, and a block dequantizes by ``2 ** (e - 127)``.
         ``out`` is then required as contiguous float8_e4m3fn
         ``[num_heads // 8, sum_q, 8, 512]``. Supported with all 128 query heads on
         the calling rank (DP attention, no attention TP); every batch size, query
         length and top-k is then served by the fused cubin or the split-KV
-        reduction kernel. Other head counts raise.
+        reduction kernel. Other head counts raise. Columns past ``sum_q`` are left
+        untouched.
     cos_sin_cache : Optional[torch.Tensor]
         FP32 ``[max_position, 64]`` rows ``cos(32) || sin(32)`` for the inverse
         RoPE at position ``seq_lens[b] - q_len[b] + i``. Required with
@@ -1912,7 +1918,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         )
         check_shape_dtype_device(
             out_scales,
-            (num_heads // 8, 8, dsv4_fused_epilogue_scale_buf_m(sum_seq_q)),
+            (num_heads // 8, 8, dsv4_fused_epilogue_scale_tokens(sum_seq_q)),
             torch.int32,
             query.device,
             "out_scales",
@@ -2016,11 +2022,6 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         cos_sin_cache.contiguous() if cos_sin_cache is not None else None,
     )
     return out
-
-
-def dsv4_fused_epilogue_scale_buf_m(sum_seq_q: int) -> int:
-    """Token extent of the fused-epilogue scale layout: ``sum_seq_q`` rounded up to 4."""
-    return (sum_seq_q + 3) // 4 * 4
 
 
 # Keep the backend-neutral spelling as a compatibility alias, while the

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -1485,6 +1485,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     hca_sparse_indices_format: Optional[Literal["compressed-page-aligned"]] = None,
     remapped_sparse_indices_buffer: Optional[torch.Tensor] = None,
     sparse_indices_are_storage_offsets: Optional[bool] = None,
+    out_scales: Optional[torch.Tensor] = None,
+    cos_sin_cache: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     r"""Decode DeepSeek V4 sparse MLA.
 
@@ -1626,6 +1628,21 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         ``False`` for logical flattened token indices or ``True`` for indices
         already adjusted to storage-row offsets. Strided pools require an
         explicit value to prevent accidental double remapping.
+    out_scales : Optional[torch.Tensor]
+        Selects the TRTLLM-GEN fused DSv4 output epilogue (inverse RoPE of the
+        trailing 64 lanes, block-128 UE8M0 scales, FP8 E4M3 values). INT32
+        ``[num_heads // 8, 8, dsv4_fused_epilogue_scale_buf_m(sum_q)]``,
+        contiguous; each word packs one head's four exponents, block 0 in the
+        least significant byte, and a block dequantizes by ``2 ** (e - 127)``.
+        ``out`` is then required as contiguous float8_e4m3fn
+        ``[num_heads // 8, sum_q, 8, 512]``. Supported with all 128 query heads on
+        the calling rank (DP attention, no attention TP); every batch size, query
+        length and top-k is then served by the fused cubin or the split-KV
+        reduction kernel. Other head counts raise.
+    cos_sin_cache : Optional[torch.Tensor]
+        FP32 ``[max_position, 64]`` rows ``cos(32) || sin(32)`` for the inverse
+        RoPE at position ``seq_lens[b] - q_len[b] + i``. Required with
+        ``out_scales``.
     """
     backend = _resolve_dsv4_sparse_mla_backend(query.device, backend)
 
@@ -1637,6 +1654,15 @@ def trtllm_batch_decode_sparse_mla_dsv4(
             f"backend={backend!r} does not accept remapped_sparse_indices_buffer "
             "or sparse_indices_are_storage_offsets"
         )
+    if out_scales is not None or cos_sin_cache is not None:
+        if backend != "trtllm-gen":
+            raise ValueError(
+                f"backend={backend!r} does not accept out_scales or cos_sin_cache"
+            )
+        if out is None or out_scales is None or cos_sin_cache is None:
+            raise ValueError(
+                "out_scales requires out (float8_e4m3fn values) and cos_sin_cache"
+            )
 
     if backend == "cute-dsl":
         if not hca_is_causal:
@@ -1850,6 +1876,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     if sparse_indices is None:
         raise ValueError("backend='trtllm-gen' requires sparse_indices")
 
+    # With out_scales, out holds FP8 values and is checked below instead of as BF16 here.
+    bf16_out = out if out_scales is None else None
     (
         swa_kv_cache,
         compressed_kv_cache,
@@ -1865,7 +1893,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         sparse_indices,
         compressed_kv_cache,
         sparse_topk_lens,
-        out,
+        bf16_out,
         sinks,
         kv_layout,
         cum_seq_lens_q,
@@ -1873,7 +1901,30 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         allow_sm120_packed_kv=False,
     )
 
-    if out is None:
+    if out_scales is not None:
+        sum_seq_q, num_heads = query_flat.size(0), query_flat.size(1)
+        check_shape_dtype_device(
+            out,
+            (num_heads // 8, sum_seq_q, 8, 512),
+            torch.float8_e4m3fn,
+            query.device,
+            "out",
+        )
+        check_shape_dtype_device(
+            out_scales,
+            (num_heads // 8, 8, dsv4_fused_epilogue_scale_buf_m(sum_seq_q)),
+            torch.int32,
+            query.device,
+            "out_scales",
+        )
+        check_shape_dtype_device(
+            cos_sin_cache,
+            (cos_sin_cache.size(0), 64),
+            torch.float32,
+            query.device,
+            "cos_sin_cache",
+        )
+    elif out is None:
         out = torch.empty(expected_out_shape, dtype=torch.bfloat16, device=query.device)
 
     check_shape_dtype_device(
@@ -1961,8 +2012,15 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         workspace_buffer.numel() * workspace_buffer.element_size(),
         sinks,
         cum_seq_lens_q.contiguous() if cum_seq_lens_q is not None else None,
+        out_scales,
+        cos_sin_cache.contiguous() if cos_sin_cache is not None else None,
     )
     return out
+
+
+def dsv4_fused_epilogue_scale_buf_m(sum_seq_q: int) -> int:
+    """Token extent of the fused-epilogue scale layout: ``sum_seq_q`` rounded up to 4."""
+    return (sum_seq_q + 3) // 4 * 4
 
 
 # Keep the backend-neutral spelling as a compatibility alias, while the

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -1237,7 +1237,7 @@ class TllmGenFmhaKernel {
         std::to_string(static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)) +
         ", fp16Softmax=" + std::to_string(selectKernelParams.mUseFp16Softmax) +
         ", usesSpcompress=" + std::to_string(selectKernelParams.mUsesSpcompress) +
-        ", usesDsv4Ue8m0ScaleO=" + std::to_string(params.mUsesDsv4Ue8m0ScaleO);
+        ", usesDsv4Ue8m0ScaleO=" + std::to_string(selectKernelParams.mUsesDsv4Ue8m0ScaleO);
     IKL_LOG_DEBUG(
         "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
         getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut),
@@ -1256,7 +1256,7 @@ class TllmGenFmhaKernel {
                selectKernelParams.mSkipsSoftmaxWhenPossible,
                static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode),
                /*uses2QSlidingWindowKernel=*/false, selectKernelParams.mUseFp16Softmax,
-               selectKernelParams.mUsesSpcompress, params.mUsesDsv4Ue8m0ScaleO),
+               selectKernelParams.mUsesSpcompress, selectKernelParams.mUsesDsv4Ue8m0ScaleO),
         info);
   }
 

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -246,7 +246,7 @@ class TllmGenFmhaKernel {
                          bool dynamicNumTokensPerPage, bool reuseSmemKForV, bool uses2CtaMma,
                          bool groupsTokensHeadsQ, int sparseMlaType, bool skipsSoftmax,
                          int bf16QFp8KvTransformMode, bool uses2QSlidingWindowKernel,
-                         bool fp16Softmax, bool usesSpcompress) const {
+                         bool fp16Softmax, bool usesSpcompress, bool usesDsv4Ue8m0ScaleO) const {
     FLASHINFER_CHECK((headDimPerCtaV >= 32) && (headDimQk >= 32) && (headDimV >= 32) &&
                          (headDimPerCtaV <= 1024) && (headDimQk <= 1024) && (headDimV <= 1024),
                      "Expect (32 <= headDim <= 1024), got headDimPerCtaV=%d, headDimQk=%d, "
@@ -303,7 +303,8 @@ class TllmGenFmhaKernel {
     // Bit 54 - 54: uses2QSlidingWindowKernel (Keeps generation 2Qx1KV SlidingWindowCustom).
     // Bit 55 - 55: fp16Softmax.
     // Bit 56 - 56: usesSpcompress.
-    // Bit 57 - 63: unused.
+    // Bit 57 - 57: usesDsv4Ue8m0ScaleO.
+    // Bit 58 - 63: unused.
     return (static_cast<uint64_t>(qkvLayout) << 0) | (static_cast<uint64_t>(maskType) << 2) |
            (static_cast<uint64_t>(kernelType) << 5) | (static_cast<uint64_t>(scheduler) << 8) |
            (static_cast<uint64_t>(multiCtasKvMode) << 10) |
@@ -321,7 +322,8 @@ class TllmGenFmhaKernel {
            (static_cast<uint64_t>(groupsTokensHeadsQ) << 53) |
            (static_cast<uint64_t>(uses2QSlidingWindowKernel) << 54) |
            (static_cast<uint64_t>(fp16Softmax) << 55) |
-           (static_cast<uint64_t>(usesSpcompress) << 56);
+           (static_cast<uint64_t>(usesSpcompress) << 56) |
+           (static_cast<uint64_t>(usesDsv4Ue8m0ScaleO) << 57);
   }
 
   inline bool is2QSlidingWindowKernel(KernelMeta const& kernelMeta) const {
@@ -335,16 +337,17 @@ class TllmGenFmhaKernel {
   }
 
   uint64_t hashID(KernelMeta const& kernelMeta) const {
-    return hashID(
-        kernelMeta.mQkvLayout, kernelMeta.mMaskType, kernelMeta.mKernelType,
-        kernelMeta.mTileScheduler, kernelMeta.mMultiCtasKvMode, kernelMeta.mHeadDimPerCtaV,
-        kernelMeta.mHeadDimQk, kernelMeta.mHeadDimV, kernelMeta.mTileSizeQ, kernelMeta.mTileSizeKv,
-        kernelMeta.mNumTokensPerPage, isDynamicNumTokensPerPageKernel(kernelMeta),
-        kernelMeta.mReuseSmemKForV, kernelMeta.m2CtaMma, kernelMeta.mGroupsTokensHeadsQ,
-        kernelMeta.mSparseAttn, kernelMeta.mSkipsSoftmaxWhenPossible,
-        getBf16QFp8KvTransformMode(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform,
-                                   kernelMeta.mSeparateTransformedKv),
-        is2QSlidingWindowKernel(kernelMeta), kernelMeta.mFp16Softmax, kernelMeta.mUsesSpcompress);
+    return hashID(kernelMeta.mQkvLayout, kernelMeta.mMaskType, kernelMeta.mKernelType,
+                  kernelMeta.mTileScheduler, kernelMeta.mMultiCtasKvMode,
+                  kernelMeta.mHeadDimPerCtaV, kernelMeta.mHeadDimQk, kernelMeta.mHeadDimV,
+                  kernelMeta.mTileSizeQ, kernelMeta.mTileSizeKv, kernelMeta.mNumTokensPerPage,
+                  isDynamicNumTokensPerPageKernel(kernelMeta), kernelMeta.mReuseSmemKForV,
+                  kernelMeta.m2CtaMma, kernelMeta.mGroupsTokensHeadsQ, kernelMeta.mSparseAttn,
+                  kernelMeta.mSkipsSoftmaxWhenPossible,
+                  getBf16QFp8KvTransformMode(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform,
+                                             kernelMeta.mSeparateTransformedKv),
+                  is2QSlidingWindowKernel(kernelMeta), kernelMeta.mFp16Softmax,
+                  kernelMeta.mUsesSpcompress, kernelMeta.mUsesDsv4Ue8m0ScaleO);
   }
 
   std::pair<bool, std::string> checkIfKernelExist(RunnerParams const& params) const {
@@ -656,6 +659,11 @@ class TllmGenFmhaKernel {
       numCtasPerSeqKv = std::min(
           tunedMaxNumCtasPerSeqKv,
           std::max(1, int32_t(params.mMultiProcessorCount / (numCtasX * numCtasY * numCtasZ))));
+      // The DSv4 fused epilogue without a fused cubin runs in the separate reduction kernel,
+      // so the KV must be split.
+      if (params.dsv4OScalePtr != nullptr && !params.mUsesDsv4Ue8m0ScaleO) {
+        numCtasPerSeqKv = std::max(numCtasPerSeqKv, 2);
+      }
       // Update the numCtasX.
       numCtasX *= numCtasPerSeqKv;
       // The current total number of CTAs.
@@ -1228,7 +1236,8 @@ class TllmGenFmhaKernel {
         ", bf16QFp8KvTransformMode=" +
         std::to_string(static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode)) +
         ", fp16Softmax=" + std::to_string(selectKernelParams.mUseFp16Softmax) +
-        ", usesSpcompress=" + std::to_string(selectKernelParams.mUsesSpcompress);
+        ", usesSpcompress=" + std::to_string(selectKernelParams.mUsesSpcompress) +
+        ", usesDsv4Ue8m0ScaleO=" + std::to_string(params.mUsesDsv4Ue8m0ScaleO);
     IKL_LOG_DEBUG(
         "Searching for kernel traits (%d available) in TllmGenFmhaKernel(%s, %s, %s, %s, %d) %s",
         getNumLoadedKernels(), toStr(mDtypeQ), toStr(mDtypeK), toStr(mDtypeV), toStr(mDtypeOut),
@@ -1247,7 +1256,7 @@ class TllmGenFmhaKernel {
                selectKernelParams.mSkipsSoftmaxWhenPossible,
                static_cast<int>(selectKernelParams.mBf16QFp8KvTransformMode),
                /*uses2QSlidingWindowKernel=*/false, selectKernelParams.mUseFp16Softmax,
-               selectKernelParams.mUsesSpcompress),
+               selectKernelParams.mUsesSpcompress, params.mUsesDsv4Ue8m0ScaleO),
         info);
   }
 

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -265,6 +265,14 @@ struct TllmGenFmhaRunnerParams {
   // The output scaling factor buffer.
   void* oSfPtr;
 
+  // DSv4 inverse-RoPE + UE8M0 FP8 output epilogue: E4M3 O as [numHeadsQ / 8, sumSeqLensQ, 8,
+  // headDimV]; packed UE8M0 exponents as [numHeadsQ / 8, 8, mDsv4ScaleBufM = align(sumSeqLensQ,
+  // 4)].
+  bool mUsesDsv4Ue8m0ScaleO{false};
+  float const* dsv4InvRopeCosSinCachePtr{nullptr};
+  void* dsv4OScalePtr{nullptr};
+  int64_t mDsv4ScaleBufM{0};
+
   // The stride between different tokens for Q.
   int qStrideTokens;
   // The stride between different heads for Q.
@@ -445,8 +453,11 @@ struct TllmGenSelectKernelParams {
         mHeadDimPerCtaV(params.mHeadDimV)
         // Note the CgaSmemReduction will be enabled based on the heuristic.
         ,
-        mMultiCtasKvMode(params.mMultiCtasKvMode ? MultiCtasKvMode::GmemReduction
-                                                 : MultiCtasKvMode::Disabled),
+        // The fused DSv4 epilogue kernels are built without split KV; Disabled pairs with
+        // Persistent.
+        mMultiCtasKvMode((params.mMultiCtasKvMode && !params.mUsesDsv4Ue8m0ScaleO)
+                             ? MultiCtasKvMode::GmemReduction
+                             : MultiCtasKvMode::Disabled),
         mForceGmemReduction(false),
         mMaskType(params.mMaskType),
         mNumTokensPerPage(params.mNumTokensPerPage),
@@ -456,7 +467,8 @@ struct TllmGenSelectKernelParams {
         mSkipsSoftmaxWhenPossible(params.mSkipsSoftmaxWhenPossible),
         mUseFp16Softmax(params.mUseFp16Softmax),
         mUsesSpcompress(params.mUsesSpcompress),
-        mTileScheduler(params.mTileScheduler),
+        mTileScheduler(params.mUsesDsv4Ue8m0ScaleO ? TileScheduler::Persistent
+                                                   : params.mTileScheduler),
         mTileSizeQ(128),
         mTileSizeKv(128),
         mUses2CtaMma(false),

--- a/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
+++ b/include/flashinfer/trtllm/fmha/fmhaRunnerParams.h
@@ -265,9 +265,8 @@ struct TllmGenFmhaRunnerParams {
   // The output scaling factor buffer.
   void* oSfPtr;
 
-  // DSv4 inverse-RoPE + UE8M0 FP8 output epilogue: E4M3 O as [numHeadsQ / 8, sumSeqLensQ, 8,
-  // headDimV]; packed UE8M0 exponents as [numHeadsQ / 8, 8, mDsv4ScaleBufM = align(sumSeqLensQ,
-  // 4)].
+  // DSv4 output epilogue (E4M3 O + packed UE8M0 scales); see
+  // trtllm_paged_attention_decode_sparse_mla_dsv4.
   bool mUsesDsv4Ue8m0ScaleO{false};
   float const* dsv4InvRopeCosSinCachePtr{nullptr};
   void* dsv4OScalePtr{nullptr};
@@ -434,6 +433,8 @@ struct TllmGenSelectKernelParams {
   bool mUseFp16Softmax;
   // Use spcompress or not.
   bool mUsesSpcompress;
+  // Use the DSv4 fused output epilogue or not.
+  bool mUsesDsv4Ue8m0ScaleO;
   // The tile scheduler.
   TileScheduler mTileScheduler;
   // The tile size for Q.
@@ -467,6 +468,7 @@ struct TllmGenSelectKernelParams {
         mSkipsSoftmaxWhenPossible(params.mSkipsSoftmaxWhenPossible),
         mUseFp16Softmax(params.mUseFp16Softmax),
         mUsesSpcompress(params.mUsesSpcompress),
+        mUsesDsv4Ue8m0ScaleO(params.mUsesDsv4Ue8m0ScaleO),
         mTileScheduler(params.mUsesDsv4Ue8m0ScaleO ? TileScheduler::Persistent
                                                    : params.mTileScheduler),
         mTileSizeQ(128),

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -846,6 +846,11 @@ struct KernelParams {
     // The output scaling factor buffer.
     params.ptrSfO = options.oSfPtr;
 
+    // DSv4 fused output epilogue; null/zero for every other kernel.
+    params.ptrDsv4InvRopeCosSinCache = options.dsv4InvRopeCosSinCachePtr;
+    params.ptrDsv4OScaleFp32 = static_cast<float*>(options.dsv4OScalePtr);
+    params.mDsv4ScaleBufM = options.mDsv4ScaleBufM;
+
     // TRT-LLM restrictions: the quantization scales must be on the device.
     params.ptrOutputScale = options.outputScalePtr;
 

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -79,9 +79,7 @@ struct KernelParams {
   int64_t const* ptrCustomMaskOffsets;
   // The debug output matrix O
   float* ptrDebugO;
-  // DSv4 inverse-RoPE + FP8 quant fusion metadata and output scale tensor, only for epilogue
-  // fusion. Unused by FlashInfer but part of the kernel-side KernelParams ABI; the field order
-  // must stay in sync with the kernels or every later field is misread by the cubins.
+  // DSv4 output epilogue (fused cubins and fmhaReduction.cu); null for every other kernel.
   float const* ptrDsv4InvRopeCosSinCache;
   // Dsv4 output block-scaled tensor, only for epilogue fusion
   float* ptrDsv4OScaleFp32;
@@ -136,8 +134,7 @@ struct KernelParams {
   int32_t mBatchSize;
   // The chunked attention size in log2.
   int32_t mChunkedAttentionSizeLog2;
-  // Padded token dimension for the DSv4 fused FP32 scale layout. Unused by FlashInfer; kept for
-  // the KernelParams ABI (see the DSv4 pointer fields above).
+  // Token extent of the DSv4 scale layout: align(sumOfSeqLensQ, 4).
   int64_t mDsv4ScaleBufM;
   // The factor to add to the maximum value to increase the probability
   //   of skip correction during next iterations.
@@ -846,7 +843,7 @@ struct KernelParams {
     // The output scaling factor buffer.
     params.ptrSfO = options.oSfPtr;
 
-    // DSv4 fused output epilogue; null/zero for every other kernel.
+    // DSv4 output epilogue; null/zero for every other kernel.
     params.ptrDsv4InvRopeCosSinCache = options.dsv4InvRopeCosSinCachePtr;
     params.ptrDsv4OScaleFp32 = static_cast<float*>(options.dsv4OScalePtr);
     params.mDsv4ScaleBufM = options.mDsv4ScaleBufM;

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -6,7 +6,7 @@ import pytest
 import torch
 
 from flashinfer.mla import (
-    dsv4_fused_epilogue_scale_buf_m,
+    dsv4_fused_epilogue_scale_tokens,
     trtllm_batch_decode_sparse_mla_dsv4,
 )
 from flashinfer.mla._core import get_trtllm_gen_fmha_module
@@ -1252,16 +1252,20 @@ def _dsv4_dequant(
     return v * torch.exp2((e - 127).float()).repeat_interleave(DSV4_QUANT_BLOCK, dim=-1)
 
 
-# Batch 1 and 4 resolve onto the split-KV reduction epilogue (head spans 128/256/512),
-# batch 16 onto the fused cubin. top_k 256 is the C128A width at short max_model_len, where
-# the KV split is forced rather than chosen.
+# batch 1/4: split-KV reducer (head span 128/256); 16: fused cubin; top_k 256: forced split.
 @pytest.mark.parametrize(
-    "batch,s_q,top_k",
-    [(1, 1, 2048), (4, 1, 2048), (16, 1, 2048), (16, 4, 2048), (4, 1, 256)],
+    "batch,s_q,top_k,is_varlen",
+    [
+        (1, 1, 2048, False),
+        (4, 1, 2048, False),
+        (16, 1, 2048, False),
+        (16, 4, 2048, True),
+        (4, 1, 256, False),
+    ],
 )
 @torch.inference_mode()
 def test_trtllm_gen_sparse_mla_dsv4_fused_epilogue(
-    batch: int, s_q: int, top_k: int
+    batch: int, s_q: int, top_k: int, is_varlen: bool
 ) -> None:
     _skip_unless_sm100_or_sm103()
     p = RawTestParamForDecode(
@@ -1270,7 +1274,7 @@ def test_trtllm_gen_sparse_mla_dsv4_fused_epilogue(
         s_q=s_q,
         h_kv=1,
         s_kv=8192,
-        is_varlen=False,
+        is_varlen=is_varlen,
         topk=DSV4_SWA_TOPK,
         extra_s_k=8192,
         extra_topk=top_k - DSV4_SWA_TOPK,
@@ -1281,12 +1285,15 @@ def test_trtllm_gen_sparse_mla_dsv4_fused_epilogue(
         sparse_case="swa128+topk4x",
     ).to_test_param()
     testcase = generate_testcase_for_decode(p)
-    sum_q = batch * s_q
+    q_lens = testcase.q_lens.tolist()
+    sum_q = sum(q_lens)
     device = testcase.q.device
     positions = torch.cat(
         [
-            torch.arange(int(n) - s_q, int(n), device=device)
-            for n in testcase.kv_scope.cache_seqlens
+            torch.arange(int(n) - q_len, int(n), device=device)
+            for n, q_len in zip(
+                testcase.kv_scope.cache_seqlens.tolist(), q_lens, strict=True
+            )
         ]
     )
     cos_sin_cache = _dsv4_cos_sin_cache(int(positions.max()) + 1, device)
@@ -1297,7 +1304,7 @@ def test_trtllm_gen_sparse_mla_dsv4_fused_epilogue(
         device=device,
     )
     out_scales = torch.zeros(
-        (n_groups, DSV4_HEADS_PER_GROUP, dsv4_fused_epilogue_scale_buf_m(sum_q)),
+        (n_groups, DSV4_HEADS_PER_GROUP, dsv4_fused_epilogue_scale_tokens(sum_q)),
         dtype=torch.int32,
         device=device,
     )
@@ -1305,6 +1312,8 @@ def test_trtllm_gen_sparse_mla_dsv4_fused_epilogue(
         p, testcase, out=out, out_scales=out_scales, cos_sin_cache=cos_sin_cache
     )
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
+    if is_varlen:
+        out_ref = out_ref[testcase.valid_q]
     out_ref = _dsv4_inverse_rope(
         out_ref.reshape(sum_q, p.h_q, p.d_v), positions, cos_sin_cache
     )

--- a/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
+++ b/tests/attention/test_trtllm_gen_sparse_mla_dsv4.py
@@ -5,7 +5,10 @@ from typing import Literal
 import pytest
 import torch
 
-from flashinfer.mla import trtllm_batch_decode_sparse_mla_dsv4
+from flashinfer.mla import (
+    dsv4_fused_epilogue_scale_buf_m,
+    trtllm_batch_decode_sparse_mla_dsv4,
+)
 from flashinfer.mla._core import get_trtllm_gen_fmha_module
 from flashinfer.utils import get_compute_capability
 
@@ -13,6 +16,10 @@ from flashinfer.utils import get_compute_capability
 WORKSPACE_SIZE = 128 * 1024 * 1024
 DSV4_HEAD_DIM = 512
 DSV4_SWA_TOPK = 128
+# Fused-epilogue output: RoPE on the trailing lanes, one UE8M0 scale per block, 8 heads per group.
+DSV4_ROPE_DIM = 64
+DSV4_QUANT_BLOCK = 128
+DSV4_HEADS_PER_GROUP = 8
 TEST_SEED_BASE = 2026
 
 DECODE_BATCH_SIZE = 3
@@ -714,6 +721,8 @@ def run_flashinfer_decode(
     sparse_indices_are_storage_offsets: bool | None = None,
     remapped_sparse_indices_buffer: torch.Tensor | None = None,
     out: torch.Tensor | None = None,
+    out_scales: torch.Tensor | None = None,
+    cos_sin_cache: torch.Tensor | None = None,
 ) -> torch.Tensor:
     assert t.decode is not None
     swa_indices = testcase.kv_scope.indices_in_kvcache[testcase.valid_q].contiguous()
@@ -790,6 +799,8 @@ def run_flashinfer_decode(
             out=out,
             remapped_sparse_indices_buffer=remapped_sparse_indices_buffer,
             sparse_indices_are_storage_offsets=sparse_indices_are_storage_offsets,
+            out_scales=out_scales,
+            cos_sin_cache=cos_sin_cache,
         )
     except RuntimeError as err:
         err_msg = str(err)
@@ -928,6 +939,8 @@ def test_trtllm_gen_sparse_mla_rejects_remap_buffer_on_other_device() -> None:
             1,
             False,
             1,
+            None,
+            None,
             None,
             None,
         )
@@ -1196,3 +1209,106 @@ def test_trtllm_gen_sparse_mla_dsv4_strided_pages_cuda_graph(monkeypatch) -> Non
     out_ref, _ = ref_sparse_attn_decode(p, testcase)
     out_ref = out_ref[testcase.valid_q]
     _assert_close(out_ans, out_ref, p.dtype)
+
+
+def _dsv4_cos_sin_cache(max_position: int, device: torch.device) -> torch.Tensor:
+    half = DSV4_ROPE_DIM // 2
+    inv_freq = 1.0 / (10000.0 ** (torch.arange(half, device=device).float() / half))
+    freqs = torch.outer(torch.arange(max_position, device=device).float(), inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).contiguous()
+
+
+def _dsv4_inverse_rope(
+    o: torch.Tensor, positions: torch.Tensor, cos_sin_cache: torch.Tensor
+) -> torch.Tensor:
+    """[T, H, 512] -> float32 with the trailing 64 interleaved lanes un-rotated."""
+    x = o.float()
+    rope_start = DSV4_HEAD_DIM - DSV4_ROPE_DIM
+    rope = x[..., rope_start:]
+    cos, sin = cos_sin_cache.index_select(0, positions).unsqueeze(1).chunk(2, dim=-1)
+    even, odd = rope[..., 0::2], rope[..., 1::2]
+    rotated = torch.empty_like(rope)
+    rotated[..., 0::2] = even * cos + odd * sin
+    rotated[..., 1::2] = odd * cos - even * sin
+    return torch.cat((x[..., :rope_start], rotated), dim=-1)
+
+
+def _dsv4_dequant(
+    values: torch.Tensor, scales: torch.Tensor, sum_q: int
+) -> torch.Tensor:
+    """[G, T, 8, 512] + [G, 8, M] -> [T, G*8, 512] float32."""
+    n_groups = values.size(0)
+    h = n_groups * DSV4_HEADS_PER_GROUP
+    v = values[:, :sum_q].float().permute(1, 0, 2, 3).reshape(sum_q, h, DSV4_HEAD_DIM)
+    e = (
+        scales[..., :sum_q]
+        .contiguous()
+        .view(torch.uint8)
+        .view(n_groups, DSV4_HEADS_PER_GROUP, sum_q, DSV4_HEAD_DIM // DSV4_QUANT_BLOCK)
+        .permute(2, 0, 1, 3)
+        .reshape(sum_q, h, -1)
+        .to(torch.int32)
+    )
+    return v * torch.exp2((e - 127).float()).repeat_interleave(DSV4_QUANT_BLOCK, dim=-1)
+
+
+# Batch 1 and 4 resolve onto the split-KV reduction epilogue (head spans 128/256/512),
+# batch 16 onto the fused cubin. top_k 256 is the C128A width at short max_model_len, where
+# the KV split is forced rather than chosen.
+@pytest.mark.parametrize(
+    "batch,s_q,top_k",
+    [(1, 1, 2048), (4, 1, 2048), (16, 1, 2048), (16, 4, 2048), (4, 1, 256)],
+)
+@torch.inference_mode()
+def test_trtllm_gen_sparse_mla_dsv4_fused_epilogue(
+    batch: int, s_q: int, top_k: int
+) -> None:
+    _skip_unless_sm100_or_sm103()
+    p = RawTestParamForDecode(
+        b=batch,
+        h_q=128,
+        s_q=s_q,
+        h_kv=1,
+        s_kv=8192,
+        is_varlen=False,
+        topk=DSV4_SWA_TOPK,
+        extra_s_k=8192,
+        extra_topk=top_k - DSV4_SWA_TOPK,
+        extra_block_size=1,
+        have_extra_topk_length=True,
+        seed=TEST_SEED_BASE,
+        dtype=torch.float8_e4m3fn,
+        sparse_case="swa128+topk4x",
+    ).to_test_param()
+    testcase = generate_testcase_for_decode(p)
+    sum_q = batch * s_q
+    device = testcase.q.device
+    positions = torch.cat(
+        [
+            torch.arange(int(n) - s_q, int(n), device=device)
+            for n in testcase.kv_scope.cache_seqlens
+        ]
+    )
+    cos_sin_cache = _dsv4_cos_sin_cache(int(positions.max()) + 1, device)
+    n_groups = p.h_q // DSV4_HEADS_PER_GROUP
+    out = torch.empty(
+        (n_groups, sum_q, DSV4_HEADS_PER_GROUP, p.d_v),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    out_scales = torch.zeros(
+        (n_groups, DSV4_HEADS_PER_GROUP, dsv4_fused_epilogue_scale_buf_m(sum_q)),
+        dtype=torch.int32,
+        device=device,
+    )
+    run_flashinfer_decode(
+        p, testcase, out=out, out_scales=out_scales, cos_sin_cache=cos_sin_cache
+    )
+    out_ref, _ = ref_sparse_attn_decode(p, testcase)
+    out_ref = _dsv4_inverse_rope(
+        out_ref.reshape(sum_q, p.h_q, p.d_v), positions, cos_sin_cache
+    )
+    assert (out_scales[..., :sum_q] != 0).all(), "scale columns left unwritten"
+    out_ans = _dsv4_dequant(out, out_scales, sum_q)
+    assert not torch.isnan(out_ans).any()
+    torch.testing.assert_close(out_ans, out_ref, rtol=1e-1, atol=1e-1)


### PR DESCRIPTION
## 📌 Description

Adds an FP8 output mode to `trtllm_batch_decode_sparse_mla_dsv4` for DeepSeek-V4 decode. With
`out` (float8_e4m3fn `[H/8, sum_q, 8, 512]`), `out_scales` (int32 `[H/8, 8, align4(sum_q)]`,
four block-128 UE8M0 exponents per word) and `cos_sin_cache` (`[max_position, 64]`), the kernel
inverse-rotates the trailing 64 lanes and quantizes in the epilogue, producing the DeepGEMM
operand directly. Without `out_scales` the call is unchanged.

Two carriers, chosen per problem:
- the fused trtllm-gen cubin (already in the pinned bundle), selected by hashing
  `mUsesDsv4Ue8m0ScaleO` (bit 57) with `MultiCtasKvMode::Disabled` + `Persistent` pinned;
- otherwise the BF16 split-KV pair with a forced >= 2-way split, whose separate reduction
  kernel (`csrc/fmhaReduction.cu`) applies the same epilogue at head spans 128/256/512.

`run()` is unchanged; the launcher gains three trailing pointer args. New helper:
`dsv4_fused_epilogue_scale_tokens(sum_seq_q)`.

**Support range:** 128 query heads on the rank (DP attention, no attention TP), FP8 query/KV.
Every batch, query length and top-k is then served. Other head counts raise; callers keep BF16.

## 🔍 Related Issues

#____

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`test_trtllm_gen_sparse_mla_dsv4_fused_epilogue`: dequantized output vs
`ref_sparse_attn_decode` + torch inverse-RoPE at the file's FP8 tolerance; batch {1, 4, 16},
q {1, 4}, a varlen row, a 256-wide index set. GB300: 111 passed, BF16 cases unchanged;
27-shape grid (batch 1..128 x q 1,2,4) all execute.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional DeepSeek V4 fused output path for sparse MLA attention.
  * Supports FP8 E4M3 outputs with block-wise UE8M0 scaling and inverse RoPE processing.
  * Added optional output-scale and cosine/sine cache inputs to the DSv4 decode API.
  * Added a helper for determining the required scale-token extent.

* **Bug Fixes**
  * Added validation and fallback handling for unsupported fused-kernel configurations.

* **Tests**
  * Added coverage for fused outputs, scaling, RoPE inversion, variable-length inputs, and numerical accuracy.

* **Documentation**
  * Added the fused epilogue helper to the public API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->