### PR TITLE
feat(sm120): add NVFP4 sparse MLA support for DeepSeek V4 Flash

### DIFF
--- a/benchmarks/bench_sparse_mla_nvfp4_cache.py
+++ b/benchmarks/bench_sparse_mla_nvfp4_cache.py
@@ -1,0 +1,138 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Benchmark DeepSeek-V4 NVFP4 sparse-MLA cache pack and append."""
+
+import argparse
+
+import numpy as np
+import torch
+
+from flashinfer.mla import nvfp4_quantize_append_sparse_mla_cache
+from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
+    get_sparse_mla_nvfp4_sm120_module,
+)
+from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.utils import is_sm120a_supported
+
+
+_D_LATENT = 512
+_INPUT_BYTES_PER_TOKEN = _D_LATENT * 2
+_CACHE_BYTES_PER_TOKEN = 384
+
+
+def _median_us(fn, warmup_ms, measure_ms):
+    fn()
+    torch.cuda.synchronize()
+    measurements = bench_gpu_time(
+        fn, dry_run_time_ms=warmup_ms, repeat_time_ms=measure_ms
+    )
+    return float(np.median(measurements)) * 1e3
+
+
+def bench_full_page_pack(num_pages, page_size, warmup_ms=100, measure_ms=1000):
+    latent_kv = torch.randn(
+        num_pages,
+        page_size,
+        _D_LATENT,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    cache = torch.empty(
+        num_pages,
+        1,
+        page_size,
+        _CACHE_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    module = get_sparse_mla_nvfp4_sm120_module()
+
+    def fn():
+        module.sparse_mla_sm120_nvfp4_quantize_pack(latent_kv, cache)
+
+    latency_us = _median_us(fn, warmup_ms, measure_ms)
+    num_tokens = num_pages * page_size
+    traffic_bytes = num_tokens * (_INPUT_BYTES_PER_TOKEN + _CACHE_BYTES_PER_TOKEN)
+    bandwidth_gbps = traffic_bytes * 1e-3 / latency_us
+    return latency_us, bandwidth_gbps
+
+
+def bench_incremental_append(
+    num_pages, page_size, num_tokens, warmup_ms=100, measure_ms=1000
+):
+    max_tokens = num_pages * page_size
+    if num_tokens > max_tokens:
+        raise ValueError(f"num_tokens={num_tokens} exceeds cache slots={max_tokens}")
+    latent_kv = torch.randn(num_tokens, _D_LATENT, dtype=torch.bfloat16, device="cuda")
+    slots = torch.randperm(max_tokens, dtype=torch.int64, device="cuda")[:num_tokens]
+    cache = torch.empty(
+        num_pages,
+        1,
+        page_size,
+        _CACHE_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+    def fn():
+        nvfp4_quantize_append_sparse_mla_cache(latent_kv, slots, cache)
+
+    latency_us = _median_us(fn, warmup_ms, measure_ms)
+    traffic_bytes = num_tokens * (_INPUT_BYTES_PER_TOKEN + _CACHE_BYTES_PER_TOKEN)
+    bandwidth_gbps = traffic_bytes * 1e-3 / latency_us
+    return latency_us, bandwidth_gbps
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--page-size", type=int, choices=(2, 64), default=64)
+    parser.add_argument("--num-pages", type=int, default=128)
+    parser.add_argument(
+        "--append-tokens", type=int, nargs="+", default=(1, 32, 256, 8192)
+    )
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--measure-ms", type=int, default=1000)
+    args = parser.parse_args()
+
+    if not is_sm120a_supported(torch.device("cuda")):
+        raise SystemExit("NVFP4 sparse MLA requires SM120/SM121")
+
+    print("operation,page_size,num_tokens,latency_us,effective_bandwidth_gbps")
+    latency_us, bandwidth_gbps = bench_full_page_pack(
+        args.num_pages, args.page_size, args.warmup_ms, args.measure_ms
+    )
+    print(
+        f"full_pack,{args.page_size},{args.num_pages * args.page_size},"
+        f"{latency_us:.3f},{bandwidth_gbps:.3f}"
+    )
+
+    for num_tokens in args.append_tokens:
+        if num_tokens > args.num_pages * args.page_size:
+            continue
+        latency_us, bandwidth_gbps = bench_incremental_append(
+            args.num_pages,
+            args.page_size,
+            num_tokens,
+            args.warmup_ms,
+            args.measure_ms,
+        )
+        print(
+            f"append,{args.page_size},{num_tokens},{latency_us:.3f},"
+            f"{bandwidth_gbps:.3f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_sparse_mla_nvfp4_decode.py
+++ b/benchmarks/bench_sparse_mla_nvfp4_decode.py
@@ -1,0 +1,514 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paired FP8/NVFP4 DeepSeek-V4 sparse-MLA decode benchmark for SM120.
+
+The NVFP4 path includes online Q/P quantization and constructs each selected-V
+tile inside the attention CTA. Both formats start from the same BF16 Q/KV
+tensors and use the same indices.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import torch
+
+from flashinfer.mla import nvfp4_quantize_pack_sparse_mla_cache
+from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
+    get_sparse_mla_nvfp4_sm120_module,
+)
+from flashinfer.mla._sparse_mla_sm120 import sparse_mla_sm120_decode_dsv4
+from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.utils import is_sm120a_supported
+
+
+_D_LATENT = 512
+_PAGE_SIZE = 64
+
+
+def _cast_scale_inv_to_ue8m0(scales_inv: torch.Tensor) -> torch.Tensor:
+    return torch.pow(2, torch.clamp_min(scales_inv, 1e-4).log2().ceil())
+
+
+def _fp32_to_ue8m0_bytes(scale_fp32: torch.Tensor) -> torch.Tensor:
+    bits = scale_fp32.to(torch.float32).view(torch.int32)
+    return ((bits >> 23) & 0xFF).to(torch.uint8)
+
+
+def _quantize_fp8_cache(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Pack BF16 KV into the upstream DSV4 FP8 FOOTER cache ABI."""
+    d_nope, d_rope, tile_size, num_tiles = 448, 64, 64, 7
+    data_stride = d_nope + d_rope * 2
+    scale_bytes = num_tiles + 1
+    bytes_per_token = data_stride + scale_bytes
+    num_pages, page_size, num_kv_heads, dim = kv_bf16.shape
+    assert dim == _D_LATENT and num_kv_heads == 1
+    kv = kv_bf16.squeeze(2)
+    result = torch.zeros(
+        num_pages,
+        page_size * bytes_per_token,
+        dtype=torch.uint8,
+        device=kv.device,
+    )
+
+    for tile_idx in range(num_tiles):
+        tile = kv[..., tile_idx * tile_size : (tile_idx + 1) * tile_size].float()
+        amax = tile.abs().amax(dim=-1).clamp(min=1e-4)
+        scale = _cast_scale_inv_to_ue8m0(amax / 448.0)
+        fp8 = (tile / scale.unsqueeze(-1)).clamp(-448, 448).to(torch.float8_e4m3fn)
+        ue8m0 = _fp32_to_ue8m0_bytes(scale)
+        for token_idx in range(page_size):
+            data_offset = token_idx * data_stride + tile_idx * tile_size
+            result[:, data_offset : data_offset + tile_size] = fp8[:, token_idx].view(
+                torch.uint8
+            )
+            scale_offset = page_size * data_stride + token_idx * scale_bytes + tile_idx
+            result[:, scale_offset] = ue8m0[:, token_idx]
+
+    rope = kv[..., d_nope:].contiguous().view(torch.uint8)
+    rope = rope.reshape(num_pages, page_size, d_rope * 2)
+    for token_idx in range(page_size):
+        rope_offset = token_idx * data_stride + d_nope
+        result[:, rope_offset : rope_offset + d_rope * 2] = rope[:, token_idx]
+    return result.view(num_pages, page_size, 1, bytes_per_token)
+
+
+def _median_us(fn, warmup_ms: int, measure_ms: int) -> float:
+    fn()
+    torch.cuda.synchronize()
+    measurements = bench_gpu_time(
+        fn, dry_run_time_ms=warmup_ms, repeat_time_ms=measure_ms
+    )
+    return float(np.median(measurements)) * 1e3
+
+
+def _allocate_decode_scratch(
+    num_tokens: int, num_heads: int, num_splits: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    device = torch.device("cuda")
+    mid_out = torch.empty(
+        num_tokens,
+        num_heads,
+        num_splits,
+        _D_LATENT,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    mid_lse = torch.empty(
+        num_tokens, num_heads, num_splits, dtype=torch.float32, device=device
+    )
+    output = torch.empty(
+        num_tokens, num_heads, _D_LATENT, dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.empty(num_tokens, num_heads, dtype=torch.float32, device=device)
+    return mid_out, mid_lse, output, out_lse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-tokens", type=int, default=32)
+    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument("--topk", type=int, nargs="+", default=(128, 512))
+    parser.add_argument(
+        "--cpb", type=int, nargs="+", default=None, help="optional tactic subset"
+    )
+    parser.add_argument(
+        "--auto-only",
+        action="store_true",
+        help="benchmark each backend's automatic chunks-per-block tactic",
+    )
+    parser.add_argument("--num-pages", type=int, default=128)
+    parser.add_argument("--extra-topk", type=int, default=0)
+    parser.add_argument("--extra-page-size", type=int, choices=(2, 64), default=64)
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--measure-ms", type=int, default=500)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--with-lengths-sink",
+        action="store_true",
+        help=(
+            "include full top-k length tensors and an attention sink, matching "
+            "the DeepSeek-V4 serving/autotune call contract"
+        ),
+    )
+    parser.add_argument(
+        "--profile-once",
+        action="store_true",
+        help=(
+            "warm up, bracket exactly one inclusive NVFP4 decode call with "
+            "the CUDA Profiler API, and exit"
+        ),
+    )
+    parser.add_argument(
+        "--probe-prefill-kernel",
+        action="store_true",
+        help=(
+            "time the 64-head single-pass streaming prefill CTA at the "
+            "decode token count as a head-grouping diagnostic"
+        ),
+    )
+    parser.add_argument(
+        "--diagnose-splits",
+        action="store_true",
+        help="print packed partial-output validity for one explicit CPB and exit",
+    )
+    args = parser.parse_args()
+
+    if not is_sm120a_supported(torch.device("cuda")):
+        raise SystemExit("NVFP4 sparse MLA requires SM120/SM121")
+    if args.num_heads not in (16, 32, 64, 128):
+        raise SystemExit("NVFP4 decode supports 16/32/64/128 heads")
+    if args.profile_once and len(args.topk) != 1:
+        raise SystemExit("--profile-once requires exactly one --topk value")
+    if args.profile_once and args.cpb is not None and len(args.cpb) != 1:
+        raise SystemExit("--profile-once accepts at most one --cpb value")
+    if args.auto_only and args.cpb is not None:
+        raise SystemExit("--auto-only and --cpb are mutually exclusive")
+
+    torch.manual_seed(args.seed)
+    kv_bf16 = (
+        torch.randn(
+            args.num_pages,
+            _PAGE_SIZE,
+            1,
+            _D_LATENT,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(
+            args.num_tokens,
+            args.num_heads,
+            _D_LATENT,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    fp8_cache = _quantize_fp8_cache(kv_bf16)
+    nvfp4_cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16.squeeze(2))
+    fp8_extra_cache = None
+    nvfp4_extra_cache = None
+    extra_indices = None
+    if args.extra_topk > 0:
+        extra_num_pages = max(
+            args.num_pages,
+            (args.extra_topk + args.extra_page_size - 1) // args.extra_page_size,
+        )
+        extra_bf16 = (
+            torch.randn(
+                extra_num_pages,
+                args.extra_page_size,
+                1,
+                _D_LATENT,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            / 10.0
+        ).clamp(-1, 1)
+        fp8_extra_cache = _quantize_fp8_cache(extra_bf16)
+        nvfp4_extra_cache = nvfp4_quantize_pack_sparse_mla_cache(extra_bf16.squeeze(2))
+        extra_indices = torch.randint(
+            0,
+            extra_num_pages * args.extra_page_size,
+            (args.num_tokens, args.extra_topk),
+            dtype=torch.int32,
+            device="cuda",
+        )
+    nvfp4_module = get_sparse_mla_nvfp4_sm120_module()
+    sm_scale = _D_LATENT**-0.5
+    attn_sink = (
+        torch.zeros(args.num_heads, dtype=torch.float32, device="cuda")
+        if args.with_lengths_sink
+        else None
+    )
+
+    print(
+        "topk,extra_topk,extra_page_size,cpb,fp8_full_us,"
+        "nvfp4_full_us,nvfp4_stage1_us,nvfp4_merge_us,speedup_pct"
+    )
+    for topk in args.topk:
+        if topk not in (128, 512):
+            raise ValueError("the initial NVFP4 decode prototype supports topk 128/512")
+        num_splits = (topk + 63) // 64 + (args.extra_topk + 63) // 64
+        indices = torch.randint(
+            0,
+            args.num_pages * _PAGE_SIZE,
+            (args.num_tokens, topk),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        topk_length = (
+            torch.full((args.num_tokens,), topk, dtype=torch.int32, device="cuda")
+            if args.with_lengths_sink
+            else None
+        )
+        extra_topk_length = (
+            torch.full(
+                (args.num_tokens,),
+                args.extra_topk,
+                dtype=torch.int32,
+                device="cuda",
+            )
+            if args.with_lengths_sink and args.extra_topk > 0
+            else None
+        )
+        fp8_mid, fp8_mid_lse, fp8_out, fp8_lse = _allocate_decode_scratch(
+            args.num_tokens, args.num_heads, num_splits
+        )
+        nv_mid, nv_mid_lse, nv_out, nv_lse = _allocate_decode_scratch(
+            args.num_tokens, args.num_heads, num_splits
+        )
+
+        def run_nv(cpb: int, *, stage1_only: bool) -> None:
+            nvfp4_module.sparse_mla_sm120_nvfp4_decode(
+                q,
+                nvfp4_cache,
+                indices,
+                nv_mid,
+                nv_mid_lse,
+                nv_out,
+                nv_lse,
+                num_splits,
+                sm_scale,
+                topk_length,
+                attn_sink,
+                nvfp4_extra_cache,
+                extra_indices,
+                extra_topk_length,
+                cpb,
+                stage1_only,
+            )
+
+        if args.probe_prefill_kernel:
+            if args.num_heads != 64:
+                raise ValueError("--probe-prefill-kernel currently requires H=64")
+
+            def run_nv_prefill_cta() -> None:
+                nvfp4_module.sparse_mla_sm120_nvfp4_prefill(
+                    q,
+                    nvfp4_cache,
+                    indices,
+                    nv_out,
+                    nv_lse,
+                    sm_scale,
+                    None,
+                    None,
+                    nvfp4_extra_cache,
+                    extra_indices,
+                    None,
+                )
+
+            prefill_cta_us = _median_us(
+                run_nv_prefill_cta, args.warmup_ms, args.measure_ms
+            )
+            print(
+                "HEAD64_CTA_PROBE,"
+                f"tokens={args.num_tokens},topk={topk},"
+                f"extra_topk={args.extra_topk},us={prefill_cta_us:.3f}"
+            )
+            return
+
+        if args.diagnose_splits:
+            if args.cpb is None or len(args.cpb) != 1:
+                raise ValueError("--diagnose-splits requires one explicit --cpb")
+            diagnose_cpb = args.cpb[0]
+            active_splits = (num_splits + diagnose_cpb - 1) // diagnose_cpb
+            nv_mid.fill_(float("nan"))
+            nv_mid_lse.fill_(float("nan"))
+            run_nv(diagnose_cpb, stage1_only=True)
+            torch.cuda.synchronize()
+            packed_mid = nv_mid.view(-1)[
+                : (args.num_tokens * args.num_heads * active_splits * _D_LATENT)
+            ].view(args.num_tokens, args.num_heads, active_splits, _D_LATENT)
+            packed_lse = nv_mid_lse.view(-1)[
+                : (args.num_tokens * args.num_heads * active_splits)
+            ].view(args.num_tokens, args.num_heads, active_splits)
+            for head_lo in range(0, args.num_heads, 16):
+                head_hi = min(head_lo + 16, args.num_heads)
+                mid_finite = packed_mid[:, head_lo:head_hi].isfinite().float().mean()
+                lse_finite = packed_lse[:, head_lo:head_hi].isfinite().float().mean()
+                print(
+                    f"SPLIT_DIAG,heads={head_lo}:{head_hi},"
+                    f"mid_finite={mid_finite.item():.6f},"
+                    f"lse_finite={lse_finite.item():.6f},"
+                    f"lse_min={packed_lse[:, head_lo:head_hi].nan_to_num().min().item():.6g},"
+                    f"lse_max={packed_lse[:, head_lo:head_hi].nan_to_num().max().item():.6g}"
+                )
+            if nvfp4_extra_cache is not None and args.extra_page_size == 64:
+
+                def direct_section(
+                    section_cache: torch.Tensor, section_indices: torch.Tensor
+                ) -> tuple[torch.Tensor, torch.Tensor]:
+                    section_splits = (section_indices.shape[1] + 63) // 64
+                    section_mid, section_mid_lse, section_out, section_lse = (
+                        _allocate_decode_scratch(
+                            args.num_tokens, args.num_heads, section_splits
+                        )
+                    )
+                    nvfp4_module.sparse_mla_sm120_nvfp4_decode(
+                        q,
+                        section_cache,
+                        section_indices,
+                        section_mid,
+                        section_mid_lse,
+                        section_out,
+                        section_lse,
+                        section_splits,
+                        sm_scale,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                        section_splits,
+                        False,
+                    )
+                    return section_out, section_lse
+
+                if active_splits == 2:
+                    main_direct, main_direct_lse = direct_section(nvfp4_cache, indices)
+                    extra_direct, extra_direct_lse = direct_section(
+                        nvfp4_extra_cache, extra_indices
+                    )
+                    torch.cuda.synchronize()
+                    for split, direct, direct_lse in (
+                        (0, main_direct, main_direct_lse),
+                        (1, extra_direct, extra_direct_lse),
+                    ):
+                        cosine = torch.nn.functional.cosine_similarity(
+                            packed_mid[:, :, split].float(), direct.float(), dim=-1
+                        )
+                        print(
+                            f"PARTIAL_DIAG,split={split},"
+                            f"cosine={cosine.mean().item():.6g},"
+                            f"max_abs={(packed_mid[:, :, split].float() - direct.float()).abs().max().item():.6g},"
+                            f"lse_max_abs={(packed_lse[:, :, split] - direct_lse).abs().max().item():.6g}"
+                        )
+            return
+
+        cpb_values = (
+            (0,)
+            if args.auto_only
+            else args.cpb
+            if args.cpb is not None
+            else range(1, num_splits + 1)
+        )
+        if any(cpb < 0 or cpb > num_splits for cpb in cpb_values):
+            raise ValueError(f"cpb must be 0 (auto) or in [1, {num_splits}]")
+
+        if args.profile_once:
+            profile_cpb = args.cpb[0] if args.cpb is not None else 0
+            run_nv(profile_cpb, stage1_only=False)
+            torch.cuda.synchronize()
+            torch.cuda.cudart().cudaProfilerStart()
+            run_nv(profile_cpb, stage1_only=False)
+            torch.cuda.synchronize()
+            torch.cuda.cudart().cudaProfilerStop()
+            print(
+                "profiled_nvfp4_calls=1,"
+                f"tokens={args.num_tokens},heads={args.num_heads},"
+                f"topk={topk},extra_topk={args.extra_topk},"
+                f"cpb={profile_cpb if profile_cpb else 'auto'}"
+            )
+            return
+
+        best_fp8 = float("inf")
+        best_nv = float("inf")
+        best_fp8_cpb = 0
+        best_nv_cpb = 0
+        for cpb in cpb_values:
+
+            def run_fp8() -> None:
+                sparse_mla_sm120_decode_dsv4(
+                    q,
+                    fp8_cache,
+                    indices,
+                    fp8_mid,
+                    fp8_mid_lse,
+                    fp8_out,
+                    fp8_lse,
+                    sm_scale,
+                    topk_length=topk_length,
+                    attn_sink=attn_sink,
+                    chunks_per_block=cpb,
+                    extra_kv_cache=fp8_extra_cache,
+                    extra_indices=extra_indices,
+                    extra_topk_length=extra_topk_length,
+                )
+
+            def run_nv_inclusive() -> None:
+                run_nv(cpb, stage1_only=False)
+
+            def run_nv_stage1() -> None:
+                run_nv(cpb, stage1_only=True)
+
+            fp8_us = _median_us(run_fp8, args.warmup_ms, args.measure_ms)
+            inclusive_us = _median_us(run_nv_inclusive, args.warmup_ms, args.measure_ms)
+            stage1_us = _median_us(run_nv_stage1, args.warmup_ms, args.measure_ms)
+            merge_us = max(0.0, inclusive_us - stage1_us)
+            speedup_pct = (fp8_us / inclusive_us - 1.0) * 100.0
+            print(
+                f"{topk},{args.extra_topk},{args.extra_page_size},{cpb},"
+                f"{fp8_us:.3f},{inclusive_us:.3f},"
+                f"{stage1_us:.3f},{merge_us:.3f},"
+                f"{speedup_pct:.2f}"
+            )
+            if fp8_us < best_fp8:
+                best_fp8, best_fp8_cpb = fp8_us, cpb
+            if inclusive_us < best_nv:
+                best_nv, best_nv_cpb = inclusive_us, cpb
+
+        # Produce outputs once after timing and quantify the expected format
+        # delta. This is not used to select a tactic.
+        sparse_mla_sm120_decode_dsv4(
+            q,
+            fp8_cache,
+            indices,
+            fp8_mid,
+            fp8_mid_lse,
+            fp8_out,
+            fp8_lse,
+            sm_scale,
+            topk_length=topk_length,
+            attn_sink=attn_sink,
+            chunks_per_block=best_fp8_cpb,
+            extra_kv_cache=fp8_extra_cache,
+            extra_indices=extra_indices,
+            extra_topk_length=extra_topk_length,
+        )
+        run_nv(best_nv_cpb, stage1_only=False)
+        torch.cuda.synchronize()
+        delta = (nv_out.float() - fp8_out.float()).abs()
+        cosine = torch.nn.functional.cosine_similarity(
+            nv_out.float(), fp8_out.float(), dim=-1
+        )
+        print(
+            f"BEST,topk={topk},extra_topk={args.extra_topk},"
+            f"extra_page_size={args.extra_page_size},fp8_cpb={best_fp8_cpb},"
+            f"nvfp4_cpb={best_nv_cpb},"
+            f"fp8_us={best_fp8:.3f},nvfp4_us={best_nv:.3f},"
+            f"speedup_pct={(best_fp8 / best_nv - 1.0) * 100.0:.2f},"
+            f"mae={delta.mean().item():.6g},max_abs={delta.max().item():.6g},"
+            f"cosine_mean={cosine.mean().item():.6g},"
+            f"lse_max_abs={(nv_lse - fp8_lse).abs().max().item():.6g}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_sparse_mla_nvfp4_decode.py
+++ b/benchmarks/bench_sparse_mla_nvfp4_decode.py
@@ -430,9 +430,10 @@ def main() -> None:
 
         best_fp8 = float("inf")
         best_nv = float("inf")
-        best_fp8_cpb = 0
+        best_fp8_cpb = None
         best_nv_cpb = 0
         for cpb in cpb_values:
+            fp8_cpb = None if cpb == 0 else cpb
 
             def run_fp8() -> None:
                 sparse_mla_sm120_decode_dsv4(
@@ -446,7 +447,7 @@ def main() -> None:
                     sm_scale,
                     topk_length=topk_length,
                     attn_sink=attn_sink,
-                    chunks_per_block=cpb,
+                    chunks_per_block=fp8_cpb,
                     extra_kv_cache=fp8_extra_cache,
                     extra_indices=extra_indices,
                     extra_topk_length=extra_topk_length,
@@ -470,7 +471,7 @@ def main() -> None:
                 f"{speedup_pct:.2f}"
             )
             if fp8_us < best_fp8:
-                best_fp8, best_fp8_cpb = fp8_us, cpb
+                best_fp8, best_fp8_cpb = fp8_us, fp8_cpb
             if inclusive_us < best_nv:
                 best_nv, best_nv_cpb = inclusive_us, cpb
 
@@ -500,7 +501,8 @@ def main() -> None:
         )
         print(
             f"BEST,topk={topk},extra_topk={args.extra_topk},"
-            f"extra_page_size={args.extra_page_size},fp8_cpb={best_fp8_cpb},"
+            f"extra_page_size={args.extra_page_size},"
+            f"fp8_cpb={best_fp8_cpb if best_fp8_cpb is not None else 'auto'},"
             f"nvfp4_cpb={best_nv_cpb},"
             f"fp8_us={best_fp8:.3f},nvfp4_us={best_nv:.3f},"
             f"speedup_pct={(best_fp8 / best_nv - 1.0) * 100.0:.2f},"

--- a/benchmarks/bench_sparse_mla_nvfp4_planner.py
+++ b/benchmarks/bench_sparse_mla_nvfp4_planner.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calibrate and inspect the SM120 NVFP4 sparse-MLA phase planner."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+
+import torch
+
+from flashinfer.mla._sparse_mla_nvfp4_sm120_plan import (
+    _CROSSOVER_PROBED_T,
+    calibrate_nvfp4_sparse_mla_sm120,
+    plan_nvfp4_sparse_mla_sm120,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--heads", type=int, default=64)
+    parser.add_argument("--topk", type=int, default=128)
+    parser.add_argument("--extra-topk", type=int, default=512)
+    parser.add_argument("--extra-page-size", type=int, default=2)
+    parser.add_argument("--no-topk-length", action="store_true")
+    parser.add_argument("--no-extra-topk-length", action="store_true")
+    parser.add_argument("--attn-sink", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    torch.cuda.set_device(args.device)
+    device = torch.device("cuda", args.device)
+    has_topk_length = not args.no_topk_length
+    has_extra_topk_length = args.extra_topk > 0 and not args.no_extra_topk_length
+    report = calibrate_nvfp4_sparse_mla_sm120(
+        device,
+        num_heads=args.heads,
+        topk=args.topk,
+        extra_topk=args.extra_topk,
+        extra_page_size=(args.extra_page_size if args.extra_topk else 0),
+        has_topk_length=has_topk_length,
+        has_extra_topk_length=has_extra_topk_length,
+        has_attn_sink=args.attn_sink,
+        force=args.force,
+    )
+    plans = {}
+    for num_tokens in _CROSSOVER_PROBED_T:
+        planned = plan_nvfp4_sparse_mla_sm120(
+            num_tokens,
+            args.heads,
+            args.topk,
+            64,
+            device,
+            extra_topk=args.extra_topk,
+            extra_page_size=(args.extra_page_size if args.extra_topk else 0),
+            has_topk_length=has_topk_length,
+            has_extra_topk_length=has_extra_topk_length,
+            has_attn_sink=args.attn_sink,
+        )
+        plans[num_tokens] = (
+            None
+            if planned is None
+            else {"variant": planned.variant.value, "cpb": planned.cpb}
+        )
+    payload = dataclasses.asdict(report)
+    payload["plans"] = plans
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_sparse_mla_nvfp4_prefill.py
+++ b/benchmarks/bench_sparse_mla_nvfp4_prefill.py
@@ -27,7 +27,11 @@ import argparse
 import numpy as np
 import torch
 
-from bench_sparse_mla_nvfp4_decode import _quantize_fp8_cache
+if __package__:
+    from .bench_sparse_mla_nvfp4_decode import _quantize_fp8_cache
+else:
+    from bench_sparse_mla_nvfp4_decode import _quantize_fp8_cache
+
 from flashinfer.mla import nvfp4_quantize_pack_sparse_mla_cache
 from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
     get_sparse_mla_nvfp4_sm120_module,

--- a/benchmarks/bench_sparse_mla_nvfp4_prefill.py
+++ b/benchmarks/bench_sparse_mla_nvfp4_prefill.py
@@ -1,0 +1,225 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Paired FP8/NVFP4 DeepSeek-V4 sparse-MLA prefill benchmark for SM120.
+
+Both paths consume the same BF16 Q/KV source tensors and sparse indices. The
+NVFP4 headline includes selected-V transpose/requantization plus online Q/P
+quantization. The FP8 path is the upstream 32-head MG prefill kernel rather
+than the standalone split-K decode kernel.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import numpy as np
+import torch
+
+from bench_sparse_mla_nvfp4_decode import _quantize_fp8_cache
+from flashinfer.mla import nvfp4_quantize_pack_sparse_mla_cache
+from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
+    get_sparse_mla_nvfp4_sm120_module,
+)
+from flashinfer.mla._sparse_mla_sm120 import _SparseMLAPagedAttentionRunner
+from flashinfer.testing.utils import bench_gpu_time
+from flashinfer.utils import is_sm120a_supported
+
+
+_D_LATENT = 512
+_PAGE_SIZE = 64
+
+
+def _median_us(fn, warmup_ms: int, measure_ms: int) -> float:
+    fn()
+    torch.cuda.synchronize()
+    measurements = bench_gpu_time(
+        fn, dry_run_time_ms=warmup_ms, repeat_time_ms=measure_ms
+    )
+    return float(np.median(measurements)) * 1e3
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-tokens", type=int, default=128)
+    parser.add_argument("--num-heads", type=int, default=128)
+    parser.add_argument("--topk", type=int, nargs="+", default=(128, 512))
+    parser.add_argument("--num-pages", type=int, default=128)
+    parser.add_argument("--extra-topk", type=int, default=0)
+    parser.add_argument("--extra-page-size", type=int, choices=(2, 64), default=64)
+    parser.add_argument("--warmup-ms", type=int, default=100)
+    parser.add_argument("--measure-ms", type=int, default=500)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--profile-once",
+        action="store_true",
+        help=(
+            "warm up, bracket exactly one NVFP4 prefill call with the CUDA "
+            "Profiler API, and exit"
+        ),
+    )
+    args = parser.parse_args()
+
+    if not is_sm120a_supported(torch.device("cuda")):
+        raise SystemExit("NVFP4 sparse MLA requires SM120/SM121")
+    if args.num_tokens <= 64:
+        raise SystemExit("paired FP8 prefill requires --num-tokens > 64")
+    if args.num_heads not in (16, 32, 64, 128):
+        raise SystemExit("NVFP4 prefill supports 16/32/64/128 heads")
+    if args.profile_once and len(args.topk) != 1:
+        raise SystemExit("--profile-once requires exactly one --topk value")
+
+    torch.manual_seed(args.seed)
+    kv_bf16 = (
+        torch.randn(
+            args.num_pages,
+            _PAGE_SIZE,
+            1,
+            _D_LATENT,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(
+            args.num_tokens,
+            args.num_heads,
+            _D_LATENT,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    fp8_cache = _quantize_fp8_cache(kv_bf16)
+    nvfp4_cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16.squeeze(2))
+    fp8_extra_cache = None
+    nvfp4_extra_cache = None
+    extra_indices = None
+    if args.extra_topk > 0:
+        extra_num_pages = max(
+            args.num_pages,
+            (args.extra_topk + args.extra_page_size - 1) // args.extra_page_size,
+        )
+        extra_bf16 = (
+            torch.randn(
+                extra_num_pages,
+                args.extra_page_size,
+                1,
+                _D_LATENT,
+                dtype=torch.bfloat16,
+                device="cuda",
+            )
+            / 10.0
+        ).clamp(-1, 1)
+        fp8_extra_cache = _quantize_fp8_cache(extra_bf16)
+        nvfp4_extra_cache = nvfp4_quantize_pack_sparse_mla_cache(extra_bf16.squeeze(2))
+        extra_indices = torch.randint(
+            0,
+            extra_num_pages * args.extra_page_size,
+            (args.num_tokens, args.extra_topk),
+            dtype=torch.int32,
+            device="cuda",
+        )
+    nvfp4_module = get_sparse_mla_nvfp4_sm120_module()
+    fp8_runner = _SparseMLAPagedAttentionRunner(
+        max_num_tokens=args.num_tokens,
+        max_num_heads=args.num_heads,
+        device=torch.device("cuda", torch.cuda.current_device()),
+    )
+    sm_scale = _D_LATENT**-0.5
+
+    print(
+        "topk,extra_topk,extra_page_size,fp8_prefill_us,"
+        "nvfp4_streaming_us,"
+        "speedup_pct,mae,max_abs,cosine_mean,lse_max_abs"
+    )
+    for topk in args.topk:
+        if topk not in (128, 512):
+            raise ValueError("the initial NVFP4 prefill kernel supports topk 128/512")
+        indices = torch.randint(
+            0,
+            args.num_pages * _PAGE_SIZE,
+            (args.num_tokens, topk),
+            dtype=torch.int32,
+            device="cuda",
+        )
+        fp8_out = torch.empty_like(q)
+        fp8_lse = torch.empty(
+            args.num_tokens, args.num_heads, dtype=torch.float32, device="cuda"
+        )
+        nv_out = torch.empty_like(q)
+        nv_lse = torch.empty_like(fp8_lse)
+
+        def run_fp8() -> None:
+            fp8_runner.run(
+                q,
+                fp8_cache,
+                indices,
+                fp8_out,
+                sm_scale,
+                extra_kv_cache=fp8_extra_cache,
+                extra_indices=extra_indices,
+                out_lse=fp8_lse,
+            )
+
+        def run_nv() -> None:
+            nvfp4_module.sparse_mla_sm120_nvfp4_prefill(
+                q,
+                nvfp4_cache,
+                indices,
+                nv_out,
+                nv_lse,
+                sm_scale,
+                None,
+                None,
+                nvfp4_extra_cache,
+                extra_indices,
+                None,
+            )
+
+        run_nv()
+        torch.cuda.synchronize()
+        if args.profile_once:
+            torch.cuda.cudart().cudaProfilerStart()
+            run_nv()
+            torch.cuda.synchronize()
+            torch.cuda.cudart().cudaProfilerStop()
+            print(
+                "profiled_nvfp4_calls=1,"
+                f"tokens={args.num_tokens},heads={args.num_heads},"
+                f"topk={topk},extra_topk={args.extra_topk}"
+            )
+            return
+        fp8_us = _median_us(run_fp8, args.warmup_ms, args.measure_ms)
+        inclusive_us = _median_us(run_nv, args.warmup_ms, args.measure_ms)
+        run_fp8()
+        run_nv()
+        torch.cuda.synchronize()
+        delta = (nv_out.float() - fp8_out.float()).abs()
+        cosine = torch.nn.functional.cosine_similarity(
+            nv_out.float(), fp8_out.float(), dim=-1
+        )
+        print(
+            f"{topk},{args.extra_topk},{args.extra_page_size},"
+            f"{fp8_us:.3f},{inclusive_us:.3f},"
+            f"{(fp8_us / inclusive_us - 1.0) * 100.0:.2f},"
+            f"{delta.mean().item():.6g},{delta.max().item():.6g},"
+            f"{cosine.mean().item():.6g},"
+            f"{(nv_lse - fp8_lse).abs().max().item():.6g}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/sparse_mla_sm120_nvfp4_common.h
+++ b/csrc/sparse_mla_sm120_nvfp4_common.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <flashinfer/attention/sparse_mla_sm120/model/nvfp4_cache_traits.cuh>
 
 #include "tvm_ffi_utils.h"
@@ -31,7 +32,14 @@ struct PagedLayout {
 
 inline PagedLayout parse_nvfp4_paged_layout(const TensorView& cache) {
   constexpr int BPT = NVFP4CacheTraits<ModelType::DSV4>::BYTES_PER_TOKEN;
+  constexpr size_t VECTOR_ALIGNMENT = alignof(uint4);
   TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "NVFP4 kv_cache must be uint8";
+  TVM_FFI_ICHECK(cache.ndim() == 2 || cache.ndim() == 3 || cache.ndim() == 4)
+      << "kv_cache must be 2D, 3D, HND, or NHD";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(cache.data_ptr()) % VECTOR_ALIGNMENT, 0)
+      << "NVFP4 kv_cache base pointer must be " << VECTOR_ALIGNMENT << "-byte aligned";
+  TVM_FFI_ICHECK_EQ(static_cast<size_t>(cache.stride(0)) % VECTOR_ALIGNMENT, 0)
+      << "NVFP4 kv_cache page stride must be a multiple of " << VECTOR_ALIGNMENT << " bytes";
   if (cache.ndim() == 2) {
     const size_t page_bytes = static_cast<size_t>(cache.size(1));
     TVM_FFI_ICHECK_EQ(page_bytes % BPT, 0);
@@ -42,7 +50,6 @@ inline PagedLayout parse_nvfp4_paged_layout(const TensorView& cache) {
             static_cast<size_t>(cache.stride(0))};
   }
 
-  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4) << "kv_cache must be 2D, 3D, HND, or NHD";
   TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), BPT)
       << "NVFP4 cache last dimension must be " << BPT;
   int page_dim;

--- a/csrc/sparse_mla_sm120_nvfp4_common.h
+++ b/csrc/sparse_mla_sm120_nvfp4_common.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <flashinfer/attention/sparse_mla_sm120/model/nvfp4_cache_traits.cuh>
+
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+struct PagedLayout {
+  int num_pages;
+  int page_size;
+  size_t page_stride_bytes;
+};
+
+inline PagedLayout parse_nvfp4_paged_layout(const TensorView& cache) {
+  constexpr int BPT = NVFP4CacheTraits<ModelType::DSV4>::BYTES_PER_TOKEN;
+  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "NVFP4 kv_cache must be uint8";
+  if (cache.ndim() == 2) {
+    const size_t page_bytes = static_cast<size_t>(cache.size(1));
+    TVM_FFI_ICHECK_EQ(page_bytes % BPT, 0);
+    TVM_FFI_ICHECK_EQ(cache.stride(1), 1) << "kv_cache byte dimension must be contiguous";
+    TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_bytes))
+        << "kv_cache page stride is smaller than its logical payload";
+    return {static_cast<int>(cache.size(0)), static_cast<int>(page_bytes / BPT),
+            static_cast<size_t>(cache.stride(0))};
+  }
+
+  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4) << "kv_cache must be 2D, 3D, HND, or NHD";
+  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), BPT)
+      << "NVFP4 cache last dimension must be " << BPT;
+  int page_dim;
+  if (cache.ndim() == 3) {
+    page_dim = 1;
+  } else if (cache.size(1) == 1) {
+    page_dim = 2;
+  } else {
+    TVM_FFI_ICHECK_EQ(cache.size(2), 1) << "4D cache requires a singleton KV-head axis";
+    page_dim = 1;
+  }
+  const int page_size = static_cast<int>(cache.size(page_dim));
+  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1)
+      << "kv_cache byte dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), BPT)
+      << "kv_cache entries inside a page must have stride " << BPT;
+  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * BPT)
+      << "kv_cache page stride is smaller than its logical payload";
+  return {static_cast<int>(cache.size(0)), page_size, static_cast<size_t>(cache.stride(0))};
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/csrc/sparse_mla_sm120_nvfp4_decode.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_decode.cu
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_runtime.h>
+
+#include <flashinfer/attention/sparse_mla_sm120/decode_dsv4_kernel.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/prefill_dsv4_nvfp4_kernel.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Optional;
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+#define NVFP4_CUDA_CHECK(call)                                            \
+  do {                                                                    \
+    const cudaError_t status = (call);                                    \
+    TVM_FFI_ICHECK_EQ(status, cudaSuccess) << cudaGetErrorString(status); \
+  } while (0)
+
+namespace {
+
+struct PagedLayout {
+  int page_size;
+  size_t page_stride_bytes;
+};
+
+PagedLayout parse_paged_layout(const TensorView& cache) {
+  constexpr int BPT = DECODE_BYTES_PER_TOKEN;
+  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "kv_cache must be uint8";
+  if (cache.ndim() == 2) {
+    const size_t page_bytes = static_cast<size_t>(cache.size(1));
+    TVM_FFI_ICHECK_EQ(page_bytes % BPT, 0);
+    TVM_FFI_ICHECK_EQ(cache.stride(1), 1) << "kv_cache byte dimension must be contiguous";
+    TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_bytes))
+        << "kv_cache page stride is smaller than its logical payload";
+    return {static_cast<int>(page_bytes / BPT), static_cast<size_t>(cache.stride(0))};
+  }
+  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4) << "kv_cache must be 2D, 3D, HND, or NHD";
+  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), BPT)
+      << "NVFP4 cache last dimension must be " << BPT;
+  int page_dim;
+  if (cache.ndim() == 3) {
+    page_dim = 1;
+  } else if (cache.size(1) == 1) {
+    page_dim = 2;
+  } else {
+    TVM_FFI_ICHECK_EQ(cache.size(2), 1) << "4D cache requires a singleton KV-head axis";
+    page_dim = 1;
+  }
+  const int page_size = static_cast<int>(cache.size(page_dim));
+  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1)
+      << "kv_cache byte dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), BPT)
+      << "kv_cache entries inside a page must have stride " << BPT;
+  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * BPT)
+      << "kv_cache page stride is smaller than its logical payload";
+  return {page_size, static_cast<size_t>(cache.stride(0))};
+}
+
+template <int NUM_HEADS, int TOPK, int PAGE_SIZE, bool DUAL_CACHE>
+void launch_decode(const bf16* q, const uint8_t* cache, const int32_t* indices, bf16* mid_out,
+                   float* mid_lse, bf16* output, float* out_lse, const int* topk_length,
+                   const float* attn_sink, const uint8_t* extra_cache, const int32_t* extra_indices,
+                   const int* extra_topk_length, int extra_topk, int extra_page_size,
+                   size_t extra_page_stride, int num_tokens, int num_splits,
+                   int chunks_per_block_override, float sm_scale, size_t page_stride,
+                   bool stage1_only, cudaStream_t stream) {
+  constexpr bool CAN_GROUP_HEADS = NUM_HEADS >= PREFILL_HEADS_PER_CTA;
+  constexpr int GROUPED_H_BLOCKS = (NUM_HEADS + PREFILL_HEADS_PER_CTA - 1) / PREFILL_HEADS_PER_CTA;
+  constexpr int UNGROUPED_H_BLOCKS = (NUM_HEADS + HPB - 1) / HPB;
+  // Grouping amortizes the local V conversion only when both the candidate
+  // range and the grouped grid are large enough. Keep the lower-overhead
+  // 16-head kernel for short attention and the small-batch tail.
+  const bool use_grouped = CAN_GROUP_HEADS && num_splits >= 8 && num_tokens * GROUPED_H_BLOCKS >= 8;
+  const int h_blocks = use_grouped ? GROUPED_H_BLOCKS : UNGROUPED_H_BLOCKS;
+
+  int chunks_per_block = chunks_per_block_override;
+  if (chunks_per_block < 1 || chunks_per_block > num_splits) {
+    int sm_count = 0;
+    int device = 0;
+    NVFP4_CUDA_CHECK(cudaGetDevice(&device));
+    NVFP4_CUDA_CHECK(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
+    const int per_token_head = num_tokens * h_blocks;
+    // Repeating Q quantization and the CTA-local V conversion for additional
+    // split waves is materially more expensive than leaving a fraction of the
+    // final wave empty. Select the fullest grid in the minimum feasible number
+    // of waves; for the common B=8/16/32,H=64,K=640 shapes this yields
+    // cpb=1/2/4 and keeps roughly 80--96 CTAs resident in one wave.
+    const int target_waves = (per_token_head + sm_count - 1) / sm_count;
+    chunks_per_block = 1;
+    float best_gap = static_cast<float>(target_waves) + 1.f;
+    for (int cpb = 1; cpb <= num_splits; ++cpb) {
+      const int effective_splits = (num_splits + cpb - 1) / cpb;
+      const int active = per_token_head * effective_splits;
+      const int ceil_waves = (active + sm_count - 1) / sm_count;
+      if (ceil_waves != target_waves) continue;
+      const float gap = static_cast<float>(ceil_waves) -
+                        static_cast<float>(active) / static_cast<float>(sm_count);
+      if (gap < best_gap - 1e-6f || (gap < best_gap + 1e-6f && cpb > chunks_per_block)) {
+        best_gap = gap;
+        chunks_per_block = cpb;
+      }
+    }
+  }
+
+  // Only ceil(num_chunks / chunks_per_block) split CTAs perform work. Pack
+  // those partials densely at the front of the caller-provided scratch so the
+  // merge neither launches empty CTAs nor scans sentinel-only split slots.
+  const int active_splits = (num_splits + chunks_per_block - 1) / chunks_per_block;
+  const bool write_direct = !stage1_only && active_splits == 1;
+  if constexpr (CAN_GROUP_HEADS) {
+    if (use_grouped) {
+      constexpr size_t DYN_SMEM_BYTES = PrefillNVFP4Smem::SIZE;
+      auto grouped_kernel =
+          sparse_mla_prefill_dsv4_nvfp4_kernel<NUM_HEADS, TOPK, PAGE_SIZE, DUAL_CACHE>;
+      NVFP4_CUDA_CHECK(cudaFuncSetAttribute(
+          grouped_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, DYN_SMEM_BYTES));
+      grouped_kernel<<<dim3(num_tokens, GROUPED_H_BLOCKS, active_splits),
+                       dim3(PREFILL_BLOCK_THREADS), DYN_SMEM_BYTES, stream>>>(
+          q, cache, indices, output, out_lse, mid_out, mid_lse, attn_sink, topk_length, extra_cache,
+          extra_indices, extra_topk_length, extra_topk, extra_page_size, extra_page_stride,
+          num_tokens, active_splits, chunks_per_block, sm_scale, page_stride, write_direct);
+    }
+  }
+  if (!use_grouped) {
+    constexpr size_t DYN_SMEM_BYTES = DecodeNVFP4Smem<ModelType::DSV4>::SIZE;
+    auto kernel = sparse_mla_decode_dsv4_nvfp4_kernel<ModelType::DSV4, NUM_HEADS, TOPK, PAGE_SIZE,
+                                                      DUAL_CACHE>;
+    NVFP4_CUDA_CHECK(
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, DYN_SMEM_BYTES));
+    kernel<<<dim3(num_tokens, UNGROUPED_H_BLOCKS, active_splits), dim3(DECODE_BLOCK_THREADS),
+             DYN_SMEM_BYTES, stream>>>(
+        q, cache, indices, mid_out, mid_lse, output, out_lse, attn_sink, topk_length, extra_cache,
+        extra_indices, extra_topk_length, extra_topk, extra_page_size, extra_page_stride,
+        num_tokens, active_splits, chunks_per_block, sm_scale, page_stride, write_direct);
+  }
+  NVFP4_CUDA_CHECK(cudaGetLastError());
+
+  if (stage1_only || write_direct) return;
+
+  if (active_splits == 2) {
+    constexpr int MERGE_H_BLOCKS = (NUM_HEADS + HPB - 1) / HPB;
+    auto merge2_kernel = sparse_mla_decode_dsv4_nvfp4_merge2_kernel<NUM_HEADS>;
+    merge2_kernel<<<dim3(num_tokens, MERGE_H_BLOCKS), dim3(DECODE_MERGE2_THREADS), 0, stream>>>(
+        mid_out, mid_lse, output, out_lse, attn_sink, num_tokens);
+    NVFP4_CUDA_CHECK(cudaGetLastError());
+    return;
+  }
+
+  constexpr int MERGE_THREADS = 64;
+  constexpr int DIMS_PER_THREAD = 512 / MERGE_THREADS;
+  auto merge_kernel =
+      sparse_mla_decode_dsv4_merge_kernel<NUM_HEADS, 512, MERGE_THREADS, DIMS_PER_THREAD>;
+  const size_t merge_smem = static_cast<size_t>(active_splits) * sizeof(float);
+  merge_kernel<<<dim3(num_tokens, NUM_HEADS), dim3(MERGE_THREADS), merge_smem, stream>>>(
+      mid_out, mid_lse, output, out_lse, attn_sink, num_tokens, active_splits, NUM_HEADS, NUM_HEADS,
+      NUM_HEADS);
+  NVFP4_CUDA_CHECK(cudaGetLastError());
+}
+
+}  // namespace
+
+void SparseMlaSm120NVFP4Decode(TensorView q, TensorView kv_cache, TensorView indices,
+                               TensorView mid_out, TensorView mid_lse, TensorView output,
+                               TensorView out_lse, int64_t num_splits, double sm_scale,
+                               Optional<TensorView> topk_length, Optional<TensorView> attn_sink,
+                               Optional<TensorView> extra_kv_cache,
+                               Optional<TensorView> extra_indices,
+                               Optional<TensorView> extra_topk_length,
+                               int64_t chunks_per_block_override, bool stage1_only) {
+  CHECK_CUDA(q);
+  CHECK_CUDA(kv_cache);
+  CHECK_CUDA(indices);
+  CHECK_CUDA(mid_out);
+  CHECK_CUDA(mid_lse);
+  CHECK_CUDA(output);
+  CHECK_CUDA(out_lse);
+  TVM_FFI_ICHECK_EQ(q.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(q.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(q.size(2), 512);
+  TVM_FFI_ICHECK(q.IsContiguous()) << "q must be contiguous";
+  TVM_FFI_ICHECK_EQ(indices.dtype(), dl_int32);
+  TVM_FFI_ICHECK_EQ(indices.ndim(), 2);
+  TVM_FFI_ICHECK(indices.IsContiguous());
+  TVM_FFI_ICHECK_EQ(mid_out.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(mid_lse.dtype(), dl_float32);
+  TVM_FFI_ICHECK_EQ(output.dtype(), dl_bfloat16);
+  TVM_FFI_ICHECK_EQ(out_lse.dtype(), dl_float32);
+  TVM_FFI_ICHECK(mid_out.IsContiguous()) << "mid_out must be contiguous";
+  TVM_FFI_ICHECK(mid_lse.IsContiguous()) << "mid_lse must be contiguous";
+  TVM_FFI_ICHECK(output.IsContiguous()) << "output must be contiguous";
+  TVM_FFI_ICHECK(out_lse.IsContiguous()) << "out_lse must be contiguous";
+  TVM_FFI_ICHECK_GT(num_splits, 0);
+
+  const int num_tokens = static_cast<int>(q.size(0));
+  const int num_heads = static_cast<int>(q.size(1));
+  const int topk = static_cast<int>(indices.size(1));
+  TVM_FFI_ICHECK_EQ(indices.size(0), num_tokens);
+  TVM_FFI_ICHECK_GT(topk, 0);
+  TVM_FFI_ICHECK_EQ(mid_out.ndim(), 4);
+  TVM_FFI_ICHECK_EQ(mid_lse.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(output.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(output.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(output.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(output.size(2), 512);
+  TVM_FFI_ICHECK_EQ(out_lse.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(out_lse.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(out_lse.size(1), num_heads);
+  TVM_FFI_ICHECK_GE(chunks_per_block_override, 0);
+  TVM_FFI_ICHECK_LE(chunks_per_block_override, num_splits);
+
+  CHECK_DEVICE(q, kv_cache);
+  CHECK_DEVICE(q, indices);
+  CHECK_DEVICE(q, mid_out);
+  CHECK_DEVICE(q, mid_lse);
+  CHECK_DEVICE(q, output);
+  CHECK_DEVICE(q, out_lse);
+  const bool has_extra = extra_kv_cache.has_value();
+  TVM_FFI_ICHECK_EQ(has_extra, extra_indices.has_value())
+      << "extra_kv_cache and extra_indices must be provided together";
+  TVM_FFI_ICHECK(!extra_topk_length.has_value() || has_extra)
+      << "extra_topk_length requires an extra cache";
+
+  int extra_topk = 0;
+  PagedLayout extra_layout{0, 0};
+  const uint8_t* extra_cache_ptr = nullptr;
+  const int32_t* extra_indices_ptr = nullptr;
+  const int* extra_topk_length_ptr = nullptr;
+  if (has_extra) {
+    const auto& extra_cache = extra_kv_cache.value();
+    const auto& extra_idx = extra_indices.value();
+    CHECK_CUDA(extra_cache);
+    CHECK_INPUT_TYPE(extra_cache, dl_uint8);
+    CHECK_INPUT_AND_TYPE(extra_idx, dl_int32);
+    CHECK_DEVICE(q, extra_cache);
+    CHECK_DEVICE(q, extra_idx);
+    TVM_FFI_ICHECK_EQ(extra_idx.ndim(), 2);
+    TVM_FFI_ICHECK(extra_idx.IsContiguous());
+    TVM_FFI_ICHECK_EQ(extra_idx.size(0), num_tokens);
+    extra_topk = static_cast<int>(extra_idx.size(1));
+    TVM_FFI_ICHECK_GT(extra_topk, 0);
+    extra_layout = parse_paged_layout(extra_cache);
+    TVM_FFI_ICHECK(extra_layout.page_size == 2 || extra_layout.page_size == 64)
+        << "NVFP4 extra cache page_size must be 2 or 64";
+    extra_cache_ptr = static_cast<const uint8_t*>(extra_cache.data_ptr());
+    extra_indices_ptr = static_cast<const int32_t*>(extra_idx.data_ptr());
+    if (extra_topk_length.has_value()) {
+      const auto& length = extra_topk_length.value();
+      CHECK_INPUT_AND_TYPE(length, dl_int32);
+      CHECK_DEVICE(q, length);
+      TVM_FFI_ICHECK_EQ(length.ndim(), 1);
+      TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+      extra_topk_length_ptr = static_cast<const int*>(length.data_ptr());
+    }
+  }
+  const int expected_splits = (topk + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW +
+                              (extra_topk + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  TVM_FFI_ICHECK_EQ(num_splits, expected_splits);
+  const PagedLayout layout = parse_paged_layout(kv_cache);
+  TVM_FFI_ICHECK_EQ(layout.page_size, 64) << "initial NVFP4 decode supports page_size=64";
+  TVM_FFI_ICHECK_EQ(mid_out.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(mid_out.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(mid_out.size(2), num_splits);
+  TVM_FFI_ICHECK_EQ(mid_out.size(3), 512);
+  TVM_FFI_ICHECK_EQ(mid_lse.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(mid_lse.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(mid_lse.size(2), num_splits);
+
+  if (topk_length.has_value()) {
+    const auto& length = topk_length.value();
+    CHECK_INPUT_AND_TYPE(length, dl_int32);
+    CHECK_DEVICE(q, length);
+    TVM_FFI_ICHECK_EQ(length.ndim(), 1);
+    TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+  }
+  if (attn_sink.has_value()) {
+    const auto& sink = attn_sink.value();
+    CHECK_INPUT_AND_TYPE(sink, dl_float32);
+    CHECK_DEVICE(q, sink);
+    TVM_FFI_ICHECK_EQ(sink.ndim(), 1);
+    TVM_FFI_ICHECK_EQ(sink.size(0), num_heads);
+  }
+
+  if (num_tokens == 0) return;
+
+  const int* topk_length_ptr =
+      topk_length.has_value() ? static_cast<const int*>(topk_length.value().data_ptr()) : nullptr;
+  const float* attn_sink_ptr =
+      attn_sink.has_value() ? static_cast<const float*>(attn_sink.value().data_ptr()) : nullptr;
+
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
+  cudaStream_t stream = get_stream(q.device());
+#define DISPATCH_NVFP4_DECODE(H, K)                                                                \
+  if (num_heads == (H) && topk == (K)) {                                                           \
+    if (has_extra) {                                                                               \
+      launch_decode<(H), (K), 64, true>(                                                           \
+          static_cast<const bf16*>(q.data_ptr()),                                                  \
+          static_cast<const uint8_t*>(kv_cache.data_ptr()),                                        \
+          static_cast<const int32_t*>(indices.data_ptr()), static_cast<bf16*>(mid_out.data_ptr()), \
+          static_cast<float*>(mid_lse.data_ptr()), static_cast<bf16*>(output.data_ptr()),          \
+          static_cast<float*>(out_lse.data_ptr()), topk_length_ptr, attn_sink_ptr,                 \
+          extra_cache_ptr, extra_indices_ptr, extra_topk_length_ptr, extra_topk,                   \
+          extra_layout.page_size, extra_layout.page_stride_bytes, num_tokens,                      \
+          static_cast<int>(num_splits), static_cast<int>(chunks_per_block_override),               \
+          static_cast<float>(sm_scale), layout.page_stride_bytes, stage1_only, stream);            \
+    } else {                                                                                       \
+      launch_decode<(H), (K), 64, false>(                                                          \
+          static_cast<const bf16*>(q.data_ptr()),                                                  \
+          static_cast<const uint8_t*>(kv_cache.data_ptr()),                                        \
+          static_cast<const int32_t*>(indices.data_ptr()), static_cast<bf16*>(mid_out.data_ptr()), \
+          static_cast<float*>(mid_lse.data_ptr()), static_cast<bf16*>(output.data_ptr()),          \
+          static_cast<float*>(out_lse.data_ptr()), topk_length_ptr, attn_sink_ptr, nullptr,        \
+          nullptr, nullptr, 0, 0, 0, num_tokens, static_cast<int>(num_splits),                     \
+          static_cast<int>(chunks_per_block_override), static_cast<float>(sm_scale),               \
+          layout.page_stride_bytes, stage1_only, stream);                                          \
+    }                                                                                              \
+    return;                                                                                        \
+  }
+  DISPATCH_NVFP4_DECODE(16, 128)
+  DISPATCH_NVFP4_DECODE(16, 512)
+  DISPATCH_NVFP4_DECODE(32, 128)
+  DISPATCH_NVFP4_DECODE(32, 512)
+  DISPATCH_NVFP4_DECODE(64, 128)
+  DISPATCH_NVFP4_DECODE(64, 512)
+  DISPATCH_NVFP4_DECODE(128, 128)
+  DISPATCH_NVFP4_DECODE(128, 512)
+#undef DISPATCH_NVFP4_DECODE
+  TVM_FFI_ICHECK(false) << "unsupported initial NVFP4 decode shape: heads=" << num_heads
+                        << ", topk=" << topk;
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_mla_sm120_nvfp4_decode,
+                              flashinfer::sparse_mla_sm120::nvfp4::SparseMlaSm120NVFP4Decode);
+
+#undef NVFP4_CUDA_CHECK

--- a/csrc/sparse_mla_sm120_nvfp4_decode.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_decode.cu
@@ -63,8 +63,8 @@ void launch_decode(const bf16* q, const uint8_t* cache, const int32_t* indices, 
     // Repeating Q quantization and the CTA-local V conversion for additional
     // split waves is materially more expensive than leaving a fraction of the
     // final wave empty. Select the fullest grid in the minimum feasible number
-    // of waves; for the common B=8/16/32,H=64,K=640 shapes this yields
-    // cpb=1/2/4 and keeps roughly 80--96 CTAs resident in one wave.
+    // of waves; representative B=8/16/32,H=64 supported shapes select the
+    // CPB that keeps roughly 80--96 CTAs resident in one wave.
     const int target_waves = (per_token_head + sm_count - 1) / sm_count;
     chunks_per_block = 1;
     float best_gap = static_cast<float>(target_waves) + 1.f;

--- a/csrc/sparse_mla_sm120_nvfp4_decode.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_decode.cu
@@ -18,8 +18,9 @@
 
 #include <flashinfer/attention/sparse_mla_sm120/decode_dsv4_kernel.cuh>
 #include <flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh>
-#include <flashinfer/attention/sparse_mla_sm120/prefill_dsv4_nvfp4_kernel.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh>
 
+#include "sparse_mla_sm120_nvfp4_common.h"
 #include "tvm_ffi_utils.h"
 
 using tvm::ffi::Optional;
@@ -34,44 +35,6 @@ namespace flashinfer::sparse_mla_sm120::nvfp4 {
 
 namespace {
 
-struct PagedLayout {
-  int page_size;
-  size_t page_stride_bytes;
-};
-
-PagedLayout parse_paged_layout(const TensorView& cache) {
-  constexpr int BPT = DECODE_BYTES_PER_TOKEN;
-  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "kv_cache must be uint8";
-  if (cache.ndim() == 2) {
-    const size_t page_bytes = static_cast<size_t>(cache.size(1));
-    TVM_FFI_ICHECK_EQ(page_bytes % BPT, 0);
-    TVM_FFI_ICHECK_EQ(cache.stride(1), 1) << "kv_cache byte dimension must be contiguous";
-    TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_bytes))
-        << "kv_cache page stride is smaller than its logical payload";
-    return {static_cast<int>(page_bytes / BPT), static_cast<size_t>(cache.stride(0))};
-  }
-  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4) << "kv_cache must be 2D, 3D, HND, or NHD";
-  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), BPT)
-      << "NVFP4 cache last dimension must be " << BPT;
-  int page_dim;
-  if (cache.ndim() == 3) {
-    page_dim = 1;
-  } else if (cache.size(1) == 1) {
-    page_dim = 2;
-  } else {
-    TVM_FFI_ICHECK_EQ(cache.size(2), 1) << "4D cache requires a singleton KV-head axis";
-    page_dim = 1;
-  }
-  const int page_size = static_cast<int>(cache.size(page_dim));
-  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1)
-      << "kv_cache byte dimension must be contiguous";
-  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), BPT)
-      << "kv_cache entries inside a page must have stride " << BPT;
-  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * BPT)
-      << "kv_cache page stride is smaller than its logical payload";
-  return {page_size, static_cast<size_t>(cache.stride(0))};
-}
-
 template <int NUM_HEADS, int TOPK, int PAGE_SIZE, bool DUAL_CACHE>
 void launch_decode(const bf16* q, const uint8_t* cache, const int32_t* indices, bf16* mid_out,
                    float* mid_lse, bf16* output, float* out_lse, const int* topk_length,
@@ -80,8 +43,9 @@ void launch_decode(const bf16* q, const uint8_t* cache, const int32_t* indices, 
                    size_t extra_page_stride, int num_tokens, int num_splits,
                    int chunks_per_block_override, float sm_scale, size_t page_stride,
                    bool stage1_only, cudaStream_t stream) {
-  constexpr bool CAN_GROUP_HEADS = NUM_HEADS >= PREFILL_HEADS_PER_CTA;
-  constexpr int GROUPED_H_BLOCKS = (NUM_HEADS + PREFILL_HEADS_PER_CTA - 1) / PREFILL_HEADS_PER_CTA;
+  constexpr bool CAN_GROUP_HEADS = NUM_HEADS >= STREAMING_HEADS_PER_CTA;
+  constexpr int GROUPED_H_BLOCKS =
+      (NUM_HEADS + STREAMING_HEADS_PER_CTA - 1) / STREAMING_HEADS_PER_CTA;
   constexpr int UNGROUPED_H_BLOCKS = (NUM_HEADS + HPB - 1) / HPB;
   // Grouping amortizes the local V conversion only when both the candidate
   // range and the grouped grid are large enough. Keep the lower-overhead
@@ -125,13 +89,13 @@ void launch_decode(const bf16* q, const uint8_t* cache, const int32_t* indices, 
   const bool write_direct = !stage1_only && active_splits == 1;
   if constexpr (CAN_GROUP_HEADS) {
     if (use_grouped) {
-      constexpr size_t DYN_SMEM_BYTES = PrefillNVFP4Smem::SIZE;
+      constexpr size_t DYN_SMEM_BYTES = StreamingNVFP4Smem::SIZE;
       auto grouped_kernel =
-          sparse_mla_prefill_dsv4_nvfp4_kernel<NUM_HEADS, TOPK, PAGE_SIZE, DUAL_CACHE>;
+          sparse_mla_streaming_dsv4_nvfp4_kernel<NUM_HEADS, TOPK, PAGE_SIZE, DUAL_CACHE>;
       NVFP4_CUDA_CHECK(cudaFuncSetAttribute(
           grouped_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, DYN_SMEM_BYTES));
       grouped_kernel<<<dim3(num_tokens, GROUPED_H_BLOCKS, active_splits),
-                       dim3(PREFILL_BLOCK_THREADS), DYN_SMEM_BYTES, stream>>>(
+                       dim3(STREAMING_BLOCK_THREADS), DYN_SMEM_BYTES, stream>>>(
           q, cache, indices, output, out_lse, mid_out, mid_lse, attn_sink, topk_length, extra_cache,
           extra_indices, extra_topk_length, extra_topk, extra_page_size, extra_page_stride,
           num_tokens, active_splits, chunks_per_block, sm_scale, page_stride, write_direct);
@@ -237,7 +201,7 @@ void SparseMlaSm120NVFP4Decode(TensorView q, TensorView kv_cache, TensorView ind
       << "extra_topk_length requires an extra cache";
 
   int extra_topk = 0;
-  PagedLayout extra_layout{0, 0};
+  PagedLayout extra_layout{0, 0, 0};
   const uint8_t* extra_cache_ptr = nullptr;
   const int32_t* extra_indices_ptr = nullptr;
   const int* extra_topk_length_ptr = nullptr;
@@ -254,7 +218,7 @@ void SparseMlaSm120NVFP4Decode(TensorView q, TensorView kv_cache, TensorView ind
     TVM_FFI_ICHECK_EQ(extra_idx.size(0), num_tokens);
     extra_topk = static_cast<int>(extra_idx.size(1));
     TVM_FFI_ICHECK_GT(extra_topk, 0);
-    extra_layout = parse_paged_layout(extra_cache);
+    extra_layout = parse_nvfp4_paged_layout(extra_cache);
     TVM_FFI_ICHECK(extra_layout.page_size == 2 || extra_layout.page_size == 64)
         << "NVFP4 extra cache page_size must be 2 or 64";
     extra_cache_ptr = static_cast<const uint8_t*>(extra_cache.data_ptr());
@@ -271,7 +235,7 @@ void SparseMlaSm120NVFP4Decode(TensorView q, TensorView kv_cache, TensorView ind
   const int expected_splits = (topk + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW +
                               (extra_topk + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
   TVM_FFI_ICHECK_EQ(num_splits, expected_splits);
-  const PagedLayout layout = parse_paged_layout(kv_cache);
+  const PagedLayout layout = parse_nvfp4_paged_layout(kv_cache);
   TVM_FFI_ICHECK_EQ(layout.page_size, 64) << "initial NVFP4 decode supports page_size=64";
   TVM_FFI_ICHECK_EQ(mid_out.size(0), num_tokens);
   TVM_FFI_ICHECK_EQ(mid_out.size(1), num_heads);

--- a/csrc/sparse_mla_sm120_nvfp4_decode.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_decode.cu
@@ -225,10 +225,12 @@ void SparseMlaSm120NVFP4Decode(TensorView q, TensorView kv_cache, TensorView ind
     extra_indices_ptr = static_cast<const int32_t*>(extra_idx.data_ptr());
     if (extra_topk_length.has_value()) {
       const auto& length = extra_topk_length.value();
-      CHECK_INPUT_AND_TYPE(length, dl_int32);
+      CHECK_CUDA(length);
+      CHECK_INPUT_TYPE(length, dl_int32);
       CHECK_DEVICE(q, length);
       TVM_FFI_ICHECK_EQ(length.ndim(), 1);
       TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+      TVM_FFI_ICHECK(length.IsContiguous()) << "extra_topk_length must be contiguous";
       extra_topk_length_ptr = static_cast<const int*>(length.data_ptr());
     }
   }
@@ -247,17 +249,21 @@ void SparseMlaSm120NVFP4Decode(TensorView q, TensorView kv_cache, TensorView ind
 
   if (topk_length.has_value()) {
     const auto& length = topk_length.value();
-    CHECK_INPUT_AND_TYPE(length, dl_int32);
+    CHECK_CUDA(length);
+    CHECK_INPUT_TYPE(length, dl_int32);
     CHECK_DEVICE(q, length);
     TVM_FFI_ICHECK_EQ(length.ndim(), 1);
     TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+    TVM_FFI_ICHECK(length.IsContiguous()) << "topk_length must be contiguous";
   }
   if (attn_sink.has_value()) {
     const auto& sink = attn_sink.value();
-    CHECK_INPUT_AND_TYPE(sink, dl_float32);
+    CHECK_CUDA(sink);
+    CHECK_INPUT_TYPE(sink, dl_float32);
     CHECK_DEVICE(q, sink);
     TVM_FFI_ICHECK_EQ(sink.ndim(), 1);
     TVM_FFI_ICHECK_EQ(sink.size(0), num_heads);
+    TVM_FFI_ICHECK(sink.IsContiguous()) << "attn_sink must be contiguous";
   }
 
   if (num_tokens == 0) return;

--- a/csrc/sparse_mla_sm120_nvfp4_prefill.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_prefill.cu
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_runtime.h>
+
+#include <flashinfer/attention/sparse_mla_sm120/prefill_dsv4_nvfp4_kernel.cuh>
+
+#include "tvm_ffi_utils.h"
+
+using tvm::ffi::Optional;
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+#define NVFP4_PREFILL_CUDA_CHECK(call)                                    \
+  do {                                                                    \
+    const cudaError_t status = (call);                                    \
+    TVM_FFI_ICHECK_EQ(status, cudaSuccess) << cudaGetErrorString(status); \
+  } while (0)
+
+namespace {
+
+struct PagedLayout {
+  int page_size;
+  size_t page_stride_bytes;
+};
+
+PagedLayout parse_paged_layout(const TensorView& cache) {
+  constexpr int BPT = DECODE_BYTES_PER_TOKEN;
+  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "kv_cache must be uint8";
+  if (cache.ndim() == 2) {
+    const size_t page_bytes = static_cast<size_t>(cache.size(1));
+    TVM_FFI_ICHECK_EQ(page_bytes % BPT, 0);
+    TVM_FFI_ICHECK_EQ(cache.stride(1), 1) << "kv_cache byte dimension must be contiguous";
+    TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_bytes))
+        << "kv_cache page stride is smaller than its logical payload";
+    return {static_cast<int>(page_bytes / BPT), static_cast<size_t>(cache.stride(0))};
+  }
+  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4) << "kv_cache must be 2D, 3D, HND, or NHD";
+  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), BPT)
+      << "NVFP4 cache last dimension must be " << BPT;
+  int page_dim;
+  if (cache.ndim() == 3) {
+    page_dim = 1;
+  } else if (cache.size(1) == 1) {
+    page_dim = 2;
+  } else {
+    TVM_FFI_ICHECK_EQ(cache.size(2), 1) << "4D cache requires a singleton KV-head axis";
+    page_dim = 1;
+  }
+  const int page_size = static_cast<int>(cache.size(page_dim));
+  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1)
+      << "kv_cache byte dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), BPT)
+      << "kv_cache entries inside a page must have stride " << BPT;
+  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * BPT)
+      << "kv_cache page stride is smaller than its logical payload";
+  return {page_size, static_cast<size_t>(cache.stride(0))};
+}
+
+template <int NUM_HEADS, int TOPK, int PAGE_SIZE, bool DUAL_CACHE>
+void launch_prefill(const bf16* q, const uint8_t* cache, const int32_t* indices, bf16* output,
+                    float* out_lse, const int* topk_length, const float* attn_sink,
+                    const uint8_t* extra_cache, const int32_t* extra_indices,
+                    const int* extra_topk_length, int extra_topk, int extra_page_size,
+                    size_t extra_page_stride, int num_tokens, float sm_scale, size_t page_stride,
+                    cudaStream_t stream) {
+  constexpr int HEADS_PER_CTA =
+      NUM_HEADS < PREFILL_HEADS_PER_CTA ? NUM_HEADS : PREFILL_HEADS_PER_CTA;
+  constexpr int HEAD_BLOCKS = NUM_HEADS / HEADS_PER_CTA;
+  constexpr size_t DYN_SMEM_BYTES = PrefillNVFP4Smem::SIZE;
+  auto kernel = sparse_mla_prefill_dsv4_nvfp4_kernel<NUM_HEADS, TOPK, PAGE_SIZE, DUAL_CACHE>;
+  NVFP4_PREFILL_CUDA_CHECK(
+      cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, DYN_SMEM_BYTES));
+
+  kernel<<<dim3(num_tokens, HEAD_BLOCKS), dim3(PREFILL_BLOCK_THREADS), DYN_SMEM_BYTES, stream>>>(
+      q, cache, indices, output, out_lse, nullptr, nullptr, attn_sink, topk_length, extra_cache,
+      extra_indices, extra_topk_length, extra_topk, extra_page_size, extra_page_stride, num_tokens,
+      /*num_splits=*/1,
+      /*chunks_per_block=*/0, sm_scale, page_stride, /*write_direct=*/true);
+  NVFP4_PREFILL_CUDA_CHECK(cudaGetLastError());
+}
+
+}  // namespace
+
+void SparseMlaSm120NVFP4Prefill(TensorView q, TensorView kv_cache, TensorView indices,
+                                TensorView output, TensorView out_lse, double sm_scale,
+                                Optional<TensorView> topk_length, Optional<TensorView> attn_sink,
+                                Optional<TensorView> extra_kv_cache,
+                                Optional<TensorView> extra_indices,
+                                Optional<TensorView> extra_topk_length) {
+  CHECK_INPUT_AND_TYPE(q, dl_bfloat16);
+  CHECK_CUDA(kv_cache);
+  CHECK_INPUT_TYPE(kv_cache, dl_uint8);
+  CHECK_INPUT_AND_TYPE(indices, dl_int32);
+  CHECK_INPUT_AND_TYPE(output, dl_bfloat16);
+  CHECK_INPUT_AND_TYPE(out_lse, dl_float32);
+  TVM_FFI_ICHECK_EQ(q.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(q.size(2), 512);
+  TVM_FFI_ICHECK_EQ(indices.ndim(), 2);
+  TVM_FFI_ICHECK(indices.IsContiguous());
+  TVM_FFI_ICHECK(output.IsContiguous());
+  TVM_FFI_ICHECK(out_lse.IsContiguous());
+
+  CHECK_DEVICE(q, kv_cache);
+  CHECK_DEVICE(q, indices);
+  CHECK_DEVICE(q, output);
+  CHECK_DEVICE(q, out_lse);
+
+  const int num_tokens = static_cast<int>(q.size(0));
+  const int num_heads = static_cast<int>(q.size(1));
+  const int topk = static_cast<int>(indices.size(1));
+  TVM_FFI_ICHECK_GT(topk, 0);
+  const bool has_extra = extra_kv_cache.has_value();
+  TVM_FFI_ICHECK_EQ(has_extra, extra_indices.has_value())
+      << "extra_kv_cache and extra_indices must be provided together";
+  TVM_FFI_ICHECK(!extra_topk_length.has_value() || has_extra)
+      << "extra_topk_length requires an extra cache";
+
+  int extra_topk = 0;
+  PagedLayout extra_layout{0, 0};
+  const uint8_t* extra_cache_ptr = nullptr;
+  const int32_t* extra_indices_ptr = nullptr;
+  const int* extra_topk_length_ptr = nullptr;
+  if (has_extra) {
+    const auto& extra_cache = extra_kv_cache.value();
+    const auto& extra_idx = extra_indices.value();
+    CHECK_CUDA(extra_cache);
+    CHECK_INPUT_TYPE(extra_cache, dl_uint8);
+    CHECK_INPUT_AND_TYPE(extra_idx, dl_int32);
+    CHECK_DEVICE(q, extra_cache);
+    CHECK_DEVICE(q, extra_idx);
+    TVM_FFI_ICHECK_EQ(extra_idx.ndim(), 2);
+    TVM_FFI_ICHECK(extra_idx.IsContiguous());
+    TVM_FFI_ICHECK_EQ(extra_idx.size(0), num_tokens);
+    extra_topk = static_cast<int>(extra_idx.size(1));
+    TVM_FFI_ICHECK_GT(extra_topk, 0);
+    extra_layout = parse_paged_layout(extra_cache);
+    TVM_FFI_ICHECK(extra_layout.page_size == 2 || extra_layout.page_size == 64)
+        << "NVFP4 extra cache page_size must be 2 or 64";
+    extra_cache_ptr = static_cast<const uint8_t*>(extra_cache.data_ptr());
+    extra_indices_ptr = static_cast<const int32_t*>(extra_idx.data_ptr());
+    if (extra_topk_length.has_value()) {
+      const auto& length = extra_topk_length.value();
+      CHECK_INPUT_AND_TYPE(length, dl_int32);
+      CHECK_DEVICE(q, length);
+      TVM_FFI_ICHECK_EQ(length.ndim(), 1);
+      TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+      extra_topk_length_ptr = static_cast<const int*>(length.data_ptr());
+    }
+  }
+  TVM_FFI_ICHECK_EQ(indices.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(output.ndim(), 3);
+  TVM_FFI_ICHECK_EQ(output.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(output.size(1), num_heads);
+  TVM_FFI_ICHECK_EQ(output.size(2), 512);
+  TVM_FFI_ICHECK_EQ(out_lse.ndim(), 2);
+  TVM_FFI_ICHECK_EQ(out_lse.size(0), num_tokens);
+  TVM_FFI_ICHECK_EQ(out_lse.size(1), num_heads);
+
+  if (topk_length.has_value()) {
+    const auto& length = topk_length.value();
+    CHECK_INPUT_AND_TYPE(length, dl_int32);
+    CHECK_DEVICE(q, length);
+    TVM_FFI_ICHECK_EQ(length.ndim(), 1);
+    TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+  }
+  if (attn_sink.has_value()) {
+    const auto& sink = attn_sink.value();
+    CHECK_INPUT_AND_TYPE(sink, dl_float32);
+    CHECK_DEVICE(q, sink);
+    TVM_FFI_ICHECK_EQ(sink.ndim(), 1);
+    TVM_FFI_ICHECK_EQ(sink.size(0), num_heads);
+  }
+
+  const PagedLayout layout = parse_paged_layout(kv_cache);
+  TVM_FFI_ICHECK_EQ(layout.page_size, 64) << "initial NVFP4 prefill supports page_size=64";
+  const int* topk_length_ptr =
+      topk_length.has_value() ? static_cast<const int*>(topk_length.value().data_ptr()) : nullptr;
+  const float* attn_sink_ptr =
+      attn_sink.has_value() ? static_cast<const float*>(attn_sink.value().data_ptr()) : nullptr;
+
+  if (num_tokens == 0) return;
+
+  ffi::CUDADeviceGuard device_guard(q.device().device_id);
+  const cudaStream_t stream = get_stream(q.device());
+#define DISPATCH_NVFP4_PREFILL(H, K)                                                              \
+  if (num_heads == (H) && topk == (K)) {                                                          \
+    if (has_extra) {                                                                              \
+      launch_prefill<(H), (K), 64, true>(                                                         \
+          static_cast<const bf16*>(q.data_ptr()),                                                 \
+          static_cast<const uint8_t*>(kv_cache.data_ptr()),                                       \
+          static_cast<const int32_t*>(indices.data_ptr()), static_cast<bf16*>(output.data_ptr()), \
+          static_cast<float*>(out_lse.data_ptr()), topk_length_ptr, attn_sink_ptr,                \
+          extra_cache_ptr, extra_indices_ptr, extra_topk_length_ptr, extra_topk,                  \
+          extra_layout.page_size, extra_layout.page_stride_bytes, num_tokens,                     \
+          static_cast<float>(sm_scale), layout.page_stride_bytes, stream);                        \
+    } else {                                                                                      \
+      launch_prefill<(H), (K), 64, false>(                                                        \
+          static_cast<const bf16*>(q.data_ptr()),                                                 \
+          static_cast<const uint8_t*>(kv_cache.data_ptr()),                                       \
+          static_cast<const int32_t*>(indices.data_ptr()), static_cast<bf16*>(output.data_ptr()), \
+          static_cast<float*>(out_lse.data_ptr()), topk_length_ptr, attn_sink_ptr, nullptr,       \
+          nullptr, nullptr, 0, 0, 0, num_tokens, static_cast<float>(sm_scale),                    \
+          layout.page_stride_bytes, stream);                                                      \
+    }                                                                                             \
+    return;                                                                                       \
+  }
+  DISPATCH_NVFP4_PREFILL(16, 128)
+  DISPATCH_NVFP4_PREFILL(16, 512)
+  DISPATCH_NVFP4_PREFILL(32, 128)
+  DISPATCH_NVFP4_PREFILL(32, 512)
+  DISPATCH_NVFP4_PREFILL(64, 128)
+  DISPATCH_NVFP4_PREFILL(64, 512)
+  DISPATCH_NVFP4_PREFILL(128, 128)
+  DISPATCH_NVFP4_PREFILL(128, 512)
+#undef DISPATCH_NVFP4_PREFILL
+  TVM_FFI_ICHECK(false) << "unsupported initial NVFP4 prefill shape: heads=" << num_heads
+                        << ", topk=" << topk;
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_mla_sm120_nvfp4_prefill,
+                              flashinfer::sparse_mla_sm120::nvfp4::SparseMlaSm120NVFP4Prefill);
+
+#undef NVFP4_PREFILL_CUDA_CHECK

--- a/csrc/sparse_mla_sm120_nvfp4_prefill.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_prefill.cu
@@ -16,8 +16,9 @@
 
 #include <cuda_runtime.h>
 
-#include <flashinfer/attention/sparse_mla_sm120/prefill_dsv4_nvfp4_kernel.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh>
 
+#include "sparse_mla_sm120_nvfp4_common.h"
 #include "tvm_ffi_utils.h"
 
 using tvm::ffi::Optional;
@@ -32,44 +33,6 @@ namespace flashinfer::sparse_mla_sm120::nvfp4 {
 
 namespace {
 
-struct PagedLayout {
-  int page_size;
-  size_t page_stride_bytes;
-};
-
-PagedLayout parse_paged_layout(const TensorView& cache) {
-  constexpr int BPT = DECODE_BYTES_PER_TOKEN;
-  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "kv_cache must be uint8";
-  if (cache.ndim() == 2) {
-    const size_t page_bytes = static_cast<size_t>(cache.size(1));
-    TVM_FFI_ICHECK_EQ(page_bytes % BPT, 0);
-    TVM_FFI_ICHECK_EQ(cache.stride(1), 1) << "kv_cache byte dimension must be contiguous";
-    TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_bytes))
-        << "kv_cache page stride is smaller than its logical payload";
-    return {static_cast<int>(page_bytes / BPT), static_cast<size_t>(cache.stride(0))};
-  }
-  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4) << "kv_cache must be 2D, 3D, HND, or NHD";
-  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), BPT)
-      << "NVFP4 cache last dimension must be " << BPT;
-  int page_dim;
-  if (cache.ndim() == 3) {
-    page_dim = 1;
-  } else if (cache.size(1) == 1) {
-    page_dim = 2;
-  } else {
-    TVM_FFI_ICHECK_EQ(cache.size(2), 1) << "4D cache requires a singleton KV-head axis";
-    page_dim = 1;
-  }
-  const int page_size = static_cast<int>(cache.size(page_dim));
-  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1)
-      << "kv_cache byte dimension must be contiguous";
-  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), BPT)
-      << "kv_cache entries inside a page must have stride " << BPT;
-  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * BPT)
-      << "kv_cache page stride is smaller than its logical payload";
-  return {page_size, static_cast<size_t>(cache.stride(0))};
-}
-
 template <int NUM_HEADS, int TOPK, int PAGE_SIZE, bool DUAL_CACHE>
 void launch_prefill(const bf16* q, const uint8_t* cache, const int32_t* indices, bf16* output,
                     float* out_lse, const int* topk_length, const float* attn_sink,
@@ -78,14 +41,14 @@ void launch_prefill(const bf16* q, const uint8_t* cache, const int32_t* indices,
                     size_t extra_page_stride, int num_tokens, float sm_scale, size_t page_stride,
                     cudaStream_t stream) {
   constexpr int HEADS_PER_CTA =
-      NUM_HEADS < PREFILL_HEADS_PER_CTA ? NUM_HEADS : PREFILL_HEADS_PER_CTA;
+      NUM_HEADS < STREAMING_HEADS_PER_CTA ? NUM_HEADS : STREAMING_HEADS_PER_CTA;
   constexpr int HEAD_BLOCKS = NUM_HEADS / HEADS_PER_CTA;
-  constexpr size_t DYN_SMEM_BYTES = PrefillNVFP4Smem::SIZE;
-  auto kernel = sparse_mla_prefill_dsv4_nvfp4_kernel<NUM_HEADS, TOPK, PAGE_SIZE, DUAL_CACHE>;
+  constexpr size_t DYN_SMEM_BYTES = StreamingNVFP4Smem::SIZE;
+  auto kernel = sparse_mla_streaming_dsv4_nvfp4_kernel<NUM_HEADS, TOPK, PAGE_SIZE, DUAL_CACHE>;
   NVFP4_PREFILL_CUDA_CHECK(
       cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, DYN_SMEM_BYTES));
 
-  kernel<<<dim3(num_tokens, HEAD_BLOCKS), dim3(PREFILL_BLOCK_THREADS), DYN_SMEM_BYTES, stream>>>(
+  kernel<<<dim3(num_tokens, HEAD_BLOCKS), dim3(STREAMING_BLOCK_THREADS), DYN_SMEM_BYTES, stream>>>(
       q, cache, indices, output, out_lse, nullptr, nullptr, attn_sink, topk_length, extra_cache,
       extra_indices, extra_topk_length, extra_topk, extra_page_size, extra_page_stride, num_tokens,
       /*num_splits=*/1,
@@ -130,7 +93,7 @@ void SparseMlaSm120NVFP4Prefill(TensorView q, TensorView kv_cache, TensorView in
       << "extra_topk_length requires an extra cache";
 
   int extra_topk = 0;
-  PagedLayout extra_layout{0, 0};
+  PagedLayout extra_layout{0, 0, 0};
   const uint8_t* extra_cache_ptr = nullptr;
   const int32_t* extra_indices_ptr = nullptr;
   const int* extra_topk_length_ptr = nullptr;
@@ -147,7 +110,7 @@ void SparseMlaSm120NVFP4Prefill(TensorView q, TensorView kv_cache, TensorView in
     TVM_FFI_ICHECK_EQ(extra_idx.size(0), num_tokens);
     extra_topk = static_cast<int>(extra_idx.size(1));
     TVM_FFI_ICHECK_GT(extra_topk, 0);
-    extra_layout = parse_paged_layout(extra_cache);
+    extra_layout = parse_nvfp4_paged_layout(extra_cache);
     TVM_FFI_ICHECK(extra_layout.page_size == 2 || extra_layout.page_size == 64)
         << "NVFP4 extra cache page_size must be 2 or 64";
     extra_cache_ptr = static_cast<const uint8_t*>(extra_cache.data_ptr());
@@ -185,7 +148,7 @@ void SparseMlaSm120NVFP4Prefill(TensorView q, TensorView kv_cache, TensorView in
     TVM_FFI_ICHECK_EQ(sink.size(0), num_heads);
   }
 
-  const PagedLayout layout = parse_paged_layout(kv_cache);
+  const PagedLayout layout = parse_nvfp4_paged_layout(kv_cache);
   TVM_FFI_ICHECK_EQ(layout.page_size, 64) << "initial NVFP4 prefill supports page_size=64";
   const int* topk_length_ptr =
       topk_length.has_value() ? static_cast<const int*>(topk_length.value().data_ptr()) : nullptr;

--- a/csrc/sparse_mla_sm120_nvfp4_prefill.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_prefill.cu
@@ -117,10 +117,12 @@ void SparseMlaSm120NVFP4Prefill(TensorView q, TensorView kv_cache, TensorView in
     extra_indices_ptr = static_cast<const int32_t*>(extra_idx.data_ptr());
     if (extra_topk_length.has_value()) {
       const auto& length = extra_topk_length.value();
-      CHECK_INPUT_AND_TYPE(length, dl_int32);
+      CHECK_CUDA(length);
+      CHECK_INPUT_TYPE(length, dl_int32);
       CHECK_DEVICE(q, length);
       TVM_FFI_ICHECK_EQ(length.ndim(), 1);
       TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+      TVM_FFI_ICHECK(length.IsContiguous()) << "extra_topk_length must be contiguous";
       extra_topk_length_ptr = static_cast<const int*>(length.data_ptr());
     }
   }
@@ -135,17 +137,21 @@ void SparseMlaSm120NVFP4Prefill(TensorView q, TensorView kv_cache, TensorView in
 
   if (topk_length.has_value()) {
     const auto& length = topk_length.value();
-    CHECK_INPUT_AND_TYPE(length, dl_int32);
+    CHECK_CUDA(length);
+    CHECK_INPUT_TYPE(length, dl_int32);
     CHECK_DEVICE(q, length);
     TVM_FFI_ICHECK_EQ(length.ndim(), 1);
     TVM_FFI_ICHECK_EQ(length.size(0), num_tokens);
+    TVM_FFI_ICHECK(length.IsContiguous()) << "topk_length must be contiguous";
   }
   if (attn_sink.has_value()) {
     const auto& sink = attn_sink.value();
-    CHECK_INPUT_AND_TYPE(sink, dl_float32);
+    CHECK_CUDA(sink);
+    CHECK_INPUT_TYPE(sink, dl_float32);
     CHECK_DEVICE(q, sink);
     TVM_FFI_ICHECK_EQ(sink.ndim(), 1);
     TVM_FFI_ICHECK_EQ(sink.size(0), num_heads);
+    TVM_FFI_ICHECK(sink.IsContiguous()) << "attn_sink must be contiguous";
   }
 
   const PagedLayout layout = parse_nvfp4_paged_layout(kv_cache);

--- a/csrc/sparse_mla_sm120_nvfp4_quant.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_quant.cu
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Quantize DeepSeek-V4 latent KV into the paged cache layout consumed by the
+// SM120 NVFP4 sparse-MLA kernels. The E2M1 conversion intentionally uses the
+// same FlashInfer PTX helper as the dense SM120 NVFP4 attention quantizer.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <flashinfer/math.cuh>
+
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+constexpr int kDNope = 448;
+constexpr int kDRope = 64;
+constexpr int kDLatent = kDNope + kDRope;
+constexpr int kSFVecSize = 16;
+constexpr int kNumScaleGroups = kDNope / kSFVecSize;
+constexpr int kPackedNopeBytes = kDNope / 2;
+constexpr int kRopeBytes = kDRope * sizeof(__nv_bfloat16);
+constexpr int kDataBytesPerToken = kPackedNopeBytes + kRopeBytes;
+constexpr int kScaleBytesPerToken = 32;
+constexpr int kBytesPerToken = kDataBytesPerToken + kScaleBytesPerToken;
+constexpr int kThreadsPerToken = 32;
+
+static_assert(kNumScaleGroups == 28);
+static_assert(kPackedNopeBytes == 224);
+static_assert(kDataBytesPerToken == 352);
+static_assert(kBytesPerToken == 384);
+
+template <typename T>
+__device__ __forceinline__ float to_float(T value);
+
+template <>
+__device__ __forceinline__ float to_float<half>(half value) {
+  return __half2float(value);
+}
+
+template <>
+__device__ __forceinline__ float to_float<__nv_bfloat16>(__nv_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+template <typename T>
+__device__ __forceinline__ void quantize_nope_group(const T* input, uint8_t* packed_output,
+                                                    uint8_t* scale_output) {
+  float values[kSFVecSize];
+  float amax = 0.0f;
+
+#pragma unroll
+  for (int i = 0; i < kSFVecSize; ++i) {
+    const float value = to_float(input[i]);
+    values[i] = value;
+    amax = fmaxf(amax, fabsf(value));
+  }
+
+  __nv_fp8_e4m3 scale_fp8 = __nv_fp8_e4m3(amax / 6.0f);
+  *scale_output = scale_fp8.__x;
+  const float scale = static_cast<float>(scale_fp8);
+  const float scale_inv = scale == 0.0f ? 0.0f : 1.0f / scale;
+
+  float normalized[kSFVecSize];
+#pragma unroll
+  for (int i = 0; i < kSFVecSize; ++i) {
+    normalized[i] = values[i] * scale_inv;
+  }
+
+  const uint2 packed = make_uint2(
+      math::fp32_vec_to_e2m1(normalized[0], normalized[1], normalized[2], normalized[3],
+                             normalized[4], normalized[5], normalized[6], normalized[7]),
+      math::fp32_vec_to_e2m1(normalized[8], normalized[9], normalized[10], normalized[11],
+                             normalized[12], normalized[13], normalized[14], normalized[15]));
+  *reinterpret_cast<uint2*>(packed_output) = packed;
+}
+
+template <typename T>
+__device__ __forceinline__ void quantize_token(const T* input, uint8_t* data_output,
+                                               uint8_t* scale_output) {
+  const int tid = threadIdx.x;
+  if (tid < kNumScaleGroups) {
+    quantize_nope_group(input + tid * kSFVecSize, data_output + tid * (kSFVecSize / 2),
+                        scale_output + tid);
+    return;
+  }
+
+  // Four threads copy 16 BF16/FP16 RoPE elements (32 bytes) each. The cache
+  // stores the source bits unchanged; the attention ABI interprets them with
+  // the same 16-bit dtype as the source model path.
+  const int rope_lane = tid - kNumScaleGroups;
+  const uint4* rope_input = reinterpret_cast<const uint4*>(input + kDNope + rope_lane * 16);
+  uint4* rope_output = reinterpret_cast<uint4*>(data_output + kPackedNopeBytes + rope_lane * 32);
+  rope_output[0] = rope_input[0];
+  rope_output[1] = rope_input[1];
+
+  if (tid == kNumScaleGroups) {
+    *reinterpret_cast<uint32_t*>(scale_output + kNumScaleGroups) = 0;
+  }
+}
+
+template <typename T>
+__global__ void QuantizePackKernel(const T* input, uint8_t* cache, int num_pages, int page_size,
+                                   size_t page_stride_bytes) {
+  const int page_idx = blockIdx.x;
+  const int entry_idx = blockIdx.y;
+  if (page_idx >= num_pages || entry_idx >= page_size) return;
+
+  const size_t token_idx = static_cast<size_t>(page_idx) * page_size + entry_idx;
+  const T* token_input = input + token_idx * kDLatent;
+  uint8_t* page = cache + static_cast<size_t>(page_idx) * page_stride_bytes;
+  uint8_t* data_output = page + static_cast<size_t>(entry_idx) * kDataBytesPerToken;
+  uint8_t* scale_output = page + static_cast<size_t>(page_size) * kDataBytesPerToken +
+                          static_cast<size_t>(entry_idx) * kScaleBytesPerToken;
+  quantize_token(token_input, data_output, scale_output);
+}
+
+template <typename T, typename IdType>
+__global__ void QuantizeAppendKernel(const T* input, const IdType* slot_mapping, int num_tokens,
+                                     uint8_t* cache, int num_pages, int page_size,
+                                     size_t page_stride_bytes) {
+  const int token_idx = blockIdx.x;
+  if (token_idx >= num_tokens) return;
+
+  const IdType slot = slot_mapping[token_idx];
+  if (slot < 0 || static_cast<size_t>(slot) >= static_cast<size_t>(num_pages) * page_size) return;
+
+  const size_t page_idx = static_cast<size_t>(slot) / page_size;
+  const size_t entry_idx = static_cast<size_t>(slot) % page_size;
+  const T* token_input = input + static_cast<size_t>(token_idx) * kDLatent;
+  uint8_t* page = cache + page_idx * page_stride_bytes;
+  uint8_t* data_output = page + entry_idx * kDataBytesPerToken;
+  uint8_t* scale_output =
+      page + static_cast<size_t>(page_size) * kDataBytesPerToken + entry_idx * kScaleBytesPerToken;
+  quantize_token(token_input, data_output, scale_output);
+}
+
+namespace {
+
+struct CacheShape {
+  int num_pages;
+  int page_size;
+  size_t page_stride_bytes;
+};
+
+CacheShape parse_cache_shape(const TensorView& cache) {
+  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4)
+      << "cache must be [num_pages, page_size, 384], HND "
+         "[num_pages, 1, page_size, 384], or NHD "
+         "[num_pages, page_size, 1, 384]";
+  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "cache must have dtype uint8";
+  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), kBytesPerToken)
+      << "cache last dimension must be " << kBytesPerToken;
+  int page_dim;
+  if (cache.ndim() == 3) {
+    page_dim = 1;
+  } else if (cache.size(1) == 1) {
+    page_dim = 2;
+  } else {
+    TVM_FFI_ICHECK_EQ(cache.size(2), 1)
+        << "cache must have a singleton latent-head dimension at axis 1 or 2";
+    page_dim = 1;
+  }
+  const int page_size = static_cast<int>(cache.size(page_dim));
+  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1) << "cache byte dimension must be contiguous";
+  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), kBytesPerToken)
+      << "cache entries inside a page must have stride " << kBytesPerToken;
+  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * kBytesPerToken)
+      << "cache page stride is smaller than its logical page payload";
+  return {static_cast<int>(cache.size(0)), page_size, static_cast<size_t>(cache.stride(0))};
+}
+
+void check_input(const TensorView& input, int expected_tokens) {
+  TVM_FFI_ICHECK(input.ndim() == 2 || input.ndim() == 3 || input.ndim() == 4)
+      << "latent_kv must be 2D, 3D, or 4D";
+  TVM_FFI_ICHECK_EQ(input.size(input.ndim() - 1), kDLatent)
+      << "latent_kv last dimension must be " << kDLatent;
+  TVM_FFI_ICHECK_EQ(input.dtype(), dl_bfloat16) << "DeepSeek-V4 latent_kv must have dtype bfloat16";
+  TVM_FFI_ICHECK(input.IsContiguous()) << "latent_kv must be contiguous";
+
+  int64_t num_tokens = 1;
+  for (int i = 0; i + 1 < input.ndim(); ++i) num_tokens *= input.size(i);
+  TVM_FFI_ICHECK_EQ(num_tokens, expected_tokens)
+      << "latent_kv contains " << num_tokens << " rows, expected " << expected_tokens;
+}
+
+}  // namespace
+
+void SparseMlaSm120NVFP4QuantizePack(TensorView latent_kv, TensorView cache) {
+  CHECK_CUDA(latent_kv);
+  CHECK_CUDA(cache);
+  TVM_FFI_ICHECK_EQ(latent_kv.device().device_id, cache.device().device_id)
+      << "latent_kv and cache must be on the same CUDA device";
+
+  const CacheShape shape = parse_cache_shape(cache);
+  check_input(latent_kv, shape.num_pages * shape.page_size);
+  if (shape.num_pages == 0 || shape.page_size == 0) return;
+  ffi::CUDADeviceGuard device_guard(latent_kv.device().device_id);
+  cudaStream_t stream = get_stream(latent_kv.device());
+  const dim3 grid(shape.num_pages, shape.page_size);
+  const dim3 block(kThreadsPerToken);
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(latent_kv.dtype(), c_type, [&] {
+    QuantizePackKernel<c_type><<<grid, block, 0, stream>>>(
+        static_cast<const c_type*>(latent_kv.data_ptr()), static_cast<uint8_t*>(cache.data_ptr()),
+        shape.num_pages, shape.page_size, shape.page_stride_bytes);
+    return true;
+  });
+  const cudaError_t status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "NVFP4 sparse-MLA full-page pack launch failed: " << cudaGetErrorString(status);
+}
+
+void SparseMlaSm120NVFP4QuantizeAppend(TensorView latent_kv, TensorView slot_mapping,
+                                       TensorView cache) {
+  CHECK_CUDA(latent_kv);
+  CHECK_CUDA(slot_mapping);
+  CHECK_CUDA(cache);
+  TVM_FFI_ICHECK_EQ(latent_kv.device().device_id, cache.device().device_id)
+      << "latent_kv and cache must be on the same CUDA device";
+  TVM_FFI_ICHECK_EQ(slot_mapping.device().device_id, cache.device().device_id)
+      << "slot_mapping and cache must be on the same CUDA device";
+  TVM_FFI_ICHECK_EQ(slot_mapping.ndim(), 1) << "slot_mapping must be 1D";
+  TVM_FFI_ICHECK(slot_mapping.dtype() == dl_int32 || slot_mapping.dtype() == dl_int64)
+      << "slot_mapping must have dtype int32 or int64";
+  TVM_FFI_ICHECK(slot_mapping.IsContiguous()) << "slot_mapping must be contiguous";
+
+  const CacheShape shape = parse_cache_shape(cache);
+  const int num_tokens = static_cast<int>(slot_mapping.size(0));
+  check_input(latent_kv, num_tokens);
+  if (num_tokens == 0) return;
+
+  ffi::CUDADeviceGuard device_guard(latent_kv.device().device_id);
+  cudaStream_t stream = get_stream(latent_kv.device());
+  const dim3 grid(num_tokens);
+  const dim3 block(kThreadsPerToken);
+
+  DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(latent_kv.dtype(), c_type, [&] {
+    if (slot_mapping.dtype() == dl_int32) {
+      QuantizeAppendKernel<c_type, int32_t>
+          <<<grid, block, 0, stream>>>(static_cast<const c_type*>(latent_kv.data_ptr()),
+                                       static_cast<const int32_t*>(slot_mapping.data_ptr()),
+                                       num_tokens, static_cast<uint8_t*>(cache.data_ptr()),
+                                       shape.num_pages, shape.page_size, shape.page_stride_bytes);
+    } else {
+      QuantizeAppendKernel<c_type, int64_t>
+          <<<grid, block, 0, stream>>>(static_cast<const c_type*>(latent_kv.data_ptr()),
+                                       static_cast<const int64_t*>(slot_mapping.data_ptr()),
+                                       num_tokens, static_cast<uint8_t*>(cache.data_ptr()),
+                                       shape.num_pages, shape.page_size, shape.page_stride_bytes);
+    }
+    return true;
+  });
+  const cudaError_t status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "NVFP4 sparse-MLA append launch failed: " << cudaGetErrorString(status);
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_mla_sm120_nvfp4_quantize_pack,
+                              flashinfer::sparse_mla_sm120::nvfp4::SparseMlaSm120NVFP4QuantizePack);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sparse_mla_sm120_nvfp4_quantize_append,
+    flashinfer::sparse_mla_sm120::nvfp4::SparseMlaSm120NVFP4QuantizeAppend);

--- a/csrc/sparse_mla_sm120_nvfp4_quant.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_quant.cu
@@ -20,90 +20,47 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
-#include <cuda_fp8.h>
 #include <cuda_runtime.h>
 
 #include <cstddef>
 #include <cstdint>
-#include <flashinfer/math.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/common/nvfp4_quantization.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/model/nvfp4_cache_traits.cuh>
 
+#include "sparse_mla_sm120_nvfp4_common.h"
 #include "tvm_ffi_utils.h"
 
 namespace flashinfer::sparse_mla_sm120::nvfp4 {
 
-constexpr int kDNope = 448;
-constexpr int kDRope = 64;
+using Cache = NVFP4CacheTraits<ModelType::DSV4>;
+
+constexpr int kDNope = Cache::D_NOPE;
+constexpr int kDRope = Cache::D_ROPE;
 constexpr int kDLatent = kDNope + kDRope;
-constexpr int kSFVecSize = 16;
-constexpr int kNumScaleGroups = kDNope / kSFVecSize;
-constexpr int kPackedNopeBytes = kDNope / 2;
-constexpr int kRopeBytes = kDRope * sizeof(__nv_bfloat16);
-constexpr int kDataBytesPerToken = kPackedNopeBytes + kRopeBytes;
-constexpr int kScaleBytesPerToken = 32;
-constexpr int kBytesPerToken = kDataBytesPerToken + kScaleBytesPerToken;
+constexpr int kNumScaleGroups = Cache::NUM_SCALES;
+constexpr int kPackedNopeBytes = Cache::PACKED_NOPE_BYTES;
+constexpr int kDataBytesPerToken = Cache::DATA_BYTES_PER_TOKEN;
+constexpr int kScaleBytesPerToken = Cache::SCALE_BYTES_PER_TOKEN;
+constexpr int kBytesPerToken = Cache::BYTES_PER_TOKEN;
 constexpr int kThreadsPerToken = 32;
 
 static_assert(kNumScaleGroups == 28);
+static_assert(Cache::SCALE_GROUP_SIZE == SF_VEC_SIZE);
 static_assert(kPackedNopeBytes == 224);
 static_assert(kDataBytesPerToken == 352);
 static_assert(kBytesPerToken == 384);
-
-template <typename T>
-__device__ __forceinline__ float to_float(T value);
-
-template <>
-__device__ __forceinline__ float to_float<half>(half value) {
-  return __half2float(value);
-}
-
-template <>
-__device__ __forceinline__ float to_float<__nv_bfloat16>(__nv_bfloat16 value) {
-  return __bfloat162float(value);
-}
-
-template <typename T>
-__device__ __forceinline__ void quantize_nope_group(const T* input, uint8_t* packed_output,
-                                                    uint8_t* scale_output) {
-  float values[kSFVecSize];
-  float amax = 0.0f;
-
-#pragma unroll
-  for (int i = 0; i < kSFVecSize; ++i) {
-    const float value = to_float(input[i]);
-    values[i] = value;
-    amax = fmaxf(amax, fabsf(value));
-  }
-
-  __nv_fp8_e4m3 scale_fp8 = __nv_fp8_e4m3(amax / 6.0f);
-  *scale_output = scale_fp8.__x;
-  const float scale = static_cast<float>(scale_fp8);
-  const float scale_inv = scale == 0.0f ? 0.0f : 1.0f / scale;
-
-  float normalized[kSFVecSize];
-#pragma unroll
-  for (int i = 0; i < kSFVecSize; ++i) {
-    normalized[i] = values[i] * scale_inv;
-  }
-
-  const uint2 packed = make_uint2(
-      math::fp32_vec_to_e2m1(normalized[0], normalized[1], normalized[2], normalized[3],
-                             normalized[4], normalized[5], normalized[6], normalized[7]),
-      math::fp32_vec_to_e2m1(normalized[8], normalized[9], normalized[10], normalized[11],
-                             normalized[12], normalized[13], normalized[14], normalized[15]));
-  *reinterpret_cast<uint2*>(packed_output) = packed;
-}
 
 template <typename T>
 __device__ __forceinline__ void quantize_token(const T* input, uint8_t* data_output,
                                                uint8_t* scale_output) {
   const int tid = threadIdx.x;
   if (tid < kNumScaleGroups) {
-    quantize_nope_group(input + tid * kSFVecSize, data_output + tid * (kSFVecSize / 2),
-                        scale_output + tid);
+    quantize_group16_to_nvfp4(input + tid * SF_VEC_SIZE, data_output + tid * FP4_PACKED_PER_GROUP,
+                              scale_output + tid);
     return;
   }
 
-  // Four threads copy 16 BF16/FP16 RoPE elements (32 bytes) each. The cache
+  // Four threads copy 16 BF16 RoPE elements (32 bytes) each. The cache
   // stores the source bits unchanged; the attention ABI interprets them with
   // the same 16-bit dtype as the source model path.
   const int rope_lane = tid - kNumScaleGroups;
@@ -155,39 +112,6 @@ __global__ void QuantizeAppendKernel(const T* input, const IdType* slot_mapping,
 
 namespace {
 
-struct CacheShape {
-  int num_pages;
-  int page_size;
-  size_t page_stride_bytes;
-};
-
-CacheShape parse_cache_shape(const TensorView& cache) {
-  TVM_FFI_ICHECK(cache.ndim() == 3 || cache.ndim() == 4)
-      << "cache must be [num_pages, page_size, 384], HND "
-         "[num_pages, 1, page_size, 384], or NHD "
-         "[num_pages, page_size, 1, 384]";
-  TVM_FFI_ICHECK_EQ(cache.dtype(), dl_uint8) << "cache must have dtype uint8";
-  TVM_FFI_ICHECK_EQ(cache.size(cache.ndim() - 1), kBytesPerToken)
-      << "cache last dimension must be " << kBytesPerToken;
-  int page_dim;
-  if (cache.ndim() == 3) {
-    page_dim = 1;
-  } else if (cache.size(1) == 1) {
-    page_dim = 2;
-  } else {
-    TVM_FFI_ICHECK_EQ(cache.size(2), 1)
-        << "cache must have a singleton latent-head dimension at axis 1 or 2";
-    page_dim = 1;
-  }
-  const int page_size = static_cast<int>(cache.size(page_dim));
-  TVM_FFI_ICHECK_EQ(cache.stride(cache.ndim() - 1), 1) << "cache byte dimension must be contiguous";
-  TVM_FFI_ICHECK_EQ(cache.stride(page_dim), kBytesPerToken)
-      << "cache entries inside a page must have stride " << kBytesPerToken;
-  TVM_FFI_ICHECK_GE(cache.stride(0), static_cast<int64_t>(page_size) * kBytesPerToken)
-      << "cache page stride is smaller than its logical page payload";
-  return {static_cast<int>(cache.size(0)), page_size, static_cast<size_t>(cache.stride(0))};
-}
-
 void check_input(const TensorView& input, int expected_tokens) {
   TVM_FFI_ICHECK(input.ndim() == 2 || input.ndim() == 3 || input.ndim() == 4)
       << "latent_kv must be 2D, 3D, or 4D";
@@ -210,7 +134,7 @@ void SparseMlaSm120NVFP4QuantizePack(TensorView latent_kv, TensorView cache) {
   TVM_FFI_ICHECK_EQ(latent_kv.device().device_id, cache.device().device_id)
       << "latent_kv and cache must be on the same CUDA device";
 
-  const CacheShape shape = parse_cache_shape(cache);
+  const PagedLayout shape = parse_nvfp4_paged_layout(cache);
   check_input(latent_kv, shape.num_pages * shape.page_size);
   if (shape.num_pages == 0 || shape.page_size == 0) return;
   ffi::CUDADeviceGuard device_guard(latent_kv.device().device_id);
@@ -243,7 +167,7 @@ void SparseMlaSm120NVFP4QuantizeAppend(TensorView latent_kv, TensorView slot_map
       << "slot_mapping must have dtype int32 or int64";
   TVM_FFI_ICHECK(slot_mapping.IsContiguous()) << "slot_mapping must be contiguous";
 
-  const CacheShape shape = parse_cache_shape(cache);
+  const PagedLayout shape = parse_nvfp4_paged_layout(cache);
   const int num_tokens = static_cast<int>(slot_mapping.size(0));
   check_input(latent_kv, num_tokens);
   if (num_tokens == 0) return;

--- a/csrc/sparse_mla_sm120_nvfp4_quant.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_quant.cu
@@ -113,12 +113,15 @@ __global__ void QuantizeAppendKernel(const T* input, const IdType* slot_mapping,
 namespace {
 
 void check_input(const TensorView& input, int expected_tokens) {
+  constexpr size_t VECTOR_ALIGNMENT = alignof(uint4);
   TVM_FFI_ICHECK(input.ndim() == 2 || input.ndim() == 3 || input.ndim() == 4)
       << "latent_kv must be 2D, 3D, or 4D";
   TVM_FFI_ICHECK_EQ(input.size(input.ndim() - 1), kDLatent)
       << "latent_kv last dimension must be " << kDLatent;
   TVM_FFI_ICHECK_EQ(input.dtype(), dl_bfloat16) << "DeepSeek-V4 latent_kv must have dtype bfloat16";
   TVM_FFI_ICHECK(input.IsContiguous()) << "latent_kv must be contiguous";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(input.data_ptr()) % VECTOR_ALIGNMENT, 0)
+      << "latent_kv base pointer must be " << VECTOR_ALIGNMENT << "-byte aligned";
 
   int64_t num_tokens = 1;
   for (int i = 0; i + 1 < input.ndim(); ++i) num_tokens *= input.size(i);

--- a/csrc/sparse_mla_sm120_nvfp4_quant.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_quant.cu
@@ -43,12 +43,15 @@ constexpr int kDataBytesPerToken = Cache::DATA_BYTES_PER_TOKEN;
 constexpr int kScaleBytesPerToken = Cache::SCALE_BYTES_PER_TOKEN;
 constexpr int kBytesPerToken = Cache::BYTES_PER_TOKEN;
 constexpr int kThreadsPerToken = 32;
+constexpr int kOwnerByteOffset = kNumScaleGroups;
+constexpr int kDuplicateScanMaxTokens = 256;
 
 static_assert(kNumScaleGroups == 28);
 static_assert(Cache::SCALE_GROUP_SIZE == SF_VEC_SIZE);
 static_assert(kPackedNopeBytes == 224);
 static_assert(kDataBytesPerToken == 352);
 static_assert(kBytesPerToken == 384);
+static_assert(kOwnerByteOffset + sizeof(uint32_t) == kScaleBytesPerToken);
 
 template <typename T>
 __device__ __forceinline__ void quantize_token(const T* input, uint8_t* data_output,
@@ -90,24 +93,121 @@ __global__ void QuantizePackKernel(const T* input, uint8_t* cache, int num_pages
   quantize_token(token_input, data_output, scale_output);
 }
 
+__device__ __forceinline__ uint8_t* append_data_output(uint8_t* cache, size_t slot, int page_size,
+                                                       size_t page_stride_bytes) {
+  const size_t page_idx = slot / page_size;
+  const size_t entry_idx = slot % page_size;
+  return cache + page_idx * page_stride_bytes + entry_idx * kDataBytesPerToken;
+}
+
+__device__ __forceinline__ uint8_t* append_scale_output(uint8_t* cache, size_t slot, int page_size,
+                                                        size_t page_stride_bytes) {
+  const size_t page_idx = slot / page_size;
+  const size_t entry_idx = slot % page_size;
+  uint8_t* page = cache + page_idx * page_stride_bytes;
+  return page + static_cast<size_t>(page_size) * kDataBytesPerToken +
+         entry_idx * kScaleBytesPerToken;
+}
+
 template <typename T, typename IdType>
-__global__ void QuantizeAppendKernel(const T* input, const IdType* slot_mapping, int num_tokens,
-                                     uint8_t* cache, int num_pages, int page_size,
-                                     size_t page_stride_bytes) {
+__global__ void QuantizeAppendFirstKernel(const T* input, const IdType* slot_mapping,
+                                          int num_tokens, uint8_t* cache, int num_pages,
+                                          int page_size, size_t page_stride_bytes) {
   const int token_idx = blockIdx.x;
   if (token_idx >= num_tokens) return;
 
   const IdType slot = slot_mapping[token_idx];
   if (slot < 0 || static_cast<size_t>(slot) >= static_cast<size_t>(num_pages) * page_size) return;
 
-  const size_t page_idx = static_cast<size_t>(slot) / page_size;
-  const size_t entry_idx = static_cast<size_t>(slot) % page_size;
+  // For the latency-sensitive decode-sized path, each warp checks whether an
+  // earlier input row owns the same slot. Only the first occurrence writes,
+  // so duplicate mappings cannot tear a cache record across CUDA blocks.
+  bool has_earlier_duplicate = false;
+  for (int prior = threadIdx.x; prior < token_idx; prior += kThreadsPerToken) {
+    has_earlier_duplicate |= slot_mapping[prior] == slot;
+  }
+  if (__any_sync(0xffffffffu, has_earlier_duplicate)) return;
+
   const T* token_input = input + static_cast<size_t>(token_idx) * kDLatent;
-  uint8_t* page = cache + page_idx * page_stride_bytes;
-  uint8_t* data_output = page + entry_idx * kDataBytesPerToken;
+  uint8_t* data_output =
+      append_data_output(cache, static_cast<size_t>(slot), page_size, page_stride_bytes);
   uint8_t* scale_output =
-      page + static_cast<size_t>(page_size) * kDataBytesPerToken + entry_idx * kScaleBytesPerToken;
+      append_scale_output(cache, static_cast<size_t>(slot), page_size, page_stride_bytes);
   quantize_token(token_input, data_output, scale_output);
+}
+
+template <typename IdType>
+__global__ void ResetAppendOwnersKernel(const IdType* slot_mapping, int num_tokens, uint8_t* cache,
+                                        int num_pages, int page_size, size_t page_stride_bytes) {
+  const int token_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (token_idx >= num_tokens) return;
+  const IdType slot = slot_mapping[token_idx];
+  if (slot < 0 || static_cast<size_t>(slot) >= static_cast<size_t>(num_pages) * page_size) return;
+  uint8_t* scale_output =
+      append_scale_output(cache, static_cast<size_t>(slot), page_size, page_stride_bytes);
+  atomicExch(reinterpret_cast<unsigned int*>(scale_output + kOwnerByteOffset), 0xffffffffu);
+}
+
+template <typename IdType>
+__global__ void ClaimAppendOwnersKernel(const IdType* slot_mapping, int num_tokens, uint8_t* cache,
+                                        int num_pages, int page_size, size_t page_stride_bytes) {
+  const int token_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (token_idx >= num_tokens) return;
+  const IdType slot = slot_mapping[token_idx];
+  if (slot < 0 || static_cast<size_t>(slot) >= static_cast<size_t>(num_pages) * page_size) return;
+  uint8_t* scale_output =
+      append_scale_output(cache, static_cast<size_t>(slot), page_size, page_stride_bytes);
+  atomicMin(reinterpret_cast<unsigned int*>(scale_output + kOwnerByteOffset),
+            static_cast<unsigned int>(token_idx));
+}
+
+template <typename T, typename IdType>
+__global__ void QuantizeAppendWinnerKernel(const T* input, const IdType* slot_mapping,
+                                           int num_tokens, uint8_t* cache, int num_pages,
+                                           int page_size, size_t page_stride_bytes) {
+  const int token_idx = blockIdx.x;
+  if (token_idx >= num_tokens) return;
+  const IdType slot = slot_mapping[token_idx];
+  if (slot < 0 || static_cast<size_t>(slot) >= static_cast<size_t>(num_pages) * page_size) return;
+
+  uint8_t* scale_output =
+      append_scale_output(cache, static_cast<size_t>(slot), page_size, page_stride_bytes);
+  const unsigned int owner =
+      *reinterpret_cast<const unsigned int*>(scale_output + kOwnerByteOffset);
+  if (owner != static_cast<unsigned int>(token_idx)) return;
+
+  const T* token_input = input + static_cast<size_t>(token_idx) * kDLatent;
+  uint8_t* data_output =
+      append_data_output(cache, static_cast<size_t>(slot), page_size, page_stride_bytes);
+  // quantize_token restores the four-byte owner scratch to the cache ABI's
+  // required zero padding after the winning row has been selected.
+  quantize_token(token_input, data_output, scale_output);
+}
+
+template <typename T, typename IdType>
+void launch_quantize_append(const T* input, const IdType* slot_mapping, int num_tokens,
+                            uint8_t* cache, int num_pages, int page_size, size_t page_stride_bytes,
+                            cudaStream_t stream) {
+  const dim3 token_grid(num_tokens);
+  const dim3 token_block(kThreadsPerToken);
+  if (num_tokens <= kDuplicateScanMaxTokens) {
+    QuantizeAppendFirstKernel<T, IdType><<<token_grid, token_block, 0, stream>>>(
+        input, slot_mapping, num_tokens, cache, num_pages, page_size, page_stride_bytes);
+    return;
+  }
+
+  // Avoid quadratic duplicate scans for large prompt appends. The cache ABI
+  // reserves four zero-padding bytes after its 28 scales; use those bytes as
+  // an owner scratch across ordered kernels, then restore them to zero.
+  constexpr int kOwnerThreads = 256;
+  const dim3 owner_grid((num_tokens + kOwnerThreads - 1) / kOwnerThreads);
+  const dim3 owner_block(kOwnerThreads);
+  ResetAppendOwnersKernel<IdType><<<owner_grid, owner_block, 0, stream>>>(
+      slot_mapping, num_tokens, cache, num_pages, page_size, page_stride_bytes);
+  ClaimAppendOwnersKernel<IdType><<<owner_grid, owner_block, 0, stream>>>(
+      slot_mapping, num_tokens, cache, num_pages, page_size, page_stride_bytes);
+  QuantizeAppendWinnerKernel<T, IdType><<<token_grid, token_block, 0, stream>>>(
+      input, slot_mapping, num_tokens, cache, num_pages, page_size, page_stride_bytes);
 }
 
 namespace {
@@ -177,22 +277,18 @@ void SparseMlaSm120NVFP4QuantizeAppend(TensorView latent_kv, TensorView slot_map
 
   ffi::CUDADeviceGuard device_guard(latent_kv.device().device_id);
   cudaStream_t stream = get_stream(latent_kv.device());
-  const dim3 grid(num_tokens);
-  const dim3 block(kThreadsPerToken);
 
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(latent_kv.dtype(), c_type, [&] {
     if (slot_mapping.dtype() == dl_int32) {
-      QuantizeAppendKernel<c_type, int32_t>
-          <<<grid, block, 0, stream>>>(static_cast<const c_type*>(latent_kv.data_ptr()),
-                                       static_cast<const int32_t*>(slot_mapping.data_ptr()),
-                                       num_tokens, static_cast<uint8_t*>(cache.data_ptr()),
-                                       shape.num_pages, shape.page_size, shape.page_stride_bytes);
+      launch_quantize_append(static_cast<const c_type*>(latent_kv.data_ptr()),
+                             static_cast<const int32_t*>(slot_mapping.data_ptr()), num_tokens,
+                             static_cast<uint8_t*>(cache.data_ptr()), shape.num_pages,
+                             shape.page_size, shape.page_stride_bytes, stream);
     } else {
-      QuantizeAppendKernel<c_type, int64_t>
-          <<<grid, block, 0, stream>>>(static_cast<const c_type*>(latent_kv.data_ptr()),
-                                       static_cast<const int64_t*>(slot_mapping.data_ptr()),
-                                       num_tokens, static_cast<uint8_t*>(cache.data_ptr()),
-                                       shape.num_pages, shape.page_size, shape.page_stride_bytes);
+      launch_quantize_append(static_cast<const c_type*>(latent_kv.data_ptr()),
+                             static_cast<const int64_t*>(slot_mapping.data_ptr()), num_tokens,
+                             static_cast<uint8_t*>(cache.data_ptr()), shape.num_pages,
+                             shape.page_size, shape.page_stride_bytes, stream);
     }
     return true;
   });

--- a/csrc/sparse_mla_sm120_nvfp4_tile.cu
+++ b/csrc/sparse_mla_sm120_nvfp4_tile.cu
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Standalone M16N32K64 NVFP4 tile used to validate the QK/PV operand and
+// scale-factor mappings before they are wired into the sparse orchestrator.
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <flashinfer/attention/sparse_mla_sm120/arch/ldmatrix_sm120.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/arch/mma_sm120_nvfp4.cuh>
+#include <flashinfer/attention/sparse_mla_sm120/common/d2_load_b_nvfp4.cuh>
+
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+constexpr int kM = 16;
+constexpr int kN = 32;
+constexpr int kK = 64;
+constexpr int kSFVecSize = 16;
+constexpr int kPackedKBytes = kK / 2;
+constexpr int kPvN = 8;
+constexpr int kPvPackedDims = kPvN / 2;
+
+__global__ void NVFP4M16N32K64Kernel(const uint8_t* a, const uint8_t* b, const uint8_t* sfa,
+                                     const uint8_t* sfb, float* output, int iterations) {
+  __shared__ __align__(16) uint8_t sm_a[kM][kPackedKBytes];
+  __shared__ __align__(16) uint8_t sm_b[kN][kPackedKBytes];
+
+  // Physical byte copies preserve both packed E2M1 nibbles and mirror the
+  // row-major shared-memory layout used by sparse MLA.
+  for (int word = threadIdx.x; word < sizeof(sm_a) / sizeof(uint32_t); word += blockDim.x) {
+    reinterpret_cast<uint32_t*>(sm_a)[word] = reinterpret_cast<const uint32_t*>(a)[word];
+  }
+  for (int word = threadIdx.x; word < sizeof(sm_b) / sizeof(uint32_t); word += blockDim.x) {
+    reinterpret_cast<uint32_t*>(sm_b)[word] = reinterpret_cast<const uint32_t*>(b)[word];
+  }
+  __syncthreads();
+
+  const int lane = threadIdx.x;
+  const int gid = lane >> 2;
+  const int tid = lane & 3;
+  const int a_scale_row = gid + (lane & 1) * 8;
+  const uint32_t scale_a =
+      *reinterpret_cast<const uint32_t*>(sfa + a_scale_row * (kK / kSFVecSize));
+
+  uint32_t a0, a1, a2, a3;
+  ldmatrix_load_A_fp8(a0, a1, a2, a3, &sm_a[0][0], kPackedKBytes, lane);
+
+#pragma unroll
+  for (int nt = 0; nt < kN / 8; ++nt) {
+    uint32_t b0, b1;
+    ldmatrix_load_B_fp8(b0, b1, &sm_b[nt * 8][0], kPackedKBytes, lane);
+    const uint32_t scale_b =
+        *reinterpret_cast<const uint32_t*>(sfb + (nt * 8 + gid) * (kK / kSFVecSize));
+    float c0 = 0.f, c1 = 0.f, c2 = 0.f, c3 = 0.f;
+    for (int iter = 0; iter < iterations; ++iter) {
+      MmaNvfp4Result r =
+          mma_nvfp4_block_scaled_m16n8k64(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, scale_a, scale_b);
+      c0 = r.d0;
+      c1 = r.d1;
+      c2 = r.d2;
+      c3 = r.d3;
+    }
+    const int column = nt * 8 + tid * 2;
+    output[gid * kN + column] = c0;
+    output[gid * kN + column + 1] = c1;
+    output[(gid + 8) * kN + column] = c2;
+    output[(gid + 8) * kN + column + 1] = c3;
+  }
+}
+
+__global__ void NVFP4M16N8K64CandidateMajorKernel(const uint8_t* a,
+                                                  const uint8_t* candidate_major_b,
+                                                  const uint8_t* sfa, const uint8_t* sfb,
+                                                  float* output, int iterations) {
+  __shared__ __align__(16) uint8_t sm_a[kM][kPackedKBytes];
+  __shared__ __align__(16) uint8_t sm_b[kK][kPvPackedDims];
+
+  for (int word = threadIdx.x; word < sizeof(sm_a) / sizeof(uint32_t); word += blockDim.x) {
+    reinterpret_cast<uint32_t*>(sm_a)[word] = reinterpret_cast<const uint32_t*>(a)[word];
+  }
+  for (int word = threadIdx.x; word < sizeof(sm_b) / sizeof(uint32_t); word += blockDim.x) {
+    reinterpret_cast<uint32_t*>(sm_b)[word] =
+        reinterpret_cast<const uint32_t*>(candidate_major_b)[word];
+  }
+  __syncthreads();
+
+  const int lane = threadIdx.x;
+  const int gid = lane >> 2;
+  const int tid = lane & 3;
+  const int a_scale_row = gid + (lane & 1) * 8;
+  const uint32_t scale_a =
+      *reinterpret_cast<const uint32_t*>(sfa + a_scale_row * (kK / kSFVecSize));
+  const uint32_t scale_b = *reinterpret_cast<const uint32_t*>(sfb + gid * (kK / kSFVecSize));
+
+  uint32_t a0, a1, a2, a3, b0, b1;
+  ldmatrix_load_A_fp8(a0, a1, a2, a3, &sm_a[0][0], kPackedKBytes, lane);
+  d2_load_b_nvfp4<kPvPackedDims>(b0, b1, &sm_b[0][0], 0, 0, lane);
+
+  float c0 = 0.f, c1 = 0.f, c2 = 0.f, c3 = 0.f;
+  for (int iter = 0; iter < iterations; ++iter) {
+    MmaNvfp4Result r =
+        mma_nvfp4_block_scaled_m16n8k64(a0, a1, a2, a3, b0, b1, c0, c1, c2, c3, scale_a, scale_b);
+    c0 = r.d0;
+    c1 = r.d1;
+    c2 = r.d2;
+    c3 = r.d3;
+  }
+  const int column = tid * 2;
+  output[gid * kPvN + column] = c0;
+  output[gid * kPvN + column + 1] = c1;
+  output[(gid + 8) * kPvN + column] = c2;
+  output[(gid + 8) * kPvN + column + 1] = c3;
+}
+
+namespace {
+
+void check_tensor_2d(const TensorView& tensor, DLDataType dtype, int rows, int columns,
+                     const char* name) {
+  CHECK_CUDA(tensor);
+  TVM_FFI_ICHECK(tensor.IsContiguous()) << name << " must be contiguous";
+  TVM_FFI_ICHECK_EQ(tensor.dtype(), dtype) << name << " has an invalid dtype";
+  TVM_FFI_ICHECK_EQ(tensor.ndim(), 2) << name << " must be 2D";
+  TVM_FFI_ICHECK_EQ(tensor.size(0), rows) << name << " row mismatch";
+  TVM_FFI_ICHECK_EQ(tensor.size(1), columns) << name << " column mismatch";
+}
+
+}  // namespace
+
+void SparseMlaSm120NVFP4M16N32K64(TensorView a, TensorView b, TensorView sfa, TensorView sfb,
+                                  TensorView output, int64_t iterations) {
+  check_tensor_2d(a, dl_uint8, kM, kK / 2, "a");
+  check_tensor_2d(b, dl_uint8, kN, kK / 2, "b");
+  check_tensor_2d(sfa, dl_float8_e4m3fn, kM, kK / kSFVecSize, "sfa");
+  check_tensor_2d(sfb, dl_float8_e4m3fn, kN, kK / kSFVecSize, "sfb");
+  check_tensor_2d(output, dl_float32, kM, kN, "output");
+  TVM_FFI_ICHECK_GT(iterations, 0) << "iterations must be positive";
+  TVM_FFI_ICHECK_LE(iterations, 1 << 20) << "iterations is unreasonably large";
+  CHECK_DEVICE(a, b);
+  CHECK_DEVICE(a, sfa);
+  CHECK_DEVICE(a, sfb);
+  CHECK_DEVICE(a, output);
+
+  ffi::CUDADeviceGuard device_guard(a.device().device_id);
+  cudaStream_t stream = get_stream(a.device());
+  NVFP4M16N32K64Kernel<<<1, 32, 0, stream>>>(
+      static_cast<const uint8_t*>(a.data_ptr()), static_cast<const uint8_t*>(b.data_ptr()),
+      static_cast<const uint8_t*>(sfa.data_ptr()), static_cast<const uint8_t*>(sfb.data_ptr()),
+      static_cast<float*>(output.data_ptr()), static_cast<int>(iterations));
+  const cudaError_t status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "NVFP4 M16N32K64 launch failed: " << cudaGetErrorString(status);
+}
+
+void SparseMlaSm120NVFP4M16N8K64CandidateMajor(TensorView a, TensorView b, TensorView sfa,
+                                               TensorView sfb, TensorView output,
+                                               int64_t iterations) {
+  check_tensor_2d(a, dl_uint8, kM, kK / 2, "a");
+  check_tensor_2d(b, dl_uint8, kK, kPvN / 2, "b");
+  check_tensor_2d(sfa, dl_float8_e4m3fn, kM, kK / kSFVecSize, "sfa");
+  check_tensor_2d(sfb, dl_float8_e4m3fn, kPvN, kK / kSFVecSize, "sfb");
+  check_tensor_2d(output, dl_float32, kM, kPvN, "output");
+  TVM_FFI_ICHECK_GT(iterations, 0) << "iterations must be positive";
+  TVM_FFI_ICHECK_LE(iterations, 1 << 20) << "iterations is unreasonably large";
+  CHECK_DEVICE(a, b);
+  CHECK_DEVICE(a, sfa);
+  CHECK_DEVICE(a, sfb);
+  CHECK_DEVICE(a, output);
+
+  ffi::CUDADeviceGuard device_guard(a.device().device_id);
+  cudaStream_t stream = get_stream(a.device());
+  NVFP4M16N8K64CandidateMajorKernel<<<1, 32, 0, stream>>>(
+      static_cast<const uint8_t*>(a.data_ptr()), static_cast<const uint8_t*>(b.data_ptr()),
+      static_cast<const uint8_t*>(sfa.data_ptr()), static_cast<const uint8_t*>(sfb.data_ptr()),
+      static_cast<float*>(output.data_ptr()), static_cast<int>(iterations));
+  const cudaError_t status = cudaGetLastError();
+  TVM_FFI_ICHECK_EQ(status, cudaSuccess)
+      << "NVFP4 candidate-major M16N8K64 launch failed: " << cudaGetErrorString(status);
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(sparse_mla_sm120_nvfp4_m16n32k64,
+                              flashinfer::sparse_mla_sm120::nvfp4::SparseMlaSm120NVFP4M16N32K64);
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    sparse_mla_sm120_nvfp4_m16n8k64_candidate_major,
+    flashinfer::sparse_mla_sm120::nvfp4::SparseMlaSm120NVFP4M16N8K64CandidateMajor);

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -259,6 +259,8 @@ PageAttention for MLA
 
     trtllm_batch_decode_with_kv_cache_mla
     trtllm_batch_decode_sparse_mla_dsv4
+    nvfp4_quantize_pack_sparse_mla_cache
+    nvfp4_quantize_append_sparse_mla_cache
     convert_compressed_page_aligned_sparse_indices_to_hca_metadata
     DSV4HCAMetadata
     xqa_batch_decode_with_kv_cache_mla

--- a/docs/api/attention.rst
+++ b/docs/api/attention.rst
@@ -266,6 +266,7 @@ PageAttention for MLA
     xqa_batch_decode_with_kv_cache_mla
     supported_sparse_mla_sm120_configs
     SparseMLASm120DecodeConfig
+    SparseMLASm120Wrapper
 
 .. note::
 

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -139,7 +139,11 @@ from .jit.mamba import (
     gen_selective_state_update_sm90_module,
 )
 from .jit.mhc import gen_mhc_module
-from .jit.mla import gen_mla_module, gen_sparse_mla_sm120_module
+from .jit.mla import (
+    gen_mla_module,
+    gen_sparse_mla_nvfp4_sm120_module,
+    gen_sparse_mla_sm120_module,
+)
 from .jit.api_log_stats import gen_api_log_stats_module
 from .jit.norm import gen_norm_module
 from .jit.rmsnorm_silu import (
@@ -967,6 +971,7 @@ def gen_all_modules(
     # Sparse-MLA paged attention for SM120 family (DSv4 + DSv3.2 / GLM5.1).
     if has_sm120 or has_sm121:
         jit_specs.append(gen_sparse_mla_sm120_module())
+        jit_specs.append(gen_sparse_mla_nvfp4_sm120_module())
 
     # Add cuDNN FMHA module
     jit_specs.append(gen_cudnn_fmha_module())

--- a/flashinfer/jit/mla.py
+++ b/flashinfer/jit/mla.py
@@ -53,3 +53,31 @@ def gen_sparse_mla_sm120_module() -> JitSpec:
         ],
         extra_cuda_cflags=nvcc_flags,
     )
+
+
+def gen_sparse_mla_nvfp4_sm120_module() -> JitSpec:
+    """DeepSeek-V4 NVFP4 sparse-MLA cache, prefill, and decode operators."""
+    nvcc_flags = current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[12]
+    )
+    return gen_jit_spec(
+        "sparse_mla_nvfp4_sm120",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_mla_sm120_nvfp4_quant.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_mla_sm120_nvfp4_decode.cu",
+            jit_env.FLASHINFER_CSRC_DIR / "sparse_mla_sm120_nvfp4_prefill.cu",
+        ],
+        extra_cuda_cflags=nvcc_flags,
+    )
+
+
+def gen_sparse_mla_nvfp4_sm120_tile_module() -> JitSpec:
+    """Internal NVFP4 sparse-MLA MMA-layout validation operators."""
+    nvcc_flags = current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[12]
+    )
+    return gen_jit_spec(
+        "sparse_mla_nvfp4_sm120_tile",
+        [jit_env.FLASHINFER_CSRC_DIR / "sparse_mla_sm120_nvfp4_tile.cu"],
+        extra_cuda_cflags=nvcc_flags,
+    )

--- a/flashinfer/mla/__init__.py
+++ b/flashinfer/mla/__init__.py
@@ -32,6 +32,13 @@ _SPARSE_MLA_SM120_LAZY_EXPORTS = frozenset(
     }
 )
 
+_SPARSE_MLA_NVFP4_SM120_LAZY_EXPORTS = frozenset(
+    {
+        "nvfp4_quantize_append_sparse_mla_cache",
+        "nvfp4_quantize_pack_sparse_mla_cache",
+    }
+)
+
 
 def __getattr__(name: str):
     """Resolve lazily-exported MLA APIs without loading their runtime at import."""
@@ -48,11 +55,20 @@ def __getattr__(name: str):
         value = getattr(_sparse_mla_sm120, name)
         globals()[name] = value
         return value
+    if name in _SPARSE_MLA_NVFP4_SM120_LAZY_EXPORTS:
+        from . import _sparse_mla_nvfp4_sm120
+
+        value = getattr(_sparse_mla_nvfp4_sm120, name)
+        globals()[name] = value
+        return value
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__():
     """Include lazily-exported names alongside the module globals."""
     return sorted(
-        set(globals()) | _PRIMS_TS_LAZY_EXPORTS | _SPARSE_MLA_SM120_LAZY_EXPORTS
+        set(globals())
+        | _PRIMS_TS_LAZY_EXPORTS
+        | _SPARSE_MLA_SM120_LAZY_EXPORTS
+        | _SPARSE_MLA_NVFP4_SM120_LAZY_EXPORTS
     )

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -285,10 +285,13 @@ def _workspace_tensor_view(
 ) -> Tuple[Optional[torch.Tensor], int]:
     if not workspace_buffer.is_contiguous():
         return None, byte_offset
-    # Element size is device independent. Avoid a CUDA allocation while
-    # partitioning caller-owned storage so this path stays graph-capture safe.
-    elem_size = torch.empty((), dtype=dtype).element_size()
-    byte_offset = ((byte_offset + elem_size - 1) // elem_size) * elem_size
+    # Keep every scratch view 16-byte aligned for vectorized kernel accesses.
+    # dtype.itemsize avoids creating a tensor on the process-wide default
+    # device while partitioning caller-owned storage during graph capture.
+    elem_size = dtype.itemsize
+    alignment = math.lcm(16, elem_size)
+    address = workspace_buffer.data_ptr() + byte_offset
+    byte_offset += (-address) % alignment
     numel = math.prod(shape)
     byte_end = byte_offset + numel * elem_size
     workspace_bytes = workspace_buffer.numel() * workspace_buffer.element_size()

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -285,9 +285,9 @@ def _workspace_tensor_view(
 ) -> Tuple[Optional[torch.Tensor], int]:
     if not workspace_buffer.is_contiguous():
         return None, byte_offset
-    elem_size = torch.empty(
-        (), dtype=dtype, device=workspace_buffer.device
-    ).element_size()
+    # Element size is device independent. Avoid a CUDA allocation while
+    # partitioning caller-owned storage so this path stays graph-capture safe.
+    elem_size = torch.empty((), dtype=dtype).element_size()
     byte_offset = ((byte_offset + elem_size - 1) // elem_size) * elem_size
     numel = math.prod(shape)
     byte_end = byte_offset + numel * elem_size
@@ -338,6 +338,194 @@ def _sparse_mla_decode_workspace(
     return mid_out, mid_lse
 
 
+_NVFP4_SPARSE_MLA_SPLIT_TILE = 64
+
+
+def _nvfp4_sparse_mla_page_size(cache: torch.Tensor) -> int:
+    """Return the paged-token dimension after public-layout normalization."""
+    if cache.ndim == 3:
+        return int(cache.shape[1])
+    if cache.ndim == 4 and cache.shape[1] == 1:
+        return int(cache.shape[2])
+    if cache.ndim == 4 and cache.shape[2] == 1:
+        return int(cache.shape[1])
+    raise ValueError(f"unsupported NVFP4 sparse MLA cache shape {tuple(cache.shape)}")
+
+
+def _nvfp4_sparse_mla_workspace(
+    workspace_buffer: torch.Tensor,
+    *,
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    extra_topk: int,
+    use_prefill: bool,
+) -> Tuple[
+    int,
+    Optional[torch.Tensor],
+    Optional[torch.Tensor],
+    torch.Tensor,
+]:
+    """Partition caller-owned scratch for allocation-free NVFP4 sparse MLA."""
+    num_splits = (
+        topk + _NVFP4_SPARSE_MLA_SPLIT_TILE - 1
+    ) // _NVFP4_SPARSE_MLA_SPLIT_TILE + (
+        extra_topk + _NVFP4_SPARSE_MLA_SPLIT_TILE - 1
+    ) // _NVFP4_SPARSE_MLA_SPLIT_TILE
+
+    workspace_bytes = workspace_buffer.numel() * workspace_buffer.element_size()
+    if use_prefill:
+        # Streaming prefill constructs selected-V tiles in CTA-local shared
+        # memory and only needs a final-LSE scratch row.
+        bytes_per_token = num_heads * 4
+    else:
+        bytes_per_token = num_heads * num_splits * (512 * 2 + 4)
+        bytes_per_token += num_heads * 4
+    max_chunk_tokens = min(num_tokens, workspace_bytes // bytes_per_token)
+    if max_chunk_tokens < 1:
+        phase = "prefill" if use_prefill else "decode"
+        raise ValueError(
+            f"NVFP4 sparse MLA {phase} requires at least {bytes_per_token} "
+            f"workspace bytes for one token, got {workspace_bytes}"
+        )
+    if max_chunk_tokens != num_tokens:
+        phase = "prefill" if use_prefill else "decode"
+        raise ValueError(
+            f"NVFP4 sparse MLA {phase} requires workspace for all query "
+            f"tokens: need {bytes_per_token * num_tokens} bytes, got "
+            f"{workspace_bytes}"
+        )
+
+    offset = 0
+    mid_out: Optional[torch.Tensor] = None
+    mid_lse: Optional[torch.Tensor] = None
+    if not use_prefill:
+        mid_out, offset = _workspace_tensor_view(
+            workspace_buffer,
+            byte_offset=offset,
+            shape=(max_chunk_tokens, num_heads, num_splits, 512),
+            dtype=torch.bfloat16,
+        )
+        mid_lse, offset = _workspace_tensor_view(
+            workspace_buffer,
+            byte_offset=offset,
+            shape=(max_chunk_tokens, num_heads, num_splits),
+            dtype=torch.float32,
+        )
+        if mid_out is None or mid_lse is None:
+            raise ValueError("NVFP4 sparse MLA decode workspace partition failed")
+
+    scratch_lse, _ = _workspace_tensor_view(
+        workspace_buffer,
+        byte_offset=offset,
+        shape=(max_chunk_tokens, num_heads),
+        dtype=torch.float32,
+    )
+    if scratch_lse is None:
+        raise ValueError("NVFP4 sparse MLA LSE workspace partition failed")
+    return max_chunk_tokens, mid_out, mid_lse, scratch_lse
+
+
+def _run_nvfp4_sparse_mla_sm120(
+    *,
+    query: torch.Tensor,
+    kv_cache: torch.Tensor,
+    workspace_buffer: torch.Tensor,
+    primary_segment: _NormalizedSparseMLASegment,
+    extra_segment: Optional[_NormalizedSparseMLASegment],
+    output: torch.Tensor,
+    output_lse: Optional[torch.Tensor],
+    sm_scale: float,
+    attn_sink: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Run the NVFP4 implementation behind the shared sparse-MLA facade."""
+    if query.dtype != torch.bfloat16 or not query.is_contiguous():
+        raise ValueError("NVFP4 sparse MLA query must be contiguous BF16")
+    num_tokens, num_heads, head_dim = query.shape
+    if head_dim != 512:
+        raise ValueError(f"NVFP4 sparse MLA requires head dim 512, got {head_dim}")
+    if num_heads not in (16, 32, 64, 128):
+        raise ValueError(
+            f"NVFP4 sparse MLA supports 16, 32, 64, or 128 query heads, got {num_heads}"
+        )
+    topk = primary_segment.indices.shape[1]
+    if topk not in (128, 512):
+        raise ValueError(
+            f"NVFP4 sparse MLA supports primary top-k 128 or 512, got {topk}"
+        )
+    extra_topk = extra_segment.indices.shape[1] if extra_segment is not None else 0
+    from ._sparse_mla_nvfp4_sm120_plan import (
+        NVFP4KernelVariant,
+        plan_nvfp4_sparse_mla_sm120,
+    )
+
+    planned = plan_nvfp4_sparse_mla_sm120(
+        num_tokens,
+        num_heads,
+        topk,
+        _nvfp4_sparse_mla_page_size(kv_cache),
+        query.device,
+        extra_topk=extra_topk,
+        extra_page_size=(
+            _nvfp4_sparse_mla_page_size(extra_segment.kv_cache)
+            if extra_segment is not None and extra_segment.kv_cache is not None
+            else 0
+        ),
+        has_topk_length=primary_segment.lengths is not None,
+        has_extra_topk_length=(
+            extra_segment is not None and extra_segment.lengths is not None
+        ),
+        has_attn_sink=attn_sink is not None,
+    )
+    if planned is None:
+        raise ValueError(
+            "no NVFP4 sparse MLA prefill or decode kernel serves "
+            f"T={num_tokens}, H={num_heads}, topk={topk}, "
+            f"extra_topk={extra_topk}"
+        )
+    use_prefill = planned.variant is NVFP4KernelVariant.PREFILL_STREAMING
+    max_chunk_tokens, mid_out, mid_lse, scratch_lse = _nvfp4_sparse_mla_workspace(
+        workspace_buffer,
+        num_tokens=num_tokens,
+        num_heads=num_heads,
+        topk=topk,
+        extra_topk=extra_topk,
+        use_prefill=use_prefill,
+    )
+    if max_chunk_tokens != num_tokens:
+        # Kept as an internal invariant even though the workspace helper
+        # currently rejects partial batches. It prevents token slicing from
+        # being reintroduced silently in this one-launch path.
+        raise RuntimeError(
+            "NVFP4 sparse MLA workspace unexpectedly truncated the batch"
+        )
+
+    from ._sparse_mla_nvfp4_sm120 import (
+        _sparse_mla_nvfp4_sm120_paged_attention,
+    )
+
+    _sparse_mla_nvfp4_sm120_paged_attention(
+        query,
+        kv_cache,
+        primary_segment.indices,
+        output,
+        output_lse if output_lse is not None else scratch_lse,
+        sm_scale,
+        topk_length=primary_segment.lengths,
+        attn_sink=attn_sink,
+        extra_kv_cache=(extra_segment.kv_cache if extra_segment is not None else None),
+        extra_indices=(extra_segment.indices if extra_segment is not None else None),
+        extra_topk_length=(
+            extra_segment.lengths if extra_segment is not None else None
+        ),
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+        use_prefill=use_prefill,
+        chunks_per_block_override=planned.cpb,
+    )
+    return output_lse
+
+
 def _trtllm_batch_decode_sparse_mla_sm120(
     query: torch.Tensor,
     kv_cache: torch.Tensor,
@@ -349,6 +537,7 @@ def _trtllm_batch_decode_sparse_mla_sm120(
     lse: Optional[torch.Tensor],
     return_lse: bool,
     kv_scale_format: str,
+    kv_cache_format: Literal["fp8", "nvfp4"] = "fp8",
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     if not is_sm12x_supported(query.device):
         raise ValueError(
@@ -383,8 +572,6 @@ def _trtllm_batch_decode_sparse_mla_sm120(
     )
     primary_segment = segments[0]
     extra_segment = segments[1] if len(segments) > 1 else None
-
-    from ._sparse_mla_sm120 import _SparseMLAPagedAttentionRunner
 
     query_flat = query.reshape(batch_size * q_len_per_request, num_heads, head_dim)
     expected_out_shape = (batch_size, q_len_per_request, num_heads, 512)
@@ -430,6 +617,32 @@ def _trtllm_batch_decode_sparse_mla_sm120(
                 )
             )
         return out
+
+    if kv_cache_format == "nvfp4":
+        if return_lse and out_lse_arg is None:
+            out_lse_arg = torch.empty(
+                flat_lse_shape, dtype=torch.float32, device=query.device
+            )
+        _run_nvfp4_sparse_mla_sm120(
+            query=query_flat,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace_buffer,
+            primary_segment=primary_segment,
+            extra_segment=extra_segment,
+            output=out_flat,
+            output_lse=out_lse_arg,
+            sm_scale=float(sm_scale),
+            attn_sink=_normalize_optional_mla_sink(sinks, "backend='sparse'"),
+        )
+        if return_lse:
+            return out, user_lse if user_lse is not None else out_lse_arg
+        return out
+    if kv_cache_format != "fp8":
+        raise ValueError(
+            f"kv_cache_format must be either 'fp8' or 'nvfp4', got {kv_cache_format!r}"
+        )
+
+    from ._sparse_mla_sm120 import _SparseMLAPagedAttentionRunner
 
     runner = _SparseMLAPagedAttentionRunner(
         max_num_tokens=query_flat.shape[0],
@@ -831,6 +1044,26 @@ def _check_sm120_dsv4_kv_cache_layout(
     return kv_cache
 
 
+def _check_nvfp4_page_strides(
+    kv_cache: torch.Tensor,
+    kv_layout: Literal["HND", "NHD"],
+    name: str,
+) -> None:
+    """Validate the 384-byte logical row inside a possibly padded page."""
+    page_dim = 1 if kv_cache.ndim == 3 or kv_layout == "NHD" else 2
+    page_size = kv_cache.shape[page_dim]
+    if kv_cache.stride(-1) != 1 or kv_cache.stride(page_dim) != 384:
+        raise ValueError(
+            f"NVFP4 {name} entries must be contiguous inside each page; "
+            f"got strides {kv_cache.stride()}"
+        )
+    if kv_cache.stride(0) < page_size * 384:
+        raise ValueError(
+            f"NVFP4 {name} page stride {kv_cache.stride(0)} is smaller than "
+            f"the logical {page_size * 384}-byte page"
+        )
+
+
 def _normalize_dsv4_topk_lens(
     topk_lens: torch.Tensor,
     batch_size: int,
@@ -1137,6 +1370,7 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
     bmm2_scale: float,
     sinks: Optional[torch.Tensor],
     kv_layout: Literal["HND", "NHD"],
+    kv_cache_format: Literal["fp8", "nvfp4"],
 ) -> torch.Tensor:
     if bmm2_scale != 1.0:
         raise ValueError("SM120 DSv4 sparse MLA does not support bmm2_scale")
@@ -1157,25 +1391,46 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
         )
     if swa_topk_lens is None:
         raise ValueError("backend='sparse' requires swa_topk_lens")
+    if kv_cache_format == "nvfp4" and num_heads == 8:
+        raise ValueError("NVFP4 sparse MLA does not yet support 8 query heads")
 
     swa_kv_cache = _check_sm120_dsv4_kv_cache_layout(
         swa_kv_cache, kv_layout, "swa_kv_cache"
     )
-    if swa_kv_cache.dtype == torch.uint8:
-        if swa_kv_cache.size(-1) != 584:
+    if kv_cache_format == "nvfp4":
+        if swa_kv_cache.dtype != torch.uint8 or swa_kv_cache.size(-1) != 384:
             raise ValueError(
-                "Expected packed SM120 DSV4 swa_kv_cache head dim 584, got "
-                f"{swa_kv_cache.size(-1)}"
+                "Expected NVFP4 SM120 DSv4 swa_kv_cache with dtype uint8 and "
+                f"head dim 384, got {swa_kv_cache.dtype} "
+                f"{tuple(swa_kv_cache.shape)}"
             )
-    elif swa_kv_cache.dtype != query.dtype:
-        raise ValueError(
-            f"swa_kv_cache dtype must match query dtype, got {swa_kv_cache.dtype} "
-            f"and {query.dtype}"
+        _check_nvfp4_page_strides(swa_kv_cache, kv_layout, "swa_kv_cache")
+        primary_page_size = (
+            swa_kv_cache.shape[1]
+            if swa_kv_cache.ndim == 3 or kv_layout == "NHD"
+            else swa_kv_cache.shape[2]
         )
-    elif swa_kv_cache.size(-1) != 512:
-        raise ValueError(
-            f"Expected swa_kv_cache head dim 512, got {swa_kv_cache.size(-1)}"
-        )
+        if primary_page_size != 64:
+            raise ValueError(
+                "NVFP4 sparse MLA primary cache requires page_size=64, got "
+                f"{primary_page_size}"
+            )
+    else:
+        if swa_kv_cache.dtype == torch.uint8:
+            if swa_kv_cache.size(-1) != 584:
+                raise ValueError(
+                    "Expected packed SM120 DSV4 swa_kv_cache head dim 584, got "
+                    f"{swa_kv_cache.size(-1)}"
+                )
+        elif swa_kv_cache.dtype != query.dtype:
+            raise ValueError(
+                f"swa_kv_cache dtype must match query dtype, got {swa_kv_cache.dtype} "
+                f"and {query.dtype}"
+            )
+        elif swa_kv_cache.size(-1) != 512:
+            raise ValueError(
+                f"Expected swa_kv_cache head dim 512, got {swa_kv_cache.size(-1)}"
+            )
 
     if (extra_sparse_indices is None) != (extra_sparse_topk_lens is None):
         raise ValueError(
@@ -1196,22 +1451,47 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
         compressed_kv_cache = _check_sm120_dsv4_kv_cache_layout(
             compressed_kv_cache, kv_layout, "compressed_kv_cache"
         )
-        if compressed_kv_cache.dtype == torch.uint8:
-            if compressed_kv_cache.size(-1) != 584:
+        if kv_cache_format == "nvfp4":
+            if (
+                compressed_kv_cache.dtype != torch.uint8
+                or compressed_kv_cache.size(-1) != 384
+            ):
                 raise ValueError(
-                    "Expected packed SM120 DSV4 compressed_kv_cache head dim 584, "
-                    f"got {compressed_kv_cache.size(-1)}"
+                    "Expected NVFP4 SM120 DSv4 compressed_kv_cache with dtype "
+                    "uint8 and head dim 384, got "
+                    f"{compressed_kv_cache.dtype} "
+                    f"{tuple(compressed_kv_cache.shape)}"
                 )
-        elif compressed_kv_cache.dtype != query.dtype:
-            raise ValueError(
-                "compressed_kv_cache dtype must match query dtype, got "
-                f"{compressed_kv_cache.dtype} and {query.dtype}"
+            _check_nvfp4_page_strides(
+                compressed_kv_cache, kv_layout, "compressed_kv_cache"
             )
-        elif compressed_kv_cache.size(-1) != 512:
-            raise ValueError(
-                "Expected compressed_kv_cache head dim 512, got "
-                f"{compressed_kv_cache.size(-1)}"
+            extra_page_size = (
+                compressed_kv_cache.shape[1]
+                if compressed_kv_cache.ndim == 3 or kv_layout == "NHD"
+                else compressed_kv_cache.shape[2]
             )
+            if extra_page_size not in (2, 64):
+                raise ValueError(
+                    "NVFP4 sparse MLA extra cache requires page_size 2 or 64, "
+                    f"got {extra_page_size}"
+                )
+        else:
+            if compressed_kv_cache.dtype == torch.uint8:
+                if compressed_kv_cache.size(-1) != 584:
+                    raise ValueError(
+                        "Expected packed SM120 DSV4 compressed_kv_cache head dim "
+                        f"584, got {compressed_kv_cache.size(-1)}"
+                    )
+            elif compressed_kv_cache.dtype != query.dtype:
+                raise ValueError(
+                    "compressed_kv_cache dtype must match query dtype, got "
+                    f"{compressed_kv_cache.dtype} and {query.dtype}"
+                )
+            elif compressed_kv_cache.size(-1) != 512:
+                raise ValueError(
+                    "Expected compressed_kv_cache head dim 512, got "
+                    f"{compressed_kv_cache.size(-1)}"
+                )
         sparse_mla_segments.append(
             _SparseMLASegment(
                 indices=extra_sparse_indices,
@@ -1233,6 +1513,7 @@ def _trtllm_batch_decode_sparse_mla_dsv4_sm120(
             lse=None,
             return_lse=False,
             kv_scale_format="auto",
+            kv_cache_format=kv_cache_format,
         ),
     )
     if query.ndim == 3:
@@ -1571,6 +1852,8 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     sparse_indices_are_storage_offsets: Optional[bool] = None,
     dsv4_inv_rope_cos_sin_cache: Optional[torch.Tensor] = None,
     dsv4_output_scale: Optional[torch.Tensor] = None,
+    *,
+    kv_cache_format: Literal["fp8", "nvfp4"] = "fp8",
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode DeepSeek V4 sparse MLA.
 
@@ -1753,8 +2036,20 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         ``[sum_q, 16, 4096]`` and group-major strides
         ``(4096, sum_q * 4096, 1)``; ``out_scale`` uses the packed UE8M0
         layout described above.
+    kv_cache_format : {"fp8", "nvfp4"}
+        SM120/SM121 sparse-cache storage format. ``"fp8"`` preserves the
+        existing 584-byte DSv4 cache ABI. ``"nvfp4"`` selects the 384-byte
+        group-16 NVFP4 cache ABI and its native prefill/decode kernels.
+        NVFP4 currently supports 16/32/64/128 heads, primary top-k 128 or 512,
+        primary page size 64, and optional extra-cache page size 2 or 64.
     """
     backend = _resolve_dsv4_sparse_mla_backend(query.device, backend)
+    if kv_cache_format not in ("fp8", "nvfp4"):
+        raise ValueError(
+            f"kv_cache_format must be either 'fp8' or 'nvfp4', got {kv_cache_format!r}"
+        )
+    if kv_cache_format == "nvfp4" and backend != "sparse":
+        raise ValueError("kv_cache_format='nvfp4' requires backend='sparse'")
 
     rope_quant = dsv4_inv_rope_cos_sin_cache is not None
     if dsv4_output_scale is not None and not rope_quant:
@@ -1964,6 +2259,7 @@ def trtllm_batch_decode_sparse_mla_dsv4(
             bmm2_scale=float(bmm2_scale),
             sinks=sinks,
             kv_layout=kv_layout,
+            kv_cache_format=kv_cache_format,
         )
 
     if (

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -500,6 +500,10 @@ def _run_nvfp4_sparse_mla_sm120(
             "NVFP4 sparse MLA workspace unexpectedly truncated the batch"
         )
 
+    # The shared public wrapper delegates to this same allocation-free op.
+    # This facade has already planned the phase in order to partition its
+    # caller-owned byte workspace, so pass that result through instead of
+    # constructing a wrapper and planning the call a second time.
     from ._sparse_mla_nvfp4_sm120 import (
         _sparse_mla_nvfp4_sm120_paged_attention,
     )
@@ -642,9 +646,9 @@ def _trtllm_batch_decode_sparse_mla_sm120(
             f"kv_cache_format must be either 'fp8' or 'nvfp4', got {kv_cache_format!r}"
         )
 
-    from ._sparse_mla_sm120 import _SparseMLAPagedAttentionRunner
+    from ._sparse_mla_sm120 import SparseMLASm120Wrapper
 
-    runner = _SparseMLAPagedAttentionRunner(
+    runner = SparseMLASm120Wrapper(
         max_num_tokens=query_flat.shape[0],
         max_num_heads=num_heads,
         kv_scale_format=kv_scale_format,
@@ -1872,11 +1876,13 @@ def trtllm_batch_decode_sparse_mla_dsv4(
     length for the SWA validity window.
 
     On SM120/SM121, this calls the packed sparse backend. ``swa_kv_cache`` is
-    the required packed uint8 SWA pool with 584 bytes per token. ``sparse_indices``
-    and ``swa_topk_lens`` describe the active SWA segment. To add a compressed
-    segment, pass ``compressed_kv_cache`` as another packed uint8 pool and pass
-    ``extra_sparse_indices`` with ``extra_sparse_topk_lens``. The SM120/SM121
-    path accepts BF16 query tensors and produces BF16 output.
+    the required packed uint8 SWA pool: 584 bytes per token for FP8 or 384
+    bytes per token for group-16 NVFP4, selected by ``kv_cache_format``.
+    ``sparse_indices`` and ``swa_topk_lens`` describe the active SWA segment.
+    To add a compressed segment, pass ``compressed_kv_cache`` as another pool
+    in the same format and pass ``extra_sparse_indices`` with
+    ``extra_sparse_topk_lens``. The SM120/SM121 path accepts BF16 query tensors
+    and produces BF16 output.
 
     With ``backend="cute-dsl"`` on SM100/SM103, this calls the DeepSeek V4
     HCA kernel. Its SWA stream consumes arbitrary physical token-row indices,
@@ -1892,8 +1898,9 @@ def trtllm_batch_decode_sparse_mla_dsv4(
         ``cum_seq_lens_q`` is provided. SM100/SM103 accepts BF16 or FP8 E4M3;
         SM120/SM121 accepts BF16.
     swa_kv_cache : torch.Tensor
-        SWA KV cache. TRTLLM-GEN uses head dim 512; SM120 sparse uses packed
-        uint8 head dim 584. Layout follows ``kv_layout``.
+        SWA KV cache. TRTLLM-GEN uses head dim 512; SM120 sparse uses an opaque
+        packed uint8 record with last dimension 584 (FP8) or 384 (NVFP4).
+        Layout follows ``kv_layout``.
     workspace_buffer : torch.Tensor
         Byte workspace used by TRTLLM-GEN or HCA split-K reduction. The
         TRTLLM-GEN multi-CTA KV counters are managed in a separate internal

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 
 import torch
 
+from ..api_logging import flashinfer_api
 from ..jit.mla import (
     gen_sparse_mla_nvfp4_sm120_module,
     gen_sparse_mla_nvfp4_sm120_tile_module,
@@ -244,6 +245,7 @@ def _validate_unique_slots(slot_mapping: torch.Tensor, capacity: int) -> None:
 
 
 @supported_compute_capability([120, 121])
+@flashinfer_api
 def nvfp4_quantize_pack_sparse_mla_cache(
     latent_kv: torch.Tensor,
     *,
@@ -251,17 +253,26 @@ def nvfp4_quantize_pack_sparse_mla_cache(
 ) -> torch.Tensor:
     r"""Quantize complete DeepSeek-V4 latent-KV pages to the NVFP4 cache ABI.
 
-    ``latent_kv`` has shape ``[num_pages, page_size, 512]``. A singleton
-    latent-head axis is also accepted in HND or NHD position. The first 448
-    values are quantized in groups of 16 to packed E2M1 with E4M3 scales; the
-    final 64 BF16 RoPE values are copied bit-for-bit.
+    Parameters
+    ----------
+    latent_kv : torch.Tensor
+        Contiguous CUDA BF16 tensor with shape
+        ``[num_pages, page_size, 512]``. A singleton latent-head axis is also
+        accepted in HND or NHD position. The first 448 values are quantized in
+        groups of 16 to packed E2M1 with E4M3 scales; the final 64 BF16 RoPE
+        values are copied bit-for-bit.
+    kv_layout : str
+        Output layout, either ``"HND"`` or ``"NHD"``.
 
-    The returned uint8 tensor is an opaque paged cache with logical shape
-    ``[num_pages, 1, page_size, 384]`` for HND or
-    ``[num_pages, page_size, 1, 384]`` for NHD. Within each physical page it
-    stores ``page_size * 352`` data bytes followed by ``page_size * 32`` scale
-    bytes. Consumers must not interpret the last dimension as a contiguous
-    per-token record.
+    Returns
+    -------
+    torch.Tensor
+        Opaque uint8 paged cache with logical shape
+        ``[num_pages, 1, page_size, 384]`` for HND or
+        ``[num_pages, page_size, 1, 384]`` for NHD. Within each physical page
+        it stores ``page_size * 352`` data bytes followed by
+        ``page_size * 32`` scale bytes. Consumers must not interpret the last
+        dimension as a contiguous per-token record.
     """
     if kv_layout not in ("HND", "NHD"):
         raise ValueError(f"kv_layout must be 'HND' or 'NHD', got {kv_layout!r}")
@@ -299,6 +310,7 @@ def nvfp4_quantize_pack_sparse_mla_cache(
 
 
 @supported_compute_capability([120, 121])
+@flashinfer_api
 def nvfp4_quantize_append_sparse_mla_cache(
     latent_kv: torch.Tensor,
     slot_mapping: torch.Tensor,
@@ -306,14 +318,23 @@ def nvfp4_quantize_append_sparse_mla_cache(
 ) -> None:
     r"""Quantize and append DeepSeek-V4 latent KV by physical cache slot.
 
-    ``cache`` accepts the 3D shorthand ``[num_pages, page_size, 384]`` in
-    addition to the public 4D HND/NHD layouts. ``slot_mapping[i]`` is
-    ``page_id * page_size + entry_id``. Page-strided views are accepted so the
-    cache can live inside vLLM's packed physical block allocation. Negative and
-    out-of-range slots are padding and are ignored. Valid slots must be unique;
-    set ``FLASHINFER_VALIDATE_INPUTS=1`` to check that invariant eagerly outside
-    CUDA Graph capture. Only the addressed data row and scale slot are written,
-    so prefill history is reused directly by decode.
+    Parameters
+    ----------
+    latent_kv : torch.Tensor
+        Contiguous CUDA BF16 tensor with one 512-element latent-KV row per
+        entry in ``slot_mapping``.
+    slot_mapping : torch.Tensor
+        Contiguous 1D CUDA int32 or int64 tensor. ``slot_mapping[i]`` is
+        ``page_id * page_size + entry_id``. Negative and out-of-range slots
+        are padding and are ignored. Valid slots must be unique; set
+        ``FLASHINFER_VALIDATE_INPUTS=1`` to check that invariant eagerly
+        outside CUDA Graph capture.
+    cache : torch.Tensor
+        Destination opaque uint8 paged cache. The 3D shorthand
+        ``[num_pages, page_size, 384]`` and public 4D HND/NHD layouts are
+        accepted. Page-strided views may place the cache inside vLLM's packed
+        physical block allocation. Only addressed data rows and scale slots
+        are written, so prefill history is reused directly by decode.
     """
     num_pages, page_size, _ = _cache_shape(cache)
     if not slot_mapping.is_cuda:

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
@@ -1,0 +1,741 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NVFP4 cache primitives for DeepSeek-V4 sparse MLA on SM120."""
+
+from __future__ import annotations
+
+import functools
+from types import SimpleNamespace
+from typing import Any
+
+import torch
+
+from ..autotuner import (
+    AutoTuner,
+    ConstraintSpec,
+    DynamicTensorSpec,
+    OptimizationProfile,
+    TunableRunner,
+    TuningConfig,
+)
+from ..jit.mla import (
+    gen_sparse_mla_nvfp4_sm120_module,
+    gen_sparse_mla_nvfp4_sm120_tile_module,
+)
+from ..utils import (
+    register_custom_op,
+    register_fake_op,
+    supported_compute_capability,
+)
+
+
+_D_NOPE = 448
+_D_ROPE = 64
+_D_LATENT = _D_NOPE + _D_ROPE
+_PACKED_NOPE_BYTES = _D_NOPE // 2
+_ROPE_BYTES = _D_ROPE * 2
+_DATA_BYTES_PER_TOKEN = _PACKED_NOPE_BYTES + _ROPE_BYTES
+_SCALE_BYTES_PER_TOKEN = 32
+_BYTES_PER_TOKEN = _DATA_BYTES_PER_TOKEN + _SCALE_BYTES_PER_TOKEN
+_CANDIDATES_PER_CHUNK = 64
+_DECODE_TOKEN_BUCKETS = (1, 4, 8, 16, 32, 64)
+_DECODE_AUTOTUNE_OP = "sparse_mla_sm120_nvfp4_decode"
+_decode_hot_cache: dict[tuple[Any, ...], int] = {}
+
+
+def _decode_token_buckets(*_args, **_kwargs) -> tuple[int, ...]:
+    return _DECODE_TOKEN_BUCKETS
+
+
+def _decode_token_bucket(num_tokens: int) -> int:
+    for bucket in _DECODE_TOKEN_BUCKETS:
+        if num_tokens <= bucket:
+            return bucket
+    return _DECODE_TOKEN_BUCKETS[-1]
+
+
+def _init_decode_q(shapes, dtype, device):
+    return (
+        (torch.randn(shapes, device=device, dtype=torch.float32) / 10.0)
+        .clamp(-1, 1)
+        .to(dtype)
+    )
+
+
+def _init_decode_indices(shapes, dtype, device):
+    # The live paged pools used for serving contain far more than 256 rows.
+    # The autotuner profiles latency only, so arbitrary legal rows are enough.
+    return torch.randint(0, 256, shapes, dtype=dtype, device=device)
+
+
+def _init_decode_topk_length(shapes, dtype, device):
+    return torch.full(shapes, 1 << 30, dtype=dtype, device=device)
+
+
+def _decode_inputs_pre_hook(inputs):
+    inputs = list(inputs)
+    indices = inputs[1] if len(inputs) > 1 else None
+    topk_length = inputs[6] if len(inputs) > 6 else None
+    extra_indices = inputs[8] if len(inputs) > 8 else None
+    extra_topk_length = inputs[9] if len(inputs) > 9 else None
+    if topk_length is not None and indices is not None:
+        inputs[6] = torch.full_like(topk_length, indices.shape[-1])
+    if extra_topk_length is not None and extra_indices is not None:
+        inputs[9] = torch.full_like(extra_topk_length, extra_indices.shape[-1])
+    return inputs
+
+
+@functools.cache
+def _decode_tuning_config() -> TuningConfig:
+    # Keep the bucket and scratch-shape contract aligned with the existing FP8
+    # DSv4 sparse-MLA tuner so paired serving warms the same live batch shapes.
+    return TuningConfig(
+        dynamic_tensor_specs=(
+            DynamicTensorSpec(
+                input_idx=(0, 1, 6, 8, 9),
+                dim_idx=(0, 0, 0, 0, 0),
+                gen_tuning_buckets=_decode_token_buckets,
+                map_to_tuning_buckets=_decode_token_bucket,
+            ),
+        ),
+        tensor_initializers=(
+            (0, _init_decode_q),
+            (1, _init_decode_indices),
+            (6, _init_decode_topk_length),
+            (8, _init_decode_indices),
+            (9, _init_decode_topk_length),
+        ),
+        inputs_pre_hook=_decode_inputs_pre_hook,
+        constraint_specs=(
+            ConstraintSpec(2, 0, lambda shapes: shapes[0][0]),
+            ConstraintSpec(3, 0, lambda shapes: shapes[0][0]),
+            ConstraintSpec(4, 0, lambda shapes: shapes[0][0]),
+            ConstraintSpec(5, 0, lambda shapes: shapes[0][0]),
+        ),
+    )
+
+
+def _cache_page_size(cache: torch.Tensor | None) -> int:
+    if cache is None:
+        return 0
+    if cache.ndim == 3:
+        return int(cache.shape[1])
+    if cache.ndim == 4 and cache.shape[1] == 1:
+        return int(cache.shape[2])
+    if cache.ndim == 4 and cache.shape[2] == 1:
+        return int(cache.shape[1])
+    raise ValueError(f"unsupported NVFP4 cache shape for decode tuning: {cache.shape}")
+
+
+class _SparseMlaNvfp4DecodeRunner(TunableRunner):
+    """Tune chunks-per-block while preserving the native streaming kernel."""
+
+    def __init__(
+        self,
+        module,
+        primary_page_size: int,
+        extra_page_size: int,
+    ) -> None:
+        self.module = module
+        self.primary_page_size = primary_page_size
+        self.extra_page_size = extra_page_size
+
+    def get_cache_key_extras(self, inputs: list[torch.Tensor]) -> tuple[Any, ...]:
+        topk_length = inputs[6] if len(inputs) > 6 else None
+        attn_sink = inputs[7] if len(inputs) > 7 else None
+        extra_indices = inputs[8] if len(inputs) > 8 else None
+        extra_topk_length = inputs[9] if len(inputs) > 9 else None
+        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+        return (
+            topk_length is not None,
+            attn_sink is not None,
+            int(extra_topk),
+            extra_topk_length is not None,
+            self.primary_page_size,
+            self.extra_page_size,
+        )
+
+    def get_valid_tactics(
+        self,
+        inputs: list[torch.Tensor],
+        profile: OptimizationProfile,
+    ) -> list[int]:
+        del profile
+        indices = inputs[1]
+        extra_indices = inputs[8] if len(inputs) > 8 else None
+        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+        num_splits = (
+            indices.shape[-1] + _CANDIDATES_PER_CHUNK - 1
+        ) // _CANDIDATES_PER_CHUNK + (
+            extra_topk + _CANDIDATES_PER_CHUNK - 1
+        ) // _CANDIDATES_PER_CHUNK
+        return list(range(1, num_splits + 1))
+
+    def forward(
+        self,
+        inputs: list[torch.Tensor],
+        tactic: int = -1,
+        do_preparation: bool = False,
+        **kwargs,
+    ) -> torch.Tensor:
+        del do_preparation
+        q, indices, mid_out, mid_lse, output, out_lse = inputs[:6]
+        topk_length, attn_sink, extra_indices, extra_topk_length = inputs[6:10]
+        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+        num_splits = (
+            indices.shape[-1] + _CANDIDATES_PER_CHUNK - 1
+        ) // _CANDIDATES_PER_CHUNK + (
+            extra_topk + _CANDIDATES_PER_CHUNK - 1
+        ) // _CANDIDATES_PER_CHUNK
+        self.module.sparse_mla_sm120_nvfp4_decode(
+            q,
+            kwargs["kv_cache"],
+            indices,
+            mid_out,
+            mid_lse,
+            output,
+            out_lse,
+            num_splits,
+            kwargs["sm_scale"],
+            topk_length,
+            attn_sink,
+            kwargs.get("extra_kv_cache"),
+            extra_indices,
+            extra_topk_length,
+            int(tactic) if int(tactic) > 0 else 0,
+            False,
+        )
+        return output
+
+
+def _decode_hot_key(
+    runner: _SparseMlaNvfp4DecodeRunner,
+    inputs: list[torch.Tensor],
+) -> tuple[Any, ...]:
+    q, indices = inputs[:2]
+    extra_indices = inputs[8] if len(inputs) > 8 else None
+    extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+    num_splits = (
+        indices.shape[-1] + _CANDIDATES_PER_CHUNK - 1
+    ) // _CANDIDATES_PER_CHUNK + (
+        extra_topk + _CANDIDATES_PER_CHUNK - 1
+    ) // _CANDIDATES_PER_CHUNK
+    return (
+        _decode_token_bucket(q.shape[0]),
+        q.shape[1],
+        indices.shape[-1],
+        extra_topk,
+        num_splits,
+        runner.get_cache_key_extras(inputs),
+    )
+
+
+def _run_nvfp4_decode(
+    runner: _SparseMlaNvfp4DecodeRunner,
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    mid_out: torch.Tensor,
+    mid_lse: torch.Tensor,
+    output: torch.Tensor,
+    out_lse: torch.Tensor,
+    sm_scale: float,
+    topk_length: torch.Tensor | None,
+    attn_sink: torch.Tensor | None,
+    extra_kv_cache: torch.Tensor | None,
+    extra_indices: torch.Tensor | None,
+    extra_topk_length: torch.Tensor | None,
+    chunks_per_block_override: int,
+) -> None:
+    inputs = [
+        q,
+        indices,
+        mid_out,
+        mid_lse,
+        output,
+        out_lse,
+        topk_length,
+        attn_sink,
+        extra_indices,
+        extra_topk_length,
+    ]
+    forward_kwargs = {
+        "sm_scale": sm_scale,
+        "kv_cache": kv_cache,
+        "extra_kv_cache": extra_kv_cache,
+    }
+    if chunks_per_block_override > 0:
+        runner(
+            inputs=inputs,
+            tactic=chunks_per_block_override,
+            **forward_kwargs,
+        )
+        return
+
+    tuner = AutoTuner.get()
+    if not tuner.is_tuning_mode:
+        cached_tactic = _decode_hot_cache.get(_decode_hot_key(runner, inputs))
+        if cached_tactic is not None:
+            runner(inputs=inputs, tactic=cached_tactic, **forward_kwargs)
+            return
+
+    chosen, tactic = tuner.choose_one(
+        _DECODE_AUTOTUNE_OP,
+        [runner],
+        _decode_tuning_config(),
+        inputs,
+        **forward_kwargs,
+    )
+    if int(tactic) > 0:
+        _decode_hot_cache[_decode_hot_key(runner, inputs)] = int(tactic)
+    chosen(inputs=inputs, tactic=tactic, **forward_kwargs)
+
+
+@functools.cache
+def get_sparse_mla_nvfp4_sm120_module():
+    module = gen_sparse_mla_nvfp4_sm120_module().build_and_load()
+    decode_runners: dict[tuple[int, int], _SparseMlaNvfp4DecodeRunner] = {}
+
+    def get_decode_runner(
+        kv_cache: torch.Tensor,
+        extra_kv_cache: torch.Tensor | None,
+    ) -> _SparseMlaNvfp4DecodeRunner:
+        page_key = (
+            _cache_page_size(kv_cache),
+            _cache_page_size(extra_kv_cache),
+        )
+        runner = decode_runners.get(page_key)
+        if runner is None:
+            runner = _SparseMlaNvfp4DecodeRunner(module, *page_key)
+            decode_runners[page_key] = runner
+        return runner
+
+    @register_custom_op(
+        "flashinfer::sparse_mla_nvfp4_sm120_paged_attention",
+        mutates_args=(
+            "mid_out",
+            "mid_lse",
+            "output",
+            "out_lse",
+        ),
+    )
+    def _paged_attention(
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        indices: torch.Tensor,
+        mid_out: torch.Tensor | None,
+        mid_lse: torch.Tensor | None,
+        output: torch.Tensor,
+        out_lse: torch.Tensor,
+        sm_scale: float,
+        topk_length: torch.Tensor | None,
+        attn_sink: torch.Tensor | None,
+        extra_kv_cache: torch.Tensor | None,
+        extra_indices: torch.Tensor | None,
+        extra_topk_length: torch.Tensor | None,
+        use_prefill: bool,
+        chunks_per_block_override: int,
+    ) -> None:
+        if not use_prefill:
+            if mid_out is None or mid_lse is None:
+                raise ValueError("NVFP4 decode requires mid_out and mid_lse workspace")
+            _run_nvfp4_decode(
+                get_decode_runner(kv_cache, extra_kv_cache),
+                q,
+                kv_cache,
+                indices,
+                mid_out,
+                mid_lse,
+                output,
+                out_lse,
+                sm_scale,
+                topk_length,
+                attn_sink,
+                extra_kv_cache,
+                extra_indices,
+                extra_topk_length,
+                chunks_per_block_override,
+            )
+        else:
+            module.sparse_mla_sm120_nvfp4_prefill(
+                q,
+                kv_cache,
+                indices,
+                output,
+                out_lse,
+                sm_scale,
+                topk_length,
+                attn_sink,
+                extra_kv_cache,
+                extra_indices,
+                extra_topk_length,
+            )
+
+    @register_fake_op("flashinfer::sparse_mla_nvfp4_sm120_paged_attention")
+    def _fake_paged_attention(*_args, **_kwargs) -> None:
+        return None
+
+    return SimpleNamespace(
+        paged_attention=_paged_attention,
+        sparse_mla_sm120_nvfp4_quantize_pack=module.sparse_mla_sm120_nvfp4_quantize_pack,
+        sparse_mla_sm120_nvfp4_quantize_append=module.sparse_mla_sm120_nvfp4_quantize_append,
+        sparse_mla_sm120_nvfp4_decode=module.sparse_mla_sm120_nvfp4_decode,
+        sparse_mla_sm120_nvfp4_prefill=module.sparse_mla_sm120_nvfp4_prefill,
+    )
+
+
+@functools.cache
+def get_sparse_mla_nvfp4_sm120_tile_module():
+    """Build the test-only MMA-layout validation module."""
+    return gen_sparse_mla_nvfp4_sm120_tile_module().build_and_load()
+
+
+@supported_compute_capability([120, 121])
+def _sparse_mla_nvfp4_sm120_paged_attention(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    output: torch.Tensor,
+    out_lse: torch.Tensor,
+    sm_scale: float,
+    *,
+    topk_length: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    extra_kv_cache: torch.Tensor | None = None,
+    extra_indices: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+    mid_out: torch.Tensor | None = None,
+    mid_lse: torch.Tensor | None = None,
+    use_prefill: bool | None = None,
+    chunks_per_block_override: int = 0,
+) -> None:
+    """Run the allocation-free NVFP4 sparse-MLA custom op."""
+    get_sparse_mla_nvfp4_sm120_module().paged_attention(
+        q,
+        kv_cache,
+        indices,
+        mid_out,
+        mid_lse,
+        output,
+        out_lse,
+        sm_scale,
+        topk_length,
+        attn_sink,
+        extra_kv_cache,
+        extra_indices,
+        extra_topk_length,
+        q.shape[0] > 64 if use_prefill is None else use_prefill,
+        chunks_per_block_override,
+    )
+
+
+def _check_latent_kv(latent_kv: torch.Tensor, *, expected_rows: int | None) -> int:
+    if not latent_kv.is_cuda:
+        raise ValueError(f"latent_kv must be a CUDA tensor, got {latent_kv.device}")
+    if latent_kv.dtype != torch.bfloat16:
+        raise ValueError(
+            f"DeepSeek-V4 latent_kv must have dtype torch.bfloat16, got {latent_kv.dtype}"
+        )
+    if latent_kv.ndim not in (2, 3, 4):
+        raise ValueError(
+            f"latent_kv must be 2D, 3D, or 4D, got shape={tuple(latent_kv.shape)}"
+        )
+    if latent_kv.shape[-1] != _D_LATENT:
+        raise ValueError(
+            f"latent_kv last dimension must be {_D_LATENT}, got {latent_kv.shape[-1]}"
+        )
+    if not latent_kv.is_contiguous():
+        raise ValueError("latent_kv must be contiguous")
+    rows = latent_kv.numel() // _D_LATENT
+    if expected_rows is not None and rows != expected_rows:
+        raise ValueError(
+            f"latent_kv contains {rows} rows, expected {expected_rows} rows"
+        )
+    return rows
+
+
+def _cache_shape(cache: torch.Tensor) -> tuple[int, int, str]:
+    if not cache.is_cuda:
+        raise ValueError(f"cache must be a CUDA tensor, got {cache.device}")
+    if cache.dtype != torch.uint8:
+        raise ValueError(f"cache must have dtype torch.uint8, got {cache.dtype}")
+    if cache.ndim not in (3, 4) or cache.shape[-1] != _BYTES_PER_TOKEN:
+        raise ValueError(
+            "cache must be [num_pages, page_size, 384], HND "
+            "[num_pages, 1, page_size, 384], or NHD "
+            f"[num_pages, page_size, 1, 384], got shape={tuple(cache.shape)}"
+        )
+    if cache.ndim == 3:
+        num_pages, page_size, layout = cache.shape[0], cache.shape[1], "NHD"
+    elif cache.shape[1] == 1:
+        num_pages, page_size, layout = cache.shape[0], cache.shape[2], "HND"
+    elif cache.shape[2] == 1:
+        num_pages, page_size, layout = cache.shape[0], cache.shape[1], "NHD"
+    else:
+        raise ValueError(
+            "cache must have a singleton latent-head dimension at axis 1 or 2"
+        )
+    page_dim = 1 if cache.ndim == 3 or layout == "NHD" else 2
+    if cache.stride(-1) != 1 or cache.stride(page_dim) != _BYTES_PER_TOKEN:
+        raise ValueError(
+            "cache entries must be contiguous inside each page with strides "
+            f"(..., {_BYTES_PER_TOKEN}, 1), got {cache.stride()}"
+        )
+    if cache.stride(0) < page_size * _BYTES_PER_TOKEN:
+        raise ValueError(
+            "cache page stride must cover the logical page payload, got "
+            f"stride(0)={cache.stride(0)} for page_size={page_size}"
+        )
+    return int(num_pages), int(page_size), layout
+
+
+@supported_compute_capability([120, 121])
+def nvfp4_quantize_pack_sparse_mla_cache(
+    latent_kv: torch.Tensor,
+    *,
+    kv_layout: str = "HND",
+) -> torch.Tensor:
+    r"""Quantize complete DeepSeek-V4 latent-KV pages to the NVFP4 cache ABI.
+
+    ``latent_kv`` has shape ``[num_pages, page_size, 512]``. A singleton
+    latent-head axis is also accepted in HND or NHD position. The first 448
+    values are quantized in groups of 16 to packed E2M1 with E4M3 scales; the
+    final 64 BF16 RoPE values are copied bit-for-bit.
+
+    The returned uint8 tensor is an opaque paged cache with logical shape
+    ``[num_pages, 1, page_size, 384]`` for HND or
+    ``[num_pages, page_size, 1, 384]`` for NHD. Within each physical page it
+    stores ``page_size * 352`` data bytes followed by ``page_size * 32`` scale
+    bytes. Consumers must not interpret the last dimension as a contiguous
+    per-token record.
+    """
+    if kv_layout not in ("HND", "NHD"):
+        raise ValueError(f"kv_layout must be 'HND' or 'NHD', got {kv_layout!r}")
+    _check_latent_kv(latent_kv, expected_rows=None)
+
+    if latent_kv.ndim == 2:
+        raise ValueError(
+            "full-page pack requires a page dimension; use shape "
+            "[num_pages, page_size, 512]"
+        )
+    if latent_kv.ndim == 3:
+        num_pages, page_size = latent_kv.shape[:2]
+    elif latent_kv.shape[1] == 1:
+        num_pages, page_size = latent_kv.shape[0], latent_kv.shape[2]
+    elif latent_kv.shape[2] == 1:
+        num_pages, page_size = latent_kv.shape[0], latent_kv.shape[1]
+    else:
+        raise ValueError(
+            "4D latent_kv must have a singleton latent-head dimension at axis 1 or 2"
+        )
+
+    _check_latent_kv(latent_kv, expected_rows=int(num_pages) * int(page_size))
+    cache_shape = (
+        (num_pages, 1, page_size, _BYTES_PER_TOKEN)
+        if kv_layout == "HND"
+        else (num_pages, page_size, 1, _BYTES_PER_TOKEN)
+    )
+    cache = torch.empty(cache_shape, dtype=torch.uint8, device=latent_kv.device)
+    if int(num_pages) == 0 or int(page_size) == 0:
+        return cache
+    get_sparse_mla_nvfp4_sm120_module().sparse_mla_sm120_nvfp4_quantize_pack(
+        latent_kv, cache
+    )
+    return cache
+
+
+@supported_compute_capability([120, 121])
+def nvfp4_quantize_append_sparse_mla_cache(
+    latent_kv: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    cache: torch.Tensor,
+) -> None:
+    r"""Quantize and append DeepSeek-V4 latent KV by physical cache slot.
+
+    ``cache`` accepts the 3D shorthand ``[num_pages, page_size, 384]`` in
+    addition to the public 4D HND/NHD layouts. ``slot_mapping[i]`` is
+    ``page_id * page_size + entry_id``. Page-strided views are accepted so the
+    cache can live inside vLLM's packed physical block allocation. Negative and
+    out-of-range slots are padding and are ignored. Only the addressed data row
+    and scale slot are written, so prefill history is reused directly by decode.
+    """
+    num_pages, page_size, _ = _cache_shape(cache)
+    if not slot_mapping.is_cuda:
+        raise ValueError(
+            f"slot_mapping must be a CUDA tensor, got {slot_mapping.device}"
+        )
+    if slot_mapping.dtype not in (torch.int32, torch.int64):
+        raise ValueError(
+            f"slot_mapping must have dtype torch.int32 or torch.int64, got {slot_mapping.dtype}"
+        )
+    if slot_mapping.ndim != 1 or not slot_mapping.is_contiguous():
+        raise ValueError("slot_mapping must be a contiguous 1D tensor")
+    if latent_kv.device != cache.device or slot_mapping.device != cache.device:
+        raise ValueError(
+            "latent_kv, slot_mapping, and cache must be on the same device"
+        )
+    _check_latent_kv(latent_kv, expected_rows=slot_mapping.numel())
+    if num_pages * page_size == 0 and slot_mapping.numel() != 0:
+        raise ValueError("cannot append to an empty cache")
+
+    get_sparse_mla_nvfp4_sm120_module().sparse_mla_sm120_nvfp4_quantize_append(
+        latent_kv, slot_mapping, cache
+    )
+
+
+@supported_compute_capability([120, 121])
+def _nvfp4_sparse_mla_m16n32k64(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    sfa: torch.Tensor,
+    sfb: torch.Tensor,
+    *,
+    iterations: int = 1,
+) -> torch.Tensor:
+    """Run the internal M16N32K64 NVFP4 validation tile."""
+    output = torch.empty((16, 32), dtype=torch.float32, device=a.device)
+    get_sparse_mla_nvfp4_sm120_tile_module().sparse_mla_sm120_nvfp4_m16n32k64(
+        a, b, sfa, sfb, output, iterations
+    )
+    return output
+
+
+@supported_compute_capability([120, 121])
+def _nvfp4_sparse_mla_m16n8k64_candidate_major(
+    a: torch.Tensor,
+    b: torch.Tensor,
+    sfa: torch.Tensor,
+    sfb: torch.Tensor,
+    *,
+    iterations: int = 1,
+) -> torch.Tensor:
+    """Run the internal candidate-major PV validation tile."""
+    output = torch.empty((16, 8), dtype=torch.float32, device=a.device)
+    get_sparse_mla_nvfp4_sm120_tile_module().sparse_mla_sm120_nvfp4_m16n8k64_candidate_major(
+        a, b, sfa, sfb, output, iterations
+    )
+    return output
+
+
+@supported_compute_capability([120, 121])
+def _nvfp4_sparse_mla_decode(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    *,
+    topk_length: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    extra_kv_cache: torch.Tensor | None = None,
+    extra_indices: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+    chunks_per_block_override: int = 0,
+    stage1_only: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the internal DeepSeek-V4 NVFP4 sparse-MLA decode prototype."""
+    if q.ndim != 3 or q.shape[-1] != _D_LATENT:
+        raise ValueError(f"q must be [T, H, {_D_LATENT}], got {tuple(q.shape)}")
+    if q.dtype != torch.bfloat16 or not q.is_cuda or not q.is_contiguous():
+        raise ValueError("q must be a contiguous CUDA bfloat16 tensor")
+    if indices.ndim != 2 or indices.dtype != torch.int32:
+        raise ValueError("indices must be a 2D int32 tensor")
+    num_tokens, num_heads, _ = q.shape
+    topk = indices.shape[1]
+    if (extra_kv_cache is None) != (extra_indices is None):
+        raise ValueError("extra_kv_cache and extra_indices must be provided together")
+    if extra_topk_length is not None and extra_indices is None:
+        raise ValueError("extra_topk_length requires extra_indices")
+    extra_topk = extra_indices.shape[1] if extra_indices is not None else 0
+    num_splits = (topk + 63) // 64 + (extra_topk + 63) // 64
+    mid_out = torch.empty(
+        (num_tokens, num_heads, num_splits, _D_LATENT),
+        dtype=torch.bfloat16,
+        device=q.device,
+    )
+    mid_lse = torch.empty(
+        (num_tokens, num_heads, num_splits),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    output = torch.empty_like(q)
+    out_lse = torch.empty((num_tokens, num_heads), dtype=torch.float32, device=q.device)
+    get_sparse_mla_nvfp4_sm120_module().sparse_mla_sm120_nvfp4_decode(
+        q,
+        kv_cache,
+        indices,
+        mid_out,
+        mid_lse,
+        output,
+        out_lse,
+        num_splits,
+        sm_scale,
+        topk_length,
+        attn_sink,
+        extra_kv_cache,
+        extra_indices,
+        extra_topk_length,
+        chunks_per_block_override,
+        stage1_only,
+    )
+    return output, out_lse
+
+
+@supported_compute_capability([120, 121])
+def _nvfp4_sparse_mla_prefill(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    *,
+    topk_length: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+    extra_kv_cache: torch.Tensor | None = None,
+    extra_indices: torch.Tensor | None = None,
+    extra_topk_length: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Run the single-launch streaming DeepSeek-V4 NVFP4 prefill kernel."""
+    if q.ndim != 3 or q.shape[-1] != _D_LATENT:
+        raise ValueError(f"q must be [T, H, {_D_LATENT}], got {tuple(q.shape)}")
+    if q.dtype != torch.bfloat16 or not q.is_cuda or not q.is_contiguous():
+        raise ValueError("q must be a contiguous CUDA bfloat16 tensor")
+    if indices.ndim != 2 or indices.dtype != torch.int32:
+        raise ValueError("indices must be a 2D int32 tensor")
+    num_tokens, num_heads, _ = q.shape
+    if (extra_kv_cache is None) != (extra_indices is None):
+        raise ValueError("extra_kv_cache and extra_indices must be provided together")
+    if extra_topk_length is not None and extra_indices is None:
+        raise ValueError("extra_topk_length requires extra_indices")
+    output = torch.empty_like(q)
+    out_lse = torch.empty((num_tokens, num_heads), dtype=torch.float32, device=q.device)
+    get_sparse_mla_nvfp4_sm120_module().sparse_mla_sm120_nvfp4_prefill(
+        q,
+        kv_cache,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        topk_length,
+        attn_sink,
+        extra_kv_cache,
+        extra_indices,
+        extra_topk_length,
+    )
+    return output, out_lse
+
+
+__all__ = [
+    "nvfp4_quantize_append_sparse_mla_cache",
+    "nvfp4_quantize_pack_sparse_mla_cache",
+]

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
@@ -18,18 +18,9 @@ from __future__ import annotations
 
 import functools
 from types import SimpleNamespace
-from typing import Any
 
 import torch
 
-from ..autotuner import (
-    AutoTuner,
-    ConstraintSpec,
-    DynamicTensorSpec,
-    OptimizationProfile,
-    TunableRunner,
-    TuningConfig,
-)
 from ..jit.mla import (
     gen_sparse_mla_nvfp4_sm120_module,
     gen_sparse_mla_nvfp4_sm120_tile_module,
@@ -49,278 +40,11 @@ _ROPE_BYTES = _D_ROPE * 2
 _DATA_BYTES_PER_TOKEN = _PACKED_NOPE_BYTES + _ROPE_BYTES
 _SCALE_BYTES_PER_TOKEN = 32
 _BYTES_PER_TOKEN = _DATA_BYTES_PER_TOKEN + _SCALE_BYTES_PER_TOKEN
-_CANDIDATES_PER_CHUNK = 64
-_DECODE_TOKEN_BUCKETS = (1, 4, 8, 16, 32, 64)
-_DECODE_AUTOTUNE_OP = "sparse_mla_sm120_nvfp4_decode"
-_decode_hot_cache: dict[tuple[Any, ...], int] = {}
-
-
-def _decode_token_buckets(*_args, **_kwargs) -> tuple[int, ...]:
-    return _DECODE_TOKEN_BUCKETS
-
-
-def _decode_token_bucket(num_tokens: int) -> int:
-    for bucket in _DECODE_TOKEN_BUCKETS:
-        if num_tokens <= bucket:
-            return bucket
-    return _DECODE_TOKEN_BUCKETS[-1]
-
-
-def _init_decode_q(shapes, dtype, device):
-    return (
-        (torch.randn(shapes, device=device, dtype=torch.float32) / 10.0)
-        .clamp(-1, 1)
-        .to(dtype)
-    )
-
-
-def _init_decode_indices(shapes, dtype, device):
-    # The live paged pools used for serving contain far more than 256 rows.
-    # The autotuner profiles latency only, so arbitrary legal rows are enough.
-    return torch.randint(0, 256, shapes, dtype=dtype, device=device)
-
-
-def _init_decode_topk_length(shapes, dtype, device):
-    return torch.full(shapes, 1 << 30, dtype=dtype, device=device)
-
-
-def _decode_inputs_pre_hook(inputs):
-    inputs = list(inputs)
-    indices = inputs[1] if len(inputs) > 1 else None
-    topk_length = inputs[6] if len(inputs) > 6 else None
-    extra_indices = inputs[8] if len(inputs) > 8 else None
-    extra_topk_length = inputs[9] if len(inputs) > 9 else None
-    if topk_length is not None and indices is not None:
-        inputs[6] = torch.full_like(topk_length, indices.shape[-1])
-    if extra_topk_length is not None and extra_indices is not None:
-        inputs[9] = torch.full_like(extra_topk_length, extra_indices.shape[-1])
-    return inputs
-
-
-@functools.cache
-def _decode_tuning_config() -> TuningConfig:
-    # Keep the bucket and scratch-shape contract aligned with the existing FP8
-    # DSv4 sparse-MLA tuner so paired serving warms the same live batch shapes.
-    return TuningConfig(
-        dynamic_tensor_specs=(
-            DynamicTensorSpec(
-                input_idx=(0, 1, 6, 8, 9),
-                dim_idx=(0, 0, 0, 0, 0),
-                gen_tuning_buckets=_decode_token_buckets,
-                map_to_tuning_buckets=_decode_token_bucket,
-            ),
-        ),
-        tensor_initializers=(
-            (0, _init_decode_q),
-            (1, _init_decode_indices),
-            (6, _init_decode_topk_length),
-            (8, _init_decode_indices),
-            (9, _init_decode_topk_length),
-        ),
-        inputs_pre_hook=_decode_inputs_pre_hook,
-        constraint_specs=(
-            ConstraintSpec(2, 0, lambda shapes: shapes[0][0]),
-            ConstraintSpec(3, 0, lambda shapes: shapes[0][0]),
-            ConstraintSpec(4, 0, lambda shapes: shapes[0][0]),
-            ConstraintSpec(5, 0, lambda shapes: shapes[0][0]),
-        ),
-    )
-
-
-def _cache_page_size(cache: torch.Tensor | None) -> int:
-    if cache is None:
-        return 0
-    if cache.ndim == 3:
-        return int(cache.shape[1])
-    if cache.ndim == 4 and cache.shape[1] == 1:
-        return int(cache.shape[2])
-    if cache.ndim == 4 and cache.shape[2] == 1:
-        return int(cache.shape[1])
-    raise ValueError(f"unsupported NVFP4 cache shape for decode tuning: {cache.shape}")
-
-
-class _SparseMlaNvfp4DecodeRunner(TunableRunner):
-    """Tune chunks-per-block while preserving the native streaming kernel."""
-
-    def __init__(
-        self,
-        module,
-        primary_page_size: int,
-        extra_page_size: int,
-    ) -> None:
-        self.module = module
-        self.primary_page_size = primary_page_size
-        self.extra_page_size = extra_page_size
-
-    def get_cache_key_extras(self, inputs: list[torch.Tensor]) -> tuple[Any, ...]:
-        topk_length = inputs[6] if len(inputs) > 6 else None
-        attn_sink = inputs[7] if len(inputs) > 7 else None
-        extra_indices = inputs[8] if len(inputs) > 8 else None
-        extra_topk_length = inputs[9] if len(inputs) > 9 else None
-        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-        return (
-            topk_length is not None,
-            attn_sink is not None,
-            int(extra_topk),
-            extra_topk_length is not None,
-            self.primary_page_size,
-            self.extra_page_size,
-        )
-
-    def get_valid_tactics(
-        self,
-        inputs: list[torch.Tensor],
-        profile: OptimizationProfile,
-    ) -> list[int]:
-        del profile
-        indices = inputs[1]
-        extra_indices = inputs[8] if len(inputs) > 8 else None
-        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-        num_splits = (
-            indices.shape[-1] + _CANDIDATES_PER_CHUNK - 1
-        ) // _CANDIDATES_PER_CHUNK + (
-            extra_topk + _CANDIDATES_PER_CHUNK - 1
-        ) // _CANDIDATES_PER_CHUNK
-        return list(range(1, num_splits + 1))
-
-    def forward(
-        self,
-        inputs: list[torch.Tensor],
-        tactic: int = -1,
-        do_preparation: bool = False,
-        **kwargs,
-    ) -> torch.Tensor:
-        del do_preparation
-        q, indices, mid_out, mid_lse, output, out_lse = inputs[:6]
-        topk_length, attn_sink, extra_indices, extra_topk_length = inputs[6:10]
-        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-        num_splits = (
-            indices.shape[-1] + _CANDIDATES_PER_CHUNK - 1
-        ) // _CANDIDATES_PER_CHUNK + (
-            extra_topk + _CANDIDATES_PER_CHUNK - 1
-        ) // _CANDIDATES_PER_CHUNK
-        self.module.sparse_mla_sm120_nvfp4_decode(
-            q,
-            kwargs["kv_cache"],
-            indices,
-            mid_out,
-            mid_lse,
-            output,
-            out_lse,
-            num_splits,
-            kwargs["sm_scale"],
-            topk_length,
-            attn_sink,
-            kwargs.get("extra_kv_cache"),
-            extra_indices,
-            extra_topk_length,
-            int(tactic) if int(tactic) > 0 else 0,
-            False,
-        )
-        return output
-
-
-def _decode_hot_key(
-    runner: _SparseMlaNvfp4DecodeRunner,
-    inputs: list[torch.Tensor],
-) -> tuple[Any, ...]:
-    q, indices = inputs[:2]
-    extra_indices = inputs[8] if len(inputs) > 8 else None
-    extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-    num_splits = (
-        indices.shape[-1] + _CANDIDATES_PER_CHUNK - 1
-    ) // _CANDIDATES_PER_CHUNK + (
-        extra_topk + _CANDIDATES_PER_CHUNK - 1
-    ) // _CANDIDATES_PER_CHUNK
-    return (
-        _decode_token_bucket(q.shape[0]),
-        q.shape[1],
-        indices.shape[-1],
-        extra_topk,
-        num_splits,
-        runner.get_cache_key_extras(inputs),
-    )
-
-
-def _run_nvfp4_decode(
-    runner: _SparseMlaNvfp4DecodeRunner,
-    q: torch.Tensor,
-    kv_cache: torch.Tensor,
-    indices: torch.Tensor,
-    mid_out: torch.Tensor,
-    mid_lse: torch.Tensor,
-    output: torch.Tensor,
-    out_lse: torch.Tensor,
-    sm_scale: float,
-    topk_length: torch.Tensor | None,
-    attn_sink: torch.Tensor | None,
-    extra_kv_cache: torch.Tensor | None,
-    extra_indices: torch.Tensor | None,
-    extra_topk_length: torch.Tensor | None,
-    chunks_per_block_override: int,
-) -> None:
-    inputs = [
-        q,
-        indices,
-        mid_out,
-        mid_lse,
-        output,
-        out_lse,
-        topk_length,
-        attn_sink,
-        extra_indices,
-        extra_topk_length,
-    ]
-    forward_kwargs = {
-        "sm_scale": sm_scale,
-        "kv_cache": kv_cache,
-        "extra_kv_cache": extra_kv_cache,
-    }
-    if chunks_per_block_override > 0:
-        runner(
-            inputs=inputs,
-            tactic=chunks_per_block_override,
-            **forward_kwargs,
-        )
-        return
-
-    tuner = AutoTuner.get()
-    if not tuner.is_tuning_mode:
-        cached_tactic = _decode_hot_cache.get(_decode_hot_key(runner, inputs))
-        if cached_tactic is not None:
-            runner(inputs=inputs, tactic=cached_tactic, **forward_kwargs)
-            return
-
-    chosen, tactic = tuner.choose_one(
-        _DECODE_AUTOTUNE_OP,
-        [runner],
-        _decode_tuning_config(),
-        inputs,
-        **forward_kwargs,
-    )
-    if int(tactic) > 0:
-        _decode_hot_cache[_decode_hot_key(runner, inputs)] = int(tactic)
-    chosen(inputs=inputs, tactic=tactic, **forward_kwargs)
 
 
 @functools.cache
 def get_sparse_mla_nvfp4_sm120_module():
     module = gen_sparse_mla_nvfp4_sm120_module().build_and_load()
-    decode_runners: dict[tuple[int, int], _SparseMlaNvfp4DecodeRunner] = {}
-
-    def get_decode_runner(
-        kv_cache: torch.Tensor,
-        extra_kv_cache: torch.Tensor | None,
-    ) -> _SparseMlaNvfp4DecodeRunner:
-        page_key = (
-            _cache_page_size(kv_cache),
-            _cache_page_size(extra_kv_cache),
-        )
-        runner = decode_runners.get(page_key)
-        if runner is None:
-            runner = _SparseMlaNvfp4DecodeRunner(module, *page_key)
-            decode_runners[page_key] = runner
-        return runner
 
     @register_custom_op(
         "flashinfer::sparse_mla_nvfp4_sm120_paged_attention",
@@ -351,8 +75,10 @@ def get_sparse_mla_nvfp4_sm120_module():
         if not use_prefill:
             if mid_out is None or mid_lse is None:
                 raise ValueError("NVFP4 decode requires mid_out and mid_lse workspace")
-            _run_nvfp4_decode(
-                get_decode_runner(kv_cache, extra_kv_cache),
+            num_splits = (indices.shape[1] + 63) // 64
+            if extra_indices is not None:
+                num_splits += (extra_indices.shape[1] + 63) // 64
+            module.sparse_mla_sm120_nvfp4_decode(
                 q,
                 kv_cache,
                 indices,
@@ -360,6 +86,7 @@ def get_sparse_mla_nvfp4_sm120_module():
                 mid_lse,
                 output,
                 out_lse,
+                num_splits,
                 sm_scale,
                 topk_length,
                 attn_sink,
@@ -367,6 +94,7 @@ def get_sparse_mla_nvfp4_sm120_module():
                 extra_indices,
                 extra_topk_length,
                 chunks_per_block_override,
+                False,
             )
         else:
             module.sparse_mla_sm120_nvfp4_prefill(
@@ -418,7 +146,7 @@ def _sparse_mla_nvfp4_sm120_paged_attention(
     extra_topk_length: torch.Tensor | None = None,
     mid_out: torch.Tensor | None = None,
     mid_lse: torch.Tensor | None = None,
-    use_prefill: bool | None = None,
+    use_prefill: bool,
     chunks_per_block_override: int = 0,
 ) -> None:
     """Run the allocation-free NVFP4 sparse-MLA custom op."""
@@ -436,7 +164,7 @@ def _sparse_mla_nvfp4_sm120_paged_attention(
         extra_kv_cache,
         extra_indices,
         extra_topk_length,
-        q.shape[0] > 64 if use_prefill is None else use_prefill,
+        use_prefill,
         chunks_per_block_override,
     )
 

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
@@ -229,6 +229,20 @@ def _cache_shape(cache: torch.Tensor) -> tuple[int, int, str]:
     return int(num_pages), int(page_size), layout
 
 
+def _validate_unique_slots(slot_mapping: torch.Tensor, capacity: int) -> None:
+    """Reject write races when defensive MLA input checks are enabled."""
+    from ._core import _validate_dsv4_sync_checks
+
+    if slot_mapping.numel() < 2 or not _validate_dsv4_sync_checks(slot_mapping.device):
+        return
+    ordered = torch.sort(slot_mapping).values
+    duplicate_valid = (
+        (ordered[1:] == ordered[:-1]) & (ordered[1:] >= 0) & (ordered[1:] < capacity)
+    )
+    if duplicate_valid.any().item():
+        raise ValueError("valid slot_mapping entries must be unique")
+
+
 @supported_compute_capability([120, 121])
 def nvfp4_quantize_pack_sparse_mla_cache(
     latent_kv: torch.Tensor,
@@ -296,8 +310,10 @@ def nvfp4_quantize_append_sparse_mla_cache(
     addition to the public 4D HND/NHD layouts. ``slot_mapping[i]`` is
     ``page_id * page_size + entry_id``. Page-strided views are accepted so the
     cache can live inside vLLM's packed physical block allocation. Negative and
-    out-of-range slots are padding and are ignored. Only the addressed data row
-    and scale slot are written, so prefill history is reused directly by decode.
+    out-of-range slots are padding and are ignored. Valid slots must be unique;
+    set ``FLASHINFER_VALIDATE_INPUTS=1`` to check that invariant eagerly outside
+    CUDA Graph capture. Only the addressed data row and scale slot are written,
+    so prefill history is reused directly by decode.
     """
     num_pages, page_size, _ = _cache_shape(cache)
     if not slot_mapping.is_cuda:
@@ -317,6 +333,7 @@ def nvfp4_quantize_append_sparse_mla_cache(
     _check_latent_kv(latent_kv, expected_rows=slot_mapping.numel())
     if num_pages * page_size == 0 and slot_mapping.numel() != 0:
         raise ValueError("cannot append to an empty cache")
+    _validate_unique_slots(slot_mapping, num_pages * page_size)
 
     get_sparse_mla_nvfp4_sm120_module().sparse_mla_sm120_nvfp4_quantize_append(
         latent_kv, slot_mapping, cache

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120.py
@@ -230,20 +230,6 @@ def _cache_shape(cache: torch.Tensor) -> tuple[int, int, str]:
     return int(num_pages), int(page_size), layout
 
 
-def _validate_unique_slots(slot_mapping: torch.Tensor, capacity: int) -> None:
-    """Reject write races when defensive MLA input checks are enabled."""
-    from ._core import _validate_dsv4_sync_checks
-
-    if slot_mapping.numel() < 2 or not _validate_dsv4_sync_checks(slot_mapping.device):
-        return
-    ordered = torch.sort(slot_mapping).values
-    duplicate_valid = (
-        (ordered[1:] == ordered[:-1]) & (ordered[1:] >= 0) & (ordered[1:] < capacity)
-    )
-    if duplicate_valid.any().item():
-        raise ValueError("valid slot_mapping entries must be unique")
-
-
 @supported_compute_capability([120, 121])
 @flashinfer_api
 def nvfp4_quantize_pack_sparse_mla_cache(
@@ -326,9 +312,8 @@ def nvfp4_quantize_append_sparse_mla_cache(
     slot_mapping : torch.Tensor
         Contiguous 1D CUDA int32 or int64 tensor. ``slot_mapping[i]`` is
         ``page_id * page_size + entry_id``. Negative and out-of-range slots
-        are padding and are ignored. Valid slots must be unique; set
-        ``FLASHINFER_VALIDATE_INPUTS=1`` to check that invariant eagerly
-        outside CUDA Graph capture.
+        are padding and are ignored. If a valid slot occurs more than once,
+        the lowest-index input row is written deterministically.
     cache : torch.Tensor
         Destination opaque uint8 paged cache. The 3D shorthand
         ``[num_pages, page_size, 384]`` and public 4D HND/NHD layouts are
@@ -354,7 +339,6 @@ def nvfp4_quantize_append_sparse_mla_cache(
     _check_latent_kv(latent_kv, expected_rows=slot_mapping.numel())
     if num_pages * page_size == 0 and slot_mapping.numel() != 0:
         raise ValueError("cannot append to an empty cache")
-    _validate_unique_slots(slot_mapping, num_pages * page_size)
 
     get_sparse_mla_nvfp4_sm120_module().sparse_mla_sm120_nvfp4_quantize_append(
         latent_kv, slot_mapping, cache

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120_plan.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120_plan.py
@@ -1,0 +1,748 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Calibrated decode/prefill planner for SM120 NVFP4 sparse MLA.
+
+The 64-query-token value in this module is only the split-K decode kernel's
+implementation envelope.  Inside that envelope, a separately keyed NVFP4
+calibration compares split-K decode (including merge) with streaming prefill
+and records the measured phase plus the best decode CPB for each probe bucket.
+Per-bucket phase records preserve GPU wave-boundary non-monotonicity that a
+single threshold cannot express.  The dispatch policy and persistence
+primitives are shared with the existing FP8 planner; FP8 measurements are
+never reused for NVFP4.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+import torch
+
+from ..autotuner import AutoTuner
+from . import _sparse_mla_sm120_cpb as _cpb
+from ._sparse_mla_sm120_cpb import CalibrationError
+from ._sparse_mla_sm120_plan import _select_calibrated_variant
+
+logger = logging.getLogger(__name__)
+
+_PLAN_VERSION = 1
+_FAMILY_PREFIX = f"dsv4_nvfp4_v{_PLAN_VERSION}"
+_AUTOTUNE_OP = "sparse_mla_sm120_nvfp4"
+_BYTES_PER_TOKEN = 384
+_CANDIDATES_PER_CHUNK = 64
+_DECODE_MAX_TOKENS = 64
+_SUPPORTED_HEADS = frozenset({16, 32, 64, 128})
+_SUPPORTED_PRIMARY_TOPKS = frozenset({128, 512})
+_SUPPORTED_PRIMARY_PAGE_SIZES = frozenset({64})
+_SUPPORTED_EXTRA_PAGE_SIZES = frozenset({2, 64})
+
+# Match the FP8 crossover policy, adding T=1 because single-request decode is
+# an important NVFP4 latency corner.  Non-probe decode batches use the next
+# larger bucket's measured CPB.
+_CROSSOVER_PROBED_T = (1, 4, 8, 16, 24, 32, 48, 64)
+_CROSSOVER_MARGIN = 0.95
+
+# The calibration timing protocol queues calls and rotates index sets, keeping
+# launch latency overlap and cache residency close to steady-state serving.
+_POOL_BYTES_TARGET = 2 << 30
+_POOL_BYTES_MIN = 512 << 20
+_MIN_POOL_PER_SEGMENT = 128 << 20
+_WARMUP_ITERS = 3
+_TIMED_BATCHES = 5
+_MIN_BATCH_CALLS = 8
+_MAX_BATCH_CALLS = 256
+
+
+class NVFP4KernelVariant(enum.Enum):
+    """NVFP4 sparse-MLA implementation selected for one call."""
+
+    DECODE_SPLITK = "decode_splitk"
+    PREFILL_STREAMING = "prefill_streaming"
+
+
+@dataclass(frozen=True)
+class NVFP4PlannedCall:
+    """Planner output; CPB is meaningful only for split-K decode."""
+
+    variant: NVFP4KernelVariant
+    cpb: int  # 0 asks the C++ decode launcher for its safe heuristic
+
+
+@dataclass(frozen=True)
+class NVFP4CalibrationReport:
+    """Measured result for one exact NVFP4 sparse-MLA cache configuration."""
+
+    family: str
+    num_heads: int
+    topk: int
+    extra_topk: int
+    extra_page_size: int
+    decode_max_tokens: Optional[int]
+    phase_by_token_bucket: dict[int, str]
+    cpb_by_token_bucket: dict[int, int]
+    decode_latency_us: dict[int, float]
+    prefill_latency_us: dict[int, float]
+
+
+_plan_memo: dict[tuple, NVFP4KernelVariant] = {}
+_calibration_lock = threading.RLock()
+_calibrating: set[tuple[str, str, int, int]] = set()
+
+
+def _token_bucket(num_tokens: int) -> int:
+    for bucket in _CROSSOVER_PROBED_T:
+        if num_tokens <= bucket:
+            return bucket
+    return _CROSSOVER_PROBED_T[-1]
+
+
+def _family_key(
+    *,
+    primary_page_size: int,
+    extra_topk: int,
+    extra_page_size: int,
+    has_topk_length: bool,
+    has_extra_topk_length: bool,
+    has_attn_sink: bool,
+) -> str:
+    """Build a format- and ABI-specific calibration namespace."""
+    return (
+        f"{_FAMILY_PREFIX}_p{primary_page_size}_e{extra_topk}"
+        f"p{extra_page_size}_l{int(has_topk_length)}"
+        f"x{int(has_extra_topk_length)}_s{int(has_attn_sink)}"
+    )
+
+
+def _phase_family(family: str, token_bucket: int) -> str:
+    """Namespace one measured phase decision without assuming monotonicity."""
+    return f"{family}_t{token_bucket}"
+
+
+def _phase_grid_complete(
+    device: torch.device, family: str, num_heads: int, topk: int
+) -> bool:
+    return all(
+        _cpb.get_decode_max_tokens(
+            device, _phase_family(family, token_bucket), num_heads, topk
+        )
+        is not None
+        for token_bucket in _CROSSOVER_PROBED_T
+    )
+
+
+def _monotonic_decode_max_tokens(
+    decode_by_token_bucket: dict[int, bool],
+) -> Optional[int]:
+    """Return a threshold only when measured phase choices form a prefix."""
+    decode_max_tokens = 0
+    saw_prefill = False
+    for token_bucket in sorted(decode_by_token_bucket):
+        if decode_by_token_bucket[token_bucket]:
+            if saw_prefill:
+                return None
+            decode_max_tokens = token_bucket
+        else:
+            saw_prefill = True
+    return decode_max_tokens
+
+
+def _eligible(
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    primary_page_size: int,
+    extra_topk: int,
+    extra_page_size: int,
+) -> tuple[bool, bool]:
+    common = (
+        num_tokens >= 1
+        and num_heads in _SUPPORTED_HEADS
+        and topk in _SUPPORTED_PRIMARY_TOPKS
+        and primary_page_size in _SUPPORTED_PRIMARY_PAGE_SIZES
+        and (
+            (extra_topk == 0 and extra_page_size == 0)
+            or (extra_topk > 0 and extra_page_size in _SUPPORTED_EXTRA_PAGE_SIZES)
+        )
+    )
+    return common and num_tokens <= _DECODE_MAX_TOKENS, common
+
+
+def _autotune_skipped() -> bool:
+    tuner = AutoTuner.get()
+    skip_stack = tuner._get_skip_ops_stack()
+    return bool(skip_stack) and _AUTOTUNE_OP in skip_stack[-1]
+
+
+def _maybe_calibrate(
+    *,
+    device: torch.device,
+    family: str,
+    num_heads: int,
+    topk: int,
+    primary_page_size: int,
+    extra_topk: int,
+    extra_page_size: int,
+    has_topk_length: bool,
+    has_extra_topk_length: bool,
+    has_attn_sink: bool,
+) -> None:
+    tuner = AutoTuner.get()
+    if (
+        not tuner.is_tuning_mode
+        or _autotune_skipped()
+        or torch.cuda.is_current_stream_capturing()
+        or _cpb.is_crossover_failed(device, family)
+    ):
+        return
+
+    key = (_cpb._device_key(device), family, num_heads, topk)
+    with _calibration_lock:
+        if _phase_grid_complete(device, family, num_heads, topk):
+            return
+        if key in _calibrating:
+            return
+        _calibrating.add(key)
+        try:
+            calibrate_nvfp4_sparse_mla_sm120(
+                device,
+                num_heads=num_heads,
+                topk=topk,
+                primary_page_size=primary_page_size,
+                extra_topk=extra_topk,
+                extra_page_size=extra_page_size,
+                has_topk_length=has_topk_length,
+                has_extra_topk_length=has_extra_topk_length,
+                has_attn_sink=has_attn_sink,
+                force=True,
+            )
+        except (CalibrationError, torch.cuda.OutOfMemoryError, RuntimeError) as e:
+            logger.warning(
+                "SM120 NVFP4 sparse-MLA calibration failed for H=%d, topk=%d, "
+                "extra_topk=%d, extra_page_size=%d (%s); using decode-first "
+                "routing and the C++ CPB heuristic.",
+                num_heads,
+                topk,
+                extra_topk,
+                extra_page_size,
+                e,
+            )
+            _cpb.mark_crossover_failed(device, family)
+        finally:
+            _calibrating.discard(key)
+
+
+def plan_nvfp4_sparse_mla_sm120(
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    primary_page_size: int,
+    device: torch.device,
+    *,
+    extra_topk: int = 0,
+    extra_page_size: int = 0,
+    has_topk_length: bool = False,
+    has_extra_topk_length: bool = False,
+    has_attn_sink: bool = False,
+) -> Optional[NVFP4PlannedCall]:
+    """Select independently calibrated NVFP4 prefill/decode execution."""
+    device = torch.device(device)
+    if has_extra_topk_length and extra_topk == 0:
+        raise ValueError("has_extra_topk_length requires extra_topk > 0")
+    decode_ok, prefill_ok = _eligible(
+        num_tokens,
+        num_heads,
+        topk,
+        primary_page_size,
+        extra_topk,
+        extra_page_size,
+    )
+    if not decode_ok and not prefill_ok:
+        return None
+
+    family = _family_key(
+        primary_page_size=primary_page_size,
+        extra_topk=extra_topk,
+        extra_page_size=extra_page_size,
+        has_topk_length=has_topk_length,
+        has_extra_topk_length=has_extra_topk_length,
+        has_attn_sink=has_attn_sink,
+    )
+    token_bucket = _token_bucket(num_tokens)
+    phase_family = _phase_family(family, token_bucket)
+    phase_record = _cpb.get_decode_max_tokens(device, phase_family, num_heads, topk)
+    if decode_ok and phase_record is None:
+        _maybe_calibrate(
+            device=device,
+            family=family,
+            num_heads=num_heads,
+            topk=topk,
+            primary_page_size=primary_page_size,
+            extra_topk=extra_topk,
+            extra_page_size=extra_page_size,
+            has_topk_length=has_topk_length,
+            has_extra_topk_length=has_extra_topk_length,
+            has_attn_sink=has_attn_sink,
+        )
+        phase_record = _cpb.get_decode_max_tokens(device, phase_family, num_heads, topk)
+
+    t_bucket = token_bucket if num_tokens <= _DECODE_MAX_TOKENS else -1
+    memo_key = (
+        family,
+        num_heads,
+        topk,
+        t_bucket,
+        _cpb._device_key(device),
+        _cpb._constants_version,
+    )
+    variant = _plan_memo.get(memo_key)
+    if variant is None:
+        variant = _select_calibrated_variant(
+            decode_eligible=decode_ok,
+            decode_variant=NVFP4KernelVariant.DECODE_SPLITK,
+            prefill_variant=(
+                NVFP4KernelVariant.PREFILL_STREAMING if prefill_ok else None
+            ),
+            # Each bucket stores its own phase.  The shared selector consumes
+            # the decision directly, so NVFP4 does not inherit FP8's
+            # monotonic crossover assumption.
+            decode_preferred=(None if phase_record is None else phase_record > 0),
+        )
+        if variant is None:
+            return None
+        _plan_memo[memo_key] = variant
+
+    if variant is NVFP4KernelVariant.PREFILL_STREAMING:
+        return NVFP4PlannedCall(variant, 0)
+    cpb = _cpb.get_cpb_override(
+        device, family, num_heads, topk, _token_bucket(num_tokens)
+    )
+    return NVFP4PlannedCall(variant, 0 if cpb is None else cpb)
+
+
+def _allocate_cache_pool(
+    page_size: int, pool_bytes: int, device: torch.device
+) -> tuple[torch.Tensor, int]:
+    page_bytes = page_size * _BYTES_PER_TOKEN
+    num_pages = max(1, pool_bytes // page_bytes)
+    cache = torch.empty(
+        (num_pages, page_size, _BYTES_PER_TOKEN),
+        dtype=torch.uint8,
+        device=device,
+    )
+    return cache, num_pages * page_size
+
+
+def _allocate_calibration_pools(
+    device: torch.device,
+    primary_page_size: int,
+    topk: int,
+    extra_topk: int,
+    extra_page_size: int,
+) -> tuple[torch.Tensor, int, Optional[torch.Tensor], int]:
+    total_bytes = _POOL_BYTES_TARGET
+    while True:
+        total_topk = topk + extra_topk
+        if extra_topk:
+            primary_bytes = max(_MIN_POOL_PER_SEGMENT, total_bytes * topk // total_topk)
+            extra_bytes = max(
+                _MIN_POOL_PER_SEGMENT, total_bytes * extra_topk // total_topk
+            )
+        else:
+            primary_bytes, extra_bytes = total_bytes, 0
+        primary_cache = None
+        extra_cache = None
+        try:
+            primary_cache, primary_slots = _allocate_cache_pool(
+                primary_page_size, primary_bytes, device
+            )
+            if extra_topk:
+                extra_cache, extra_slots = _allocate_cache_pool(
+                    extra_page_size, extra_bytes, device
+                )
+            else:
+                extra_slots = 0
+            return primary_cache, primary_slots, extra_cache, extra_slots
+        except torch.cuda.OutOfMemoryError:
+            del primary_cache, extra_cache
+            if total_bytes <= _POOL_BYTES_MIN:
+                raise CalibrationError(
+                    "cannot allocate a >=512 MiB aggregate NVFP4 KV pool for "
+                    "sparse-MLA calibration"
+                ) from None
+            total_bytes //= 2
+            torch.cuda.empty_cache()
+
+
+def _make_index_sets(
+    *,
+    num_tokens: int,
+    topk: int,
+    primary_slots: int,
+    extra_topk: int,
+    extra_slots: int,
+    device: torch.device,
+) -> list[tuple[torch.Tensor, Optional[torch.Tensor]]]:
+    props = torch.cuda.get_device_properties(device)
+    l2_bytes = int(getattr(props, "L2_cache_size", 0) or 0)
+    footprint = max(1, num_tokens * (topk + extra_topk) * _BYTES_PER_TOKEN)
+    count = (
+        _MIN_BATCH_CALLS
+        if not l2_bytes
+        else min(
+            _MAX_BATCH_CALLS,
+            max(_MIN_BATCH_CALLS, l2_bytes // footprint + 2),
+        )
+    )
+    result = []
+    for _ in range(count):
+        primary = torch.randint(
+            0,
+            primary_slots,
+            (num_tokens, topk),
+            dtype=torch.int32,
+            device=device,
+        )
+        extra = (
+            torch.randint(
+                0,
+                extra_slots,
+                (num_tokens, extra_topk),
+                dtype=torch.int32,
+                device=device,
+            )
+            if extra_topk
+            else None
+        )
+        result.append((primary, extra))
+    return result
+
+
+def _time_indexed_calls(
+    call: Callable[[torch.Tensor, Optional[torch.Tensor]], None],
+    index_sets: list[tuple[torch.Tensor, Optional[torch.Tensor]]],
+) -> float:
+    for i in range(_WARMUP_ITERS):
+        call(*index_sets[i % len(index_sets)])
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    best = float("inf")
+    for _ in range(_TIMED_BATCHES):
+        start.record()
+        for indices in index_sets:
+            call(indices[0], indices[1])
+        end.record()
+        torch.cuda.synchronize()
+        best = min(best, start.elapsed_time(end) / len(index_sets))
+    return best * 1e3  # CUDA events report milliseconds.
+
+
+def _make_calibration_calls(
+    *,
+    module,
+    device: torch.device,
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    primary_cache: torch.Tensor,
+    extra_topk: int,
+    extra_cache: Optional[torch.Tensor],
+    has_topk_length: bool,
+    has_extra_topk_length: bool,
+    has_attn_sink: bool,
+) -> tuple[
+    Callable[[int], Callable[[torch.Tensor, Optional[torch.Tensor]], None]],
+    Callable[[torch.Tensor, Optional[torch.Tensor]], None],
+]:
+    num_splits = (topk + _CANDIDATES_PER_CHUNK - 1) // _CANDIDATES_PER_CHUNK
+    num_splits += (extra_topk + _CANDIDATES_PER_CHUNK - 1) // _CANDIDATES_PER_CHUNK
+    q = (
+        (
+            torch.randn(
+                num_tokens,
+                num_heads,
+                512,
+                dtype=torch.float32,
+                device=device,
+            )
+            / 10.0
+        )
+        .clamp(-1, 1)
+        .to(torch.bfloat16)
+    )
+    mid_out = torch.empty(
+        (num_tokens, num_heads, num_splits, 512),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    mid_lse = torch.empty(
+        (num_tokens, num_heads, num_splits),
+        dtype=torch.float32,
+        device=device,
+    )
+    output = torch.empty_like(q)
+    out_lse = torch.empty((num_tokens, num_heads), dtype=torch.float32, device=device)
+    topk_length = (
+        torch.full((num_tokens,), topk, dtype=torch.int32, device=device)
+        if has_topk_length
+        else None
+    )
+    extra_topk_length = (
+        torch.full((num_tokens,), extra_topk, dtype=torch.int32, device=device)
+        if has_extra_topk_length
+        else None
+    )
+    attn_sink = (
+        torch.zeros((num_heads,), dtype=torch.float32, device=device)
+        if has_attn_sink
+        else None
+    )
+    sm_scale = 512**-0.5
+
+    def build_decode(
+        cpb: int,
+    ) -> Callable[[torch.Tensor, Optional[torch.Tensor]], None]:
+        def call(indices: torch.Tensor, extra_indices: Optional[torch.Tensor]) -> None:
+            module.sparse_mla_sm120_nvfp4_decode(
+                q,
+                primary_cache,
+                indices,
+                mid_out,
+                mid_lse,
+                output,
+                out_lse,
+                num_splits,
+                sm_scale,
+                topk_length,
+                attn_sink,
+                extra_cache,
+                extra_indices,
+                extra_topk_length,
+                cpb,
+                False,
+            )
+
+        return call
+
+    def prefill(indices: torch.Tensor, extra_indices: Optional[torch.Tensor]) -> None:
+        module.sparse_mla_sm120_nvfp4_prefill(
+            q,
+            primary_cache,
+            indices,
+            output,
+            out_lse,
+            sm_scale,
+            topk_length,
+            attn_sink,
+            extra_cache,
+            extra_indices,
+            extra_topk_length,
+        )
+
+    return build_decode, prefill
+
+
+def calibrate_nvfp4_sparse_mla_sm120(
+    device: torch.device,
+    *,
+    num_heads: int,
+    topk: int,
+    primary_page_size: int = 64,
+    extra_topk: int = 0,
+    extra_page_size: int = 0,
+    has_topk_length: bool = False,
+    has_extra_topk_length: bool = False,
+    has_attn_sink: bool = False,
+    force: bool = False,
+) -> NVFP4CalibrationReport:
+    """Calibrate one exact NVFP4 sparse-MLA shape family on an idle GPU.
+
+    This is intentionally kept in the internal module while the cache ABI and
+    public calibration surface are under upstream review.  Normal serving
+    warmup invokes it lazily inside ``autotune(True)``.
+    """
+    device = torch.device(device)
+    if torch.cuda.is_current_stream_capturing():
+        raise CalibrationError(
+            "NVFP4 sparse-MLA calibration must not run under CUDA graph capture"
+        )
+    decode_ok, prefill_ok = _eligible(
+        1,
+        num_heads,
+        topk,
+        primary_page_size,
+        extra_topk,
+        extra_page_size,
+    )
+    if not decode_ok or not prefill_ok:
+        raise ValueError(
+            "unsupported NVFP4 calibration shape: "
+            f"heads={num_heads}, topk={topk}, primary_page_size="
+            f"{primary_page_size}, extra_topk={extra_topk}, "
+            f"extra_page_size={extra_page_size}"
+        )
+    if has_extra_topk_length and extra_topk == 0:
+        raise ValueError("has_extra_topk_length requires extra_topk > 0")
+
+    family = _family_key(
+        primary_page_size=primary_page_size,
+        extra_topk=extra_topk,
+        extra_page_size=extra_page_size,
+        has_topk_length=has_topk_length,
+        has_extra_topk_length=has_extra_topk_length,
+        has_attn_sink=has_attn_sink,
+    )
+    existing_phase = {
+        token_bucket: _cpb.get_decode_max_tokens(
+            device,
+            _phase_family(family, token_bucket),
+            num_heads,
+            topk,
+        )
+        for token_bucket in _CROSSOVER_PROBED_T
+    }
+    if all(value is not None for value in existing_phase.values()) and not force:
+        cpbs = {
+            t: cpb
+            for t in _CROSSOVER_PROBED_T
+            if (cpb := _cpb.get_cpb_override(device, family, num_heads, topk, t))
+            is not None
+        }
+        return NVFP4CalibrationReport(
+            family,
+            num_heads,
+            topk,
+            extra_topk,
+            extra_page_size,
+            _monotonic_decode_max_tokens(
+                {
+                    token_bucket: bool(value)
+                    for token_bucket, value in existing_phase.items()
+                }
+            ),
+            {
+                token_bucket: "decode" if value else "prefill"
+                for token_bucket, value in existing_phase.items()
+            },
+            cpbs,
+            {},
+            {},
+        )
+
+    from ._sparse_mla_nvfp4_sm120 import get_sparse_mla_nvfp4_sm120_module
+
+    module = get_sparse_mla_nvfp4_sm120_module()
+    primary_cache, primary_slots, extra_cache, extra_slots = (
+        _allocate_calibration_pools(
+            device,
+            primary_page_size,
+            topk,
+            extra_topk,
+            extra_page_size,
+        )
+    )
+    num_splits = (topk + _CANDIDATES_PER_CHUNK - 1) // _CANDIDATES_PER_CHUNK
+    num_splits += (extra_topk + _CANDIDATES_PER_CHUNK - 1) // _CANDIDATES_PER_CHUNK
+    cpb_by_t: dict[int, int] = {}
+    decode_us: dict[int, float] = {}
+    prefill_us: dict[int, float] = {}
+    decode_by_t: dict[int, bool] = {}
+
+    for num_tokens in _CROSSOVER_PROBED_T:
+        index_sets = _make_index_sets(
+            num_tokens=num_tokens,
+            topk=topk,
+            primary_slots=primary_slots,
+            extra_topk=extra_topk,
+            extra_slots=extra_slots,
+            device=device,
+        )
+        build_decode, prefill = _make_calibration_calls(
+            module=module,
+            device=device,
+            num_tokens=num_tokens,
+            num_heads=num_heads,
+            topk=topk,
+            primary_cache=primary_cache,
+            extra_topk=extra_topk,
+            extra_cache=extra_cache,
+            has_topk_length=has_topk_length,
+            has_extra_topk_length=has_extra_topk_length,
+            has_attn_sink=has_attn_sink,
+        )
+        best_cpb = 1
+        best_decode_us = float("inf")
+        for cpb in range(1, num_splits + 1):
+            latency_us = _time_indexed_calls(build_decode(cpb), index_sets)
+            if latency_us <= best_decode_us:
+                best_cpb, best_decode_us = cpb, latency_us
+        measured_prefill_us = _time_indexed_calls(prefill, index_sets)
+        cpb_by_t[num_tokens] = best_cpb
+        decode_us[num_tokens] = best_decode_us
+        prefill_us[num_tokens] = measured_prefill_us
+        decode_by_t[num_tokens] = (
+            best_decode_us <= _CROSSOVER_MARGIN * measured_prefill_us
+        )
+
+    for num_tokens, cpb in cpb_by_t.items():
+        _cpb.save_cpb_override(device, family, num_heads, topk, num_tokens, cpb)
+    _cpb.save_crossover(
+        device,
+        {
+            f"{_phase_family(family, token_bucket)}|{num_heads}|{topk}": (
+                token_bucket if use_decode else 0
+            )
+            for token_bucket, use_decode in decode_by_t.items()
+        },
+    )
+    phase_by_t = {
+        token_bucket: "decode" if use_decode else "prefill"
+        for token_bucket, use_decode in decode_by_t.items()
+    }
+    logger.info(
+        "Calibrated SM120 NVFP4 sparse MLA H=%d topk=%d extra_topk=%d "
+        "extra_page_size=%d: phases=%s, cpb=%s",
+        num_heads,
+        topk,
+        extra_topk,
+        extra_page_size,
+        phase_by_t,
+        cpb_by_t,
+    )
+    return NVFP4CalibrationReport(
+        family,
+        num_heads,
+        topk,
+        extra_topk,
+        extra_page_size,
+        _monotonic_decode_max_tokens(decode_by_t),
+        phase_by_t,
+        cpb_by_t,
+        decode_us,
+        prefill_us,
+    )
+
+
+__all__ = [
+    "NVFP4CalibrationReport",
+    "NVFP4KernelVariant",
+    "NVFP4PlannedCall",
+    "calibrate_nvfp4_sparse_mla_sm120",
+    "plan_nvfp4_sparse_mla_sm120",
+]

--- a/flashinfer/mla/_sparse_mla_nvfp4_sm120_plan.py
+++ b/flashinfer/mla/_sparse_mla_nvfp4_sm120_plan.py
@@ -63,9 +63,6 @@ _CROSSOVER_MARGIN = 0.95
 _POOL_BYTES_TARGET = 2 << 30
 _POOL_BYTES_MIN = 512 << 20
 _MIN_POOL_PER_SEGMENT = 128 << 20
-_WARMUP_ITERS = 3
-_TIMED_BATCHES = 5
-_MIN_BATCH_CALLS = 8
 _MAX_BATCH_CALLS = 256
 
 
@@ -398,16 +395,12 @@ def _make_index_sets(
     extra_slots: int,
     device: torch.device,
 ) -> list[tuple[torch.Tensor, Optional[torch.Tensor]]]:
-    props = torch.cuda.get_device_properties(device)
-    l2_bytes = int(getattr(props, "L2_cache_size", 0) or 0)
-    footprint = max(1, num_tokens * (topk + extra_topk) * _BYTES_PER_TOKEN)
-    count = (
-        _MIN_BATCH_CALLS
-        if not l2_bytes
-        else min(
-            _MAX_BATCH_CALLS,
-            max(_MIN_BATCH_CALLS, l2_bytes // footprint + 2),
-        )
+    count = _cpb.calibration_batch_count(
+        num_tokens,
+        topk + extra_topk,
+        _BYTES_PER_TOKEN,
+        device,
+        max_batch_calls=_MAX_BATCH_CALLS,
     )
     result = []
     for _ in range(count):
@@ -437,20 +430,7 @@ def _time_indexed_calls(
     call: Callable[[torch.Tensor, Optional[torch.Tensor]], None],
     index_sets: list[tuple[torch.Tensor, Optional[torch.Tensor]]],
 ) -> float:
-    for i in range(_WARMUP_ITERS):
-        call(*index_sets[i % len(index_sets)])
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    best = float("inf")
-    for _ in range(_TIMED_BATCHES):
-        start.record()
-        for indices in index_sets:
-            call(indices[0], indices[1])
-        end.record()
-        torch.cuda.synchronize()
-        best = min(best, start.elapsed_time(end) / len(index_sets))
-    return best * 1e3  # CUDA events report milliseconds.
+    return _cpb.time_calibration_calls(call, index_sets) * 1e6
 
 
 def _make_calibration_calls(

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -75,7 +75,7 @@ import functools
 import logging
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import torch
 
@@ -127,9 +127,13 @@ from ._sparse_mla_sm120_cpb import (  # noqa: E402
     calibrate_sparse_mla_sm120,  # noqa: F401  (lazy re-export)
 )
 
+if TYPE_CHECKING:
+    from ._sparse_mla_nvfp4_sm120_plan import NVFP4PlannedCall
+
 logger = logging.getLogger(__name__)
 
 _KV_SCALE_FORMATS = frozenset({"auto", "pow2_fp32", "arbitrary_fp32"})
+_KV_CACHE_FORMATS = frozenset({"fp8", "nvfp4"})
 
 # Page block size the decode kernels are instantiated for (same constant for
 # both families; every instantiated kernel is pbs=64).
@@ -143,12 +147,10 @@ class SparseMLASm120DecodeConfig:
 
     Decode-form calls (``num_tokens <= max_num_tokens``) prefer a standalone
     decode kernel when their shape matches one of the instantiations
-    described here; decode-eligible is not required, since the prefill
-    orchestrator serves any remaining decode-form shape at
-    ``num_tokens >= 1`` (and crossover calibration may route even eligible
-    shapes to prefill past a measured ``num_tokens`` threshold). Larger calls
-    go through the prefill orchestrator, which has its own separately
-    instantiated shape envelope; this config describes decode only.
+    described here. For FP8, the prefill orchestrator can serve remaining
+    decode-form shapes in its own envelope; NVFP4 currently uses the same
+    exact head/top-k envelope for both kernels. Crossover calibration may
+    route an eligible shape to prefill. This config describes decode only.
 
     Attributes
     ----------
@@ -161,18 +163,29 @@ class SparseMLASm120DecodeConfig:
     max_num_tokens : int
         Largest ``num_tokens`` routed to the decode kernels (inclusive).
     topks : frozenset[int]
-        The calibrated top-k values (the crossover sweep points). Decode
-        serves ANY ``topk >= min_topk`` — topk is a runtime kernel argument —
-        so this set is documentation of what has measured crossover data,
-        not the eligibility boundary.
+        The calibrated top-k values (the crossover sweep points). When
+        ``topk_is_runtime`` is true, this documents measured values rather
+        than the eligibility boundary; otherwise it is the exact set.
     min_topk : int
         Smallest legal ``topk`` (the indices-row width). ``513`` for the
         sliding-window family (the window must fit the buffer); ``1``
         elsewhere.
     max_num_heads : int
-        Every ``num_heads`` in ``[1, max_num_heads]`` is served: dedicated
-        instantiations at ``{8, 16, 32, 64, 128}`` plus one
-        runtime-head-count instantiation covering any other count.
+        Upper bound of the head-count envelope.
+    kv_cache_format : str
+        Packed cache format described by this entry (``"fp8"`` or
+        ``"nvfp4"``).
+    bytes_per_token : int
+        Logical packed-cache bytes per token.
+    head_counts : Optional[frozenset[int]]
+        Exact instantiated head counts when the kernel has no runtime-head
+        fallback. ``None`` means every count in ``[1, max_num_heads]``.
+    topk_is_runtime : bool
+        Whether every ``topk >= min_topk`` is accepted. When false, only
+        values in ``topks`` are instantiated.
+    extra_page_block_sizes : frozenset[int]
+        Exact page sizes accepted by the optional secondary cache when the
+        family has a finite set exposed here. Empty means unspecified.
     """
 
     d_qk: int
@@ -181,17 +194,29 @@ class SparseMLASm120DecodeConfig:
     topks: frozenset[int]
     min_topk: int
     max_num_heads: int
+    kv_cache_format: str = "fp8"
+    bytes_per_token: int = 0
+    head_counts: Optional[frozenset[int]] = None
+    topk_is_runtime: bool = True
+    extra_page_block_sizes: frozenset[int] = frozenset()
 
     def supported_num_heads(self) -> tuple[int, ...]:
-        """Every head count from 1 through ``max_num_heads`` (runtime-H)."""
+        """Sorted instantiated head counts, including any runtime-H envelope."""
+        if self.head_counts is not None:
+            return tuple(sorted(self.head_counts))
         return tuple(range(1, self.max_num_heads + 1))
 
     def supported_topk(self, num_heads: Optional[int] = None) -> tuple[int, ...]:
         """Sorted calibrated top-k values for ``num_heads`` (or any head count).
 
-        Decode serves any ``topk >= min_topk``; these are the values with
-        measured crossover data."""
-        if num_heads is None or 1 <= num_heads <= self.max_num_heads:
+        For a runtime-top-k family these are the values with measured
+        crossover data; otherwise this is the exact instantiated set."""
+        head_supported = num_heads is None or (
+            num_heads in self.head_counts
+            if self.head_counts is not None
+            else 1 <= num_heads <= self.max_num_heads
+        )
+        if head_supported:
             return tuple(sorted(self.topks))
         return ()
 
@@ -205,37 +230,49 @@ class SparseMLASm120DecodeConfig:
     ) -> bool:
         """True iff a decode-form call with this shape is decode-instantiated.
 
-        Decode-instantiated shapes may still route to prefill past the
-        calibrated crossover, and non-instantiated decode-form shapes are
-        served by prefill; this predicate describes the decode envelope only.
+        Decode-instantiated shapes may still route to prefill according to
+        calibration. This predicate describes the decode envelope only.
         """
         if page_block_size is None:
             page_block_size = self.page_block_size
+        head_supported = (
+            num_heads in self.head_counts
+            if self.head_counts is not None
+            else 1 <= num_heads <= self.max_num_heads
+        )
+        topk_supported = (
+            topk >= self.min_topk if self.topk_is_runtime else topk in self.topks
+        )
         return (
             num_tokens <= self.max_num_tokens
             and page_block_size == self.page_block_size
-            and 1 <= num_heads <= self.max_num_heads
-            and topk >= self.min_topk
+            and head_supported
+            and topk_supported
         )
 
 
 @flashinfer_api
-def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig]:
+def supported_sparse_mla_sm120_configs(
+    *, kv_cache_format: str = "fp8"
+) -> dict[str, SparseMLASm120DecodeConfig]:
     """Enumerate the instantiated SM120 sparse-MLA decode kernel configurations.
 
     Lets callers validate a serving configuration at initialization time
     instead of discovering an uninstantiated ``(num_heads, topk)`` pair on the
     first decode-form request.
 
+    Parameters
+    ----------
+    kv_cache_format : {"fp8", "nvfp4"}
+        Storage format whose independently calibrated kernel envelope is
+        requested. Defaults to ``"fp8"`` for backward compatibility.
+
     Returns
     -------
     dict[str, SparseMLASm120DecodeConfig]
-        Mapping from kernel family to its instantiated decode set, keyed by
-        ``"dsv4"`` (``d_qk=512``), ``"dsv3_2"`` (``d_qk=576``, power-of-2
-        FP32 scales), ``"glm_nsa"`` (``d_qk=576``, arbitrary FP32 scales;
-        shares the DSv3.2 decode instantiations), ``"glm53_nope"``
-        (GLM-5.3 native NoPE, ``d_qk=512``, arbitrary FP32 scales), and
-        ``"dots3_swa"`` (sliding-window family, ``d_qk=1088``, UE8M0 scales).
+        Mapping from kernel family to its instantiated decode set. FP8 returns
+        DSv4, DSv3.2, GLM-NSA, GLM53_NOPE, and DOTS3_SWA entries. NVFP4
+        currently returns the independently calibrated DSv4 entry.
 
     Examples
     --------
@@ -243,7 +280,33 @@ def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig
     >>> configs = flashinfer.mla.supported_sparse_mla_sm120_configs()
     >>> configs["dsv4"].supports_decode(num_heads=64, topk=256)
     True
+    >>> nvfp4 = flashinfer.mla.supported_sparse_mla_sm120_configs(
+    ...     kv_cache_format="nvfp4"
+    ... )
+    >>> nvfp4["dsv4"].bytes_per_token
+    384
     """
+    if kv_cache_format not in _KV_CACHE_FORMATS:
+        raise ValueError(
+            f"kv_cache_format must be either 'fp8' or 'nvfp4', got {kv_cache_format!r}"
+        )
+    if kv_cache_format == "nvfp4":
+        return {
+            "dsv4": SparseMLASm120DecodeConfig(
+                d_qk=512,
+                page_block_size=64,
+                max_num_tokens=64,
+                topks=frozenset({128, 512}),
+                min_topk=128,
+                max_num_heads=128,
+                kv_cache_format="nvfp4",
+                bytes_per_token=384,
+                head_counts=frozenset({16, 32, 64, 128}),
+                topk_is_runtime=False,
+                extra_page_block_sizes=frozenset({2, 64}),
+            )
+        }
+
     dsv3_2 = SparseMLASm120DecodeConfig(
         d_qk=576,
         page_block_size=_DECODE_DSV3_2_PAGE_BLOCK_SIZE,
@@ -251,6 +314,7 @@ def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig
         topks=_DECODE_DSV3_2_TOPKS,
         min_topk=1,
         max_num_heads=_DECODE_MAX_HEADS,
+        bytes_per_token=_BPT_DSV3_2,
     )
     return {
         "dsv4": SparseMLASm120DecodeConfig(
@@ -260,6 +324,7 @@ def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig
             topks=_DECODE_DSV4_TOPKS,
             min_topk=1,
             max_num_heads=_DECODE_MAX_HEADS,
+            bytes_per_token=_BPT_DSV4,
         ),
         "dsv3_2": dsv3_2,
         "glm_nsa": dsv3_2,
@@ -270,6 +335,7 @@ def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig
             topks=frozenset({_DECODE_GLM53_NOPE_TOPK}),
             min_topk=1,
             max_num_heads=_DECODE_MAX_HEADS,
+            bytes_per_token=_BPT_DSV3_2,
         ),
         "dots3_swa": SparseMLASm120DecodeConfig(
             d_qk=1088,
@@ -278,6 +344,7 @@ def supported_sparse_mla_sm120_configs() -> dict[str, SparseMLASm120DecodeConfig
             topks=frozenset({_DECODE_DOTS3_SWA_TOPK}),
             min_topk=513,
             max_num_heads=_DECODE_MAX_HEADS,
+            bytes_per_token=_BPT_DOTS3_SWA,
         ),
     }
 
@@ -480,14 +547,17 @@ def _decode_scratch_views(
     num_heads: int,
     num_splits: int,
     d_v: int,
+    *,
+    scratch_heads: Optional[int] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Resolve caller-supplied scratch buffers for split-K decode kernels.
 
-    The scratch head dim is the true ``num_heads`` for the dedicated
-    ``num_heads=8`` instantiation and HPB(16)-aligned otherwise (the runtime-H
-    kernel writes both halves of its head tile unconditionally).
+    By default, the scratch head dim is the true ``num_heads`` for the
+    dedicated ``num_heads=8`` instantiation and HPB(16)-aligned otherwise.
+    ``scratch_heads`` overrides that policy for kernels with an exact-H ABI.
     """
-    scratch_heads = _decode_scratch_heads(num_heads)
+    if scratch_heads is None:
+        scratch_heads = _decode_scratch_heads(num_heads)
     if mid_out is None or mid_lse is None:
         raise ValueError(
             "SM120 sparse-MLA decode requires caller-supplied mid_out and "
@@ -852,12 +922,15 @@ class _SparseMLAPagedAttentionRunner:
         GLM-style arbitrary FP32 inline scales (GLM_NSA at ``d_qk=576``,
         GLM53_NOPE at ``d_qk=512``); ``"auto"`` at ``d_qk=512`` selects
         DSV4.
+    kv_cache_format : {"fp8", "nvfp4"}
+        Packed cache format. Both formats reuse this wrapper and its ``run``
+        signature; each format keeps its own planner and internal kernels.
     device : Optional[torch.device]
         Allocation target. Defaults to the current CUDA device.
 
     Example
     -------
-    >>> runner = _SparseMLAPagedAttentionRunner()
+    >>> runner = flashinfer.mla.SparseMLASm120Wrapper()
     >>> runner.run(q, kv_cache, indices, output, sm_scale=...)
     """
 
@@ -869,6 +942,7 @@ class _SparseMLAPagedAttentionRunner:
         *,
         d_v: int = _D_V,
         kv_scale_format: str = "auto",
+        kv_cache_format: str = "fp8",
         device: Optional[torch.device] = None,
     ) -> None:
         if (max_num_tokens is None) != (max_num_heads is None):
@@ -881,6 +955,20 @@ class _SparseMLAPagedAttentionRunner:
             raise ValueError(f"max_num_heads must be in (0, 128], got {max_num_heads}")
         _require_supported_d_v(d_v)
         self._kv_scale_format = _normalize_kv_scale_format(kv_scale_format)
+        if kv_cache_format not in _KV_CACHE_FORMATS:
+            raise ValueError(
+                "kv_cache_format must be either 'fp8' or 'nvfp4', got "
+                f"{kv_cache_format!r}"
+            )
+        if kv_cache_format == "nvfp4":
+            if d_v != 512:
+                raise ValueError("NVFP4 sparse MLA requires d_v=512")
+            if self._kv_scale_format != "auto":
+                raise ValueError(
+                    "kv_scale_format applies to FP8 caches and must remain 'auto' "
+                    "when kv_cache_format='nvfp4'"
+                )
+        self._kv_cache_format = kv_cache_format
 
         if device is None:
             device = torch.device("cuda", torch.cuda.current_device())
@@ -945,6 +1033,61 @@ class _SparseMLAPagedAttentionRunner:
             )
         return self._out_lse[:num_tokens, :num_heads]
 
+    def _plan_nvfp4_call(
+        self,
+        q: torch.Tensor,
+        kv_cache: torch.Tensor,
+        indices: torch.Tensor,
+        topk_length: Optional[torch.Tensor],
+        attn_sink: Optional[torch.Tensor],
+        extra_kv_cache: Optional[torch.Tensor],
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_length: Optional[torch.Tensor],
+        prefill_impl: Optional[str],
+    ) -> "NVFP4PlannedCall":
+        if prefill_impl not in (None, "auto", "mg"):
+            raise ValueError(
+                "NVFP4 sparse MLA supports prefill_impl=None, 'auto', or 'mg'"
+            )
+        if q.ndim != 3 or q.shape[-1] != 512:
+            raise ValueError(f"NVFP4 q must be [T, H, 512], got {tuple(q.shape)}")
+        if (extra_kv_cache is None) != (extra_indices is None):
+            raise ValueError(
+                "extra_kv_cache and extra_indices must be provided together"
+            )
+        if extra_topk_length is not None and extra_indices is None:
+            raise ValueError(
+                "extra_topk_length requires extra_kv_cache and extra_indices"
+            )
+
+        from ._sparse_mla_nvfp4_sm120 import _cache_shape
+        from ._sparse_mla_nvfp4_sm120_plan import plan_nvfp4_sparse_mla_sm120
+
+        _, page_size, _ = _cache_shape(kv_cache)
+        extra_page_size = 0
+        if extra_kv_cache is not None:
+            _, extra_page_size, _ = _cache_shape(extra_kv_cache)
+        extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
+        planned = plan_nvfp4_sparse_mla_sm120(
+            q.shape[0],
+            q.shape[1],
+            indices.shape[-1],
+            page_size,
+            q.device,
+            extra_topk=extra_topk,
+            extra_page_size=extra_page_size,
+            has_topk_length=topk_length is not None,
+            has_extra_topk_length=extra_topk_length is not None,
+            has_attn_sink=attn_sink is not None,
+        )
+        if planned is None:
+            raise ValueError(
+                "no NVFP4 sparse MLA prefill or decode kernel serves "
+                f"T={q.shape[0]}, H={q.shape[1]}, topk={indices.shape[-1]}, "
+                f"extra_topk={extra_topk}"
+            )
+        return planned
+
     def _maybe_allocate_decode_scratch(
         self,
         q: torch.Tensor,
@@ -955,10 +1098,11 @@ class _SparseMLAPagedAttentionRunner:
         mid_out: Optional[torch.Tensor],
         mid_lse: Optional[torch.Tensor],
         prefill_impl: Optional[str],
+        nvfp4_planned: Optional["NVFP4PlannedCall"] = None,
     ) -> tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
         if (mid_out is None) != (mid_lse is None):
             raise ValueError("mid_out and mid_lse must be passed together")
-        if mid_out is not None:
+        if mid_out is not None and self._kv_cache_format == "fp8":
             return mid_out, mid_lse
 
         num_tokens, num_heads, d_qk = q.shape
@@ -966,32 +1110,53 @@ class _SparseMLAPagedAttentionRunner:
             # The op no-ops on empty requests before planning, and prefill-form
             # calls never route to decode — skip the plan() lookup on both.
             return None, None
-        model_type = _resolve_model_type(d_qk, self._kv_scale_format)
         topk = indices.shape[-1]
         extra_topk = extra_indices.shape[-1] if extra_indices is not None else 0
-        # Route with the same memoized plan() the op makes; only a
-        # decode-routed call consumes split-K scratch. A dispatch miss
-        # (None) falls through so the op reports it.
-        planned = plan(
-            num_tokens,
-            num_heads,
-            topk,
-            model_type,
-            _packed_kv_page_block_size(
-                kv_cache, model_type=model_type, name="kv_cache"
-            ),
-            extra_kv_cache is not None,
-            _normalize_prefill_impl(prefill_impl),
-            q.device,
-            extra_topk=extra_topk,
-        )
-        if planned is None or planned.variant is not KernelVariant.DECODE_SPLITK:
-            return None, None
+        if self._kv_cache_format == "nvfp4":
+            from ._sparse_mla_nvfp4_sm120_plan import NVFP4KernelVariant
 
-        num_splits = _decode_dsv4_num_splits(topk, extra_topk, model_type)
+            if (
+                nvfp4_planned is None
+                or nvfp4_planned.variant is not NVFP4KernelVariant.DECODE_SPLITK
+            ):
+                return None, None
+            num_splits = (topk + 63) // 64 + (extra_topk + 63) // 64
+            scratch_heads = num_heads
+        else:
+            model_type = _resolve_model_type(d_qk, self._kv_scale_format)
+            # Route with the same memoized plan() the op makes; only a
+            # decode-routed call consumes split-K scratch. A dispatch miss
+            # (None) falls through so the op reports it.
+            planned = plan(
+                num_tokens,
+                num_heads,
+                topk,
+                model_type,
+                _packed_kv_page_block_size(
+                    kv_cache, model_type=model_type, name="kv_cache"
+                ),
+                extra_kv_cache is not None,
+                _normalize_prefill_impl(prefill_impl),
+                q.device,
+                extra_topk=extra_topk,
+            )
+            if planned is None or planned.variant is not KernelVariant.DECODE_SPLITK:
+                return None, None
+            num_splits = _decode_dsv4_num_splits(topk, extra_topk, model_type)
+            scratch_heads = _decode_scratch_heads(num_heads)
+        if mid_out is not None:
+            return _decode_scratch_views(
+                mid_out,
+                mid_lse,
+                num_tokens,
+                num_heads,
+                num_splits,
+                self._d_v,
+                scratch_heads=scratch_heads,
+            )
         need_out: tuple[int, ...] = (
             num_tokens,
-            _decode_scratch_heads(num_heads),
+            scratch_heads,
             num_splits,
             self._d_v,
         )
@@ -1008,6 +1173,16 @@ class _SparseMLAPagedAttentionRunner:
             self._mid_out = torch.empty(need_out, dtype=torch.bfloat16, device=q.device)
             self._mid_lse = torch.empty(
                 need_out[:3], dtype=torch.float32, device=q.device
+            )
+        if self._kv_cache_format == "nvfp4":
+            return _decode_scratch_views(
+                self._mid_out,
+                self._mid_lse,
+                num_tokens,
+                num_heads,
+                num_splits,
+                self._d_v,
+                scratch_heads=scratch_heads,
             )
         return self._mid_out, self._mid_lse
 
@@ -1051,7 +1226,8 @@ class _SparseMLAPagedAttentionRunner:
         ``"swapab"`` raises ``ValueError`` on shapes outside its envelope
         (DSV3_2 family, single cache, whole-tile ``topk``, ``num_heads`` in
         {64, 128}) and is a no-op distinction for DSV4, where only the
-        non-swapAB path exists.
+        non-swapAB path exists. NVFP4 accepts ``None``, ``"auto"``, or
+        ``"mg"`` and uses its separately calibrated streaming/split-K planner.
         """
         if q.dim() == 4:
             if q.size(1) != 1:
@@ -1076,6 +1252,23 @@ class _SparseMLAPagedAttentionRunner:
             raise ValueError(
                 f"num_heads ({num_heads}) exceeds max_num_heads ({self._max_num_heads})"
             )
+        if num_tokens == 0:
+            out_lse_view = self._get_out_lse(num_tokens, num_heads, out_lse)
+            return out_lse_view if return_lse else None
+
+        nvfp4_planned = None
+        if self._kv_cache_format == "nvfp4":
+            nvfp4_planned = self._plan_nvfp4_call(
+                q,
+                kv_cache,
+                indices,
+                topk_length,
+                attn_sink,
+                extra_kv_cache,
+                extra_indices,
+                extra_topk_length,
+                prefill_impl,
+            )
 
         mid_out, mid_lse = self._maybe_allocate_decode_scratch(
             q,
@@ -1086,9 +1279,37 @@ class _SparseMLAPagedAttentionRunner:
             mid_out,
             mid_lse,
             prefill_impl,
+            nvfp4_planned,
         )
 
         out_lse_view = self._get_out_lse(num_tokens, num_heads, out_lse)
+        if self._kv_cache_format == "nvfp4":
+            from ._sparse_mla_nvfp4_sm120 import (
+                _sparse_mla_nvfp4_sm120_paged_attention,
+            )
+            from ._sparse_mla_nvfp4_sm120_plan import NVFP4KernelVariant
+
+            _sparse_mla_nvfp4_sm120_paged_attention(
+                q,
+                kv_cache,
+                indices,
+                output,
+                out_lse_view,
+                sm_scale,
+                topk_length=topk_length,
+                attn_sink=attn_sink,
+                extra_kv_cache=extra_kv_cache,
+                extra_indices=extra_indices,
+                extra_topk_length=extra_topk_length,
+                mid_out=mid_out,
+                mid_lse=mid_lse,
+                use_prefill=(
+                    nvfp4_planned.variant is NVFP4KernelVariant.PREFILL_STREAMING
+                ),
+                chunks_per_block_override=nvfp4_planned.cpb,
+            )
+            return out_lse_view if return_lse else None
+
         _sparse_mla_sm120_paged_attention(
             q,
             kv_cache,
@@ -1122,7 +1343,8 @@ class _SparseMLAPagedAttentionRunner:
 #   calls then allocate nothing.
 # - ``run()`` is the single entry point. There is no separate plan stage;
 #   dispatch decisions are made internally per call and memoized.
-# - ``d_v`` and ``kv_scale_format`` are fixed at construction and select the
+# - ``d_v``, ``kv_scale_format``, and ``kv_cache_format`` are fixed at
+#   construction and select the
 #   model-type semantics applied to every ``run()`` call (512 for
 #   DSV3_2 / DSV4 / GLM variants, 1024 for DOTS3_SWA; scale semantics per
 #   ``kv_scale_format``).

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -455,6 +455,23 @@ def _normalize_kv_scale_format(kv_scale_format: str) -> str:
     return fmt
 
 
+def _normalize_nvfp4_indices(indices: torch.Tensor, name: str) -> torch.Tensor:
+    """Flatten the singleton query axis accepted by the shared FP8 API."""
+    if indices.ndim == 3:
+        if indices.shape[1] != 1:
+            raise ValueError(
+                f"NVFP4 {name} must have shape [T, 1, topk] when 3-D, got "
+                f"{tuple(indices.shape)}"
+            )
+        indices = indices.squeeze(1)
+    if indices.ndim != 2:
+        raise ValueError(
+            f"NVFP4 {name} must have shape [T, topk] or [T, 1, topk], got "
+            f"{tuple(indices.shape)}"
+        )
+    return indices
+
+
 def _resolve_model_type(d_qk: int, kv_scale_format: str) -> int:
     fmt = _normalize_kv_scale_format(kv_scale_format)
     if d_qk == 576:
@@ -1228,6 +1245,9 @@ class _SparseMLAPagedAttentionRunner:
         {64, 128}) and is a no-op distinction for DSV4, where only the
         non-swapAB path exists. NVFP4 accepts ``None``, ``"auto"``, or
         ``"mg"`` and uses its separately calibrated streaming/split-K planner.
+        NVFP4 also accepts ``indices``/``extra_indices`` as either
+        ``[num_tokens, topk]`` or ``[num_tokens, 1, topk]``; the singleton
+        query axis is normalized before planning and launch.
         """
         if q.dim() == 4:
             if q.size(1) != 1:
@@ -1242,6 +1262,10 @@ class _SparseMLAPagedAttentionRunner:
                     f"output.shape={tuple(output.shape)}"
                 )
             output = output.squeeze(1)
+        if self._kv_cache_format == "nvfp4":
+            indices = _normalize_nvfp4_indices(indices, "indices")
+            if extra_indices is not None:
+                extra_indices = _normalize_nvfp4_indices(extra_indices, "extra_indices")
         num_tokens, num_heads, _ = q.shape
         if self._max_num_tokens is not None and num_tokens > self._max_num_tokens:
             raise ValueError(

--- a/flashinfer/mla/_sparse_mla_sm120_cpb.py
+++ b/flashinfer/mla/_sparse_mla_sm120_cpb.py
@@ -344,6 +344,45 @@ def _allocate_kv_pool(family: str, device: torch.device) -> tuple[torch.Tensor, 
     return kv_cache, kv_cache.shape[0] * 64
 
 
+def calibration_batch_count(
+    num_tokens: int,
+    total_topk: int,
+    bytes_per_token: int,
+    device: torch.device,
+    *,
+    max_batch_calls: int = _MAX_BATCH_CALLS,
+) -> int:
+    """Number of rotating index sets needed to evict one call's KV footprint."""
+    l2 = int(getattr(torch.cuda.get_device_properties(device), "L2_cache_size", 0) or 0)
+    footprint = max(1, num_tokens * total_topk * bytes_per_token)
+    if not l2:
+        return _MIN_BATCH_CALLS
+    return min(max_batch_calls, max(_MIN_BATCH_CALLS, l2 // footprint + 2))
+
+
+def time_calibration_calls(
+    call: Callable[..., None],
+    argument_sets: list[tuple[Any, ...]],
+) -> float:
+    """Return steady-state seconds/call using the shared queued timing protocol."""
+    if not argument_sets:
+        raise ValueError("calibration requires at least one argument set")
+    for i in range(_WARMUP_ITERS):
+        call(*argument_sets[i % len(argument_sets)])
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    best = float("inf")
+    for _ in range(_TIMED_BATCHES):
+        start.record()
+        for args in argument_sets:
+            call(*args)
+        end.record()
+        torch.cuda.synchronize()
+        best = min(best, start.elapsed_time(end) / 1e3 / len(argument_sets))
+    return best
+
+
 def _time_call_fresh_indices(
     call: Callable[[torch.Tensor], None],
     num_tokens: int,
@@ -373,33 +412,21 @@ def _time_call_fresh_indices(
     # A set recurs after K-1 intervening calls; require the reuse distance to
     # cover L2 so no gathered page survives between visits. Without a known
     # L2 size, the minimum batch still hides launch latency.
-    l2 = int(getattr(torch.cuda.get_device_properties(device), "L2_cache_size", 0) or 0)
-    footprint = max(1, num_tokens * topk * bytes_per_token)
-    k = (
-        _MIN_BATCH_CALLS
-        if not l2
-        else min(_MAX_BATCH_CALLS, max(_MIN_BATCH_CALLS, l2 // footprint + 2))
+    k = calibration_batch_count(
+        num_tokens,
+        topk,
+        bytes_per_token,
+        device,
     )
     sets = [
-        torch.randint(
-            0, num_slots, (num_tokens, topk), dtype=torch.int32, device=device
+        (
+            torch.randint(
+                0, num_slots, (num_tokens, topk), dtype=torch.int32, device=device
+            ),
         )
         for _ in range(k)
     ]
-    for i in range(_WARMUP_ITERS):
-        call(sets[i % k])
-    torch.cuda.synchronize()
-    start = torch.cuda.Event(enable_timing=True)
-    end = torch.cuda.Event(enable_timing=True)
-    best = float("inf")
-    for _ in range(_TIMED_BATCHES):
-        start.record()
-        for indices in sets:
-            call(indices)
-        end.record()
-        torch.cuda.synchronize()
-        best = min(best, start.elapsed_time(end) / 1e3 / k)
-    return best
+    return time_calibration_calls(call, sets)
 
 
 def _make_decode_call_builder(

--- a/flashinfer/mla/_sparse_mla_sm120_plan.py
+++ b/flashinfer/mla/_sparse_mla_sm120_plan.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import enum
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, TypeVar
 
 import torch
 
@@ -53,6 +53,8 @@ from . import _sparse_mla_sm120_cpb as _cpb
 from ._sparse_mla_sm120_cpb import CalibrationError
 
 logger = logging.getLogger(__name__)
+
+_VariantT = TypeVar("_VariantT")
 
 # Kernel-side constants. Mirrored from
 # include/flashinfer/attention/sparse_mla_sm120/{arch,model}/*.cuh.
@@ -240,6 +242,33 @@ class PlannedCall:
 
     variant: KernelVariant
     cpb: int  # decode only; -1 selects the C++ heuristic
+
+
+def _select_calibrated_variant(
+    *,
+    decode_eligible: bool,
+    decode_variant: _VariantT,
+    prefill_variant: Optional[_VariantT],
+    decode_preferred: Optional[bool],
+) -> Optional[_VariantT]:
+    """Shared decode/prefill crossover policy.
+
+    ``decode_eligible`` is an implementation envelope, not a performance
+    threshold.  When both implementations can serve the call, the caller
+    converts its independently keyed calibration record into
+    ``decode_preferred``.  Missing calibration deliberately retains the safe
+    historical decode-first fallback.
+
+    The helper is format agnostic: FP8 and NVFP4 share this policy while
+    looking up independently keyed measurements.
+    """
+    if not decode_eligible:
+        return prefill_variant
+    if prefill_variant is None:
+        return decode_variant
+    if decode_preferred is None or decode_preferred:
+        return decode_variant
+    return prefill_variant
 
 
 # ── Envelopes (single source of truth; C++ re-checks them defensively) ────
@@ -641,15 +670,14 @@ def _decide(
     pf = prefill_variant(
         model_type, num_heads, topk, page_block_size, has_extra, prefill_impl_pref
     )
-    if not decode_splitk_eligible(
-        model_type, num_heads, topk, page_block_size, has_extra, num_tokens
-    ):
-        return pf
-    if pf is None:
-        return KernelVariant.DECODE_SPLITK
     crossover = _cpb.get_decode_max_tokens(
         device, _MODEL_TYPE_TO_FAMILY[model_type], num_heads, topk
     )
-    if crossover is None or num_tokens <= crossover:
-        return KernelVariant.DECODE_SPLITK
-    return pf
+    return _select_calibrated_variant(
+        decode_eligible=decode_splitk_eligible(
+            model_type, num_heads, topk, page_block_size, has_extra, num_tokens
+        ),
+        decode_variant=KernelVariant.DECODE_SPLITK,
+        prefill_variant=pf,
+        decode_preferred=(None if crossover is None else num_tokens <= crossover),
+    )

--- a/include/flashinfer/attention/sparse_mla_sm120/arch/mma_sm120_nvfp4.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/arch/mma_sm120_nvfp4.cuh
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025 by SageAttention team.
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "common.cuh"
+
+// SM120 register-register NVFP4 block-scaled MMA used by sparse MLA.
+//
+// A is a row-major 16x64 E2M1 tile (four 32-bit registers per lane), B is a
+// column-major 64x8 E2M1 tile (two registers per lane), and each uint32 scale
+// operand packs the four E4M3 scale-vector entries for the K64 tile. The scale
+// selectors match the first N8 instruction in FlashInfer's upstream dense
+// SM120 NVFP4 composite atom. The instruction form is adapted from
+// attention/sm120/nvfp4_attention_sm120/common/cute_extension.h; this compact
+// wrapper avoids pulling the dense kernel's CuTe/CUTLASS type stack into the
+// sparse MLA hot path.
+
+struct MmaNvfp4Result {
+  float d0, d1, d2, d3;
+};
+
+__device__ __forceinline__ MmaNvfp4Result mma_nvfp4_block_scaled_m16n8k64(
+    uint32_t a0, uint32_t a1, uint32_t a2, uint32_t a3, uint32_t b0, uint32_t b1, float c0,
+    float c1, float c2, float c3, uint32_t scale_a, uint32_t scale_b) {
+  MmaNvfp4Result r;
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
+  asm volatile(
+      "mma.sync.aligned.kind::mxf4nvf4.block_scale.scale_vec::4X.m16n8k64.row.col."
+      "f32.e2m1.e2m1.f32.ue4m3 "
+      "{%0, %1, %2, %3}, {%4, %5, %6, %7}, {%8, %9}, "
+      "{%10, %11, %12, %13}, {%14}, {%15, %16}, {%17}, {%18, %19};\n"
+      : "=f"(r.d0), "=f"(r.d1), "=f"(r.d2), "=f"(r.d3)
+      : "r"(a0), "r"(a1), "r"(a2), "r"(a3), "r"(b0), "r"(b1), "f"(c0), "f"(c1), "f"(c2), "f"(c3),
+        "r"(scale_a), "n"(static_cast<uint16_t>(0)), "n"(static_cast<uint16_t>(0)), "r"(scale_b),
+        "n"(static_cast<uint16_t>(0)), "n"(static_cast<uint16_t>(0)));
+#else
+  (void)a0;
+  (void)a1;
+  (void)a2;
+  (void)a3;
+  (void)b0;
+  (void)b1;
+  (void)c0;
+  (void)c1;
+  (void)c2;
+  (void)c3;
+  (void)scale_a;
+  (void)scale_b;
+#endif
+  return r;
+}

--- a/include/flashinfer/attention/sparse_mla_sm120/common/d2_load_b_nvfp4.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/d2_load_b_nvfp4.cuh
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+// Directly produce the SM120 M16N8K64 NVFP4 B registers from a candidate-major
+// packed cache. Each lane loads all eight N dimensions for one candidate as a
+// 32-bit word, then warp shuffles perform the 8x8 nibble transpose. Compared
+// with scalar per-dimension gathering this reduces shared loads from sixteen
+// bytes to two words per lane.
+template <int KV_STRIDE>
+__device__ __forceinline__ void d2_load_b_nvfp4(uint32_t& b0, uint32_t& b1,
+                                                const uint8_t* __restrict__ kv_smem, int entry_base,
+                                                int dim, int lane) {
+  const int gid = lane >> 2;
+  const int tid = lane & 3;
+  // dim is the first dimension of an aligned N8 output tile.
+  const int byte_column = dim >> 1;
+  const int nibble_shift = gid * 4;
+  const uint32_t candidate_word0 = *reinterpret_cast<const uint32_t*>(
+      kv_smem + (size_t)(entry_base + lane) * KV_STRIDE + byte_column);
+  const uint32_t candidate_word1 = *reinterpret_cast<const uint32_t*>(
+      kv_smem + (size_t)(entry_base + 32 + lane) * KV_STRIDE + byte_column);
+
+  b0 = 0;
+  b1 = 0;
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int source_lane = tid * 8 + i;
+    const uint32_t v0 =
+        (__shfl_sync(0xffffffffu, candidate_word0, source_lane) >> nibble_shift) & 0xFu;
+    const uint32_t v1 =
+        (__shfl_sync(0xffffffffu, candidate_word1, source_lane) >> nibble_shift) & 0xFu;
+    b0 |= v0 << (i * 4);
+    b1 |= v1 << (i * 4);
+  }
+}
+
+// Produce two adjacent N8 operands together. The N16 source for one candidate
+// is one aligned uint64 load, so the pair shares address arithmetic and lets
+// ptxas issue LDS.64 instead of two independently scheduled LDS.32 operations.
+// Shuffle count is unchanged (each output nibble is distinct), but the common
+// transpose loop exposes substantially more instruction-level parallelism.
+template <int KV_STRIDE>
+__device__ __forceinline__ void d2_load_b_nvfp4_n16(uint32_t& b00, uint32_t& b01, uint32_t& b10,
+                                                    uint32_t& b11,
+                                                    const uint8_t* __restrict__ kv_smem,
+                                                    int entry_base, int dim, int lane) {
+  const int gid = lane >> 2;
+  const int tid = lane & 3;
+  const int byte_column = dim >> 1;
+  const int nibble_shift = gid * 4;
+  const uint2 candidate0 = *reinterpret_cast<const uint2*>(
+      kv_smem + (size_t)(entry_base + lane) * KV_STRIDE + byte_column);
+  const uint2 candidate1 = *reinterpret_cast<const uint2*>(
+      kv_smem + (size_t)(entry_base + 32 + lane) * KV_STRIDE + byte_column);
+
+  b00 = 0;
+  b01 = 0;
+  b10 = 0;
+  b11 = 0;
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    const int source_lane = tid * 8 + i;
+    const uint32_t c00 = __shfl_sync(0xffffffffu, candidate0.x, source_lane);
+    const uint32_t c01 = __shfl_sync(0xffffffffu, candidate0.y, source_lane);
+    const uint32_t c10 = __shfl_sync(0xffffffffu, candidate1.x, source_lane);
+    const uint32_t c11 = __shfl_sync(0xffffffffu, candidate1.y, source_lane);
+    b00 |= ((c00 >> nibble_shift) & 0xFu) << (i * 4);
+    b01 |= ((c10 >> nibble_shift) & 0xFu) << (i * 4);
+    b10 |= ((c01 >> nibble_shift) & 0xFu) << (i * 4);
+    b11 |= ((c11 >> nibble_shift) & 0xFu) << (i * 4);
+  }
+}

--- a/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_quant.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_quant.cuh
@@ -17,77 +17,17 @@
 #pragma once
 
 #include <cuda_bf16.h>
-#include <cuda_fp8.h>
-
-#include <cstdint>
-#include <flashinfer/math.cuh>
 
 #include "../arch/barrier.cuh"
-#include "../model/kv_cache_traits.cuh"
+#include "../model/nvfp4_cache_traits.cuh"
+#include "nvfp4_quantization.cuh"
 
 namespace flashinfer::sparse_mla_sm120::nvfp4 {
 
-constexpr int SF_VEC_SIZE = 16;
-constexpr int FP4_PACKED_PER_GROUP = SF_VEC_SIZE / 2;
-constexpr int DSV4_NVFP4_NUM_SCALES = KVCacheTraits<ModelType::DSV4>::D_NOPE / SF_VEC_SIZE;
-constexpr int DSV4_NVFP4_Q_PACKED_STRIDE = KVCacheTraits<ModelType::DSV4>::D_NOPE / 2 + 16;
-constexpr int DSV4_NVFP4_SCALE_STRIDE = 32;
-
-__device__ __forceinline__ float e4m3_byte_to_float(uint8_t byte) {
-  __nv_fp8_e4m3 value;
-  value.__x = byte;
-  return static_cast<float>(value);
-}
-
-__device__ __forceinline__ uint8_t float_to_e4m3_byte(float value) {
-  return __nv_fp8_e4m3(value).__x;
-}
-
-__device__ __forceinline__ void quantize_fp32_group16_to_nvfp4_regs(const float values[SF_VEC_SIZE],
-                                                                    uint2& packed_output,
-                                                                    uint8_t& scale_output) {
-  float amax = 0.f;
-#pragma unroll
-  for (int i = 0; i < SF_VEC_SIZE; ++i) amax = fmaxf(amax, fabsf(values[i]));
-
-  const uint8_t scale_byte = float_to_e4m3_byte(amax / 6.f);
-  scale_output = scale_byte;
-  const float scale = e4m3_byte_to_float(scale_byte);
-  const float scale_inv = scale == 0.f ? 0.f : 1.f / scale;
-  float normalized[SF_VEC_SIZE];
-#pragma unroll
-  for (int i = 0; i < SF_VEC_SIZE; ++i) normalized[i] = values[i] * scale_inv;
-
-  packed_output = make_uint2(
-      math::fp32_vec_to_e2m1(normalized[0], normalized[1], normalized[2], normalized[3],
-                             normalized[4], normalized[5], normalized[6], normalized[7]),
-      math::fp32_vec_to_e2m1(normalized[8], normalized[9], normalized[10], normalized[11],
-                             normalized[12], normalized[13], normalized[14], normalized[15]));
-}
-
-__device__ __forceinline__ void quantize_fp32_group16_to_nvfp4(const float values[SF_VEC_SIZE],
-                                                               uint8_t* packed_output,
-                                                               uint8_t* scale_output) {
-  uint2 packed;
-  uint8_t scale;
-  quantize_fp32_group16_to_nvfp4_regs(values, packed, scale);
-  *reinterpret_cast<uint2*>(packed_output) = packed;
-  *scale_output = scale;
-}
-
-__device__ __forceinline__ void quantize_bf16_group16_to_nvfp4(const bf16* input,
-                                                               uint8_t* packed_output,
-                                                               uint8_t* scale_output) {
-  float values[SF_VEC_SIZE];
-#pragma unroll
-  for (int i = 0; i < SF_VEC_SIZE / 2; ++i) {
-    const __nv_bfloat162 pair = *reinterpret_cast<const __nv_bfloat162*>(input + i * 2);
-    const float2 converted = __bfloat1622float2(pair);
-    values[i * 2] = converted.x;
-    values[i * 2 + 1] = converted.y;
-  }
-  quantize_fp32_group16_to_nvfp4(values, packed_output, scale_output);
-}
+constexpr int DSV4_NVFP4_NUM_SCALES = NVFP4CacheTraits<ModelType::DSV4>::NUM_SCALES;
+constexpr int DSV4_NVFP4_Q_PACKED_STRIDE = NVFP4CacheTraits<ModelType::DSV4>::Q_PACKED_STRIDE;
+constexpr int DSV4_NVFP4_SCALE_STRIDE = NVFP4CacheTraits<ModelType::DSV4>::Q_SCALE_STRIDE;
+static_assert(NVFP4CacheTraits<ModelType::DSV4>::SCALE_GROUP_SIZE == SF_VEC_SIZE);
 
 template <int MATH_THREADS, int PACKED_STRIDE = DSV4_NVFP4_Q_PACKED_STRIDE,
           int SCALE_STRIDE = DSV4_NVFP4_SCALE_STRIDE>
@@ -104,7 +44,7 @@ __device__ __forceinline__ void quantize_q_nvfp4_to_smem(uint8_t* q_nope_fp4,
     uint8_t* scale_dst = q_nope_scales + head * SCALE_STRIDE + group_in_head;
     if (head < valid_hpb) {
       const bf16* src = q_base + head * KV::D_QK + group_in_head * SF_VEC_SIZE;
-      quantize_bf16_group16_to_nvfp4(src, packed_dst, scale_dst);
+      quantize_group16_to_nvfp4(src, packed_dst, scale_dst);
     } else {
       *reinterpret_cast<uint2*>(packed_dst) = make_uint2(0, 0);
       *scale_dst = 0;

--- a/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_quant.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_quant.cuh
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#include <cstdint>
+#include <flashinfer/math.cuh>
+
+#include "../arch/barrier.cuh"
+#include "../model/kv_cache_traits.cuh"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+constexpr int SF_VEC_SIZE = 16;
+constexpr int FP4_PACKED_PER_GROUP = SF_VEC_SIZE / 2;
+constexpr int DSV4_NVFP4_NUM_SCALES = KVCacheTraits<ModelType::DSV4>::D_NOPE / SF_VEC_SIZE;
+constexpr int DSV4_NVFP4_Q_PACKED_STRIDE = KVCacheTraits<ModelType::DSV4>::D_NOPE / 2 + 16;
+constexpr int DSV4_NVFP4_SCALE_STRIDE = 32;
+
+__device__ __forceinline__ float e4m3_byte_to_float(uint8_t byte) {
+  __nv_fp8_e4m3 value;
+  value.__x = byte;
+  return static_cast<float>(value);
+}
+
+__device__ __forceinline__ uint8_t float_to_e4m3_byte(float value) {
+  return __nv_fp8_e4m3(value).__x;
+}
+
+__device__ __forceinline__ void quantize_fp32_group16_to_nvfp4_regs(const float values[SF_VEC_SIZE],
+                                                                    uint2& packed_output,
+                                                                    uint8_t& scale_output) {
+  float amax = 0.f;
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE; ++i) amax = fmaxf(amax, fabsf(values[i]));
+
+  const uint8_t scale_byte = float_to_e4m3_byte(amax / 6.f);
+  scale_output = scale_byte;
+  const float scale = e4m3_byte_to_float(scale_byte);
+  const float scale_inv = scale == 0.f ? 0.f : 1.f / scale;
+  float normalized[SF_VEC_SIZE];
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE; ++i) normalized[i] = values[i] * scale_inv;
+
+  packed_output = make_uint2(
+      math::fp32_vec_to_e2m1(normalized[0], normalized[1], normalized[2], normalized[3],
+                             normalized[4], normalized[5], normalized[6], normalized[7]),
+      math::fp32_vec_to_e2m1(normalized[8], normalized[9], normalized[10], normalized[11],
+                             normalized[12], normalized[13], normalized[14], normalized[15]));
+}
+
+__device__ __forceinline__ void quantize_fp32_group16_to_nvfp4(const float values[SF_VEC_SIZE],
+                                                               uint8_t* packed_output,
+                                                               uint8_t* scale_output) {
+  uint2 packed;
+  uint8_t scale;
+  quantize_fp32_group16_to_nvfp4_regs(values, packed, scale);
+  *reinterpret_cast<uint2*>(packed_output) = packed;
+  *scale_output = scale;
+}
+
+__device__ __forceinline__ void quantize_bf16_group16_to_nvfp4(const bf16* input,
+                                                               uint8_t* packed_output,
+                                                               uint8_t* scale_output) {
+  float values[SF_VEC_SIZE];
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE / 2; ++i) {
+    const __nv_bfloat162 pair = *reinterpret_cast<const __nv_bfloat162*>(input + i * 2);
+    const float2 converted = __bfloat1622float2(pair);
+    values[i * 2] = converted.x;
+    values[i * 2 + 1] = converted.y;
+  }
+  quantize_fp32_group16_to_nvfp4(values, packed_output, scale_output);
+}
+
+template <int MATH_THREADS, int PACKED_STRIDE = DSV4_NVFP4_Q_PACKED_STRIDE,
+          int SCALE_STRIDE = DSV4_NVFP4_SCALE_STRIDE>
+__device__ __forceinline__ void quantize_q_nvfp4_to_smem(uint8_t* q_nope_fp4,
+                                                         uint8_t* q_nope_scales, bf16* q_rope,
+                                                         const bf16* q_base, int valid_hpb = HPB) {
+  using KV = KVCacheTraits<ModelType::DSV4>;
+  constexpr int NUM_GROUPS = HPB * DSV4_NVFP4_NUM_SCALES;
+
+  for (int group = threadIdx.x; group < NUM_GROUPS; group += MATH_THREADS) {
+    const int head = group / DSV4_NVFP4_NUM_SCALES;
+    const int group_in_head = group % DSV4_NVFP4_NUM_SCALES;
+    uint8_t* packed_dst = q_nope_fp4 + head * PACKED_STRIDE + group_in_head * FP4_PACKED_PER_GROUP;
+    uint8_t* scale_dst = q_nope_scales + head * SCALE_STRIDE + group_in_head;
+    if (head < valid_hpb) {
+      const bf16* src = q_base + head * KV::D_QK + group_in_head * SF_VEC_SIZE;
+      quantize_bf16_group16_to_nvfp4(src, packed_dst, scale_dst);
+    } else {
+      *reinterpret_cast<uint2*>(packed_dst) = make_uint2(0, 0);
+      *scale_dst = 0;
+    }
+  }
+
+  for (int i = threadIdx.x; i < HPB * KV::D_ROPE; i += MATH_THREADS) {
+    const int head = i / KV::D_ROPE;
+    const int dim = i % KV::D_ROPE;
+    q_rope[i] =
+        (head < valid_hpb) ? q_base[head * KV::D_QK + KV::D_NOPE + dim] : __float2bfloat16(0.f);
+  }
+  bar_sync_t<2, MATH_THREADS>();
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_quantization.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_quantization.cuh
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_fp8.h>
+
+#include <cstdint>
+#include <flashinfer/math.cuh>
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+constexpr int SF_VEC_SIZE = 16;
+constexpr int FP4_PACKED_PER_GROUP = SF_VEC_SIZE / 2;
+
+__device__ __forceinline__ float e4m3_byte_to_float(uint8_t byte) {
+  __nv_fp8_e4m3 value;
+  value.__x = byte;
+  return static_cast<float>(value);
+}
+
+__device__ __forceinline__ uint8_t float_to_e4m3_byte(float value) {
+  return __nv_fp8_e4m3(value).__x;
+}
+
+template <typename T>
+__device__ __forceinline__ float nvfp4_input_to_float(T value);
+
+template <>
+__device__ __forceinline__ float nvfp4_input_to_float<half>(half value) {
+  return __half2float(value);
+}
+
+template <>
+__device__ __forceinline__ float nvfp4_input_to_float<__nv_bfloat16>(__nv_bfloat16 value) {
+  return __bfloat162float(value);
+}
+
+// Linear NVFP4 group primitive used by both Q staging and the paged latent-KV
+// writer. One E4M3 scale covers 16 values and the E2M1 payload occupies 8 bytes.
+__device__ __forceinline__ void quantize_fp32_group16_to_nvfp4_regs(const float values[SF_VEC_SIZE],
+                                                                    uint2& packed_output,
+                                                                    uint8_t& scale_output) {
+  float amax = 0.f;
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE; ++i) amax = fmaxf(amax, fabsf(values[i]));
+
+  const uint8_t scale_byte = float_to_e4m3_byte(amax / 6.f);
+  scale_output = scale_byte;
+  const float scale = e4m3_byte_to_float(scale_byte);
+  const float scale_inv = scale == 0.f ? 0.f : 1.f / scale;
+  float normalized[SF_VEC_SIZE];
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE; ++i) normalized[i] = values[i] * scale_inv;
+
+  packed_output = make_uint2(
+      math::fp32_vec_to_e2m1(normalized[0], normalized[1], normalized[2], normalized[3],
+                             normalized[4], normalized[5], normalized[6], normalized[7]),
+      math::fp32_vec_to_e2m1(normalized[8], normalized[9], normalized[10], normalized[11],
+                             normalized[12], normalized[13], normalized[14], normalized[15]));
+}
+
+__device__ __forceinline__ void quantize_fp32_group16_to_nvfp4(const float values[SF_VEC_SIZE],
+                                                               uint8_t* packed_output,
+                                                               uint8_t* scale_output) {
+  uint2 packed;
+  uint8_t scale;
+  quantize_fp32_group16_to_nvfp4_regs(values, packed, scale);
+  *reinterpret_cast<uint2*>(packed_output) = packed;
+  *scale_output = scale;
+}
+
+template <typename T>
+__device__ __forceinline__ void quantize_group16_to_nvfp4(const T* input, uint8_t* packed_output,
+                                                          uint8_t* scale_output) {
+  float values[SF_VEC_SIZE];
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE; ++i) values[i] = nvfp4_input_to_float(input[i]);
+  quantize_fp32_group16_to_nvfp4(values, packed_output, scale_output);
+}
+
+// Keep the vectorized conversions used by the attention hot path while the
+// scalar template above serves format writers with other 16-bit inputs.
+__device__ __forceinline__ void quantize_group16_to_nvfp4(const __nv_bfloat16* input,
+                                                          uint8_t* packed_output,
+                                                          uint8_t* scale_output) {
+  float values[SF_VEC_SIZE];
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE / 2; ++i) {
+    const __nv_bfloat162 pair = *reinterpret_cast<const __nv_bfloat162*>(input + i * 2);
+    const float2 converted = __bfloat1622float2(pair);
+    values[i * 2] = converted.x;
+    values[i * 2 + 1] = converted.y;
+  }
+  quantize_fp32_group16_to_nvfp4(values, packed_output, scale_output);
+}
+
+__device__ __forceinline__ void quantize_group16_to_nvfp4(const half* input, uint8_t* packed_output,
+                                                          uint8_t* scale_output) {
+  float values[SF_VEC_SIZE];
+#pragma unroll
+  for (int i = 0; i < SF_VEC_SIZE / 2; ++i) {
+    const half2 pair = *reinterpret_cast<const half2*>(input + i * 2);
+    const float2 converted = __half22float2(pair);
+    values[i * 2] = converted.x;
+    values[i * 2 + 1] = converted.y;
+  }
+  quantize_fp32_group16_to_nvfp4(values, packed_output, scale_output);
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_vt.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/nvfp4_vt.cuh
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_fp16.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "../model/nvfp4_cache_traits.cuh"
+#include "nvfp4_quantization.cuh"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+using DSV4NVFP4Cache = NVFP4CacheTraits<ModelType::DSV4>;
+static_assert(DSV4NVFP4Cache::SCALE_GROUP_SIZE == SF_VEC_SIZE);
+
+constexpr int NVFP4_VT_CANDIDATES = 64;
+constexpr int NVFP4_VT_PACKED_K_BYTES = NVFP4_VT_CANDIDATES / 2;
+constexpr int NVFP4_VT_SCALE_GROUPS = NVFP4_VT_CANDIDATES / SF_VEC_SIZE;
+constexpr int NVFP4_VT_DATA_BYTES = DSV4NVFP4Cache::D_NOPE * NVFP4_VT_PACKED_K_BYTES;
+constexpr int NVFP4_VT_SCALE_BYTES = DSV4NVFP4Cache::D_NOPE * NVFP4_VT_SCALE_GROUPS;
+
+// Decode two packed E2M1 values with the native SM100+ conversion. The V^T
+// preparation consumes two source candidates at a time.
+__device__ __forceinline__ float2 e2m1x2_code_to_float2(uint8_t codes) {
+  uint32_t fp16x2;
+  const uint32_t packed = codes;
+  asm volatile(
+      "{\n"
+      ".reg .b8 fp4_byte;\n"
+      "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+      "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
+      "}"
+      : "=r"(fp16x2)
+      : "r"(packed));
+  const __half2 h2 = *reinterpret_cast<const __half2*>(&fp16x2);
+  return __half22float2(h2);
+}
+
+__device__ __forceinline__ uint64_t transpose_e2m1_16x16_stage(uint64_t packed, int lane_in_group,
+                                                               int distance, uint64_t low_mask) {
+  const uint32_t packed_lo = static_cast<uint32_t>(packed);
+  const uint32_t packed_hi = static_cast<uint32_t>(packed >> 32);
+  const uint64_t partner =
+      static_cast<uint64_t>(__shfl_xor_sync(0xffffffffu, packed_lo, distance, SF_VEC_SIZE)) |
+      (static_cast<uint64_t>(__shfl_xor_sync(0xffffffffu, packed_hi, distance, SF_VEC_SIZE)) << 32);
+  const int shift = distance * 4;
+  if (lane_in_group & distance) {
+    return ((partner & ~low_mask) >> shift) | (packed & ~low_mask);
+  }
+  return (packed & low_mask) | ((partner & low_mask) << shift);
+}
+
+// Transpose one 16-candidate x 16-dimension E2M1 tile entirely in registers.
+__device__ __forceinline__ uint64_t transpose_e2m1_16x16(uint64_t packed, int lane_in_group) {
+  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 8, 0x00000000ffffffffULL);
+  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 4, 0x0000ffff0000ffffULL);
+  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 2, 0x00ff00ff00ff00ffULL);
+  return transpose_e2m1_16x16_stage(packed, lane_in_group, 1, 0x0f0f0f0f0f0f0f0fULL);
+}
+
+// Convert one token-major 64-candidate shared-memory tile into the layout
+// consumed by block-scaled P x V. Source scales are absorbed and the result is
+// requantized without a global V^T workspace.
+template <int WORKER_THREADS, int KV_SMEM_STRIDE, int THREAD_BASE = 0>
+__device__ __forceinline__ void prepare_nvfp4_vt_from_smem(const uint8_t* __restrict__ kv_fp4,
+                                                           const uint8_t* __restrict__ kv_sc,
+                                                           uint8_t* __restrict__ vt_data,
+                                                           uint8_t* __restrict__ vt_sc) {
+  constexpr int NUM_DIM_GROUPS = DSV4NVFP4Cache::D_NOPE / SF_VEC_SIZE;
+  constexpr int DIM_GROUPS_PER_ITER = WORKER_THREADS / NVFP4_VT_CANDIDATES;
+  static_assert(WORKER_THREADS >= NVFP4_VT_CANDIDATES && WORKER_THREADS % NVFP4_VT_CANDIDATES == 0);
+
+  const int worker_tid = threadIdx.x - THREAD_BASE;
+  const int warp = worker_tid / 32;
+  const int lane = worker_tid & 31;
+  const int lane_in_group = lane & (SF_VEC_SIZE - 1);
+  const int half_warp = lane / SF_VEC_SIZE;
+  const int warp_cand_pair = warp & 1;
+  const int cand_group = warp_cand_pair * 2 + half_warp;
+  const int cand = cand_group * SF_VEC_SIZE + lane_in_group;
+
+  for (int dim_group = warp / 2; dim_group < NUM_DIM_GROUPS; dim_group += DIM_GROUPS_PER_ITER) {
+    const uint64_t packed = *reinterpret_cast<const uint64_t*>(
+        kv_fp4 + (size_t)cand * KV_SMEM_STRIDE + dim_group * FP4_PACKED_PER_GROUP);
+    const float source_scale =
+        e4m3_byte_to_float(kv_sc[(size_t)cand * DSV4NVFP4Cache::SCALE_BYTES_PER_TOKEN + dim_group]);
+    const uint64_t transposed = transpose_e2m1_16x16(packed, lane_in_group);
+
+    float values[SF_VEC_SIZE];
+#pragma unroll
+    for (int source_pair = 0; source_pair < SF_VEC_SIZE / 2; ++source_pair) {
+      const int source_lane0 = source_pair * 2;
+      const int source_lane1 = source_lane0 + 1;
+      const uint8_t codes = static_cast<uint8_t>(transposed >> (source_pair * 8));
+      const float2 decoded = e2m1x2_code_to_float2(codes);
+      const float scale0 = __shfl_sync(0xffffffffu, source_scale, source_lane0, SF_VEC_SIZE);
+      const float scale1 = __shfl_sync(0xffffffffu, source_scale, source_lane1, SF_VEC_SIZE);
+      values[source_lane0] = decoded.x * scale0;
+      values[source_lane1] = decoded.y * scale1;
+    }
+
+    const int dim = dim_group * SF_VEC_SIZE + lane_in_group;
+    uint2 quantized;
+    uint8_t quantized_scale;
+    quantize_fp32_group16_to_nvfp4_regs(values, quantized, quantized_scale);
+
+    // Adjacent half-warps cover adjacent candidate groups. Merge their 8-byte
+    // results into one aligned 16-byte transaction.
+    const int peer_lane = lane_in_group + SF_VEC_SIZE;
+    const uint32_t peer_lo = __shfl_sync(0xffffffffu, quantized.x, peer_lane);
+    const uint32_t peer_hi = __shfl_sync(0xffffffffu, quantized.y, peer_lane);
+    const uint32_t peer_scale =
+        __shfl_sync(0xffffffffu, static_cast<uint32_t>(quantized_scale), peer_lane);
+    if (half_warp == 0) {
+      *reinterpret_cast<uint4*>(vt_data + dim * NVFP4_VT_PACKED_K_BYTES + warp_cand_pair * 16) =
+          make_uint4(quantized.x, quantized.y, peer_lo, peer_hi);
+      *reinterpret_cast<uint16_t*>(vt_sc + dim * NVFP4_VT_SCALE_GROUPS + warp_cand_pair * 2) =
+          static_cast<uint16_t>(quantized_scale) | static_cast<uint16_t>(peer_scale << 8);
+    }
+  }
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
@@ -1,0 +1,902 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "arch/barrier.cuh"
+#include "arch/cp_async.cuh"
+#include "arch/ldmatrix_sm120.cuh"
+#include "arch/mma_sm120.cuh"
+#include "arch/mma_sm120_nvfp4.cuh"
+#include "common/d2_load_b_nvfp4.cuh"
+#include "common/nvfp4_quant.cuh"
+#include "model/kv_cache_traits.cuh"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+constexpr int DECODE_N_WARPS = 8;
+constexpr int DECODE_IO_WARPS = 2;
+constexpr int DECODE_BLOCK_THREADS = (DECODE_N_WARPS + DECODE_IO_WARPS) * 32;
+constexpr int DECODE_MATH_THREADS = DECODE_N_WARPS * 32;
+constexpr int DECODE_MERGE2_THREADS = 512;
+constexpr int DECODE_CAND_WINDOW = 64;
+constexpr int DECODE_KV_BUF_COUNT = 2;
+constexpr int DECODE_ENTRIES_PER_WARP = DECODE_CAND_WINDOW / DECODE_N_WARPS;
+constexpr int DECODE_QK_N_TILES = DECODE_ENTRIES_PER_WARP / 8;
+constexpr int DECODE_PACKED_NOPE_BYTES = 448 / 2;
+constexpr int DECODE_DATA_BYTES_PER_TOKEN = DECODE_PACKED_NOPE_BYTES + 64 * sizeof(bf16);
+constexpr int DECODE_SCALE_BYTES_PER_TOKEN = 32;
+constexpr int DECODE_BYTES_PER_TOKEN = DECODE_DATA_BYTES_PER_TOKEN + DECODE_SCALE_BYTES_PER_TOKEN;
+constexpr int DECODE_KV_SMEM_STRIDE = DECODE_PACKED_NOPE_BYTES + 16;
+constexpr int DECODE_W_PACKED_STRIDE = DECODE_CAND_WINDOW / 2 + 16;
+constexpr int DECODE_VT_PACKED_K_BYTES = DECODE_CAND_WINDOW / 2;
+constexpr int DECODE_VT_SCALE_GROUPS = DECODE_CAND_WINDOW / SF_VEC_SIZE;
+constexpr int DECODE_VT_DATA_BYTES = 448 * DECODE_VT_PACKED_K_BYTES;
+constexpr int DECODE_VT_SCALE_BYTES = 448 * DECODE_VT_SCALE_GROUPS;
+
+static_assert(DECODE_DATA_BYTES_PER_TOKEN == 352);
+static_assert(DECODE_BYTES_PER_TOKEN == 384);
+static_assert(DECODE_KV_SMEM_STRIDE == 240);
+
+template <ModelType MT>
+struct DecodeNVFP4Smem {
+  using KV = KVCacheTraits<MT>;
+  static_assert(MT == ModelType::DSV4);
+
+  static constexpr size_t SMEM_Q_ROPE = HPB * KV::D_ROPE * sizeof(bf16);
+  static constexpr size_t SMEM_Q_FP4 = HPB * DSV4_NVFP4_Q_PACKED_STRIDE;
+  static constexpr size_t SMEM_Q_SC = HPB * DSV4_NVFP4_SCALE_STRIDE;
+  static constexpr size_t SMEM_KV_FP4_BUF = DECODE_CAND_WINDOW * DECODE_KV_SMEM_STRIDE;
+  static constexpr size_t SMEM_KV_SC_BUF = DECODE_CAND_WINDOW * DECODE_SCALE_BYTES_PER_TOKEN;
+  static constexpr size_t SMEM_KV_ROPE_BUF = DECODE_CAND_WINDOW * KV::D_ROPE * sizeof(bf16);
+  static constexpr size_t SMEM_MBAR_PAIR = 2 * sizeof(uint64_t);
+  static constexpr size_t SMEM_REDUCE = 2 * DECODE_N_WARPS * HPB * sizeof(float);
+  static constexpr size_t SMEM_W_SC = HPB * DECODE_VT_SCALE_GROUPS;
+  static constexpr size_t SMEM_W_FP4 = HPB * DECODE_W_PACKED_STRIDE;
+  static constexpr size_t SMEM_VT_DATA = DECODE_VT_DATA_BYTES;
+  static constexpr size_t SMEM_VT_SC = DECODE_VT_SCALE_BYTES;
+
+  static constexpr size_t OFF_Q_ROPE = 0;
+  static constexpr size_t OFF_Q_FP4 = OFF_Q_ROPE + SMEM_Q_ROPE;
+  static constexpr size_t OFF_Q_SC = OFF_Q_FP4 + SMEM_Q_FP4;
+  static constexpr size_t OFF_KV_FP4 = OFF_Q_SC + SMEM_Q_SC;
+  static constexpr size_t OFF_KV_SC = OFF_KV_FP4 + DECODE_KV_BUF_COUNT * SMEM_KV_FP4_BUF;
+  static constexpr size_t OFF_KV_ROPE = OFF_KV_SC + DECODE_KV_BUF_COUNT * SMEM_KV_SC_BUF;
+  static constexpr size_t OFF_MBAR_FULL_UNALIGNED =
+      OFF_KV_ROPE + DECODE_KV_BUF_COUNT * SMEM_KV_ROPE_BUF;
+  static constexpr size_t OFF_MBAR_FULL = (OFF_MBAR_FULL_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t OFF_MBAR_EMPTY = OFF_MBAR_FULL + SMEM_MBAR_PAIR;
+  static constexpr size_t OFF_MBAR_VT = OFF_MBAR_EMPTY + SMEM_MBAR_PAIR;
+  static constexpr size_t OFF_REDUCE = OFF_MBAR_VT + sizeof(uint64_t);
+  static constexpr size_t OFF_W_SC = OFF_REDUCE + SMEM_REDUCE;
+  static constexpr size_t OFF_W_FP4_UNALIGNED = OFF_W_SC + SMEM_W_SC;
+  static constexpr size_t OFF_W_FP4 = (OFF_W_FP4_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t OFF_VT_DATA_UNALIGNED = OFF_W_FP4 + SMEM_W_FP4;
+  static constexpr size_t OFF_VT_DATA = (OFF_VT_DATA_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t OFF_VT_SC = OFF_VT_DATA + SMEM_VT_DATA;
+  static constexpr size_t SIZE = OFF_VT_SC + SMEM_VT_SC;
+
+  char* base;
+
+  __device__ static DecodeNVFP4Smem init(char* base) { return DecodeNVFP4Smem{base}; }
+  __device__ __forceinline__ bf16* q_rope() const {
+    return reinterpret_cast<bf16*>(base + OFF_Q_ROPE);
+  }
+  __device__ __forceinline__ uint8_t* q_fp4() const {
+    return reinterpret_cast<uint8_t*>(base + OFF_Q_FP4);
+  }
+  __device__ __forceinline__ uint8_t* q_sc() const {
+    return reinterpret_cast<uint8_t*>(base + OFF_Q_SC);
+  }
+  __device__ __forceinline__ uint8_t* kv_fp4(int parity) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_KV_FP4 + parity * SMEM_KV_FP4_BUF);
+  }
+  __device__ __forceinline__ uint8_t* kv_sc(int parity) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_KV_SC + parity * SMEM_KV_SC_BUF);
+  }
+  __device__ __forceinline__ bf16* kv_rope(int parity) const {
+    return reinterpret_cast<bf16*>(base + OFF_KV_ROPE + parity * SMEM_KV_ROPE_BUF);
+  }
+  __device__ __forceinline__ uint64_t* mbar_full(int parity) const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_FULL) + parity;
+  }
+  __device__ __forceinline__ uint64_t* mbar_empty(int parity) const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_EMPTY) + parity;
+  }
+  __device__ __forceinline__ uint64_t* mbar_vt() const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_VT);
+  }
+  __device__ __forceinline__ float* warp_max() const {
+    return reinterpret_cast<float*>(base + OFF_REDUCE);
+  }
+  __device__ __forceinline__ float* warp_sum() const { return warp_max() + DECODE_N_WARPS * HPB; }
+  __device__ __forceinline__ uint8_t* w_sc() const {
+    return reinterpret_cast<uint8_t*>(base + OFF_W_SC);
+  }
+  __device__ __forceinline__ uint8_t* w_fp4() const {
+    return reinterpret_cast<uint8_t*>(base + OFF_W_FP4);
+  }
+  __device__ __forceinline__ uint8_t* vt_data() const {
+    return reinterpret_cast<uint8_t*>(base + OFF_VT_DATA);
+  }
+  __device__ __forceinline__ uint8_t* vt_sc() const {
+    return reinterpret_cast<uint8_t*>(base + OFF_VT_SC);
+  }
+};
+
+__device__ __forceinline__ float e2m1_code_to_float(uint8_t code) {
+  constexpr float magnitude[8] = {0.f, 0.5f, 1.f, 1.5f, 2.f, 3.f, 4.f, 6.f};
+  const float value = magnitude[code & 7];
+  return (code & 8) ? -value : value;
+}
+
+// Decode two packed E2M1 values with the native SM100+ conversion.  The
+// prepare kernel consumes two source candidates at a time, so this avoids two
+// independent scalar LUT lookups while preserving the low-/high-nibble order.
+__device__ __forceinline__ float2 e2m1x2_code_to_float2(uint8_t codes) {
+  uint32_t fp16x2;
+  const uint32_t packed = codes;
+  asm volatile(
+      "{\n"
+      ".reg .b8 fp4_byte;\n"
+      "mov.b32 {fp4_byte, _, _, _}, %1;\n"
+      "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
+      "}"
+      : "=r"(fp16x2)
+      : "r"(packed));
+  const __half2 h2 = *reinterpret_cast<const __half2*>(&fp16x2);
+  return __half22float2(h2);
+}
+
+__device__ __forceinline__ uint64_t transpose_e2m1_16x16_stage(uint64_t packed, int lane_in_group,
+                                                               int distance, uint64_t low_mask) {
+  const uint32_t packed_lo = static_cast<uint32_t>(packed);
+  const uint32_t packed_hi = static_cast<uint32_t>(packed >> 32);
+  const uint64_t partner =
+      static_cast<uint64_t>(__shfl_xor_sync(0xffffffffu, packed_lo, distance, SF_VEC_SIZE)) |
+      (static_cast<uint64_t>(__shfl_xor_sync(0xffffffffu, packed_hi, distance, SF_VEC_SIZE)) << 32);
+  const int shift = distance * 4;
+  if (lane_in_group & distance) {
+    return ((partner & ~low_mask) >> shift) | (packed & ~low_mask);
+  }
+  return (packed & low_mask) | ((partner & low_mask) << shift);
+}
+
+// Transpose one 16-candidate x 16-dimension E2M1 tile entirely in registers.
+// Four butterfly stages replace the per-output-lane gather of all 16 packed
+// source values (8 shuffles per lane instead of 32).
+__device__ __forceinline__ uint64_t transpose_e2m1_16x16(uint64_t packed, int lane_in_group) {
+  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 8, 0x00000000ffffffffULL);
+  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 4, 0x0000ffff0000ffffULL);
+  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 2, 0x00ff00ff00ff00ffULL);
+  return transpose_e2m1_16x16_stage(packed, lane_in_group, 1, 0x0f0f0f0f0f0f0f0fULL);
+}
+
+// Convert one token-major 64-candidate shared-memory tile into the
+// candidate-reduction layout consumed by block-scaled P x V.  The conversion
+// stays inside the CTA: source scales are absorbed, the 16x16 E2M1 tiles are
+// transposed in registers, and the result is requantized into the ephemeral
+// V^T operand.  KV_SMEM_STRIDE allows decode's padded source rows and
+// prefill's compact rows to share the same implementation.
+template <int WORKER_THREADS, int KV_SMEM_STRIDE, int THREAD_BASE = 0>
+__device__ __forceinline__ void prepare_nvfp4_vt_from_smem(const uint8_t* __restrict__ kv_fp4,
+                                                           const uint8_t* __restrict__ kv_sc,
+                                                           uint8_t* __restrict__ vt_data,
+                                                           uint8_t* __restrict__ vt_sc) {
+  constexpr int NUM_DIM_GROUPS = 448 / SF_VEC_SIZE;
+  constexpr int DIM_GROUPS_PER_ITER = WORKER_THREADS / 64;
+  static_assert(WORKER_THREADS >= 64 && WORKER_THREADS % 64 == 0);
+
+  const int worker_tid = threadIdx.x - THREAD_BASE;
+  const int warp = worker_tid / 32;
+  const int lane = worker_tid & 31;
+  const int lane_in_group = lane & (SF_VEC_SIZE - 1);
+  const int half_warp = lane / SF_VEC_SIZE;
+  const int warp_cand_pair = warp & 1;
+  const int cand_group = warp_cand_pair * 2 + half_warp;
+  const int cand = cand_group * SF_VEC_SIZE + lane_in_group;
+
+  for (int dim_group = warp / 2; dim_group < NUM_DIM_GROUPS; dim_group += DIM_GROUPS_PER_ITER) {
+    const uint64_t packed = *reinterpret_cast<const uint64_t*>(
+        kv_fp4 + (size_t)cand * KV_SMEM_STRIDE + dim_group * FP4_PACKED_PER_GROUP);
+    const float source_scale =
+        e4m3_byte_to_float(kv_sc[(size_t)cand * DECODE_SCALE_BYTES_PER_TOKEN + dim_group]);
+    const uint64_t transposed = transpose_e2m1_16x16(packed, lane_in_group);
+
+    float values[SF_VEC_SIZE];
+#pragma unroll
+    for (int source_pair = 0; source_pair < SF_VEC_SIZE / 2; ++source_pair) {
+      const int source_lane0 = source_pair * 2;
+      const int source_lane1 = source_lane0 + 1;
+      const uint8_t codes = static_cast<uint8_t>(transposed >> (source_pair * 8));
+      const float2 decoded = e2m1x2_code_to_float2(codes);
+      const float scale0 = __shfl_sync(0xffffffffu, source_scale, source_lane0, SF_VEC_SIZE);
+      const float scale1 = __shfl_sync(0xffffffffu, source_scale, source_lane1, SF_VEC_SIZE);
+      values[source_lane0] = decoded.x * scale0;
+      values[source_lane1] = decoded.y * scale1;
+    }
+
+    const int dim = dim_group * SF_VEC_SIZE + lane_in_group;
+    uint2 quantized;
+    uint8_t quantized_scale;
+    quantize_fp32_group16_to_nvfp4_regs(values, quantized, quantized_scale);
+
+    // Adjacent half-warps cover adjacent candidate groups.  Merge their
+    // 8-byte results into one aligned 16-byte transaction; paired warps fill
+    // the complete 64-candidate row.
+    const int peer_lane = lane_in_group + SF_VEC_SIZE;
+    const uint32_t peer_lo = __shfl_sync(0xffffffffu, quantized.x, peer_lane);
+    const uint32_t peer_hi = __shfl_sync(0xffffffffu, quantized.y, peer_lane);
+    const uint32_t peer_scale =
+        __shfl_sync(0xffffffffu, static_cast<uint32_t>(quantized_scale), peer_lane);
+    if (half_warp == 0) {
+      *reinterpret_cast<uint4*>(vt_data + dim * DECODE_VT_PACKED_K_BYTES + warp_cand_pair * 16) =
+          make_uint4(quantized.x, quantized.y, peer_lo, peer_hi);
+      *reinterpret_cast<uint16_t*>(vt_sc + dim * DECODE_VT_SCALE_GROUPS + warp_cand_pair * 2) =
+          static_cast<uint16_t>(quantized_scale) | static_cast<uint16_t>(peer_scale << 8);
+    }
+  }
+}
+
+template <ModelType MT, int NUM_HEADS, int TOPK, int PAGE_BLOCK_SIZE, bool DUAL_CACHE = false>
+__global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_nvfp4_kernel(
+    const bf16* __restrict__ q, const uint8_t* __restrict__ kv_cache,
+    const int32_t* __restrict__ indices, bf16* __restrict__ mid_out, float* __restrict__ mid_lse,
+    bf16* __restrict__ output, float* __restrict__ out_lse, const float* __restrict__ attn_sink,
+    const int* __restrict__ topk_length_ptr, const uint8_t* __restrict__ extra_kv_cache,
+    const int32_t* __restrict__ extra_indices, const int* __restrict__ extra_topk_length_ptr,
+    int extra_topk, int extra_page_block_size, size_t stride_extra_kv_block, int num_tokens,
+    int num_splits, int chunks_per_block, float sm_scale, size_t stride_kv_block,
+    bool write_direct) {
+  using KV = KVCacheTraits<MT>;
+  static_assert(MT == ModelType::DSV4);
+  constexpr int D_NOPE = KV::D_NOPE;
+  constexpr int D_ROPE_C = KV::D_ROPE;
+  constexpr int D_QK = KV::D_QK;
+  constexpr int D_V_C = KV::D_V;
+  constexpr int NUM_K64_TILES = D_NOPE / 64;
+  constexpr int VALID_HPB = (NUM_HEADS < HPB) ? NUM_HEADS : HPB;
+  constexpr int PV_SCALE_GROUPS = D_NOPE / SF_VEC_SIZE;
+  constexpr int PV_GROUPS_PER_WARP = (PV_SCALE_GROUPS + DECODE_N_WARPS - 1) / DECODE_N_WARPS;
+  constexpr int PV_N8_TILES_PER_GROUP = SF_VEC_SIZE / 8;
+  constexpr int ROPE_DIMS_PER_WARP = D_ROPE_C / DECODE_N_WARPS;
+  constexpr int ROPE_N_TILES = ROPE_DIMS_PER_WARP / 8;
+  constexpr int ROPE_K_ITERS = DECODE_CAND_WINDOW / 16;
+  const int token_idx = blockIdx.x;
+  const int h_start = blockIdx.y * HPB;
+  const int split_idx = blockIdx.z;
+  if (token_idx >= num_tokens) return;
+
+  int topk_len = topk_length_ptr ? __ldg(topk_length_ptr + token_idx) : TOPK;
+  topk_len = max(0, min(topk_len, TOPK));
+  const int num_main_chunks = (topk_len + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  int extra_topk_len = 0;
+  if constexpr (DUAL_CACHE) {
+    extra_topk_len = extra_topk_length_ptr ? __ldg(extra_topk_length_ptr + token_idx) : extra_topk;
+    extra_topk_len = max(0, min(extra_topk_len, extra_topk));
+  }
+  const int num_extra_chunks = (extra_topk_len + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  const int num_chunks = num_main_chunks + num_extra_chunks;
+  const int chunk_lo = split_idx * chunks_per_block;
+  const int chunk_hi = min(chunk_lo + chunks_per_block, num_chunks);
+  const int warp_id = threadIdx.x / 32;
+  const int lane = threadIdx.x & 31;
+  const bool is_io = warp_id >= DECODE_N_WARPS;
+
+  if (chunk_lo >= num_chunks) {
+    if (!is_io) {
+      if (write_direct) {
+        for (int i = threadIdx.x; i < VALID_HPB * D_V_C; i += DECODE_MATH_THREADS) {
+          output[((size_t)token_idx * NUM_HEADS + h_start) * D_V_C + i] = __float2bfloat16(0.f);
+        }
+        if (threadIdx.x < VALID_HPB) {
+          const int h = h_start + threadIdx.x;
+          out_lse[(size_t)token_idx * NUM_HEADS + h] =
+              attn_sink ? __ldg(attn_sink + h) * LOG2E : -1e30f;
+        }
+      } else if (threadIdx.x < VALID_HPB) {
+        const int h = h_start + threadIdx.x;
+        mid_lse[(size_t)token_idx * NUM_HEADS * num_splits + (size_t)h * num_splits + split_idx] =
+            -1e30f;
+      }
+    }
+    return;
+  }
+
+  extern __shared__ __align__(16) char smem_raw[];
+  auto sm = DecodeNVFP4Smem<MT>::init(smem_raw);
+  __shared__ bf16 sm_p_full[HPB][DECODE_CAND_WINDOW];
+  const int32_t* idx_base = indices + (size_t)token_idx * TOPK;
+
+  if (threadIdx.x == 0) {
+#pragma unroll
+    for (int i = 0; i < DECODE_KV_BUF_COUNT; ++i) {
+      mbarrier_init(sm.mbar_full(i), 1);
+      mbarrier_init(sm.mbar_empty(i), 1);
+    }
+  }
+  __syncthreads();
+
+  constexpr uint32_t BULK_NOPE_BYTES = DECODE_PACKED_NOPE_BYTES;
+  constexpr uint32_t BULK_ROPE_BYTES = D_ROPE_C * sizeof(bf16);
+  constexpr uint32_t BULK_TX_BYTES = DECODE_CAND_WINDOW * (BULK_NOPE_BYTES + BULK_ROPE_BYTES);
+
+  auto issue_gather = [&](int chunk_idx, int buf) {
+    bool is_extra = false;
+    int section_chunk = chunk_idx;
+    int section_len = topk_len;
+    int section_topk = TOPK;
+    int section_page_block_size = PAGE_BLOCK_SIZE;
+    size_t section_stride = stride_kv_block;
+    const uint8_t* section_kv = kv_cache;
+    const int32_t* section_indices = idx_base;
+    if constexpr (DUAL_CACHE) {
+      is_extra = chunk_idx >= num_main_chunks;
+      if (is_extra) {
+        section_chunk = chunk_idx - num_main_chunks;
+        section_len = extra_topk_len;
+        section_topk = extra_topk;
+        section_page_block_size = extra_page_block_size;
+        section_stride = stride_extra_kv_block;
+        section_kv = extra_kv_cache;
+        section_indices = extra_indices + (size_t)token_idx * section_topk;
+      }
+    }
+    const int chunk_start = section_chunk * DECODE_CAND_WINDOW;
+    const int chunk_end = min(chunk_start + DECODE_CAND_WINDOW, section_len);
+    uint8_t* fp4_dst = sm.kv_fp4(buf);
+    bf16* rope_dst = sm.kv_rope(buf);
+    uint8_t* scale_dst = sm.kv_sc(buf);
+
+    const int io_warp = warp_id - DECODE_N_WARPS;
+    const int entry = (io_warp & 1) * 32 + lane;
+    const int cand = chunk_start + entry;
+    const int idx_raw = (cand < chunk_end) ? section_indices[cand] : -1;
+    if (io_warp < 2) {
+      uint4 s0 = make_uint4(0, 0, 0, 0);
+      uint4 s1 = make_uint4(0, 0, 0, 0);
+      if (idx_raw >= 0) {
+        int page;
+        int slot;
+        if constexpr (DUAL_CACHE) {
+          if (is_extra && section_page_block_size == 2) {
+            page = idx_raw >> 1;
+            slot = idx_raw & 1;
+          } else {
+            page = idx_raw >> 6;
+            slot = idx_raw & 63;
+          }
+        } else {
+          page = idx_raw / PAGE_BLOCK_SIZE;
+          slot = idx_raw - page * PAGE_BLOCK_SIZE;
+        }
+        const uint8_t* scale_src = section_kv + (size_t)page * section_stride +
+                                   (size_t)section_page_block_size * DECODE_DATA_BYTES_PER_TOKEN +
+                                   (size_t)slot * DECODE_SCALE_BYTES_PER_TOKEN;
+        s0 = *reinterpret_cast<const uint4*>(scale_src);
+        s1 = *reinterpret_cast<const uint4*>(scale_src + sizeof(uint4));
+      }
+      *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * DECODE_SCALE_BYTES_PER_TOKEN) = s0;
+      *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * DECODE_SCALE_BYTES_PER_TOKEN +
+                                sizeof(uint4)) = s1;
+      __threadfence_block();
+    }
+
+    const int idx = idx_raw >= 0 ? idx_raw : 0;
+    int page;
+    int slot;
+    if constexpr (DUAL_CACHE) {
+      if (is_extra && section_page_block_size == 2) {
+        page = idx >> 1;
+        slot = idx & 1;
+      } else {
+        page = idx >> 6;
+        slot = idx & 63;
+      }
+    } else {
+      page = idx / PAGE_BLOCK_SIZE;
+      slot = idx - page * PAGE_BLOCK_SIZE;
+    }
+    const uint8_t* data_src =
+        section_kv + (size_t)page * section_stride + (size_t)slot * DECODE_DATA_BYTES_PER_TOKEN;
+    if (io_warp == 0 && lane == 0) mbarrier_arrive_expect_tx(sm.mbar_full(buf), BULK_TX_BYTES);
+    bar_sync_t<4, DECODE_IO_WARPS * 32>();
+    cp_async_bulk_g2s(fp4_dst + (size_t)entry * DECODE_KV_SMEM_STRIDE, data_src, BULK_NOPE_BYTES,
+                      sm.mbar_full(buf));
+    cp_async_bulk_g2s(rope_dst + (size_t)entry * D_ROPE_C, data_src + DECODE_PACKED_NOPE_BYTES,
+                      BULK_ROPE_BYTES, sm.mbar_full(buf));
+  };
+
+  if (is_io) {
+    uint32_t phase = 1;
+    int state_idx = 0;
+    for (int chunk = chunk_lo; chunk < chunk_hi; ++chunk) {
+      const int buf = (chunk - chunk_lo) % DECODE_KV_BUF_COUNT;
+      mbarrier_wait_parity(sm.mbar_empty(state_idx), phase);
+      issue_gather(chunk, buf);
+      if (++state_idx == DECODE_KV_BUF_COUNT) {
+        state_idx = 0;
+        phase ^= 1;
+      }
+    }
+    return;
+  }
+
+  const int gid = lane >> 2;
+  const int tid = lane & 3;
+  const bf16* q_base = q + (size_t)token_idx * NUM_HEADS * D_QK + (size_t)h_start * D_QK;
+  quantize_q_nvfp4_to_smem<DECODE_MATH_THREADS>(sm.q_fp4(), sm.q_sc(), sm.q_rope(), q_base,
+                                                VALID_HPB);
+
+  float acc_nope[PV_GROUPS_PER_WARP][PV_N8_TILES_PER_GROUP][4] = {0};
+  float acc_rope[ROPE_N_TILES][4] = {0};
+  float global_max[2] = {-1e30f, -1e30f};
+  float global_sum[2] = {0.f, 0.f};
+  uint32_t cons_phase = 0;
+  int cons_idx = 0;
+
+  for (int chunk = chunk_lo; chunk < chunk_hi; ++chunk) {
+    const int buf = (chunk - chunk_lo) % DECODE_KV_BUF_COUNT;
+    bool is_extra_chunk = false;
+    int section_chunk = chunk;
+    int section_len = topk_len;
+    const int32_t* section_indices = idx_base;
+    if constexpr (DUAL_CACHE) {
+      is_extra_chunk = chunk >= num_main_chunks;
+      if (is_extra_chunk) {
+        section_chunk = chunk - num_main_chunks;
+        section_len = extra_topk_len;
+        section_indices = extra_indices + (size_t)token_idx * extra_topk;
+      }
+    }
+    const int chunk_start = section_chunk * DECODE_CAND_WINDOW;
+    const int chunk_end = min(chunk_start + DECODE_CAND_WINDOW, section_len);
+    mbarrier_wait_parity(sm.mbar_full(cons_idx), cons_phase);
+
+    uint8_t* sm_kv_fp4 = sm.kv_fp4(buf);
+    uint8_t* sm_kv_sc = sm.kv_sc(buf);
+    bf16* sm_kv_rope = sm.kv_rope(buf);
+
+    float qk[DECODE_QK_N_TILES][4] = {0};
+    const int warp_first_cand = warp_id * DECODE_ENTRIES_PER_WARP;
+#pragma unroll
+    for (int kt = 0; kt < NUM_K64_TILES; ++kt) {
+      const int scale_row = gid + (lane & 1) * 8;
+      const uint32_t scale_a = *reinterpret_cast<const uint32_t*>(
+          sm.q_sc() + scale_row * DSV4_NVFP4_SCALE_STRIDE + kt * 4);
+      uint32_t a0, a1, a2, a3;
+      ldmatrix_load_A_fp8(a0, a1, a2, a3, sm.q_fp4() + kt * 32, DSV4_NVFP4_Q_PACKED_STRIDE, lane);
+#pragma unroll
+      for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
+        const int cand_row_base = warp_first_cand + nt * 8;
+        const uint32_t scale_b = *reinterpret_cast<const uint32_t*>(
+            sm_kv_sc + (size_t)(cand_row_base + gid) * DECODE_SCALE_BYTES_PER_TOKEN + kt * 4);
+        uint32_t b0, b1;
+        ldmatrix_load_B_fp8(b0, b1,
+                            sm_kv_fp4 + (size_t)cand_row_base * DECODE_KV_SMEM_STRIDE + kt * 32,
+                            DECODE_KV_SMEM_STRIDE, lane);
+        MmaNvfp4Result r = mma_nvfp4_block_scaled_m16n8k64(
+            a0, a1, a2, a3, b0, b1, qk[nt][0], qk[nt][1], qk[nt][2], qk[nt][3], scale_a, scale_b);
+        qk[nt][0] = r.d0;
+        qk[nt][1] = r.d1;
+        qk[nt][2] = r.d2;
+        qk[nt][3] = r.d3;
+      }
+    }
+
+#pragma unroll
+    for (int ks = 0; ks < D_ROPE_C / 16; ++ks) {
+      uint32_t a0, a1, a2, a3;
+      ldmatrix_load_A_bf16(a0, a1, a2, a3, sm.q_rope() + ks * 16, D_ROPE_C, lane);
+#pragma unroll
+      for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
+        const int cand_row_base = warp_first_cand + nt * 8;
+        const bf16* rope_row = sm_kv_rope + (size_t)(cand_row_base + gid) * D_ROPE_C + ks * 16;
+        const uint32_t b0 = *reinterpret_cast<const uint32_t*>(rope_row + tid * 2);
+        const uint32_t b1 = *reinterpret_cast<const uint32_t*>(rope_row + tid * 2 + 8);
+        MmaBf16Result r =
+            mma_bf16_m16n8k16(a0, a1, a2, a3, b0, b1, qk[nt][0], qk[nt][1], qk[nt][2], qk[nt][3]);
+        qk[nt][0] = r.d0;
+        qk[nt][1] = r.d1;
+        qk[nt][2] = r.d2;
+        qk[nt][3] = r.d3;
+      }
+    }
+
+#pragma unroll
+    for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
+      const int c0 = warp_first_cand + nt * 8 + tid * 2;
+      const int c1 = c0 + 1;
+      const int abs_c0 = chunk_start + c0;
+      const int abs_c1 = chunk_start + c1;
+      const int idx0 = abs_c0 < section_len ? section_indices[abs_c0] : -1;
+      const int idx1 = abs_c1 < section_len ? section_indices[abs_c1] : -1;
+      if (abs_c0 >= chunk_end || idx0 < 0) qk[nt][0] = qk[nt][2] = -1e30f;
+      if (abs_c1 >= chunk_end || idx1 < 0) qk[nt][1] = qk[nt][3] = -1e30f;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) qk[nt][i] *= sm_scale * LOG2E;
+    }
+
+    float local_max[2] = {-1e30f, -1e30f};
+#pragma unroll
+    for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
+      local_max[0] = fmaxf(local_max[0], fmaxf(qk[nt][0], qk[nt][1]));
+      local_max[1] = fmaxf(local_max[1], fmaxf(qk[nt][2], qk[nt][3]));
+    }
+#pragma unroll
+    for (int s = 2; s >= 1; s >>= 1) {
+      local_max[0] = fmaxf(local_max[0], __shfl_xor_sync(0xffffffff, local_max[0], s));
+      local_max[1] = fmaxf(local_max[1], __shfl_xor_sync(0xffffffff, local_max[1], s));
+    }
+    float local_sum[2] = {0.f, 0.f};
+    float p[DECODE_QK_N_TILES][4];
+#pragma unroll
+    for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
+      p[nt][0] = exp2f(qk[nt][0] - local_max[0]);
+      p[nt][1] = exp2f(qk[nt][1] - local_max[0]);
+      p[nt][2] = exp2f(qk[nt][2] - local_max[1]);
+      p[nt][3] = exp2f(qk[nt][3] - local_max[1]);
+      local_sum[0] += p[nt][0] + p[nt][1];
+      local_sum[1] += p[nt][2] + p[nt][3];
+    }
+#pragma unroll
+    for (int s = 2; s >= 1; s >>= 1) {
+      local_sum[0] += __shfl_xor_sync(0xffffffff, local_sum[0], s);
+      local_sum[1] += __shfl_xor_sync(0xffffffff, local_sum[1], s);
+    }
+
+    if (tid == 0) {
+      sm.warp_max()[warp_id * HPB + gid] = local_max[0];
+      sm.warp_max()[warp_id * HPB + gid + 8] = local_max[1];
+      sm.warp_sum()[warp_id * HPB + gid] = local_sum[0];
+      sm.warp_sum()[warp_id * HPB + gid + 8] = local_sum[1];
+    }
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+    if (threadIdx.x < VALID_HPB) {
+      const int h = threadIdx.x;
+      float block_max = -1e30f;
+#pragma unroll
+      for (int w = 0; w < DECODE_N_WARPS; ++w)
+        block_max = fmaxf(block_max, sm.warp_max()[w * HPB + h]);
+      float block_sum = 0.f;
+#pragma unroll
+      for (int w = 0; w < DECODE_N_WARPS; ++w)
+        block_sum += sm.warp_sum()[w * HPB + h] * exp2f(sm.warp_max()[w * HPB + h] - block_max);
+      sm.warp_max()[h] = block_max;
+      sm.warp_sum()[h] = block_sum;
+    }
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+
+    const float block_max0 = sm.warp_max()[gid];
+    const float block_max1 = sm.warp_max()[gid + 8];
+    const float block_sum0 = sm.warp_sum()[gid];
+    const float block_sum1 = sm.warp_sum()[gid + 8];
+    const float new_max0 = fmaxf(global_max[0], block_max0);
+    const float new_max1 = fmaxf(global_max[1], block_max1);
+    const float alpha0 = global_max[0] > -1e29f ? exp2f(global_max[0] - new_max0) : 0.f;
+    const float alpha1 = global_max[1] > -1e29f ? exp2f(global_max[1] - new_max1) : 0.f;
+    const float block_rescale0 = exp2f(block_max0 - new_max0);
+    const float block_rescale1 = exp2f(block_max1 - new_max1);
+    const float warp_rescale0 = exp2f(local_max[0] - new_max0);
+    const float warp_rescale1 = exp2f(local_max[1] - new_max1);
+
+    if (chunk > chunk_lo) {
+#pragma unroll
+      for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
+#pragma unroll
+        for (int nt = 0; nt < PV_N8_TILES_PER_GROUP; ++nt) {
+          acc_nope[slot][nt][0] *= alpha0;
+          acc_nope[slot][nt][1] *= alpha0;
+          acc_nope[slot][nt][2] *= alpha1;
+          acc_nope[slot][nt][3] *= alpha1;
+        }
+      }
+#pragma unroll
+      for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
+        acc_rope[nt][0] *= alpha0;
+        acc_rope[nt][1] *= alpha0;
+        acc_rope[nt][2] *= alpha1;
+        acc_rope[nt][3] *= alpha1;
+      }
+      global_sum[0] = global_sum[0] * alpha0 + block_sum0 * block_rescale0;
+      global_sum[1] = global_sum[1] * alpha1 + block_sum1 * block_rescale1;
+    } else {
+      global_sum[0] = block_sum0 * block_rescale0;
+      global_sum[1] = block_sum1 * block_rescale1;
+    }
+    global_max[0] = new_max0;
+    global_max[1] = new_max1;
+
+    float w_pre[DECODE_QK_N_TILES][4];
+#pragma unroll
+    for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
+      w_pre[nt][0] = p[nt][0] * warp_rescale0;
+      w_pre[nt][1] = p[nt][1] * warp_rescale0;
+      w_pre[nt][2] = p[nt][2] * warp_rescale1;
+      w_pre[nt][3] = p[nt][3] * warp_rescale1;
+      const int c0 = nt * 8 + tid * 2;
+      const int c1 = c0 + 1;
+      sm_p_full[gid][warp_first_cand + c0] = __float2bfloat16(w_pre[nt][0]);
+      sm_p_full[gid][warp_first_cand + c1] = __float2bfloat16(w_pre[nt][1]);
+      sm_p_full[gid + 8][warp_first_cand + c0] = __float2bfloat16(w_pre[nt][2]);
+      sm_p_full[gid + 8][warp_first_cand + c1] = __float2bfloat16(w_pre[nt][3]);
+    }
+
+    // Reuse the current QK source tile directly.  All 256 math threads
+    // transpose/dequantize/requantize token-major paged V into the single
+    // ephemeral CTA-local V^T stage; the producer warps have already started
+    // gathering the next candidate tile into the other source buffer.
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+    prepare_nvfp4_vt_from_smem<DECODE_MATH_THREADS, DECODE_KV_SMEM_STRIDE>(
+        sm_kv_fp4, sm_kv_sc, sm.vt_data(), sm.vt_sc());
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+
+    for (int task = threadIdx.x; task < HPB * DECODE_VT_SCALE_GROUPS; task += DECODE_MATH_THREADS) {
+      const int head = task / DECODE_VT_SCALE_GROUPS;
+      const int cand_group = task % DECODE_VT_SCALE_GROUPS;
+      quantize_bf16_group16_to_nvfp4(
+          &sm_p_full[head][cand_group * SF_VEC_SIZE],
+          sm.w_fp4() + head * DECODE_W_PACKED_STRIDE + cand_group * FP4_PACKED_PER_GROUP,
+          sm.w_sc() + head * DECODE_VT_SCALE_GROUPS + cand_group);
+    }
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+
+    const int p_scale_row = gid + (lane & 1) * 8;
+    const uint32_t scale_a =
+        *reinterpret_cast<const uint32_t*>(sm.w_sc() + p_scale_row * DECODE_VT_SCALE_GROUPS);
+    uint32_t a0, a1, a2, a3;
+    ldmatrix_load_A_fp8(a0, a1, a2, a3, sm.w_fp4(), DECODE_W_PACKED_STRIDE, lane);
+
+#pragma unroll
+    for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
+      const int scale_group = slot * DECODE_N_WARPS + warp_id;
+      if (scale_group >= PV_SCALE_GROUPS) continue;
+      const int dim = scale_group * SF_VEC_SIZE;
+      uint32_t b00, b01, b10, b11;
+      ldmatrix_load_B_fp8(b00, b01, sm.vt_data() + dim * DECODE_VT_PACKED_K_BYTES,
+                          DECODE_VT_PACKED_K_BYTES, lane);
+      ldmatrix_load_B_fp8(b10, b11, sm.vt_data() + (dim + 8) * DECODE_VT_PACKED_K_BYTES,
+                          DECODE_VT_PACKED_K_BYTES, lane);
+      const uint32_t scale_b0 =
+          *reinterpret_cast<const uint32_t*>(sm.vt_sc() + (dim + gid) * DECODE_VT_SCALE_GROUPS);
+      const uint32_t scale_b1 =
+          *reinterpret_cast<const uint32_t*>(sm.vt_sc() + (dim + 8 + gid) * DECODE_VT_SCALE_GROUPS);
+      MmaNvfp4Result r0 = mma_nvfp4_block_scaled_m16n8k64(a0, a1, a2, a3, b00, b01, 0.f, 0.f, 0.f,
+                                                          0.f, scale_a, scale_b0);
+      MmaNvfp4Result r1 = mma_nvfp4_block_scaled_m16n8k64(a0, a1, a2, a3, b10, b11, 0.f, 0.f, 0.f,
+                                                          0.f, scale_a, scale_b1);
+      acc_nope[slot][0][0] += r0.d0;
+      acc_nope[slot][0][1] += r0.d1;
+      acc_nope[slot][0][2] += r0.d2;
+      acc_nope[slot][0][3] += r0.d3;
+      acc_nope[slot][1][0] += r1.d0;
+      acc_nope[slot][1][1] += r1.d1;
+      acc_nope[slot][1][2] += r1.d2;
+      acc_nope[slot][1][3] += r1.d3;
+    }
+
+    const int rope_dim_base = warp_id * ROPE_DIMS_PER_WARP;
+#pragma unroll
+    for (int ks = 0; ks < ROPE_K_ITERS; ++ks) {
+      uint32_t a0, a1, a2, a3;
+      ldmatrix_load_A_bf16(a0, a1, a2, a3, reinterpret_cast<const bf16*>(&sm_p_full[0][ks * 16]),
+                           DECODE_CAND_WINDOW, lane);
+#pragma unroll
+      for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
+        const int n_col = rope_dim_base + nt * 8;
+        const int k_base = ks * 16;
+        const int ent0 = k_base + tid * 2;
+        const int ent1 = ent0 + 1;
+        const int ent8 = ent0 + 8;
+        const int ent9 = ent0 + 9;
+        const int col = n_col + gid;
+        const uint16_t v0 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent0 * D_ROPE_C + col);
+        const uint16_t v1 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent1 * D_ROPE_C + col);
+        const uint16_t v8 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent8 * D_ROPE_C + col);
+        const uint16_t v9 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent9 * D_ROPE_C + col);
+        const uint32_t b0 = (uint32_t)v0 | ((uint32_t)v1 << 16);
+        const uint32_t b1 = (uint32_t)v8 | ((uint32_t)v9 << 16);
+        MmaBf16Result r = mma_bf16_m16n8k16(a0, a1, a2, a3, b0, b1, acc_rope[nt][0],
+                                            acc_rope[nt][1], acc_rope[nt][2], acc_rope[nt][3]);
+        acc_rope[nt][0] = r.d0;
+        acc_rope[nt][1] = r.d1;
+        acc_rope[nt][2] = r.d2;
+        acc_rope[nt][3] = r.d3;
+      }
+    }
+
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+    if (threadIdx.x == 0) mbarrier_arrive(sm.mbar_empty(cons_idx));
+    if (++cons_idx == DECODE_KV_BUF_COUNT) {
+      cons_idx = 0;
+      cons_phase ^= 1;
+    }
+  }
+
+  if (write_direct) {
+    if (warp_id == 0 && tid == 0) {
+      float lse0 = global_sum[0] > 0.f ? log2f(global_sum[0]) + global_max[0] : -1e30f;
+      float lse1 = global_sum[1] > 0.f ? log2f(global_sum[1]) + global_max[1] : -1e30f;
+      float output_scale0 = 1.f;
+      float output_scale1 = 1.f;
+      if (attn_sink != nullptr) {
+        const float sink0 = __ldg(attn_sink + h_start + gid) * LOG2E;
+        const float max0 = fmaxf(lse0, sink0);
+        const float attn_mass0 = lse0 > -1e29f ? exp2f(lse0 - max0) : 0.f;
+        const float sink_mass0 = exp2f(sink0 - max0);
+        const float total0 = attn_mass0 + sink_mass0;
+        output_scale0 = total0 > 0.f ? attn_mass0 / total0 : 0.f;
+        lse0 = total0 > 0.f ? log2f(total0) + max0 : -1e30f;
+        if constexpr (VALID_HPB > 8) {
+          const float sink1 = __ldg(attn_sink + h_start + gid + 8) * LOG2E;
+          const float max1 = fmaxf(lse1, sink1);
+          const float attn_mass1 = lse1 > -1e29f ? exp2f(lse1 - max1) : 0.f;
+          const float sink_mass1 = exp2f(sink1 - max1);
+          const float total1 = attn_mass1 + sink_mass1;
+          output_scale1 = total1 > 0.f ? attn_mass1 / total1 : 0.f;
+          lse1 = total1 > 0.f ? log2f(total1) + max1 : -1e30f;
+        }
+      }
+      sm.warp_max()[gid] = output_scale0;
+      sm.warp_sum()[gid] = lse0;
+      if constexpr (VALID_HPB > 8) {
+        sm.warp_max()[gid + 8] = output_scale1;
+        sm.warp_sum()[gid + 8] = lse1;
+      }
+    }
+    bar_sync_t<3, DECODE_MATH_THREADS>();
+  }
+
+  const float direct_scale0 = write_direct ? sm.warp_max()[gid] : 1.f;
+  const float direct_scale1 = write_direct ? sm.warp_max()[gid + 8] : 1.f;
+  const float inv_sum0 = global_sum[0] > 0.f ? direct_scale0 / global_sum[0] : 0.f;
+  const float inv_sum1 = global_sum[1] > 0.f ? direct_scale1 / global_sum[1] : 0.f;
+  bf16* destination =
+      write_direct
+          ? output + ((size_t)token_idx * NUM_HEADS + h_start) * D_V_C
+          : mid_out + (((size_t)token_idx * NUM_HEADS + h_start) * (size_t)num_splits + split_idx) *
+                          D_V_C;
+  const size_t head_stride = write_direct ? D_V_C : (size_t)num_splits * D_V_C;
+
+#pragma unroll
+  for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
+    const int scale_group = slot * DECODE_N_WARPS + warp_id;
+    if (scale_group >= PV_SCALE_GROUPS) continue;
+#pragma unroll
+    for (int nt = 0; nt < PV_N8_TILES_PER_GROUP; ++nt) {
+      const int d0 = scale_group * SF_VEC_SIZE + nt * 8 + tid * 2;
+      const __nv_bfloat162 lo =
+          __floats2bfloat162_rn(acc_nope[slot][nt][0] * inv_sum0, acc_nope[slot][nt][1] * inv_sum0);
+      const __nv_bfloat162 hi =
+          __floats2bfloat162_rn(acc_nope[slot][nt][2] * inv_sum1, acc_nope[slot][nt][3] * inv_sum1);
+      *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)gid * head_stride + d0]) = lo;
+      if constexpr (VALID_HPB > 8) {
+        *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)(gid + 8) * head_stride + d0]) = hi;
+      }
+    }
+  }
+#pragma unroll
+  for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
+    const int d0 = D_NOPE + warp_id * ROPE_DIMS_PER_WARP + nt * 8 + tid * 2;
+    const __nv_bfloat162 lo =
+        __floats2bfloat162_rn(acc_rope[nt][0] * inv_sum0, acc_rope[nt][1] * inv_sum0);
+    const __nv_bfloat162 hi =
+        __floats2bfloat162_rn(acc_rope[nt][2] * inv_sum1, acc_rope[nt][3] * inv_sum1);
+    *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)gid * head_stride + d0]) = lo;
+    if constexpr (VALID_HPB > 8) {
+      *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)(gid + 8) * head_stride + d0]) = hi;
+    }
+  }
+  if (warp_id == 0 && tid == 0) {
+    if (write_direct) {
+      out_lse[(size_t)token_idx * NUM_HEADS + h_start + gid] = sm.warp_sum()[gid];
+      if constexpr (VALID_HPB > 8) {
+        out_lse[(size_t)token_idx * NUM_HEADS + h_start + gid + 8] = sm.warp_sum()[gid + 8];
+      }
+    } else {
+      const float lse0 = global_sum[0] > 0.f ? log2f(global_sum[0]) + global_max[0] : -1e30f;
+      const float lse1 = global_sum[1] > 0.f ? log2f(global_sum[1]) + global_max[1] : -1e30f;
+      const size_t lse_base =
+          (size_t)token_idx * NUM_HEADS * num_splits + (size_t)h_start * num_splits;
+      mid_lse[lse_base + (size_t)gid * num_splits + split_idx] = lse0;
+      if constexpr (VALID_HPB > 8) {
+        mid_lse[lse_base + (size_t)(gid + 8) * num_splits + split_idx] = lse1;
+      }
+    }
+  }
+}
+
+template <int NUM_HEADS>
+__global__ void __launch_bounds__(DECODE_MERGE2_THREADS, 2)
+    sparse_mla_decode_dsv4_nvfp4_merge2_kernel(const bf16* __restrict__ mid_out,
+                                               const float* __restrict__ mid_lse,
+                                               bf16* __restrict__ output,
+                                               float* __restrict__ out_lse,
+                                               const float* __restrict__ attn_sink,
+                                               int num_tokens) {
+  constexpr int D_V = 512;
+  constexpr int VECS_PER_HEAD = D_V / 8;
+  constexpr int H_BLOCKS = (NUM_HEADS + HPB - 1) / HPB;
+  const int token_idx = blockIdx.x;
+  const int head_block = blockIdx.y;
+  if (token_idx >= num_tokens || head_block >= H_BLOCKS) return;
+  const int h_start = head_block * HPB;
+  constexpr int VALID_HPB = NUM_HEADS < HPB ? NUM_HEADS : HPB;
+  __shared__ float weight0[HPB];
+  __shared__ float weight1[HPB];
+
+  if (threadIdx.x < VALID_HPB) {
+    const int local_head = threadIdx.x;
+    const int h = h_start + local_head;
+    const float* lse_ptr = mid_lse + ((size_t)token_idx * NUM_HEADS + h) * 2;
+    const float lse0 = lse_ptr[0];
+    const float lse1 = lse_ptr[1];
+    float global_max = fmaxf(lse0, lse1);
+    if (global_max <= -1e29f) global_max = 0.f;
+    float total = (lse0 > -1e29f ? exp2f(lse0 - global_max) : 0.f) +
+                  (lse1 > -1e29f ? exp2f(lse1 - global_max) : 0.f);
+    if (attn_sink != nullptr) {
+      const float sink_log2 = __ldg(attn_sink + h) * LOG2E;
+      if (sink_log2 > global_max) {
+        total *= exp2f(global_max - sink_log2);
+        global_max = sink_log2;
+      }
+      total += exp2f(sink_log2 - global_max);
+    }
+    const float inv_total = total > 0.f ? 1.f / total : 0.f;
+    weight0[local_head] = (lse0 > -1e29f ? exp2f(lse0 - global_max) : 0.f) * inv_total;
+    weight1[local_head] = (lse1 > -1e29f ? exp2f(lse1 - global_max) : 0.f) * inv_total;
+    out_lse[(size_t)token_idx * NUM_HEADS + h] = total > 0.f ? log2f(total) + global_max : -1e30f;
+  }
+  __syncthreads();
+
+  for (int vec = threadIdx.x; vec < VALID_HPB * VECS_PER_HEAD; vec += DECODE_MERGE2_THREADS) {
+    const int local_head = vec / VECS_PER_HEAD;
+    const int dim = (vec % VECS_PER_HEAD) * 8;
+    const bf16* partial =
+        mid_out + ((size_t)token_idx * NUM_HEADS + h_start + local_head) * 2 * D_V + dim;
+    const float w0 = weight0[local_head];
+    const float w1 = weight1[local_head];
+    // A ragged split can contain no valid indices. Its LSE/weight is the
+    // sentinel/zero pair, and its stage-1 accumulator is intentionally
+    // irrelevant (it may contain NaN after masked MMA lanes). Do not read
+    // that row: IEEE NaN * 0 would otherwise poison the merged output.
+    uint4 packed0 = make_uint4(0, 0, 0, 0);
+    uint4 packed1 = make_uint4(0, 0, 0, 0);
+    if (w0 > 0.f) packed0 = *reinterpret_cast<const uint4*>(partial);
+    if (w1 > 0.f) packed1 = *reinterpret_cast<const uint4*>(partial + D_V);
+    const __nv_bfloat162* pairs0 = reinterpret_cast<const __nv_bfloat162*>(&packed0);
+    const __nv_bfloat162* pairs1 = reinterpret_cast<const __nv_bfloat162*>(&packed1);
+    uint4 merged;
+    __nv_bfloat162* output_pairs = reinterpret_cast<__nv_bfloat162*>(&merged);
+#pragma unroll
+    for (int pair = 0; pair < 4; ++pair) {
+      const float2 value0 = __bfloat1622float2(pairs0[pair]);
+      const float2 value1 = __bfloat1622float2(pairs1[pair]);
+      output_pairs[pair] =
+          __floats2bfloat162_rn(value0.x * w0 + value1.x * w1, value0.y * w0 + value1.y * w1);
+    }
+    bf16* final_output =
+        output + ((size_t)token_idx * NUM_HEADS + h_start + local_head) * D_V + dim;
+    *reinterpret_cast<uint4*>(final_output) = merged;
+  }
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
@@ -23,7 +23,8 @@
 #include "arch/mma_sm120_nvfp4.cuh"
 #include "common/d2_load_b_nvfp4.cuh"
 #include "common/nvfp4_quant.cuh"
-#include "model/kv_cache_traits.cuh"
+#include "common/nvfp4_vt.cuh"
+#include "model/nvfp4_cache_traits.cuh"
 
 namespace flashinfer::sparse_mla_sm120::nvfp4 {
 
@@ -32,20 +33,20 @@ constexpr int DECODE_IO_WARPS = 2;
 constexpr int DECODE_BLOCK_THREADS = (DECODE_N_WARPS + DECODE_IO_WARPS) * 32;
 constexpr int DECODE_MATH_THREADS = DECODE_N_WARPS * 32;
 constexpr int DECODE_MERGE2_THREADS = 512;
-constexpr int DECODE_CAND_WINDOW = 64;
+constexpr int DECODE_CAND_WINDOW = NVFP4_VT_CANDIDATES;
 constexpr int DECODE_KV_BUF_COUNT = 2;
 constexpr int DECODE_ENTRIES_PER_WARP = DECODE_CAND_WINDOW / DECODE_N_WARPS;
 constexpr int DECODE_QK_N_TILES = DECODE_ENTRIES_PER_WARP / 8;
-constexpr int DECODE_PACKED_NOPE_BYTES = 448 / 2;
-constexpr int DECODE_DATA_BYTES_PER_TOKEN = DECODE_PACKED_NOPE_BYTES + 64 * sizeof(bf16);
-constexpr int DECODE_SCALE_BYTES_PER_TOKEN = 32;
-constexpr int DECODE_BYTES_PER_TOKEN = DECODE_DATA_BYTES_PER_TOKEN + DECODE_SCALE_BYTES_PER_TOKEN;
-constexpr int DECODE_KV_SMEM_STRIDE = DECODE_PACKED_NOPE_BYTES + 16;
+constexpr int DECODE_PACKED_NOPE_BYTES = DSV4NVFP4Cache::PACKED_NOPE_BYTES;
+constexpr int DECODE_DATA_BYTES_PER_TOKEN = DSV4NVFP4Cache::DATA_BYTES_PER_TOKEN;
+constexpr int DECODE_SCALE_BYTES_PER_TOKEN = DSV4NVFP4Cache::SCALE_BYTES_PER_TOKEN;
+constexpr int DECODE_BYTES_PER_TOKEN = DSV4NVFP4Cache::BYTES_PER_TOKEN;
+constexpr int DECODE_KV_SMEM_STRIDE = DSV4NVFP4Cache::KV_SMEM_STRIDE;
 constexpr int DECODE_W_PACKED_STRIDE = DECODE_CAND_WINDOW / 2 + 16;
-constexpr int DECODE_VT_PACKED_K_BYTES = DECODE_CAND_WINDOW / 2;
-constexpr int DECODE_VT_SCALE_GROUPS = DECODE_CAND_WINDOW / SF_VEC_SIZE;
-constexpr int DECODE_VT_DATA_BYTES = 448 * DECODE_VT_PACKED_K_BYTES;
-constexpr int DECODE_VT_SCALE_BYTES = 448 * DECODE_VT_SCALE_GROUPS;
+constexpr int DECODE_VT_PACKED_K_BYTES = NVFP4_VT_PACKED_K_BYTES;
+constexpr int DECODE_VT_SCALE_GROUPS = NVFP4_VT_SCALE_GROUPS;
+constexpr int DECODE_VT_DATA_BYTES = NVFP4_VT_DATA_BYTES;
+constexpr int DECODE_VT_SCALE_BYTES = NVFP4_VT_SCALE_BYTES;
 
 static_assert(DECODE_DATA_BYTES_PER_TOKEN == 352);
 static_assert(DECODE_BYTES_PER_TOKEN == 384);
@@ -136,120 +137,6 @@ struct DecodeNVFP4Smem {
     return reinterpret_cast<uint8_t*>(base + OFF_VT_SC);
   }
 };
-
-__device__ __forceinline__ float e2m1_code_to_float(uint8_t code) {
-  constexpr float magnitude[8] = {0.f, 0.5f, 1.f, 1.5f, 2.f, 3.f, 4.f, 6.f};
-  const float value = magnitude[code & 7];
-  return (code & 8) ? -value : value;
-}
-
-// Decode two packed E2M1 values with the native SM100+ conversion.  The
-// prepare kernel consumes two source candidates at a time, so this avoids two
-// independent scalar LUT lookups while preserving the low-/high-nibble order.
-__device__ __forceinline__ float2 e2m1x2_code_to_float2(uint8_t codes) {
-  uint32_t fp16x2;
-  const uint32_t packed = codes;
-  asm volatile(
-      "{\n"
-      ".reg .b8 fp4_byte;\n"
-      "mov.b32 {fp4_byte, _, _, _}, %1;\n"
-      "cvt.rn.f16x2.e2m1x2 %0, fp4_byte;\n"
-      "}"
-      : "=r"(fp16x2)
-      : "r"(packed));
-  const __half2 h2 = *reinterpret_cast<const __half2*>(&fp16x2);
-  return __half22float2(h2);
-}
-
-__device__ __forceinline__ uint64_t transpose_e2m1_16x16_stage(uint64_t packed, int lane_in_group,
-                                                               int distance, uint64_t low_mask) {
-  const uint32_t packed_lo = static_cast<uint32_t>(packed);
-  const uint32_t packed_hi = static_cast<uint32_t>(packed >> 32);
-  const uint64_t partner =
-      static_cast<uint64_t>(__shfl_xor_sync(0xffffffffu, packed_lo, distance, SF_VEC_SIZE)) |
-      (static_cast<uint64_t>(__shfl_xor_sync(0xffffffffu, packed_hi, distance, SF_VEC_SIZE)) << 32);
-  const int shift = distance * 4;
-  if (lane_in_group & distance) {
-    return ((partner & ~low_mask) >> shift) | (packed & ~low_mask);
-  }
-  return (packed & low_mask) | ((partner & low_mask) << shift);
-}
-
-// Transpose one 16-candidate x 16-dimension E2M1 tile entirely in registers.
-// Four butterfly stages replace the per-output-lane gather of all 16 packed
-// source values (8 shuffles per lane instead of 32).
-__device__ __forceinline__ uint64_t transpose_e2m1_16x16(uint64_t packed, int lane_in_group) {
-  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 8, 0x00000000ffffffffULL);
-  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 4, 0x0000ffff0000ffffULL);
-  packed = transpose_e2m1_16x16_stage(packed, lane_in_group, 2, 0x00ff00ff00ff00ffULL);
-  return transpose_e2m1_16x16_stage(packed, lane_in_group, 1, 0x0f0f0f0f0f0f0f0fULL);
-}
-
-// Convert one token-major 64-candidate shared-memory tile into the
-// candidate-reduction layout consumed by block-scaled P x V.  The conversion
-// stays inside the CTA: source scales are absorbed, the 16x16 E2M1 tiles are
-// transposed in registers, and the result is requantized into the ephemeral
-// V^T operand.  KV_SMEM_STRIDE allows decode's padded source rows and
-// prefill's compact rows to share the same implementation.
-template <int WORKER_THREADS, int KV_SMEM_STRIDE, int THREAD_BASE = 0>
-__device__ __forceinline__ void prepare_nvfp4_vt_from_smem(const uint8_t* __restrict__ kv_fp4,
-                                                           const uint8_t* __restrict__ kv_sc,
-                                                           uint8_t* __restrict__ vt_data,
-                                                           uint8_t* __restrict__ vt_sc) {
-  constexpr int NUM_DIM_GROUPS = 448 / SF_VEC_SIZE;
-  constexpr int DIM_GROUPS_PER_ITER = WORKER_THREADS / 64;
-  static_assert(WORKER_THREADS >= 64 && WORKER_THREADS % 64 == 0);
-
-  const int worker_tid = threadIdx.x - THREAD_BASE;
-  const int warp = worker_tid / 32;
-  const int lane = worker_tid & 31;
-  const int lane_in_group = lane & (SF_VEC_SIZE - 1);
-  const int half_warp = lane / SF_VEC_SIZE;
-  const int warp_cand_pair = warp & 1;
-  const int cand_group = warp_cand_pair * 2 + half_warp;
-  const int cand = cand_group * SF_VEC_SIZE + lane_in_group;
-
-  for (int dim_group = warp / 2; dim_group < NUM_DIM_GROUPS; dim_group += DIM_GROUPS_PER_ITER) {
-    const uint64_t packed = *reinterpret_cast<const uint64_t*>(
-        kv_fp4 + (size_t)cand * KV_SMEM_STRIDE + dim_group * FP4_PACKED_PER_GROUP);
-    const float source_scale =
-        e4m3_byte_to_float(kv_sc[(size_t)cand * DECODE_SCALE_BYTES_PER_TOKEN + dim_group]);
-    const uint64_t transposed = transpose_e2m1_16x16(packed, lane_in_group);
-
-    float values[SF_VEC_SIZE];
-#pragma unroll
-    for (int source_pair = 0; source_pair < SF_VEC_SIZE / 2; ++source_pair) {
-      const int source_lane0 = source_pair * 2;
-      const int source_lane1 = source_lane0 + 1;
-      const uint8_t codes = static_cast<uint8_t>(transposed >> (source_pair * 8));
-      const float2 decoded = e2m1x2_code_to_float2(codes);
-      const float scale0 = __shfl_sync(0xffffffffu, source_scale, source_lane0, SF_VEC_SIZE);
-      const float scale1 = __shfl_sync(0xffffffffu, source_scale, source_lane1, SF_VEC_SIZE);
-      values[source_lane0] = decoded.x * scale0;
-      values[source_lane1] = decoded.y * scale1;
-    }
-
-    const int dim = dim_group * SF_VEC_SIZE + lane_in_group;
-    uint2 quantized;
-    uint8_t quantized_scale;
-    quantize_fp32_group16_to_nvfp4_regs(values, quantized, quantized_scale);
-
-    // Adjacent half-warps cover adjacent candidate groups.  Merge their
-    // 8-byte results into one aligned 16-byte transaction; paired warps fill
-    // the complete 64-candidate row.
-    const int peer_lane = lane_in_group + SF_VEC_SIZE;
-    const uint32_t peer_lo = __shfl_sync(0xffffffffu, quantized.x, peer_lane);
-    const uint32_t peer_hi = __shfl_sync(0xffffffffu, quantized.y, peer_lane);
-    const uint32_t peer_scale =
-        __shfl_sync(0xffffffffu, static_cast<uint32_t>(quantized_scale), peer_lane);
-    if (half_warp == 0) {
-      *reinterpret_cast<uint4*>(vt_data + dim * DECODE_VT_PACKED_K_BYTES + warp_cand_pair * 16) =
-          make_uint4(quantized.x, quantized.y, peer_lo, peer_hi);
-      *reinterpret_cast<uint16_t*>(vt_sc + dim * DECODE_VT_SCALE_GROUPS + warp_cand_pair * 2) =
-          static_cast<uint16_t>(quantized_scale) | static_cast<uint16_t>(peer_scale << 8);
-    }
-  }
-}
 
 template <ModelType MT, int NUM_HEADS, int TOPK, int PAGE_BLOCK_SIZE, bool DUAL_CACHE = false>
 __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_nvfp4_kernel(
@@ -647,7 +534,7 @@ __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_n
     for (int task = threadIdx.x; task < HPB * DECODE_VT_SCALE_GROUPS; task += DECODE_MATH_THREADS) {
       const int head = task / DECODE_VT_SCALE_GROUPS;
       const int cand_group = task % DECODE_VT_SCALE_GROUPS;
-      quantize_bf16_group16_to_nvfp4(
+      quantize_group16_to_nvfp4(
           &sm_p_full[head][cand_group * SF_VEC_SIZE],
           sm.w_fp4() + head * DECODE_W_PACKED_STRIDE + cand_group * FP4_PACKED_PER_GROUP,
           sm.w_sc() + head * DECODE_VT_SCALE_GROUPS + cand_group);

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
@@ -403,6 +403,7 @@ __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_n
       }
     }
 
+    bool valid_candidate[DECODE_QK_N_TILES][2];
 #pragma unroll
     for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
       const int c0 = warp_first_cand + nt * 8 + tid * 2;
@@ -411,10 +412,13 @@ __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_n
       const int abs_c1 = chunk_start + c1;
       const int idx0 = abs_c0 < section_len ? section_indices[abs_c0] : -1;
       const int idx1 = abs_c1 < section_len ? section_indices[abs_c1] : -1;
-      if (abs_c0 >= chunk_end || idx0 < 0) qk[nt][0] = qk[nt][2] = -1e30f;
-      if (abs_c1 >= chunk_end || idx1 < 0) qk[nt][1] = qk[nt][3] = -1e30f;
-#pragma unroll
-      for (int i = 0; i < 4; ++i) qk[nt][i] *= sm_scale * LOG2E;
+      valid_candidate[nt][0] = abs_c0 < chunk_end && idx0 >= 0;
+      valid_candidate[nt][1] = abs_c1 < chunk_end && idx1 >= 0;
+      const float qk_scale = sm_scale * LOG2E;
+      qk[nt][0] = valid_candidate[nt][0] ? qk[nt][0] * qk_scale : -1e30f;
+      qk[nt][2] = valid_candidate[nt][0] ? qk[nt][2] * qk_scale : -1e30f;
+      qk[nt][1] = valid_candidate[nt][1] ? qk[nt][1] * qk_scale : -1e30f;
+      qk[nt][3] = valid_candidate[nt][1] ? qk[nt][3] * qk_scale : -1e30f;
     }
 
     float local_max[2] = {-1e30f, -1e30f};
@@ -432,10 +436,10 @@ __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_n
     float p[DECODE_QK_N_TILES][4];
 #pragma unroll
     for (int nt = 0; nt < DECODE_QK_N_TILES; ++nt) {
-      p[nt][0] = exp2f(qk[nt][0] - local_max[0]);
-      p[nt][1] = exp2f(qk[nt][1] - local_max[0]);
-      p[nt][2] = exp2f(qk[nt][2] - local_max[1]);
-      p[nt][3] = exp2f(qk[nt][3] - local_max[1]);
+      p[nt][0] = valid_candidate[nt][0] ? exp2f(qk[nt][0] - local_max[0]) : 0.f;
+      p[nt][1] = valid_candidate[nt][1] ? exp2f(qk[nt][1] - local_max[0]) : 0.f;
+      p[nt][2] = valid_candidate[nt][0] ? exp2f(qk[nt][2] - local_max[1]) : 0.f;
+      p[nt][3] = valid_candidate[nt][1] ? exp2f(qk[nt][3] - local_max[1]) : 0.f;
       local_sum[0] += p[nt][0] + p[nt][1];
       local_sum[1] += p[nt][2] + p[nt][3];
     }

--- a/include/flashinfer/attention/sparse_mla_sm120/model/nvfp4_cache_traits.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/nvfp4_cache_traits.cuh
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "kv_cache_traits.cuh"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+template <ModelType MT>
+struct NVFP4CacheTraits;
+
+template <>
+struct NVFP4CacheTraits<ModelType::DSV4> {
+  using Model = KVCacheTraits<ModelType::DSV4>;
+
+  static constexpr int D_NOPE = Model::D_NOPE;
+  static constexpr int D_ROPE = Model::D_ROPE;
+  static constexpr int D_QK = Model::D_QK;
+  static constexpr int D_V = Model::D_V;
+
+  // Per-token paged-cache ABI:
+  //   [page_size * 352B data][page_size * 32B E4M3 scale footer]
+  // Each data row contains 224B packed E2M1 NoPE followed by 128B BF16 RoPE.
+  static constexpr int SCALE_GROUP_SIZE = 16;
+  static constexpr int NUM_SCALES = D_NOPE / SCALE_GROUP_SIZE;
+  static constexpr int PACKED_NOPE_BYTES = D_NOPE / 2;
+  static constexpr int ROPE_BYTES = D_ROPE * sizeof(bf16);
+  static constexpr int DATA_BYTES_PER_TOKEN = PACKED_NOPE_BYTES + ROPE_BYTES;
+  static constexpr int SCALE_BYTES_PER_TOKEN = (NUM_SCALES + 15) / 16 * 16;
+  static constexpr int BYTES_PER_TOKEN = DATA_BYTES_PER_TOKEN + SCALE_BYTES_PER_TOKEN;
+
+  // Shared-memory Q/K rows retain padding needed by ldmatrix and bulk copies.
+  static constexpr int KV_SMEM_STRIDE = PACKED_NOPE_BYTES + 16;
+  static constexpr int Q_PACKED_STRIDE = PACKED_NOPE_BYTES + 16;
+  static constexpr int Q_SCALE_STRIDE = SCALE_BYTES_PER_TOKEN;
+};
+
+static_assert(NVFP4CacheTraits<ModelType::DSV4>::NUM_SCALES == 28);
+static_assert(NVFP4CacheTraits<ModelType::DSV4>::DATA_BYTES_PER_TOKEN == 352);
+static_assert(NVFP4CacheTraits<ModelType::DSV4>::BYTES_PER_TOKEN == 384);
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_dsv4_nvfp4_kernel.cuh
@@ -1,0 +1,806 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "decode_dsv4_nvfp4_kernel.cuh"
+
+namespace flashinfer::sparse_mla_sm120::nvfp4 {
+
+constexpr int PREFILL_HEAD_GROUPS = 4;
+constexpr int PREFILL_HEADS_PER_CTA = PREFILL_HEAD_GROUPS * HPB;
+// A 64-head CTA amortizes one selected-V transpose over four 16-head groups.
+// Eight producer warps sustain the online candidate-axis requantization while
+// eight math warps retain four output accumulator groups.
+constexpr int PREFILL_GATHER_WARPS = 2;
+constexpr int PREFILL_IO_WARPS = 8;
+constexpr int PREFILL_IO_MAX_REGS = 64;
+constexpr int PREFILL_MATH_MAX_REGS = 192;
+constexpr int PREFILL_VT_PIPE_STAGES = 1;
+constexpr int PREFILL_KV_SMEM_STRIDE = DECODE_PACKED_NOPE_BYTES;
+constexpr int PREFILL_Q_FP4_STRIDE = DECODE_PACKED_NOPE_BYTES;
+constexpr int PREFILL_Q_SCALE_STRIDE = DSV4_NVFP4_NUM_SCALES;
+constexpr int PREFILL_W_PACKED_STRIDE = DECODE_CAND_WINDOW / 2;
+constexpr int PREFILL_BLOCK_THREADS = (DECODE_N_WARPS + PREFILL_IO_WARPS) * 32;
+constexpr int PREFILL_MATH_THREADS = DECODE_MATH_THREADS;
+// Padding breaks the 128-byte head-to-head alias in the probability staging
+// matrix.  A multiple of eight BF16 elements preserves ldmatrix alignment
+// while cutting the dominant P-quant shared-load bank conflict in half.
+constexpr int PREFILL_P_STRIDE = DECODE_CAND_WINDOW + 8;
+
+// Four 16-head groups share one selected-K gather and one transient V^T tile.
+// The resulting 64-head CTA amortizes online V preparation while retaining the
+// native NVFP4 QK/PV atoms validated by the decode path.
+struct PrefillNVFP4Smem {
+  static constexpr size_t SMEM_Q_ROPE = PREFILL_HEADS_PER_CTA * 64 * sizeof(bf16);
+  static constexpr size_t SMEM_Q_FP4 = PREFILL_HEADS_PER_CTA * PREFILL_Q_FP4_STRIDE;
+  static constexpr size_t SMEM_Q_SC = PREFILL_HEADS_PER_CTA * PREFILL_Q_SCALE_STRIDE;
+  static constexpr size_t SMEM_KV_FP4_BUF = DECODE_CAND_WINDOW * PREFILL_KV_SMEM_STRIDE;
+  static constexpr size_t SMEM_KV_SC_BUF = DECODE_CAND_WINDOW * DECODE_SCALE_BYTES_PER_TOKEN;
+  static constexpr size_t SMEM_KV_ROPE_BUF = DECODE_CAND_WINDOW * 64 * sizeof(bf16);
+  static constexpr size_t SMEM_MBAR_PAIR = 2 * sizeof(uint64_t);
+  static constexpr size_t SMEM_MBAR_VT_PIPE = PREFILL_VT_PIPE_STAGES * sizeof(uint64_t);
+  static constexpr size_t SMEM_REDUCE = PREFILL_HEAD_GROUPS * DECODE_N_WARPS * HPB * sizeof(float);
+  static constexpr size_t SMEM_W_SC = PREFILL_HEADS_PER_CTA * DECODE_VT_SCALE_GROUPS;
+  static constexpr size_t SMEM_W_FP4 = PREFILL_HEADS_PER_CTA * PREFILL_W_PACKED_STRIDE;
+  // One CTA-local full V^T tile is consumed immediately after preparation and
+  // never leaves shared memory.  KV itself remains double buffered.
+  static constexpr size_t SMEM_VT_DATA = PREFILL_VT_PIPE_STAGES * DECODE_VT_DATA_BYTES;
+  static constexpr size_t SMEM_VT_SC = PREFILL_VT_PIPE_STAGES * DECODE_VT_SCALE_BYTES;
+  static constexpr size_t SMEM_P_FULL = PREFILL_HEADS_PER_CTA * PREFILL_P_STRIDE * sizeof(bf16);
+
+  static constexpr size_t OFF_Q_ROPE = 0;
+  static constexpr size_t OFF_Q_FP4 = OFF_Q_ROPE + SMEM_Q_ROPE;
+  static constexpr size_t OFF_Q_SC = OFF_Q_FP4 + SMEM_Q_FP4;
+  static constexpr size_t OFF_KV_FP4 = OFF_Q_SC + SMEM_Q_SC;
+  static constexpr size_t OFF_KV_SC = OFF_KV_FP4 + DECODE_KV_BUF_COUNT * SMEM_KV_FP4_BUF;
+  static constexpr size_t OFF_KV_ROPE = OFF_KV_SC + DECODE_KV_BUF_COUNT * SMEM_KV_SC_BUF;
+  static constexpr size_t OFF_MBAR_FULL_UNALIGNED =
+      OFF_KV_ROPE + DECODE_KV_BUF_COUNT * SMEM_KV_ROPE_BUF;
+  static constexpr size_t OFF_MBAR_FULL = (OFF_MBAR_FULL_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t OFF_MBAR_EMPTY = OFF_MBAR_FULL + SMEM_MBAR_PAIR;
+  static constexpr size_t OFF_MBAR_VT_FULL = OFF_MBAR_EMPTY + SMEM_MBAR_PAIR;
+  static constexpr size_t OFF_MBAR_VT_EMPTY = OFF_MBAR_VT_FULL + SMEM_MBAR_VT_PIPE;
+  static constexpr size_t OFF_REDUCE = OFF_MBAR_VT_EMPTY + SMEM_MBAR_VT_PIPE;
+  // Softmax reduction is dead before P quantization starts, and P operands
+  // are dead before the next chunk's reduction.  Reuse that storage for W.
+  static constexpr size_t OFF_W_SC = OFF_REDUCE;
+  static constexpr size_t OFF_W_FP4_UNALIGNED = OFF_W_SC + SMEM_W_SC;
+  static constexpr size_t OFF_W_FP4 = (OFF_W_FP4_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t OFF_W_END = OFF_W_FP4 + SMEM_W_FP4;
+  static constexpr size_t OFF_REDUCE_END = OFF_REDUCE + SMEM_REDUCE;
+  static constexpr size_t OFF_VT_DATA_UNALIGNED =
+      OFF_W_END > OFF_REDUCE_END ? OFF_W_END : OFF_REDUCE_END;
+  static constexpr size_t OFF_VT_DATA = (OFF_VT_DATA_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t OFF_VT_SC = OFF_VT_DATA + SMEM_VT_DATA;
+  static constexpr size_t OFF_P_FULL_UNALIGNED = OFF_VT_SC + SMEM_VT_SC;
+  static constexpr size_t OFF_P_FULL = (OFF_P_FULL_UNALIGNED + 15) / 16 * 16;
+  static constexpr size_t SIZE = OFF_P_FULL + SMEM_P_FULL;
+
+  char* base;
+
+  __device__ static PrefillNVFP4Smem init(char* base) { return PrefillNVFP4Smem{base}; }
+  __device__ __forceinline__ bf16* q_rope(int group) const {
+    return reinterpret_cast<bf16*>(base + OFF_Q_ROPE) + group * HPB * 64;
+  }
+  __device__ __forceinline__ uint8_t* q_fp4(int group) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_Q_FP4) + group * HPB * PREFILL_Q_FP4_STRIDE;
+  }
+  __device__ __forceinline__ uint8_t* q_sc(int group) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_Q_SC) + group * HPB * PREFILL_Q_SCALE_STRIDE;
+  }
+  __device__ __forceinline__ uint8_t* kv_fp4(int parity) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_KV_FP4) + parity * SMEM_KV_FP4_BUF;
+  }
+  __device__ __forceinline__ uint8_t* kv_sc(int parity) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_KV_SC) + parity * SMEM_KV_SC_BUF;
+  }
+  __device__ __forceinline__ bf16* kv_rope(int parity) const {
+    return reinterpret_cast<bf16*>(base + OFF_KV_ROPE) + parity * DECODE_CAND_WINDOW * 64;
+  }
+  __device__ __forceinline__ uint64_t* mbar_full(int parity) const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_FULL) + parity;
+  }
+  __device__ __forceinline__ uint64_t* mbar_empty(int parity) const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_EMPTY) + parity;
+  }
+  __device__ __forceinline__ uint64_t* mbar_vt_full(int stage) const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_VT_FULL) + stage;
+  }
+  __device__ __forceinline__ uint64_t* mbar_vt_empty(int stage) const {
+    return reinterpret_cast<uint64_t*>(base + OFF_MBAR_VT_EMPTY) + stage;
+  }
+  __device__ __forceinline__ float* warp_max() const {
+    return reinterpret_cast<float*>(base + OFF_REDUCE);
+  }
+  __device__ __forceinline__ uint8_t* w_sc(int group) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_W_SC) + group * HPB * DECODE_VT_SCALE_GROUPS;
+  }
+  __device__ __forceinline__ uint8_t* w_fp4(int group) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_W_FP4) + group * HPB * PREFILL_W_PACKED_STRIDE;
+  }
+  __device__ __forceinline__ uint8_t* vt_data(int stage) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_VT_DATA) + stage * DECODE_VT_DATA_BYTES;
+  }
+  __device__ __forceinline__ uint8_t* vt_sc(int stage) const {
+    return reinterpret_cast<uint8_t*>(base + OFF_VT_SC) + stage * DECODE_VT_SCALE_BYTES;
+  }
+  __device__ __forceinline__ bf16* p_full(int group) const {
+    return reinterpret_cast<bf16*>(base + OFF_P_FULL) + group * HPB * PREFILL_P_STRIDE;
+  }
+};
+
+static_assert(PrefillNVFP4Smem::SIZE <= 99 * 1024);
+
+template <int NUM_HEADS, int TOPK, int PAGE_BLOCK_SIZE, bool DUAL_CACHE = false>
+__global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_dsv4_nvfp4_kernel(
+    const bf16* __restrict__ q, const uint8_t* __restrict__ kv_cache,
+    const int32_t* __restrict__ indices, bf16* __restrict__ output, float* __restrict__ out_lse,
+    bf16* __restrict__ mid_out, float* __restrict__ mid_lse, const float* __restrict__ attn_sink,
+    const int* __restrict__ topk_length_ptr, const uint8_t* __restrict__ extra_kv_cache,
+    const int32_t* __restrict__ extra_indices, const int* __restrict__ extra_topk_length_ptr,
+    int extra_topk, int extra_page_block_size, size_t stride_extra_kv_block, int num_tokens,
+    int num_splits, int chunks_per_block, float sm_scale, size_t stride_kv_block,
+    bool write_direct) {
+  static_assert(NUM_HEADS <= PREFILL_HEADS_PER_CTA || NUM_HEADS % PREFILL_HEADS_PER_CTA == 0);
+  constexpr int VALID_HEAD_GROUPS =
+      NUM_HEADS < PREFILL_HEADS_PER_CTA ? (NUM_HEADS + HPB - 1) / HPB : PREFILL_HEAD_GROUPS;
+  constexpr int HEADS_PER_CTA = VALID_HEAD_GROUPS * HPB;
+  constexpr int D_NOPE = 448;
+  constexpr int D_ROPE = 64;
+  constexpr int D_QK = 512;
+  constexpr int D_V = 512;
+  constexpr int HEAD_BLOCKS = NUM_HEADS / HEADS_PER_CTA;
+  constexpr int NUM_K64_TILES = D_NOPE / 64;
+  constexpr int PV_SCALE_GROUPS = D_NOPE / SF_VEC_SIZE;
+  constexpr int PV_GROUPS_PER_WARP = (PV_SCALE_GROUPS + DECODE_N_WARPS - 1) / DECODE_N_WARPS;
+  constexpr int PV_N8_TILES_PER_GROUP = SF_VEC_SIZE / 8;
+  constexpr int ROPE_DIMS_PER_WARP = D_ROPE / DECODE_N_WARPS;
+  constexpr int ROPE_N_TILES = ROPE_DIMS_PER_WARP / 8;
+  constexpr int ROPE_K_ITERS = DECODE_CAND_WINDOW / 16;
+  constexpr int REDUCE_GROUP_STRIDE = DECODE_N_WARPS * HPB;
+  const int token_idx = blockIdx.x;
+  const int head_block = blockIdx.y;
+  const int split_idx = blockIdx.z;
+  if (token_idx >= num_tokens || head_block >= HEAD_BLOCKS) return;
+  const int h_start = head_block * HEADS_PER_CTA;
+  int topk_len = topk_length_ptr ? __ldg(topk_length_ptr + token_idx) : TOPK;
+  topk_len = max(0, min(topk_len, TOPK));
+  const int num_main_chunks = (topk_len + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  int extra_topk_len = 0;
+  if constexpr (DUAL_CACHE) {
+    extra_topk_len = extra_topk_length_ptr ? __ldg(extra_topk_length_ptr + token_idx) : extra_topk;
+    extra_topk_len = max(0, min(extra_topk_len, extra_topk));
+  }
+  const int num_extra_chunks = (extra_topk_len + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  const int num_chunks = num_main_chunks + num_extra_chunks;
+  const int chunk_lo = chunks_per_block > 0 ? split_idx * chunks_per_block : 0;
+  const int chunk_hi =
+      chunks_per_block > 0 ? min(chunk_lo + chunks_per_block, num_chunks) : num_chunks;
+  const int warp_id = threadIdx.x / 32;
+  const int lane = threadIdx.x & 31;
+  const bool is_io = warp_id >= DECODE_N_WARPS;
+
+  extern __shared__ __align__(16) char smem_raw[];
+  auto sm = PrefillNVFP4Smem::init(smem_raw);
+  const int32_t* idx_base = indices + (size_t)token_idx * TOPK;
+
+  if (threadIdx.x == 0) {
+#pragma unroll
+    for (int i = 0; i < DECODE_KV_BUF_COUNT; ++i) {
+      mbarrier_init(sm.mbar_full(i), 1);
+      mbarrier_init(sm.mbar_empty(i), 1);
+    }
+#pragma unroll
+    for (int stage = 0; stage < PREFILL_VT_PIPE_STAGES; ++stage) {
+      mbarrier_init(sm.mbar_vt_full(stage), 1);
+      mbarrier_init(sm.mbar_vt_empty(stage), 1);
+    }
+  }
+  __syncthreads();
+
+  if (chunk_lo >= num_chunks) {
+    if (!is_io) {
+      for (int i = threadIdx.x; i < HEADS_PER_CTA * D_V; i += PREFILL_MATH_THREADS) {
+        const int head = i / D_V;
+        const int dim = i - head * D_V;
+        if (write_direct) {
+          output[((size_t)token_idx * NUM_HEADS + h_start + head) * D_V + dim] =
+              __float2bfloat16(0.f);
+        } else {
+          mid_out[(((size_t)token_idx * NUM_HEADS + h_start + head) * num_splits + split_idx) *
+                      D_V +
+                  dim] = __float2bfloat16(0.f);
+        }
+      }
+      if (threadIdx.x < HEADS_PER_CTA) {
+        const int h = h_start + threadIdx.x;
+        if (write_direct) {
+          out_lse[(size_t)token_idx * NUM_HEADS + h] =
+              attn_sink ? __ldg(attn_sink + h) * LOG2E : -1e30f;
+        } else {
+          mid_lse[((size_t)token_idx * NUM_HEADS + h) * num_splits + split_idx] = -1e30f;
+        }
+      }
+    }
+    return;
+  }
+
+  constexpr uint32_t BULK_NOPE_BYTES = DECODE_PACKED_NOPE_BYTES;
+  constexpr uint32_t BULK_ROPE_BYTES = D_ROPE * sizeof(bf16);
+  constexpr uint32_t BULK_TX_BYTES = DECODE_CAND_WINDOW * (BULK_NOPE_BYTES + BULK_ROPE_BYTES);
+
+  auto issue_gather = [&](int chunk_idx, int buf) {
+    bool is_extra = false;
+    int section_chunk = chunk_idx;
+    int section_len = topk_len;
+    int section_page_block_size = PAGE_BLOCK_SIZE;
+    size_t section_stride = stride_kv_block;
+    const uint8_t* section_kv = kv_cache;
+    const int32_t* section_indices = idx_base;
+    if constexpr (DUAL_CACHE) {
+      is_extra = chunk_idx >= num_main_chunks;
+      if (is_extra) {
+        section_chunk = chunk_idx - num_main_chunks;
+        section_len = extra_topk_len;
+        section_page_block_size = extra_page_block_size;
+        section_stride = stride_extra_kv_block;
+        section_kv = extra_kv_cache;
+        section_indices = extra_indices + (size_t)token_idx * extra_topk;
+      }
+    }
+    const int chunk_start = section_chunk * DECODE_CAND_WINDOW;
+    const int chunk_end = min(chunk_start + DECODE_CAND_WINDOW, section_len);
+    uint8_t* fp4_dst = sm.kv_fp4(buf);
+    bf16* rope_dst = sm.kv_rope(buf);
+    uint8_t* scale_dst = sm.kv_sc(buf);
+    const int io_warp = warp_id - DECODE_N_WARPS;
+    const int entry = io_warp * 32 + lane;
+    const int cand = chunk_start + entry;
+    const int idx_raw = cand < chunk_end ? section_indices[cand] : -1;
+
+    uint4 s0 = make_uint4(0, 0, 0, 0);
+    uint4 s1 = make_uint4(0, 0, 0, 0);
+    if (idx_raw >= 0) {
+      int page;
+      int slot;
+      if constexpr (DUAL_CACHE) {
+        if (is_extra && section_page_block_size == 2) {
+          page = idx_raw >> 1;
+          slot = idx_raw & 1;
+        } else {
+          page = idx_raw >> 6;
+          slot = idx_raw & 63;
+        }
+      } else {
+        page = idx_raw / PAGE_BLOCK_SIZE;
+        slot = idx_raw - page * PAGE_BLOCK_SIZE;
+      }
+      const uint8_t* scale_src = section_kv + (size_t)page * section_stride +
+                                 (size_t)section_page_block_size * DECODE_DATA_BYTES_PER_TOKEN +
+                                 (size_t)slot * DECODE_SCALE_BYTES_PER_TOKEN;
+      s0 = *reinterpret_cast<const uint4*>(scale_src);
+      s1 = *reinterpret_cast<const uint4*>(scale_src + sizeof(uint4));
+    }
+    *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * DECODE_SCALE_BYTES_PER_TOKEN) = s0;
+    *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * DECODE_SCALE_BYTES_PER_TOKEN +
+                              sizeof(uint4)) = s1;
+    __threadfence_block();
+
+    const int idx = idx_raw >= 0 ? idx_raw : 0;
+    int page;
+    int slot;
+    if constexpr (DUAL_CACHE) {
+      if (is_extra && section_page_block_size == 2) {
+        page = idx >> 1;
+        slot = idx & 1;
+      } else {
+        page = idx >> 6;
+        slot = idx & 63;
+      }
+    } else {
+      page = idx / PAGE_BLOCK_SIZE;
+      slot = idx - page * PAGE_BLOCK_SIZE;
+    }
+    const uint8_t* data_src =
+        section_kv + (size_t)page * section_stride + (size_t)slot * DECODE_DATA_BYTES_PER_TOKEN;
+    if (io_warp == 0 && lane == 0) mbarrier_arrive_expect_tx(sm.mbar_full(buf), BULK_TX_BYTES);
+    bar_sync_t<4, PREFILL_GATHER_WARPS * 32>();
+    cp_async_bulk_g2s(fp4_dst + (size_t)entry * PREFILL_KV_SMEM_STRIDE, data_src, BULK_NOPE_BYTES,
+                      sm.mbar_full(buf));
+    cp_async_bulk_g2s(rope_dst + (size_t)entry * D_ROPE, data_src + DECODE_PACKED_NOPE_BYTES,
+                      BULK_ROPE_BYTES, sm.mbar_full(buf));
+  };
+
+  if (is_io) {
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" : : "n"(PREFILL_IO_MAX_REGS));
+    // KV gather remains double buffered.  The complete CTA-local V^T stage is
+    // released immediately after P x V, so producer can gather N+1 meanwhile.
+    uint32_t empty_phase = 1;
+    uint32_t full_phase = 0;
+    uint32_t vt_empty_phase[PREFILL_VT_PIPE_STAGES] = {};
+#pragma unroll
+    for (int stage = 0; stage < PREFILL_VT_PIPE_STAGES; ++stage) vt_empty_phase[stage] = 1;
+    int state_idx = 0;
+    for (int chunk = chunk_lo; chunk < chunk_hi; ++chunk) {
+      const int buf = (chunk - chunk_lo) % DECODE_KV_BUF_COUNT;
+      mbarrier_wait_parity(sm.mbar_empty(state_idx), empty_phase);
+      if (threadIdx.x < PREFILL_MATH_THREADS + PREFILL_GATHER_WARPS * 32) issue_gather(chunk, buf);
+      mbarrier_wait_parity(sm.mbar_full(state_idx), full_phase);
+      const int stage = chunk % PREFILL_VT_PIPE_STAGES;
+      mbarrier_wait_parity(sm.mbar_vt_empty(stage), vt_empty_phase[stage]);
+      prepare_nvfp4_vt_from_smem<PREFILL_IO_WARPS * 32, PREFILL_KV_SMEM_STRIDE,
+                                 PREFILL_MATH_THREADS>(sm.kv_fp4(buf), sm.kv_sc(buf),
+                                                       sm.vt_data(stage), sm.vt_sc(stage));
+      bar_sync_t<4, PREFILL_IO_WARPS * 32>();
+      if (threadIdx.x == PREFILL_MATH_THREADS) mbarrier_arrive(sm.mbar_vt_full(stage));
+      vt_empty_phase[stage] ^= 1;
+      if (++state_idx == DECODE_KV_BUF_COUNT) {
+        state_idx = 0;
+        empty_phase ^= 1;
+        full_phase ^= 1;
+      }
+    }
+    return;
+  }
+
+  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" : : "n"(PREFILL_MATH_MAX_REGS));
+
+  const int gid = lane >> 2;
+  const int tid = lane & 3;
+#pragma unroll
+  for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+    const bf16* q_base =
+        q + (size_t)token_idx * NUM_HEADS * D_QK + (size_t)(h_start + group * HPB) * D_QK;
+    quantize_q_nvfp4_to_smem<PREFILL_MATH_THREADS, PREFILL_Q_FP4_STRIDE, PREFILL_Q_SCALE_STRIDE>(
+        sm.q_fp4(group), sm.q_sc(group), sm.q_rope(group), q_base, HPB);
+  }
+
+  float acc_nope[PREFILL_HEAD_GROUPS][PV_GROUPS_PER_WARP][PV_N8_TILES_PER_GROUP][4] = {0};
+  float acc_rope[PREFILL_HEAD_GROUPS][ROPE_N_TILES][4] = {0};
+  float global_max[PREFILL_HEAD_GROUPS][2];
+  float global_sum[PREFILL_HEAD_GROUPS][2];
+#pragma unroll
+  for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+    global_max[group][0] = global_max[group][1] = -1e30f;
+    global_sum[group][0] = global_sum[group][1] = 0.f;
+  }
+
+  uint32_t cons_phase = 0;
+  uint32_t vt_full_phase[PREFILL_VT_PIPE_STAGES] = {};
+  int cons_idx = 0;
+  for (int chunk = chunk_lo; chunk < chunk_hi; ++chunk) {
+    const int buf = (chunk - chunk_lo) % DECODE_KV_BUF_COUNT;
+    int section_chunk = chunk;
+    int section_len = topk_len;
+    const int32_t* section_indices = idx_base;
+    if constexpr (DUAL_CACHE) {
+      if (chunk >= num_main_chunks) {
+        section_chunk = chunk - num_main_chunks;
+        section_len = extra_topk_len;
+        section_indices = extra_indices + (size_t)token_idx * extra_topk;
+      }
+    }
+    const int chunk_start = section_chunk * DECODE_CAND_WINDOW;
+    const int chunk_end = min(chunk_start + DECODE_CAND_WINDOW, section_len);
+    mbarrier_wait_parity(sm.mbar_full(cons_idx), cons_phase);
+    uint8_t* sm_kv_fp4 = sm.kv_fp4(buf);
+    uint8_t* sm_kv_sc = sm.kv_sc(buf);
+    bf16* sm_kv_rope = sm.kv_rope(buf);
+    const int warp_first_cand = warp_id * DECODE_ENTRIES_PER_WARP;
+
+    float qk[PREFILL_HEAD_GROUPS][DECODE_QK_N_TILES][4] = {0};
+#pragma unroll
+    for (int kt = 0; kt < NUM_K64_TILES; ++kt) {
+      const int cand_row_base = warp_first_cand;
+      const uint32_t scale_b = *reinterpret_cast<const uint32_t*>(
+          sm_kv_sc + (size_t)(cand_row_base + gid) * DECODE_SCALE_BYTES_PER_TOKEN + kt * 4);
+      uint32_t b0, b1;
+      ldmatrix_load_B_fp8(b0, b1,
+                          sm_kv_fp4 + (size_t)cand_row_base * PREFILL_KV_SMEM_STRIDE + kt * 32,
+                          PREFILL_KV_SMEM_STRIDE, lane);
+#pragma unroll
+      for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+        const int scale_row = gid + (lane & 1) * 8;
+        const uint32_t scale_a = *reinterpret_cast<const uint32_t*>(
+            sm.q_sc(group) + scale_row * PREFILL_Q_SCALE_STRIDE + kt * 4);
+        uint32_t a0, a1, a2, a3;
+        ldmatrix_load_A_fp8(a0, a1, a2, a3, sm.q_fp4(group) + kt * 32, PREFILL_Q_FP4_STRIDE, lane);
+        MmaNvfp4Result r = mma_nvfp4_block_scaled_m16n8k64(a0, a1, a2, a3, b0, b1, qk[group][0][0],
+                                                           qk[group][0][1], qk[group][0][2],
+                                                           qk[group][0][3], scale_a, scale_b);
+        qk[group][0][0] = r.d0;
+        qk[group][0][1] = r.d1;
+        qk[group][0][2] = r.d2;
+        qk[group][0][3] = r.d3;
+      }
+    }
+
+#pragma unroll
+    for (int ks = 0; ks < D_ROPE / 16; ++ks) {
+      const int cand_row_base = warp_first_cand;
+      const bf16* rope_row = sm_kv_rope + (size_t)(cand_row_base + gid) * D_ROPE + ks * 16;
+      const uint32_t b0 = *reinterpret_cast<const uint32_t*>(rope_row + tid * 2);
+      const uint32_t b1 = *reinterpret_cast<const uint32_t*>(rope_row + tid * 2 + 8);
+#pragma unroll
+      for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+        uint32_t a0, a1, a2, a3;
+        ldmatrix_load_A_bf16(a0, a1, a2, a3, sm.q_rope(group) + ks * 16, D_ROPE, lane);
+        MmaBf16Result r = mma_bf16_m16n8k16(a0, a1, a2, a3, b0, b1, qk[group][0][0],
+                                            qk[group][0][1], qk[group][0][2], qk[group][0][3]);
+        qk[group][0][0] = r.d0;
+        qk[group][0][1] = r.d1;
+        qk[group][0][2] = r.d2;
+        qk[group][0][3] = r.d3;
+      }
+    }
+
+    float local_max[PREFILL_HEAD_GROUPS][2];
+    float local_sum[PREFILL_HEAD_GROUPS][2];
+    float p[PREFILL_HEAD_GROUPS][DECODE_QK_N_TILES][4];
+    float block_max_value[PREFILL_HEAD_GROUPS][2];
+#pragma unroll
+    for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+      const int c0 = warp_first_cand + tid * 2;
+      const int c1 = c0 + 1;
+      const int abs_c0 = chunk_start + c0;
+      const int abs_c1 = chunk_start + c1;
+      const int idx0 = abs_c0 < section_len ? section_indices[abs_c0] : -1;
+      const int idx1 = abs_c1 < section_len ? section_indices[abs_c1] : -1;
+      if (abs_c0 >= chunk_end || idx0 < 0) qk[group][0][0] = qk[group][0][2] = -1e30f;
+      if (abs_c1 >= chunk_end || idx1 < 0) qk[group][0][1] = qk[group][0][3] = -1e30f;
+#pragma unroll
+      for (int i = 0; i < 4; ++i) qk[group][0][i] *= sm_scale * LOG2E;
+
+      local_max[group][0] = fmaxf(qk[group][0][0], qk[group][0][1]);
+      local_max[group][1] = fmaxf(qk[group][0][2], qk[group][0][3]);
+#pragma unroll
+      for (int s = 2; s >= 1; s >>= 1) {
+        local_max[group][0] =
+            fmaxf(local_max[group][0], __shfl_xor_sync(0xffffffff, local_max[group][0], s));
+        local_max[group][1] =
+            fmaxf(local_max[group][1], __shfl_xor_sync(0xffffffff, local_max[group][1], s));
+      }
+      p[group][0][0] = exp2f(qk[group][0][0] - local_max[group][0]);
+      p[group][0][1] = exp2f(qk[group][0][1] - local_max[group][0]);
+      p[group][0][2] = exp2f(qk[group][0][2] - local_max[group][1]);
+      p[group][0][3] = exp2f(qk[group][0][3] - local_max[group][1]);
+      local_sum[group][0] = p[group][0][0] + p[group][0][1];
+      local_sum[group][1] = p[group][0][2] + p[group][0][3];
+#pragma unroll
+      for (int s = 2; s >= 1; s >>= 1) {
+        local_sum[group][0] += __shfl_xor_sync(0xffffffff, local_sum[group][0], s);
+        local_sum[group][1] += __shfl_xor_sync(0xffffffff, local_sum[group][1], s);
+      }
+      if (tid == 0) {
+        const int base = (group * DECODE_N_WARPS + warp_id) * HPB;
+        sm.warp_max()[base + gid] = local_max[group][0];
+        sm.warp_max()[base + gid + 8] = local_max[group][1];
+      }
+    }
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+    if (threadIdx.x < HEADS_PER_CTA) {
+      const int group = threadIdx.x / HPB;
+      const int head = threadIdx.x % HPB;
+      float block_max = -1e30f;
+#pragma unroll
+      for (int w = 0; w < DECODE_N_WARPS; ++w)
+        block_max = fmaxf(block_max, sm.warp_max()[(group * DECODE_N_WARPS + w) * HPB + head]);
+      const int group_base = group * REDUCE_GROUP_STRIDE;
+      sm.warp_max()[group_base + head] = block_max;
+    }
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+#pragma unroll
+    for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+      const int group_base = group * REDUCE_GROUP_STRIDE;
+      block_max_value[group][0] = sm.warp_max()[group_base + gid];
+      block_max_value[group][1] = sm.warp_max()[group_base + gid + 8];
+    }
+    // All warps must retain block max in registers before warp 0's slots are
+    // recycled for the rescaled local sums.
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+#pragma unroll
+    for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+      if (tid == 0) {
+        const int base = (group * DECODE_N_WARPS + warp_id) * HPB;
+        sm.warp_max()[base + gid] =
+            local_sum[group][0] * exp2f(local_max[group][0] - block_max_value[group][0]);
+        sm.warp_max()[base + gid + 8] =
+            local_sum[group][1] * exp2f(local_max[group][1] - block_max_value[group][1]);
+      }
+    }
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+    if (threadIdx.x < HEADS_PER_CTA) {
+      const int group = threadIdx.x / HPB;
+      const int head = threadIdx.x % HPB;
+      float block_sum = 0.f;
+#pragma unroll
+      for (int w = 0; w < DECODE_N_WARPS; ++w)
+        block_sum += sm.warp_max()[(group * DECODE_N_WARPS + w) * HPB + head];
+      sm.warp_max()[group * REDUCE_GROUP_STRIDE + head] = block_sum;
+    }
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+#pragma unroll
+    for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+      const int group_base = group * REDUCE_GROUP_STRIDE;
+      const float block_max0 = block_max_value[group][0];
+      const float block_max1 = block_max_value[group][1];
+      const float block_sum0 = sm.warp_max()[group_base + gid];
+      const float block_sum1 = sm.warp_max()[group_base + gid + 8];
+      const float new_max0 = fmaxf(global_max[group][0], block_max0);
+      const float new_max1 = fmaxf(global_max[group][1], block_max1);
+      const float alpha0 =
+          global_max[group][0] > -1e29f ? exp2f(global_max[group][0] - new_max0) : 0.f;
+      const float alpha1 =
+          global_max[group][1] > -1e29f ? exp2f(global_max[group][1] - new_max1) : 0.f;
+      const float block_rescale0 = exp2f(block_max0 - new_max0);
+      const float block_rescale1 = exp2f(block_max1 - new_max1);
+      const float warp_rescale0 = exp2f(local_max[group][0] - new_max0);
+      const float warp_rescale1 = exp2f(local_max[group][1] - new_max1);
+
+      if (chunk > chunk_lo) {
+#pragma unroll
+        for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
+#pragma unroll
+          for (int nt = 0; nt < PV_N8_TILES_PER_GROUP; ++nt) {
+#pragma unroll
+            for (int i = 0; i < 2; ++i) {
+              acc_nope[group][slot][nt][i] *= alpha0;
+              acc_nope[group][slot][nt][i + 2] *= alpha1;
+            }
+          }
+        }
+#pragma unroll
+        for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
+          acc_rope[group][nt][0] *= alpha0;
+          acc_rope[group][nt][1] *= alpha0;
+          acc_rope[group][nt][2] *= alpha1;
+          acc_rope[group][nt][3] *= alpha1;
+        }
+        global_sum[group][0] = global_sum[group][0] * alpha0 + block_sum0 * block_rescale0;
+        global_sum[group][1] = global_sum[group][1] * alpha1 + block_sum1 * block_rescale1;
+      } else {
+        global_sum[group][0] = block_sum0 * block_rescale0;
+        global_sum[group][1] = block_sum1 * block_rescale1;
+      }
+      global_max[group][0] = new_max0;
+      global_max[group][1] = new_max1;
+
+      const float w0 = p[group][0][0] * warp_rescale0;
+      const float w1 = p[group][0][1] * warp_rescale0;
+      const float w2 = p[group][0][2] * warp_rescale1;
+      const float w3 = p[group][0][3] * warp_rescale1;
+      const int c0 = tid * 2;
+      const int c1 = c0 + 1;
+      bf16* p_group = sm.p_full(group);
+      p_group[gid * PREFILL_P_STRIDE + warp_first_cand + c0] = __float2bfloat16(w0);
+      p_group[gid * PREFILL_P_STRIDE + warp_first_cand + c1] = __float2bfloat16(w1);
+      p_group[(gid + 8) * PREFILL_P_STRIDE + warp_first_cand + c0] = __float2bfloat16(w2);
+      p_group[(gid + 8) * PREFILL_P_STRIDE + warp_first_cand + c1] = __float2bfloat16(w3);
+    }
+
+    // P production is local to the math consumer.  In parallel the IO warps
+    // transpose/requantize the gathered 64-candidate V tile in shared memory.
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+    for (int task = threadIdx.x; task < HEADS_PER_CTA * DECODE_VT_SCALE_GROUPS;
+         task += PREFILL_MATH_THREADS) {
+      const int head = task / DECODE_VT_SCALE_GROUPS;
+      const int group = head / HPB;
+      const int head_in_group = head % HPB;
+      const int cand_group = task % DECODE_VT_SCALE_GROUPS;
+      quantize_bf16_group16_to_nvfp4(
+          sm.p_full(group) + head_in_group * PREFILL_P_STRIDE + cand_group * SF_VEC_SIZE,
+          sm.w_fp4(group) + head_in_group * PREFILL_W_PACKED_STRIDE +
+              cand_group * FP4_PACKED_PER_GROUP,
+          sm.w_sc(group) + head_in_group * DECODE_VT_SCALE_GROUPS + cand_group);
+    }
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    const int vt_stage = chunk % PREFILL_VT_PIPE_STAGES;
+    mbarrier_wait_parity(sm.mbar_vt_full(vt_stage), vt_full_phase[vt_stage]);
+
+    uint32_t p_scale_a[PREFILL_HEAD_GROUPS];
+    uint32_t p_a0[PREFILL_HEAD_GROUPS], p_a1[PREFILL_HEAD_GROUPS];
+    uint32_t p_a2[PREFILL_HEAD_GROUPS], p_a3[PREFILL_HEAD_GROUPS];
+#pragma unroll
+    for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+      const int p_scale_row = gid + (lane & 1) * 8;
+      p_scale_a[group] =
+          *reinterpret_cast<const uint32_t*>(sm.w_sc(group) + p_scale_row * DECODE_VT_SCALE_GROUPS);
+      ldmatrix_load_A_fp8(p_a0[group], p_a1[group], p_a2[group], p_a3[group], sm.w_fp4(group),
+                          PREFILL_W_PACKED_STRIDE, lane);
+    }
+
+#pragma unroll
+    for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
+      const int scale_group = slot * DECODE_N_WARPS + warp_id;
+      if (scale_group >= PV_SCALE_GROUPS) continue;
+      const int dim = scale_group * SF_VEC_SIZE;
+      const uint8_t* vt_data = sm.vt_data(vt_stage);
+      const uint8_t* vt_sc = sm.vt_sc(vt_stage);
+      uint32_t b00, b01, b10, b11;
+      ldmatrix_load_B_fp8(b00, b01, vt_data + dim * DECODE_VT_PACKED_K_BYTES,
+                          DECODE_VT_PACKED_K_BYTES, lane);
+      ldmatrix_load_B_fp8(b10, b11, vt_data + (dim + 8) * DECODE_VT_PACKED_K_BYTES,
+                          DECODE_VT_PACKED_K_BYTES, lane);
+      const uint32_t scale_b0 =
+          *reinterpret_cast<const uint32_t*>(vt_sc + (dim + gid) * DECODE_VT_SCALE_GROUPS);
+      const uint32_t scale_b1 =
+          *reinterpret_cast<const uint32_t*>(vt_sc + (dim + 8 + gid) * DECODE_VT_SCALE_GROUPS);
+#pragma unroll
+      for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+        MmaNvfp4Result r0 =
+            mma_nvfp4_block_scaled_m16n8k64(p_a0[group], p_a1[group], p_a2[group], p_a3[group], b00,
+                                            b01, 0.f, 0.f, 0.f, 0.f, p_scale_a[group], scale_b0);
+        MmaNvfp4Result r1 =
+            mma_nvfp4_block_scaled_m16n8k64(p_a0[group], p_a1[group], p_a2[group], p_a3[group], b10,
+                                            b11, 0.f, 0.f, 0.f, 0.f, p_scale_a[group], scale_b1);
+        acc_nope[group][slot][0][0] += r0.d0;
+        acc_nope[group][slot][0][1] += r0.d1;
+        acc_nope[group][slot][0][2] += r0.d2;
+        acc_nope[group][slot][0][3] += r0.d3;
+        acc_nope[group][slot][1][0] += r1.d0;
+        acc_nope[group][slot][1][1] += r1.d1;
+        acc_nope[group][slot][1][2] += r1.d2;
+        acc_nope[group][slot][1][3] += r1.d3;
+      }
+    }
+
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    if (threadIdx.x == 0) mbarrier_arrive(sm.mbar_vt_empty(vt_stage));
+    vt_full_phase[vt_stage] ^= 1;
+
+    const int rope_dim_base = warp_id * ROPE_DIMS_PER_WARP;
+#pragma unroll
+    for (int ks = 0; ks < ROPE_K_ITERS; ++ks) {
+      uint32_t rope_a0[PREFILL_HEAD_GROUPS], rope_a1[PREFILL_HEAD_GROUPS];
+      uint32_t rope_a2[PREFILL_HEAD_GROUPS], rope_a3[PREFILL_HEAD_GROUPS];
+#pragma unroll
+      for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+        ldmatrix_load_A_bf16(rope_a0[group], rope_a1[group], rope_a2[group], rope_a3[group],
+                             sm.p_full(group) + ks * 16, PREFILL_P_STRIDE, lane);
+      }
+#pragma unroll
+      for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
+        const int n_col = rope_dim_base + nt * 8;
+        const int k_base = ks * 16;
+        const int ent0 = k_base + tid * 2;
+        const int ent1 = ent0 + 1;
+        const int ent8 = ent0 + 8;
+        const int ent9 = ent0 + 9;
+        const int col = n_col + gid;
+        const uint16_t v0 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent0 * D_ROPE + col);
+        const uint16_t v1 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent1 * D_ROPE + col);
+        const uint16_t v8 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent8 * D_ROPE + col);
+        const uint16_t v9 =
+            *reinterpret_cast<const uint16_t*>(sm_kv_rope + (size_t)ent9 * D_ROPE + col);
+        const uint32_t b0 = (uint32_t)v0 | ((uint32_t)v1 << 16);
+        const uint32_t b1 = (uint32_t)v8 | ((uint32_t)v9 << 16);
+#pragma unroll
+        for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+          MmaBf16Result r =
+              mma_bf16_m16n8k16(rope_a0[group], rope_a1[group], rope_a2[group], rope_a3[group], b0,
+                                b1, acc_rope[group][nt][0], acc_rope[group][nt][1],
+                                acc_rope[group][nt][2], acc_rope[group][nt][3]);
+          acc_rope[group][nt][0] = r.d0;
+          acc_rope[group][nt][1] = r.d1;
+          acc_rope[group][nt][2] = r.d2;
+          acc_rope[group][nt][3] = r.d3;
+        }
+      }
+    }
+
+    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    if (threadIdx.x == 0) mbarrier_arrive(sm.mbar_empty(cons_idx));
+    if (++cons_idx == DECODE_KV_BUF_COUNT) {
+      cons_idx = 0;
+      cons_phase ^= 1;
+    }
+  }
+
+  float* final_output_scale = reinterpret_cast<float*>(sm.p_full(0));
+  if (warp_id == 0 && tid == 0) {
+#pragma unroll
+    for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+      float lse0 =
+          global_sum[group][0] > 0.f ? log2f(global_sum[group][0]) + global_max[group][0] : -1e30f;
+      float lse1 =
+          global_sum[group][1] > 0.f ? log2f(global_sum[group][1]) + global_max[group][1] : -1e30f;
+      float output_scale0 = 1.f;
+      float output_scale1 = 1.f;
+      const int h0 = h_start + group * HPB + gid;
+      if (write_direct && attn_sink != nullptr) {
+        const float sink0 = __ldg(attn_sink + h0) * LOG2E;
+        const float max0 = fmaxf(lse0, sink0);
+        const float attn_mass0 = lse0 > -1e29f ? exp2f(lse0 - max0) : 0.f;
+        const float sink_mass0 = exp2f(sink0 - max0);
+        const float total0 = attn_mass0 + sink_mass0;
+        output_scale0 = total0 > 0.f ? attn_mass0 / total0 : 0.f;
+        lse0 = total0 > 0.f ? log2f(total0) + max0 : -1e30f;
+        const float sink1 = __ldg(attn_sink + h0 + 8) * LOG2E;
+        const float max1 = fmaxf(lse1, sink1);
+        const float attn_mass1 = lse1 > -1e29f ? exp2f(lse1 - max1) : 0.f;
+        const float sink_mass1 = exp2f(sink1 - max1);
+        const float total1 = attn_mass1 + sink_mass1;
+        output_scale1 = total1 > 0.f ? attn_mass1 / total1 : 0.f;
+        lse1 = total1 > 0.f ? log2f(total1) + max1 : -1e30f;
+      }
+      final_output_scale[group * HPB + gid] = output_scale0;
+      final_output_scale[group * HPB + gid + 8] = output_scale1;
+      if (write_direct) {
+        out_lse[(size_t)token_idx * NUM_HEADS + h0] = lse0;
+        out_lse[(size_t)token_idx * NUM_HEADS + h0 + 8] = lse1;
+      } else {
+        const size_t lse_base = (size_t)token_idx * NUM_HEADS * num_splits;
+        mid_lse[lse_base + (size_t)h0 * num_splits + split_idx] = lse0;
+        mid_lse[lse_base + (size_t)(h0 + 8) * num_splits + split_idx] = lse1;
+      }
+    }
+  }
+  bar_sync_t<3, PREFILL_MATH_THREADS>();
+
+#pragma unroll
+  for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
+    const float inv_sum0 = global_sum[group][0] > 0.f
+                               ? final_output_scale[group * HPB + gid] / global_sum[group][0]
+                               : 0.f;
+    const float inv_sum1 = global_sum[group][1] > 0.f
+                               ? final_output_scale[group * HPB + gid + 8] / global_sum[group][1]
+                               : 0.f;
+    const int group_h_start = h_start + group * HPB;
+    bf16* destination =
+        write_direct
+            ? output + ((size_t)token_idx * NUM_HEADS + group_h_start) * D_V
+            : mid_out +
+                  (((size_t)token_idx * NUM_HEADS + group_h_start) * num_splits + split_idx) * D_V;
+    const size_t head_stride = write_direct ? D_V : (size_t)num_splits * D_V;
+#pragma unroll
+    for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
+      const int scale_group = slot * DECODE_N_WARPS + warp_id;
+      if (scale_group >= PV_SCALE_GROUPS) continue;
+#pragma unroll
+      for (int nt = 0; nt < PV_N8_TILES_PER_GROUP; ++nt) {
+        const int d0 = scale_group * SF_VEC_SIZE + nt * 8 + tid * 2;
+        const __nv_bfloat162 lo = __floats2bfloat162_rn(acc_nope[group][slot][nt][0] * inv_sum0,
+                                                        acc_nope[group][slot][nt][1] * inv_sum0);
+        const __nv_bfloat162 hi = __floats2bfloat162_rn(acc_nope[group][slot][nt][2] * inv_sum1,
+                                                        acc_nope[group][slot][nt][3] * inv_sum1);
+        *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)gid * head_stride + d0]) = lo;
+        *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)(gid + 8) * head_stride + d0]) = hi;
+      }
+    }
+#pragma unroll
+    for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
+      const int d0 = D_NOPE + warp_id * ROPE_DIMS_PER_WARP + nt * 8 + tid * 2;
+      const __nv_bfloat162 lo = __floats2bfloat162_rn(acc_rope[group][nt][0] * inv_sum0,
+                                                      acc_rope[group][nt][1] * inv_sum0);
+      const __nv_bfloat162 hi = __floats2bfloat162_rn(acc_rope[group][nt][2] * inv_sum1,
+                                                      acc_rope[group][nt][3] * inv_sum1);
+      *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)gid * head_stride + d0]) = lo;
+      *reinterpret_cast<__nv_bfloat162*>(&destination[(size_t)(gid + 8) * head_stride + d0]) = hi;
+    }
+  }
+}
+
+}  // namespace flashinfer::sparse_mla_sm120::nvfp4

--- a/include/flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh
@@ -16,60 +16,82 @@
 
 #pragma once
 
-#include "decode_dsv4_nvfp4_kernel.cuh"
+#include "arch/barrier.cuh"
+#include "arch/cp_async.cuh"
+#include "arch/ldmatrix_sm120.cuh"
+#include "arch/mma_sm120.cuh"
+#include "arch/mma_sm120_nvfp4.cuh"
+#include "common/d2_load_b_nvfp4.cuh"
+#include "common/nvfp4_quant.cuh"
+#include "common/nvfp4_vt.cuh"
+#include "model/nvfp4_cache_traits.cuh"
 
 namespace flashinfer::sparse_mla_sm120::nvfp4 {
 
-constexpr int PREFILL_HEAD_GROUPS = 4;
-constexpr int PREFILL_HEADS_PER_CTA = PREFILL_HEAD_GROUPS * HPB;
+// This grouped streaming kernel is shared by direct-write prefill and by the
+// grouped split-K decode tactic. Phase-specific launchers keep their public
+// ABI and workspace policy separate.
+constexpr int STREAMING_HEAD_GROUPS = 4;
+constexpr int STREAMING_HEADS_PER_CTA = STREAMING_HEAD_GROUPS * HPB;
 // A 64-head CTA amortizes one selected-V transpose over four 16-head groups.
 // Eight producer warps sustain the online candidate-axis requantization while
 // eight math warps retain four output accumulator groups.
-constexpr int PREFILL_GATHER_WARPS = 2;
-constexpr int PREFILL_IO_WARPS = 8;
-constexpr int PREFILL_IO_MAX_REGS = 64;
-constexpr int PREFILL_MATH_MAX_REGS = 192;
-constexpr int PREFILL_VT_PIPE_STAGES = 1;
-constexpr int PREFILL_KV_SMEM_STRIDE = DECODE_PACKED_NOPE_BYTES;
-constexpr int PREFILL_Q_FP4_STRIDE = DECODE_PACKED_NOPE_BYTES;
-constexpr int PREFILL_Q_SCALE_STRIDE = DSV4_NVFP4_NUM_SCALES;
-constexpr int PREFILL_W_PACKED_STRIDE = DECODE_CAND_WINDOW / 2;
-constexpr int PREFILL_BLOCK_THREADS = (DECODE_N_WARPS + PREFILL_IO_WARPS) * 32;
-constexpr int PREFILL_MATH_THREADS = DECODE_MATH_THREADS;
+constexpr int STREAMING_GATHER_WARPS = 2;
+constexpr int STREAMING_IO_WARPS = 8;
+constexpr int STREAMING_N_WARPS = 8;
+constexpr int STREAMING_IO_MAX_REGS = 64;
+constexpr int STREAMING_MATH_MAX_REGS = 192;
+constexpr int STREAMING_VT_PIPE_STAGES = 1;
+constexpr int STREAMING_CAND_WINDOW = NVFP4_VT_CANDIDATES;
+constexpr int STREAMING_KV_BUF_COUNT = 2;
+constexpr int STREAMING_ENTRIES_PER_WARP = STREAMING_CAND_WINDOW / STREAMING_N_WARPS;
+constexpr int STREAMING_QK_N_TILES = STREAMING_ENTRIES_PER_WARP / 8;
+constexpr int STREAMING_PACKED_NOPE_BYTES = DSV4NVFP4Cache::PACKED_NOPE_BYTES;
+constexpr int STREAMING_DATA_BYTES_PER_TOKEN = DSV4NVFP4Cache::DATA_BYTES_PER_TOKEN;
+constexpr int STREAMING_SCALE_BYTES_PER_TOKEN = DSV4NVFP4Cache::SCALE_BYTES_PER_TOKEN;
+constexpr int STREAMING_KV_SMEM_STRIDE = STREAMING_PACKED_NOPE_BYTES;
+constexpr int STREAMING_Q_FP4_STRIDE = STREAMING_PACKED_NOPE_BYTES;
+constexpr int STREAMING_Q_SCALE_STRIDE = DSV4_NVFP4_NUM_SCALES;
+constexpr int STREAMING_W_PACKED_STRIDE = STREAMING_CAND_WINDOW / 2;
+constexpr int STREAMING_BLOCK_THREADS = (STREAMING_N_WARPS + STREAMING_IO_WARPS) * 32;
+constexpr int STREAMING_MATH_THREADS = STREAMING_N_WARPS * 32;
 // Padding breaks the 128-byte head-to-head alias in the probability staging
 // matrix.  A multiple of eight BF16 elements preserves ldmatrix alignment
 // while cutting the dominant P-quant shared-load bank conflict in half.
-constexpr int PREFILL_P_STRIDE = DECODE_CAND_WINDOW + 8;
+constexpr int STREAMING_P_STRIDE = STREAMING_CAND_WINDOW + 8;
 
 // Four 16-head groups share one selected-K gather and one transient V^T tile.
 // The resulting 64-head CTA amortizes online V preparation while retaining the
 // native NVFP4 QK/PV atoms validated by the decode path.
-struct PrefillNVFP4Smem {
-  static constexpr size_t SMEM_Q_ROPE = PREFILL_HEADS_PER_CTA * 64 * sizeof(bf16);
-  static constexpr size_t SMEM_Q_FP4 = PREFILL_HEADS_PER_CTA * PREFILL_Q_FP4_STRIDE;
-  static constexpr size_t SMEM_Q_SC = PREFILL_HEADS_PER_CTA * PREFILL_Q_SCALE_STRIDE;
-  static constexpr size_t SMEM_KV_FP4_BUF = DECODE_CAND_WINDOW * PREFILL_KV_SMEM_STRIDE;
-  static constexpr size_t SMEM_KV_SC_BUF = DECODE_CAND_WINDOW * DECODE_SCALE_BYTES_PER_TOKEN;
-  static constexpr size_t SMEM_KV_ROPE_BUF = DECODE_CAND_WINDOW * 64 * sizeof(bf16);
+struct StreamingNVFP4Smem {
+  static constexpr size_t SMEM_Q_ROPE =
+      STREAMING_HEADS_PER_CTA * DSV4NVFP4Cache::D_ROPE * sizeof(bf16);
+  static constexpr size_t SMEM_Q_FP4 = STREAMING_HEADS_PER_CTA * STREAMING_Q_FP4_STRIDE;
+  static constexpr size_t SMEM_Q_SC = STREAMING_HEADS_PER_CTA * STREAMING_Q_SCALE_STRIDE;
+  static constexpr size_t SMEM_KV_FP4_BUF = STREAMING_CAND_WINDOW * STREAMING_KV_SMEM_STRIDE;
+  static constexpr size_t SMEM_KV_SC_BUF = STREAMING_CAND_WINDOW * STREAMING_SCALE_BYTES_PER_TOKEN;
+  static constexpr size_t SMEM_KV_ROPE_BUF =
+      STREAMING_CAND_WINDOW * DSV4NVFP4Cache::D_ROPE * sizeof(bf16);
   static constexpr size_t SMEM_MBAR_PAIR = 2 * sizeof(uint64_t);
-  static constexpr size_t SMEM_MBAR_VT_PIPE = PREFILL_VT_PIPE_STAGES * sizeof(uint64_t);
-  static constexpr size_t SMEM_REDUCE = PREFILL_HEAD_GROUPS * DECODE_N_WARPS * HPB * sizeof(float);
-  static constexpr size_t SMEM_W_SC = PREFILL_HEADS_PER_CTA * DECODE_VT_SCALE_GROUPS;
-  static constexpr size_t SMEM_W_FP4 = PREFILL_HEADS_PER_CTA * PREFILL_W_PACKED_STRIDE;
+  static constexpr size_t SMEM_MBAR_VT_PIPE = STREAMING_VT_PIPE_STAGES * sizeof(uint64_t);
+  static constexpr size_t SMEM_REDUCE =
+      STREAMING_HEAD_GROUPS * STREAMING_N_WARPS * HPB * sizeof(float);
+  static constexpr size_t SMEM_W_SC = STREAMING_HEADS_PER_CTA * NVFP4_VT_SCALE_GROUPS;
+  static constexpr size_t SMEM_W_FP4 = STREAMING_HEADS_PER_CTA * STREAMING_W_PACKED_STRIDE;
   // One CTA-local full V^T tile is consumed immediately after preparation and
   // never leaves shared memory.  KV itself remains double buffered.
-  static constexpr size_t SMEM_VT_DATA = PREFILL_VT_PIPE_STAGES * DECODE_VT_DATA_BYTES;
-  static constexpr size_t SMEM_VT_SC = PREFILL_VT_PIPE_STAGES * DECODE_VT_SCALE_BYTES;
-  static constexpr size_t SMEM_P_FULL = PREFILL_HEADS_PER_CTA * PREFILL_P_STRIDE * sizeof(bf16);
+  static constexpr size_t SMEM_VT_DATA = STREAMING_VT_PIPE_STAGES * NVFP4_VT_DATA_BYTES;
+  static constexpr size_t SMEM_VT_SC = STREAMING_VT_PIPE_STAGES * NVFP4_VT_SCALE_BYTES;
+  static constexpr size_t SMEM_P_FULL = STREAMING_HEADS_PER_CTA * STREAMING_P_STRIDE * sizeof(bf16);
 
   static constexpr size_t OFF_Q_ROPE = 0;
   static constexpr size_t OFF_Q_FP4 = OFF_Q_ROPE + SMEM_Q_ROPE;
   static constexpr size_t OFF_Q_SC = OFF_Q_FP4 + SMEM_Q_FP4;
   static constexpr size_t OFF_KV_FP4 = OFF_Q_SC + SMEM_Q_SC;
-  static constexpr size_t OFF_KV_SC = OFF_KV_FP4 + DECODE_KV_BUF_COUNT * SMEM_KV_FP4_BUF;
-  static constexpr size_t OFF_KV_ROPE = OFF_KV_SC + DECODE_KV_BUF_COUNT * SMEM_KV_SC_BUF;
+  static constexpr size_t OFF_KV_SC = OFF_KV_FP4 + STREAMING_KV_BUF_COUNT * SMEM_KV_FP4_BUF;
+  static constexpr size_t OFF_KV_ROPE = OFF_KV_SC + STREAMING_KV_BUF_COUNT * SMEM_KV_SC_BUF;
   static constexpr size_t OFF_MBAR_FULL_UNALIGNED =
-      OFF_KV_ROPE + DECODE_KV_BUF_COUNT * SMEM_KV_ROPE_BUF;
+      OFF_KV_ROPE + STREAMING_KV_BUF_COUNT * SMEM_KV_ROPE_BUF;
   static constexpr size_t OFF_MBAR_FULL = (OFF_MBAR_FULL_UNALIGNED + 15) / 16 * 16;
   static constexpr size_t OFF_MBAR_EMPTY = OFF_MBAR_FULL + SMEM_MBAR_PAIR;
   static constexpr size_t OFF_MBAR_VT_FULL = OFF_MBAR_EMPTY + SMEM_MBAR_PAIR;
@@ -92,15 +114,15 @@ struct PrefillNVFP4Smem {
 
   char* base;
 
-  __device__ static PrefillNVFP4Smem init(char* base) { return PrefillNVFP4Smem{base}; }
+  __device__ static StreamingNVFP4Smem init(char* base) { return StreamingNVFP4Smem{base}; }
   __device__ __forceinline__ bf16* q_rope(int group) const {
-    return reinterpret_cast<bf16*>(base + OFF_Q_ROPE) + group * HPB * 64;
+    return reinterpret_cast<bf16*>(base + OFF_Q_ROPE) + group * HPB * DSV4NVFP4Cache::D_ROPE;
   }
   __device__ __forceinline__ uint8_t* q_fp4(int group) const {
-    return reinterpret_cast<uint8_t*>(base + OFF_Q_FP4) + group * HPB * PREFILL_Q_FP4_STRIDE;
+    return reinterpret_cast<uint8_t*>(base + OFF_Q_FP4) + group * HPB * STREAMING_Q_FP4_STRIDE;
   }
   __device__ __forceinline__ uint8_t* q_sc(int group) const {
-    return reinterpret_cast<uint8_t*>(base + OFF_Q_SC) + group * HPB * PREFILL_Q_SCALE_STRIDE;
+    return reinterpret_cast<uint8_t*>(base + OFF_Q_SC) + group * HPB * STREAMING_Q_SCALE_STRIDE;
   }
   __device__ __forceinline__ uint8_t* kv_fp4(int parity) const {
     return reinterpret_cast<uint8_t*>(base + OFF_KV_FP4) + parity * SMEM_KV_FP4_BUF;
@@ -109,7 +131,8 @@ struct PrefillNVFP4Smem {
     return reinterpret_cast<uint8_t*>(base + OFF_KV_SC) + parity * SMEM_KV_SC_BUF;
   }
   __device__ __forceinline__ bf16* kv_rope(int parity) const {
-    return reinterpret_cast<bf16*>(base + OFF_KV_ROPE) + parity * DECODE_CAND_WINDOW * 64;
+    return reinterpret_cast<bf16*>(base + OFF_KV_ROPE) +
+           parity * STREAMING_CAND_WINDOW * DSV4NVFP4Cache::D_ROPE;
   }
   __device__ __forceinline__ uint64_t* mbar_full(int parity) const {
     return reinterpret_cast<uint64_t*>(base + OFF_MBAR_FULL) + parity;
@@ -127,51 +150,52 @@ struct PrefillNVFP4Smem {
     return reinterpret_cast<float*>(base + OFF_REDUCE);
   }
   __device__ __forceinline__ uint8_t* w_sc(int group) const {
-    return reinterpret_cast<uint8_t*>(base + OFF_W_SC) + group * HPB * DECODE_VT_SCALE_GROUPS;
+    return reinterpret_cast<uint8_t*>(base + OFF_W_SC) + group * HPB * NVFP4_VT_SCALE_GROUPS;
   }
   __device__ __forceinline__ uint8_t* w_fp4(int group) const {
-    return reinterpret_cast<uint8_t*>(base + OFF_W_FP4) + group * HPB * PREFILL_W_PACKED_STRIDE;
+    return reinterpret_cast<uint8_t*>(base + OFF_W_FP4) + group * HPB * STREAMING_W_PACKED_STRIDE;
   }
   __device__ __forceinline__ uint8_t* vt_data(int stage) const {
-    return reinterpret_cast<uint8_t*>(base + OFF_VT_DATA) + stage * DECODE_VT_DATA_BYTES;
+    return reinterpret_cast<uint8_t*>(base + OFF_VT_DATA) + stage * NVFP4_VT_DATA_BYTES;
   }
   __device__ __forceinline__ uint8_t* vt_sc(int stage) const {
-    return reinterpret_cast<uint8_t*>(base + OFF_VT_SC) + stage * DECODE_VT_SCALE_BYTES;
+    return reinterpret_cast<uint8_t*>(base + OFF_VT_SC) + stage * NVFP4_VT_SCALE_BYTES;
   }
   __device__ __forceinline__ bf16* p_full(int group) const {
-    return reinterpret_cast<bf16*>(base + OFF_P_FULL) + group * HPB * PREFILL_P_STRIDE;
+    return reinterpret_cast<bf16*>(base + OFF_P_FULL) + group * HPB * STREAMING_P_STRIDE;
   }
 };
 
-static_assert(PrefillNVFP4Smem::SIZE <= 99 * 1024);
+static_assert(StreamingNVFP4Smem::SIZE <= 99 * 1024);
 
 template <int NUM_HEADS, int TOPK, int PAGE_BLOCK_SIZE, bool DUAL_CACHE = false>
-__global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_dsv4_nvfp4_kernel(
-    const bf16* __restrict__ q, const uint8_t* __restrict__ kv_cache,
-    const int32_t* __restrict__ indices, bf16* __restrict__ output, float* __restrict__ out_lse,
-    bf16* __restrict__ mid_out, float* __restrict__ mid_lse, const float* __restrict__ attn_sink,
-    const int* __restrict__ topk_length_ptr, const uint8_t* __restrict__ extra_kv_cache,
-    const int32_t* __restrict__ extra_indices, const int* __restrict__ extra_topk_length_ptr,
-    int extra_topk, int extra_page_block_size, size_t stride_extra_kv_block, int num_tokens,
-    int num_splits, int chunks_per_block, float sm_scale, size_t stride_kv_block,
-    bool write_direct) {
-  static_assert(NUM_HEADS <= PREFILL_HEADS_PER_CTA || NUM_HEADS % PREFILL_HEADS_PER_CTA == 0);
+__global__ void __launch_bounds__(STREAMING_BLOCK_THREADS, 1)
+    sparse_mla_streaming_dsv4_nvfp4_kernel(
+        const bf16* __restrict__ q, const uint8_t* __restrict__ kv_cache,
+        const int32_t* __restrict__ indices, bf16* __restrict__ output, float* __restrict__ out_lse,
+        bf16* __restrict__ mid_out, float* __restrict__ mid_lse,
+        const float* __restrict__ attn_sink, const int* __restrict__ topk_length_ptr,
+        const uint8_t* __restrict__ extra_kv_cache, const int32_t* __restrict__ extra_indices,
+        const int* __restrict__ extra_topk_length_ptr, int extra_topk, int extra_page_block_size,
+        size_t stride_extra_kv_block, int num_tokens, int num_splits, int chunks_per_block,
+        float sm_scale, size_t stride_kv_block, bool write_direct) {
+  static_assert(NUM_HEADS <= STREAMING_HEADS_PER_CTA || NUM_HEADS % STREAMING_HEADS_PER_CTA == 0);
   constexpr int VALID_HEAD_GROUPS =
-      NUM_HEADS < PREFILL_HEADS_PER_CTA ? (NUM_HEADS + HPB - 1) / HPB : PREFILL_HEAD_GROUPS;
+      NUM_HEADS < STREAMING_HEADS_PER_CTA ? (NUM_HEADS + HPB - 1) / HPB : STREAMING_HEAD_GROUPS;
   constexpr int HEADS_PER_CTA = VALID_HEAD_GROUPS * HPB;
-  constexpr int D_NOPE = 448;
-  constexpr int D_ROPE = 64;
-  constexpr int D_QK = 512;
-  constexpr int D_V = 512;
+  constexpr int D_NOPE = DSV4NVFP4Cache::D_NOPE;
+  constexpr int D_ROPE = DSV4NVFP4Cache::D_ROPE;
+  constexpr int D_QK = DSV4NVFP4Cache::D_QK;
+  constexpr int D_V = DSV4NVFP4Cache::D_V;
   constexpr int HEAD_BLOCKS = NUM_HEADS / HEADS_PER_CTA;
   constexpr int NUM_K64_TILES = D_NOPE / 64;
   constexpr int PV_SCALE_GROUPS = D_NOPE / SF_VEC_SIZE;
-  constexpr int PV_GROUPS_PER_WARP = (PV_SCALE_GROUPS + DECODE_N_WARPS - 1) / DECODE_N_WARPS;
+  constexpr int PV_GROUPS_PER_WARP = (PV_SCALE_GROUPS + STREAMING_N_WARPS - 1) / STREAMING_N_WARPS;
   constexpr int PV_N8_TILES_PER_GROUP = SF_VEC_SIZE / 8;
-  constexpr int ROPE_DIMS_PER_WARP = D_ROPE / DECODE_N_WARPS;
+  constexpr int ROPE_DIMS_PER_WARP = D_ROPE / STREAMING_N_WARPS;
   constexpr int ROPE_N_TILES = ROPE_DIMS_PER_WARP / 8;
-  constexpr int ROPE_K_ITERS = DECODE_CAND_WINDOW / 16;
-  constexpr int REDUCE_GROUP_STRIDE = DECODE_N_WARPS * HPB;
+  constexpr int ROPE_K_ITERS = STREAMING_CAND_WINDOW / 16;
+  constexpr int REDUCE_GROUP_STRIDE = STREAMING_N_WARPS * HPB;
   const int token_idx = blockIdx.x;
   const int head_block = blockIdx.y;
   const int split_idx = blockIdx.z;
@@ -179,33 +203,33 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
   const int h_start = head_block * HEADS_PER_CTA;
   int topk_len = topk_length_ptr ? __ldg(topk_length_ptr + token_idx) : TOPK;
   topk_len = max(0, min(topk_len, TOPK));
-  const int num_main_chunks = (topk_len + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  const int num_main_chunks = (topk_len + STREAMING_CAND_WINDOW - 1) / STREAMING_CAND_WINDOW;
   int extra_topk_len = 0;
   if constexpr (DUAL_CACHE) {
     extra_topk_len = extra_topk_length_ptr ? __ldg(extra_topk_length_ptr + token_idx) : extra_topk;
     extra_topk_len = max(0, min(extra_topk_len, extra_topk));
   }
-  const int num_extra_chunks = (extra_topk_len + DECODE_CAND_WINDOW - 1) / DECODE_CAND_WINDOW;
+  const int num_extra_chunks = (extra_topk_len + STREAMING_CAND_WINDOW - 1) / STREAMING_CAND_WINDOW;
   const int num_chunks = num_main_chunks + num_extra_chunks;
   const int chunk_lo = chunks_per_block > 0 ? split_idx * chunks_per_block : 0;
   const int chunk_hi =
       chunks_per_block > 0 ? min(chunk_lo + chunks_per_block, num_chunks) : num_chunks;
   const int warp_id = threadIdx.x / 32;
   const int lane = threadIdx.x & 31;
-  const bool is_io = warp_id >= DECODE_N_WARPS;
+  const bool is_io = warp_id >= STREAMING_N_WARPS;
 
   extern __shared__ __align__(16) char smem_raw[];
-  auto sm = PrefillNVFP4Smem::init(smem_raw);
+  auto sm = StreamingNVFP4Smem::init(smem_raw);
   const int32_t* idx_base = indices + (size_t)token_idx * TOPK;
 
   if (threadIdx.x == 0) {
 #pragma unroll
-    for (int i = 0; i < DECODE_KV_BUF_COUNT; ++i) {
+    for (int i = 0; i < STREAMING_KV_BUF_COUNT; ++i) {
       mbarrier_init(sm.mbar_full(i), 1);
       mbarrier_init(sm.mbar_empty(i), 1);
     }
 #pragma unroll
-    for (int stage = 0; stage < PREFILL_VT_PIPE_STAGES; ++stage) {
+    for (int stage = 0; stage < STREAMING_VT_PIPE_STAGES; ++stage) {
       mbarrier_init(sm.mbar_vt_full(stage), 1);
       mbarrier_init(sm.mbar_vt_empty(stage), 1);
     }
@@ -214,7 +238,7 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
 
   if (chunk_lo >= num_chunks) {
     if (!is_io) {
-      for (int i = threadIdx.x; i < HEADS_PER_CTA * D_V; i += PREFILL_MATH_THREADS) {
+      for (int i = threadIdx.x; i < HEADS_PER_CTA * D_V; i += STREAMING_MATH_THREADS) {
         const int head = i / D_V;
         const int dim = i - head * D_V;
         if (write_direct) {
@@ -239,9 +263,9 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
     return;
   }
 
-  constexpr uint32_t BULK_NOPE_BYTES = DECODE_PACKED_NOPE_BYTES;
+  constexpr uint32_t BULK_NOPE_BYTES = STREAMING_PACKED_NOPE_BYTES;
   constexpr uint32_t BULK_ROPE_BYTES = D_ROPE * sizeof(bf16);
-  constexpr uint32_t BULK_TX_BYTES = DECODE_CAND_WINDOW * (BULK_NOPE_BYTES + BULK_ROPE_BYTES);
+  constexpr uint32_t BULK_TX_BYTES = STREAMING_CAND_WINDOW * (BULK_NOPE_BYTES + BULK_ROPE_BYTES);
 
   auto issue_gather = [&](int chunk_idx, int buf) {
     bool is_extra = false;
@@ -262,12 +286,12 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
         section_indices = extra_indices + (size_t)token_idx * extra_topk;
       }
     }
-    const int chunk_start = section_chunk * DECODE_CAND_WINDOW;
-    const int chunk_end = min(chunk_start + DECODE_CAND_WINDOW, section_len);
+    const int chunk_start = section_chunk * STREAMING_CAND_WINDOW;
+    const int chunk_end = min(chunk_start + STREAMING_CAND_WINDOW, section_len);
     uint8_t* fp4_dst = sm.kv_fp4(buf);
     bf16* rope_dst = sm.kv_rope(buf);
     uint8_t* scale_dst = sm.kv_sc(buf);
-    const int io_warp = warp_id - DECODE_N_WARPS;
+    const int io_warp = warp_id - STREAMING_N_WARPS;
     const int entry = io_warp * 32 + lane;
     const int cand = chunk_start + entry;
     const int idx_raw = cand < chunk_end ? section_indices[cand] : -1;
@@ -290,13 +314,13 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
         slot = idx_raw - page * PAGE_BLOCK_SIZE;
       }
       const uint8_t* scale_src = section_kv + (size_t)page * section_stride +
-                                 (size_t)section_page_block_size * DECODE_DATA_BYTES_PER_TOKEN +
-                                 (size_t)slot * DECODE_SCALE_BYTES_PER_TOKEN;
+                                 (size_t)section_page_block_size * STREAMING_DATA_BYTES_PER_TOKEN +
+                                 (size_t)slot * STREAMING_SCALE_BYTES_PER_TOKEN;
       s0 = *reinterpret_cast<const uint4*>(scale_src);
       s1 = *reinterpret_cast<const uint4*>(scale_src + sizeof(uint4));
     }
-    *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * DECODE_SCALE_BYTES_PER_TOKEN) = s0;
-    *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * DECODE_SCALE_BYTES_PER_TOKEN +
+    *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * STREAMING_SCALE_BYTES_PER_TOKEN) = s0;
+    *reinterpret_cast<uint4*>(scale_dst + (size_t)entry * STREAMING_SCALE_BYTES_PER_TOKEN +
                               sizeof(uint4)) = s1;
     __threadfence_block();
 
@@ -316,39 +340,40 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
       slot = idx - page * PAGE_BLOCK_SIZE;
     }
     const uint8_t* data_src =
-        section_kv + (size_t)page * section_stride + (size_t)slot * DECODE_DATA_BYTES_PER_TOKEN;
+        section_kv + (size_t)page * section_stride + (size_t)slot * STREAMING_DATA_BYTES_PER_TOKEN;
     if (io_warp == 0 && lane == 0) mbarrier_arrive_expect_tx(sm.mbar_full(buf), BULK_TX_BYTES);
-    bar_sync_t<4, PREFILL_GATHER_WARPS * 32>();
-    cp_async_bulk_g2s(fp4_dst + (size_t)entry * PREFILL_KV_SMEM_STRIDE, data_src, BULK_NOPE_BYTES,
+    bar_sync_t<4, STREAMING_GATHER_WARPS * 32>();
+    cp_async_bulk_g2s(fp4_dst + (size_t)entry * STREAMING_KV_SMEM_STRIDE, data_src, BULK_NOPE_BYTES,
                       sm.mbar_full(buf));
-    cp_async_bulk_g2s(rope_dst + (size_t)entry * D_ROPE, data_src + DECODE_PACKED_NOPE_BYTES,
+    cp_async_bulk_g2s(rope_dst + (size_t)entry * D_ROPE, data_src + STREAMING_PACKED_NOPE_BYTES,
                       BULK_ROPE_BYTES, sm.mbar_full(buf));
   };
 
   if (is_io) {
-    asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" : : "n"(PREFILL_IO_MAX_REGS));
+    asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" : : "n"(STREAMING_IO_MAX_REGS));
     // KV gather remains double buffered.  The complete CTA-local V^T stage is
     // released immediately after P x V, so producer can gather N+1 meanwhile.
     uint32_t empty_phase = 1;
     uint32_t full_phase = 0;
-    uint32_t vt_empty_phase[PREFILL_VT_PIPE_STAGES] = {};
+    uint32_t vt_empty_phase[STREAMING_VT_PIPE_STAGES] = {};
 #pragma unroll
-    for (int stage = 0; stage < PREFILL_VT_PIPE_STAGES; ++stage) vt_empty_phase[stage] = 1;
+    for (int stage = 0; stage < STREAMING_VT_PIPE_STAGES; ++stage) vt_empty_phase[stage] = 1;
     int state_idx = 0;
     for (int chunk = chunk_lo; chunk < chunk_hi; ++chunk) {
-      const int buf = (chunk - chunk_lo) % DECODE_KV_BUF_COUNT;
+      const int buf = (chunk - chunk_lo) % STREAMING_KV_BUF_COUNT;
       mbarrier_wait_parity(sm.mbar_empty(state_idx), empty_phase);
-      if (threadIdx.x < PREFILL_MATH_THREADS + PREFILL_GATHER_WARPS * 32) issue_gather(chunk, buf);
+      if (threadIdx.x < STREAMING_MATH_THREADS + STREAMING_GATHER_WARPS * 32)
+        issue_gather(chunk, buf);
       mbarrier_wait_parity(sm.mbar_full(state_idx), full_phase);
-      const int stage = chunk % PREFILL_VT_PIPE_STAGES;
+      const int stage = chunk % STREAMING_VT_PIPE_STAGES;
       mbarrier_wait_parity(sm.mbar_vt_empty(stage), vt_empty_phase[stage]);
-      prepare_nvfp4_vt_from_smem<PREFILL_IO_WARPS * 32, PREFILL_KV_SMEM_STRIDE,
-                                 PREFILL_MATH_THREADS>(sm.kv_fp4(buf), sm.kv_sc(buf),
-                                                       sm.vt_data(stage), sm.vt_sc(stage));
-      bar_sync_t<4, PREFILL_IO_WARPS * 32>();
-      if (threadIdx.x == PREFILL_MATH_THREADS) mbarrier_arrive(sm.mbar_vt_full(stage));
+      prepare_nvfp4_vt_from_smem<STREAMING_IO_WARPS * 32, STREAMING_KV_SMEM_STRIDE,
+                                 STREAMING_MATH_THREADS>(sm.kv_fp4(buf), sm.kv_sc(buf),
+                                                         sm.vt_data(stage), sm.vt_sc(stage));
+      bar_sync_t<4, STREAMING_IO_WARPS * 32>();
+      if (threadIdx.x == STREAMING_MATH_THREADS) mbarrier_arrive(sm.mbar_vt_full(stage));
       vt_empty_phase[stage] ^= 1;
-      if (++state_idx == DECODE_KV_BUF_COUNT) {
+      if (++state_idx == STREAMING_KV_BUF_COUNT) {
         state_idx = 0;
         empty_phase ^= 1;
         full_phase ^= 1;
@@ -357,7 +382,7 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
     return;
   }
 
-  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" : : "n"(PREFILL_MATH_MAX_REGS));
+  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" : : "n"(STREAMING_MATH_MAX_REGS));
 
   const int gid = lane >> 2;
   const int tid = lane & 3;
@@ -365,14 +390,15 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
   for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
     const bf16* q_base =
         q + (size_t)token_idx * NUM_HEADS * D_QK + (size_t)(h_start + group * HPB) * D_QK;
-    quantize_q_nvfp4_to_smem<PREFILL_MATH_THREADS, PREFILL_Q_FP4_STRIDE, PREFILL_Q_SCALE_STRIDE>(
-        sm.q_fp4(group), sm.q_sc(group), sm.q_rope(group), q_base, HPB);
+    quantize_q_nvfp4_to_smem<STREAMING_MATH_THREADS, STREAMING_Q_FP4_STRIDE,
+                             STREAMING_Q_SCALE_STRIDE>(sm.q_fp4(group), sm.q_sc(group),
+                                                       sm.q_rope(group), q_base, HPB);
   }
 
-  float acc_nope[PREFILL_HEAD_GROUPS][PV_GROUPS_PER_WARP][PV_N8_TILES_PER_GROUP][4] = {0};
-  float acc_rope[PREFILL_HEAD_GROUPS][ROPE_N_TILES][4] = {0};
-  float global_max[PREFILL_HEAD_GROUPS][2];
-  float global_sum[PREFILL_HEAD_GROUPS][2];
+  float acc_nope[STREAMING_HEAD_GROUPS][PV_GROUPS_PER_WARP][PV_N8_TILES_PER_GROUP][4] = {0};
+  float acc_rope[STREAMING_HEAD_GROUPS][ROPE_N_TILES][4] = {0};
+  float global_max[STREAMING_HEAD_GROUPS][2];
+  float global_sum[STREAMING_HEAD_GROUPS][2];
 #pragma unroll
   for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
     global_max[group][0] = global_max[group][1] = -1e30f;
@@ -380,10 +406,10 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
   }
 
   uint32_t cons_phase = 0;
-  uint32_t vt_full_phase[PREFILL_VT_PIPE_STAGES] = {};
+  uint32_t vt_full_phase[STREAMING_VT_PIPE_STAGES] = {};
   int cons_idx = 0;
   for (int chunk = chunk_lo; chunk < chunk_hi; ++chunk) {
-    const int buf = (chunk - chunk_lo) % DECODE_KV_BUF_COUNT;
+    const int buf = (chunk - chunk_lo) % STREAMING_KV_BUF_COUNT;
     int section_chunk = chunk;
     int section_len = topk_len;
     const int32_t* section_indices = idx_base;
@@ -394,31 +420,32 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
         section_indices = extra_indices + (size_t)token_idx * extra_topk;
       }
     }
-    const int chunk_start = section_chunk * DECODE_CAND_WINDOW;
-    const int chunk_end = min(chunk_start + DECODE_CAND_WINDOW, section_len);
+    const int chunk_start = section_chunk * STREAMING_CAND_WINDOW;
+    const int chunk_end = min(chunk_start + STREAMING_CAND_WINDOW, section_len);
     mbarrier_wait_parity(sm.mbar_full(cons_idx), cons_phase);
     uint8_t* sm_kv_fp4 = sm.kv_fp4(buf);
     uint8_t* sm_kv_sc = sm.kv_sc(buf);
     bf16* sm_kv_rope = sm.kv_rope(buf);
-    const int warp_first_cand = warp_id * DECODE_ENTRIES_PER_WARP;
+    const int warp_first_cand = warp_id * STREAMING_ENTRIES_PER_WARP;
 
-    float qk[PREFILL_HEAD_GROUPS][DECODE_QK_N_TILES][4] = {0};
+    float qk[STREAMING_HEAD_GROUPS][STREAMING_QK_N_TILES][4] = {0};
 #pragma unroll
     for (int kt = 0; kt < NUM_K64_TILES; ++kt) {
       const int cand_row_base = warp_first_cand;
       const uint32_t scale_b = *reinterpret_cast<const uint32_t*>(
-          sm_kv_sc + (size_t)(cand_row_base + gid) * DECODE_SCALE_BYTES_PER_TOKEN + kt * 4);
+          sm_kv_sc + (size_t)(cand_row_base + gid) * STREAMING_SCALE_BYTES_PER_TOKEN + kt * 4);
       uint32_t b0, b1;
       ldmatrix_load_B_fp8(b0, b1,
-                          sm_kv_fp4 + (size_t)cand_row_base * PREFILL_KV_SMEM_STRIDE + kt * 32,
-                          PREFILL_KV_SMEM_STRIDE, lane);
+                          sm_kv_fp4 + (size_t)cand_row_base * STREAMING_KV_SMEM_STRIDE + kt * 32,
+                          STREAMING_KV_SMEM_STRIDE, lane);
 #pragma unroll
       for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
         const int scale_row = gid + (lane & 1) * 8;
         const uint32_t scale_a = *reinterpret_cast<const uint32_t*>(
-            sm.q_sc(group) + scale_row * PREFILL_Q_SCALE_STRIDE + kt * 4);
+            sm.q_sc(group) + scale_row * STREAMING_Q_SCALE_STRIDE + kt * 4);
         uint32_t a0, a1, a2, a3;
-        ldmatrix_load_A_fp8(a0, a1, a2, a3, sm.q_fp4(group) + kt * 32, PREFILL_Q_FP4_STRIDE, lane);
+        ldmatrix_load_A_fp8(a0, a1, a2, a3, sm.q_fp4(group) + kt * 32, STREAMING_Q_FP4_STRIDE,
+                            lane);
         MmaNvfp4Result r = mma_nvfp4_block_scaled_m16n8k64(a0, a1, a2, a3, b0, b1, qk[group][0][0],
                                                            qk[group][0][1], qk[group][0][2],
                                                            qk[group][0][3], scale_a, scale_b);
@@ -448,10 +475,10 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
       }
     }
 
-    float local_max[PREFILL_HEAD_GROUPS][2];
-    float local_sum[PREFILL_HEAD_GROUPS][2];
-    float p[PREFILL_HEAD_GROUPS][DECODE_QK_N_TILES][4];
-    float block_max_value[PREFILL_HEAD_GROUPS][2];
+    float local_max[STREAMING_HEAD_GROUPS][2];
+    float local_sum[STREAMING_HEAD_GROUPS][2];
+    float p[STREAMING_HEAD_GROUPS][STREAMING_QK_N_TILES][4];
+    float block_max_value[STREAMING_HEAD_GROUPS][2];
 #pragma unroll
     for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
       const int c0 = warp_first_cand + tid * 2;
@@ -486,24 +513,24 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
         local_sum[group][1] += __shfl_xor_sync(0xffffffff, local_sum[group][1], s);
       }
       if (tid == 0) {
-        const int base = (group * DECODE_N_WARPS + warp_id) * HPB;
+        const int base = (group * STREAMING_N_WARPS + warp_id) * HPB;
         sm.warp_max()[base + gid] = local_max[group][0];
         sm.warp_max()[base + gid + 8] = local_max[group][1];
       }
     }
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
 
     if (threadIdx.x < HEADS_PER_CTA) {
       const int group = threadIdx.x / HPB;
       const int head = threadIdx.x % HPB;
       float block_max = -1e30f;
 #pragma unroll
-      for (int w = 0; w < DECODE_N_WARPS; ++w)
-        block_max = fmaxf(block_max, sm.warp_max()[(group * DECODE_N_WARPS + w) * HPB + head]);
+      for (int w = 0; w < STREAMING_N_WARPS; ++w)
+        block_max = fmaxf(block_max, sm.warp_max()[(group * STREAMING_N_WARPS + w) * HPB + head]);
       const int group_base = group * REDUCE_GROUP_STRIDE;
       sm.warp_max()[group_base + head] = block_max;
     }
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
 
 #pragma unroll
     for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
@@ -513,30 +540,30 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
     }
     // All warps must retain block max in registers before warp 0's slots are
     // recycled for the rescaled local sums.
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
 
 #pragma unroll
     for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
       if (tid == 0) {
-        const int base = (group * DECODE_N_WARPS + warp_id) * HPB;
+        const int base = (group * STREAMING_N_WARPS + warp_id) * HPB;
         sm.warp_max()[base + gid] =
             local_sum[group][0] * exp2f(local_max[group][0] - block_max_value[group][0]);
         sm.warp_max()[base + gid + 8] =
             local_sum[group][1] * exp2f(local_max[group][1] - block_max_value[group][1]);
       }
     }
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
 
     if (threadIdx.x < HEADS_PER_CTA) {
       const int group = threadIdx.x / HPB;
       const int head = threadIdx.x % HPB;
       float block_sum = 0.f;
 #pragma unroll
-      for (int w = 0; w < DECODE_N_WARPS; ++w)
-        block_sum += sm.warp_max()[(group * DECODE_N_WARPS + w) * HPB + head];
+      for (int w = 0; w < STREAMING_N_WARPS; ++w)
+        block_sum += sm.warp_max()[(group * STREAMING_N_WARPS + w) * HPB + head];
       sm.warp_max()[group * REDUCE_GROUP_STRIDE + head] = block_sum;
     }
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
 
 #pragma unroll
     for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
@@ -591,60 +618,60 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
       const int c0 = tid * 2;
       const int c1 = c0 + 1;
       bf16* p_group = sm.p_full(group);
-      p_group[gid * PREFILL_P_STRIDE + warp_first_cand + c0] = __float2bfloat16(w0);
-      p_group[gid * PREFILL_P_STRIDE + warp_first_cand + c1] = __float2bfloat16(w1);
-      p_group[(gid + 8) * PREFILL_P_STRIDE + warp_first_cand + c0] = __float2bfloat16(w2);
-      p_group[(gid + 8) * PREFILL_P_STRIDE + warp_first_cand + c1] = __float2bfloat16(w3);
+      p_group[gid * STREAMING_P_STRIDE + warp_first_cand + c0] = __float2bfloat16(w0);
+      p_group[gid * STREAMING_P_STRIDE + warp_first_cand + c1] = __float2bfloat16(w1);
+      p_group[(gid + 8) * STREAMING_P_STRIDE + warp_first_cand + c0] = __float2bfloat16(w2);
+      p_group[(gid + 8) * STREAMING_P_STRIDE + warp_first_cand + c1] = __float2bfloat16(w3);
     }
 
     // P production is local to the math consumer.  In parallel the IO warps
     // transpose/requantize the gathered 64-candidate V tile in shared memory.
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
 
-    for (int task = threadIdx.x; task < HEADS_PER_CTA * DECODE_VT_SCALE_GROUPS;
-         task += PREFILL_MATH_THREADS) {
-      const int head = task / DECODE_VT_SCALE_GROUPS;
+    for (int task = threadIdx.x; task < HEADS_PER_CTA * NVFP4_VT_SCALE_GROUPS;
+         task += STREAMING_MATH_THREADS) {
+      const int head = task / NVFP4_VT_SCALE_GROUPS;
       const int group = head / HPB;
       const int head_in_group = head % HPB;
-      const int cand_group = task % DECODE_VT_SCALE_GROUPS;
-      quantize_bf16_group16_to_nvfp4(
-          sm.p_full(group) + head_in_group * PREFILL_P_STRIDE + cand_group * SF_VEC_SIZE,
-          sm.w_fp4(group) + head_in_group * PREFILL_W_PACKED_STRIDE +
+      const int cand_group = task % NVFP4_VT_SCALE_GROUPS;
+      quantize_group16_to_nvfp4(
+          sm.p_full(group) + head_in_group * STREAMING_P_STRIDE + cand_group * SF_VEC_SIZE,
+          sm.w_fp4(group) + head_in_group * STREAMING_W_PACKED_STRIDE +
               cand_group * FP4_PACKED_PER_GROUP,
-          sm.w_sc(group) + head_in_group * DECODE_VT_SCALE_GROUPS + cand_group);
+          sm.w_sc(group) + head_in_group * NVFP4_VT_SCALE_GROUPS + cand_group);
     }
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
-    const int vt_stage = chunk % PREFILL_VT_PIPE_STAGES;
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
+    const int vt_stage = chunk % STREAMING_VT_PIPE_STAGES;
     mbarrier_wait_parity(sm.mbar_vt_full(vt_stage), vt_full_phase[vt_stage]);
 
-    uint32_t p_scale_a[PREFILL_HEAD_GROUPS];
-    uint32_t p_a0[PREFILL_HEAD_GROUPS], p_a1[PREFILL_HEAD_GROUPS];
-    uint32_t p_a2[PREFILL_HEAD_GROUPS], p_a3[PREFILL_HEAD_GROUPS];
+    uint32_t p_scale_a[STREAMING_HEAD_GROUPS];
+    uint32_t p_a0[STREAMING_HEAD_GROUPS], p_a1[STREAMING_HEAD_GROUPS];
+    uint32_t p_a2[STREAMING_HEAD_GROUPS], p_a3[STREAMING_HEAD_GROUPS];
 #pragma unroll
     for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
       const int p_scale_row = gid + (lane & 1) * 8;
       p_scale_a[group] =
-          *reinterpret_cast<const uint32_t*>(sm.w_sc(group) + p_scale_row * DECODE_VT_SCALE_GROUPS);
+          *reinterpret_cast<const uint32_t*>(sm.w_sc(group) + p_scale_row * NVFP4_VT_SCALE_GROUPS);
       ldmatrix_load_A_fp8(p_a0[group], p_a1[group], p_a2[group], p_a3[group], sm.w_fp4(group),
-                          PREFILL_W_PACKED_STRIDE, lane);
+                          STREAMING_W_PACKED_STRIDE, lane);
     }
 
 #pragma unroll
     for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
-      const int scale_group = slot * DECODE_N_WARPS + warp_id;
+      const int scale_group = slot * STREAMING_N_WARPS + warp_id;
       if (scale_group >= PV_SCALE_GROUPS) continue;
       const int dim = scale_group * SF_VEC_SIZE;
       const uint8_t* vt_data = sm.vt_data(vt_stage);
       const uint8_t* vt_sc = sm.vt_sc(vt_stage);
       uint32_t b00, b01, b10, b11;
-      ldmatrix_load_B_fp8(b00, b01, vt_data + dim * DECODE_VT_PACKED_K_BYTES,
-                          DECODE_VT_PACKED_K_BYTES, lane);
-      ldmatrix_load_B_fp8(b10, b11, vt_data + (dim + 8) * DECODE_VT_PACKED_K_BYTES,
-                          DECODE_VT_PACKED_K_BYTES, lane);
+      ldmatrix_load_B_fp8(b00, b01, vt_data + dim * NVFP4_VT_PACKED_K_BYTES,
+                          NVFP4_VT_PACKED_K_BYTES, lane);
+      ldmatrix_load_B_fp8(b10, b11, vt_data + (dim + 8) * NVFP4_VT_PACKED_K_BYTES,
+                          NVFP4_VT_PACKED_K_BYTES, lane);
       const uint32_t scale_b0 =
-          *reinterpret_cast<const uint32_t*>(vt_sc + (dim + gid) * DECODE_VT_SCALE_GROUPS);
+          *reinterpret_cast<const uint32_t*>(vt_sc + (dim + gid) * NVFP4_VT_SCALE_GROUPS);
       const uint32_t scale_b1 =
-          *reinterpret_cast<const uint32_t*>(vt_sc + (dim + 8 + gid) * DECODE_VT_SCALE_GROUPS);
+          *reinterpret_cast<const uint32_t*>(vt_sc + (dim + 8 + gid) * NVFP4_VT_SCALE_GROUPS);
 #pragma unroll
       for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
         MmaNvfp4Result r0 =
@@ -664,19 +691,19 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
       }
     }
 
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
     if (threadIdx.x == 0) mbarrier_arrive(sm.mbar_vt_empty(vt_stage));
     vt_full_phase[vt_stage] ^= 1;
 
     const int rope_dim_base = warp_id * ROPE_DIMS_PER_WARP;
 #pragma unroll
     for (int ks = 0; ks < ROPE_K_ITERS; ++ks) {
-      uint32_t rope_a0[PREFILL_HEAD_GROUPS], rope_a1[PREFILL_HEAD_GROUPS];
-      uint32_t rope_a2[PREFILL_HEAD_GROUPS], rope_a3[PREFILL_HEAD_GROUPS];
+      uint32_t rope_a0[STREAMING_HEAD_GROUPS], rope_a1[STREAMING_HEAD_GROUPS];
+      uint32_t rope_a2[STREAMING_HEAD_GROUPS], rope_a3[STREAMING_HEAD_GROUPS];
 #pragma unroll
       for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
         ldmatrix_load_A_bf16(rope_a0[group], rope_a1[group], rope_a2[group], rope_a3[group],
-                             sm.p_full(group) + ks * 16, PREFILL_P_STRIDE, lane);
+                             sm.p_full(group) + ks * 16, STREAMING_P_STRIDE, lane);
       }
 #pragma unroll
       for (int nt = 0; nt < ROPE_N_TILES; ++nt) {
@@ -711,9 +738,9 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
       }
     }
 
-    bar_sync_t<3, PREFILL_MATH_THREADS>();
+    bar_sync_t<3, STREAMING_MATH_THREADS>();
     if (threadIdx.x == 0) mbarrier_arrive(sm.mbar_empty(cons_idx));
-    if (++cons_idx == DECODE_KV_BUF_COUNT) {
+    if (++cons_idx == STREAMING_KV_BUF_COUNT) {
       cons_idx = 0;
       cons_phase ^= 1;
     }
@@ -758,7 +785,7 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
       }
     }
   }
-  bar_sync_t<3, PREFILL_MATH_THREADS>();
+  bar_sync_t<3, STREAMING_MATH_THREADS>();
 
 #pragma unroll
   for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
@@ -777,7 +804,7 @@ __global__ void __launch_bounds__(PREFILL_BLOCK_THREADS, 1) sparse_mla_prefill_d
     const size_t head_stride = write_direct ? D_V : (size_t)num_splits * D_V;
 #pragma unroll
     for (int slot = 0; slot < PV_GROUPS_PER_WARP; ++slot) {
-      const int scale_group = slot * DECODE_N_WARPS + warp_id;
+      const int scale_group = slot * STREAMING_N_WARPS + warp_id;
       if (scale_group >= PV_SCALE_GROUPS) continue;
 #pragma unroll
       for (int nt = 0; nt < PV_N8_TILES_PER_GROUP; ++nt) {

--- a/include/flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh
@@ -479,18 +479,21 @@ __global__ void __launch_bounds__(STREAMING_BLOCK_THREADS, 1)
     float local_sum[STREAMING_HEAD_GROUPS][2];
     float p[STREAMING_HEAD_GROUPS][STREAMING_QK_N_TILES][4];
     float block_max_value[STREAMING_HEAD_GROUPS][2];
+    const int c0 = warp_first_cand + tid * 2;
+    const int c1 = c0 + 1;
+    const int abs_c0 = chunk_start + c0;
+    const int abs_c1 = chunk_start + c1;
+    const int idx0 = abs_c0 < section_len ? section_indices[abs_c0] : -1;
+    const int idx1 = abs_c1 < section_len ? section_indices[abs_c1] : -1;
+    const bool valid_c0 = abs_c0 < chunk_end && idx0 >= 0;
+    const bool valid_c1 = abs_c1 < chunk_end && idx1 >= 0;
+    const float qk_scale = sm_scale * LOG2E;
 #pragma unroll
     for (int group = 0; group < VALID_HEAD_GROUPS; ++group) {
-      const int c0 = warp_first_cand + tid * 2;
-      const int c1 = c0 + 1;
-      const int abs_c0 = chunk_start + c0;
-      const int abs_c1 = chunk_start + c1;
-      const int idx0 = abs_c0 < section_len ? section_indices[abs_c0] : -1;
-      const int idx1 = abs_c1 < section_len ? section_indices[abs_c1] : -1;
-      if (abs_c0 >= chunk_end || idx0 < 0) qk[group][0][0] = qk[group][0][2] = -1e30f;
-      if (abs_c1 >= chunk_end || idx1 < 0) qk[group][0][1] = qk[group][0][3] = -1e30f;
-#pragma unroll
-      for (int i = 0; i < 4; ++i) qk[group][0][i] *= sm_scale * LOG2E;
+      qk[group][0][0] = valid_c0 ? qk[group][0][0] * qk_scale : -1e30f;
+      qk[group][0][2] = valid_c0 ? qk[group][0][2] * qk_scale : -1e30f;
+      qk[group][0][1] = valid_c1 ? qk[group][0][1] * qk_scale : -1e30f;
+      qk[group][0][3] = valid_c1 ? qk[group][0][3] * qk_scale : -1e30f;
 
       local_max[group][0] = fmaxf(qk[group][0][0], qk[group][0][1]);
       local_max[group][1] = fmaxf(qk[group][0][2], qk[group][0][3]);
@@ -501,10 +504,10 @@ __global__ void __launch_bounds__(STREAMING_BLOCK_THREADS, 1)
         local_max[group][1] =
             fmaxf(local_max[group][1], __shfl_xor_sync(0xffffffff, local_max[group][1], s));
       }
-      p[group][0][0] = exp2f(qk[group][0][0] - local_max[group][0]);
-      p[group][0][1] = exp2f(qk[group][0][1] - local_max[group][0]);
-      p[group][0][2] = exp2f(qk[group][0][2] - local_max[group][1]);
-      p[group][0][3] = exp2f(qk[group][0][3] - local_max[group][1]);
+      p[group][0][0] = valid_c0 ? exp2f(qk[group][0][0] - local_max[group][0]) : 0.f;
+      p[group][0][1] = valid_c1 ? exp2f(qk[group][0][1] - local_max[group][0]) : 0.f;
+      p[group][0][2] = valid_c0 ? exp2f(qk[group][0][2] - local_max[group][1]) : 0.f;
+      p[group][0][3] = valid_c1 ? exp2f(qk[group][0][3] - local_max[group][1]) : 0.f;
       local_sum[group][0] = p[group][0][0] + p[group][0][1];
       local_sum[group][1] = p[group][0][2] + p[group][0][3];
 #pragma unroll

--- a/tests/attention/test_sparse_mla_nvfp4_sm120.py
+++ b/tests/attention/test_sparse_mla_nvfp4_sm120.py
@@ -19,15 +19,12 @@ import pytest
 import torch
 
 import flashinfer
-from flashinfer.autotuner import OptimizationProfile
 from flashinfer.mla import (
     nvfp4_quantize_append_sparse_mla_cache,
     nvfp4_quantize_pack_sparse_mla_cache,
 )
 from flashinfer.mla._core import _nvfp4_sparse_mla_workspace
 from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
-    _SparseMlaNvfp4DecodeRunner,
-    _decode_token_bucket,
     _nvfp4_sparse_mla_decode,
     _nvfp4_sparse_mla_prefill,
     _nvfp4_sparse_mla_m16n8k64_candidate_major,
@@ -54,36 +51,11 @@ def test_nvfp4_sparse_mla_reuses_fp8_public_api() -> None:
     assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
     assert parameter.default == "fp8"
 
-
-def test_nvfp4_sparse_mla_decode_autotune_contract() -> None:
-    """The NVFP4 tuner covers live batch buckets and every split-K tactic."""
-    inputs = [
-        torch.empty((8, 64, 512), dtype=torch.bfloat16, device="meta"),
-        torch.empty((8, 128), dtype=torch.int32, device="meta"),
-        torch.empty((8, 64, 10, 512), dtype=torch.bfloat16, device="meta"),
-        torch.empty((8, 64, 10), dtype=torch.float32, device="meta"),
-        torch.empty((8, 64, 512), dtype=torch.bfloat16, device="meta"),
-        torch.empty((8, 64), dtype=torch.float32, device="meta"),
-        torch.empty((8,), dtype=torch.int32, device="meta"),
-        torch.empty((64,), dtype=torch.float32, device="meta"),
-        torch.empty((8, 512), dtype=torch.int32, device="meta"),
-        torch.empty((8,), dtype=torch.int32, device="meta"),
-    ]
-    runner = _SparseMlaNvfp4DecodeRunner(
-        object(), primary_page_size=64, extra_page_size=2
-    )
-    profile = OptimizationProfile(shapes=[], tensor_initializers=[])
-
-    assert runner.get_valid_tactics(inputs, profile) == list(range(1, 11))
-    assert runner.get_cache_key_extras(inputs) == (True, True, 512, True, 64, 2)
-    assert [_decode_token_bucket(tokens) for tokens in (1, 2, 8, 9, 33, 65)] == [
-        1,
-        4,
-        8,
-        16,
-        64,
-        64,
-    ]
+    wrapper_parameter = inspect.signature(
+        flashinfer.mla.SparseMLASm120Wrapper.__init__
+    ).parameters["kv_cache_format"]
+    assert wrapper_parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert wrapper_parameter.default == "fp8"
 
 
 def _require_sm120() -> None:
@@ -609,6 +581,49 @@ def test_nvfp4_sparse_mla_decode_matches_dequantized_reference(
     )
     torch.testing.assert_close(prefill_output, reference, atol=5e-2, rtol=5e-2)
     torch.testing.assert_close(prefill_lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [2, 65])
+def test_nvfp4_sparse_mla_shared_wrapper_matches_reference(num_tokens: int) -> None:
+    """The existing SM120 wrapper routes NVFP4 through its independent planner."""
+    _require_sm120()
+    torch.manual_seed(20260911 + num_tokens)
+    num_heads, topk = 16, 128
+    kv_bf16 = (
+        torch.randn(4, 64, 512, dtype=torch.bfloat16, device="cuda") / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, 4 * 64, (num_tokens, topk), dtype=torch.int32, device="cuda"
+    )
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16)
+    output = torch.empty_like(q)
+    runner = flashinfer.mla.SparseMLASm120Wrapper(
+        max_num_tokens=num_tokens,
+        max_num_heads=num_heads,
+        kv_cache_format="nvfp4",
+        device=q.device,
+    )
+    lse = runner.run(
+        q,
+        cache,
+        indices,
+        output,
+        512**-0.5,
+        return_lse=True,
+    )
+
+    reference, reference_lse = _reference_sparse_attention(
+        _dequantize_nvfp4_query(q),
+        _dequantize_nvfp4_cache(cache),
+        indices,
+        512**-0.5,
+    )
+    torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(lse, reference_lse, atol=2e-2, rtol=2e-2)
 
 
 @pytest.mark.parametrize("extra_page_size,extra_topk", [(2, 128), (64, 512)])

--- a/tests/attention/test_sparse_mla_nvfp4_sm120.py
+++ b/tests/attention/test_sparse_mla_nvfp4_sm120.py
@@ -335,6 +335,54 @@ def test_nvfp4_sparse_mla_append_writes_only_selected_slots(page_size):
         assert torch.all(scales[0, 1] == 0xA5)
 
 
+@pytest.mark.parametrize("misaligned", ["input", "cache_base", "page_stride"])
+def test_nvfp4_sparse_mla_append_rejects_misaligned_vector_accesses(
+    misaligned: str,
+) -> None:
+    """Vectorized BF16/uint4 accesses require a 16-byte-aligned cache ABI."""
+    _require_sm120()
+    latent_kv = torch.empty(1, 512, dtype=torch.bfloat16, device="cuda")
+    slots = torch.zeros(1, dtype=torch.int32, device="cuda")
+    cache = torch.empty(2, 2, _BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda")
+    expected_error = "kv_cache"
+
+    if misaligned == "input":
+        input_storage = torch.empty(513, dtype=torch.bfloat16, device="cuda")
+        latent_kv = input_storage[1:].view(1, 512)
+        expected_error = "latent_kv"
+    elif misaligned == "cache_base":
+        cache_storage = torch.empty(cache.numel() + 1, dtype=torch.uint8, device="cuda")
+        cache = cache_storage[1:].view_as(cache)
+    else:
+        page_stride = 2 * _BYTES_PER_TOKEN + 1
+        cache_storage = torch.empty(
+            page_stride + 2 * _BYTES_PER_TOKEN,
+            dtype=torch.uint8,
+            device="cuda",
+        )
+        cache = torch.as_strided(
+            cache_storage,
+            size=(2, 2, _BYTES_PER_TOKEN),
+            stride=(page_stride, _BYTES_PER_TOKEN, 1),
+        )
+
+    with pytest.raises(RuntimeError, match=rf"{expected_error}.*16"):
+        nvfp4_quantize_append_sparse_mla_cache(latent_kv, slots, cache)
+
+
+def test_nvfp4_sparse_mla_append_rejects_duplicate_valid_slots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_sm120()
+    monkeypatch.setenv("FLASHINFER_VALIDATE_INPUTS", "1")
+    latent_kv = torch.empty(2, 512, dtype=torch.bfloat16, device="cuda")
+    slots = torch.zeros(2, dtype=torch.int32, device="cuda")
+    cache = torch.empty(1, 2, _BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda")
+
+    with pytest.raises(ValueError, match="must be unique"):
+        nvfp4_quantize_append_sparse_mla_cache(latent_kv, slots, cache)
+
+
 def test_nvfp4_sparse_mla_pack_rejects_wrong_dtype():
     _require_sm120()
     latent_kv = torch.empty(1, 2, 512, dtype=torch.float16, device="cuda")
@@ -624,6 +672,62 @@ def test_nvfp4_sparse_mla_shared_wrapper_matches_reference(num_tokens: int) -> N
     )
     torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
     torch.testing.assert_close(lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("num_tokens", [2, 65])
+def test_nvfp4_sparse_mla_shared_wrapper_normalizes_singleton_indices(
+    num_tokens: int,
+) -> None:
+    """The shared FP8/NVFP4 ABI accepts [T, 1, topk] for both cache sections."""
+    _require_sm120()
+    torch.manual_seed(20260912 + num_tokens)
+    num_heads, topk = 16, 128
+    main_kv = torch.randn(4, 64, 512, dtype=torch.bfloat16, device="cuda") / 10
+    extra_kv = torch.randn(64, 2, 512, dtype=torch.bfloat16, device="cuda") / 10
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+        / 10
+    )
+    indices = torch.randint(
+        0, 4 * 64, (num_tokens, topk), dtype=torch.int32, device="cuda"
+    )
+    extra_indices = torch.randint(
+        0, 64 * 2, (num_tokens, topk), dtype=torch.int32, device="cuda"
+    )
+    main_cache = nvfp4_quantize_pack_sparse_mla_cache(main_kv)
+    extra_cache = nvfp4_quantize_pack_sparse_mla_cache(extra_kv)
+    output_2d = torch.empty_like(q)
+    output_3d = torch.empty_like(q)
+    runner = flashinfer.mla.SparseMLASm120Wrapper(
+        max_num_tokens=num_tokens,
+        max_num_heads=num_heads,
+        kv_cache_format="nvfp4",
+        device=q.device,
+    )
+
+    lse_2d = runner.run(
+        q,
+        main_cache,
+        indices,
+        output_2d,
+        512**-0.5,
+        extra_kv_cache=extra_cache,
+        extra_indices=extra_indices,
+        return_lse=True,
+    ).clone()
+    lse_3d = runner.run(
+        q,
+        main_cache,
+        indices.unsqueeze(1),
+        output_3d,
+        512**-0.5,
+        extra_kv_cache=extra_cache,
+        extra_indices=extra_indices.unsqueeze(1),
+        return_lse=True,
+    )
+
+    torch.testing.assert_close(output_3d, output_2d, atol=0, rtol=0)
+    torch.testing.assert_close(lse_3d, lse_2d, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize("extra_page_size,extra_topk", [(2, 128), (64, 512)])
@@ -1086,3 +1190,67 @@ def test_nvfp4_sparse_mla_decode_zero_topk_length(with_sink: bool) -> None:
         assert torch.all(lse < -1e29)
     else:
         torch.testing.assert_close(lse, attn_sink.unsqueeze(0) * math.log2(math.e))
+
+
+@pytest.mark.parametrize("with_sink", [False, True])
+def test_nvfp4_sparse_mla_invalid_nonempty_chunks_have_zero_probability(
+    with_sink: bool,
+) -> None:
+    """Negative candidates stay masked when topk_length itself is nonzero."""
+    _require_sm120()
+    torch.manual_seed(20260913 + int(with_sink))
+    num_heads, topk = 16, 128
+    kv = torch.randn(2, 64, 512, dtype=torch.bfloat16, device="cuda")
+    q = torch.randn(1, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv)
+    indices = torch.full((1, topk), -1, dtype=torch.int32, device="cuda")
+    attn_sink = (
+        torch.linspace(-2.0, 2.0, num_heads, dtype=torch.float32, device="cuda")
+        if with_sink
+        else None
+    )
+
+    for attention in (_nvfp4_sparse_mla_decode, _nvfp4_sparse_mla_prefill):
+        output, lse = attention(
+            q,
+            cache,
+            indices,
+            512**-0.5,
+            attn_sink=attn_sink,
+        )
+        assert torch.count_nonzero(output) == 0
+        if attn_sink is None:
+            assert torch.all(lse < -1e29)
+        else:
+            torch.testing.assert_close(lse, attn_sink.unsqueeze(0) * math.log2(math.e))
+
+
+@pytest.mark.parametrize("invalid_chunk", ["first", "last"])
+def test_nvfp4_sparse_mla_skips_fully_invalid_chunk_in_nonempty_row(
+    invalid_chunk: str,
+) -> None:
+    """An invalid tile must not change the online softmax around a valid tile."""
+    _require_sm120()
+    torch.manual_seed(20260915 + int(invalid_chunk == "last"))
+    num_heads, topk = 16, 128
+    kv = (torch.randn(2, 64, 512, dtype=torch.bfloat16, device="cuda") / 10).clamp(
+        -1, 1
+    )
+    q = (
+        torch.randn(1, num_heads, 512, dtype=torch.bfloat16, device="cuda") / 10
+    ).clamp(-1, 1)
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv)
+    indices = torch.randint(0, 128, (1, topk), dtype=torch.int32, device="cuda")
+    invalid_slice = slice(0, 64) if invalid_chunk == "first" else slice(64, 128)
+    indices[:, invalid_slice] = -1
+    reference, reference_lse = _reference_sparse_attention(
+        _dequantize_nvfp4_query(q),
+        _dequantize_nvfp4_cache(cache),
+        indices,
+        512**-0.5,
+    )
+
+    for attention in (_nvfp4_sparse_mla_decode, _nvfp4_sparse_mla_prefill):
+        output, lse = attention(q, cache, indices, 512**-0.5)
+        torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+        torch.testing.assert_close(lse, reference_lse, atol=2e-2, rtol=2e-2)

--- a/tests/attention/test_sparse_mla_nvfp4_sm120.py
+++ b/tests/attention/test_sparse_mla_nvfp4_sm120.py
@@ -1,0 +1,1073 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.autotuner import OptimizationProfile
+from flashinfer.mla import (
+    nvfp4_quantize_append_sparse_mla_cache,
+    nvfp4_quantize_pack_sparse_mla_cache,
+)
+from flashinfer.mla._core import _nvfp4_sparse_mla_workspace
+from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
+    _SparseMlaNvfp4DecodeRunner,
+    _decode_token_bucket,
+    _nvfp4_sparse_mla_decode,
+    _nvfp4_sparse_mla_prefill,
+    _nvfp4_sparse_mla_m16n8k64_candidate_major,
+    _nvfp4_sparse_mla_m16n32k64,
+)
+from flashinfer.utils import is_sm120a_supported
+
+
+_D_NOPE = 448
+_D_ROPE = 64
+_PACKED_NOPE_BYTES = 224
+_ROPE_BYTES = 128
+_DATA_BYTES_PER_TOKEN = 352
+_SCALE_BYTES_PER_TOKEN = 32
+_BYTES_PER_TOKEN = 384
+
+
+def test_nvfp4_sparse_mla_reuses_fp8_public_api() -> None:
+    """The format selector is additive, keyword-only, and FP8 by default."""
+    parameter = inspect.signature(
+        flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4
+    ).parameters["kv_cache_format"]
+
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameter.default == "fp8"
+
+
+def test_nvfp4_sparse_mla_decode_autotune_contract() -> None:
+    """The NVFP4 tuner covers live batch buckets and every split-K tactic."""
+    inputs = [
+        torch.empty((8, 64, 512), dtype=torch.bfloat16, device="meta"),
+        torch.empty((8, 128), dtype=torch.int32, device="meta"),
+        torch.empty((8, 64, 10, 512), dtype=torch.bfloat16, device="meta"),
+        torch.empty((8, 64, 10), dtype=torch.float32, device="meta"),
+        torch.empty((8, 64, 512), dtype=torch.bfloat16, device="meta"),
+        torch.empty((8, 64), dtype=torch.float32, device="meta"),
+        torch.empty((8,), dtype=torch.int32, device="meta"),
+        torch.empty((64,), dtype=torch.float32, device="meta"),
+        torch.empty((8, 512), dtype=torch.int32, device="meta"),
+        torch.empty((8,), dtype=torch.int32, device="meta"),
+    ]
+    runner = _SparseMlaNvfp4DecodeRunner(
+        object(), primary_page_size=64, extra_page_size=2
+    )
+    profile = OptimizationProfile(shapes=[], tensor_initializers=[])
+
+    assert runner.get_valid_tactics(inputs, profile) == list(range(1, 11))
+    assert runner.get_cache_key_extras(inputs) == (True, True, 512, True, 64, 2)
+    assert [_decode_token_bucket(tokens) for tokens in (1, 2, 8, 9, 33, 65)] == [
+        1,
+        4,
+        8,
+        16,
+        64,
+        64,
+    ]
+
+
+def _require_sm120() -> None:
+    if not is_sm120a_supported(torch.device("cuda")):
+        pytest.skip("NVFP4 sparse MLA requires SM120/SM121")
+
+
+def _split_cache(cache: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if cache.shape[1] == 1:
+        page_size = cache.shape[2]
+    else:
+        page_size = cache.shape[1]
+    flat = cache.reshape(cache.shape[0], page_size * _BYTES_PER_TOKEN)
+    data = flat[:, : page_size * _DATA_BYTES_PER_TOKEN].reshape(
+        cache.shape[0], page_size, _DATA_BYTES_PER_TOKEN
+    )
+    scales = flat[:, page_size * _DATA_BYTES_PER_TOKEN :].reshape(
+        cache.shape[0], page_size, _SCALE_BYTES_PER_TOKEN
+    )
+    return data, scales
+
+
+def _reference_rows(latent_kv: torch.Tensor) -> tuple[torch.Tensor, ...]:
+    rows = latent_kv.reshape(-1, _D_NOPE + _D_ROPE)
+    global_scale = torch.ones(1, dtype=torch.float32, device=latent_kv.device)
+    packed, scales = flashinfer.nvfp4_kv_quantize(
+        rows[:, :_D_NOPE].contiguous(), global_scale
+    )
+    rope = (
+        rows[:, _D_NOPE:]
+        .contiguous()
+        .view(torch.uint8)
+        .reshape(rows.shape[0], _ROPE_BYTES)
+    )
+    return packed, scales.view(torch.uint8), rope
+
+
+def _dequantize_linear_nvfp4(
+    packed: torch.Tensor, scales: torch.Tensor
+) -> torch.Tensor:
+    lut = torch.tensor(
+        [
+            0.0,
+            0.5,
+            1.0,
+            1.5,
+            2.0,
+            3.0,
+            4.0,
+            6.0,
+            -0.0,
+            -0.5,
+            -1.0,
+            -1.5,
+            -2.0,
+            -3.0,
+            -4.0,
+            -6.0,
+        ],
+        dtype=torch.float32,
+        device=packed.device,
+    )
+    codes = torch.stack((packed & 0xF, packed >> 4), dim=-1).reshape(
+        packed.shape[0], -1
+    )
+    values = lut[codes.long()]
+    scale_values = scales.view(torch.float8_e4m3fn).float()
+    return values * scale_values.repeat_interleave(16, dim=-1)
+
+
+def _dequantize_nvfp4_cache(cache: torch.Tensor) -> torch.Tensor:
+    data, scales = _split_cache(cache)
+    num_pages, page_size = data.shape[:2]
+    nope = _dequantize_linear_nvfp4(
+        data[..., :_PACKED_NOPE_BYTES].reshape(-1, _PACKED_NOPE_BYTES),
+        scales[..., : _D_NOPE // 16].reshape(-1, _D_NOPE // 16),
+    )
+    rope = (
+        data[..., _PACKED_NOPE_BYTES:]
+        .contiguous()
+        .view(torch.bfloat16)
+        .reshape(-1, _D_ROPE)
+        .float()
+    )
+    return torch.cat((nope, rope), dim=-1).reshape(
+        num_pages, page_size, 1, _D_NOPE + _D_ROPE
+    )
+
+
+def _dequantize_nvfp4_query(q: torch.Tensor) -> torch.Tensor:
+    q_flat = q.reshape(-1, _D_NOPE + _D_ROPE)
+    global_scale = torch.ones(1, dtype=torch.float32, device=q.device)
+    packed, scales = flashinfer.nvfp4_kv_quantize(
+        q_flat[:, :_D_NOPE].contiguous(), global_scale
+    )
+    nope = _dequantize_linear_nvfp4(packed, scales)
+    return torch.cat((nope, q_flat[:, _D_NOPE:].float()), dim=-1).reshape_as(q.float())
+
+
+def _reference_sparse_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    *,
+    topk_length: torch.Tensor | None = None,
+    attn_sink: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    num_tokens, num_heads, dim = q.shape
+    topk = indices.shape[1]
+    invalid = indices < 0
+    if topk_length is not None:
+        positions = torch.arange(topk, device=q.device).unsqueeze(0)
+        invalid = invalid | (positions >= topk_length.unsqueeze(1))
+    gathered = kv.reshape(-1, dim).index_select(
+        0, indices.clamp_min(0).reshape(-1).long()
+    )
+    gathered = gathered.reshape(num_tokens, topk, dim)
+    logits = torch.einsum("thd,tkd->thk", q, gathered) * sm_scale
+    logits.masked_fill_(invalid.unsqueeze(1), float("-inf"))
+    lse = torch.logsumexp(logits, dim=-1)
+    safe_lse = torch.where(torch.isneginf(lse), torch.inf, lse)
+    weights = torch.exp(logits - safe_lse.unsqueeze(-1))
+    output = torch.einsum("thk,tkd->thd", weights, gathered)
+
+    if attn_sink is not None:
+        sink = attn_sink.float().unsqueeze(0)
+        output *= torch.sigmoid(lse - sink).unsqueeze(-1)
+        lse = torch.logaddexp(lse, sink)
+
+    return output.to(torch.bfloat16), lse * math.log2(math.e)
+
+
+@pytest.mark.parametrize("page_size", [2, 64])
+@pytest.mark.parametrize("kv_layout", ["HND", "NHD"])
+def test_nvfp4_sparse_mla_full_page_pack(page_size, kv_layout):
+    _require_sm120()
+    torch.manual_seed(42)
+    latent_kv = torch.randn(
+        2, page_size, _D_NOPE + _D_ROPE, dtype=torch.bfloat16, device="cuda"
+    )
+
+    cache = nvfp4_quantize_pack_sparse_mla_cache(latent_kv, kv_layout=kv_layout)
+    data, scales = _split_cache(cache)
+    packed_ref, scales_ref, rope_ref = _reference_rows(latent_kv)
+
+    assert cache.dtype == torch.uint8
+    expected_shape = (
+        (2, 1, page_size, _BYTES_PER_TOKEN)
+        if kv_layout == "HND"
+        else (2, page_size, 1, _BYTES_PER_TOKEN)
+    )
+    assert cache.shape == expected_shape
+    torch.testing.assert_close(
+        data[..., :_PACKED_NOPE_BYTES].reshape_as(packed_ref), packed_ref
+    )
+    torch.testing.assert_close(
+        data[..., _PACKED_NOPE_BYTES:].reshape_as(rope_ref), rope_ref
+    )
+    torch.testing.assert_close(scales[..., :28].reshape_as(scales_ref), scales_ref)
+    assert torch.count_nonzero(scales[..., 28:]) == 0
+
+
+@pytest.mark.parametrize("page_size", [2, 64])
+@pytest.mark.parametrize("index_dtype", [torch.int32, torch.int64])
+def test_nvfp4_sparse_mla_incremental_append_matches_full_pack(page_size, index_dtype):
+    _require_sm120()
+    torch.manual_seed(7)
+    num_pages = 2
+    latent_kv = torch.randn(
+        num_pages,
+        page_size,
+        _D_NOPE + _D_ROPE,
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    full_cache = nvfp4_quantize_pack_sparse_mla_cache(latent_kv)
+    append_cache = torch.full_like(full_cache, 0xA5)
+    slots = torch.arange(num_pages * page_size, dtype=index_dtype, device="cuda")
+
+    nvfp4_quantize_append_sparse_mla_cache(
+        latent_kv.reshape(-1, _D_NOPE + _D_ROPE), slots, append_cache
+    )
+    torch.testing.assert_close(append_cache, full_cache)
+
+
+def test_nvfp4_sparse_mla_incremental_append_accepts_3d_cache() -> None:
+    """vLLM uses the latent-head-free [pages, page_size, bytes] shorthand."""
+    _require_sm120()
+    torch.manual_seed(8)
+    latent_kv = torch.randn(2, 64, 512, dtype=torch.bfloat16, device="cuda")
+    expected = nvfp4_quantize_pack_sparse_mla_cache(latent_kv, kv_layout="NHD").squeeze(
+        2
+    )
+    actual = torch.empty_like(expected)
+    slots = torch.arange(128, dtype=torch.int64, device="cuda")
+    nvfp4_quantize_append_sparse_mla_cache(latent_kv.reshape(-1, 512), slots, actual)
+    torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize("page_size", [2, 64])
+def test_nvfp4_sparse_mla_pack_and_append_accept_page_stride(page_size: int) -> None:
+    """Packed vLLM pools leave padding between logical cache pages."""
+    _require_sm120()
+    torch.manual_seed(9 + page_size)
+    num_pages = 3
+    latent_kv = torch.randn(
+        num_pages, page_size, 512, dtype=torch.bfloat16, device="cuda"
+    )
+    expected = nvfp4_quantize_pack_sparse_mla_cache(latent_kv, kv_layout="NHD").squeeze(
+        2
+    )
+    logical_page_bytes = page_size * _BYTES_PER_TOKEN
+    page_stride = logical_page_bytes + 3 * _BYTES_PER_TOKEN
+
+    def make_strided_cache() -> torch.Tensor:
+        backing = torch.full(
+            (num_pages * page_stride,), 0xA5, dtype=torch.uint8, device="cuda"
+        )
+        return torch.as_strided(
+            backing,
+            size=(num_pages, page_size, _BYTES_PER_TOKEN),
+            stride=(page_stride, _BYTES_PER_TOKEN, 1),
+        )
+
+    append_cache = make_strided_cache()
+    slots = torch.arange(num_pages * page_size, dtype=torch.int64, device="cuda")
+    nvfp4_quantize_append_sparse_mla_cache(
+        latent_kv.reshape(-1, 512), slots, append_cache
+    )
+
+    # A page is internally opaque but contiguous, so compare its complete byte
+    # payload against the independently packed contiguous implementation.
+    for page in range(num_pages):
+        torch.testing.assert_close(
+            append_cache[page].reshape(-1), expected[page].reshape(-1), atol=0, rtol=0
+        )
+
+
+@pytest.mark.parametrize("page_size", [2, 64])
+def test_nvfp4_sparse_mla_append_writes_only_selected_slots(page_size):
+    _require_sm120()
+    torch.manual_seed(11)
+    num_pages = 2
+    inputs = torch.randn(4, _D_NOPE + _D_ROPE, dtype=torch.bfloat16, device="cuda")
+    slots = torch.tensor(
+        [0, num_pages * page_size - 1, -1, num_pages * page_size],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    cache = torch.full(
+        (num_pages, 1, page_size, _BYTES_PER_TOKEN),
+        0xA5,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+    nvfp4_quantize_append_sparse_mla_cache(inputs, slots, cache)
+    data, scales = _split_cache(cache)
+    packed_ref, scales_ref, rope_ref = _reference_rows(inputs)
+
+    for input_idx, slot in enumerate((0, num_pages * page_size - 1)):
+        page_idx, entry_idx = divmod(slot, page_size)
+        torch.testing.assert_close(
+            data[page_idx, entry_idx, :_PACKED_NOPE_BYTES], packed_ref[input_idx]
+        )
+        torch.testing.assert_close(
+            data[page_idx, entry_idx, _PACKED_NOPE_BYTES:], rope_ref[input_idx]
+        )
+        torch.testing.assert_close(
+            scales[page_idx, entry_idx, :28], scales_ref[input_idx]
+        )
+        assert torch.count_nonzero(scales[page_idx, entry_idx, 28:]) == 0
+
+    if page_size > 2:
+        assert torch.all(data[0, 1] == 0xA5)
+        assert torch.all(scales[0, 1] == 0xA5)
+
+
+def test_nvfp4_sparse_mla_pack_rejects_wrong_dtype():
+    _require_sm120()
+    latent_kv = torch.empty(1, 2, 512, dtype=torch.float16, device="cuda")
+    with pytest.raises(ValueError, match="bfloat16"):
+        nvfp4_quantize_pack_sparse_mla_cache(latent_kv)
+
+
+def test_nvfp4_sparse_mla_known_encoding_and_nonfinite_contract():
+    _require_sm120()
+    latent_kv = torch.zeros(1, 2, 512, dtype=torch.bfloat16, device="cuda")
+    latent_kv[0, 0, :16] = torch.tensor(
+        [
+            0.0,
+            -0.0,
+            0.5,
+            -0.5,
+            1.0,
+            -1.0,
+            1.5,
+            -1.5,
+            2.0,
+            -2.0,
+            3.0,
+            -3.0,
+            4.0,
+            -4.0,
+            6.0,
+            -6.0,
+        ],
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+    latent_kv[0, 1, :16] = torch.tensor(
+        [
+            float("nan"),
+            float("inf"),
+            -float("inf"),
+            torch.finfo(torch.bfloat16).max,
+            torch.finfo(torch.bfloat16).tiny,
+            -torch.finfo(torch.bfloat16).tiny,
+            0.25,
+            -0.25,
+            0.75,
+            -0.75,
+            1.25,
+            -1.25,
+            2.5,
+            -2.5,
+            5.0,
+            -5.0,
+        ],
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    cache = nvfp4_quantize_pack_sparse_mla_cache(latent_kv)
+    data, scales = _split_cache(cache)
+    packed_ref, scales_ref, _ = _reference_rows(latent_kv)
+
+    # Low nibble is the earlier element. With scale=1, these are the exact
+    # positive/negative E2M1 codes from zero through six.
+    expected = torch.tensor(
+        [0x80, 0x91, 0xA2, 0xB3, 0xC4, 0xD5, 0xE6, 0xF7],
+        dtype=torch.uint8,
+        device="cuda",
+    )
+    torch.testing.assert_close(data[0, 0, :8], expected)
+    assert scales[0, 0, 0].item() == 0x38  # E4M3 encoding of 1.0.
+
+    # NaN/Inf, BF16 max/min-normal, and decision-boundary behavior is defined
+    # to match FlashInfer's existing linear NVFP4 KV quantizer byte-for-byte.
+    torch.testing.assert_close(
+        data[..., :_PACKED_NOPE_BYTES].reshape_as(packed_ref), packed_ref
+    )
+    torch.testing.assert_close(scales[..., :28].reshape_as(scales_ref), scales_ref)
+
+
+@pytest.mark.parametrize("iterations", [1, 7])
+def test_nvfp4_sparse_mla_m16n32k64_matches_reference(iterations):
+    _require_sm120()
+    torch.manual_seed(20260831)
+    a_bf16 = (torch.randn(16, 64, device="cuda") / 3).to(torch.bfloat16)
+    b_bf16 = (torch.randn(32, 64, device="cuda") / 3).to(torch.bfloat16)
+    global_scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    a, sfa = flashinfer.nvfp4_kv_quantize(a_bf16, global_scale)
+    b, sfb = flashinfer.nvfp4_kv_quantize(b_bf16, global_scale)
+
+    output = _nvfp4_sparse_mla_m16n32k64(
+        a,
+        b,
+        sfa.view(torch.float8_e4m3fn),
+        sfb.view(torch.float8_e4m3fn),
+        iterations=iterations,
+    )
+    a_dequant = _dequantize_linear_nvfp4(a, sfa)
+    b_dequant = _dequantize_linear_nvfp4(b, sfb)
+    reference = torch.matmul(a_dequant, b_dequant.T) * iterations
+    torch.testing.assert_close(output, reference, atol=2e-4, rtol=2e-4)
+
+
+@pytest.mark.parametrize("iterations", [1, 7])
+def test_nvfp4_sparse_mla_candidate_major_pv_tile_matches_reference(iterations):
+    _require_sm120()
+    torch.manual_seed(20260901)
+    a_bf16 = (torch.randn(16, 64, device="cuda") / 3).to(torch.bfloat16)
+    # Quantize V in the mathematical [N, K] orientation, then repack its raw
+    # E2M1 codes into sparse MLA's candidate-major [K, packed-N] cache view.
+    b_bf16 = (torch.randn(8, 64, device="cuda") / 3).to(torch.bfloat16)
+    global_scale = torch.ones(1, dtype=torch.float32, device="cuda")
+    a, sfa = flashinfer.nvfp4_kv_quantize(a_bf16, global_scale)
+    b_row_major, sfb = flashinfer.nvfp4_kv_quantize(b_bf16, global_scale)
+    b_codes = torch.stack((b_row_major & 0xF, b_row_major >> 4), dim=-1).reshape(8, 64)
+    b_codes_candidate_major = b_codes.T.contiguous()
+    b_candidate_major = (
+        b_codes_candidate_major[:, 0::2] | (b_codes_candidate_major[:, 1::2] << 4)
+    ).contiguous()
+
+    output = _nvfp4_sparse_mla_m16n8k64_candidate_major(
+        a,
+        b_candidate_major,
+        sfa.view(torch.float8_e4m3fn),
+        sfb.view(torch.float8_e4m3fn),
+        iterations=iterations,
+    )
+    a_dequant = _dequantize_linear_nvfp4(a, sfa)
+    b_dequant = _dequantize_linear_nvfp4(b_row_major, sfb)
+    reference = torch.matmul(a_dequant, b_dequant.T) * iterations
+    torch.testing.assert_close(output, reference, atol=2e-4, rtol=2e-4)
+
+
+def test_nvfp4_sparse_mla_decode_workspace_has_no_global_vt() -> None:
+    """Decode scratch contains only split outputs/LSE, not materialized V^T."""
+    _require_sm120()
+    num_tokens, num_heads, topk, extra_topk = 2, 128, 128, 128
+    num_splits = topk // 64 + extra_topk // 64
+    bytes_per_token = (
+        num_heads * num_splits * (_D_NOPE + _D_ROPE) * 2
+        + num_heads * num_splits * 4
+        + num_heads * 4
+    )
+    workspace = torch.empty(
+        num_tokens * bytes_per_token, dtype=torch.uint8, device="cuda"
+    )
+    chunk_tokens, mid_out, mid_lse, scratch_lse = _nvfp4_sparse_mla_workspace(
+        workspace,
+        num_tokens=num_tokens,
+        num_heads=num_heads,
+        topk=topk,
+        extra_topk=extra_topk,
+        use_prefill=False,
+    )
+
+    assert chunk_tokens == num_tokens
+    assert mid_out is not None and mid_lse is not None
+    assert mid_out.shape == (num_tokens, num_heads, num_splits, 512)
+    assert mid_lse.shape == (num_tokens, num_heads, num_splits)
+    assert scratch_lse.shape == (num_tokens, num_heads)
+    assert mid_out.data_ptr() == workspace.data_ptr()
+
+
+@pytest.mark.parametrize(
+    "topk,chunks_per_block,topk_len", [(128, 2, 111), (512, 6, 389)]
+)
+@pytest.mark.parametrize("with_sink", [False, True])
+def test_nvfp4_sparse_mla_decode_matches_dequantized_reference(
+    topk: int, chunks_per_block: int, topk_len: int, with_sink: bool
+) -> None:
+    """Cover the direct and two-split epilogues with online quantization."""
+    _require_sm120()
+    torch.manual_seed(20260902 + topk + int(with_sink))
+    num_tokens, num_heads = 2, 128
+    num_pages, page_size = 16, 64
+    kv_bf16 = (
+        torch.randn(
+            num_pages,
+            page_size,
+            1,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(
+            num_tokens,
+            num_heads,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0,
+        num_pages * page_size,
+        (num_tokens, topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    # Exercise both the explicit length and negative-index masks.
+    indices[:, topk_len - 7 : topk_len] = -1
+    topk_length = torch.full((num_tokens,), topk_len, dtype=torch.int32, device="cuda")
+    attn_sink = (
+        torch.linspace(-1.0, 1.0, num_heads, dtype=torch.float32, device="cuda")
+        if with_sink
+        else None
+    )
+    sm_scale = (_D_NOPE + _D_ROPE) ** -0.5
+
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16.squeeze(2))
+    q_dequant = _dequantize_nvfp4_query(q)
+    kv_dequant = _dequantize_nvfp4_cache(cache)
+    reference, reference_lse = _reference_sparse_attention(
+        q_dequant,
+        kv_dequant,
+        indices,
+        sm_scale,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+    )
+    output, lse = _nvfp4_sparse_mla_decode(
+        q,
+        cache,
+        indices,
+        sm_scale,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+        chunks_per_block_override=chunks_per_block,
+    )
+
+    # Q/K use the exact dequantized NVFP4 operands above. The remaining delta
+    # comes from online P quantization and the candidate-axis V requantization.
+    torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+    prefill_output, prefill_lse = _nvfp4_sparse_mla_prefill(
+        q,
+        cache,
+        indices,
+        sm_scale,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+    )
+    torch.testing.assert_close(prefill_output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(prefill_lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("extra_page_size,extra_topk", [(2, 128), (64, 512)])
+@pytest.mark.parametrize("with_sink", [False, True])
+def test_nvfp4_sparse_mla_decode_dual_cache_matches_reference(
+    extra_page_size: int, extra_topk: int, with_sink: bool
+) -> None:
+    """Main and C4A/C128A cache sections share one online softmax."""
+    _require_sm120()
+    torch.manual_seed(20260904 + extra_page_size + int(with_sink))
+    num_tokens, num_heads, main_topk = 2, 128, 128
+    main_pages, main_page_size = 8, 64
+    extra_pages = max(16, (extra_topk + extra_page_size - 1) // extra_page_size)
+    main_bf16 = (
+        torch.randn(
+            main_pages,
+            main_page_size,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    extra_bf16 = (
+        torch.randn(
+            extra_pages,
+            extra_page_size,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(
+            num_tokens,
+            num_heads,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    main_indices = torch.randint(
+        0,
+        main_pages * main_page_size,
+        (num_tokens, main_topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    extra_indices = torch.randint(
+        0,
+        extra_pages * extra_page_size,
+        (num_tokens, extra_topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    main_lengths = torch.tensor([111, 97], dtype=torch.int32, device="cuda")
+    extra_lengths = torch.tensor(
+        [extra_topk - 13, max(1, extra_topk - 29)],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    main_indices[:, 91:96] = -1
+    extra_indices[:, 37:43] = -1
+    attn_sink = (
+        torch.linspace(-1.0, 1.0, num_heads, dtype=torch.float32, device="cuda")
+        if with_sink
+        else None
+    )
+    sm_scale = (_D_NOPE + _D_ROPE) ** -0.5
+
+    main_cache = nvfp4_quantize_pack_sparse_mla_cache(main_bf16)
+    extra_cache = nvfp4_quantize_pack_sparse_mla_cache(extra_bf16)
+    main_dequant = _dequantize_nvfp4_cache(main_cache)
+    extra_dequant = _dequantize_nvfp4_cache(extra_cache)
+    q_dequant = _dequantize_nvfp4_query(q)
+
+    ref_main_indices = main_indices.clone()
+    ref_extra_indices = extra_indices.clone()
+    for token in range(num_tokens):
+        ref_main_indices[token, int(main_lengths[token].item()) :] = -1
+        ref_extra_indices[token, int(extra_lengths[token].item()) :] = -1
+    main_rows = main_pages * main_page_size
+    virtual_kv = torch.cat(
+        (main_dequant.reshape(-1, 512), extra_dequant.reshape(-1, 512)), dim=0
+    ).reshape(1, -1, 1, 512)
+    virtual_indices = torch.cat(
+        (
+            ref_main_indices,
+            torch.where(
+                ref_extra_indices < 0,
+                ref_extra_indices,
+                ref_extra_indices + main_rows,
+            ),
+        ),
+        dim=1,
+    )
+    reference, reference_lse = _reference_sparse_attention(
+        q_dequant,
+        virtual_kv,
+        virtual_indices,
+        sm_scale,
+        attn_sink=attn_sink,
+    )
+
+    total_splits = (main_topk + 63) // 64 + (extra_topk + 63) // 64
+    output, lse = _nvfp4_sparse_mla_decode(
+        q,
+        main_cache,
+        main_indices,
+        sm_scale,
+        topk_length=main_lengths,
+        attn_sink=attn_sink,
+        extra_kv_cache=extra_cache,
+        extra_indices=extra_indices,
+        extra_topk_length=extra_lengths,
+        chunks_per_block_override=(total_splits + 1) // 2,
+    )
+
+    torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+    prefill_output, prefill_lse = _nvfp4_sparse_mla_prefill(
+        q,
+        main_cache,
+        main_indices,
+        sm_scale,
+        topk_length=main_lengths,
+        attn_sink=attn_sink,
+        extra_kv_cache=extra_cache,
+        extra_indices=extra_indices,
+        extra_topk_length=extra_lengths,
+    )
+    torch.testing.assert_close(prefill_output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(prefill_lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("num_heads", [16, 32, 64])
+def test_nvfp4_sparse_mla_supported_head_counts(num_heads: int) -> None:
+    """Decode and prefill share the vLLM padded-head dispatch set."""
+    _require_sm120()
+    torch.manual_seed(20260905 + num_heads)
+    num_tokens, topk = 1, 128
+    kv_bf16 = (
+        torch.randn(4, 64, 512, dtype=torch.bfloat16, device="cuda") / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, 4 * 64, (num_tokens, topk), dtype=torch.int32, device="cuda"
+    )
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16)
+    reference, reference_lse = _reference_sparse_attention(
+        _dequantize_nvfp4_query(q),
+        _dequantize_nvfp4_cache(cache),
+        indices,
+        512**-0.5,
+    )
+
+    decode_output, decode_lse = _nvfp4_sparse_mla_decode(
+        q,
+        cache,
+        indices,
+        512**-0.5,
+        chunks_per_block_override=2,
+    )
+    prefill_output, prefill_lse = _nvfp4_sparse_mla_prefill(
+        q, cache, indices, 512**-0.5
+    )
+    torch.testing.assert_close(decode_output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(decode_lse, reference_lse, atol=2e-2, rtol=2e-2)
+    torch.testing.assert_close(prefill_output, reference, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(prefill_lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+
+def test_nvfp4_sparse_mla_public_api_decode_dual_cache() -> None:
+    """The DSv4 public dispatcher routes both NVFP4 cache segments."""
+    _require_sm120()
+    torch.manual_seed(20260906)
+    num_tokens, num_heads = 2, 16
+    main_topk, extra_topk = 128, 128
+    main_pages, main_page_size = 4, 64
+    extra_pages, extra_page_size = 64, 2
+    main_bf16 = (
+        torch.randn(
+            main_pages,
+            main_page_size,
+            512,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    extra_bf16 = (
+        torch.randn(
+            extra_pages,
+            extra_page_size,
+            512,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+        / 10.0
+    ).clamp(-1, 1)
+    main_indices = torch.randint(
+        0,
+        main_pages * main_page_size,
+        (num_tokens, main_topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    extra_indices = torch.randint(
+        0,
+        extra_pages * extra_page_size,
+        (num_tokens, extra_topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    main_lengths = torch.tensor([111, 97], dtype=torch.int32, device="cuda")
+    extra_lengths = torch.tensor([119, 103], dtype=torch.int32, device="cuda")
+    main_cache = nvfp4_quantize_pack_sparse_mla_cache(main_bf16)
+    extra_cache = nvfp4_quantize_pack_sparse_mla_cache(extra_bf16)
+
+    main_ref_indices = main_indices.clone()
+    extra_ref_indices = extra_indices.clone()
+    for token in range(num_tokens):
+        main_ref_indices[token, int(main_lengths[token].item()) :] = -1
+        extra_ref_indices[token, int(extra_lengths[token].item()) :] = -1
+    main_rows = main_pages * main_page_size
+    virtual_kv = torch.cat(
+        (
+            _dequantize_nvfp4_cache(main_cache).reshape(-1, 512),
+            _dequantize_nvfp4_cache(extra_cache).reshape(-1, 512),
+        ),
+        dim=0,
+    ).reshape(1, -1, 1, 512)
+    virtual_indices = torch.cat(
+        (
+            main_ref_indices,
+            torch.where(
+                extra_ref_indices < 0,
+                extra_ref_indices,
+                extra_ref_indices + main_rows,
+            ),
+        ),
+        dim=1,
+    )
+    reference, _ = _reference_sparse_attention(
+        _dequantize_nvfp4_query(q),
+        virtual_kv,
+        virtual_indices,
+        512**-0.5,
+    )
+    workspace = torch.empty(1 << 20, dtype=torch.uint8, device="cuda")
+    output = torch.empty_like(q)
+    returned = flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+        query=q,
+        swa_kv_cache=main_cache,
+        workspace_buffer=workspace,
+        sparse_indices=main_indices,
+        compressed_kv_cache=extra_cache,
+        swa_topk_lens=main_lengths,
+        extra_sparse_indices=extra_indices,
+        extra_sparse_topk_lens=extra_lengths,
+        out=output,
+        bmm1_scale=512**-0.5,
+        backend="sparse",
+        kv_cache_format="nvfp4",
+    )
+
+    assert returned.data_ptr() == output.data_ptr()
+    torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+    with pytest.raises(ValueError, match="head dim 584"):
+        flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+            query=q,
+            swa_kv_cache=main_cache,
+            workspace_buffer=workspace,
+            sparse_indices=main_indices,
+            swa_topk_lens=main_lengths,
+            bmm1_scale=512**-0.5,
+            backend="sparse",
+        )
+    with pytest.raises(ValueError, match="workspace"):
+        flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+            query=q,
+            swa_kv_cache=main_cache,
+            workspace_buffer=torch.empty(1, dtype=torch.uint8, device="cuda"),
+            sparse_indices=main_indices,
+            swa_topk_lens=main_lengths,
+            bmm1_scale=512**-0.5,
+            backend="sparse",
+            kv_cache_format="nvfp4",
+        )
+
+
+def test_nvfp4_sparse_mla_public_api_prefill_minimal_workspace() -> None:
+    """Streaming prefill only reserves the caller-owned final LSE scratch."""
+    _require_sm120()
+    torch.manual_seed(20260907)
+    num_tokens, num_heads, topk = 129, 16, 128
+    kv_bf16 = (
+        torch.randn(4, 64, 512, dtype=torch.bfloat16, device="cuda") / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, 4 * 64, (num_tokens, topk), dtype=torch.int32, device="cuda"
+    )
+    lengths = torch.full((num_tokens,), 117, dtype=torch.int32, device="cuda")
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16)
+    reference, _ = _reference_sparse_attention(
+        _dequantize_nvfp4_query(q),
+        _dequantize_nvfp4_cache(cache),
+        indices,
+        512**-0.5,
+        topk_length=lengths,
+    )
+    bytes_per_token = num_heads * 4
+    workspace = torch.empty(
+        num_tokens * bytes_per_token, dtype=torch.uint8, device="cuda"
+    )
+    output = torch.empty_like(q)
+
+    flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+        query=q,
+        swa_kv_cache=cache,
+        workspace_buffer=workspace,
+        sparse_indices=indices,
+        swa_topk_lens=lengths,
+        out=output,
+        bmm1_scale=512**-0.5,
+        backend="sparse",
+        kv_cache_format="nvfp4",
+    )
+    torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+
+
+def test_nvfp4_sparse_mla_public_api_empty_pp_slice() -> None:
+    """Empty PP/CUDA-graph metadata is a no-op, not a workspace error."""
+    _require_sm120()
+    num_heads, topk = 16, 128
+    q = torch.empty((0, num_heads, 512), dtype=torch.bfloat16, device="cuda")
+    # vLLM prefill metadata retains its singleton q-length dimension.
+    indices = torch.empty((0, 1, topk), dtype=torch.int32, device="cuda")
+    lengths = torch.empty((0, 1), dtype=torch.int32, device="cuda")
+    cache = torch.empty((1, 1, 64, _BYTES_PER_TOKEN), dtype=torch.uint8, device="cuda")
+    workspace = torch.empty(1, dtype=torch.uint8, device="cuda")
+    output = torch.empty_like(q)
+
+    returned = flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+        query=q,
+        swa_kv_cache=cache,
+        workspace_buffer=workspace,
+        sparse_indices=indices,
+        swa_topk_lens=lengths,
+        out=output,
+        bmm1_scale=512**-0.5,
+        backend="sparse",
+        kv_cache_format="nvfp4",
+    )
+
+    assert returned.data_ptr() == output.data_ptr()
+    assert returned.shape == (0, num_heads, 512)
+
+
+@pytest.mark.parametrize("num_tokens", [2, 65])
+def test_nvfp4_sparse_mla_public_api_cuda_graph(num_tokens: int) -> None:
+    """Both public decode and prefill routes are replayable in a CUDA Graph."""
+    _require_sm120()
+    torch.manual_seed(20260908 + num_tokens)
+    num_heads, topk = 16, 128
+    kv_bf16 = (
+        torch.randn(4, 64, 512, dtype=torch.bfloat16, device="cuda") / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+        / 10.0
+    ).clamp(-1, 1)
+    replay_q = (torch.randn_like(q, dtype=torch.bfloat16, device="cuda") / 10.0).clamp(
+        -1, 1
+    )
+    indices = torch.randint(
+        0, 4 * 64, (num_tokens, topk), dtype=torch.int32, device="cuda"
+    )
+    lengths = torch.full((num_tokens,), topk, dtype=torch.int32, device="cuda")
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16)
+    workspace = torch.empty(8 << 20, dtype=torch.uint8, device="cuda")
+    output = torch.empty_like(q)
+
+    def run() -> None:
+        flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
+            query=q,
+            swa_kv_cache=cache,
+            workspace_buffer=workspace,
+            sparse_indices=indices,
+            swa_topk_lens=lengths,
+            out=output,
+            bmm1_scale=512**-0.5,
+            backend="sparse",
+            kv_cache_format="nvfp4",
+        )
+
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    q.copy_(replay_q)
+    graph.replay()
+    torch.cuda.synchronize()
+    reference, _ = _reference_sparse_attention(
+        _dequantize_nvfp4_query(replay_q),
+        _dequantize_nvfp4_cache(cache),
+        indices,
+        512**-0.5,
+        topk_length=lengths,
+    )
+    torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+
+
+@pytest.mark.parametrize("with_sink", [False, True])
+def test_nvfp4_sparse_mla_decode_zero_topk_length(with_sink: bool) -> None:
+    """An empty sparse row produces zero output and sink-aware LSE."""
+    _require_sm120()
+    torch.manual_seed(20260903)
+    num_heads, topk = 128, 128
+    kv = torch.randn(1, 64, _D_NOPE + _D_ROPE, dtype=torch.bfloat16, device="cuda")
+    q = torch.randn(
+        1, num_heads, _D_NOPE + _D_ROPE, dtype=torch.bfloat16, device="cuda"
+    )
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv)
+    indices = torch.zeros((1, topk), dtype=torch.int32, device="cuda")
+    topk_length = torch.zeros(1, dtype=torch.int32, device="cuda")
+    attn_sink = (
+        torch.linspace(-2.0, 2.0, num_heads, dtype=torch.float32, device="cuda")
+        if with_sink
+        else None
+    )
+
+    output, lse = _nvfp4_sparse_mla_decode(
+        q,
+        cache,
+        indices,
+        (_D_NOPE + _D_ROPE) ** -0.5,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+        chunks_per_block_override=2,
+    )
+
+    assert torch.count_nonzero(output) == 0
+    if attn_sink is None:
+        assert torch.all(lse < -1e29)
+    else:
+        torch.testing.assert_close(lse, attn_sink.unsqueeze(0) * math.log2(math.e))

--- a/tests/attention/test_sparse_mla_nvfp4_sm120.py
+++ b/tests/attention/test_sparse_mla_nvfp4_sm120.py
@@ -23,7 +23,10 @@ from flashinfer.mla import (
     nvfp4_quantize_append_sparse_mla_cache,
     nvfp4_quantize_pack_sparse_mla_cache,
 )
-from flashinfer.mla._core import _nvfp4_sparse_mla_workspace
+from flashinfer.mla._core import (
+    _nvfp4_sparse_mla_workspace,
+    _workspace_tensor_view,
+)
 from flashinfer.mla._sparse_mla_nvfp4_sm120 import (
     _nvfp4_sparse_mla_decode,
     _nvfp4_sparse_mla_prefill,
@@ -370,17 +373,30 @@ def test_nvfp4_sparse_mla_append_rejects_misaligned_vector_accesses(
         nvfp4_quantize_append_sparse_mla_cache(latent_kv, slots, cache)
 
 
-def test_nvfp4_sparse_mla_append_rejects_duplicate_valid_slots(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize("num_tokens", [4, 257])
+@pytest.mark.parametrize("slot_dtype", [torch.int32, torch.int64])
+def test_nvfp4_sparse_mla_append_duplicate_slots_use_first_row(
+    num_tokens: int, slot_dtype: torch.dtype
 ) -> None:
     _require_sm120()
-    monkeypatch.setenv("FLASHINFER_VALIDATE_INPUTS", "1")
-    latent_kv = torch.empty(2, 512, dtype=torch.bfloat16, device="cuda")
-    slots = torch.zeros(2, dtype=torch.int32, device="cuda")
-    cache = torch.empty(1, 2, _BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda")
+    torch.manual_seed(20260907 + num_tokens)
+    latent_kv = torch.randn(num_tokens, 512, dtype=torch.bfloat16, device="cuda")
+    slots = torch.full((num_tokens,), -1, dtype=slot_dtype, device="cuda")
+    slots[0] = 0
+    slots[-1] = 0
+    cache = torch.full((1, 2, _BYTES_PER_TOKEN), 0xA5, dtype=torch.uint8, device="cuda")
 
-    with pytest.raises(ValueError, match="must be unique"):
-        nvfp4_quantize_append_sparse_mla_cache(latent_kv, slots, cache)
+    nvfp4_quantize_append_sparse_mla_cache(latent_kv, slots, cache)
+    expected = nvfp4_quantize_pack_sparse_mla_cache(latent_kv[:1].view(1, 1, 512))
+    actual_data, actual_scales = _split_cache(cache)
+    expected_data, expected_scales = _split_cache(expected)
+
+    torch.testing.assert_close(actual_data[0, 0], expected_data[0, 0], rtol=0, atol=0)
+    torch.testing.assert_close(
+        actual_scales[0, 0], expected_scales[0, 0], rtol=0, atol=0
+    )
+    assert torch.all(actual_data[0, 1] == 0xA5)
+    assert torch.all(actual_scales[0, 1] == 0xA5)
 
 
 def test_nvfp4_sparse_mla_pack_rejects_wrong_dtype():
@@ -541,6 +557,78 @@ def test_nvfp4_sparse_mla_decode_workspace_has_no_global_vt() -> None:
     assert mid_lse.shape == (num_tokens, num_heads, num_splits)
     assert scratch_lse.shape == (num_tokens, num_heads)
     assert mid_out.data_ptr() == workspace.data_ptr()
+
+
+def test_workspace_tensor_view_aligns_sliced_storage_without_allocating(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _require_sm120()
+    storage = torch.empty(4096 + 16, dtype=torch.uint8, device="cuda")
+    workspace = storage[1:]
+    assert workspace.is_contiguous()
+    assert workspace.data_ptr() % 16 == 1
+    previous_default = torch.get_default_device()
+    torch.set_default_device("cuda")
+    try:
+        with monkeypatch.context() as context:
+
+            def reject_tensor_allocation(*args, **kwargs):
+                raise AssertionError(
+                    "workspace partitioning must not allocate a tensor"
+                )
+
+            context.setattr(torch, "empty", reject_tensor_allocation)
+            view, byte_end = _workspace_tensor_view(
+                workspace,
+                byte_offset=0,
+                shape=(2, 8, 64),
+                dtype=torch.bfloat16,
+            )
+    finally:
+        torch.set_default_device(previous_default)
+
+    assert view is not None
+    assert view.data_ptr() % 16 == 0
+    assert byte_end <= workspace.numel()
+
+
+@pytest.mark.parametrize("phase", ["decode", "prefill"])
+@pytest.mark.parametrize(
+    "optional_name,optional_dtype,logical_size",
+    [
+        ("topk_length", torch.int32, 2),
+        ("extra_topk_length", torch.int32, 2),
+        ("attn_sink", torch.float32, 16),
+    ],
+)
+def test_nvfp4_sparse_mla_rejects_strided_optional_tensors(
+    phase: str,
+    optional_name: str,
+    optional_dtype: torch.dtype,
+    logical_size: int,
+) -> None:
+    _require_sm120()
+    num_tokens, num_heads, topk = 2, 16, 128
+    q = torch.zeros(num_tokens, num_heads, 512, dtype=torch.bfloat16, device="cuda")
+    cache = torch.empty(2, 64, _BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda")
+    indices = torch.zeros(num_tokens, topk, dtype=torch.int32, device="cuda")
+    strided = torch.zeros(logical_size * 2, dtype=optional_dtype, device="cuda")[::2]
+    kwargs = {optional_name: strided}
+    if optional_name == "extra_topk_length":
+        kwargs.update(
+            extra_kv_cache=torch.empty(
+                1, 2, _BYTES_PER_TOKEN, dtype=torch.uint8, device="cuda"
+            ),
+            extra_indices=torch.zeros(
+                num_tokens, topk, dtype=torch.int32, device="cuda"
+            ),
+        )
+    attention = (
+        _nvfp4_sparse_mla_decode if phase == "decode" else _nvfp4_sparse_mla_prefill
+    )
+
+    with pytest.raises(RuntimeError, match=rf"{optional_name} must be contiguous"):
+        attention(q, cache, indices, 1.0 / math.sqrt(512), **kwargs)
 
 
 @pytest.mark.parametrize(
@@ -987,7 +1075,9 @@ def test_nvfp4_sparse_mla_public_api_decode_dual_cache() -> None:
         virtual_indices,
         512**-0.5,
     )
-    workspace = torch.empty(1 << 20, dtype=torch.uint8, device="cuda")
+    workspace_storage = torch.empty((1 << 20) + 1, dtype=torch.uint8, device="cuda")
+    workspace = workspace_storage[1:]
+    assert workspace.data_ptr() % 16 == 1
     output = torch.empty_like(q)
     returned = flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4(
         query=q,

--- a/tests/attention/test_sparse_mla_nvfp4_sm120_plan.py
+++ b/tests/attention/test_sparse_mla_nvfp4_sm120_plan.py
@@ -1,0 +1,196 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure-Python tests for the independently calibrated NVFP4 planner."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from flashinfer.mla import _sparse_mla_nvfp4_sm120_plan as plan_mod
+from flashinfer.mla import _sparse_mla_sm120_cpb as cpb_mod
+
+
+@pytest.fixture
+def planner_state(monkeypatch):
+    crossover: dict[str, int] = {}
+    cpb: dict[str, int] = {}
+    monkeypatch.setattr(cpb_mod, "_device_key", lambda _device: "0:Fake SM120")
+    monkeypatch.setattr(cpb_mod, "_maybe_load_disk", lambda: None)
+    monkeypatch.setattr(
+        cpb_mod,
+        "get_decode_max_tokens",
+        lambda _device, family, heads, topk: crossover.get(f"{family}|{heads}|{topk}"),
+    )
+    monkeypatch.setattr(
+        cpb_mod,
+        "get_cpb_override",
+        lambda _device, family, heads, topk, tokens: cpb.get(
+            f"{family}|{heads}|{topk}|{tokens}"
+        ),
+    )
+    # Unit tests inject calibration records directly; GPU timing is covered by
+    # the SM120 integration/benchmark path.
+    monkeypatch.setattr(plan_mod, "_maybe_calibrate", lambda **_kwargs: None)
+    plan_mod._plan_memo.clear()
+    yield crossover, cpb
+    plan_mod._plan_memo.clear()
+
+
+def _family(**kwargs) -> str:
+    defaults = dict(
+        primary_page_size=64,
+        extra_topk=0,
+        extra_page_size=0,
+        has_topk_length=True,
+        has_extra_topk_length=False,
+        has_attn_sink=False,
+    )
+    defaults.update(kwargs)
+    return plan_mod._family_key(**defaults)
+
+
+def _plan(tokens: int, **kwargs):
+    defaults = dict(
+        num_tokens=tokens,
+        num_heads=64,
+        topk=128,
+        primary_page_size=64,
+        device=torch.device("cpu"),
+        has_topk_length=True,
+    )
+    defaults.update(kwargs)
+    return plan_mod.plan_nvfp4_sparse_mla_sm120(**defaults)
+
+
+def _phase_key(family: str, tokens: int, *, heads: int = 64, topk: int = 128) -> str:
+    return f"{plan_mod._phase_family(family, tokens)}|{heads}|{topk}"
+
+
+def test_nvfp4_unknown_crossover_keeps_safe_decode_fallback(planner_state) -> None:
+    planned = _plan(32)
+    assert planned is not None
+    assert planned.variant is plan_mod.NVFP4KernelVariant.DECODE_SPLITK
+    assert planned.cpb == 0
+
+
+def test_nvfp4_calibrated_crossover_replaces_fixed_64_policy(planner_state) -> None:
+    crossover, cpb = planner_state
+    family = _family()
+    crossover[_phase_key(family, 8)] = 8
+    crossover[_phase_key(family, 16)] = 0
+    cpb[f"{family}|64|128|8"] = 2
+    plan_mod._plan_memo.clear()
+
+    at_crossover = _plan(8)
+    above_crossover = _plan(9)
+    assert at_crossover is not None
+    assert at_crossover.variant is plan_mod.NVFP4KernelVariant.DECODE_SPLITK
+    assert at_crossover.cpb == 2
+    assert above_crossover is not None
+    assert above_crossover.variant is plan_mod.NVFP4KernelVariant.PREFILL_STREAMING
+
+
+def test_nvfp4_decode_cpb_uses_calibrated_token_bucket(planner_state) -> None:
+    crossover, cpb = planner_state
+    family = _family()
+    crossover[_phase_key(family, 16)] = 16
+    cpb[f"{family}|64|128|16"] = 3
+    plan_mod._plan_memo.clear()
+
+    planned = _plan(9)
+    assert planned is not None
+    assert planned.variant is plan_mod.NVFP4KernelVariant.DECODE_SPLITK
+    assert planned.cpb == 3
+
+
+def test_nvfp4_64_is_only_decode_envelope(planner_state) -> None:
+    crossover, _ = planner_state
+    family = _family()
+    crossover[_phase_key(family, 64)] = 64
+    plan_mod._plan_memo.clear()
+
+    assert _plan(64).variant is plan_mod.NVFP4KernelVariant.DECODE_SPLITK
+    assert _plan(65).variant is plan_mod.NVFP4KernelVariant.PREFILL_STREAMING
+    assert _plan(8192).variant is plan_mod.NVFP4KernelVariant.PREFILL_STREAMING
+
+
+def test_nvfp4_phase_table_preserves_non_monotonic_wave_boundaries(
+    planner_state,
+) -> None:
+    crossover, cpb = planner_state
+    family = _family()
+    crossover[_phase_key(family, 48)] = 0
+    crossover[_phase_key(family, 64)] = 64
+    cpb[f"{family}|64|128|64"] = 7
+    plan_mod._plan_memo.clear()
+
+    at_48 = _plan(48)
+    at_64 = _plan(64)
+    assert at_48.variant is plan_mod.NVFP4KernelVariant.PREFILL_STREAMING
+    assert at_64.variant is plan_mod.NVFP4KernelVariant.DECODE_SPLITK
+    assert at_64.cpb == 7
+    assert plan_mod._monotonic_decode_max_tokens({48: False, 64: True}) is None
+
+
+def test_nvfp4_calibration_namespace_is_format_and_shape_specific() -> None:
+    main = _family()
+    dual_p2 = _family(
+        extra_topk=512,
+        extra_page_size=2,
+        has_extra_topk_length=True,
+    )
+    dual_p64 = _family(
+        extra_topk=512,
+        extra_page_size=64,
+        has_extra_topk_length=True,
+    )
+    with_sink = _family(has_attn_sink=True)
+
+    assert main.startswith("dsv4_nvfp4_v")
+    assert len({main, dual_p2, dual_p64, with_sink}) == 4
+    assert main != "dsv4"  # An FP8 record can never satisfy this lookup.
+
+
+def test_nvfp4_planner_rejects_shapes_outside_both_envelopes(
+    planner_state,
+) -> None:
+    assert _plan(8, num_heads=8) is None
+    assert _plan(8, topk=256) is None
+    assert _plan(8, primary_page_size=32) is None
+    assert _plan(8, extra_topk=512, extra_page_size=1) is None
+    with pytest.raises(ValueError, match="has_extra_topk_length"):
+        _plan(8, has_extra_topk_length=True)
+
+
+def test_nvfp4_plan_rechecks_lookup_after_lazy_calibration(
+    planner_state, monkeypatch
+) -> None:
+    crossover, cpb = planner_state
+    family = _family()
+    calls = []
+
+    def inject(**kwargs) -> None:
+        calls.append(kwargs)
+        crossover[_phase_key(family, 16)] = 16
+        cpb[f"{family}|64|128|16"] = 4
+
+    monkeypatch.setattr(plan_mod, "_maybe_calibrate", inject)
+    planned = _plan(12)
+
+    assert len(calls) == 1
+    assert planned is not None
+    assert planned.variant is plan_mod.NVFP4KernelVariant.DECODE_SPLITK
+    assert planned.cpb == 4

--- a/tests/attention/test_sparse_mla_sm120_dispatch.py
+++ b/tests/attention/test_sparse_mla_sm120_dispatch.py
@@ -57,6 +57,7 @@ from flashinfer.mla._sparse_mla_sm120 import (
     _MODEL_TYPE_GLM_NSA,
     _MODEL_TYPE_GLM53_NOPE,
     _MODEL_TYPE_DOTS3_SWA,
+    _decode_scratch_views,
     _decode_dispatch_error_message,
     _resolve_model_type,
 )
@@ -124,6 +125,43 @@ def test_supported_configs_families() -> None:
     )
     assert "supported_sparse_mla_sm120_configs" in dir(flashinfer.mla)
     assert "SparseMLASm120DecodeConfig" in dir(flashinfer.mla)
+
+
+def test_supported_configs_nvfp4_envelope() -> None:
+    """The shared query API exposes the exact, independently keyed NVFP4 set."""
+    configs = supported_sparse_mla_sm120_configs(kv_cache_format="nvfp4")
+    assert set(configs) == {"dsv4"}
+    dsv4 = configs["dsv4"]
+    assert dsv4.kv_cache_format == "nvfp4"
+    assert dsv4.bytes_per_token == 384
+    assert dsv4.supported_num_heads() == (16, 32, 64, 128)
+    assert dsv4.supported_topk() == (128, 512)
+    assert dsv4.extra_page_block_sizes == frozenset({2, 64})
+    assert dsv4.supports_decode(64, 128)
+    assert not dsv4.supports_decode(8, 128)
+    assert not dsv4.supports_decode(64, 256)
+
+    with pytest.raises(ValueError, match="kv_cache_format"):
+        supported_sparse_mla_sm120_configs(kv_cache_format="int4")
+
+
+def test_nvfp4_exact_head_scratch_view() -> None:
+    """The shared scratch slicer also supports NVFP4's exact-head ABI."""
+    mid_out = torch.empty((8, 64, 9, 512), dtype=torch.bfloat16, device="meta")
+    mid_lse = torch.empty((8, 64, 9), dtype=torch.float32, device="meta")
+
+    out_view, lse_view = _decode_scratch_views(
+        mid_out,
+        mid_lse,
+        num_tokens=2,
+        num_heads=16,
+        num_splits=2,
+        d_v=512,
+        scratch_heads=16,
+    )
+
+    assert out_view.shape == (2, 16, 2, 512)
+    assert lse_view.shape == (2, 16, 2)
 
 
 def test_supported_helpers() -> None:


### PR DESCRIPTION
## 📌 Description

This PR adds native NVFP4 sparse MLA support on SM120/SM121 for the DeepSeek V4 Flash attention path. The feature is opt-in through `kv_cache_format="nvfp4"` on the existing `flashinfer.mla.trtllm_batch_decode_sparse_mla_dsv4` API; the existing FP8 cache ABI and behavior remain unchanged and are still the default.

### Implementation

- Adds a 384-byte/token paged NVFP4 cache ABI:
  - the 448-dimensional NoPE payload is quantized in groups of 16 to packed E2M1 values with one E4M3 scale per group;
  - the 64-dimensional RoPE payload remains BF16;
  - full-page packing and incremental slot-based append helpers support HND/NHD layouts and page-strided vLLM cache allocations.
- Adds separate native attention kernels for both phases:
  - a single-launch streaming prefill kernel that gathers paged NVFP4 V directly, performs the candidate-tile transpose in CTA-local storage, and double-buffers the next source tile without a global transposed-V workspace;
  - a grouped split-K decode kernel with an autotuned chunks-per-block tactic and split reduction.
- Reuses the existing sparse-MLA facade and planner persistence mechanism while maintaining an independent NVFP4 calibration namespace. The planner measures the streaming-prefill versus split-K-decode crossover and decode tactic for each supported serving shape; it does not reuse FP8 measurements.
- Supports primary and optional extra sparse cache segments, dynamic top-k lengths, attention sinks, caller-owned workspace, CUDA Graph capture, AOT/JIT registration, and empty pipeline-parallel slices.
- Adds correctness tests plus reproducible cache, prefill, decode, and planner benchmarks.

The currently supported NVFP4 surface is 16/32/64/128 query heads, primary top-k 128 or 512, primary page size 64, and optional extra-cache page size 2 or 64.

### Performance

Measurements below are medians on an NVIDIA RTX PRO 5000 Blackwell GPU (SM120), CUDA 13.0. FP8 and NVFP4 use the same generated inputs and independently selected tactics.

| Phase and shape | FP8 | NVFP4 | Speedup |
| --- | ---: | ---: | ---: |
| Prefill: T=8192, H=64, K=128 | 3909.632 us | 2337.792 us | 1.6724x (+67.24%) |
| Prefill: T=8192, H=64, K=128+512 | 10216.448 us | 7179.264 us | 1.4230x (+42.30%) |
| Prefill: T=8192, H=128, K=128+512 | 20149.248 us | 14240.768 us | 1.4149x (+41.49%) |
| Decode: T=8, H=64, K=128+512 | 43.008 us | 32.768 us | 1.3125x (+31.25%) |

Reproduction:

```bash
python benchmarks/bench_sparse_mla_nvfp4_prefill.py \
  --num-tokens 8192 --num-heads 64 --topk 128 \
  --extra-topk 512 --extra-page-size 64

python benchmarks/bench_sparse_mla_nvfp4_decode.py \
  --num-tokens 8 --num-heads 64 --topk 128 \
  --extra-topk 512 --extra-page-size 64
```

A paired DeepSeek-V4-Flash serving run using `vllm/vllm-openai:v0.26.0`, PP=4, 256 requests, concurrency 32, ISL=8192, OSL=1, prefix cache disabled, and a 16K scheduled-token budget measured 80.466 s for FP8 and 73.808 s for NVFP4 over three runs: 1.0902x end-to-end speedup and +9.02% token throughput.

## 🔍 Related Issues

Related NVFP4 SM120 work: #3640 and #4502.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

SM120 regression results:

```text
pytest -q   tests/attention/test_sparse_mla_nvfp4_sm120.py   tests/attention/test_sparse_mla_nvfp4_sm120_plan.py   tests/attention/test_sparse_mla_sm120_dispatch.py
# 77 passed

pytest -q tests/attention/test_sparse_mla_sm120.py -k dsv4_public_api
# 5 passed, 483 deselected

pre-commit run --all-files
# all hooks passed (clang-format, mypy, ruff check, ruff format, and repository checks)
```

The GPU test matrix covers bit-level cache packing/append, HND/NHD and strided pages, numerical references for prefill and decode, single/dual cache layouts, supported head counts, ragged lengths, attention sinks, public API dispatch, empty PP slices, CUDA Graph replay, and planner policy.

## Reviewer Notes

- FP8 remains the default. NVFP4 is explicitly selected with `kv_cache_format="nvfp4"`.
- Operator gains are shape-dependent. Long-prompt production shapes show the largest prefill gains; short-K/small-head decode shapes can be neutral, so NVFP4 uses its own calibrated phase/CPB decisions rather than an FP8 tactic or a fixed query-token threshold.
- In the strict ISL=8192/OSL=256 serving experiment, full-request throughput improved by 3.67% due primarily to lower TTFT, while steady-window decode throughput was 0.57% below FP8. The decode operator path is included and independently tuned, but additional serving-level decode optimization remains follow-up work.
- Implementation, tests, benchmarking, and PR drafting were AI-assisted; the listed checks and measurements were run on hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added NVFP4 cache packing and incremental append support for DeepSeek-V4 sparse MLA.
  * Added NVFP4 sparse MLA decode and prefill on compatible SM120/SM121 GPUs.
  * Added FP8 or NVFP4 cache format selection, optional extra KV data, attention sinks, and runtime top-k lengths.
  * Added automatic performance planning and calibration for decode versus prefill.

* **Documentation**
  * Documented the new NVFP4 cache APIs.

* **Benchmarks**
  * Added NVFP4 packing, append, decode, prefill, and planning benchmarks.

* **Bug Fixes**
  * Added validation for invalid cache alignment and slot mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->