### PR TITLE
fix(mla): scope NoPE sparse_mla_top_k_lens requirement to non-sparse backends

### DIFF
--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -3253,14 +3253,6 @@ def trtllm_batch_decode_with_kv_cache_mla(
         kv_lora_rank == nope_mla_dimensions.kv_lora_rank
         and qk_rope_head_dim == nope_mla_dimensions.qk_rope_head_dim
     )
-    if is_nope_mla and sparse_mla_top_k <= 0:
-        raise ValueError(
-            "Native qk_rope_head_dim=0 TRTLLM-GEN MLA requires sparse_mla_top_k > 0"
-        )
-    if is_nope_mla and sparse_mla_top_k_lens is None:
-        raise ValueError(
-            "Native qk_rope_head_dim=0 TRTLLM-GEN MLA requires sparse_mla_top_k_lens"
-        )
     if sparse_mla_top_k_lens is not None:
         if not is_nope_mla:
             raise ValueError(
@@ -3302,6 +3294,24 @@ def trtllm_batch_decode_with_kv_cache_mla(
             backend = "sparse"
         elif cc[0] != 10:
             backend = "xqa"
+
+    # The native no-rope trtllm-gen/cute-dsl kernels require the per-token
+    # active top-k length; the SM120 sparse backend bounds each row by its
+    # -1 entries instead and does not consume sparse_mla_top_k_lens.
+    if is_nope_mla and backend != "sparse":
+        if sparse_mla_top_k <= 0:
+            raise ValueError(
+                "Native qk_rope_head_dim=0 TRTLLM-GEN MLA requires sparse_mla_top_k > 0"
+            )
+        if sparse_mla_top_k_lens is None:
+            raise ValueError(
+                "Native qk_rope_head_dim=0 TRTLLM-GEN MLA requires sparse_mla_top_k_lens"
+            )
+    if sparse_mla_top_k_lens is not None and backend == "sparse":
+        raise ValueError(
+            "sparse_mla_top_k_lens is not supported by the SM120 sparse MLA "
+            "backend; pass per-token active top-k lengths via seq_lens instead"
+        )
 
     if backend == "xqa":
         if multi_ctas_kv_counter_buffer is not None:


### PR DESCRIPTION
## Summary

`trtllm_batch_decode_with_kv_cache_mla` rejects the native NoPE form (`kv_lora_rank=512`, `qk_rope_head_dim=0`) at API entry unless `sparse_mla_top_k_lens` is provided. That requirement belongs to the native no-rope trtllm-gen/cute-dsl kernels (#4108), which consume the per-token active top-k length. The SM120 sparse backend (`backend="sparse"`, the v32 / GLM53_NOPE families) bounds each row by its `-1` page-table entries and never reads `sparse_mla_top_k_lens` — so the entry-level check makes the SM120 GLM-5.3-Flash NoPE path uncallable. (#4842 hit the same wall and dropped the check wholesale; this PR keeps the guard where the consuming kernels are instead.)

Move the requirement past backend resolution and apply it only when a non-`sparse` backend will run. The `sparse_mla_top_k_lens` shape/dtype validation for callers that do pass it is unchanged, as is the SM100 native-NoPE contract.

## Testing

- vLLM `FLASHINFER_MLA_SPARSE_SM120` + GLM-5.3-Flash-NVFP4, TP4 on 4×RTX PRO 6000 (SM120): previously raised `Native qk_rope_head_dim=0 TRTLLM-GEN MLA requires sparse_mla_top_k_lens` during CUDA graph capture; with this change the server boots and serves (companion vLLM PR: vllm-project/vllm#55277). GSM8K strict-match 0.9325.
- Existing trtllm-gen NoPE callers are unaffected: the requirement still fires for `trtllm-gen` / `cute-dsl` / `xqa` / unresolved `auto` on non-SM120 parts.

Signed-off-by: Zihua Wu <zihuaw@nvidia.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for sparse attention configurations with positive top-k values and per-token top-k lengths.
  * Updated backend-specific handling so SM120 uses per-token sequence lengths and rejects unsupported sparse top-k length settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->