### PR TITLE
fix(ci): anchor bot command matching to line start, outside code fences

### DIFF
--- a/.github/workflows/ci-bot-commands.yml
+++ b/.github/workflows/ci-bot-commands.yml
@@ -106,10 +106,24 @@ jobs:
           # Leading whitespace is allowed (indented commands are common); anything
           # to the left of the handle - `>` for a quoted reply, `|` for a table
           # cell, a backtick for an inline code span, prose - is not.
+          # A fence closes only on the delimiter that opened it: a ``` block may
+          # legitimately contain a ~~~ line as content, and treating that as the
+          # close would let a command later in the same block through -- exactly
+          # the bug this change exists to prevent.
+          #
+          # `|| CMD=""` because grep exits 1 when nothing matches, which is the
+          # normal case for an ordinary comment. Today the runner shell is
+          # `bash -e` without pipefail, so only grep's status could propagate;
+          # adding `shell: bash` or a `defaults.run.shell` later would enable
+          # pipefail and abort the step before it writes any command= output.
           CMD=$(printf '%s\n' "$COMMENT_BODY" | tr -d '\r' \
-            | awk '/^[[:space:]]*(```|~~~)/ { fenced = !fenced; next } !fenced' \
+            | awk '
+                /^[[:space:]]*```/ { if (!f) { f = 1; d = "b" } else if (d == "b") { f = 0 } ; next }
+                /^[[:space:]]*~~~/ { if (!f) { f = 1; d = "t" } else if (d == "t") { f = 0 } ; next }
+                !f
+              ' \
             | grep -iEm1 '^[[:space:]]*@flashinfer-bot[[:space:]]+(run|rerun|stop)([[:space:]]|$)' \
-            | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+            | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//') || CMD=""
 
           # Same order as before: `rerun failed` must be tested before `rerun`.
           # The trailing `([[:space:]]|$)` keeps `run` from matching `running`.

--- a/.github/workflows/ci-bot-commands.yml
+++ b/.github/workflows/ci-bot-commands.yml
@@ -20,7 +20,9 @@ permissions:
 
 jobs:
   handle-command:
-    # Only run on PR comments mentioning @flashinfer-bot
+    # Cheap pre-filter only. Workflow expressions have no regex, so this cannot
+    # tell a command from prose that mentions one; `Parse command` below is the
+    # authoritative match and every handler step is gated on its output.
     if: |
       github.event.issue.pull_request &&
       contains(github.event.comment.body, '@flashinfer-bot')
@@ -93,13 +95,31 @@ jobs:
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
-          if echo "$COMMENT_BODY" | grep -qi "@flashinfer-bot rerun failed"; then
+          # A command counts only when it STARTS a line that is not inside a
+          # fenced code block. These matches used to be unanchored, so merely
+          # writing about a command ran it: on #4880 four review/progress comments
+          # that quoted the phrase in prose, a table cell, an inline code span or
+          # a ``` block each re-applied `run-ci`, and under
+          # `cancel-in-progress` that cancelled and restarted a ~4.5h GPU run.
+          #
+          # Reduce the body to the first line that IS a command, then classify it.
+          # Leading whitespace is allowed (indented commands are common); anything
+          # to the left of the handle - `>` for a quoted reply, `|` for a table
+          # cell, a backtick for an inline code span, prose - is not.
+          CMD=$(printf '%s\n' "$COMMENT_BODY" | tr -d '\r' \
+            | awk '/^[[:space:]]*(```|~~~)/ { fenced = !fenced; next } !fenced' \
+            | grep -iEm1 '^[[:space:]]*@flashinfer-bot[[:space:]]+(run|rerun|stop)([[:space:]]|$)' \
+            | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')
+
+          # Same order as before: `rerun failed` must be tested before `rerun`.
+          # The trailing `([[:space:]]|$)` keeps `run` from matching `running`.
+          if echo "$CMD" | grep -qiE '^@flashinfer-bot[[:space:]]+rerun[[:space:]]+failed([[:space:]]|$)'; then
             echo "command=rerun-failed" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMENT_BODY" | grep -qi "@flashinfer-bot rerun"; then
+          elif echo "$CMD" | grep -qiE '^@flashinfer-bot[[:space:]]+rerun([[:space:]]|$)'; then
             echo "command=rerun" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMENT_BODY" | grep -qi "@flashinfer-bot stop"; then
+          elif echo "$CMD" | grep -qiE '^@flashinfer-bot[[:space:]]+stop([[:space:]]|$)'; then
             echo "command=stop" >> "$GITHUB_OUTPUT"
-          elif echo "$COMMENT_BODY" | grep -qi "@flashinfer-bot run"; then
+          elif echo "$CMD" | grep -qiE '^@flashinfer-bot[[:space:]]+run([[:space:]]|$)'; then
             echo "command=run" >> "$GITHUB_OUTPUT"
           else
             echo "command=unknown" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`.github/workflows/ci-bot-commands.yml` decides whether a PR comment is a bot command with
unanchored substring matches:

```
# BOT below stands for the literal bot handle, elided so this PR does not trigger itself.
if: github.event.issue.pull_request && contains(github.event.comment.body, 'BOT')
...
elif echo "$COMMENT_BODY" | grep -qi "BOT run"; then
```

Neither is anchored, so the phrase matches **anywhere** in a comment body — inside inline code
spans, fenced blocks, markdown tables, and quoted reply history. *Writing about* a command runs it.

Each accidental fire re-applies the `run-ci` label, which emits a `labeled` event, which under
`concurrency: cancel-in-progress` **cancels the in-flight GPU run and starts a new one**. A run is
~4.5 hours, so each accident is expensive. The known workaround is to write the handle with a
zero-width entity (`@flashinfer&#8203;-bot`) — a hack no contributor should need to know.

### The fix

A command counts only when it **starts a line that is not inside a fenced code block.**

Implemented entirely inside the `Parse command` step, in two stages:

1. `awk` drops fenced code blocks (both ``` and `~~~`, including indented fences).
2. `grep -iEm1 '^[[:space:]]*@flashinfer&#8203;-bot[[:space:]]+(run|rerun|stop)([[:space:]]|$)'` takes the first
   surviving line that *begins* with the handle. Leading whitespace is allowed; anything else to the
   left — `>` for a quoted reply, `|` for a table cell, a backtick for an inline span, or prose — is not.

The four existing classifiers then run against that single extracted line, gaining `^` anchors and a
trailing word boundary. Order (`rerun failed` before `rerun`) is unchanged.

**Why not the job-level `if:`** — GitHub Actions expressions have no regex (only
`contains`/`startsWith`/`endsWith`), so the job guard cannot be anchored. It is left as-is and
re-commented as a cheap pre-filter. This is harmless: a prose comment now spawns a job that resolves
`command=unknown` and takes no action, since every handler step is gated on `steps.parse.outputs.command`.

No bot-author guard is included. It would not have prevented any of these accidents — they came from
**humans writing documentation**, not from the bot. It is worth adding separately as complementary
hardening, but anchoring is the actual fix.

## 🔍 Related Issues

No tracking issue. The behaviour was found while working on #4880, where four documentation
comments each cancelled and restarted an in-flight ~4.5 hour GPU run — but the problem is
repo-wide and predates it (see the replay below, spanning 2025-10-18 → 2026-09-04 across five
PRs). This change is independent of #4880: `git grep` confirms lines 26 and 96-102 of
`ci-bot-commands.yml` are the only consumers of `comment.body` on `main`.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed. — see the replay, corpus and verification below.
- [x] All tests are passing (`unittest`, etc.).

**This file cannot be tested by CI.** `issue_comment` workflows always load from the default
branch, so zero CI runs on this PR execute the changed file; it takes effect only once merged.
All verification below was therefore done out-of-band.

### Repo-wide replay

I replayed **every** issue comment in this repository's history through both matchers — 19,930
comments, of which 725 are handle-bearing PR comments spanning 2025-10-18 → 2026-09-04.

| | old | new |
|---|---|---|
| fires | 689 | 666 |
| suppressed (old fired, new does not) | — | **31** |
| newly honored (old ignored, new fires) | — | **8** |
| reclassified to a different command | — | **0** |

**All 31 suppressions are accidental. Zero legitimate commands are lost.** By how the phrase was
embedded: 21 inline code span, 4 bare in a prose sentence, 2 table cell, 2 fenced block, 2 blockquote.

8 of the 31 were by users authorized to trigger CI (`aleozlx` ×4, `Anerudhan`, `mhoqueanik`,
`qsang-nv`, `yongwww`) across 5 PRs (#4880, #4795, #4341, #3471, #2529) over 7 months — these are the
ones that actually consumed GPU CI, and every one is documentation prose. **This is a repo-wide
problem, not a #4880 artifact.** The other 23 were by users with only `read` permission, so the bot
replied "unauthorized" and no CI ever started; the only loss there is a feedback reaction.

The 4 "bare in prose" cases are the most arguable, e.g. *"Could a maintainer please approve the
external CI for this PR? @flashinfer​-bot run"* (#4435). I checked all three authors
(`foraxe`, `DocJlm`, `Archie-wang`): each has only `read` and is not in `ci-users`, so none of these
started CI under the old code either.

**The change also fixes a latent bug in the other direction.** `@flashinfer​-bot` + two spaces +
`run` matched *nothing* under the old literal-substring rule. It was silently ignored 8 times by 4
authorized maintainers (`yzh119` ×3, `yongwww` ×3, `jiahanc`, `kahyunnam`); 7 of the 8 carry zero
reactions, confirming the handler never fired. Those now work.

### Corpus

33 hand-built cases + the 11 real #4880 comments. Verified three ways: against an independent Python
model of the pipeline, by executing the shipped step under `bash -e`, and live in a sandbox repo.

**MUST TRIGGER — all preserved**

| case | body | old | new |
|---|---|---|---|
| bare run | `@flashinfer&#8203;-bot run` | run | run |
| with path | `@flashinfer&#8203;-bot run tests/gemm/test_x.py` | run | run |
| multiple paths | `@flashinfer&#8203;-bot run tests/a.py tests/b.py` | run | run |
| leading spaces | `␣␣␣@flashinfer&#8203;-bot run` | run | run |
| leading tab | `⇥@flashinfer&#8203;-bot rerun failed` | rerun-failed | rerun-failed |
| mixed case | `@FlashInfer&#8203;-Bot RUN` | run | run |
| mixed case rerun | `@FLASHINFER&#8203;-BOT ReRun` | rerun | rerun |
| first line of multi-line | `@flashinfer&#8203;-bot run\n\nKicking off CI.` | run | run |
| later line of multi-line | `Rebased.\n\n@flashinfer&#8203;-bot run` | run | run |
| middle line | `Fixed lint.\n@flashinfer&#8203;-bot run tests/utils/\nThanks!` | run | run |
| rerun | `@flashinfer&#8203;-bot rerun` | rerun | rerun |
| rerun failed | `@flashinfer&#8203;-bot rerun failed` | rerun-failed | rerun-failed |
| stop | `@flashinfer&#8203;-bot stop` | stop | stop |
| trailing prose | `@flashinfer&#8203;-bot run please` | run | run |
| after a fenced block | a log in a backtick fence, then `@flashinfer&#8203;-bot run` below it | run | run |
| CRLF line endings | `Rebased.\r\n@flashinfer&#8203;-bot run\r\n` | run | run |
| trailing whitespace | `@flashinfer&#8203;-bot run␣␣␣` | run | run |
| after a bullet list | list then `@flashinfer&#8203;-bot rerun failed` | rerun-failed | rerun-failed |
| **double space** | `@flashinfer&#8203;-bot␣␣run` | **unknown** | **run** |

**MUST NOT TRIGGER — all now suppressed**

| case | body | old | new |
|---|---|---|---|
| inline code span, in prose | ``The command is `@flashinfer&#8203;-bot run` -- type it on its own line.`` | run | **unknown** |
| inline code span at line start | code span first on the line, then prose | run | **unknown** |
| fenced block | backtick fence listing the commands | stop | **unknown** |
| fenced block with language | backtick fence tagged `bash` | run | **unknown** |
| tilde fence | `~~~` block | rerun-failed | **unknown** |
| blockquote | `> @flashinfer&#8203;-bot run` | run | **unknown** |
| nested blockquote | `> > @flashinfer&#8203;-bot rerun` | rerun | **unknown** |
| prose, mid-sentence | `I will ask a maintainer to @flashinfer&#8203;-bot run this once...` | run | **unknown** |
| table cell | `\| `@flashinfer&#8203;-bot run` \| full suite \|` | stop | **unknown** |
| cc mention only | `cc @flashinfer&#8203;-bot -- could you take a look?` | unknown | unknown |
| bullet + inline span | `- **`fix(ci): bind COMMENT_BODY in the @flashinfer&#8203;-bot run handler`**` | run | **unknown** |
| heading | ``### How `@flashinfer&#8203;-bot run` works`` | run | **unknown** |
| indented fence in a numbered list | `1.` then an indented backtick fence | run | **unknown** |
| prose, sentence start | `Someone should @flashinfer&#8203;-bot run the suite again;` | run | **unknown** |
| quoted reply history | `> On Tue, alex wrote:\n> @flashinfer&#8203;-bot run tests/g...` | run | **unknown** |
| the 4 real #4880 documentation comments | (verbatim from the API) | run ×4 | **unknown ×4** |
| the 7 real #4880 genuine commands | (verbatim from the API) | run ×7 | run ×7 |

### How it was verified

- **Offline**: an independent Python model of the pipeline agrees with the shipped shell step on all
  44 corpus cases and on all 725 real handle-bearing comments — 0 divergences.
- **Under the real shell**: the `Parse command` step extracted verbatim from the committed file, run
  as `bash -e` with `COMMENT_BODY` in the environment. All cases exit `rc=0` and always write a
  `command=` output, including empty, whitespace-only, and non-matching bodies.
- **GNU toolchain**: the runner image is not macOS, so the corpus was also run on `ubuntu-24.04`
  (`GNU grep 3.11`, `GNU Awk 5.2.1`) — **44/44 PASS, 0 FAIL**.
- **Live**: 12 headline cases posted as real PR comments in a sandbox repo running a byte-identical
  copy of the step, driven by a real `issue_comment` event — 6 fired, 6 did not, **0 mismatches**,
  matching predictions exactly.

## 🔬 Experimental Track

<!-- Not an experimental-track PR; section left as the template provides it. -->

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

### Reviewability is the safety property

`issue_comment` workflows always load from the **default branch**, so this file is executed by zero
CI runs on this PR and cannot be tested by any PR. Nothing here validates it before it lands on
`main`. That is why the change is confined to one file with a small, obvious diff, and why the
verification above was done out-of-band in a sandbox repo instead.

### Residual gaps

**Still trigger, arguably should not.** The fence handling is a simple toggle, so a fence nested
inside another fence flips it back off, and these leak (verified live):

````
```
BOT run
```
````

The same applies to a `~~~` outer fence containing a ``` inner fence. This is ordinary CommonMark
nesting and is exactly what a comment documenting *this change* would type. Fixing it properly means
tracking the opening fence's character and length, which costs the diff its obviousness; it occurs
**zero** times in 725 real comments. Also still triggering: 4-space-indented code blocks, and HTML
constructs (`<details>`, `<pre>`, `<!-- -->`), since none of these is a fence.

A line that *begins* with the handle and continues into prose — `@flashinfer​-bot run is the command you
want.` — still fires. This is inherent and unfixable: `run <paths>` is documented, so the two forms
are textually identical.

**No longer trigger, arguably should.** All fail closed (no CI started, never a false trigger):

- A command below an **unterminated** fence is swallowed. A line that merely *starts* with a
  triple-backtick while actually being a one-line inline code span in GFM (a command wrapped in
  triple backticks on its own line) also flips fence parity, dropping a genuine command later in
  the same comment.
- Anything to the left of the handle on the line: a bullet (`- `), `1. `, bold (`**`), a non-breaking
  space, or prose.
- `@flashinfer&#8203;-bot run-ci` and `@flashinfer&#8203;-bot running ...` now resolve to `unknown` (previously `run`), because of
  the added word boundary. Intentional tightening.
- Precedence is now positional rather than by-keyword: a `stop` line above a `rerun failed` line
  yields `stop`, where the old code yielded `rerun-failed`. Only observable in a comment containing
  two different commands; occurs zero times in 725 real comments.

**Feedback loss.** Comments that no longer parse get no reaction at all, since the "Unauthorized
user" step is gated on `command != 'unknown'`. A mis-shaped command is now silent for authorized and
unauthorized commenters alike.

**Latent, not currently reachable.** The step is correct today because the runner shell is
`bash -e 0` *without* `pipefail`, so the `CMD=$(... | grep ... | sed ...)` assignment takes `sed`'s
status 0 even when `grep` matches nothing. If anyone later adds `shell: bash` to this step or a
`defaults.run.shell: bash` to the workflow, `pipefail` turns on and the assignment returns 1 under
`set -e` — a red X on every prose comment mentioning the handle. Fail-safe (never a false trigger),
but worth knowing; a trailing `|| true` would immunize it.

### Scope

Touches only `.github/workflows/ci-bot-commands.yml` (+25/-5). Confirmed with `git grep` that lines
26 and 96-102 are the only consumers of `comment.body` on `main`, so this is independent of #4880.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command detection to avoid interpreting regular prose, quoted replies, inline code, tables, and fenced code blocks as commands.
  - Preserved content inside code fences when opening and closing delimiters do not match.
  - Improved handling when no valid command is found, preventing unnecessary processing failures.
- **Documentation**
  - Clarified workflow filtering behavior for more transparent command processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->