### PR TITLE
test: skip MonoMoE on GPUs with fewer than 128 SMs

### DIFF
--- a/tests/moe/test_monomoe.py
+++ b/tests/moe/test_monomoe.py
@@ -18,6 +18,7 @@ from flashinfer.fused_moe import alloc_scratchpad, has_monomoe, mono_moe
 from flashinfer.utils import is_sm90a_supported
 
 BLOCK = 128
+_MONOMOE_GRID_SIZE = 128
 
 
 # ── Block-FP8 quantization / reference helpers (inlined) ─────────────────────
@@ -160,6 +161,12 @@ def _run_and_compare(x, logits, weights, N, K, top_k, scratchpad=None):
 def _require_monomoe(dev):
     if not is_sm90a_supported(dev):
         pytest.skip("monomoe requires SM90a (Hopper)")
+    sm_count = torch.cuda.get_device_properties(dev).multi_processor_count
+    if sm_count < _MONOMOE_GRID_SIZE:
+        pytest.skip(
+            "monomoe requires at least "
+            f"{_MONOMOE_GRID_SIZE} SMs for co-residency; got {sm_count}"
+        )
     if not has_monomoe():
         pytest.skip("monomoe unavailable for the E=256/N=512/K=2048 shape")
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

 The MonoMoE kernel uses a fixed `GRID_SIZE=128` and requires all blocks to be  co-resident to avoid deadlock. The launcher therefore requires the GPU's SM  count to be at least 128.

  Previously, `tests/moe/test_monomoe.py` only checked for SM90a support. This  allowed the tests to run on SM90a GPUs with fewer than 128 SMs, where they failed at the launcher's expected co-residency check.

  This PR updates `_require_monomoe()` to:

  - Query the target GPU's `multi_processor_count`.
  - Skip MonoMoE tests when the GPU has fewer than 128 SMs.
  - Perform the check before loading or running the kernel.

  The existing C++ runtime check remains unchanged as a safety guard for public API callers.

## 🔍 Related Issues

https://github.com/flashinfer-ai/flashinfer/issues/4953

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x]  Verified on an SM90a GPU with 114 SMs. The MonoMoE tests are now skipped with the expected co-residency requirement instead of failing in the C++ launcher.

## Reviewer Notes
`_MONOMOE_GRID_SIZE=128` mirrors the fixed kernel configuration in  `csrc/fused_moe/monomoe/src/moe_interface.h`.

  A deterministic hardware capability check uses `pytest.skip` rather than  catching the launcher exception and marking it as `xfail`. This also avoids unnecessary test-data allocation, reference computation, and JIT loading on unsupported devices.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Monomoe test requirements to skip tests on CUDA devices with fewer than 128 streaming multiprocessors.
  * Preserved existing compatibility checks for supported GPU architectures and Monomoe availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->