### PR TITLE
docs: teach agents the PR guidelines in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,23 @@ Install hooks to run on every commit:
 pre-commit install
 ```
 
+## Opening a Pull Request
+
+Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) when opening a PR. The two requirements most often
+missed:
+
+- **Keep the default PR template.** Fill in `.github/pull_request_template.md` (Description,
+  Related Issues, Checklist, Tests, Reviewer Notes). Do **not** overwrite or replace it with a
+  custom or tool-generated description format. The title and description normally become the
+  commit title and message on squash-merge, and are what a `git bisect` surfaces months later
+  when someone is hunting the owner of a regression.
+- **Report before/after numbers for performance work.** A perf PR must include measurements from
+  a reproducible benchmark (e.g. `benchmarks/flashinfer_benchmark.py`), naming the GPU and the
+  problem sizes. Speedup ratios without absolute numbers, or numbers without a named GPU, are
+  not enough.
+
+→ **For the complete contribution rules, see [`CONTRIBUTING.md`](CONTRIBUTING.md)**
+
 ## Code Review
 
 When reviewing a diff (as an agent or a human), follow the shared focus areas, kernel-review


### PR DESCRIPTION
## 📌 Description

`CONTRIBUTING.md` already tells contributors to keep the default PR template and to report
before/after numbers for performance work, and `docs/code_review_guidance.md` (item 6) carries the
reviewer-side counterpart. Neither is reachable from the file coding agents are actually pointed at.

`AGENTS.md` sends agents to `CLAUDE.md` for "build, test, style, and **contribution workflows**",
but `CLAUDE.md` had no mention of pull requests at all — zero matches for "pull request", "PR
template" or `pull_request_template`, and no link to `CONTRIBUTING.md`. It does link
`docs/code_review_guidance.md`, but only under **Code Review**, gated on *"When reviewing a
diff"* — so an agent *opening* a PR never reaches it. The one document agents read
unconditionally was the one place the rule was missing.

This adds a short **Opening a Pull Request** section just before **Code Review**, stating both
rules inline (so they survive without a click) and pointing to `CONTRIBUTING.md` as the full
source of truth. Docs only — no code, no behavior change.

Observed impact: across 13 recently screened PRs, 3 replaced the default template with a
tool-generated description format — the exact failure mode `CONTRIBUTING.md` names.

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Documentation-only change to `CLAUDE.md`; there is no code path to test. `pre-commit run
--all-files` passes clean.

## Reviewer Notes

- Placement is deliberate: **Opening a Pull Request** sits immediately before **Code Review**, so
  authoring guidance precedes review guidance and follows **Code Linting**, the other pre-submit step.
- Both rules are stated inline rather than only linked. An agent that follows the link is fine
  either way; one that skims is not, and skimming is the failure mode this fixes.
- Wording is copied in substance from `CONTRIBUTING.md` so the two cannot drift into disagreement.
  If you would rather `CLAUDE.md` only link out, say so and I will cut it down to the pointer.
- This PR fills in the default template, which felt like the minimum bar for a change about
  filling in the default template.

<sub>Authored with AI assistance (Claude Code); the gap was found while screening recent PRs.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for opening pull requests, including following contribution rules, preserving the default template, and documenting reproducible benchmark results.
  * Clarified that pull request titles and descriptions become the squash-merge commit message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->