### PR TITLE
fix(ci): publish the test scope with GITHUB_TOKEN, not the bot PAT

### DIFF
--- a/.github/workflows/ci-bot-commands.yml
+++ b/.github/workflows/ci-bot-commands.yml
@@ -116,6 +116,16 @@ jobs:
         if: steps.check-permission.outputs.authorized == 'true' && steps.parse.outputs.command == 'run'
         env:
           GH_TOKEN: ${{ secrets.FLASHINFER_BOT_TOKEN }}
+          # Commit statuses are published with GITHUB_TOKEN, not the bot PAT. The
+          # `permissions:` block at the top of this file grants `statuses: write` to
+          # GITHUB_TOKEN only -- it does not apply to a PAT -- and the bot PAT has no
+          # commit-status permission, so publishing a scope with it fails:
+          #     gh: Resource not accessible by personal access token (HTTP 403)
+          # The PAT is still required for the label, because a `labeled` event raised by
+          # GITHUB_TOKEN does not trigger workflows. A status needs to trigger nothing;
+          # pr-test.yml reads it with GITHUB_TOKEN too. So splitting by purpose is safe
+          # and keeps the privileged token's blast radius smaller.
+          STATUS_TOKEN: ${{ github.token }}
           # Step-level env does not cross steps, so the comment body has to be bound
           # here too -- `Parse command` binding it is not enough. Passed through the
           # environment rather than interpolated into the script, so the body is data.
@@ -228,7 +238,7 @@ jobs:
           # Same reasoning as HEAD_SHA: a failure here must not cost the label. 0 means
           # "assume no previous chunks", which at worst leaves a stale trailing chunk
           # -- strictly better than starting no CI at all.
-          PREV_MAX=$(gh api "/repos/${{ github.repository }}/commits/${HEAD_SHA}/status" \
+          PREV_MAX=$(GH_TOKEN="$STATUS_TOKEN" gh api "/repos/${{ github.repository }}/commits/${HEAD_SHA}/status" \
             --jq '[.statuses[].context
               | select(test("^ci/test-scope-[0-9]+$"))
               | sub("^ci/test-scope-"; "") | tonumber] | max // 0') \
@@ -238,7 +248,7 @@ jobs:
           publish_chunk() {
             # No SHA means no status to key on; skip rather than POST to an empty path.
             [ -n "${HEAD_SHA}" ] || return 0
-            gh api -X POST "/repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
+            GH_TOKEN="$STATUS_TOKEN" gh api -X POST "/repos/${{ github.repository }}/statuses/${HEAD_SHA}" \
               -f state=success \
               -f context="ci/test-scope-$1" \
               -f description="$2" \


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

A valid scoped command fails in production:

```
gh: Resource not accessible by personal access token (HTTP 403)
##[error]Process completed with exit code 1
```

The `Handle` step runs with `GH_TOKEN` set to the bot PAT. The `permissions:` block at the top
of the file grants `statuses: write` to **`GITHUB_TOKEN`** — it does not apply to a PAT — and the
bot PAT carries no commit-status permission. So `POST /repos/.../statuses/{sha}`, which is how a
scope reaches the test job, is refused.

**Effect: the targeted-testing path does not work at all.** A valid scoped command fails the
handler, applies no label, and starts no CI. Bare and malformed commands are unaffected, because
neither touches the statuses API.

**Fix:** publish the scope with `${{ github.token }}`. The PAT is still required for the label,
because a `labeled` event raised by `GITHUB_TOKEN` does not trigger workflows. A status needs to
trigger nothing, and `pr-test.yml` already reads it with `GITHUB_TOKEN`. Splitting by purpose also
keeps the privileged token's blast radius smaller. Alternative would be granting the PAT
`repo:status`, which needs token administration and widens it instead.

## 🔍 Related Issues

Fixes the scoped path introduced in #4880. Found by driving the merged handler on throwaway PR
#4959.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

**This file cannot be tested by CI**, on this PR or any other: `issue_comment` workflows load from
the default branch, so it takes effect only once merged. That is also why the bug reached `main`.

Verification therefore has to be post-merge: after this lands, re-issue a scoped command on #4959
and confirm the scope publishes and `Targeted Unittest` lanes appear.

**Why the pre-merge sandbox missed it.** The scoped path *was* exercised end to end before merge,
in a scratch repository running byte-identical logic — publish, chunk, reassemble, matrix, all the
way into the runner's parsed argv. But that mirror ran the step under `${{ github.token }}`, while
production runs it under the PAT. Faithful in behaviour, wrong in identity — and authorization is a
property of identity, so no amount of logic fidelity could have caught it. The check that would
have: diffing the two workflows' `GH_TOKEN:` lines against their `permissions:` blocks.

## Reviewer Notes

Three lines of substance: one added `env:` entry and two `GH_TOKEN="$STATUS_TOKEN"` prefixes. No
control flow changes.

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed commit status publishing for the “run” bot command by using the appropriate authorization token.
  * Preserved workflow-triggering capabilities while ensuring status updates are successfully posted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->