### PR TITLE
perf(gemm): cute-dsl bf16-nvfp4 dense gemm fix to include no-autotune fallback tactic

### DIFF
--- a/flashinfer/gemm/gemm_bf16_fp4_cute_dsl.py
+++ b/flashinfer/gemm/gemm_bf16_fp4_cute_dsl.py
@@ -639,6 +639,45 @@ def _sm100_bf16_fp4_tactic_configs() -> List[Tuple]:
 
 _SM100_BF16_FP4_TACTICS = tuple(_sm100_bf16_fp4_tactic_configs())
 
+
+def _sm100_bf16_fp4_tactic_ctas(tactic: Tuple, m: int, n: int) -> int:
+    """CTA count this tactic launches for a public ``(m, n)``.
+
+    The kernel's M mode carries public output channels ``n`` and its N mode
+    carries public rows ``m`` (see ``_sm100_bf16_fp4_tactic_configs``).  A
+    256-wide M tile is produced by a two-CTA cluster, so it costs two CTAs per
+    tile; every other shape is one.
+    """
+    (tile_n, tile_m, _), _, _ = tactic
+    ctas_per_tile = 2 if tile_n == 256 else 1
+    return -(-n // tile_n) * ctas_per_tile * -(-m // tile_m)
+
+
+def _select_sm100_bf16_fp4_default_tactic(
+    valid_tactics: List[Tuple], m: int, n: int, sm_count: int
+) -> Tuple:
+    """Pick the no-autotune fallback tactic for the SM100/103 dense W4A16 GEMM.
+
+    Ranks by ``waves x per-CTA bytes`` (``tile_n`` FP4 weights at half a byte,
+    ``tile_m`` BF16 activations at two): a wider row tile cuts waves but makes
+    each CTA dearer, so the best tile is an interior one that grows with ``m``.
+    A heuristic -- 1.07x off the per-shape optimum in geomean over 18 measured
+    shapes, worst 1.34x, against 2.8x/10.2x for the ``valid_tactics[0]`` rule
+    it replaces.  Ties go to ``raster_along_m=False``.
+    """
+
+    def rank(tactic: Tuple) -> Tuple:
+        tile_n, tile_m, _ = tactic[0]
+        waves = -(-_sm100_bf16_fp4_tactic_ctas(tactic, m, n) // sm_count)
+        return (
+            waves * (tile_n + 4 * tile_m),
+            bool(tactic[2]),
+            _SM100_BF16_FP4_TACTICS.index(tactic),
+        )
+
+    return min(valid_tactics, key=rank)
+
+
 _SM100_BF16_FP4_CUTE_DSL_TUNING_CONFIG = TuningConfig(
     dynamic_tensor_specs=(
         DynamicTensorSpec(
@@ -717,7 +756,7 @@ def _get_sm100_bf16_fp4_kernel(
         k,
         max_active_clusters=max_active_clusters,
         stream=stream,
-        options="--opt-level 3 --enable-tvm-ffi",
+        options="--opt-level 2 --enable-tvm-ffi",
     )
     _SM100_BF16_FP4_KERNEL_CACHE[cache_key] = compiled
     return compiled
@@ -863,10 +902,12 @@ def _cute_dsl_sm100_bf16_fp4_runner(enable_pdl: bool = True) -> TunableRunner:
             a, b, b_descale, alpha_for_launch, _, out, _ = inputs
             if tactic == -1:
                 valid = self.get_valid_tactics(inputs, None)
+                m, k = map(int, a.shape)
                 if valid:
-                    tactic = valid[0]
+                    tactic = _select_sm100_bf16_fp4_default_tactic(
+                        valid, m, int(b.shape[0]), get_device_sm_count(a.device)
+                    )
                 else:
-                    m, k = map(int, a.shape)
                     raise ValueError(
                         "no SM100 cute-dsl w4a16 tactic supports "
                         f"m={m}, n={int(b.shape[0])}, k={k}"


### PR DESCRIPTION
## 📌 Description

Two fixes to the SM100/SM103 CuTe-DSL dense W4A16 (`mm_bf16_fp4`) path. Both affect only the no-autotune path; autotuned callers are untouched by change 2 and lose ~2.7% from change 1 (see below).

### 1. Restore `--opt-level 2` (regression from #4686)

#4686 dropped this path's explicit `--opt-level 2` and let the CuTe DSL default (3) apply. On B300 that is a 1.5-1.8x regression on the shapes the perf CI runs:

| case | m | before (O3) | after (O2) |
|---|---:|---:|---:|
| 4K-hidden-prefill | 256 | 0.0952 ms | 0.0523 ms |
| 4K-hidden-decode | 1 | 0.0183 ms | 0.0120 ms |

Measured per tactic, **O3 is ~2-3% faster on 26 of the 30 tactics and 1.44-1.81x slower on exactly 4** — cluster `(1,1)` + `raster_along_m=True` + a narrow N tile, the same 4 at m=1 and m=256. The no-autotune path always selects `((128, 8, 256), (1, 1), True)`, the worst cell in that space, which is why #4686's autotuned benchmarks reported a real ~1.03x win while CI regressed. Reverting the level costs autotuned callers that ~2.7% and buys back 1.8x for everyone who does not autotune.

Not register pressure: `ncu` shows 128 registers/thread and zero local-memory traffic under both levels with an identical launch config; issued warps/scheduler drops 0.67 -> 0.39 at unchanged occupancy. The kernel goes latency-bound, so there is no register budget to retune. Worth reporting the cliff itself to the CuTe DSL team separately.

The 15 -> 30 raster-direction tactic expansion from #4686 is kept — it is inert on the no-autotune path and only widens the autotuner's search.

### 2. Shape-aware no-autotune default tactic

`forward()`'s `tactic == -1` path took `valid_tactics[0]`, which is always the smallest row tile (`route_tile=8`) regardless of `m`, because `get_valid_tactics()` filters on legality only. Each CTA streams all of K for its tile, so weights are re-read once per row tile — `ceil(m/8)` of them. That is harmless at m <= 8 (one tile) and degrades linearly above it: measured 2.1-5.1x off the best tactic at m=128, 6.1-9.1x at m=512, 8.7-10.2x at m=2048. Every caller that does not autotune pays this, including the perf CI suite.

`_select_sm100_bf16_fp4_default_tactic()` now ranks by `waves x per-CTA bytes` (`tile_n` FP4 weights at 1/2 byte, `tile_m` BF16 activations at 2; K is common to all tactics and cancels). The two terms oppose each other, so the optimum is an interior tile that widens with `m`. Ties go to `raster_along_m=False`, which also keeps the default clear of the level-3 cliff above.

Rejected on measurement, so they are not retried: ranking on wave count alone picks a 3-wave tactic over a faster 4-wave one at m=2048, n=k=4096 (it ignores per-CTA cost), and breaking ties toward the 2-CTA cluster helps m=512 but is worse overall (geomean 1.12 vs 1.07).

---

## ⏱️ Performance

End-to-end through `mm_bf16_fp4`, no `--autotune`, B200 (148 SMs), CUPTI, `--num_iters 30 --dry_run_iters 5`. Speedup of change 2 over the previous default, at `--opt-level 2`:

| m | (n,k)=(4096,4096) | (6656,19968) | (19968,6656) |
|---:|---:|---:|---:|
| 1 / 8 | 1.00x | 1.00x | 1.00x |
| 32 | 1.00x | 1.84x | 2.14x |
| 128 | 2.65x | 4.87x | 4.64x |
| 512 | 5.50x | 7.28x | 7.71x |
| 2048 | 7.94x | 7.26x | 9.27x |

Geomean 2.64x, max 9.27x, no shape slower than before. Against per-tactic ground truth (30 tactics x 18 shapes) the heuristic lands 1.069 geomean from the per-shape optimum, worst 1.336x, versus 2.823 / 10.223 for the rule it replaces. It is a heuristic to stop the untuned path being catastrophic, not a replacement for autotuning.

---

## 🧪 Tests

*   **18/18 shapes:** the tactic actually launched matches the selector's independently computed prediction (verified by intercepting `_launch_cute_dsl_sm100`); all outputs finite.
*   **9/9 shapes:** pass `flashinfer_benchmark.py --refcheck` (fp32 reference).
*   **Linting:** `ruff check` and `ruff format` clean.

> **Note:** Measured on B300 SXM6 (cc 10.3) for change 1 and B200 (cc 10.0) for change 2; both report 148 SMs and share the code path. **Not measured on GB300.**