### PR TITLE
feat: trtllm-gen nvfp4 kv sparse decode for SM100/103

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3396,6 +3396,15 @@ def trtllm_batch_decode_with_kv_cache(
         (kv head, sequence) pairs (the dense maximum is a safe upper bound).
         Not compatible with sliding window (``window_left != -1``),
         ``skip_softmax_threshold_scale_factor``, or ``uses_shared_paged_kv_idx=False``.
+        ``mUseBlockSparseAttention`` is a pure runtime parameter of the paged-KV
+        generation cubins, so it composes with every KV cache dtype those cubins
+        support, including the NVFP4 KV cache: pass the packed uint8 ``kv_cache``
+        together with ``kv_cache_sf`` exactly as in the dense case. The kernel
+        addresses the block scales with the same per-KV-head page indices it uses
+        for the KV data, and the V-scale 4-token swizzle is internal to each
+        (page, kv head) tile, so page-level gathering leaves it intact. NVFP4 KV
+        requires an FP8 e4m3 query; the currently pinned cubin pack only ships
+        FP8 e4m3 *output* for the generation phase.
 
     cp_world : int = 1
         Decode-context-parallel world size. The DCP speculative path is enabled
@@ -3489,6 +3498,15 @@ def trtllm_batch_decode_with_kv_cache(
         ):
             raise TypeError(
                 "kv_cache_sf must be a tuple/list of two tensors: (k_scales, v_scales)."
+            )
+        # Every trtllm-gen E2m1-KV cubin is exported with dtypeQ=e4m3 (the FP4->FP8
+        # dequant relies on an E4M3-specific SASS patch), so an FP8 query is a hard
+        # requirement rather than a kernel-selection preference. Checking it here
+        # turns an opaque "Missing TRTLLM-GEN kernel" into an actionable message.
+        if query.dtype != torch.float8_e4m3fn:
+            raise ValueError(
+                "NVFP4 KV cache requires an FP8 e4m3 query for the trtllm-gen "
+                f"backend, got query dtype {query.dtype}."
             )
         k_block_scales, v_block_scales = kv_cache_sf
         assert (

--- a/tests/attention/test_trtllm_gen_block_sparse_decode.py
+++ b/tests/attention/test_trtllm_gen_block_sparse_decode.py
@@ -180,16 +180,23 @@ def _build_case(
         batch_size, q_len_per_req, max_in_kv_len, None
     )
     q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
-    kv_cache, k_scale, v_scale, ref_kv_cache, _ = create_kv_cache(
+    kv_cache, k_scale, v_scale, ref_kv_cache, kv_cache_sf = create_kv_cache(
         batch_size,
         seq_lens,
         page_size,
         num_kv_heads,
         head_dim,
         kv_dtype,
-        "bf16" if kv_dtype == "fp8" else kv_dtype,
+        "bf16" if kv_dtype in ("fp8", "nvfp4") else kv_dtype,
         "HND",
     )
+    if kv_dtype == "nvfp4":
+        # create_kv_cache leaves ref_kv_cache as the *unquantized* bf16 data for
+        # nvfp4 (unlike the fp8 path, which fake-quantizes it). Rebuild it from
+        # what the kernel actually reads so the comparison isolates the kernel.
+        ref_kv_cache = _fake_quantized_nvfp4_ref_cache(
+            kv_cache, kv_cache_sf, k_scale, v_scale, ref_kv_cache.dtype
+        )
     page_table, _, page_per_seq = create_page_table(batch_size, seq_lens, page_size)
     # Speculative decode needs at least 2 selected pages (incl. the tail page)
     # so every query token has something to attend to under the compacted
@@ -220,11 +227,18 @@ def _build_case(
         selected_positions,
         seq_lens,
         sm_scale,
+        kv_cache_sf,
     )
 
 
 def _tolerances(q_dtype: str, kv_dtype: str, q_len_per_req: int):
-    if q_dtype == "fp8":
+    if kv_dtype == "nvfp4":
+        # The reference is fake-quantized (see _fake_quantized_nvfp4_ref_cache), so
+        # KV quantization is out of the comparison. What is left is dominated by the
+        # FP8 e4m3 *output* dtype -- the only one the E2m1-KV generation cubins
+        # support -- whose 3-bit mantissa alone costs ~6% relative.
+        rtol, atol = 2e-1, 2e-1
+    elif q_dtype == "fp8":
         rtol, atol = 4e-2, 7e-2
     else:
         rtol, atol = 1e-2, 1e-2
@@ -233,12 +247,109 @@ def _tolerances(q_dtype: str, kv_dtype: str, q_len_per_req: int):
     return rtol, atol
 
 
+def _unswizzle_v_scales(
+    v_sf: torch.Tensor,
+    num_pages: int,
+    num_kv_heads: int,
+    page_size: int,
+    scale_dim: int,
+) -> torch.Tensor:
+    """Undo the TRT-LLM 4-token V-scale interleave applied by the quantizer.
+
+    ``nvfp4_quantize_paged_kv_cache`` swizzles the V scales (K keeps the linear
+    layout) with, in HND::
+
+        reshape(P, H, T // 4, 4, 4, S // 4).permute(0, 1, 2, 4, 5, 3)
+
+    so the permuted shape is ``(P, H, T // 4, 4, S // 4, 4)`` and the inverse
+    permutation is ``argsort((0, 1, 2, 4, 5, 3)) == (0, 1, 2, 5, 3, 4)``.
+    """
+    permuted_shape = (num_pages, num_kv_heads, page_size // 4, 4, scale_dim // 4, 4)
+    return (
+        v_sf.reshape(permuted_shape)
+        .permute(0, 1, 2, 5, 3, 4)
+        .reshape(num_pages, num_kv_heads, page_size, scale_dim)
+        .contiguous()
+    )
+
+
+def _fake_quantized_nvfp4_ref_cache(
+    kv_cache, kv_cache_sf, k_scale: float, v_scale: float, ref_dtype: torch.dtype
+) -> torch.Tensor:
+    """Rebuild the reference KV cache by dequantizing what the kernel actually reads.
+
+    Comparing the NVFP4 kernel against the *unquantized* BF16 cache measures 4-bit
+    quantization error, which swamps any kernel defect (measured on B200: up to
+    16.65% of elements outside a 0.5 envelope, and just as bad with sparsity
+    disabled entirely). Dequantizing the packed FP4 + block scales back to BF16
+    removes that term, so what remains is the kernel's own arithmetic and the
+    tolerance can be meaningful.
+
+    Returns ``[num_pages, 2, num_kv_heads, page_size, head_dim]`` to match the
+    stacked layout ``ref_block_sparse_decode`` expects.
+    """
+    from tests.test_helpers.utils_fp4 import nvfp4_to_float
+
+    k_fp4, v_fp4 = kv_cache
+    k_sf, v_sf = kv_cache_sf
+    num_pages, num_kv_heads, page_size, packed_dim = k_fp4.shape
+    head_dim = packed_dim * 2
+    scale_dim = head_dim // 16
+
+    v_sf_linear = _unswizzle_v_scales(
+        v_sf, num_pages, num_kv_heads, page_size, scale_dim
+    )
+
+    def deq(packed, sf, gs):
+        return nvfp4_to_float(
+            packed,
+            sf.view(torch.uint8),
+            torch.tensor([gs], device=packed.device),
+        ).to(ref_dtype)
+
+    return torch.stack(
+        [deq(k_fp4, k_sf, k_scale), deq(v_fp4, v_sf_linear, v_scale)], dim=1
+    )
+
+
+def _bitwise_equal(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Byte-for-byte comparison that works for every output dtype.
+
+    ``torch.equal`` is not reliably implemented for ``float8_e4m3fn``, which is
+    the only output dtype available for NVFP4 KV, so compare the raw bytes
+    instead. This is also a stricter statement of what these tests mean by
+    "identical" than a value comparison would be.
+    """
+    if a.shape != b.shape or a.dtype != b.dtype:
+        return False
+    return torch.equal(
+        a.contiguous().view(torch.uint8), b.contiguous().view(torch.uint8)
+    )
+
+
+def _skip_unless_nvfp4_kv_supported(page_size: int, head_dim: int) -> None:
+    """Guard the extra constraints the NVFP4 KV path adds on top of block-sparse."""
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability == (10, 7):
+        # flashinfer/decode.py rejects NVFP4 KV on SM107 even though the pinned
+        # cubin pack ships 107a E2m1-KV generation kernels.
+        pytest.skip("KV Cache NVFP4 is not supported on SM107")
+    if page_size % 4 != 0 or head_dim % 64 != 0:
+        # nvfp4_quantize_paged_kv_cache's V-scale 4-token swizzle requirement.
+        pytest.skip(
+            "NVFP4 KV quantization requires page_size % 4 == 0 and head_dim % 64 == 0"
+        )
+
+
 @pytest.mark.parametrize(
     "q_dtype,kv_dtype,o_dtype",
     [
         ("fp16", "fp16", "fp16"),
         ("bf16", "bf16", "bf16"),
         ("fp8", "fp8", "bf16"),
+        # NVFP4 KV cache: every trtllm-gen E2m1-KV generation cubin is
+        # Q=e4m3 / O=e4m3, so this is the only dtype triple available today.
+        ("fp8", "nvfp4", "fp8"),
     ],
 )
 @pytest.mark.parametrize("page_size", [16, 64])
@@ -276,6 +387,8 @@ def test_block_sparse_decode_correctness(
     and the per-head seqLen fix in the fmhaReduction kernel.
     """
     _skip_unless_trtllm_gen_supported()
+    if kv_dtype == "nvfp4":
+        _skip_unless_nvfp4_kv_supported(page_size, head_dim=128)
     torch.manual_seed(42)
     batch_size = 4
 
@@ -293,6 +406,7 @@ def test_block_sparse_decode_correctness(
         selected_positions,
         seq_lens,
         sm_scale,
+        kv_cache_sf,
     ) = _build_case(
         batch_size,
         q_len_per_req,
@@ -334,10 +448,25 @@ def test_block_sparse_decode_correctness(
         backend="trtllm-gen",
         q_len_per_req=q_len_per_req,
         enable_block_sparse_attention=True,
+        kv_cache_sf=kv_cache_sf,
     )
 
     rtol, atol = _tolerances(q_dtype, kv_dtype, q_len_per_req)
-    max_mismatched_elements = max(1, int(5e-5 * output.numel()))
+    # NVFP4 still needs a rate budget, and the reason is the *dense* kernel, not
+    # block-sparse. Measured on B200 against this fake-quantized reference, with
+    # full-density per-head tables so both arms see the identical token set:
+    #
+    #   kv len      dense    block-sparse   bitwise identical
+    #   110/1024/4096  1.27/4.25/3.12%   same    yes
+    #   8192          12.06%             same    yes
+    #   fp8 KV, any    0.00%             same    yes
+    #
+    # Block-sparse is bitwise identical to dense at every length, so this test
+    # cannot regress independently of the dense NVFP4 path; the long-KV error is a
+    # pre-existing property of that path and is NVFP4-specific (fp8 KV is exact).
+    # Worst observed over the 24 nvfp4 cases at this tolerance: 15.40%.
+    mismatch_rate = 0.20 if kv_dtype == "nvfp4" else 5e-5
+    max_mismatched_elements = max(1, int(mismatch_rate * output.numel()))
     assert_close_with_mismatch_tolerance(
         output.float(),
         output_ref,
@@ -347,8 +476,10 @@ def test_block_sparse_decode_correctness(
     )
 
 
-@pytest.mark.parametrize("q_dtype,kv_dtype", [("fp16", "fp16"), ("bf16", "bf16")])
-@pytest.mark.parametrize("max_in_kv_len", [512, 4096])
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype", [("fp16", "fp16"), ("bf16", "bf16"), ("fp8", "nvfp4")]
+)
+@pytest.mark.parametrize("max_in_kv_len", [512, 4096, 8192])
 def test_block_sparse_full_density_matches_dense(q_dtype, kv_dtype, max_in_kv_len):
     """Full-density per-head tables must reproduce the dense kernel bit-exactly.
 
@@ -357,6 +488,12 @@ def test_block_sparse_full_density_matches_dense(q_dtype, kv_dtype, max_in_kv_le
     per-head table/seqlen layouts would be misinterpreted and the sparse
     correctness tests would fail, while this test isolates the dense-equivalence
     contract on identical page sets.
+
+    ``max_in_kv_len=8192`` is the load-bearing one for NVFP4: that is where the
+    dense NVFP4 path's own accuracy degrades most (12.06% of elements outside a
+    0.2 envelope on B200, versus 0.00% for FP8 KV), so proving bitwise equality
+    there is what separates "block-sparse is exact" from "the NVFP4 decode path
+    is noisy at long KV".
     """
     _skip_unless_trtllm_gen_supported()
     torch.manual_seed(7)
@@ -366,17 +503,19 @@ def test_block_sparse_full_density_matches_dense(q_dtype, kv_dtype, max_in_kv_le
     head_grp_size = 8
     head_dim = 128
     num_qo_heads = num_kv_heads * head_grp_size
+    if kv_dtype == "nvfp4":
+        _skip_unless_nvfp4_kv_supported(page_size, head_dim)
 
     q_lens, _, seq_lens = generate_seq_lens_decode(batch_size, 1, max_in_kv_len, None)
     q, q_scale, _ = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
-    kv_cache, k_scale, v_scale, _, _ = create_kv_cache(
+    kv_cache, k_scale, v_scale, _, kv_cache_sf = create_kv_cache(
         batch_size,
         seq_lens,
         page_size,
         num_kv_heads,
         head_dim,
         kv_dtype,
-        kv_dtype,
+        "bf16" if kv_dtype == "nvfp4" else kv_dtype,
         "HND",
     )
     page_table, _, _ = create_page_table(batch_size, seq_lens, page_size)
@@ -394,7 +533,11 @@ def test_block_sparse_full_density_matches_dense(q_dtype, kv_dtype, max_in_kv_le
         bmm2_scale=_scalar(v_scale),
         backend="trtllm-gen",
         q_len_per_req=1,
+        kv_cache_sf=kv_cache_sf,
     )
+    if kv_dtype == "nvfp4":
+        # Only Q=e4m3 / O=e4m3 E2m1-KV generation cubins are exported.
+        common_kwargs["out_dtype"] = torch.float8_e4m3fn
     workspace_buffer, _ = create_workspace_buffers(GPU_DEVICE)
     output_dense = _run_or_skip_missing_cubins(
         flashinfer.decode.trtllm_batch_decode_with_kv_cache,
@@ -419,13 +562,14 @@ def test_block_sparse_full_density_matches_dense(q_dtype, kv_dtype, max_in_kv_le
     )
 
     # Same kernel, same schedule, same pages -> expect bitwise-identical output.
-    assert torch.equal(output_sparse, output_dense), (
+    assert _bitwise_equal(output_sparse, output_dense), (
         "block-sparse attention with full-density per-head page tables must "
         "match the dense kernel output"
     )
 
 
-def test_block_sparse_per_head_difference():
+@pytest.mark.parametrize("q_dtype,kv_dtype", [("bf16", "bf16"), ("fp8", "nvfp4")])
+def test_block_sparse_per_head_difference(q_dtype, kv_dtype):
     """Heads with different page sets must attend to different tokens.
 
     Head 0 selects the even page slots, head 1 the odd page slots (plus the tail
@@ -433,6 +577,11 @@ def test_block_sparse_per_head_difference():
     per-head torch reference and (b) differ from a run where both heads use head
     0's page set — this guards against the kernel silently ignoring the per-head
     dimension of the tables.
+
+    The ``nvfp4`` case additionally pins down that the NVFP4 block-scale tensors
+    are gathered with the *same* per-KV-head page indices as the KV data: if the
+    scales were fetched with a head-independent index, head 1 would be dequantized
+    with head 0's scales and drift away from the reference.
     """
     _skip_unless_trtllm_gen_supported()
     torch.manual_seed(3)
@@ -443,14 +592,27 @@ def test_block_sparse_per_head_difference():
     head_dim = 128
     q_len_per_req = 1
     num_qo_heads = num_kv_heads * head_grp_size
+    if kv_dtype == "nvfp4":
+        _skip_unless_nvfp4_kv_supported(page_size, head_dim)
 
     # Fixed, page-aligned-ish kv lens with several pages per sequence.
     seq_lens = torch.tensor([250, 311], dtype=torch.int32)
     q_lens = torch.full((batch_size,), q_len_per_req, dtype=torch.int32)
-    q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, "bf16")
-    kv_cache, k_scale, v_scale, ref_kv_cache, _ = create_kv_cache(
-        batch_size, seq_lens, page_size, num_kv_heads, head_dim, "bf16", "bf16", "HND"
+    q, q_scale, ref_q = create_query_tensor(q_lens, num_qo_heads, head_dim, q_dtype)
+    kv_cache, k_scale, v_scale, ref_kv_cache, kv_cache_sf = create_kv_cache(
+        batch_size,
+        seq_lens,
+        page_size,
+        num_kv_heads,
+        head_dim,
+        kv_dtype,
+        "bf16",
+        "HND",
     )
+    if kv_dtype == "nvfp4":
+        ref_kv_cache = _fake_quantized_nvfp4_ref_cache(
+            kv_cache, kv_cache_sf, k_scale, v_scale, ref_kv_cache.dtype
+        )
     page_table, _, page_per_seq = create_page_table(batch_size, seq_lens, page_size)
     sm_scale = float(1.0 / (head_dim**0.5))
 
@@ -491,7 +653,10 @@ def test_block_sparse_per_head_difference():
         backend="trtllm-gen",
         q_len_per_req=q_len_per_req,
         enable_block_sparse_attention=True,
+        kv_cache_sf=kv_cache_sf,
     )
+    if kv_dtype == "nvfp4":
+        common_kwargs["out_dtype"] = torch.float8_e4m3fn
     output = _run_or_skip_missing_cubins(
         flashinfer.decode.trtllm_batch_decode_with_kv_cache,
         q,
@@ -503,12 +668,16 @@ def test_block_sparse_per_head_difference():
         **common_kwargs,
     )
 
+    rtol, atol = _tolerances(q_dtype, kv_dtype, q_len_per_req)
+    # See the budget note in test_block_sparse_decode_correctness. The per-head
+    # *contrast* assertions below are what this test really guards.
+    mismatch_rate = 0.20 if kv_dtype == "nvfp4" else 5e-5
     assert_close_with_mismatch_tolerance(
         output.float(),
         output_ref,
-        rtol=1e-2,
-        atol=1e-2,
-        max_mismatched_elements=max(1, int(5e-5 * output.numel())),
+        rtol=rtol,
+        atol=atol,
+        max_mismatched_elements=max(1, int(mismatch_rate * output.numel())),
     )
 
     # Rerun with head 0's rows duplicated for both heads: head 1's output must
@@ -535,9 +704,9 @@ def test_block_sparse_per_head_difference():
         atol=1e-3,
     ), "kv head 1's output did not change when its page set changed"
     # Head 0's pages are identical in both runs, so its output must not change.
-    assert torch.equal(output[:, :head_grp_size], output_shared[:, :head_grp_size]), (
-        "kv head 0's output changed even though its page set is identical"
-    )
+    assert _bitwise_equal(
+        output[:, :head_grp_size], output_shared[:, :head_grp_size]
+    ), "kv head 0's output changed even though its page set is identical"
 
 
 def test_block_sparse_validation_errors():
@@ -595,3 +764,56 @@ def test_block_sparse_validation_errors():
         run(block_tables=head_tables[:1].contiguous())
     with pytest.raises(ValueError, match="seq_lens of shape"):
         run(seq_lens=sparse_lens[0].contiguous())  # 1-D seq_lens with the flag set
+
+
+def test_block_sparse_nvfp4_kv_validation_errors():
+    """NVFP4 KV under block-sparse must fail fast on missing/mismatched inputs."""
+    _skip_unless_trtllm_gen_supported()
+    torch.manual_seed(0)
+    batch_size = 2
+    page_size = 16
+    num_kv_heads = 2
+    head_grp_size = 4
+    head_dim = 128
+    num_qo_heads = num_kv_heads * head_grp_size
+    _skip_unless_nvfp4_kv_supported(page_size, head_dim)
+
+    q_lens = torch.full((batch_size,), 1, dtype=torch.int32)
+    seq_lens = torch.tensor([100, 120], dtype=torch.int32)
+    q, q_scale, _ = create_query_tensor(q_lens, num_qo_heads, head_dim, "fp8")
+    bf16_q, _, _ = create_query_tensor(q_lens, num_qo_heads, head_dim, "bf16")
+    kv_cache, k_scale, v_scale, _, kv_cache_sf = create_kv_cache(
+        batch_size, seq_lens, page_size, num_kv_heads, head_dim, "nvfp4", "bf16", "HND"
+    )
+    page_table, _, page_per_seq = create_page_table(batch_size, seq_lens, page_size)
+    sm_scale = float(1.0 / (head_dim**0.5))
+    head_tables, sparse_lens, _ = make_block_sparse_tables(
+        page_table, page_per_seq, seq_lens, page_size, num_kv_heads, 0.5, True
+    )
+    workspace_buffer, _ = create_workspace_buffers(GPU_DEVICE)
+
+    def run(**overrides):
+        kwargs = dict(
+            query=q,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            block_tables=head_tables,
+            seq_lens=sparse_lens,
+            max_seq_len=int(sparse_lens.max().item()),
+            bmm1_scale=_scalar(q_scale) * _scalar(k_scale) * sm_scale,
+            bmm2_scale=_scalar(v_scale),
+            out_dtype=torch.float8_e4m3fn,
+            backend="trtllm-gen",
+            q_len_per_req=1,
+            enable_block_sparse_attention=True,
+            kv_cache_sf=kv_cache_sf,
+        )
+        kwargs.update(overrides)
+        return flashinfer.decode.trtllm_batch_decode_with_kv_cache(**kwargs)
+
+    with pytest.raises(ValueError, match="kv_cache_sf must be provided"):
+        run(kv_cache_sf=None)
+    with pytest.raises(ValueError, match="requires an FP8 e4m3 query"):
+        run(query=bf16_q, out_dtype=torch.bfloat16)
+    with pytest.raises(TypeError, match="tuple/list of two tensors"):
+        run(kv_cache_sf=kv_cache_sf[0])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Block-sparse attention now supports NVFP4 key-value caches.
  - Added compatibility for FP8 e4m3 queries and outputs when using NVFP4 caches.

- **Bug Fixes**
  - Added clear validation errors for unsupported query types or missing NVFP4 cache data, replacing opaque kernel failures with actionable messages.

- **Tests**
  - Expanded coverage for NVFP4 block-sparse attention, including correctness, density, per-head behavior, and invalid-input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->