### PR TITLE
Add cuDNN backend for linear attention

### DIFF
--- a/benchmarks/bench_gdn_prefill.py
+++ b/benchmarks/bench_gdn_prefill.py
@@ -20,6 +20,15 @@ Performance benchmark for GDN (Gated Delta Network) prefill kernel.
 Compares FlashInfer GDN prefill against FLA baseline across
 Qwen3.5 family model configurations.
 
+The default timing is CUDA events around each call, so host dispatch is inside
+the number. Pass --use-cuda-graph to replay a captured graph instead and compare
+kernels alone.
+
+The cuDNN column pays one conversion the native path does not: FlashInfer's
+public alpha is linear space and cuDNN's GDN engine takes a log gate, so the
+wrapper runs a .log() inside the timed call. Every column passes
+output_state=None so no backend is charged a state copy another avoids.
+
 Usage:
   python bench_gdn_prefill.py
   python bench_gdn_prefill.py --warmup 10 --iters 100
@@ -45,6 +54,24 @@ try:
 except ImportError:
     fla_gdn = None
     _has_fla = False
+
+
+def _cudnn_rejection_reason(device):
+    """Why the cuDNN backend cannot run this benchmark, or None if it can."""
+    tokens, heads, dim = 64, 1, 128
+    qkv = dict(dtype=torch.float16, device=device)
+    try:
+        chunk_gated_delta_rule(
+            torch.randn(tokens, heads, dim, **qkv),
+            torch.randn(tokens, heads, dim, **qkv),
+            torch.randn(tokens, heads, dim, **qkv),
+            cu_seqlens=torch.tensor([0, tokens], dtype=torch.int32, device=device),
+            backend="cudnn",
+        )
+    except Exception as exc:
+        return f"{type(exc).__name__}: {exc}"
+    return None
+
 
 HEAD_CONFIGS = [
     # (h_qk, h_v, d, label)
@@ -83,6 +110,8 @@ SEQ_CONFIGS = [
     (tuple(8192 * (i + 1) for i in range(32)), "8192x32"),
 ]
 
+DRIFT_THRESHOLD = 0.02
+
 
 def _gdn_tflops(total_tokens, h_v, d, time_ms):
     """Calculate TFLOPS: 2 GEMMs (kv outer product + q@state) per token per head."""
@@ -98,8 +127,8 @@ def get_num_rotating_buffers(num_iters: int, q, k, v) -> int:
     return max(1, min(num_iters, (total_bytes + nbytes - 1) // nbytes))
 
 
-def bench_fi(args, endpoints, h_qk, h_v, d):
-    """Benchmark FlashInfer GDN prefill."""
+def bench_fi(args, endpoints, h_qk, h_v, d, backend="auto"):
+    """Benchmark FlashInfer GDN prefill on the given public API backend."""
     device = "cuda"
     dtype = torch.float16
     N = len(endpoints)
@@ -114,10 +143,11 @@ def bench_fi(args, endpoints, h_qk, h_v, d):
     # FlashInfer's g is the linear-space forget gate alpha in (0, 1)
     # ("defaults to all ones" = no decay). Log-space gates (e.g. logsigmoid)
     # are out of domain and produce NaN outputs/state.
-    g = torch.rand(T, h_v, dtype=torch.float32, device=device)
+    g = torch.rand(T, h_v, dtype=torch.float32, device=device).clamp_min(
+        torch.finfo(torch.float32).tiny
+    )
     beta = torch.rand(T, h_v, dtype=torch.float32, device=device).sigmoid()
     h0 = torch.randn((N, h_v, d, d), dtype=torch.float32, device=device)
-    state_out = torch.zeros_like(h0)
 
     num_buffer = get_num_rotating_buffers(args.iters, q, k, v)
     q = [q.clone() for _ in range(num_buffer)]
@@ -138,8 +168,7 @@ def bench_fi(args, endpoints, h_qk, h_v, d):
             True,
             cu_seqlens,
             False,
-            None,
-            state_out,
+            backend=backend,
         )
         rotation_buffer_idx += 1
 
@@ -151,24 +180,27 @@ def bench_fi(args, endpoints, h_qk, h_v, d):
         use_cuda_graph=args.use_cuda_graph,
     )
     torch.cuda.empty_cache()
-    return np.average(times)
+    return float(np.median(times))
 
 
 def bench_fla(args, endpoints, h_qk, h_v, d):
     """Benchmark FLA baseline."""
     device = "cuda"
     dtype = torch.float16
-    h = h_v
     N = len(endpoints)
     T = endpoints[-1]
     cu_seqlens = torch.tensor([0] + list(endpoints), dtype=torch.int32, device=device)
 
-    q = torch.randn((1, T, h, d), dtype=dtype, device=device)
+    q = torch.randn((1, T, h_qk, d), dtype=dtype, device=device)
     k = F.normalize(
-        torch.randn(1, T, h, d, dtype=torch.float32, device=device), p=2, dim=-1
+        torch.randn(1, T, h_qk, d, dtype=torch.float32, device=device), p=2, dim=-1
     ).to(dtype)
     v = torch.randn((1, T, h_v, d), dtype=dtype, device=device)
-    g = F.logsigmoid(torch.rand(1, T, h_v, dtype=torch.float32, device=device))
+    g = (
+        torch.rand(1, T, h_v, dtype=torch.float32, device=device)
+        .clamp_min(torch.finfo(torch.float32).tiny)
+        .log()
+    )
     beta = torch.rand(1, T, h_v, dtype=torch.float32, device=device).sigmoid()
     h0 = torch.randn((N, h_v, d, d), dtype=torch.float32, device=device)
 
@@ -202,7 +234,7 @@ def bench_fla(args, endpoints, h_qk, h_v, d):
         use_cuda_graph=args.use_cuda_graph,
     )
     torch.cuda.empty_cache()
-    return np.average(times)
+    return float(np.median(times))
 
 
 def main():
@@ -212,6 +244,11 @@ def main():
     parser.add_argument("--cooling-time", type=float, default=0.1)
     parser.add_argument("--use-cupti", action="store_true")
     parser.add_argument("--use-cuda-graph", action="store_true")
+    parser.add_argument(
+        "--skip-cudnn",
+        action="store_true",
+        help="Do not measure the cuDNN backend column",
+    )
     args = parser.parse_args()
 
     device = torch.device("cuda")
@@ -230,6 +267,11 @@ def main():
             "Benchmarking FlashInfer only."
         )
 
+    cudnn_reason = None if args.skip_cudnn else _cudnn_rejection_reason(device)
+    has_cudnn = not args.skip_cudnn and cudnn_reason is None
+    if cudnn_reason is not None:
+        print(f"Warning: cuDNN backend unavailable: {cudnn_reason}")
+
     print(f"\nGPU: {torch.cuda.get_device_name(0)} [{arch_label}]")
     print("Models: Qwen3.5 family (397B, 122B, 35B, 27B, 9B, 4B, 2B, 0.8B), d=128")
     print()
@@ -238,28 +280,59 @@ def main():
         f"{'Heads':<15s}  {'Seqlens':<16s}  {'h_qk':>4s} {'h_v':>4s}"
         f"  {fi_col:>22s}  {'TFLOPS':>7s}"
     )
+    if has_cudnn:
+        header += f"  {'cuDNN':>10s}  {'FI/cuDNN':>9s}"
     if _has_fla:
         header += f"  {'FLA/Triton':>10s}  {'Speedup':>8s}"
     print(header)
     print("-" * len(header))
 
+    order = ["FI"]
+    if has_cudnn:
+        order.append("cuDNN")
+    if _has_fla:
+        order.append("FLA")
+
     for h_qk, h_v, d, h_label in HEAD_CONFIGS:
         for endpoints, s_label in SEQ_CONFIGS:
             gc.collect()
             T = endpoints[-1]
-            fi_ms = bench_fi(args, endpoints, h_qk, h_v, d)
-            time.sleep(args.cooling_time)
+            block_medians = {name: [] for name in order}
+            for name in order + order[::-1]:
+                if name == "FLA":
+                    block_medians[name].append(bench_fla(args, endpoints, h_qk, h_v, d))
+                else:
+                    block_medians[name].append(
+                        bench_fi(
+                            args,
+                            endpoints,
+                            h_qk,
+                            h_v,
+                            d,
+                            backend="cudnn" if name == "cuDNN" else "auto",
+                        )
+                    )
+                time.sleep(args.cooling_time)
+            fi_ms = float(np.median(block_medians["FI"]))
             tflops = _gdn_tflops(T, h_v, d, fi_ms)
             row = (
                 f"{h_label:<15s}  {s_label:<16s}  {h_qk:>4d} {h_v:>4d}"
                 f"  {fi_ms:>21.3f}ms  {tflops:>6.1f}"
             )
+            if has_cudnn:
+                cudnn_ms = float(np.median(block_medians["cuDNN"]))
+                speedup = fi_ms / cudnn_ms
+                marker = "+" if speedup > 1.0 else "-"
+                row += f"  {cudnn_ms:>9.3f}ms  {speedup:>8.2f}x {marker}"
             if _has_fla:
-                fla_ms = bench_fla(args, endpoints, h_qk, h_v, d)
-                time.sleep(args.cooling_time)
+                fla_ms = float(np.median(block_medians["FLA"]))
                 speedup = fla_ms / fi_ms
                 marker = "+" if speedup > 1.0 else "-"
                 row += f"  {fla_ms:>9.3f}ms  {speedup:>7.2f}x {marker}"
+            outer = block_medians[order[0]]
+            drift = abs(outer[1] - outer[0]) / np.median(outer)
+            if drift > DRIFT_THRESHOLD:
+                row += f"  drift {drift * 100:.1f}%"
             print(row)
         print()
 

--- a/benchmarks/bench_recurrent_kda_prefill.py
+++ b/benchmarks/bench_recurrent_kda_prefill.py
@@ -25,9 +25,11 @@ The FlashInfer candidate is always invoked through the public
 device/shape policy, while ``nonpersistent`` supplies the same explicit
 workspace and packed sequence order used by the historical benchmark to keep
 B200 on the direct schedule family. ``--backend`` selects one public API
-backend per invocation; compare auto, CuTe DSL, and Cake with separate commands
-over the same case set. The resolved backend, logical schedule, physical module
-variants, and target are recorded during untimed warmup. With
+backend per invocation; compare auto, CuTe DSL, Cake, and cuDNN with separate
+commands over the same case set. ``--backend cudnn`` runs the fused cuDNN
+SM100 engine, which takes packed input only, so fixed-layout cases are dropped
+and recorded as skip entries. The resolved backend, logical schedule, physical
+module variants, and target are recorded during untimed warmup. With
 ``--flash-kda-peer``, two commit-verified MoonshotAI/FlashKDA measurements are
 reported:
 
@@ -37,8 +39,11 @@ reported:
 
 All paths use the same deterministic tensors and seeds. Preinitialized
 rotating state buffers ensure every timed invocation sees the same initial
-state. The FlashInfer path updates each state slot in place inside the kernel;
-it has no state scratch or copy-back. Allocation, metadata, sequence ordering,
+state. The candidate lets ``recurrent_kda`` allocate its own output, so no
+backend is charged a copy another avoids; the FlashKDA peer scopes keep the
+preallocated outputs ``_fwd_raw`` requires. Cake and CuTe DSL update the state
+slot in the kernel, while cuDNN allocates its final state and copies it back
+inside the timed scope. Metadata, sequence ordering,
 build/JIT, and state-pool reset are outside the measured region.
 """
 
@@ -64,6 +69,7 @@ FLASH_KDA_CUTLASS_COMMIT = "5c149f52a436782210263fb2f19b354443a61c6a"
 DEFAULT_LEGACY_STATE_ROTATIONS = 1024
 DEFAULT_H12_STATE_ROTATIONS = 4096
 DEFAULT_PRODUCTION_STATE_BUDGET_BYTES = 8 * 1024**3
+STATE_DTYPE = torch.bfloat16
 _CUPTI_ESTIMATE_CALLS_PER_BLOCK = 1 + 5
 SUPPORTED_FLASH_KDA_ARCHS = {(10, 0): "sm100a", (10, 3): "sm103a"}
 BENCHMARKS_DIR = Path(__file__).resolve().parent
@@ -85,7 +91,6 @@ class PreparedCase:
     peer_raw_run: Optional[Callable[[], None]]
     peer_adapted_run: Optional[Callable[[], None]]
     reset_state_pools: Callable[[], None]
-    candidate_output: torch.Tensor
     candidate_state_pool: torch.Tensor
     peer_raw_output: Optional[torch.Tensor]
     peer_raw_final_state: Optional[torch.Tensor]
@@ -248,7 +253,7 @@ def _default_state_rotations(case: Case) -> int:
     )
     if case not in PRODUCTION_CASES:
         return base
-    state_bytes = len(case.seq_lens) * case.num_heads * 128 * 128 * 2
+    state_bytes = len(case.seq_lens) * case.num_heads * 128 * 128 * STATE_DTYPE.itemsize
     budget_capacity = max(8, DEFAULT_PRODUCTION_STATE_BUDGET_BYTES // state_bytes)
     return min(base, budget_capacity)
 
@@ -423,12 +428,11 @@ def _make_case(
             device="cuda",
         )
         * 0.25
-    ).to(torch.bfloat16)
+    ).to(STATE_DTYPE)
     candidate_state_pool = _make_state_pool(initial_state, state_rotations)
-    candidate_output = torch.empty_like(q)
     candidate_workspace = (
         RecurrentKDAPrefillWorkspace(q.device)
-        if candidate_route == "nonpersistent"
+        if candidate_route == "nonpersistent" and candidate_backend != "cudnn"
         else None
     )
     state_cursors = {"pr": [0], "adapted": [0]}
@@ -449,7 +453,9 @@ def _make_case(
             dtype=torch.int32,
             device="cuda",
         )
-        if case.packed and candidate_route == "nonpersistent"
+        if case.packed
+        and candidate_route == "nonpersistent"
+        and candidate_backend != "cudnn"
         else None
     )
     scale = float(1.0 / np.sqrt(128.0))
@@ -461,7 +467,7 @@ def _make_case(
                 f"PR state rotations exhausted: {state_index} >= {state_rotations}"
             )
         state_cursors["pr"][0] += 1
-        return recurrent_kda(
+        output, final_state = recurrent_kda(
             q=q,
             k=k,
             v=v,
@@ -471,8 +477,7 @@ def _make_case(
             dt_bias=dt_bias,
             scale=scale,
             initial_state=candidate_state_pool[state_index],
-            output=candidate_output,
-            output_final_state=False,
+            output_final_state=True,
             use_qk_l2norm_in_kernel=True,
             use_gate_in_kernel=True,
             lower_bound=-5.0,
@@ -482,6 +487,7 @@ def _make_case(
             prefill_workspace=candidate_workspace,
             backend=candidate_backend,
         )
+        return output, final_state
 
     peer_raw_run = None
     peer_adapted_run = None
@@ -575,10 +581,13 @@ def _make_case(
     # harness while keeping route logging out of every timed call.
     kda_prefill_module = import_module("flashinfer.kda_prefill")
     kda_prefill_cute_module = import_module("flashinfer.kda_prefill_cute")
+    cudnn_module = import_module("flashinfer.cudnn")
     original_get_module = kda_prefill_module._get_flash_kda_prefill_module
     original_cute_run = kda_prefill_cute_module._run_cute_dsl_kda_prefill
+    original_cudnn_run = cudnn_module.cudnn_recurrent_kda
     resolved_cake_routes = []
     resolved_backends = []
+    resolved_cudnn_calls = []
 
     def recording_get_module(variant, target):
         resolved_cake_routes.append((variant, target))
@@ -588,16 +597,33 @@ def _make_case(
         resolved_backends.append("cute-dsl")
         return original_cute_run(**kwargs)
 
+    def recording_cudnn_run(*call_args, **kwargs):
+        resolved_cudnn_calls.append("cudnn")
+        return original_cudnn_run(*call_args, **kwargs)
+
     kda_prefill_module._get_flash_kda_prefill_module = recording_get_module
     kda_prefill_cute_module._run_cute_dsl_kda_prefill = recording_cute_run
+    cudnn_module.cudnn_recurrent_kda = recording_cudnn_run
     try:
         candidate_run()
         torch.cuda.synchronize()
     finally:
         kda_prefill_module._get_flash_kda_prefill_module = original_get_module
         kda_prefill_cute_module._run_cute_dsl_kda_prefill = original_cute_run
+        cudnn_module.cudnn_recurrent_kda = original_cudnn_run
         reset_state_pools()
-    if resolved_backends:
+    if resolved_cudnn_calls:
+        if len(resolved_cudnn_calls) != 1 or resolved_backends or resolved_cake_routes:
+            raise RuntimeError(
+                "expected exactly one cuDNN route during warmup, got "
+                f"cudnn={resolved_cudnn_calls}, backends={resolved_backends}, "
+                f"cake={resolved_cake_routes}"
+            )
+        resolved_backend = "cudnn"
+        resolved_variant = "frost"
+        resolved_target = "sm100"
+        resolved_physical_variants = ["frost"]
+    elif resolved_backends:
         if resolved_backends != ["cute-dsl"] or resolved_cake_routes:
             raise RuntimeError(
                 "expected exactly one CuTe DSL route during warmup, got "
@@ -634,6 +660,7 @@ def _make_case(
         "candidate_route": candidate_route,
         "requested_backend": candidate_backend,
         "resolved_backend": resolved_backend,
+        "state_dtype": str(initial_state.dtype).removeprefix("torch."),
         "seed": case.seed,
         "state_rotation_capacity": state_rotations,
     }
@@ -642,7 +669,6 @@ def _make_case(
         peer_raw_run=peer_raw_run,
         peer_adapted_run=peer_adapted_run,
         reset_state_pools=reset_state_pools,
-        candidate_output=candidate_output,
         candidate_state_pool=candidate_state_pool,
         peer_raw_output=peer_raw_output,
         peer_raw_final_state=peer_raw_final_state,
@@ -661,7 +687,7 @@ def _check_peer(prepared: PreparedCase) -> dict[str, float]:
     assert prepared.peer_adapted_output is not None
     assert prepared.peer_adapted_state_pool is not None
     prepared.reset_state_pools()
-    prepared.candidate_run()
+    candidate_output, _ = prepared.candidate_run()
     prepared.peer_raw_run()
     prepared.peer_adapted_run()
     torch.cuda.synchronize()
@@ -671,7 +697,7 @@ def _check_peer(prepared: PreparedCase) -> dict[str, float]:
     comparisons = (
         (
             "raw_output_max_abs",
-            prepared.candidate_output,
+            candidate_output,
             prepared.peer_raw_output,
         ),
         (
@@ -681,7 +707,7 @@ def _check_peer(prepared: PreparedCase) -> dict[str, float]:
         ),
         (
             "adapted_output_max_abs",
-            prepared.candidate_output,
+            candidate_output,
             prepared.peer_adapted_output,
         ),
         ("adapted_state_max_abs", candidate_state, adapted_state),
@@ -751,7 +777,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--backend",
-        choices=("auto", "cute-dsl", "cake"),
+        choices=("auto", "cute-dsl", "cake", "cudnn"),
         default="auto",
         help=(
             "Select one backend for this invocation of the public recurrent_kda "
@@ -835,6 +861,28 @@ def main() -> None:
         "production": PRODUCTION_CASES,
     }[args.case_set]
     results = []
+    if args.backend == "cudnn":
+        fixed = [case for case in selected_cases if not case.packed]
+        if fixed:
+            names = [case.name for case in fixed]
+            print(
+                f"Skipping {len(fixed)} fixed-layout case(s) under --backend cudnn "
+                f"(packed input only): {', '.join(names)}"
+            )
+            results.extend(
+                {
+                    "name": case.name,
+                    "layout": "fixed",
+                    "requested_backend": args.backend,
+                    "skipped": True,
+                    "skip_reason": (
+                        "the cuDNN linear-attention engines accept packed THD "
+                        "input only"
+                    ),
+                }
+                for case in fixed
+            )
+            selected_cases = [case for case in selected_cases if case.packed]
     for case in selected_cases:
         state_rotations = args.state_rotations
         if state_rotations is None:

--- a/docs/api/cudnn.rst
+++ b/docs/api/cudnn.rst
@@ -15,3 +15,43 @@ backend for ``BatchPrefillWithPagedKVCacheWrapper`` /
 
     cudnn_batch_decode_with_kv_cache
     cudnn_batch_prefill_with_kv_cache
+
+Linear attention
+----------------
+
+cuDNN's fused SM100 linear-attention engines, reachable either directly or as
+``backend="cudnn"`` on :func:`flashinfer.chunk_gated_delta_rule`,
+:func:`flashinfer.chunk_gated_delta_rule2`,
+:func:`flashinfer.chunk_gated_delta_product` and
+:func:`flashinfer.recurrent_kda`. ``"cudnn"`` is never selected implicitly for
+GDN or KDA, both of which have FlashInfer kernels of their own; GDN-2 and GDP
+have none, so their ``"auto"`` resolves here.
+
+These wrappers gate on one thing only: cudnn-frontend 1.28+ with the
+``cutedsl`` extra, the release that first carries the ``graph.gdn`` /
+``graph.gdn2`` / ``graph.gdp`` / ``graph.kda`` nodes. There is no cuDNN backend-version floor
+-- the FROST engines behind those nodes are CuTeDSL kernels the frontend
+compiles itself. Every other requirement, including the SM100 family
+(SM100-SM103 and SM107), the head dims, the input dtypes and the head-count
+relations, belongs to the engine, which declines a graph it cannot serve (the
+per-engine reason is logged by the frontend; the raised
+``cudnnGraphNotSupportedError`` itself is generic). Arguments
+FlashInfer has that cuDNN's entry points do not -- state checkpointing, indexed
+state pools, the context-parallel delta rule, speculative decode -- are
+rejected by the routing layer before the call.
+
+The recurrent state crosses this boundary untransposed. FlashInfer holds it
+V-major as ``[N, H, V, K]`` and so does cuDNN, so ``initial_state`` and
+``output_state`` buffers are passed straight through. cuDNN's ops take the
+state in float32 or bfloat16 and return ``final_state`` in whichever was
+given, so a bfloat16 state pool crosses with no copy at all. The gate domain
+does differ: the GDN, GDN-2 and GDP forget gates are linear-space alpha at
+this boundary and log-space in cuDNN, so the wrapper takes a log.
+
+.. autosummary::
+    :toctree: ../generated
+
+    cudnn_chunk_gated_delta_product
+    cudnn_chunk_gated_delta_rule
+    cudnn_chunk_gated_delta_rule2
+    cudnn_recurrent_kda

--- a/docs/api/cudnn.rst
+++ b/docs/api/cudnn.rst
@@ -27,9 +27,9 @@ cuDNN's fused SM100 linear-attention engines, reachable either directly or as
 GDN or KDA, both of which have FlashInfer kernels of their own; GDN-2 and GDP
 have none, so their ``"auto"`` resolves here.
 
-These wrappers gate on one thing only: cudnn-frontend 1.28+ with the
-``cutedsl`` extra, the release that first carries the ``graph.gdn`` /
-``graph.gdn2`` / ``graph.gdp`` / ``graph.kda`` nodes. There is no cuDNN backend-version floor
+These wrappers gate on one thing only: cudnn-frontend 1.29+ with the
+``cutedsl`` extra, the release whose ``graph.gdn`` / ``graph.gdn2`` /
+``graph.gdp`` / ``graph.kda`` nodes take ``gate_domain``. There is no cuDNN backend-version floor
 -- the FROST engines behind those nodes are CuTeDSL kernels the frontend
 compiles itself. Every other requirement, including the SM100 family
 (SM100-SM103 and SM107), the head dims, the input dtypes and the head-count
@@ -44,9 +44,9 @@ The recurrent state crosses this boundary untransposed. FlashInfer holds it
 V-major as ``[N, H, V, K]`` and so does cuDNN, so ``initial_state`` and
 ``output_state`` buffers are passed straight through. cuDNN's ops take the
 state in float32 or bfloat16 and return ``final_state`` in whichever was
-given, so a bfloat16 state pool crosses with no copy at all. The gate domain
-does differ: the GDN, GDN-2 and GDP forget gates are linear-space alpha at
-this boundary and log-space in cuDNN, so the wrapper takes a log.
+given, so a bfloat16 state pool crosses with no copy at all. The GDN and GDP
+forget gates are linear-space alpha at this boundary and cross as
+``gate_domain="linear"``; the GDN-2 and KDA gates are log-space on both sides.
 
 .. autosummary::
     :toctree: ../generated

--- a/docs/api/gdn2_prefill.rst
+++ b/docs/api/gdn2_prefill.rst
@@ -1,0 +1,21 @@
+.. _apigdn2_prefill:
+
+flashinfer.gdn2_prefill
+=======================
+
+Gated Delta-Rule 2 prefill. ``chunk_gated_delta_rule2`` is the chunked GDN-2
+scan: GDN's per-head scalar forget and erase gates become per key channel, and
+a third per-value-channel write gate scales the incoming value.
+
+FlashInfer carries no GDN-2 kernel of its own, so this runs on cuDNN's fused
+SM100 linear-attention engine
+(:func:`flashinfer.cudnn.cudnn_chunk_gated_delta_rule2`). It needs an
+SM100-family device and cudnn-frontend 1.28+ with the ``cutedsl`` extra; the
+engine declines anything else it cannot serve.
+
+.. currentmodule:: flashinfer.gdn2_prefill
+
+.. autosummary::
+    :toctree: ../generated
+
+    chunk_gated_delta_rule2

--- a/docs/api/gdp_prefill.rst
+++ b/docs/api/gdp_prefill.rst
@@ -1,0 +1,21 @@
+.. _apigdp_prefill:
+
+flashinfer.gdp_prefill
+======================
+
+Gated DeltaProduct prefill. ``chunk_gated_delta_product`` is the chunked GDP
+scan: GDN with ``num_householder`` beta-gated Householder updates per token
+instead of one, on an expanded k/v/beta sub-token timeline.
+
+FlashInfer carries no GDP kernel of its own, so this runs on cuDNN's fused
+SM100 linear-attention engine
+(:func:`flashinfer.cudnn.cudnn_chunk_gated_delta_product`). It needs an
+SM100-family device and cudnn-frontend 1.28+ with the ``cutedsl`` extra; the
+engine declines anything else it cannot serve.
+
+.. currentmodule:: flashinfer.gdp_prefill
+
+.. autosummary::
+    :toctree: ../generated
+
+    chunk_gated_delta_product

--- a/docs/fi_trace.rst
+++ b/docs/fi_trace.rst
@@ -191,6 +191,12 @@ files when ``FLASHINFER_TRACE_DUMP=1``:
    * - ``flashinfer.gdn_prefill``
      - ``chunk_gated_delta_rule``
      - ``gdn``
+   * - ``flashinfer.gdn2_prefill``
+     - ``chunk_gated_delta_rule2``
+     - ``gdn2``
+   * - ``flashinfer.gdp_prefill``
+     - ``chunk_gated_delta_product``
+     - ``gdp``
    * - ``flashinfer.fused_moe``
      - ``trtllm_fp8_block_scale_moe`` (6 routing types)
      - ``moe``

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,8 @@ FlashInfer is a library and kernel generator for Large Language Models that prov
    api/gdn_decode
    api/gdn_fused_decode
    api/gdn_prefill
+   api/gdn2_prefill
+   api/gdp_prefill
    api/kda
    api/kda_decode
    api/kda_prefill

--- a/flashinfer/__init__.py
+++ b/flashinfer/__init__.py
@@ -173,6 +173,8 @@ with contextlib.suppress(ImportError):
         CuteDslBf16MoEWrapper as CuteDslBf16MoEWrapper,
     )
     from .gdn_prefill import chunk_gated_delta_rule as chunk_gated_delta_rule
+from .gdn2_prefill import chunk_gated_delta_rule2 as chunk_gated_delta_rule2
+from .gdp_prefill import chunk_gated_delta_product as chunk_gated_delta_product
 
 
 # The fused GDN decode step is surfaced here like the other GDN APIs; the

--- a/flashinfer/cudnn/__init__.py
+++ b/flashinfer/cudnn/__init__.py
@@ -1,2 +1,8 @@
 from .decode import cudnn_batch_decode_with_kv_cache
 from .prefill import cudnn_batch_prefill_with_kv_cache
+from .linear_attention import (
+    cudnn_chunk_gated_delta_product,
+    cudnn_chunk_gated_delta_rule,
+    cudnn_chunk_gated_delta_rule2,
+    cudnn_recurrent_kda,
+)

--- a/flashinfer/cudnn/linear_attention.py
+++ b/flashinfer/cudnn/linear_attention.py
@@ -1,0 +1,896 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import math
+from enum import Enum
+from typing import Optional, Union
+
+import torch
+
+from ..api_logging import flashinfer_api
+from ..utils import _get_cache_buf
+
+try:
+    import cudnn
+
+    CUDNN_AVAILABLE = True
+except Exception:
+    cudnn = None
+    CUDNN_AVAILABLE = False
+
+_MIN_FRONTEND_VERSION = (1, 28)
+
+# Global cudnn handle. need to make it per device in future
+_cudnn_handle = None
+
+
+def _check_cudnn_frontend(feature: str) -> None:
+    """Fail fast on a frontend that has no linear-attention graph node."""
+    if not CUDNN_AVAILABLE:
+        raise RuntimeError(
+            f"cuDNN {feature} requires the cudnn Python frontend. Install with: "
+            "pip install -U 'nvidia-cudnn-frontend[cutedsl]'"
+        )
+    try:
+        version = tuple(int(part) for part in cudnn.__version__.split(".")[:2])
+    except (ValueError, AttributeError):
+        return
+    if version < _MIN_FRONTEND_VERSION:
+        want = ".".join(str(part) for part in _MIN_FRONTEND_VERSION)
+        raise RuntimeError(
+            f"cuDNN {feature} requires cudnn-frontend >= {want}, found "
+            f"{cudnn.__version__}. Upgrade with: "
+            "pip install -U 'nvidia-cudnn-frontend[cutedsl]'"
+        )
+
+
+def _create_cudnn_handle(stream: torch.cuda.Stream):
+    global _cudnn_handle
+
+    if _cudnn_handle is None:
+        _cudnn_handle = cudnn.create_handle()
+    cudnn.set_stream(_cudnn_handle, stream.cuda_stream)
+    return _cudnn_handle
+
+
+# Tensor ids
+class UIDs(Enum):
+    RESERVED_INVALID_UID = 0
+
+    Q_UID = 1  # Query tensor
+    K_UID = 2  # Key tensor
+    V_UID = 3  # Value tensor
+
+    G_UID = 10  # Forget gate, log space
+    BETA_UID = 11  # Update / erase gate
+    W_UID = 12  # GDN-2 write gate
+
+    CU_SEQLENS_UID = 100  # Packed sequence boundaries
+
+    A_LOG_UID = 150  # Safe-gate log decay rate
+    DT_BIAS_UID = 151  # Safe-gate bias
+
+    INITIAL_STATE_UID = 200  # Incoming recurrent state
+
+    O_UID = 1000  # Output tensor
+    FINAL_STATE_UID = 1001  # Outgoing recurrent state
+
+
+def _la_graph_key_fn(
+    family: str,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    o: torch.Tensor,
+    *,
+    w: Optional[torch.Tensor] = None,
+    a_log: Optional[torch.Tensor] = None,
+    dt_bias: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    final_state: Optional[torch.Tensor] = None,
+    num_householder: Optional[int] = None,
+    scale: float,
+    use_qk_l2norm: bool,
+    use_beta_sigmoid: bool,
+    safe_gate: bool,
+    gate_lower_bound: Optional[float],
+    batch_invariant: bool,
+):
+    def layout(t):
+        return None if t is None else (t.shape, t.stride(), t.dtype)
+
+    return (
+        family,
+        layout(q),
+        layout(k),
+        layout(v),
+        layout(g),
+        layout(beta),
+        layout(w),
+        layout(cu_seqlens),
+        layout(o),
+        layout(initial_state),
+        layout(final_state),
+        layout(a_log),
+        layout(dt_bias),
+        num_householder,
+        scale,
+        use_qk_l2norm,
+        use_beta_sigmoid,
+        safe_gate,
+        gate_lower_bound,
+        batch_invariant,
+    )
+
+
+if CUDNN_AVAILABLE:
+
+    @cudnn.jit(heur_modes=[cudnn.heur_mode.A])
+    @cudnn.graph_cache(key_fn=_la_graph_key_fn)
+    def _build_la_graph(
+        family: str,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        o: torch.Tensor,
+        *,
+        w: Optional[torch.Tensor] = None,
+        a_log: Optional[torch.Tensor] = None,
+        dt_bias: Optional[torch.Tensor] = None,
+        initial_state: Optional[torch.Tensor] = None,
+        final_state: Optional[torch.Tensor] = None,
+        num_householder: Optional[int] = None,
+        scale: float,
+        use_qk_l2norm: bool,
+        use_beta_sigmoid: bool,
+        safe_gate: bool,
+        gate_lower_bound: Optional[float],
+        batch_invariant: bool,
+    ):
+        handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
+
+        if not cudnn.datatypes.is_torch_available():
+            raise RuntimeError("torch is not available")
+
+        def dtype_of(t):
+            return cudnn.datatypes._torch_to_cudnn_data_type(t.dtype)
+
+        with cudnn.graph(handle) as (graph, _):
+
+            def declare(t, name, uid):
+                if t is None:
+                    return None
+                return graph.tensor(
+                    name=name,
+                    dim=list(t.shape),
+                    stride=list(t.stride()),
+                    data_type=dtype_of(t),
+                ).set_uid(uid.value)
+
+            cudnn_q = declare(q, "q", UIDs.Q_UID)
+            cudnn_k = declare(k, "k", UIDs.K_UID)
+            cudnn_v = declare(v, "v", UIDs.V_UID)
+            cudnn_g = declare(g, "g", UIDs.G_UID)
+            cudnn_beta = declare(beta, "beta", UIDs.BETA_UID)
+            cudnn_w = declare(w, "w", UIDs.W_UID)
+            cudnn_cu_seqlens = declare(cu_seqlens, "cu_seqlens", UIDs.CU_SEQLENS_UID)
+            cudnn_a_log = declare(a_log, "a_log", UIDs.A_LOG_UID)
+            cudnn_dt_bias = declare(dt_bias, "dt_bias", UIDs.DT_BIAS_UID)
+            cudnn_initial_state = declare(
+                initial_state, "initial_state", UIDs.INITIAL_STATE_UID
+            )
+
+            ports = dict(
+                q=cudnn_q,
+                k=cudnn_k,
+                v=cudnn_v,
+                g=cudnn_g,
+                beta=cudnn_beta,
+                cu_seqlens=cudnn_cu_seqlens,
+                initial_state=cudnn_initial_state,
+                a_log=cudnn_a_log,
+                dt_bias=cudnn_dt_bias,
+            )
+            attrs = dict(
+                scale=scale,
+                output_final_state=final_state is not None,
+                use_qk_l2norm=use_qk_l2norm,
+                use_beta_sigmoid=use_beta_sigmoid,
+                safe_gate=safe_gate,
+                batch_invariant=batch_invariant,
+                name=family,
+            )
+            if family == "gdn2":
+                ports["w"] = cudnn_w
+            if family in ("kda", "gdn2"):
+                attrs["gate_lower_bound"] = gate_lower_bound
+            if family == "gdp":
+                attrs["num_householder"] = num_householder
+
+            O, fs, _checkpoints = getattr(graph, family)(**ports, **attrs)
+
+            O.set_uid(UIDs.O_UID.value).set_output(True).set_dim(
+                list(o.shape)
+            ).set_stride(list(o.stride())).set_data_type(dtype_of(o))
+            if fs is not None:
+                fs.set_uid(UIDs.FINAL_STATE_UID.value).set_output(True).set_dim(
+                    list(final_state.shape)
+                ).set_stride(list(final_state.stride())).set_data_type(
+                    dtype_of(final_state)
+                )
+
+            tensors = [cudnn_q, cudnn_k, cudnn_v, O]
+            if fs is not None:
+                tensors.append(fs)
+            return graph, tensors
+
+
+def _run_la_graph(
+    family: str,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    o: torch.Tensor,
+    *,
+    w: Optional[torch.Tensor] = None,
+    a_log: Optional[torch.Tensor] = None,
+    dt_bias: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    final_state: Optional[torch.Tensor] = None,
+    num_householder: Optional[int] = None,
+    scale: float,
+    use_qk_l2norm: bool,
+    use_beta_sigmoid: bool,
+    safe_gate: bool,
+    gate_lower_bound: Optional[float],
+    batch_invariant: bool,
+) -> None:
+    graph, _ = _build_la_graph(
+        family,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        o,
+        w=w,
+        a_log=a_log,
+        dt_bias=dt_bias,
+        initial_state=initial_state,
+        final_state=final_state,
+        num_householder=num_householder,
+        scale=scale,
+        use_qk_l2norm=use_qk_l2norm,
+        use_beta_sigmoid=use_beta_sigmoid,
+        safe_gate=safe_gate,
+        gate_lower_bound=gate_lower_bound,
+        batch_invariant=batch_invariant,
+    )
+
+    var_map = {
+        UIDs.Q_UID.value: q,
+        UIDs.K_UID.value: k,
+        UIDs.V_UID.value: v,
+        UIDs.G_UID.value: g,
+        UIDs.BETA_UID.value: beta,
+        UIDs.CU_SEQLENS_UID.value: cu_seqlens,
+        UIDs.O_UID.value: o,
+    }
+    if w is not None:
+        var_map[UIDs.W_UID.value] = w
+    if a_log is not None:
+        var_map[UIDs.A_LOG_UID.value] = a_log
+    if dt_bias is not None:
+        var_map[UIDs.DT_BIAS_UID.value] = dt_bias
+    if initial_state is not None:
+        var_map[UIDs.INITIAL_STATE_UID.value] = initial_state
+    if final_state is not None:
+        var_map[UIDs.FINAL_STATE_UID.value] = final_state
+
+    workspace_buffer = _get_cache_buf(
+        "cudnn_linear_attention", max(graph.get_workspace_size(), 1), q.device
+    )
+    handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
+    graph.execute(var_map, workspace=workspace_buffer, handle=handle)
+
+
+def _state_out(
+    initial_state: Optional[torch.Tensor],
+    output_state: Optional[torch.Tensor],
+    num_seqs: int,
+    num_heads: int,
+    head_dim: int,
+    v_dim: int,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    """Pick the buffer cuDNN writes the final state into."""
+    if output_state is not None:
+        return output_state
+    dtype = torch.float32 if initial_state is None else initial_state.dtype
+    return torch.empty(num_seqs, num_heads, v_dim, head_dim, dtype=dtype, device=device)
+
+
+@flashinfer_api
+def cudnn_chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    batch_invariant: bool = False,
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated Delta Rule prefill on cuDNN's fused SM100 engine.
+
+    Argument meanings match :func:`flashinfer.chunk_gated_delta_rule`.
+
+    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    the engine decides for itself: it declines a graph it cannot serve (the
+    per-engine reason lands in the frontend's log).
+
+    Parameters
+    ----------
+    q, k, v : torch.Tensor
+        ``[total_seq_len, num_q_heads / num_k_heads / num_v_heads, 128]``,
+        packed. Strides are passed through to cuDNN, so only the innermost dim
+        has to be contiguous.
+    g : torch.Tensor, optional
+        Per-head forget gate in linear space (``alpha = exp(log_g)``), shape
+        ``[total_seq_len, num_sab_heads]``. cuDNN's gate is natural-log, so
+        this is converted; the conversion keeps ``g``'s own dtype, which cuDNN
+        reads at float32, bfloat16 or float16. All-ones when ``None``.
+    beta : torch.Tensor, optional
+        Per-head update gate ``[total_seq_len, num_sab_heads]``, post-sigmoid,
+        in float32 or ``q.dtype``. All-ones when ``None``.
+    scale : float, optional
+        Query scale; ``1 / sqrt(head_dim)`` when ``None`` or ``0.0``, matching
+        the native GDN path.
+    initial_state, output_state : torch.Tensor, optional
+        State ``[num_seqs, num_sab_heads, 128, 128]``, V-major, float32 or
+        bfloat16. cuDNN uses the same layout, so these pass through
+        untransposed and ``output_state`` is written in place by the kernel.
+        ``output_state`` must not alias ``initial_state``: the engines split
+        one sequence across CTAs, so the chunk-0 CTA reading the incoming
+        state would race the last-chunk CTA writing the outgoing one. Like the
+        state-slot uniqueness ``state_indices`` relies on, this is a caller
+        precondition rather than a launch-time check.
+    output_final_state : bool
+        Return the outgoing recurrent state alongside the output; when unset
+        no state is written at all.
+    cu_seqlens : torch.Tensor
+        ``[num_seqs + 1]`` int32 or int64. Required.
+    use_qk_l2norm_in_kernel : bool
+        Fuse the q/k L2 normalization into the kernel.
+    output : torch.Tensor, optional
+        Pre-allocated ``[total_seq_len, num_o_heads, 128]``, written in place
+        by the kernel.
+    batch_invariant : bool
+        Disable the split-K partition so the reduction order, and hence the
+        result, does not depend on how sequences are batched. Costs the
+        parallelism split-K exists to create on few long sequences and saves
+        its fixed scheduling cost on many short ones.
+
+    Returns
+    -------
+    torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
+        ``output``, or ``(output, final_state)`` when ``output_final_state``.
+    """
+    _check_cudnn_frontend("chunk_gated_delta_rule")
+    if cu_seqlens is None:
+        raise ValueError("cudnn_chunk_gated_delta_rule: cu_seqlens is required")
+
+    total, num_q_heads, head_dim = q.shape
+    v_dim = v.shape[2]
+    num_sab_heads = max(num_q_heads, v.shape[1])
+
+    g_log = (
+        torch.zeros(total, num_sab_heads, dtype=q.dtype, device=q.device)
+        if g is None
+        else torch.log(g)
+    )
+    if beta is None:
+        beta = torch.ones(total, num_sab_heads, dtype=torch.float32, device=q.device)
+
+    if output is None:
+        output = torch.empty(
+            total, num_sab_heads, v_dim, dtype=q.dtype, device=q.device
+        )
+    num_seqs = cu_seqlens.shape[0] - 1
+    final_state = (
+        _state_out(
+            initial_state,
+            output_state,
+            num_seqs,
+            num_sab_heads,
+            head_dim,
+            v_dim,
+            q.device,
+        )
+        if output_final_state
+        else None
+    )
+
+    _run_la_graph(
+        "gdn",
+        q,
+        k,
+        v,
+        g_log,
+        beta,
+        cu_seqlens,
+        output,
+        initial_state=initial_state,
+        final_state=final_state,
+        scale=float(scale) if scale else 1.0 / math.sqrt(head_dim),
+        use_qk_l2norm=bool(use_qk_l2norm_in_kernel),
+        use_beta_sigmoid=False,
+        safe_gate=False,
+        gate_lower_bound=None,
+        batch_invariant=bool(batch_invariant),
+    )
+    if not output_final_state:
+        return output
+    return output, final_state
+
+
+@flashinfer_api
+def cudnn_chunk_gated_delta_product(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    num_householder: int = 1,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    batch_invariant: bool = False,
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated DeltaProduct prefill on cuDNN's fused SM100 engine.
+
+    GDP applies ``n = num_householder`` beta-gated Householder updates per
+    token with one per-head scalar decay per token: the GDN recurrence on an
+    expanded sub-token timeline, with the decay acting before the token's
+    updates and the readout following the last one. ``num_householder == 1``
+    is exactly :func:`cudnn_chunk_gated_delta_rule`.
+
+    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    the engine decides for itself: it declines a graph it cannot serve (the
+    per-engine reason lands in the frontend's log).
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        ``[total_seq_len, num_q_heads, head_size]``, packed at real-token
+        rows. Strides are passed through to cuDNN, so only the innermost dim
+        has to be contiguous.
+    k, v : torch.Tensor
+        ``[total_seq_len * num_householder, num_k_heads / num_v_heads,
+        head_size]``, packed on the expanded sub-token timeline: the ``n``
+        Householder updates of token ``t`` occupy rows ``t*n .. t*n + n - 1``.
+        ``num_k_heads`` must equal ``num_q_heads`` or ``num_v_heads``.
+    g : torch.Tensor, optional
+        Per-head forget gate in linear space (``alpha = exp(log_g)``), shape
+        ``[total_seq_len, num_sab_heads]`` at real-token rows. cuDNN's gate is
+        natural-log, so this is converted; the conversion keeps ``g``'s own
+        dtype. All-ones when ``None``.
+    beta : torch.Tensor, optional
+        Per-head, per-Householder update gate
+        ``[total_seq_len * num_householder, num_sab_heads]``, post-sigmoid,
+        in float32 or ``q.dtype``. All-ones when ``None``.
+    num_householder : int
+        Householder updates per token (``n >= 1``).
+    scale : float, optional
+        Query scale; ``1 / sqrt(head_size)`` when ``None`` or ``0.0``,
+        matching the native GDN path.
+    initial_state, output_state : torch.Tensor, optional
+        State ``[num_seqs, num_sab_heads, head_size, head_size]``, V-major,
+        float32 or bfloat16. ``output_state`` must not alias
+        ``initial_state``; see :func:`cudnn_chunk_gated_delta_rule`.
+    output_final_state : bool
+        Return the outgoing recurrent state alongside the output; when unset
+        no state is written at all.
+    cu_seqlens : torch.Tensor
+        ``[num_seqs + 1]`` int32 or int64, over the real tokens. Required.
+    use_qk_l2norm_in_kernel : bool
+        Fuse the q/k L2 normalization into the kernel.
+    output : torch.Tensor, optional
+        Pre-allocated ``[total_seq_len, num_o_heads, head_size]`` at
+        real-token rows, written in place by the kernel.
+    batch_invariant : bool
+        Disable the split-K partition; see
+        :func:`cudnn_chunk_gated_delta_rule`.
+
+    Returns
+    -------
+    torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
+        ``output``, or ``(output, final_state)`` when ``output_final_state``.
+    """
+    _check_cudnn_frontend("chunk_gated_delta_product")
+    if cu_seqlens is None:
+        raise ValueError("cudnn_chunk_gated_delta_product: cu_seqlens is required")
+
+    total, num_q_heads, head_dim = q.shape
+    v_dim = v.shape[2]
+    num_sab_heads = max(num_q_heads, v.shape[1])
+    n = int(num_householder)
+
+    g_log = (
+        torch.zeros(total, num_sab_heads, dtype=q.dtype, device=q.device)
+        if g is None
+        else torch.log(g)
+    )
+    if beta is None:
+        beta = torch.ones(
+            total * n, num_sab_heads, dtype=torch.float32, device=q.device
+        )
+
+    if output is None:
+        output = torch.empty(
+            total, num_sab_heads, v_dim, dtype=q.dtype, device=q.device
+        )
+    num_seqs = cu_seqlens.shape[0] - 1
+    final_state = (
+        _state_out(
+            initial_state,
+            output_state,
+            num_seqs,
+            num_sab_heads,
+            head_dim,
+            v_dim,
+            q.device,
+        )
+        if output_final_state
+        else None
+    )
+
+    _run_la_graph(
+        "gdp",
+        q,
+        k,
+        v,
+        g_log,
+        beta,
+        cu_seqlens,
+        output,
+        initial_state=initial_state,
+        final_state=final_state,
+        num_householder=n,
+        scale=float(scale) if scale else 1.0 / math.sqrt(head_dim),
+        use_qk_l2norm=bool(use_qk_l2norm_in_kernel),
+        use_beta_sigmoid=False,
+        safe_gate=False,
+        gate_lower_bound=None,
+        batch_invariant=bool(batch_invariant),
+    )
+    if not output_final_state:
+        return output
+    return output, final_state
+
+
+@flashinfer_api
+def cudnn_chunk_gated_delta_rule2(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    w: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    batch_invariant: bool = False,
+) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated Delta Rule 2 prefill on cuDNN's fused SM100 engine.
+
+    Argument meanings match :func:`flashinfer.chunk_gated_delta_rule2`.
+
+    GDN-2 generalizes GDN's per-head scalar gates to channel-wise ones: the
+    forget gate ``g`` and erase gate ``beta`` are per key channel and the write
+    gate ``w`` is per value channel.
+
+    .. math::
+
+        S_t &= \mathrm{diag}(g_t) S_{t-1} \\
+        v^{new}_t &= w_t \odot v_t - (\beta_t \odot k_t)^\top S_t \\
+        S_t &\mathrel{+}= k_t \otimes v^{new}_t \\
+        o_t &= \mathrm{scale} \cdot q_t^\top S_t
+
+    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    the engine decides for itself.
+
+    Parameters
+    ----------
+    q, k, v : torch.Tensor
+        ``[total_seq_len, num_q_heads / num_k_heads / num_v_heads, 128]``,
+        packed.
+    g : torch.Tensor, optional
+        Channel-wise forget gate in linear space, shape
+        ``[total_seq_len, num_sab_heads, 128]``. Converted to cuDNN's log-space
+        gate at ``g``'s own dtype, which cuDNN reads at float32, bfloat16 or
+        float16. All-ones when ``None``.
+    beta : torch.Tensor, optional
+        Channel-wise erase gate ``[total_seq_len, num_sab_heads, 128]``,
+        converted to ``q.dtype``. All-ones when ``None``.
+    w : torch.Tensor, optional
+        Channel-wise write gate ``[total_seq_len, num_sab_heads, 128]``,
+        converted to ``q.dtype``. All-ones when ``None``.
+    scale : float, optional
+        Query scale; ``1 / sqrt(head_dim)`` when ``None`` or ``0.0``, matching
+        the native GDN path.
+    initial_state, output_state : torch.Tensor, optional
+        State ``[num_seqs, num_sab_heads, 128, 128]``, V-major, float32 or
+        bfloat16. ``output_state`` must not alias ``initial_state``; see
+        :func:`cudnn_chunk_gated_delta_rule`.
+    output_final_state : bool
+        Return the outgoing recurrent state alongside the output; when unset
+        no state is written at all.
+    cu_seqlens : torch.Tensor
+        ``[num_seqs + 1]`` int32 or int64. Required.
+    use_qk_l2norm_in_kernel : bool
+        Fuse the q/k L2 normalization into the kernel.
+    output : torch.Tensor, optional
+        Pre-allocated ``[total_seq_len, num_o_heads, 128]``.
+    batch_invariant : bool
+        Disable the split-K partition; see
+        :func:`cudnn_chunk_gated_delta_rule`.
+
+    Returns
+    -------
+    torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
+        ``output``, or ``(output, final_state)`` when ``output_final_state``.
+    """
+    _check_cudnn_frontend("chunk_gated_delta_rule2")
+    if cu_seqlens is None:
+        raise ValueError("cudnn_chunk_gated_delta_rule2: cu_seqlens is required")
+
+    total, num_q_heads, head_dim = q.shape
+    v_dim = v.shape[2]
+    num_sab_heads = max(num_q_heads, v.shape[1])
+
+    g_log = (
+        torch.zeros(total, num_sab_heads, head_dim, dtype=q.dtype, device=q.device)
+        if g is None
+        else torch.log(g)
+    )
+    if beta is None:
+        beta = torch.ones(
+            total, num_sab_heads, head_dim, dtype=q.dtype, device=q.device
+        )
+    elif beta.dtype != q.dtype:
+        beta = beta.to(q.dtype)
+    if w is None:
+        w = torch.ones(total, num_sab_heads, v_dim, dtype=q.dtype, device=q.device)
+    elif w.dtype != q.dtype:
+        w = w.to(q.dtype)
+
+    if output is None:
+        output = torch.empty(
+            total, num_sab_heads, v_dim, dtype=q.dtype, device=q.device
+        )
+    num_seqs = cu_seqlens.shape[0] - 1
+    final_state = (
+        _state_out(
+            initial_state,
+            output_state,
+            num_seqs,
+            num_sab_heads,
+            head_dim,
+            v_dim,
+            q.device,
+        )
+        if output_final_state
+        else None
+    )
+
+    _run_la_graph(
+        "gdn2",
+        q,
+        k,
+        v,
+        g_log,
+        beta,
+        cu_seqlens,
+        output,
+        w=w,
+        initial_state=initial_state,
+        final_state=final_state,
+        scale=float(scale) if scale else 1.0 / math.sqrt(head_dim),
+        use_qk_l2norm=bool(use_qk_l2norm_in_kernel),
+        use_beta_sigmoid=False,
+        safe_gate=False,
+        gate_lower_bound=None,
+        batch_invariant=bool(batch_invariant),
+    )
+    if not output_final_state:
+        return output
+    return output, final_state
+
+
+@flashinfer_api
+def cudnn_recurrent_kda(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    A_log: Optional[torch.Tensor] = None,
+    dt_bias: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    use_qk_l2norm_in_kernel: bool = True,
+    use_gate_in_kernel: bool = False,
+    lower_bound: Optional[float] = None,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    beta_is_logit: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    batch_invariant: bool = False,
+) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
+    r"""Kimi Delta Attention prefill on cuDNN's fused SM100 engine.
+
+    Argument meanings match :func:`flashinfer.recurrent_kda`, restricted to the
+    ordinary multi-token prefill subset: no speculative decode, no state pool,
+    no ``initial_state_source``.
+
+    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    the engine decides for itself.
+
+    Parameters
+    ----------
+    q, k, v : torch.Tensor
+        ``[1, total_tokens, H, 128]`` or ``[total_tokens, H, 128]``, bfloat16
+        or float16.
+    g : torch.Tensor
+        Channel-wise gate ``[..., total_tokens, HV, 128]``. Log-space unless
+        ``use_gate_in_kernel``, in which case it is the raw pre-activation and
+        cuDNN applies the safe-gate transform from ``A_log`` / ``dt_bias`` /
+        ``lower_bound``. float32, bfloat16 or float16; cuDNN takes all three
+        and only the gate's memory format follows the choice, so this is
+        forwarded with no copy. In float16 the kernel's chunk-cumulative decay
+        inverse bounds how strong the decay may be (roughly ``alpha >= 0.9``
+        per token per channel before it overflows); bfloat16 carries an
+        fp32-like exponent and has no such bound.
+    beta : torch.Tensor
+        ``[..., total_tokens, HV]``. Post-sigmoid in float32 or ``q.dtype``,
+        or ``q.dtype`` logits when ``beta_is_logit``.
+    A_log, dt_bias : torch.Tensor, optional
+        Safe-gate parameters, required together when ``use_gate_in_kernel``.
+    scale : float, optional
+        Query scale; ``1 / sqrt(head_dim)`` when ``None``.
+    output_final_state : bool
+        Return the final state alongside the output. This gates only the
+        return value; see ``initial_state`` for when a state is written.
+    use_qk_l2norm_in_kernel : bool
+        Fuse the q/k L2 normalization into the kernel.
+    use_gate_in_kernel : bool
+        Read ``g`` as the raw pre-activation and apply the safe-gate transform
+        from ``A_log`` / ``dt_bias`` / ``lower_bound`` in the kernel.
+    beta_is_logit : bool
+        Read ``beta`` as logits and apply the sigmoid in the kernel.
+    lower_bound : float, optional
+        Safe-gate lower bound, forwarded as cuDNN's ``gate_lower_bound``.
+    cu_seqlens : torch.Tensor
+        ``[num_seqs + 1]`` int32 or int64. Required.
+    initial_state, output_state : torch.Tensor, optional
+        State ``[num_seqs, HV, 128, 128]``, V-major, float32 or bfloat16.
+        Following the Cake and CuTe DSL prefill backends, ``initial_state`` is
+        advanced to the final state whenever one is given and no separate
+        ``output_state`` is supplied, independently of
+        ``output_final_state`` -- which gates only what is returned.
+        ``output_state`` must not alias ``initial_state``; see
+        :func:`cudnn_chunk_gated_delta_rule`.
+    output : torch.Tensor, optional
+        Pre-allocated output, written in place by the kernel.
+    batch_invariant : bool
+        Disable the split-K partition; see
+        :func:`cudnn_chunk_gated_delta_rule`.
+
+    Returns
+    -------
+    Tuple[torch.Tensor, Optional[torch.Tensor]]
+        ``(output, final_state)``, with ``final_state`` ``None`` when
+        ``output_final_state=False``.
+    """
+    _check_cudnn_frontend("recurrent_kda")
+    if cu_seqlens is None:
+        raise ValueError("cudnn_recurrent_kda: cu_seqlens is required")
+    if use_gate_in_kernel and (A_log is None or dt_bias is None):
+        raise ValueError(
+            "cudnn_recurrent_kda: use_gate_in_kernel requires both A_log and dt_bias"
+        )
+
+    out_shape = tuple(v.shape)
+    q = q.squeeze(0) if q.dim() == 4 else q
+    k = k.squeeze(0) if k.dim() == 4 else k
+    v = v.squeeze(0) if v.dim() == 4 else v
+    g = g.squeeze(0) if g.dim() == 4 else g
+    beta = beta.squeeze(0) if beta.dim() == 3 else beta
+    head_dim = q.shape[-1]
+    v_dim = v.shape[2]
+    if v.shape[1] < q.shape[1]:
+        raise NotImplementedError(
+            f"cudnn_recurrent_kda: cuDNN carries the KDA state at max(H, HV) heads, "
+            f"FlashInfer at HV; got H={q.shape[1]} > HV={v.shape[1]}"
+        )
+    num_heads = v.shape[1]
+    if beta_is_logit and beta.dtype != q.dtype:
+        beta = beta.to(q.dtype)
+
+    if output is None:
+        output = torch.empty(
+            q.shape[0], num_heads, v_dim, dtype=q.dtype, device=q.device
+        )
+    o = output.squeeze(0) if output.dim() == 4 else output
+    num_seqs = cu_seqlens.shape[0] - 1
+    final_state = (
+        _state_out(
+            initial_state, output_state, num_seqs, num_heads, head_dim, v_dim, q.device
+        )
+        if (output_final_state or output_state is not None or initial_state is not None)
+        else None
+    )
+
+    _run_la_graph(
+        "kda",
+        q,
+        k,
+        v,
+        g,
+        beta,
+        cu_seqlens,
+        o,
+        a_log=A_log.float() if use_gate_in_kernel else None,
+        dt_bias=(dt_bias.float().reshape(-1, head_dim) if use_gate_in_kernel else None),
+        initial_state=initial_state,
+        final_state=final_state,
+        scale=float(scale) if scale is not None else 1.0 / math.sqrt(head_dim),
+        use_qk_l2norm=bool(use_qk_l2norm_in_kernel),
+        use_beta_sigmoid=bool(beta_is_logit),
+        safe_gate=bool(use_gate_in_kernel),
+        gate_lower_bound=float(lower_bound) if lower_bound is not None else None,
+        batch_invariant=bool(batch_invariant),
+    )
+
+    if output_state is None and initial_state is not None:
+        initial_state.copy_(final_state)
+        final_state = initial_state
+    return output.reshape(out_shape), final_state if output_final_state else None

--- a/flashinfer/cudnn/linear_attention.py
+++ b/flashinfer/cudnn/linear_attention.py
@@ -21,7 +21,7 @@ from typing import Optional, Union
 import torch
 
 from ..api_logging import flashinfer_api
-from ..utils import _get_cache_buf
+from ..utils import _get_cache_buf, get_device_index
 
 try:
     import cudnn
@@ -31,10 +31,20 @@ except Exception:
     cudnn = None
     CUDNN_AVAILABLE = False
 
-_MIN_FRONTEND_VERSION = (1, 28)
+_MIN_FRONTEND_VERSION = (1, 29)
 
-# Global cudnn handle. need to make it per device in future
-_cudnn_handle = None
+
+def _linear_gate(g: Optional[torch.Tensor], ones_shape, dtype, device):
+    """The GDN / GDP forget gate for the graph as linear alpha
+    (``gate_domain="linear"``); all-ones when ``None``."""
+    if g is None:
+        g = torch.ones(*ones_shape, dtype=dtype, device=device)
+    return g
+
+
+# One cuDNN handle per device: a handle binds the device that is current when
+# it is created and only takes streams of that device.
+_cudnn_handles: dict = {}
 
 
 def _check_cudnn_frontend(feature: str) -> None:
@@ -58,12 +68,13 @@ def _check_cudnn_frontend(feature: str) -> None:
 
 
 def _create_cudnn_handle(stream: torch.cuda.Stream):
-    global _cudnn_handle
-
-    if _cudnn_handle is None:
-        _cudnn_handle = cudnn.create_handle()
-    cudnn.set_stream(_cudnn_handle, stream.cuda_stream)
-    return _cudnn_handle
+    handle = _cudnn_handles.get(stream.device_index)
+    if handle is None:
+        with torch.cuda.device(stream.device_index):
+            handle = cudnn.create_handle()
+        _cudnn_handles[stream.device_index] = handle
+    cudnn.set_stream(handle, stream.cuda_stream)
+    return handle
 
 
 # Tensor ids
@@ -74,7 +85,7 @@ class UIDs(Enum):
     K_UID = 2  # Key tensor
     V_UID = 3  # Value tensor
 
-    G_UID = 10  # Forget gate, log space
+    G_UID = 10  # Forget gate
     BETA_UID = 11  # Update / erase gate
     W_UID = 12  # GDN-2 write gate
 
@@ -111,12 +122,14 @@ def _la_graph_key_fn(
     safe_gate: bool,
     gate_lower_bound: Optional[float],
     batch_invariant: bool,
+    gate_domain: str = "log",
 ):
     def layout(t):
         return None if t is None else (t.shape, t.stride(), t.dtype)
 
     return (
         family,
+        get_device_index(q.device),
         layout(q),
         layout(k),
         layout(v),
@@ -136,6 +149,7 @@ def _la_graph_key_fn(
         safe_gate,
         gate_lower_bound,
         batch_invariant,
+        gate_domain,
     )
 
 
@@ -165,6 +179,7 @@ if CUDNN_AVAILABLE:
         safe_gate: bool,
         gate_lower_bound: Optional[float],
         batch_invariant: bool,
+        gate_domain: str = "log",
     ):
         handle = _create_cudnn_handle(torch.cuda.current_stream(q.device))
 
@@ -225,6 +240,7 @@ if CUDNN_AVAILABLE:
                 attrs["gate_lower_bound"] = gate_lower_bound
             if family == "gdp":
                 attrs["num_householder"] = num_householder
+            attrs["gate_domain"] = gate_domain
 
             O, fs, _checkpoints = getattr(graph, family)(**ports, **attrs)
 
@@ -266,6 +282,7 @@ def _run_la_graph(
     safe_gate: bool,
     gate_lower_bound: Optional[float],
     batch_invariant: bool,
+    gate_domain: str = "log",
 ) -> None:
     graph, _ = _build_la_graph(
         family,
@@ -288,6 +305,7 @@ def _run_la_graph(
         safe_gate=safe_gate,
         gate_lower_bound=gate_lower_bound,
         batch_invariant=batch_invariant,
+        gate_domain=gate_domain,
     )
 
     var_map = {
@@ -353,7 +371,7 @@ def cudnn_chunk_gated_delta_rule(
 
     Argument meanings match :func:`flashinfer.chunk_gated_delta_rule`.
 
-    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    Requires cudnn-frontend 1.29+ with the ``cutedsl`` extra. Everything else
     the engine decides for itself: it declines a graph it cannot serve (the
     per-engine reason lands in the frontend's log).
 
@@ -365,9 +383,9 @@ def cudnn_chunk_gated_delta_rule(
         has to be contiguous.
     g : torch.Tensor, optional
         Per-head forget gate in linear space (``alpha = exp(log_g)``), shape
-        ``[total_seq_len, num_sab_heads]``. cuDNN's gate is natural-log, so
-        this is converted; the conversion keeps ``g``'s own dtype, which cuDNN
-        reads at float32, bfloat16 or float16. All-ones when ``None``.
+        ``[total_seq_len, num_sab_heads]``, passed to cuDNN as is
+        (``gate_domain="linear"``) at ``g``'s own dtype, which cuDNN reads at
+        float32, bfloat16 or float16. All-ones when ``None``.
     beta : torch.Tensor, optional
         Per-head update gate ``[total_seq_len, num_sab_heads]``, post-sigmoid,
         in float32 or ``q.dtype``. All-ones when ``None``.
@@ -412,11 +430,7 @@ def cudnn_chunk_gated_delta_rule(
     v_dim = v.shape[2]
     num_sab_heads = max(num_q_heads, v.shape[1])
 
-    g_log = (
-        torch.zeros(total, num_sab_heads, dtype=q.dtype, device=q.device)
-        if g is None
-        else torch.log(g)
-    )
+    g_in = _linear_gate(g, (total, num_sab_heads), q.dtype, q.device)
     if beta is None:
         beta = torch.ones(total, num_sab_heads, dtype=torch.float32, device=q.device)
 
@@ -444,7 +458,7 @@ def cudnn_chunk_gated_delta_rule(
         q,
         k,
         v,
-        g_log,
+        g_in,
         beta,
         cu_seqlens,
         output,
@@ -456,6 +470,7 @@ def cudnn_chunk_gated_delta_rule(
         safe_gate=False,
         gate_lower_bound=None,
         batch_invariant=bool(batch_invariant),
+        gate_domain="linear",
     )
     if not output_final_state:
         return output
@@ -487,7 +502,7 @@ def cudnn_chunk_gated_delta_product(
     updates and the readout following the last one. ``num_householder == 1``
     is exactly :func:`cudnn_chunk_gated_delta_rule`.
 
-    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    Requires cudnn-frontend 1.29+ with the ``cutedsl`` extra. Everything else
     the engine decides for itself: it declines a graph it cannot serve (the
     per-engine reason lands in the frontend's log).
 
@@ -504,9 +519,9 @@ def cudnn_chunk_gated_delta_product(
         ``num_k_heads`` must equal ``num_q_heads`` or ``num_v_heads``.
     g : torch.Tensor, optional
         Per-head forget gate in linear space (``alpha = exp(log_g)``), shape
-        ``[total_seq_len, num_sab_heads]`` at real-token rows. cuDNN's gate is
-        natural-log, so this is converted; the conversion keeps ``g``'s own
-        dtype. All-ones when ``None``.
+        ``[total_seq_len, num_sab_heads]`` at real-token rows, passed to cuDNN
+        as is (``gate_domain="linear"``) at ``g``'s own dtype. All-ones when
+        ``None``.
     beta : torch.Tensor, optional
         Per-head, per-Householder update gate
         ``[total_seq_len * num_householder, num_sab_heads]``, post-sigmoid,
@@ -548,11 +563,7 @@ def cudnn_chunk_gated_delta_product(
     num_sab_heads = max(num_q_heads, v.shape[1])
     n = int(num_householder)
 
-    g_log = (
-        torch.zeros(total, num_sab_heads, dtype=q.dtype, device=q.device)
-        if g is None
-        else torch.log(g)
-    )
+    g_in = _linear_gate(g, (total, num_sab_heads), q.dtype, q.device)
     if beta is None:
         beta = torch.ones(
             total * n, num_sab_heads, dtype=torch.float32, device=q.device
@@ -582,7 +593,7 @@ def cudnn_chunk_gated_delta_product(
         q,
         k,
         v,
-        g_log,
+        g_in,
         beta,
         cu_seqlens,
         output,
@@ -595,6 +606,7 @@ def cudnn_chunk_gated_delta_product(
         safe_gate=False,
         gate_lower_bound=None,
         batch_invariant=bool(batch_invariant),
+        gate_domain="linear",
     )
     if not output_final_state:
         return output
@@ -628,12 +640,12 @@ def cudnn_chunk_gated_delta_rule2(
 
     .. math::
 
-        S_t &= \mathrm{diag}(g_t) S_{t-1} \\
+        S_t &= \mathrm{diag}(e^{g_t}) S_{t-1} \\
         v^{new}_t &= w_t \odot v_t - (\beta_t \odot k_t)^\top S_t \\
         S_t &\mathrel{+}= k_t \otimes v^{new}_t \\
         o_t &= \mathrm{scale} \cdot q_t^\top S_t
 
-    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    Requires cudnn-frontend 1.29+ with the ``cutedsl`` extra. Everything else
     the engine decides for itself.
 
     Parameters
@@ -642,10 +654,10 @@ def cudnn_chunk_gated_delta_rule2(
         ``[total_seq_len, num_q_heads / num_k_heads / num_v_heads, 128]``,
         packed.
     g : torch.Tensor, optional
-        Channel-wise forget gate in linear space, shape
-        ``[total_seq_len, num_sab_heads, 128]``. Converted to cuDNN's log-space
-        gate at ``g``'s own dtype, which cuDNN reads at float32, bfloat16 or
-        float16. All-ones when ``None``.
+        Channel-wise forget gate as the natural-log decay, shape
+        ``[total_seq_len, num_sab_heads, 128]``, passed to cuDNN as is
+        (``gate_domain="log"``) at ``g``'s own dtype, which cuDNN reads at
+        float32, bfloat16 or float16. All-zeros when ``None``.
     beta : torch.Tensor, optional
         Channel-wise erase gate ``[total_seq_len, num_sab_heads, 128]``,
         converted to ``q.dtype``. All-ones when ``None``.
@@ -685,11 +697,8 @@ def cudnn_chunk_gated_delta_rule2(
     v_dim = v.shape[2]
     num_sab_heads = max(num_q_heads, v.shape[1])
 
-    g_log = (
-        torch.zeros(total, num_sab_heads, head_dim, dtype=q.dtype, device=q.device)
-        if g is None
-        else torch.log(g)
-    )
+    if g is None:
+        g = torch.zeros(total, num_sab_heads, head_dim, dtype=q.dtype, device=q.device)
     if beta is None:
         beta = torch.ones(
             total, num_sab_heads, head_dim, dtype=q.dtype, device=q.device
@@ -725,7 +734,7 @@ def cudnn_chunk_gated_delta_rule2(
         q,
         k,
         v,
-        g_log,
+        g,
         beta,
         cu_seqlens,
         output,
@@ -738,6 +747,7 @@ def cudnn_chunk_gated_delta_rule2(
         safe_gate=False,
         gate_lower_bound=None,
         batch_invariant=bool(batch_invariant),
+        gate_domain="log",
     )
     if not output_final_state:
         return output
@@ -769,9 +779,9 @@ def cudnn_recurrent_kda(
 
     Argument meanings match :func:`flashinfer.recurrent_kda`, restricted to the
     ordinary multi-token prefill subset: no speculative decode, no state pool,
-    no ``initial_state_source``.
+    no ``initial_state_source``, no state checkpoints.
 
-    Requires cudnn-frontend 1.28+ with the ``cutedsl`` extra. Everything else
+    Requires cudnn-frontend 1.29+ with the ``cutedsl`` extra. Everything else
     the engine decides for itself.
 
     Parameters

--- a/flashinfer/gdn2_prefill.py
+++ b/flashinfer/gdn2_prefill.py
@@ -1,0 +1,152 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Literal, Optional, Tuple, Union
+
+import torch
+
+from .api_logging import flashinfer_api
+from .trace.templates.gdn2 import gdn2_prefill_trace
+
+_CU_SEQLENS_DTYPES = (torch.int32, torch.int64)
+
+
+@flashinfer_api(trace=gdn2_prefill_trace)
+def chunk_gated_delta_rule2(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    w: Optional[torch.Tensor] = None,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    *,
+    backend: Literal["auto", "cudnn"] = "auto",
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated Delta Rule 2 (GDN-2) attention for prefill.
+
+    GDN-2 generalizes :func:`flashinfer.chunk_gated_delta_rule`'s per-head
+    scalar gates to channel-wise ones: the forget gate ``g`` and the erase gate
+    ``beta`` are per key channel, and a third gate ``w`` scales the incoming
+    value per value channel.
+
+    .. math::
+
+        S_t &= \mathrm{diag}(g_t) S_{t-1} \\
+        v^{new}_t &= w_t \odot v_t - (\beta_t \odot k_t)^\top S_t \\
+        S_t &\mathrel{+}= k_t \otimes v^{new}_t \\
+        o_t &= \mathrm{scale} \cdot q_t^\top S_t
+
+    Setting ``g``, ``beta`` and ``w`` to per-channel constants recovers GDN:
+    :math:`w \equiv \beta` and a channel-constant :math:`g` make the update the
+    scalar-gated delta rule.
+
+    Only varlen (packed / THD) input is accepted, matching
+    :func:`flashinfer.chunk_gated_delta_rule`: pass ``cu_seqlens`` and lay the
+    tokens of all sequences end to end.
+
+    Parameters
+    ----------
+    q, k, v : torch.Tensor
+        ``[total_seq_len, num_q_heads / num_k_heads / num_v_heads, head_size]``,
+        float16 or bfloat16.  ``num_k_heads`` must equal ``num_q_heads`` or
+        ``num_v_heads``, and the query and value head counts must be equal or
+        one a multiple of the other.  Strides are honored, so only the innermost
+        dimension has to be contiguous.
+    g : torch.Tensor, optional
+        Channel-wise forget gate in linear space (``alpha``, elementwise in
+        ``(0, 1]``), shape ``[total_seq_len, num_sab_heads, head_size]``, at
+        float32, bfloat16 or float16.  All-ones (no decay) when ``None``.
+    beta : torch.Tensor, optional
+        Channel-wise erase gate ``[total_seq_len, num_sab_heads, head_size]``,
+        post-sigmoid, read at ``q.dtype``.  All-ones when ``None``.
+    w : torch.Tensor, optional
+        Channel-wise write gate ``[total_seq_len, num_sab_heads, head_size]``,
+        read at ``q.dtype``.  All-ones when ``None``.
+    scale : float, optional
+        Query scale; ``1 / sqrt(head_size)`` when ``None`` or ``0.0``, matching
+        :func:`flashinfer.chunk_gated_delta_rule`.
+    initial_state : torch.Tensor, optional
+        Incoming recurrent state ``[num_seqs, num_sab_heads, head_size,
+        head_size]``, V-major (``[..., V, K]``), float32 or bfloat16.  A zero
+        state when ``None``.
+    output_final_state : bool
+        Return the outgoing recurrent state alongside the output.
+    cu_seqlens : torch.Tensor
+        Cumulative sequence lengths ``[num_seqs + 1]``, int32 or int64.
+        Required.
+    use_qk_l2norm_in_kernel : bool
+        Fuse the q/k L2 normalization into the kernel instead of expecting
+        pre-normalized inputs.
+    output : torch.Tensor, optional
+        Pre-allocated output ``[total_seq_len, num_o_heads, head_size]``,
+        written in place.  Allocated internally when ``None``.
+    output_state : torch.Tensor, optional
+        Pre-allocated final-state buffer, written in place.  Allocated
+        internally when ``None`` and ``output_final_state`` is set.  It must
+        not alias ``initial_state``; the kernel splits one sequence across
+        CTAs, so the CTA reading the incoming state would race the one writing
+        the outgoing state.
+    backend : Literal["auto", "cudnn"], optional
+        FlashInfer carries no GDN-2 kernel of its own, so ``"auto"`` (default)
+        and ``"cudnn"`` both run cuDNN's fused SM100 linear-attention engine
+        through :func:`flashinfer.cudnn.cudnn_chunk_gated_delta_rule2`.
+
+    Returns
+    -------
+    torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
+        ``output``, or ``(output, final_state)`` when ``output_final_state``.
+
+    Note
+    ----
+    Requires an SM100-family (Blackwell) device and cudnn-frontend 1.28+ with
+    the ``cutedsl`` extra (``pip install 'nvidia-cudnn-frontend[cutedsl]'``).
+    Everything finer -- head dims, input dtypes, head-count relations -- is the
+    engine's call: a graph it cannot serve is declined by cuDNN (the per-engine
+    reason lands in the frontend's log).
+    """
+    if backend not in ("auto", "cudnn"):
+        raise ValueError(f'backend must be "auto" or "cudnn", got {backend!r}')
+    if cu_seqlens is None:
+        raise ValueError("cu_seqlens is required for varlen mode")
+    if cu_seqlens.dtype not in _CU_SEQLENS_DTYPES:
+        raise ValueError(
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
+        )
+
+    from .cudnn import cudnn_chunk_gated_delta_rule2
+
+    return cudnn_chunk_gated_delta_rule2(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        w,
+        scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        output=output,
+        output_state=output_state,
+    )

--- a/flashinfer/gdn2_prefill.py
+++ b/flashinfer/gdn2_prefill.py
@@ -51,7 +51,7 @@ def chunk_gated_delta_rule2(
 
     .. math::
 
-        S_t &= \mathrm{diag}(g_t) S_{t-1} \\
+        S_t &= \mathrm{diag}(e^{g_t}) S_{t-1} \\
         v^{new}_t &= w_t \odot v_t - (\beta_t \odot k_t)^\top S_t \\
         S_t &\mathrel{+}= k_t \otimes v^{new}_t \\
         o_t &= \mathrm{scale} \cdot q_t^\top S_t
@@ -73,9 +73,10 @@ def chunk_gated_delta_rule2(
         one a multiple of the other.  Strides are honored, so only the innermost
         dimension has to be contiguous.
     g : torch.Tensor, optional
-        Channel-wise forget gate in linear space (``alpha``, elementwise in
-        ``(0, 1]``), shape ``[total_seq_len, num_sab_heads, head_size]``, at
-        float32, bfloat16 or float16.  All-ones (no decay) when ``None``.
+        Channel-wise forget gate as the natural-log decay (``ln alpha``,
+        elementwise ``<= 0``), shape ``[total_seq_len, num_sab_heads,
+        head_size]``, at float32, bfloat16 or float16.  All-zeros (no decay)
+        when ``None``.
     beta : torch.Tensor, optional
         Channel-wise erase gate ``[total_seq_len, num_sab_heads, head_size]``,
         post-sigmoid, read at ``q.dtype``.  All-ones when ``None``.
@@ -118,7 +119,7 @@ def chunk_gated_delta_rule2(
 
     Note
     ----
-    Requires an SM100-family (Blackwell) device and cudnn-frontend 1.28+ with
+    Requires an SM100-family (Blackwell) device and cudnn-frontend 1.29+ with
     the ``cutedsl`` extra (``pip install 'nvidia-cudnn-frontend[cutedsl]'``).
     Everything finer -- head dims, input dtypes, head-count relations -- is the
     engine's call: a graph it cannot serve is declined by cuDNN (the per-engine

--- a/flashinfer/gdn_prefill.py
+++ b/flashinfer/gdn_prefill.py
@@ -529,7 +529,7 @@ def chunk_gated_delta_rule(
     use_cp: Literal["auto"] | bool = "auto",
     state_indices: Optional[torch.Tensor] = None,
     _cp_chunk_len: Optional[int] = None,
-    backend: Literal["auto", "flashinfer", "cake_gdn"] = "auto",
+    backend: Literal["auto", "flashinfer", "cake_gdn", "cudnn"] = "auto",
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Chunked Gated Delta Rule (GDN) attention for prefill.
 
@@ -635,10 +635,12 @@ def chunk_gated_delta_rule(
         Internal context-parallel chunk-length override used for testing and
         tuning. ``None`` lets the CP backend select the length automatically;
         an explicit value must be a multiple of 64.
-
-    backend : {"auto", "flashinfer", "cake_gdn"}
-        ``auto`` selects GDN non-CP only for an exact frozen non-CP manifest row;
-        explicit ``cake_gdn`` requests fail closed.
+    backend : {"auto", "flashinfer", "cake_gdn", "cudnn"}
+        ``auto`` routes among FlashInfer's own SM90/SM100/SM120 kernels and
+        selects GDN non-CP only for an exact frozen non-CP manifest row;
+        explicit ``cake_gdn`` requests fail closed.  ``cudnn`` runs cuDNN's
+        fused SM100 linear-attention engine through
+        :func:`flashinfer.cudnn.cudnn_chunk_gated_delta_rule`.
 
     Returns
     -------
@@ -661,7 +663,7 @@ def chunk_gated_delta_rule(
       ``nvidia-cutlass-dsl[cu13]>=4.4.2`` (``pip install
       flashinfer-python[cu13]``).
     """
-    if backend not in ("auto", "flashinfer", "cake_gdn"):
+    if backend not in ("auto", "flashinfer", "cake_gdn", "cudnn"):
         raise ValueError(f"unsupported GDN backend: {backend!r}")
     if backend == "cake_gdn" and (not _CAKE_GDN_AVAILABLE or _cake_gdn is None):
         raise RuntimeError("the source-only Cake GDN backend is not installed")
@@ -708,6 +710,38 @@ def chunk_gated_delta_rule(
     head_size = q.size(2)
     num_o_heads = max(num_q_heads, num_v_heads)
     num_sab_heads = num_o_heads
+
+    if backend == "cudnn":
+        from .cudnn import cudnn_chunk_gated_delta_rule
+
+        unsupported = [
+            name
+            for name, requested in (
+                ("use_cp", use_cp is True or _cp_chunk_len is not None),
+                ("checkpoint_every_n_tokens", checkpoint_every_n_tokens > 0),
+                ("state_indices", state_indices is not None),
+            )
+            if requested
+        ]
+        if unsupported:
+            raise NotImplementedError(
+                'chunk_gated_delta_rule(backend="cudnn") does not support '
+                + ", ".join(unsupported)
+            )
+        return cudnn_chunk_gated_delta_rule(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            output=output,
+            output_state=output_state,
+        )
 
     if checkpoint_every_n_tokens > 0:
         assert state_checkpoints is not None and checkpoint_cu_starts is not None

--- a/flashinfer/gdp_prefill.py
+++ b/flashinfer/gdp_prefill.py
@@ -1,0 +1,158 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Literal, Optional, Tuple, Union
+
+import torch
+
+from .api_logging import flashinfer_api
+from .trace.templates.gdp import gdp_prefill_trace
+
+_CU_SEQLENS_DTYPES = (torch.int32, torch.int64)
+
+
+@flashinfer_api(trace=gdp_prefill_trace)
+def chunk_gated_delta_product(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    num_householder: int = 1,
+    scale: Optional[float] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    output_final_state: bool = False,
+    cu_seqlens: Optional[torch.Tensor] = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    output: Optional[torch.Tensor] = None,
+    output_state: Optional[torch.Tensor] = None,
+    *,
+    backend: Literal["auto", "cudnn"] = "auto",
+) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+    r"""Chunked Gated DeltaProduct (GDP) attention for prefill.
+
+    GDP generalizes :func:`flashinfer.chunk_gated_delta_rule` from one
+    beta-gated Householder update per token to ``n = num_householder`` of
+    them, with one per-head scalar decay per token: the decay acts before the
+    token's updates and the readout follows the last one. Per real token, with
+    sub-token rows ``t*n .. t*n + n - 1`` of ``k`` / ``v`` / ``beta``,
+
+    .. math::
+
+        S &\mathrel{*}= \alpha_t \\
+        v^{new}_{t,j} &= \beta_{t,j} (v_{t,j} - S k_{t,j}),
+            \quad S \mathrel{+}= v^{new}_{t,j} \otimes k_{t,j},
+            \quad j = 0 \ldots n - 1 \\
+        o_t &= \mathrm{scale} \cdot S q_t
+
+    ``num_householder == 1`` is exactly
+    :func:`flashinfer.chunk_gated_delta_rule`.
+
+    Only varlen (packed / THD) input is accepted, matching
+    :func:`flashinfer.chunk_gated_delta_rule`: pass ``cu_seqlens`` over the
+    real tokens and lay the tokens of all sequences end to end.
+
+    Parameters
+    ----------
+    q : torch.Tensor
+        ``[total_seq_len, num_q_heads, head_size]``, float16 or bfloat16, at
+        real-token rows.  Strides are honored, so only the innermost dimension
+        has to be contiguous.
+    k, v : torch.Tensor
+        ``[total_seq_len * num_householder, num_k_heads / num_v_heads,
+        head_size]``, float16 or bfloat16, on the expanded sub-token timeline:
+        the ``n`` Householder updates of token ``t`` occupy rows
+        ``t*n .. t*n + n - 1``.  ``num_k_heads`` must equal ``num_q_heads`` or
+        ``num_v_heads``.
+    g : torch.Tensor, optional
+        Per-head forget gate in linear space (``alpha``, elementwise in
+        ``(0, 1]``), shape ``[total_seq_len, num_sab_heads]`` at real-token
+        rows, at float32, bfloat16 or float16.  All-ones (no decay) when
+        ``None``.
+    beta : torch.Tensor, optional
+        Per-head, per-Householder update gate ``[total_seq_len *
+        num_householder, num_sab_heads]``, post-sigmoid, in float32 or
+        ``q.dtype``.  All-ones when ``None``.
+    num_householder : int
+        Householder updates per token (``n >= 1``).
+    scale : float, optional
+        Query scale; ``1 / sqrt(head_size)`` when ``None`` or ``0.0``, matching
+        :func:`flashinfer.chunk_gated_delta_rule`.
+    initial_state : torch.Tensor, optional
+        Incoming recurrent state ``[num_seqs, num_sab_heads, head_size,
+        head_size]``, V-major (``[..., V, K]``), float32 or bfloat16.  A zero
+        state when ``None``.
+    output_final_state : bool
+        Return the outgoing recurrent state alongside the output.
+    cu_seqlens : torch.Tensor
+        Cumulative real-token sequence lengths ``[num_seqs + 1]``, int32 or
+        int64.  Required.
+    use_qk_l2norm_in_kernel : bool
+        Fuse the q/k L2 normalization into the kernel instead of expecting
+        pre-normalized inputs.
+    output : torch.Tensor, optional
+        Pre-allocated output ``[total_seq_len, num_o_heads, head_size]`` at
+        real-token rows, written in place.  Allocated internally when ``None``.
+    output_state : torch.Tensor, optional
+        Pre-allocated final-state buffer, written in place.  Allocated
+        internally when ``None`` and ``output_final_state`` is set.  It must
+        not alias ``initial_state``; the kernel splits one sequence across
+        CTAs, so the CTA reading the incoming state would race the one writing
+        the outgoing state.
+    backend : Literal["auto", "cudnn"], optional
+        FlashInfer carries no GDP kernel of its own, so ``"auto"`` (default)
+        and ``"cudnn"`` both run cuDNN's fused SM100 linear-attention engine
+        through :func:`flashinfer.cudnn.cudnn_chunk_gated_delta_product`.
+
+    Returns
+    -------
+    torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
+        ``output``, or ``(output, final_state)`` when ``output_final_state``.
+
+    Note
+    ----
+    Requires an SM100-family (Blackwell) device and cudnn-frontend 1.28+ with
+    the ``cutedsl`` extra (``pip install 'nvidia-cudnn-frontend[cutedsl]'``).
+    Everything finer -- head dims, input dtypes, head-count relations -- is the
+    engine's call: a graph it cannot serve is declined by cuDNN (the per-engine
+    reason lands in the frontend's log).
+    """
+    if backend not in ("auto", "cudnn"):
+        raise ValueError(f'backend must be "auto" or "cudnn", got {backend!r}')
+    if cu_seqlens is None:
+        raise ValueError("cu_seqlens is required for varlen mode")
+    if cu_seqlens.dtype not in _CU_SEQLENS_DTYPES:
+        raise ValueError(
+            f"cu_seqlens must have an integer dtype, got {cu_seqlens.dtype}"
+        )
+
+    from .cudnn import cudnn_chunk_gated_delta_product
+
+    return cudnn_chunk_gated_delta_product(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        num_householder,
+        scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        output=output,
+        output_state=output_state,
+    )

--- a/flashinfer/gdp_prefill.py
+++ b/flashinfer/gdp_prefill.py
@@ -124,7 +124,7 @@ def chunk_gated_delta_product(
 
     Note
     ----
-    Requires an SM100-family (Blackwell) device and cudnn-frontend 1.28+ with
+    Requires an SM100-family (Blackwell) device and cudnn-frontend 1.29+ with
     the ``cutedsl`` extra (``pip install 'nvidia-cudnn-frontend[cutedsl]'``).
     Everything finer -- head dims, input dtypes, head-count relations -- is the
     engine's call: a graph it cannot serve is declined by cuDNN (the per-engine

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -70,7 +70,7 @@ def recurrent_kda(
     disable_state_update: bool = False,
     correction_cache: Optional[torch.Tensor] = None,
     kg_cache: Optional[torch.Tensor] = None,
-    backend: Literal["auto", "cute-dsl", "cake"] = "auto",
+    backend: Literal["auto", "cute-dsl", "cake", "cudnn"] = "auto",
 ) -> (
     tuple[torch.Tensor, Optional[torch.Tensor]]
     | tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]
@@ -89,7 +89,7 @@ def recurrent_kda(
     selection. ``backend="auto"`` prefers CuTe DSL for supported plain prefill
     contracts and keeps Cake as the feature-complete fallback; use
     ``backend="cake"`` to select and benchmark the generated portfolio
-    explicitly.
+    explicitly, and ``backend="cudnn"`` to run cuDNN's fused SM100 engine.
     Compatible equal-head D128 unbounded-softplus T=1 decode calls use their
     frozen Cake specialization automatically. The Cake path accepts any
     positive runtime head count, so Kimi-Linear tensor parallelism maps global
@@ -250,7 +250,7 @@ def recurrent_kda(
             must be divisible by 32, except that the SM100-family exact-N16
             frozen route also accepts multiples of 16. SGLang normally uses
             64 or a larger cache-page-aligned multiple.
-        backend (Literal["auto", "cute-dsl", "cake"]):
+        backend (Literal["auto", "cute-dsl", "cake", "cudnn"]):
             Implementation backend. ``"auto"`` selects the architecture-
             appropriate CuTe DSL kernel for supported ordinary multi-token
             prefill, including the SM120 backend and SM100-family state
@@ -262,6 +262,12 @@ def recurrent_kda(
             The SM100-family kernel additionally needs
             ``nvidia-cutlass-dsl>=4.7``; below that ``"auto"`` uses Cake there
             and ``"cute-dsl"`` raises :class:`ImportError`.
+            ``"cudnn"`` runs cuDNN's fused SM100 linear-attention engine
+            through :func:`flashinfer.cudnn.cudnn_recurrent_kda`, and raises
+            ``NotImplementedError`` carrying the reason when that engine cannot
+            serve the call. It is never selected implicitly, and it covers
+            ordinary multi-token prefill only: no speculative decode, no state
+            pool, no ``initial_state_source``.
 
     Returns:
         Tuple of ``(output, final_state)`` where ``final_state`` is ``None``
@@ -274,9 +280,53 @@ def recurrent_kda(
         prefill_workspace, _kda_prefill.RecurrentKDAPrefillWorkspace
     ):
         raise TypeError("prefill_workspace must be a RecurrentKDAPrefillWorkspace")
-    if backend not in ("auto", "cute-dsl", "cake"):
+    if backend not in ("auto", "cute-dsl", "cake", "cudnn"):
         raise ValueError(
-            f"backend must be 'auto', 'cute-dsl', or 'cake', got {backend!r}"
+            f"backend must be 'auto', 'cute-dsl', 'cake', or 'cudnn', got {backend!r}"
+        )
+    if backend == "cudnn":
+        from .cudnn import cudnn_recurrent_kda
+
+        unsupported = [
+            name
+            for name, requested in (
+                ("num_spec_tokens", num_spec_tokens is not None),
+                ("num_accepted_tokens", num_accepted_tokens is not None),
+                ("initial_state_source", initial_state_source is not None),
+                ("initial_state_indices", initial_state_indices is not None),
+                ("seq_order", seq_order is not None),
+                ("prefill_workspace", prefill_workspace is not None),
+                ("ssm_state_indices", ssm_state_indices is not None),
+                ("checkpoint_every_n_tokens", checkpoint_every_n_tokens > 0),
+                ("checkpoint_state_indices", checkpoint_state_indices is not None),
+                ("disable_state_update", disable_state_update),
+                ("correction_cache", correction_cache is not None),
+                ("kg_cache", kg_cache is not None),
+            )
+            if requested
+        ]
+        if unsupported:
+            raise NotImplementedError(
+                'recurrent_kda(backend="cudnn") does not support '
+                + ", ".join(unsupported)
+            )
+        return cudnn_recurrent_kda(
+            q,
+            k,
+            v,
+            g,
+            beta,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            scale=scale,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            use_gate_in_kernel=use_gate_in_kernel,
+            lower_bound=lower_bound,
+            cu_seqlens=cu_seqlens,
+            beta_is_logit=beta_is_logit,
+            output=output,
         )
     if checkpoint_state_indices is not None and backend == "cake":
         raise ValueError("checkpoint_state_indices is supported only by CuTe DSL")

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -267,7 +267,7 @@ def recurrent_kda(
             ``NotImplementedError`` carrying the reason when that engine cannot
             serve the call. It is never selected implicitly, and it covers
             ordinary multi-token prefill only: no speculative decode, no state
-            pool, no ``initial_state_source``.
+            pool, no ``initial_state_source``, no state checkpoints.
 
     Returns:
         Tuple of ``(output, final_state)`` where ``final_state`` is ``None``
@@ -297,7 +297,9 @@ def recurrent_kda(
                 ("seq_order", seq_order is not None),
                 ("prefill_workspace", prefill_workspace is not None),
                 ("ssm_state_indices", ssm_state_indices is not None),
-                ("checkpoint_every_n_tokens", checkpoint_every_n_tokens > 0),
+                ("state_checkpoints", state_checkpoints is not None),
+                ("checkpoint_cu_starts", checkpoint_cu_starts is not None),
+                ("checkpoint_every_n_tokens", checkpoint_every_n_tokens != 0),
                 ("checkpoint_state_indices", checkpoint_state_indices is not None),
                 ("disable_state_update", disable_state_update),
                 ("correction_cache", correction_cache is not None),

--- a/flashinfer/trace/templates/gdn2.py
+++ b/flashinfer/trace/templates/gdn2.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TraceTemplate for Gated Delta Net 2 (GDN-2) prefill."""
+
+import math
+
+import torch
+
+from ..template import Const, Scalar, Tensor, TraceTemplate, Var
+
+
+@torch.no_grad()
+def _gdn2_prefill_reference(q, k, v, g, beta, w, initial_state, cu_seqlens, scale):
+    """Gated Delta Net 2 prefill reference, state V-major as ``[N, H, V, K]``.
+
+    All three gates are per channel: ``g`` and ``beta`` on the key dimension,
+    ``w`` on the value dimension. Per token,
+
+        S = diag(g) S
+        v_new = w * v - S (beta * k)
+        S += v_new (x) k
+        o = scale * S q
+    """
+    total_seq_len, num_q_heads, head_size = q.shape
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    num_seqs = cu_seqlens.size(0) - 1
+    device = q.device
+
+    if scale is None or scale == 0.0:
+        scale = 1.0 / math.sqrt(head_size)
+
+    q_exp = q.float().repeat_interleave(num_sab_heads // num_q_heads, dim=1)
+    k_exp = k.float().repeat_interleave(num_sab_heads // num_k_heads, dim=1)
+    v_exp = v.float().repeat_interleave(num_sab_heads // num_v_heads, dim=1)
+    g_f32 = g.float()
+    beta_f32 = beta.float()
+    w_f32 = w.float()
+
+    output = torch.zeros(
+        (total_seq_len, num_sab_heads, head_size), dtype=q.dtype, device=device
+    )
+    final_state = torch.zeros(
+        (num_seqs, num_sab_heads, head_size, head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    for seq_idx in range(num_seqs):
+        start = int(cu_seqlens[seq_idx].item())
+        end = int(cu_seqlens[seq_idx + 1].item())
+        if end <= start:
+            if initial_state is not None:
+                final_state[seq_idx] = initial_state[seq_idx].float()
+            continue
+        if initial_state is not None:
+            state = initial_state[seq_idx].clone().float()  # [H, V, K]
+        else:
+            state = torch.zeros(
+                (num_sab_heads, head_size, head_size),
+                dtype=torch.float32,
+                device=device,
+            )
+        for t in range(start, end):
+            key = k_exp[t]
+            state = state * g_f32[t][:, None, :]
+            erased = beta_f32[t] * key
+            v_new = w_f32[t] * v_exp[t] - torch.einsum("hvk,hk->hv", state, erased)
+            state = state + v_new[:, :, None] * key[:, None, :]
+            projected = torch.einsum("hvk,hk->hv", state, q_exp[t])
+            output[t] = (scale * projected).to(q.dtype)
+        final_state[seq_idx] = state
+
+    return output, final_state
+
+
+def _gdn2_prefill_init(
+    *,
+    total_seq_len: int,
+    num_seqs: int = 4,
+    len_cu_seqlens: int = 0,  # derived
+    num_q_heads: int = 4,
+    num_k_heads: int = 4,
+    num_v_heads: int = 8,
+    head_size: int = 128,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for ``flashinfer.gdn2_prefill.chunk_gated_delta_rule2``."""
+    del len_cu_seqlens
+    torch.manual_seed(seed)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    def qkv(num_heads, normalize):
+        x = torch.randn(
+            total_seq_len, num_heads, head_size, dtype=torch.float32, device=device
+        )
+        if normalize:
+            x = torch.nn.functional.normalize(x, p=2.0, dim=-1)
+        return x.to(torch.bfloat16).contiguous()
+
+    def channel_gate(dtype):
+        return (
+            torch.empty(
+                total_seq_len,
+                num_sab_heads,
+                head_size,
+                dtype=torch.float32,
+                device=device,
+            )
+            .uniform_(0.1, 1.0)
+            .to(dtype)
+        )
+
+    base = total_seq_len // max(1, num_seqs)
+    rem = total_seq_len % max(1, num_seqs)
+    cum = [0]
+    for i in range(num_seqs):
+        cum.append(cum[-1] + base + (1 if i < rem else 0))
+    return {
+        "q": qkv(num_q_heads, True),
+        "k": qkv(num_k_heads, True),
+        "v": qkv(num_v_heads, False),
+        "g": channel_gate(torch.float32),
+        "beta": channel_gate(torch.bfloat16),
+        "w": channel_gate(torch.bfloat16),
+        "cu_seqlens": torch.tensor(cum, dtype=torch.int64, device=device),
+    }
+
+
+gdn2_prefill_trace = TraceTemplate(
+    op_type="gdn2",
+    name_prefix="gdn2_prefill",
+    description=(
+        "Gated Delta Net 2 prefill: GDN's per-head scalar forget and erase "
+        "gates become per key channel and a third write gate scales the "
+        "incoming value per value channel. The state is in k-last layout "
+        "[N, H, V, K]."
+    ),
+    axes={
+        "total_seq_len": Var(
+            description="Total number of tokens across all sequences in the batch."
+        ),
+        "num_seqs": Var(description="Number of sequences in the batch."),
+        "num_q_heads": Const(description="Number of query heads.", abbrev="qk"),
+        "num_k_heads": Const(description="Number of key heads.", abbrev=""),
+        "num_v_heads": Const(
+            description="Number of value heads (GVA: more value heads than query heads).",
+            abbrev="v",
+        ),
+        "head_size": Const(
+            description="Dimension of each attention head (K in query/key space, V in value space).",
+            abbrev="d",
+        ),
+        "len_cu_seqlens": Var(description="Length of cu_seqlens array (num_seqs + 1)."),
+    },
+    inputs={
+        "q": Tensor(
+            ["total_seq_len", "num_q_heads", "head_size"],
+            description="Query tensor.",
+        ),
+        "k": Tensor(
+            ["total_seq_len", "num_k_heads", "head_size"],
+            description="Key tensor.",
+        ),
+        "v": Tensor(
+            ["total_seq_len", "num_v_heads", "head_size"],
+            description="Value tensor.",
+        ),
+        "g": Tensor(
+            ["total_seq_len", "num_v_heads", "head_size"],
+            description="Channel-wise forget gate in linear space, per key channel.",
+        ),
+        "beta": Tensor(
+            ["total_seq_len", "num_v_heads", "head_size"],
+            description="Channel-wise erase gate, post-sigmoid, per key channel.",
+        ),
+        "w": Tensor(
+            ["total_seq_len", "num_v_heads", "head_size"],
+            description="Channel-wise write gate, per value channel.",
+        ),
+        "initial_state": Tensor(
+            ["num_seqs", "num_v_heads", "head_size", "head_size"],
+            optional=True,
+            description="Incoming recurrent state in k-last layout [N, H, V, K].",
+        ),
+        "cu_seqlens": Tensor(
+            ["len_cu_seqlens"],
+            description="Cumulative sequence lengths for variable-length batching.",
+        ),
+        "scale": Scalar(
+            "float32",
+            optional=True,
+            description="Scale factor. Default is 1/sqrt(head_size).",
+        ),
+    },
+    outputs={
+        "output": Tensor(
+            ["total_seq_len", "num_v_heads", "head_size"],
+            dtype_from="q",
+            description="Attention output. Shape follows num_v_heads in GVA mode.",
+        ),
+        "final_state": Tensor(
+            ["num_seqs", "num_v_heads", "head_size", "head_size"],
+            dtype="float32",
+            description="Outgoing recurrent state in k-last layout [N, H, V, K].",
+        ),
+    },
+    constraints=[
+        "num_v_heads >= num_q_heads",
+        "num_v_heads % num_q_heads == 0",
+        "num_k_heads == num_q_heads",
+        "len_cu_seqlens == num_seqs + 1",
+        "total_seq_len == cu_seqlens[-1].item()",
+    ],
+    tags=["stage:prefill", "status:verified"],
+    reference=_gdn2_prefill_reference,
+    init=_gdn2_prefill_init,
+)

--- a/flashinfer/trace/templates/gdn2.py
+++ b/flashinfer/trace/templates/gdn2.py
@@ -134,7 +134,7 @@ def _gdn2_prefill_init(
         "q": qkv(num_q_heads, True),
         "k": qkv(num_k_heads, True),
         "v": qkv(num_v_heads, False),
-        "g": channel_gate(torch.float32),
+        "g": channel_gate(torch.float32).log(),
         "beta": channel_gate(torch.bfloat16),
         "w": channel_gate(torch.bfloat16),
         "cu_seqlens": torch.tensor(cum, dtype=torch.int64, device=device),
@@ -182,7 +182,7 @@ gdn2_prefill_trace = TraceTemplate(
         ),
         "g": Tensor(
             ["total_seq_len", "num_v_heads", "head_size"],
-            description="Channel-wise forget gate in linear space, per key channel.",
+            description="Channel-wise forget gate as the natural-log decay, per key channel.",
         ),
         "beta": Tensor(
             ["total_seq_len", "num_v_heads", "head_size"],

--- a/flashinfer/trace/templates/gdp.py
+++ b/flashinfer/trace/templates/gdp.py
@@ -1,0 +1,246 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TraceTemplate for Gated DeltaProduct (GDP) prefill."""
+
+import math
+
+import torch
+
+from ..template import Const, Scalar, Tensor, TraceTemplate, Var
+
+
+@torch.no_grad()
+def _gdp_prefill_reference(
+    q, k, v, g, beta, initial_state, cu_seqlens, scale, num_householder
+):
+    """Gated DeltaProduct prefill reference, state V-major as ``[N, H, V, K]``.
+
+    Per real token, with ``n = num_householder`` and sub-token rows
+    ``t*n .. t*n + n - 1`` of k/v/beta,
+
+        S = alpha_t S
+        for j in 0..n-1:
+            v_new = beta_{t,j} * (v_{t,j} - S k_{t,j})
+            S += v_new (x) k_{t,j}
+        o_t = scale * S q_t
+    """
+    total_seq_len, num_q_heads, head_size = q.shape
+    num_k_heads = k.shape[1]
+    num_v_heads = v.shape[1]
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    num_seqs = cu_seqlens.size(0) - 1
+    n = int(num_householder)
+    device = q.device
+
+    if scale is None or scale == 0.0:
+        scale = 1.0 / math.sqrt(head_size)
+
+    q_exp = q.float().repeat_interleave(num_sab_heads // num_q_heads, dim=1)
+    k_exp = k.float().repeat_interleave(num_sab_heads // num_k_heads, dim=1)
+    v_exp = v.float().repeat_interleave(num_sab_heads // num_v_heads, dim=1)
+    g_f32 = (
+        torch.ones(total_seq_len, num_sab_heads, dtype=torch.float32, device=device)
+        if g is None
+        else g.float()
+    )
+    beta_f32 = (
+        torch.ones(total_seq_len * n, num_sab_heads, dtype=torch.float32, device=device)
+        if beta is None
+        else beta.float()
+    )
+
+    output = torch.zeros(
+        (total_seq_len, num_sab_heads, v.shape[2]), dtype=q.dtype, device=device
+    )
+    final_state = torch.zeros(
+        (num_seqs, num_sab_heads, v.shape[2], head_size),
+        dtype=torch.float32,
+        device=device,
+    )
+
+    for seq_idx in range(num_seqs):
+        start = int(cu_seqlens[seq_idx].item())
+        end = int(cu_seqlens[seq_idx + 1].item())
+        if end <= start:
+            if initial_state is not None:
+                final_state[seq_idx] = initial_state[seq_idx].float()
+            continue
+        if initial_state is not None:
+            state = initial_state[seq_idx].clone().float()  # [H, V, K]
+        else:
+            state = torch.zeros(
+                (num_sab_heads, v.shape[2], head_size),
+                dtype=torch.float32,
+                device=device,
+            )
+        for t in range(start, end):
+            state = state * g_f32[t][:, None, None]
+            for j in range(t * n, t * n + n):
+                key = k_exp[j]
+                v_new = v_exp[j] - torch.einsum("hvk,hk->hv", state, key)
+                v_new = beta_f32[j][:, None] * v_new
+                state = state + v_new[:, :, None] * key[:, None, :]
+            projected = torch.einsum("hvk,hk->hv", state, q_exp[t])
+            output[t] = (scale * projected).to(q.dtype)
+        final_state[seq_idx] = state
+
+    return output, final_state
+
+
+def _gdp_prefill_init(
+    *,
+    total_seq_len: int,
+    expanded_seq_len: int = 0,  # derived
+    num_seqs: int = 4,
+    len_cu_seqlens: int = 0,  # derived
+    num_householder: int = 2,
+    num_q_heads: int = 4,
+    num_k_heads: int = 4,
+    num_v_heads: int = 8,
+    head_size: int = 128,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for ``flashinfer.gdp_prefill.chunk_gated_delta_product``."""
+    del expanded_seq_len, len_cu_seqlens
+    torch.manual_seed(seed)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    expanded = total_seq_len * num_householder
+
+    def qkv(rows, num_heads, normalize):
+        x = torch.randn(rows, num_heads, head_size, dtype=torch.float32, device=device)
+        if normalize:
+            x = torch.nn.functional.normalize(x, p=2.0, dim=-1)
+        return x.to(torch.bfloat16).contiguous()
+
+    base = total_seq_len // max(1, num_seqs)
+    rem = total_seq_len % max(1, num_seqs)
+    cum = [0]
+    for i in range(num_seqs):
+        cum.append(cum[-1] + base + (1 if i < rem else 0))
+    return {
+        "q": qkv(total_seq_len, num_q_heads, True),
+        "k": qkv(expanded, num_k_heads, True),
+        "v": qkv(expanded, num_v_heads, False),
+        "g": torch.empty(
+            total_seq_len, num_sab_heads, dtype=torch.float32, device=device
+        ).uniform_(0.1, 1.0),
+        "beta": torch.empty(
+            expanded, num_sab_heads, dtype=torch.float32, device=device
+        ).uniform_(0.1, 1.0),
+        "num_householder": num_householder,
+        "cu_seqlens": torch.tensor(cum, dtype=torch.int64, device=device),
+    }
+
+
+gdp_prefill_trace = TraceTemplate(
+    op_type="gdp",
+    name_prefix="gdp_prefill",
+    description=(
+        "Gated DeltaProduct prefill: num_householder beta-gated Householder "
+        "updates per token with one per-head scalar decay per token. k/v/beta "
+        "ride the expanded sub-token timeline; q, g and the outputs live at "
+        "real-token rows. The state is in k-last layout [N, H, V, K]."
+    ),
+    axes={
+        "total_seq_len": Var(
+            description="Total number of real tokens across all sequences in the batch."
+        ),
+        "expanded_seq_len": Var(
+            description="Total sub-token rows, total_seq_len * num_householder."
+        ),
+        "num_seqs": Var(description="Number of sequences in the batch."),
+        "num_householder": Const(
+            description="Householder updates per token.", abbrev="n"
+        ),
+        "num_q_heads": Const(description="Number of query heads.", abbrev="qk"),
+        "num_k_heads": Const(description="Number of key heads.", abbrev=""),
+        "num_v_heads": Const(
+            description="Number of value heads (GVA: more value heads than query heads).",
+            abbrev="v",
+        ),
+        "head_size": Const(
+            description="Dimension of each attention head (K in query/key space, V in value space).",
+            abbrev="d",
+        ),
+        "len_cu_seqlens": Var(description="Length of cu_seqlens array (num_seqs + 1)."),
+    },
+    inputs={
+        "q": Tensor(
+            ["total_seq_len", "num_q_heads", "head_size"],
+            description="Query tensor at real-token rows.",
+        ),
+        "k": Tensor(
+            ["expanded_seq_len", "num_k_heads", "head_size"],
+            description="Key tensor on the expanded sub-token timeline.",
+        ),
+        "v": Tensor(
+            ["expanded_seq_len", "num_v_heads", "head_size"],
+            description="Value tensor on the expanded sub-token timeline.",
+        ),
+        "g": Tensor(
+            ["total_seq_len", "num_v_heads"],
+            optional=True,
+            description="Per-head forget gate in linear space, at real-token rows.",
+        ),
+        "beta": Tensor(
+            ["expanded_seq_len", "num_v_heads"],
+            optional=True,
+            description="Per-head, per-Householder update gate, post-sigmoid.",
+        ),
+        "num_householder": Scalar(
+            "int32",
+            description="Householder updates per token.",
+        ),
+        "initial_state": Tensor(
+            ["num_seqs", "num_v_heads", "head_size", "head_size"],
+            optional=True,
+            description="Incoming recurrent state in k-last layout [N, H, V, K].",
+        ),
+        "cu_seqlens": Tensor(
+            ["len_cu_seqlens"],
+            description="Cumulative real-token sequence lengths for variable-length batching.",
+        ),
+        "scale": Scalar(
+            "float32",
+            optional=True,
+            description="Scale factor. Default is 1/sqrt(head_size).",
+        ),
+    },
+    outputs={
+        "output": Tensor(
+            ["total_seq_len", "num_v_heads", "head_size"],
+            dtype_from="q",
+            description="Attention output at real-token rows. Shape follows num_v_heads in GVA mode.",
+        ),
+        "final_state": Tensor(
+            ["num_seqs", "num_v_heads", "head_size", "head_size"],
+            dtype="float32",
+            description="Outgoing recurrent state in k-last layout [N, H, V, K].",
+        ),
+    },
+    constraints=[
+        "expanded_seq_len == total_seq_len * num_householder",
+        "num_householder >= 1",
+        "num_k_heads == num_q_heads or num_k_heads == num_v_heads",
+        "num_v_heads >= num_q_heads",
+        "num_v_heads % num_q_heads == 0",
+        "len_cu_seqlens == num_seqs + 1",
+        "total_seq_len == cu_seqlens[-1].item()",
+    ],
+    tags=["stage:prefill", "status:verified"],
+    reference=_gdp_prefill_reference,
+    init=_gdp_prefill_init,
+)

--- a/tests/gdn/test_prefill_cudnn_backend.py
+++ b/tests/gdn/test_prefill_cudnn_backend.py
@@ -1,0 +1,655 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``chunk_gated_delta_rule(backend="cudnn")``: cuDNN's fused SM100 GDN engine.
+
+Three oracles, deliberately layered:
+
+* FlashInfer's own SM100 GDN kernel, the tightest bound (both are chunked
+  recurrences over the same inputs, so they agree to accumulation order).
+* ``serial_delta_rule``, an fp32 token-at-a-time recurrence that shares no code
+  with either kernel. It is what catches a bug both chunked kernels could share.
+* ``reference_delta_rule.delta_rule``, this directory's own K-major serial
+  reference, as a third independent check on the state's orientation.
+
+The graph-cache-key tests follow ``tests/attention/test_cudnn_graph_cache_key.py``:
+every host scalar in ``_la_graph_key_fn`` is baked into the built graph as a
+compile-time constant, so a same-shape call that differs only in that scalar
+must not replay the first call's graph. Each such test runs the same shapes
+twice and checks each result against an oracle recomputed for that scalar.
+
+Whether the engine can serve a call at all -- architecture, head dim, dtypes,
+head counts -- is cuDNN's decision, so nothing here re-derives it; the module
+gate only covers what a test can know without launching.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.cudnn import cudnn_chunk_gated_delta_rule
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from tests.test_helpers.cudnn_linear_attention import (
+    HEAD_DIM,
+    assert_rel_close,
+    assert_state_orientation,
+    packed_offsets,
+    rel_err,
+    requires_cudnn_linear_attention,
+    serial_delta_rule,
+    widened_view,
+)
+
+from .reference_delta_rule import delta_rule
+
+pytestmark = requires_cudnn_linear_attention
+
+KERNEL_TOLERANCE = 5e-3
+SERIAL_TOLERANCE = 5e-2
+
+HEAD_CONFIGS = [(8, 8, 8), (16, 4, 4), (4, 4, 8)]
+
+
+def _make_inputs(
+    seq_lens,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    *,
+    seed=0,
+    initial_state=False,
+    normalize=True,
+    norm_scale=1.0,
+    dtype=torch.bfloat16,
+    gate_dtype=torch.float32,
+    state_dtype=torch.float32,
+    cu_seqlens_dtype=torch.int32,
+):
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    total = sum(seq_lens)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    def norm(heads):
+        x = torch.randn(total, heads, HEAD_DIM, dtype=torch.float32, device=device)
+        if normalize:
+            x = F.normalize(x, dim=-1)
+        return (norm_scale * x).to(dtype).contiguous()
+
+    state = None
+    if initial_state:
+        state = (
+            (
+                0.01
+                * torch.randn(
+                    len(seq_lens),
+                    num_sab_heads,
+                    HEAD_DIM,
+                    HEAD_DIM,
+                    dtype=torch.float32,
+                    device=device,
+                )
+            )
+            .to(state_dtype)
+            .contiguous()
+        )
+    return {
+        "q": norm(num_q_heads),
+        "k": norm(num_k_heads),
+        "v": torch.randn(
+            total, num_v_heads, HEAD_DIM, dtype=dtype, device=device
+        ).contiguous(),
+        "g": torch.exp(
+            -F.softplus(
+                torch.randn(total, num_sab_heads, dtype=torch.float32, device=device)
+                * 0.5
+                - 2.0
+            )
+        )
+        .to(gate_dtype)
+        .contiguous(),
+        "beta": torch.rand(
+            total, num_sab_heads, dtype=torch.float32, device=device
+        ).contiguous(),
+        "initial_state": state,
+        "cu_seqlens": packed_offsets(seq_lens, device, cu_seqlens_dtype),
+    }
+
+
+def _run_cudnn(inputs, **kwargs):
+    """``backend="cudnn"`` with this file's positional convention."""
+    return chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        kwargs.pop("g", inputs["g"]),
+        kwargs.pop("beta", inputs["beta"]),
+        kwargs.pop("scale", None),
+        cu_seqlens=kwargs.pop("cu_seqlens", inputs["cu_seqlens"]),
+        backend="cudnn",
+        **kwargs,
+    )
+
+
+def _serial(inputs, *, scale=None, l2norm=False, initial_state=...):
+    if initial_state is ...:
+        initial_state = inputs["initial_state"]
+    return serial_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["cu_seqlens"],
+        alpha=inputs["g"],
+        beta=inputs["beta"],
+        initial_state=initial_state,
+        scale=HEAD_DIM**-0.5 if scale is None else scale,
+        l2norm=l2norm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_lens", [[512], [256, 768, 129], [64, 1, 2048]])
+@pytest.mark.parametrize("num_q_heads,num_k_heads,num_v_heads", HEAD_CONFIGS)
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cudnn_backend_matches_default(
+    seq_lens, num_q_heads, num_k_heads, num_v_heads, use_initial_state, dtype
+):
+    """FlashInfer's own SM100 kernel as the oracle."""
+    device = torch.device("cuda")
+    inputs = _make_inputs(
+        seq_lens,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        seed=17,
+        initial_state=use_initial_state,
+        dtype=dtype,
+    )
+    num_seqs = len(seq_lens)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+    state = inputs["initial_state"]
+
+    ref_out, ref_state = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        None,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+        cu_seqlens=inputs["cu_seqlens"],
+        output_state=torch.empty(
+            num_seqs,
+            num_sab_heads,
+            HEAD_DIM,
+            HEAD_DIM,
+            dtype=torch.float32,
+            device=device,
+        ),
+    )
+    cudnn_out, cudnn_state = _run_cudnn(
+        inputs,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+    )
+
+    assert cudnn_out.shape == ref_out.shape
+    assert cudnn_out.dtype == ref_out.dtype
+    assert cudnn_state.shape == ref_state.shape
+    assert_rel_close("output", cudnn_out, ref_out, KERNEL_TOLERANCE)
+    assert_rel_close("final_state", cudnn_state, ref_state, KERNEL_TOLERANCE)
+
+
+@pytest.mark.parametrize("use_initial_state", [False, True])
+def test_cudnn_backend_matches_serial_reference(use_initial_state):
+    """Token-at-a-time fp32 recurrence as the oracle, independent of any kernel."""
+    inputs = _make_inputs([96, 64], 4, 4, 4, seed=23, initial_state=use_initial_state)
+    ref_out, ref_state = _serial(inputs)
+    state = inputs["initial_state"]
+    out, final_state = _run_cudnn(
+        inputs,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    assert_state_orientation(final_state, ref_state)
+
+
+@pytest.mark.parametrize("num_q_heads,num_k_heads,num_v_heads", [(8, 8, 8), (16, 4, 4)])
+def test_cudnn_backend_matches_directory_reference(
+    num_q_heads, num_k_heads, num_v_heads
+):
+    """This directory's own K-major serial reference, as a third oracle.
+
+    ``reference_delta_rule.delta_rule`` carries the state K-major as
+    ``[N, HO, K, V]`` and takes no incoming state, so the comparison
+    transposes and runs from zero. Two references written independently
+    agreeing on the same kernel is what rules out a shared-oracle bug.
+    """
+    seq_lens = [128, 96]
+    inputs = _make_inputs(seq_lens, num_q_heads, num_k_heads, num_v_heads, seed=41)
+    ref_out, ref_state_kv = delta_rule(
+        inputs["q"].float(),
+        inputs["k"].float(),
+        inputs["v"].float(),
+        seq_lens,
+        alpha=inputs["g"],
+        beta=inputs["beta"],
+        scale_factor=HEAD_DIM**-0.5,
+    )
+    out, final_state = _run_cudnn(inputs, output_final_state=True)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close(
+        "final_state", final_state, ref_state_kv.transpose(-1, -2), SERIAL_TOLERANCE
+    )
+
+
+def test_cudnn_backend_applies_in_kernel_l2norm():
+    """Un-normalized q/k plus the in-kernel norm must match a hand-normalized oracle."""
+    inputs = _make_inputs([96, 64], 4, 4, 4, seed=37, normalize=False)
+    ref_out, ref_state = _serial(inputs, l2norm=True)
+    out, final_state = _run_cudnn(
+        inputs, output_final_state=True, use_qk_l2norm_in_kernel=True
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_honors_scale():
+    """A non-default scale reaches the kernel rather than being dropped."""
+    inputs = _make_inputs([256], 4, 4, 4, seed=43)
+    scale = 3.0 / math.sqrt(HEAD_DIM)
+    ref_out, _ = _serial(inputs, scale=scale)
+    out = _run_cudnn(inputs, scale=scale)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    default_out = _run_cudnn(inputs)
+    assert rel_err(out, default_out) > 0.5, "scale=3/sqrt(d) matched the default"
+
+
+@pytest.mark.parametrize("gate_dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_cudnn_backend_accepts_gate_dtypes(gate_dtype):
+    """cuDNN reads g at fp32, bf16 or fp16; the log stays at the caller's width."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=47, gate_dtype=gate_dtype)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run_cudnn(inputs, output_final_state=True)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+@pytest.mark.parametrize("beta_dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_backend_accepts_beta_dtypes(beta_dtype):
+    inputs = _make_inputs([256], 4, 4, 4, seed=53)
+    inputs["beta"] = inputs["beta"].to(beta_dtype)
+    ref_out, _ = _serial(inputs)
+    out = _run_cudnn(inputs)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_backend_carries_state_dtype(state_dtype):
+    """A bf16 state pool crosses untransposed and comes back at its own width."""
+    device = torch.device("cuda")
+    inputs = _make_inputs(
+        [192, 64], 4, 4, 4, seed=59, initial_state=True, state_dtype=state_dtype
+    )
+    ref_out, ref_state = _serial(inputs)
+    output_state = torch.empty(
+        2, 4, HEAD_DIM, HEAD_DIM, dtype=state_dtype, device=device
+    )
+    out, final_state = _run_cudnn(
+        inputs,
+        initial_state=inputs["initial_state"],
+        output_final_state=True,
+        output_state=output_state,
+    )
+    assert final_state.dtype == state_dtype
+    assert final_state.data_ptr() == output_state.data_ptr()
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_defaults_gates_to_ones():
+    """Omitting g/beta selects the identity gates rather than reading garbage."""
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, 4, 4, seed=31)
+    total = inputs["q"].shape[0]
+    implicit = _run_cudnn(inputs, g=None, beta=None)
+    explicit = _run_cudnn(
+        inputs,
+        g=torch.ones(total, 4, dtype=torch.float32, device=device),
+        beta=torch.ones(total, 4, dtype=torch.float32, device=device),
+    )
+    assert rel_err(implicit, explicit) < 1e-6
+
+
+def test_cudnn_backend_handles_zero_length_sequences():
+    """A packed batch with empty rows: the empty states pass straight through."""
+    seq_lens = [0, 65, 0, 33]
+    inputs = _make_inputs(seq_lens, 4, 4, 4, seed=61, initial_state=True)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run_cudnn(
+        inputs,
+        initial_state=inputs["initial_state"].clone(),
+        output_final_state=True,
+    )
+    assert out.shape[0] == sum(seq_lens)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    for empty in (0, 2):
+        assert_rel_close(
+            f"state[{empty}]",
+            final_state[empty],
+            inputs["initial_state"][empty],
+            1e-6,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graph cache key
+# ---------------------------------------------------------------------------
+
+
+def test_cudnn_backend_keys_the_graph_cache_on_scale():
+    """Same shapes, two scales: the second must not replay the first graph.
+
+    ``scale`` is baked into the built graph as a compile-time constant, so a
+    key that omitted it would silently compute the second call with the first
+    call's scale. The 3x multiplier puts a stale replay far outside the bound.
+    """
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=67)
+    for multiplier in (1.0, 3.0):
+        scale = multiplier / math.sqrt(HEAD_DIM)
+        out = _run_cudnn(inputs, scale=scale)
+        ref_out, _ = _serial(inputs, scale=scale)
+        assert_rel_close(f"scale={scale}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_keys_the_graph_cache_on_qk_l2norm():
+    """Same shapes, the in-kernel norm off then on, each against its own oracle.
+
+    q and k are normalized and then halved, so the flag changes the answer
+    (the norm is not a no-op) while the un-normalized arm stays a contraction
+    rather than diverging over the sequence.
+    """
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=71, norm_scale=0.5)
+    for l2norm in (False, True):
+        out = _run_cudnn(inputs, use_qk_l2norm_in_kernel=l2norm)
+        ref_out, _ = _serial(inputs, l2norm=l2norm)
+        assert_rel_close(f"use_qk_l2norm={l2norm}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_serves_both_batch_invariant_settings():
+    """Both split-K settings build and serve the same call correctly.
+
+    Reached through the cuDNN entry point: ``batch_invariant`` is a cuDNN knob
+    with no ``chunk_gated_delta_rule`` argument. The two settings are bitwise
+    identical on every shape probed, so this cannot pin the knob's membership
+    in the graph-cache key; it pins that each setting compiles and runs.
+    """
+    inputs = _make_inputs([1024], 4, 4, 4, seed=73)
+    ref_out, _ = _serial(inputs)
+    for batch_invariant in (False, True):
+        out = cudnn_chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            batch_invariant=batch_invariant,
+        )
+        assert_rel_close(
+            f"batch_invariant={batch_invariant}", out, ref_out, SERIAL_TOLERANCE
+        )
+
+
+def test_cudnn_backend_batch_invariant_is_independent_of_packing():
+    """What ``batch_invariant`` buys: a row's result does not depend on its pack.
+
+    The same sequence is run alone and as the head of a two-sequence pack; with
+    the split-K partition disabled the two must agree bitwise. The default
+    partition happens to agree on this shape too -- it engages on few long
+    sequences, not on this one -- so this pins the guarantee, not the contrast.
+    """
+    device = torch.device("cuda")
+    seq_len = 512
+    inputs = _make_inputs([seq_len, seq_len], 4, 4, 4, seed=79)
+    solo = packed_offsets([seq_len], device)
+
+    def run(cu_seqlens, rows, batch_invariant):
+        return cudnn_chunk_gated_delta_rule(
+            inputs["q"][:rows],
+            inputs["k"][:rows],
+            inputs["v"][:rows],
+            inputs["g"][:rows],
+            inputs["beta"][:rows],
+            cu_seqlens=cu_seqlens,
+            batch_invariant=batch_invariant,
+        )
+
+    packed = run(inputs["cu_seqlens"], 2 * seq_len, True)
+    alone = run(solo, seq_len, True)
+    assert torch.equal(packed[:seq_len], alone), (
+        "batch_invariant=True still let the pack change the reduction order"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Buffers, layouts and repeatability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cu_seqlens_dtype", [torch.int32, torch.int64])
+def test_cudnn_backend_accepts_both_cu_seqlens_dtypes(cu_seqlens_dtype):
+    inputs = _make_inputs(
+        [256, 256], 4, 4, 4, seed=29, cu_seqlens_dtype=cu_seqlens_dtype
+    )
+    ref_out, _ = _serial(inputs)
+    out = _run_cudnn(inputs)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_honors_output_buffers():
+    device = torch.device("cuda")
+    num_heads = 8
+    inputs = _make_inputs([384, 384], num_heads, num_heads, num_heads, seed=5)
+    out = torch.empty_like(inputs["q"])
+    state = torch.empty(
+        2, num_heads, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device
+    )
+    returned_out, returned_state = _run_cudnn(
+        inputs, output_final_state=True, output=out, output_state=state
+    )
+    assert returned_out.data_ptr() == out.data_ptr()
+    assert returned_state.data_ptr() == state.data_ptr()
+    ref_out, ref_state = _serial(inputs)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_leaves_state_alone_when_not_requested():
+    """``output_final_state=False`` returns a bare tensor and writes no state."""
+    inputs = _make_inputs([256], 4, 4, 4, seed=83, initial_state=True)
+    state = inputs["initial_state"]
+    before = state.clone()
+    out = _run_cudnn(inputs, initial_state=state)
+    assert isinstance(out, torch.Tensor)
+    assert torch.equal(state, before)
+
+
+@pytest.mark.parametrize("tensor", ["q", "k", "v", "g", "beta"])
+def test_cudnn_backend_accepts_strided_inputs(tensor):
+    """Strides are passed through, so a head-padded view must not be re-read.
+
+    Every buffer is described to cuDNN with the caller's own strides. A wrapper
+    that dropped them and assumed compactness would read the padding, so this
+    compares a widened non-contiguous view against the contiguous run.
+    """
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=89)
+    reference = _run_cudnn(inputs, output_final_state=True)
+    strided = dict(inputs)
+    strided[tensor] = widened_view(inputs[tensor], axis=1)
+    assert torch.equal(strided[tensor], inputs[tensor])
+    out, final_state = _run_cudnn(strided, output_final_state=True)
+    assert torch.equal(out, reference[0])
+    assert torch.equal(final_state, reference[1])
+
+
+def test_cudnn_backend_writes_through_a_strided_output_view():
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, 4, 4, seed=97)
+    wide = torch.zeros(256, 8, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    view = wide[:, :4]
+    reference = _run_cudnn(inputs)
+    out = _run_cudnn(inputs, output=view)
+    assert out.data_ptr() == view.data_ptr()
+    assert torch.equal(view, reference)
+    assert torch.equal(wide[:, 4:], torch.zeros_like(wide[:, 4:])), (
+        "the kernel wrote outside the caller's view"
+    )
+
+
+def test_cudnn_backend_is_deterministic():
+    """Two identical calls are bitwise equal, split-K reduction included."""
+    inputs = _make_inputs([2048, 512], 8, 8, 8, seed=101, initial_state=True)
+    first = _run_cudnn(
+        inputs, initial_state=inputs["initial_state"].clone(), output_final_state=True
+    )
+    second = _run_cudnn(
+        inputs, initial_state=inputs["initial_state"].clone(), output_final_state=True
+    )
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+
+
+def test_cudnn_backend_replays_under_cuda_graph_capture():
+    """A captured graph replays to the same buffers with the same result."""
+    device = torch.device("cuda")
+    inputs = _make_inputs([512], 4, 4, 4, seed=103)
+    out = torch.empty(512, 4, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    state = torch.zeros(1, 4, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device)
+    call = dict(output=out, output_state=state, output_final_state=True)
+
+    capture_stream = torch.cuda.Stream(device=device)
+    capture_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(capture_stream):
+        _run_cudnn(inputs, **call)
+    capture_stream.synchronize()
+    eager_out, eager_state = out.clone(), state.clone()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_out, captured_state = _run_cudnn(inputs, **call)
+    out.fill_(float("nan"))
+    state.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_out.data_ptr() == out.data_ptr()
+    assert captured_state.data_ptr() == state.data_ptr()
+    assert torch.equal(out, eager_out)
+    assert torch.equal(state, eager_state)
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+def test_cudnn_backend_rejects_state_indices():
+    device = torch.device("cuda")
+    num_heads = 8
+    inputs = _make_inputs([256], num_heads, num_heads, num_heads, seed=3)
+    pool = torch.zeros(
+        4, num_heads, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device
+    )
+    with pytest.raises(NotImplementedError, match="state_indices"):
+        _run_cudnn(
+            inputs,
+            initial_state=pool,
+            output_final_state=True,
+            output_state=pool,
+            state_indices=torch.zeros(1, dtype=torch.int32, device=device),
+        )
+
+
+def test_cudnn_backend_rejects_state_checkpoints():
+    device = torch.device("cuda")
+    num_heads = 8
+    inputs = _make_inputs([256], num_heads, num_heads, num_heads, seed=4)
+    with pytest.raises(NotImplementedError, match="checkpoint_every_n_tokens"):
+        _run_cudnn(
+            inputs,
+            output_final_state=True,
+            state_checkpoints=torch.zeros(
+                4, num_heads, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device
+            ),
+            checkpoint_cu_starts=torch.tensor([0, 4], dtype=torch.int64, device=device),
+            checkpoint_every_n_tokens=64,
+        )
+
+
+def test_cudnn_backend_rejects_context_parallel():
+    inputs = _make_inputs([256], 8, 8, 8, seed=6)
+    with pytest.raises(NotImplementedError, match="use_cp"):
+        _run_cudnn(inputs, use_cp=True)
+
+
+def test_cudnn_backend_names_every_unsupported_argument_at_once():
+    """The rejection lists all of them, so one round trip fixes the call."""
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 8, 8, 8, seed=8)
+    with pytest.raises(NotImplementedError) as excinfo:
+        _run_cudnn(
+            inputs,
+            use_cp=True,
+            state_indices=torch.zeros(1, dtype=torch.int32, device=device),
+        )
+    message = str(excinfo.value)
+    assert "use_cp" in message and "state_indices" in message
+
+
+def test_backend_argument_is_validated():
+    inputs = _make_inputs([128], 8, 8, 8, seed=1)
+    with pytest.raises(ValueError, match="backend"):
+        chunk_gated_delta_rule(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            None,
+            cu_seqlens=inputs["cu_seqlens"],
+            backend="nonesuch",
+        )
+
+
+def test_cudnn_entry_point_requires_cu_seqlens():
+    """The cuDNN wrapper's own required-argument check, reached directly."""
+    inputs = _make_inputs([128], 8, 8, 8, seed=2)
+    with pytest.raises(ValueError, match="cu_seqlens"):
+        cudnn_chunk_gated_delta_rule(
+            inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+        )

--- a/tests/gdn2/conftest.py
+++ b/tests/gdn2/conftest.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/gdn2/test_prefill_gdn2_cudnn_backend.py
+++ b/tests/gdn2/test_prefill_gdn2_cudnn_backend.py
@@ -1,0 +1,591 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``chunk_gated_delta_rule2``: cuDNN's fused SM100 GDN-2 engine.
+
+FlashInfer carries no GDN-2 kernel of its own, so there is no peer backend to
+differentiate against. Two oracles stand in:
+
+* ``serial_delta_rule2``, an fp32 token-at-a-time GDN-2 recurrence.
+* **GDN itself.** With ``g``, ``beta`` and ``w`` set to channel constants and
+  ``w == beta``, GDN-2's update ``v_new = w*v - S(beta*k)`` collapses to
+  ``beta*(v - S k)``, which is exactly the scalar-gated delta rule. Running
+  ``chunk_gated_delta_rule`` on the same inputs is therefore an independent
+  kernel oracle for the degenerate corner, and it is the check that would catch
+  a gate wired to the wrong axis.
+
+The graph-cache-key tests follow ``tests/attention/test_cudnn_graph_cache_key.py``.
+Everything the engine owns -- architecture, head dims, dtypes, head counts --
+is left to cuDNN to accept or decline.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flashinfer
+from flashinfer.cudnn import cudnn_chunk_gated_delta_rule2
+from flashinfer.gdn2_prefill import chunk_gated_delta_rule2
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from tests.test_helpers.cudnn_linear_attention import (
+    HEAD_DIM,
+    assert_rel_close,
+    assert_state_orientation,
+    packed_offsets,
+    rel_err,
+    requires_cudnn_linear_attention,
+    serial_delta_rule2,
+    widened_view,
+)
+
+pytestmark = requires_cudnn_linear_attention
+
+SERIAL_TOLERANCE = 5e-2
+KERNEL_TOLERANCE = 1e-2
+
+HEAD_CONFIGS = [(4, 4, 4), (8, 4, 4), (4, 4, 8)]
+
+
+def _make_inputs(
+    seq_lens,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    *,
+    seed=0,
+    initial_state=False,
+    normalize=True,
+    norm_scale=1.0,
+    dtype=torch.bfloat16,
+    gate_dtype=torch.float32,
+    state_dtype=torch.float32,
+    cu_seqlens_dtype=torch.int32,
+):
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    total = sum(seq_lens)
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    def norm(heads):
+        x = torch.randn(total, heads, HEAD_DIM, dtype=torch.float32, device=device)
+        if normalize:
+            x = F.normalize(x, dim=-1)
+        return (norm_scale * x).to(dtype).contiguous()
+
+    def channel_gate():
+        return (
+            torch.rand(
+                total, num_sab_heads, HEAD_DIM, dtype=torch.float32, device=device
+            )
+            .to(dtype)
+            .contiguous()
+        )
+
+    state = None
+    if initial_state:
+        state = (
+            (
+                0.01
+                * torch.randn(
+                    len(seq_lens),
+                    num_sab_heads,
+                    HEAD_DIM,
+                    HEAD_DIM,
+                    dtype=torch.float32,
+                    device=device,
+                )
+            )
+            .to(state_dtype)
+            .contiguous()
+        )
+    return {
+        "q": norm(num_q_heads),
+        "k": norm(num_k_heads),
+        "v": torch.randn(
+            total, num_v_heads, HEAD_DIM, dtype=dtype, device=device
+        ).contiguous(),
+        "g": torch.exp(
+            -F.softplus(
+                torch.randn(
+                    total, num_sab_heads, HEAD_DIM, dtype=torch.float32, device=device
+                )
+                * 0.5
+                - 2.0
+            )
+        )
+        .to(gate_dtype)
+        .contiguous(),
+        "beta": channel_gate(),
+        "w": channel_gate(),
+        "initial_state": state,
+        "cu_seqlens": packed_offsets(seq_lens, device, cu_seqlens_dtype),
+    }
+
+
+def _run(inputs, **kwargs):
+    return chunk_gated_delta_rule2(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        kwargs.pop("g", inputs["g"]),
+        kwargs.pop("beta", inputs["beta"]),
+        kwargs.pop("w", inputs["w"]),
+        kwargs.pop("scale", None),
+        cu_seqlens=kwargs.pop("cu_seqlens", inputs["cu_seqlens"]),
+        **kwargs,
+    )
+
+
+def _serial(inputs, *, scale=None, l2norm=False, initial_state=...):
+    if initial_state is ...:
+        initial_state = inputs["initial_state"]
+    return serial_delta_rule2(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["cu_seqlens"],
+        alpha=inputs["g"],
+        beta=inputs["beta"],
+        w=inputs["w"],
+        initial_state=initial_state,
+        scale=HEAD_DIM**-0.5 if scale is None else scale,
+        l2norm=l2norm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_lens", [[96, 64], [512], [64, 1, 1024]])
+@pytest.mark.parametrize("num_q_heads,num_k_heads,num_v_heads", HEAD_CONFIGS)
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_gdn2_matches_serial_reference(
+    seq_lens, num_q_heads, num_k_heads, num_v_heads, use_initial_state, dtype
+):
+    """Token-at-a-time fp32 recurrence as the oracle, independent of any kernel."""
+    inputs = _make_inputs(
+        seq_lens,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        seed=23,
+        initial_state=use_initial_state,
+        dtype=dtype,
+    )
+    ref_out, ref_state = _serial(inputs)
+    state = inputs["initial_state"]
+    out, final_state = _run(
+        inputs,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+    )
+    assert out.shape == (sum(seq_lens), max(num_q_heads, num_v_heads), HEAD_DIM)
+    assert out.dtype == dtype
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    assert_state_orientation(final_state, ref_state)
+
+
+@pytest.mark.parametrize("use_initial_state", [False, True])
+def test_gdn2_with_channel_constant_gates_matches_gdn(use_initial_state):
+    """GDN-2 degenerates to GDN when the gates are channel constants and w == beta.
+
+    ``v_new = w*v - S(beta*k)`` becomes ``beta*(v - S k)`` and the update is the
+    scalar-gated delta rule exactly. Anything that swapped GDN-2's K and V gate
+    axes, or crossed ``beta`` with ``w``, breaks this and nothing else here
+    would notice.
+    """
+    seq_lens = [256, 128]
+    inputs = _make_inputs(seq_lens, 4, 4, 4, seed=7, initial_state=use_initial_state)
+    total, heads = inputs["q"].shape[0], 4
+    device = torch.device("cuda")
+    scalar_g = torch.exp(
+        -F.softplus(
+            torch.randn(total, heads, dtype=torch.float32, device=device) * 0.5 - 2.0
+        )
+    ).contiguous()
+    scalar_beta = torch.rand(
+        total, heads, dtype=torch.float32, device=device
+    ).contiguous()
+    broadcast = (
+        lambda x, cast: x[:, :, None].expand(-1, -1, HEAD_DIM).to(cast).contiguous()
+    )
+
+    state = inputs["initial_state"]
+    gdn_out, gdn_state = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        scalar_g,
+        scalar_beta,
+        None,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+        cu_seqlens=inputs["cu_seqlens"],
+        backend="cudnn",
+    )
+    gdn2_out, gdn2_state = _run(
+        inputs,
+        g=broadcast(scalar_g, torch.float32),
+        beta=broadcast(scalar_beta, inputs["q"].dtype),
+        w=broadcast(scalar_beta, inputs["q"].dtype),
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+    )
+    assert_rel_close("output", gdn2_out, gdn_out, KERNEL_TOLERANCE)
+    assert_rel_close("final_state", gdn2_state, gdn_state, KERNEL_TOLERANCE)
+
+
+def test_gdn2_applies_in_kernel_l2norm():
+    """Un-normalized q/k plus the in-kernel norm must match a hand-normalized oracle."""
+    inputs = _make_inputs([96, 64], 4, 4, 4, seed=37, normalize=False)
+    ref_out, ref_state = _serial(inputs, l2norm=True)
+    out, final_state = _run(
+        inputs, output_final_state=True, use_qk_l2norm_in_kernel=True
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdn2_honors_scale():
+    inputs = _make_inputs([256], 4, 4, 4, seed=43)
+    scale = 3.0 / math.sqrt(HEAD_DIM)
+    ref_out, _ = _serial(inputs, scale=scale)
+    out = _run(inputs, scale=scale)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert rel_err(out, _run(inputs)) > 0.5, "scale=3/sqrt(d) matched the default"
+
+
+def test_gdn2_defaults_gates_to_ones():
+    """Omitting g/beta/w selects the identity gates."""
+    device = torch.device("cuda")
+    num_heads = 4
+    inputs = _make_inputs([256], num_heads, num_heads, num_heads, seed=31)
+    total = inputs["q"].shape[0]
+    implicit = _run(inputs, g=None, beta=None, w=None)
+    explicit = _run(
+        inputs,
+        g=torch.ones(total, num_heads, HEAD_DIM, dtype=torch.float32, device=device),
+        beta=torch.ones(
+            total, num_heads, HEAD_DIM, dtype=torch.bfloat16, device=device
+        ),
+        w=torch.ones(total, num_heads, HEAD_DIM, dtype=torch.bfloat16, device=device),
+    )
+    assert rel_err(implicit, explicit) < 1e-6
+
+
+@pytest.mark.parametrize("gate_dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_gdn2_accepts_forget_gate_dtypes(gate_dtype):
+    """``g`` may be fp32, bf16 or fp16; ``beta``/``w`` must be the io dtype."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=47, gate_dtype=gate_dtype)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(inputs, output_final_state=True)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+def test_gdn2_carries_state_dtype(state_dtype):
+    device = torch.device("cuda")
+    inputs = _make_inputs(
+        [192, 64], 4, 4, 4, seed=59, initial_state=True, state_dtype=state_dtype
+    )
+    ref_out, ref_state = _serial(inputs)
+    output_state = torch.empty(
+        2, 4, HEAD_DIM, HEAD_DIM, dtype=state_dtype, device=device
+    )
+    out, final_state = _run(
+        inputs,
+        initial_state=inputs["initial_state"],
+        output_final_state=True,
+        output_state=output_state,
+    )
+    assert final_state.dtype == state_dtype
+    assert final_state.data_ptr() == output_state.data_ptr()
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdn2_handles_zero_length_sequences():
+    seq_lens = [0, 65, 0, 33]
+    inputs = _make_inputs(seq_lens, 4, 4, 4, seed=61, initial_state=True)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(
+        inputs,
+        initial_state=inputs["initial_state"].clone(),
+        output_final_state=True,
+    )
+    assert out.shape[0] == sum(seq_lens)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    for empty in (0, 2):
+        assert_rel_close(
+            f"state[{empty}]", final_state[empty], inputs["initial_state"][empty], 1e-6
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graph cache key
+# ---------------------------------------------------------------------------
+
+
+def test_gdn2_keys_the_graph_cache_on_scale():
+    """Same shapes, two scales: the second must not replay the first graph."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=67)
+    for multiplier in (1.0, 3.0):
+        scale = multiplier / math.sqrt(HEAD_DIM)
+        out = _run(inputs, scale=scale)
+        ref_out, _ = _serial(inputs, scale=scale)
+        assert_rel_close(f"scale={scale}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdn2_keys_the_graph_cache_on_qk_l2norm():
+    """Same shapes, the in-kernel norm off then on, each against its own oracle.
+
+    q and k are normalized and then halved, so the flag changes the answer
+    while the un-normalized arm stays a contraction. GDN-2 has no ``1 - beta``
+    damping, so an un-normalized key would diverge over the sequence.
+    """
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=71, norm_scale=0.5)
+    for l2norm in (False, True):
+        out = _run(inputs, use_qk_l2norm_in_kernel=l2norm)
+        ref_out, _ = _serial(inputs, l2norm=l2norm)
+        assert_rel_close(f"use_qk_l2norm={l2norm}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdn2_does_not_share_a_graph_with_gdn():
+    """Same shapes, same scalars, different family: the key must separate them.
+
+    A GDN and a GDN-2 call can agree on every shape and every host scalar in
+    the key except ``family``, so this pins that component.
+    """
+    inputs = _make_inputs([256], 4, 4, 4, seed=109)
+    total = inputs["q"].shape[0]
+    device = torch.device("cuda")
+    scalar_g = torch.ones(total, 4, dtype=torch.float32, device=device)
+    scalar_beta = torch.ones(total, 4, dtype=torch.float32, device=device)
+    gdn_out = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        scalar_g,
+        scalar_beta,
+        None,
+        cu_seqlens=inputs["cu_seqlens"],
+        backend="cudnn",
+    )
+    gdn2_out = _run(inputs, g=None, beta=None, w=None)
+    ref_out, _ = serial_delta_rule2(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["cu_seqlens"],
+        scale=HEAD_DIM**-0.5,
+    )
+    assert_rel_close("gdn2", gdn2_out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("gdn", gdn_out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdn2_serves_both_batch_invariant_settings():
+    """Both split-K settings build and serve the same call correctly; the two
+    are bitwise identical on every shape probed, so this is a knob smoke, not
+    a cache-key pin."""
+    inputs = _make_inputs([1024], 4, 4, 4, seed=73)
+    ref_out, _ = _serial(inputs)
+    for batch_invariant in (False, True):
+        out = cudnn_chunk_gated_delta_rule2(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["w"],
+            cu_seqlens=inputs["cu_seqlens"],
+            batch_invariant=batch_invariant,
+        )
+        assert_rel_close(
+            f"batch_invariant={batch_invariant}", out, ref_out, SERIAL_TOLERANCE
+        )
+
+
+# ---------------------------------------------------------------------------
+# Buffers, layouts and repeatability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cu_seqlens_dtype", [torch.int32, torch.int64])
+def test_gdn2_accepts_both_cu_seqlens_dtypes(cu_seqlens_dtype):
+    inputs = _make_inputs(
+        [256, 256], 4, 4, 4, seed=29, cu_seqlens_dtype=cu_seqlens_dtype
+    )
+    ref_out, _ = _serial(inputs)
+    assert_rel_close("output", _run(inputs), ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdn2_honors_output_buffers():
+    device = torch.device("cuda")
+    num_heads = 8
+    inputs = _make_inputs([384, 384], num_heads, num_heads, num_heads, seed=5)
+    out = torch.empty_like(inputs["q"])
+    state = torch.empty(
+        2, num_heads, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device
+    )
+    returned_out, returned_state = _run(
+        inputs, output_final_state=True, output=out, output_state=state
+    )
+    assert returned_out.data_ptr() == out.data_ptr()
+    assert returned_state.data_ptr() == state.data_ptr()
+    ref_out, ref_state = _serial(inputs)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdn2_leaves_state_alone_when_not_requested():
+    inputs = _make_inputs([256], 4, 4, 4, seed=83, initial_state=True)
+    state = inputs["initial_state"]
+    before = state.clone()
+    out = _run(inputs, initial_state=state)
+    assert isinstance(out, torch.Tensor)
+    assert torch.equal(state, before)
+
+
+@pytest.mark.parametrize("tensor", ["q", "k", "v", "g", "beta", "w"])
+def test_gdn2_accepts_strided_inputs(tensor):
+    """Strides are passed through, so a head-padded view must not be re-read."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, seed=89)
+    reference = _run(inputs, output_final_state=True)
+    strided = dict(inputs)
+    strided[tensor] = widened_view(inputs[tensor], axis=1)
+    assert torch.equal(strided[tensor], inputs[tensor])
+    out, final_state = _run(strided, output_final_state=True)
+    assert torch.equal(out, reference[0])
+    assert torch.equal(final_state, reference[1])
+
+
+def test_gdn2_writes_through_a_strided_output_view():
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, 4, 4, seed=97)
+    wide = torch.zeros(256, 8, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    view = wide[:, :4]
+    reference = _run(inputs)
+    out = _run(inputs, output=view)
+    assert out.data_ptr() == view.data_ptr()
+    assert torch.equal(view, reference)
+    assert torch.equal(wide[:, 4:], torch.zeros_like(wide[:, 4:]))
+
+
+def test_gdn2_is_deterministic():
+    inputs = _make_inputs([2048, 512], 4, 4, 4, seed=101, initial_state=True)
+    first = _run(
+        inputs, initial_state=inputs["initial_state"].clone(), output_final_state=True
+    )
+    second = _run(
+        inputs, initial_state=inputs["initial_state"].clone(), output_final_state=True
+    )
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+
+
+def test_gdn2_replays_under_cuda_graph_capture():
+    device = torch.device("cuda")
+    inputs = _make_inputs([512], 4, 4, 4, seed=103)
+    out = torch.empty(512, 4, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    state = torch.zeros(1, 4, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device)
+    call = dict(output=out, output_state=state, output_final_state=True)
+
+    capture_stream = torch.cuda.Stream(device=device)
+    capture_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(capture_stream):
+        _run(inputs, **call)
+    capture_stream.synchronize()
+    eager_out, eager_state = out.clone(), state.clone()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_out, captured_state = _run(inputs, **call)
+    out.fill_(float("nan"))
+    state.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_out.data_ptr() == out.data_ptr()
+    assert captured_state.data_ptr() == state.data_ptr()
+    assert torch.equal(out, eager_out)
+    assert torch.equal(state, eager_state)
+
+
+# ---------------------------------------------------------------------------
+# API surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_is_exported():
+    """``flashinfer.chunk_gated_delta_rule2`` is the module function itself."""
+    assert flashinfer.chunk_gated_delta_rule2 is chunk_gated_delta_rule2
+
+
+@pytest.mark.parametrize("backend", ["auto", "cudnn"])
+def test_both_backend_values_reach_cudnn(backend):
+    """FlashInfer has no GDN-2 kernel, so ``auto`` and ``cudnn`` are one path."""
+    inputs = _make_inputs([256], 4, 4, 4, seed=113)
+    ref_out, _ = _serial(inputs)
+    assert_rel_close("output", _run(inputs, backend=backend), ref_out, SERIAL_TOLERANCE)
+
+
+def test_backend_argument_is_validated():
+    inputs = _make_inputs([128], 4, 4, 4, seed=1)
+    with pytest.raises(ValueError, match="backend"):
+        _run(inputs, backend="nonesuch")
+
+
+def test_cu_seqlens_is_required():
+    """The engines take packed THD input, so there is no dense fallback."""
+    inputs = _make_inputs([128], 4, 4, 4, seed=1)
+    with pytest.raises(ValueError, match="cu_seqlens"):
+        chunk_gated_delta_rule2(inputs["q"], inputs["k"], inputs["v"])
+
+
+def test_cu_seqlens_dtype_is_validated():
+    inputs = _make_inputs([128], 4, 4, 4, seed=1)
+    with pytest.raises(ValueError, match="integer dtype"):
+        _run(inputs, cu_seqlens=inputs["cu_seqlens"].float())
+
+
+def test_split_state_dtypes_are_declined_by_the_engine():
+    """One state dtype per kernel: cuDNN, not the wrapper, says no.
+
+    The wrapper launders nothing, so the mismatch reaches the engine and comes
+    back as a cuDNN exception rather than a Python-side ValueError.
+    """
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, 4, 4, seed=127, initial_state=True)
+    with pytest.raises(Exception) as excinfo:
+        _run(
+            inputs,
+            initial_state=inputs["initial_state"],
+            output_final_state=True,
+            output_state=torch.empty(
+                1, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device
+            ),
+        )
+    assert type(excinfo.value).__module__.startswith("cudnn"), (
+        f"expected a cuDNN decline, got {type(excinfo.value)!r}"
+    )

--- a/tests/gdn2/test_prefill_gdn2_cudnn_backend.py
+++ b/tests/gdn2/test_prefill_gdn2_cudnn_backend.py
@@ -119,7 +119,7 @@ def _make_inputs(
         "v": torch.randn(
             total, num_v_heads, HEAD_DIM, dtype=dtype, device=device
         ).contiguous(),
-        "g": torch.exp(
+        "g": (
             -F.softplus(
                 torch.randn(
                     total, num_sab_heads, HEAD_DIM, dtype=torch.float32, device=device
@@ -159,7 +159,7 @@ def _serial(inputs, *, scale=None, l2norm=False, initial_state=...):
         inputs["k"],
         inputs["v"],
         inputs["cu_seqlens"],
-        alpha=inputs["g"],
+        alpha=inputs["g"].float().exp(),
         beta=inputs["beta"],
         w=inputs["w"],
         initial_state=initial_state,
@@ -244,7 +244,7 @@ def test_gdn2_with_channel_constant_gates_matches_gdn(use_initial_state):
     )
     gdn2_out, gdn2_state = _run(
         inputs,
-        g=broadcast(scalar_g, torch.float32),
+        g=broadcast(scalar_g.log(), torch.float32),
         beta=broadcast(scalar_beta, inputs["q"].dtype),
         w=broadcast(scalar_beta, inputs["q"].dtype),
         initial_state=None if state is None else state.clone(),
@@ -275,7 +275,7 @@ def test_gdn2_honors_scale():
 
 
 def test_gdn2_defaults_gates_to_ones():
-    """Omitting g/beta/w selects the identity gates."""
+    """Omitting g/beta/w selects the identity gates: a zero log gate, unit beta and w."""
     device = torch.device("cuda")
     num_heads = 4
     inputs = _make_inputs([256], num_heads, num_heads, num_heads, seed=31)
@@ -283,7 +283,7 @@ def test_gdn2_defaults_gates_to_ones():
     implicit = _run(inputs, g=None, beta=None, w=None)
     explicit = _run(
         inputs,
-        g=torch.ones(total, num_heads, HEAD_DIM, dtype=torch.float32, device=device),
+        g=torch.zeros(total, num_heads, HEAD_DIM, dtype=torch.float32, device=device),
         beta=torch.ones(
             total, num_heads, HEAD_DIM, dtype=torch.bfloat16, device=device
         ),

--- a/tests/gdp/conftest.py
+++ b/tests/gdp/conftest.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/gdp/test_prefill_gdp_cudnn_backend.py
+++ b/tests/gdp/test_prefill_gdp_cudnn_backend.py
@@ -1,0 +1,545 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``chunk_gated_delta_product``: cuDNN's fused SM100 GDP engine.
+
+FlashInfer carries no GDP kernel of its own, so there is no peer backend to
+differentiate against. Two oracles stand in:
+
+* ``serial_delta_product``, an fp32 token-at-a-time GDP recurrence.
+* **GDN itself.** ``num_householder == 1`` is exactly the gated delta rule, so
+  running ``chunk_gated_delta_rule`` on the same inputs is an independent
+  kernel oracle for that corner, and it is the check that would catch a
+  sub-token timeline wired off by one.
+
+The graph-cache-key tests follow ``tests/attention/test_cudnn_graph_cache_key.py``.
+Everything the engine owns -- architecture, head dims, dtypes, head counts --
+is left to cuDNN to accept or decline.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flashinfer
+from flashinfer.cudnn import cudnn_chunk_gated_delta_product
+from flashinfer.gdn_prefill import chunk_gated_delta_rule
+from flashinfer.gdp_prefill import chunk_gated_delta_product
+from tests.test_helpers.cudnn_linear_attention import (
+    HEAD_DIM,
+    assert_rel_close,
+    assert_state_orientation,
+    packed_offsets,
+    rel_err,
+    requires_cudnn_linear_attention,
+    serial_delta_product,
+    widened_view,
+)
+
+pytestmark = requires_cudnn_linear_attention
+
+SERIAL_TOLERANCE = 5e-2
+KERNEL_TOLERANCE = 1e-2
+
+HEAD_CONFIGS = [(4, 4, 4), (8, 4, 4), (4, 4, 8)]
+
+
+def _make_inputs(
+    seq_lens,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    num_householder,
+    *,
+    seed=0,
+    initial_state=False,
+    normalize=True,
+    norm_scale=1.0,
+    dtype=torch.bfloat16,
+    gate_dtype=torch.float32,
+    state_dtype=torch.float32,
+    cu_seqlens_dtype=torch.int32,
+):
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    total = sum(seq_lens)
+    expanded = total * num_householder
+    num_sab_heads = max(num_q_heads, num_v_heads)
+
+    def norm(rows, heads):
+        x = torch.randn(rows, heads, HEAD_DIM, dtype=torch.float32, device=device)
+        if normalize:
+            x = F.normalize(x, dim=-1)
+        return (norm_scale * x).to(dtype).contiguous()
+
+    state = None
+    if initial_state:
+        state = (
+            (
+                0.01
+                * torch.randn(
+                    len(seq_lens),
+                    num_sab_heads,
+                    HEAD_DIM,
+                    HEAD_DIM,
+                    dtype=torch.float32,
+                    device=device,
+                )
+            )
+            .to(state_dtype)
+            .contiguous()
+        )
+    return {
+        "q": norm(total, num_q_heads),
+        "k": norm(expanded, num_k_heads),
+        "v": torch.randn(
+            expanded, num_v_heads, HEAD_DIM, dtype=dtype, device=device
+        ).contiguous(),
+        "g": torch.exp(
+            -F.softplus(
+                torch.randn(total, num_sab_heads, dtype=torch.float32, device=device)
+                * 0.5
+                - 2.0
+            )
+        )
+        .to(gate_dtype)
+        .contiguous(),
+        "beta": torch.rand(
+            expanded, num_sab_heads, dtype=torch.float32, device=device
+        ).contiguous(),
+        "num_householder": num_householder,
+        "initial_state": state,
+        "cu_seqlens": packed_offsets(seq_lens, device, cu_seqlens_dtype),
+    }
+
+
+def _run(inputs, **kwargs):
+    return chunk_gated_delta_product(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        kwargs.pop("g", inputs["g"]),
+        kwargs.pop("beta", inputs["beta"]),
+        kwargs.pop("num_householder", inputs["num_householder"]),
+        kwargs.pop("scale", None),
+        cu_seqlens=kwargs.pop("cu_seqlens", inputs["cu_seqlens"]),
+        **kwargs,
+    )
+
+
+def _serial(inputs, *, scale=None, l2norm=False, initial_state=...):
+    if initial_state is ...:
+        initial_state = inputs["initial_state"]
+    return serial_delta_product(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["cu_seqlens"],
+        num_householder=inputs["num_householder"],
+        alpha=inputs["g"],
+        beta=inputs["beta"],
+        initial_state=initial_state,
+        scale=HEAD_DIM**-0.5 if scale is None else scale,
+        l2norm=l2norm,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_lens", [[96, 64], [512], [64, 1, 1024]])
+@pytest.mark.parametrize("num_q_heads,num_k_heads,num_v_heads", HEAD_CONFIGS)
+@pytest.mark.parametrize("num_householder", [2, 3])
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_gdp_matches_serial_reference(
+    seq_lens,
+    num_q_heads,
+    num_k_heads,
+    num_v_heads,
+    num_householder,
+    use_initial_state,
+    dtype,
+):
+    """Token-at-a-time fp32 recurrence as the oracle, independent of any kernel."""
+    inputs = _make_inputs(
+        seq_lens,
+        num_q_heads,
+        num_k_heads,
+        num_v_heads,
+        num_householder,
+        seed=23,
+        initial_state=use_initial_state,
+        dtype=dtype,
+    )
+    ref_out, ref_state = _serial(inputs)
+    state = inputs["initial_state"]
+    out, final_state = _run(
+        inputs,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+    )
+    assert out.shape == (sum(seq_lens), max(num_q_heads, num_v_heads), HEAD_DIM)
+    assert out.dtype == dtype
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    assert_state_orientation(final_state, ref_state)
+
+
+@pytest.mark.parametrize("use_initial_state", [False, True])
+def test_gdp_with_num_householder_one_matches_gdn(use_initial_state):
+    """``num_householder == 1`` is exactly the gated delta rule.
+
+    Same inputs through ``chunk_gated_delta_rule`` are an independent kernel
+    oracle, and the two calls agree on every shape and every host scalar in
+    the graph cache key except ``family``, so this also pins that component.
+    """
+    seq_lens = [256, 128]
+    inputs = _make_inputs(
+        [256, 128], 4, 4, 4, 1, seed=7, initial_state=use_initial_state
+    )
+    state = inputs["initial_state"]
+    gdn_out, gdn_state = chunk_gated_delta_rule(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        None,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+        cu_seqlens=inputs["cu_seqlens"],
+        backend="cudnn",
+    )
+    gdp_out, gdp_state = _run(
+        inputs,
+        initial_state=None if state is None else state.clone(),
+        output_final_state=True,
+    )
+    assert gdp_out.shape == (sum(seq_lens), 4, HEAD_DIM)
+    assert_rel_close("output", gdp_out, gdn_out, KERNEL_TOLERANCE)
+    assert_rel_close("final_state", gdp_state, gdn_state, KERNEL_TOLERANCE)
+    ref_out, ref_state = _serial(inputs)
+    assert_rel_close("output vs serial", gdp_out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("state vs serial", gdp_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdp_applies_in_kernel_l2norm():
+    """Un-normalized q/k plus the in-kernel norm must match a hand-normalized oracle."""
+    inputs = _make_inputs([96, 64], 4, 4, 4, 2, seed=37, normalize=False)
+    ref_out, ref_state = _serial(inputs, l2norm=True)
+    out, final_state = _run(
+        inputs, output_final_state=True, use_qk_l2norm_in_kernel=True
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdp_honors_scale():
+    inputs = _make_inputs([256], 4, 4, 4, 2, seed=43)
+    scale = 3.0 / math.sqrt(HEAD_DIM)
+    ref_out, _ = _serial(inputs, scale=scale)
+    out = _run(inputs, scale=scale)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert rel_err(out, _run(inputs)) > 0.5, "scale=3/sqrt(d) matched the default"
+
+
+def test_gdp_defaults_gates_to_ones():
+    """Omitting g/beta selects the identity gates."""
+    device = torch.device("cuda")
+    num_heads = 4
+    inputs = _make_inputs([256], num_heads, num_heads, num_heads, 2, seed=31)
+    total = inputs["q"].shape[0]
+    implicit = _run(inputs, g=None, beta=None)
+    explicit = _run(
+        inputs,
+        g=torch.ones(total, num_heads, dtype=torch.float32, device=device),
+        beta=torch.ones(2 * total, num_heads, dtype=torch.float32, device=device),
+    )
+    assert rel_err(implicit, explicit) < 1e-6
+
+
+@pytest.mark.parametrize("gate_dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_gdp_accepts_forget_gate_dtypes(gate_dtype):
+    """``g`` may be fp32, bf16 or fp16, like GDN's."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, 2, seed=47, gate_dtype=gate_dtype)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(inputs, output_final_state=True)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+def test_gdp_carries_state_dtype(state_dtype):
+    device = torch.device("cuda")
+    inputs = _make_inputs(
+        [192, 64], 4, 4, 4, 2, seed=59, initial_state=True, state_dtype=state_dtype
+    )
+    ref_out, ref_state = _serial(inputs)
+    output_state = torch.empty(
+        2, 4, HEAD_DIM, HEAD_DIM, dtype=state_dtype, device=device
+    )
+    out, final_state = _run(
+        inputs,
+        initial_state=inputs["initial_state"],
+        output_final_state=True,
+        output_state=output_state,
+    )
+    assert final_state.dtype == state_dtype
+    assert final_state.data_ptr() == output_state.data_ptr()
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdp_handles_zero_length_sequences():
+    seq_lens = [0, 65, 0, 33]
+    inputs = _make_inputs(seq_lens, 4, 4, 4, 2, seed=61, initial_state=True)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(
+        inputs,
+        initial_state=inputs["initial_state"].clone(),
+        output_final_state=True,
+    )
+    assert out.shape[0] == sum(seq_lens)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    for empty in (0, 2):
+        assert_rel_close(
+            f"state[{empty}]", final_state[empty], inputs["initial_state"][empty], 1e-6
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graph cache key
+# ---------------------------------------------------------------------------
+
+
+def test_gdp_keys_the_graph_cache_on_scale():
+    """Same shapes, two scales: the second must not replay the first graph."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, 2, seed=67)
+    for multiplier in (1.0, 3.0):
+        scale = multiplier / math.sqrt(HEAD_DIM)
+        out = _run(inputs, scale=scale)
+        ref_out, _ = _serial(inputs, scale=scale)
+        assert_rel_close(f"scale={scale}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdp_keys_the_graph_cache_on_qk_l2norm():
+    """Same shapes, the in-kernel norm off then on, each against its own oracle."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, 2, seed=71, norm_scale=0.5)
+    for l2norm in (False, True):
+        out = _run(inputs, use_qk_l2norm_in_kernel=l2norm)
+        ref_out, _ = _serial(inputs, l2norm=l2norm)
+        assert_rel_close(f"use_qk_l2norm={l2norm}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdp_keys_the_graph_cache_on_num_householder():
+    """Back-to-back n=2 and n=1 calls, each against its own oracle.
+
+    The row counts differ with ``n``, so the shapes already separate the keys;
+    this pins that the wrapper threads ``num_householder`` into the built
+    graph rather than baking the first call's value.
+    """
+    for n in (2, 1):
+        inputs = _make_inputs([256], 4, 4, 4, n, seed=79)
+        out = _run(inputs)
+        ref_out, _ = _serial(inputs)
+        assert_rel_close(f"num_householder={n}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdp_serves_both_batch_invariant_settings():
+    """Both split-K settings build and serve the same call correctly."""
+    inputs = _make_inputs([1024], 4, 4, 4, 2, seed=73)
+    ref_out, _ = _serial(inputs)
+    for batch_invariant in (False, True):
+        out = cudnn_chunk_gated_delta_product(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            inputs["num_householder"],
+            cu_seqlens=inputs["cu_seqlens"],
+            batch_invariant=batch_invariant,
+        )
+        assert_rel_close(
+            f"batch_invariant={batch_invariant}", out, ref_out, SERIAL_TOLERANCE
+        )
+
+
+# ---------------------------------------------------------------------------
+# Buffers, layouts and repeatability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cu_seqlens_dtype", [torch.int32, torch.int64])
+def test_gdp_accepts_both_cu_seqlens_dtypes(cu_seqlens_dtype):
+    inputs = _make_inputs(
+        [256, 256], 4, 4, 4, 2, seed=29, cu_seqlens_dtype=cu_seqlens_dtype
+    )
+    ref_out, _ = _serial(inputs)
+    assert_rel_close("output", _run(inputs), ref_out, SERIAL_TOLERANCE)
+
+
+def test_gdp_honors_output_buffers():
+    device = torch.device("cuda")
+    num_heads = 8
+    inputs = _make_inputs([384, 384], num_heads, num_heads, num_heads, 2, seed=5)
+    out = torch.empty_like(inputs["q"])
+    state = torch.empty(
+        2, num_heads, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device
+    )
+    returned_out, returned_state = _run(
+        inputs, output_final_state=True, output=out, output_state=state
+    )
+    assert returned_out.data_ptr() == out.data_ptr()
+    assert returned_state.data_ptr() == state.data_ptr()
+    ref_out, ref_state = _serial(inputs)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_gdp_leaves_state_alone_when_not_requested():
+    inputs = _make_inputs([256], 4, 4, 4, 2, seed=83, initial_state=True)
+    state = inputs["initial_state"]
+    before = state.clone()
+    out = _run(inputs, initial_state=state)
+    assert isinstance(out, torch.Tensor)
+    assert torch.equal(state, before)
+
+
+@pytest.mark.parametrize("tensor", ["q", "k", "v", "g", "beta"])
+def test_gdp_accepts_strided_inputs(tensor):
+    """Strides are passed through, so a head-padded view must not be re-read."""
+    inputs = _make_inputs([256, 128], 4, 4, 4, 2, seed=89)
+    reference = _run(inputs, output_final_state=True)
+    strided = dict(inputs)
+    strided[tensor] = widened_view(inputs[tensor], axis=1)
+    assert torch.equal(strided[tensor], inputs[tensor])
+    out, final_state = _run(strided, output_final_state=True)
+    assert torch.equal(out, reference[0])
+    assert torch.equal(final_state, reference[1])
+
+
+def test_gdp_writes_through_a_strided_output_view():
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, 4, 4, 2, seed=97)
+    wide = torch.zeros(256, 8, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    view = wide[:, :4]
+    reference = _run(inputs)
+    out = _run(inputs, output=view)
+    assert out.data_ptr() == view.data_ptr()
+    assert torch.equal(view, reference)
+    assert torch.equal(wide[:, 4:], torch.zeros_like(wide[:, 4:]))
+
+
+def test_gdp_is_deterministic():
+    inputs = _make_inputs([2048, 512], 4, 4, 4, 2, seed=101, initial_state=True)
+    first = _run(
+        inputs, initial_state=inputs["initial_state"].clone(), output_final_state=True
+    )
+    second = _run(
+        inputs, initial_state=inputs["initial_state"].clone(), output_final_state=True
+    )
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+
+
+def test_gdp_replays_under_cuda_graph_capture():
+    device = torch.device("cuda")
+    inputs = _make_inputs([512], 4, 4, 4, 2, seed=103)
+    out = torch.empty(512, 4, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    state = torch.zeros(1, 4, HEAD_DIM, HEAD_DIM, dtype=torch.float32, device=device)
+    call = dict(output=out, output_state=state, output_final_state=True)
+
+    capture_stream = torch.cuda.Stream(device=device)
+    capture_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(capture_stream):
+        _run(inputs, **call)
+    capture_stream.synchronize()
+    eager_out, eager_state = out.clone(), state.clone()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_out, captured_state = _run(inputs, **call)
+    out.fill_(float("nan"))
+    state.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_out.data_ptr() == out.data_ptr()
+    assert captured_state.data_ptr() == state.data_ptr()
+    assert torch.equal(out, eager_out)
+    assert torch.equal(state, eager_state)
+
+
+# ---------------------------------------------------------------------------
+# API surface
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_is_exported():
+    """``flashinfer.chunk_gated_delta_product`` is the module function itself."""
+    assert flashinfer.chunk_gated_delta_product is chunk_gated_delta_product
+
+
+@pytest.mark.parametrize("backend", ["auto", "cudnn"])
+def test_both_backend_values_reach_cudnn(backend):
+    """FlashInfer has no GDP kernel, so ``auto`` and ``cudnn`` are one path."""
+    inputs = _make_inputs([256], 4, 4, 4, 2, seed=113)
+    ref_out, _ = _serial(inputs)
+    assert_rel_close("output", _run(inputs, backend=backend), ref_out, SERIAL_TOLERANCE)
+
+
+def test_backend_argument_is_validated():
+    inputs = _make_inputs([128], 4, 4, 4, 2, seed=1)
+    with pytest.raises(ValueError, match="backend"):
+        _run(inputs, backend="nonesuch")
+
+
+def test_cu_seqlens_is_required():
+    """The engines take packed THD input, so there is no dense fallback."""
+    inputs = _make_inputs([128], 4, 4, 4, 2, seed=1)
+    with pytest.raises(ValueError, match="cu_seqlens"):
+        chunk_gated_delta_product(inputs["q"], inputs["k"], inputs["v"])
+
+
+def test_cu_seqlens_dtype_is_validated():
+    inputs = _make_inputs([128], 4, 4, 4, 2, seed=1)
+    with pytest.raises(ValueError, match="integer dtype"):
+        _run(inputs, cu_seqlens=inputs["cu_seqlens"].float())
+
+
+def test_split_state_dtypes_are_declined_by_the_engine():
+    """One state dtype per kernel: cuDNN, not the wrapper, says no."""
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, 4, 4, 2, seed=127, initial_state=True)
+    with pytest.raises(Exception) as excinfo:
+        _run(
+            inputs,
+            initial_state=inputs["initial_state"],
+            output_final_state=True,
+            output_state=torch.empty(
+                1, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device
+            ),
+        )
+    assert type(excinfo.value).__module__.startswith("cudnn"), (
+        f"expected a cuDNN decline, got {type(excinfo.value)!r}"
+    )

--- a/tests/kda/test_recurrent_kda_cudnn_backend.py
+++ b/tests/kda/test_recurrent_kda_cudnn_backend.py
@@ -1,0 +1,729 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``recurrent_kda(backend="cudnn")``: cuDNN's fused SM100 KDA engine.
+
+Two oracles:
+
+* FlashInfer's own CuTe DSL and Cake prefill backends, the tightest bound.
+  Both reject a non-bf16 state and ``use_qk_l2norm_in_kernel=False``, so they
+  can only anchor the strict contract.
+* ``serial_delta_rule``, an fp32 token-at-a-time recurrence with KDA's
+  per-key-channel gate. It is the only oracle for the gate modes FlashInfer's
+  own backends do not accept, and the one that shares no code with either
+  kernel.
+
+The graph-cache-key tests follow ``tests/attention/test_cudnn_graph_cache_key.py``.
+KDA puts the most host scalars in the key of any of the three families --
+``scale``, ``use_qk_l2norm``, ``use_beta_sigmoid``, ``safe_gate``,
+``gate_lower_bound`` -- and each is baked into the built graph, so each gets a
+same-shape pair. (``batch_invariant`` is in the key too, but its two settings
+are bitwise identical, so no value-based test can pin it.)
+
+Whether the engine can serve a call is cuDNN's decision; nothing here
+re-derives it.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.cudnn import cudnn_recurrent_kda
+from flashinfer.kda import recurrent_kda
+from flashinfer.kda_prefill import RecurrentKDAPrefillWorkspace
+from tests.test_helpers.cudnn_linear_attention import (
+    HEAD_DIM,
+    assert_rel_close,
+    assert_state_orientation,
+    kda_safe_gate,
+    packed_offsets,
+    rel_err,
+    requires_cudnn_linear_attention,
+    serial_delta_rule,
+    widened_view,
+)
+
+pytestmark = requires_cudnn_linear_attention
+
+LOWER_BOUND = -5.0
+KERNEL_TOLERANCE = 2e-2
+SERIAL_TOLERANCE = 5e-2
+
+
+def _make_inputs(
+    seq_lens,
+    num_heads,
+    *,
+    num_v_heads=None,
+    initial_state=False,
+    seed=0,
+    gate_bias=0.0,
+    dtype=torch.bfloat16,
+    gate_dtype=torch.bfloat16,
+    state_dtype=torch.bfloat16,
+    cu_seqlens_dtype=torch.int64,
+):
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    total = sum(seq_lens)
+    heads_v = num_heads if num_v_heads is None else num_v_heads
+    state = None
+    if initial_state:
+        state = (
+            0.1
+            * torch.randn(
+                (len(seq_lens), heads_v, HEAD_DIM, HEAD_DIM),
+                dtype=torch.float32,
+                device=device,
+            )
+        ).to(state_dtype)
+    return {
+        "q": torch.randn(1, total, num_heads, HEAD_DIM, dtype=dtype, device=device),
+        "k": torch.randn(1, total, num_heads, HEAD_DIM, dtype=dtype, device=device),
+        "v": torch.randn(1, total, heads_v, HEAD_DIM, dtype=dtype, device=device),
+        "g": (
+            0.1
+            * torch.randn(
+                1, total, heads_v, HEAD_DIM, dtype=torch.float32, device=device
+            )
+            + gate_bias
+        ).to(gate_dtype),
+        "beta": torch.randn(1, total, heads_v, dtype=dtype, device=device),
+        "A_log": 0.1 * torch.randn(heads_v, dtype=torch.float32, device=device),
+        "dt_bias": 0.1
+        * torch.randn((heads_v, HEAD_DIM), dtype=torch.float32, device=device),
+        "initial_state": state,
+        "cu_seqlens": packed_offsets(seq_lens, device, cu_seqlens_dtype),
+    }
+
+
+def _gate_kwargs(inputs, **overrides):
+    """The in-kernel gate contract every FlashInfer KDA backend accepts."""
+    kwargs = dict(
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=True,
+        lower_bound=LOWER_BOUND,
+        cu_seqlens=inputs["cu_seqlens"],
+        beta_is_logit=True,
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _run(inputs, **kwargs):
+    return recurrent_kda(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        kwargs.pop("g", inputs["g"]),
+        kwargs.pop("beta", inputs["beta"]),
+        backend="cudnn",
+        **kwargs,
+    )
+
+
+def _run_direct(inputs, **kwargs):
+    """The cuDNN entry point, for the knobs ``recurrent_kda`` has no argument
+    for: ``output_state`` and ``batch_invariant``."""
+    return cudnn_recurrent_kda(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        kwargs.pop("g", inputs["g"]),
+        kwargs.pop("beta", inputs["beta"]),
+        **kwargs,
+    )
+
+
+def _serial(
+    inputs,
+    *,
+    scale=None,
+    safe_gate=True,
+    beta_is_logit=True,
+    l2norm=True,
+    initial_state=...,
+    g=None,
+    beta=None,
+):
+    """The fp32 oracle, driven by the same gate modes as the call under test."""
+    if initial_state is ...:
+        initial_state = inputs["initial_state"]
+    gate = inputs["g"] if g is None else g
+    raw_beta = inputs["beta"] if beta is None else beta
+    alpha = (
+        kda_safe_gate(gate[0], inputs["A_log"], inputs["dt_bias"], LOWER_BOUND)
+        if safe_gate
+        else gate[0].float().exp()
+    )
+    effective_beta = (
+        torch.sigmoid(raw_beta[0].float()) if beta_is_logit else raw_beta[0].float()
+    )
+    out, state = serial_delta_rule(
+        inputs["q"][0],
+        inputs["k"][0],
+        inputs["v"][0],
+        inputs["cu_seqlens"],
+        alpha=alpha,
+        beta=effective_beta,
+        initial_state=initial_state,
+        scale=HEAD_DIM**-0.5 if scale is None else scale,
+        l2norm=l2norm,
+    )
+    return out.unsqueeze(0), state
+
+
+# ---------------------------------------------------------------------------
+# Numerics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("seq_lens", [[512], [256, 320], [64, 1, 1024]])
+@pytest.mark.parametrize("num_heads", [4])
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("reference_backend", ["cute-dsl", "cake"])
+def test_cudnn_backend_matches_default(
+    seq_lens, num_heads, use_initial_state, reference_backend
+):
+    """Each of FlashInfer's own recurrent KDA backends as the oracle."""
+    inputs = _make_inputs(seq_lens, num_heads, initial_state=use_initial_state, seed=11)
+    state = inputs["initial_state"]
+    kwargs = _gate_kwargs(inputs, output_final_state=True)
+    args = (inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"])
+    try:
+        ref_out, ref_state = recurrent_kda(
+            *args,
+            initial_state=None if state is None else state.clone(),
+            backend=reference_backend,
+            **kwargs,
+        )
+    except (ImportError, NotImplementedError) as exc:
+        pytest.skip(f"reference backend {reference_backend} unavailable: {exc}")
+    out, final_state = _run(
+        inputs, initial_state=None if state is None else state.clone(), **kwargs
+    )
+
+    assert out.shape == inputs["q"].shape
+    assert out.dtype == inputs["q"].dtype
+    assert final_state.shape == (len(seq_lens), num_heads, HEAD_DIM, HEAD_DIM)
+    assert_rel_close("output", out, ref_out, KERNEL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, KERNEL_TOLERANCE)
+    assert_state_orientation(final_state, ref_state)
+
+
+@pytest.mark.parametrize("use_initial_state", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_cudnn_backend_matches_serial_reference(use_initial_state, dtype):
+    """Token-at-a-time fp32 recurrence as the oracle, independent of any kernel.
+
+    The fp16 arm runs at mild decay: the kernel carries the inverse of a
+    chunk-cumulative per-channel decay, which overflows float16 once alpha
+    falls well below ~0.9 per token (e.g. alpha ~ 0.08 over a 16-token chunk
+    inverts to ~e^40). The engine's own test generator bounds alpha >= 0.9
+    for the same reason; bfloat16's fp32-like exponent is unaffected, so the
+    bf16 arm keeps the strong-decay regime.
+    """
+    inputs = _make_inputs(
+        [96, 64],
+        4,
+        initial_state=use_initial_state,
+        seed=23,
+        dtype=dtype,
+        gate_bias=-4.0 if dtype == torch.float16 else 0.0,
+    )
+    ref_out, ref_state = _serial(inputs)
+    state = inputs["initial_state"]
+    out, final_state = _run(
+        inputs,
+        initial_state=None if state is None else state.clone(),
+        **_gate_kwargs(inputs, output_final_state=True),
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    assert_state_orientation(final_state, ref_state)
+
+
+def test_cudnn_backend_matches_serial_reference_with_precomputed_gates():
+    """The gate modes off: g arrives log-space and beta already post-sigmoid.
+
+    FlashInfer's own prefill backends reject this contract, so the fp32 serial
+    recurrence is the only oracle.
+    """
+    seq_lens, num_heads = [96, 64], 4
+    inputs = _make_inputs(seq_lens, num_heads, seed=19)
+    device = torch.device("cuda")
+    total = sum(seq_lens)
+    log_alpha = -F.softplus(
+        torch.randn(1, total, num_heads, HEAD_DIM, device=device) * 0.5 - 2.0
+    ).to(torch.bfloat16)
+    beta = torch.rand(1, total, num_heads, device=device).to(torch.bfloat16)
+
+    ref_out, ref_state = _serial(
+        inputs, safe_gate=False, beta_is_logit=False, g=log_alpha, beta=beta
+    )
+    out, final_state = _run(
+        inputs,
+        g=log_alpha,
+        beta=beta,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=False,
+        cu_seqlens=inputs["cu_seqlens"],
+        beta_is_logit=False,
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_can_skip_the_in_kernel_l2norm():
+    """``use_qk_l2norm_in_kernel=False``, which FlashInfer's own backends reject."""
+    seq_lens, num_heads = [96, 64], 4
+    inputs = _make_inputs(seq_lens, num_heads, seed=21)
+    device = torch.device("cuda")
+    total = sum(seq_lens)
+    for name in ("q", "k"):
+        inputs[name] = F.normalize(inputs[name].float(), dim=-1).to(torch.bfloat16)
+    log_alpha = -F.softplus(
+        torch.randn(1, total, num_heads, HEAD_DIM, device=device) * 0.5 - 2.0
+    ).to(torch.bfloat16)
+    beta = torch.rand(1, total, num_heads, device=device).to(torch.bfloat16)
+
+    ref_out, ref_state = _serial(
+        inputs,
+        safe_gate=False,
+        beta_is_logit=False,
+        l2norm=False,
+        g=log_alpha,
+        beta=beta,
+    )
+    out, final_state = _run(
+        inputs,
+        g=log_alpha,
+        beta=beta,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=False,
+        use_gate_in_kernel=False,
+        cu_seqlens=inputs["cu_seqlens"],
+        beta_is_logit=False,
+    )
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_honors_scale():
+    inputs = _make_inputs([256], 4, seed=43)
+    scale = 3.0 / math.sqrt(HEAD_DIM)
+    ref_out, _ = _serial(inputs, scale=scale)
+    out, _ = _run(inputs, scale=scale, **_gate_kwargs(inputs))
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    default_out, _ = _run(inputs, **_gate_kwargs(inputs))
+    assert rel_err(out, default_out) > 0.5, "scale=3/sqrt(d) matched the default"
+
+
+@pytest.mark.parametrize("gate_dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_cudnn_backend_accepts_gate_dtypes(gate_dtype):
+    """cuDNN reads the KDA gate at fp32, bf16 or fp16 and it is forwarded as-is."""
+    inputs = _make_inputs([256, 128], 4, seed=47, gate_dtype=gate_dtype)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(inputs, **_gate_kwargs(inputs, output_final_state=True))
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+@pytest.mark.parametrize("state_dtype", [torch.float32, torch.bfloat16])
+def test_cudnn_backend_carries_state_dtype(state_dtype):
+    """An fp32 state pool crosses too, which FlashInfer's own backends reject."""
+    device = torch.device("cuda")
+    inputs = _make_inputs(
+        [192, 64], 4, seed=59, initial_state=True, state_dtype=state_dtype
+    )
+    ref_out, ref_state = _serial(inputs)
+    output_state = torch.empty(
+        2, 4, HEAD_DIM, HEAD_DIM, dtype=state_dtype, device=device
+    )
+    out, final_state = _run_direct(
+        inputs,
+        initial_state=inputs["initial_state"],
+        output_state=output_state,
+        **_gate_kwargs(inputs, output_final_state=True),
+    )
+    assert final_state.dtype == state_dtype
+    assert final_state.data_ptr() == output_state.data_ptr()
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_supports_more_value_heads_than_query_heads():
+    """GVA: cuDNN carries the gate, beta and state at ``HO = max(H, HV)``."""
+    inputs = _make_inputs([256], 2, num_v_heads=4, seed=67)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(inputs, **_gate_kwargs(inputs, output_final_state=True))
+    assert out.shape == inputs["v"].shape
+    assert final_state.shape == (1, 4, HEAD_DIM, HEAD_DIM)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_rejects_more_query_heads_than_value_heads():
+    """FlashInfer puts the KDA state at HV, cuDNN at max(H, HV); they part here."""
+    inputs = _make_inputs([256], 4, num_v_heads=2, seed=71)
+    with pytest.raises(NotImplementedError, match="max\\(H, HV\\)"):
+        _run(inputs, **_gate_kwargs(inputs, output_final_state=True))
+
+
+def test_cudnn_backend_handles_zero_length_sequences():
+    seq_lens = [0, 65, 0, 33]
+    inputs = _make_inputs(seq_lens, 4, seed=61, initial_state=True)
+    ref_out, ref_state = _serial(inputs)
+    out, final_state = _run(
+        inputs,
+        initial_state=inputs["initial_state"].clone(),
+        **_gate_kwargs(inputs, output_final_state=True),
+    )
+    assert out.shape[1] == sum(seq_lens)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+    assert_rel_close("final_state", final_state, ref_state, SERIAL_TOLERANCE)
+    for empty in (0, 2):
+        assert_rel_close(
+            f"state[{empty}]", final_state[empty], inputs["initial_state"][empty], 1e-6
+        )
+
+
+# ---------------------------------------------------------------------------
+# Graph cache key
+# ---------------------------------------------------------------------------
+
+
+def test_cudnn_backend_keys_the_graph_cache_on_scale():
+    inputs = _make_inputs([256, 128], 4, seed=73)
+    for multiplier in (1.0, 3.0):
+        scale = multiplier / math.sqrt(HEAD_DIM)
+        out, _ = _run(inputs, scale=scale, **_gate_kwargs(inputs))
+        ref_out, _ = _serial(inputs, scale=scale)
+        assert_rel_close(f"scale={scale}", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_keys_the_graph_cache_on_gate_lower_bound():
+    """Two safe-gate calls that differ only in the bound.
+
+    ``gate_lower_bound`` is a compile-time constant of the built graph and the
+    only thing separating these two keys.
+    """
+    inputs = _make_inputs([256, 128], 4, seed=79)
+    outs = []
+    for lower_bound in (-5.0, -1.0):
+        out, _ = _run(inputs, **_gate_kwargs(inputs, lower_bound=lower_bound))
+        alpha = kda_safe_gate(
+            inputs["g"][0], inputs["A_log"], inputs["dt_bias"], lower_bound
+        )
+        ref_out, _ = serial_delta_rule(
+            inputs["q"][0],
+            inputs["k"][0],
+            inputs["v"][0],
+            inputs["cu_seqlens"],
+            alpha=alpha,
+            beta=torch.sigmoid(inputs["beta"][0].float()),
+            scale=HEAD_DIM**-0.5,
+            l2norm=True,
+        )
+        assert_rel_close(
+            f"lower_bound={lower_bound}", out, ref_out.unsqueeze(0), SERIAL_TOLERANCE
+        )
+        outs.append(out)
+    assert rel_err(outs[0], outs[1]) > 1e-3, "the two bounds produced one result"
+
+
+def test_cudnn_backend_keys_the_graph_cache_on_beta_sigmoid():
+    """Same beta buffer layout, read as logits then as post-sigmoid values."""
+    inputs = _make_inputs([256], 4, seed=83)
+    beta = torch.rand(1, 256, 4, device=torch.device("cuda")).to(torch.bfloat16)
+    for beta_is_logit in (True, False):
+        out, _ = _run(
+            inputs,
+            beta=beta,
+            **_gate_kwargs(inputs, beta_is_logit=beta_is_logit),
+        )
+        ref_out, _ = _serial(inputs, beta=beta, beta_is_logit=beta_is_logit)
+        assert_rel_close(
+            f"beta_is_logit={beta_is_logit}", out, ref_out, SERIAL_TOLERANCE
+        )
+
+
+def test_cudnn_backend_keys_the_graph_cache_on_safe_gate():
+    """Same gate buffer layout, read as a raw pre-activation then as log-alpha."""
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, seed=89)
+    log_alpha = -F.softplus(
+        torch.randn(1, 256, 4, HEAD_DIM, device=device) * 0.5 - 2.0
+    ).to(torch.bfloat16)
+    beta = torch.rand(1, 256, 4, device=device).to(torch.bfloat16)
+
+    safe_out, _ = _run(inputs, beta=beta, **_gate_kwargs(inputs, beta_is_logit=False))
+    ref_safe, _ = _serial(inputs, beta=beta, beta_is_logit=False)
+    assert_rel_close("safe_gate=True", safe_out, ref_safe, SERIAL_TOLERANCE)
+
+    plain_out, _ = _run(
+        inputs,
+        g=log_alpha,
+        beta=beta,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=False,
+        cu_seqlens=inputs["cu_seqlens"],
+        beta_is_logit=False,
+    )
+    ref_plain, _ = _serial(
+        inputs, safe_gate=False, beta_is_logit=False, g=log_alpha, beta=beta
+    )
+    assert_rel_close("safe_gate=False", plain_out, ref_plain, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_serves_both_batch_invariant_settings():
+    """Both split-K settings build and serve the same call correctly.
+
+    Reached through the cuDNN entry point (no ``recurrent_kda`` argument).
+    The two settings are bitwise identical on every shape probed, so this is
+    a knob smoke, not a cache-key pin.
+    """
+    inputs = _make_inputs([1024], 4, seed=97)
+    ref_out, _ = _serial(inputs)
+    for batch_invariant in (False, True):
+        out, _ = _run_direct(
+            inputs, batch_invariant=batch_invariant, **_gate_kwargs(inputs)
+        )
+        assert_rel_close(
+            f"batch_invariant={batch_invariant}", out, ref_out, SERIAL_TOLERANCE
+        )
+
+
+# ---------------------------------------------------------------------------
+# Buffers, layouts and repeatability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cu_seqlens_dtype", [torch.int32, torch.int64])
+def test_cudnn_backend_accepts_both_cu_seqlens_dtypes(cu_seqlens_dtype):
+    inputs = _make_inputs([256, 256], 4, seed=29, cu_seqlens_dtype=cu_seqlens_dtype)
+    ref_out, _ = _serial(inputs)
+    out, _ = _run(inputs, **_gate_kwargs(inputs))
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+
+
+def test_cudnn_backend_updates_initial_state_in_place():
+    """Matching the Cake and CuTe DSL backends, an incoming state is advanced."""
+    inputs = _make_inputs([384], 4, initial_state=True, seed=7)
+    state = inputs["initial_state"]
+    before = state.clone()
+    _, final_state = _run(
+        inputs, initial_state=state, **_gate_kwargs(inputs, output_final_state=True)
+    )
+    assert final_state.data_ptr() == state.data_ptr()
+    assert not torch.equal(state, before)
+
+
+def test_cudnn_backend_advances_initial_state_without_returning_it():
+    """``output_final_state`` gates the return value, not the in-place advance."""
+    inputs = _make_inputs([384], 4, initial_state=True, seed=17)
+    state = inputs["initial_state"]
+    before = state.clone()
+    out, final_state = _run(inputs, initial_state=state, **_gate_kwargs(inputs))
+    assert final_state is None
+    assert not torch.equal(state, before)
+    assert out.isfinite().all()
+
+
+def test_cudnn_backend_writes_a_separate_output_state_without_touching_the_input():
+    inputs = _make_inputs([384], 4, initial_state=True, seed=19)
+    device = torch.device("cuda")
+    state = inputs["initial_state"]
+    before = state.clone()
+    output_state = torch.empty(
+        1, 4, HEAD_DIM, HEAD_DIM, dtype=state.dtype, device=device
+    )
+    _, final_state = _run_direct(
+        inputs,
+        initial_state=state,
+        output_state=output_state,
+        **_gate_kwargs(inputs, output_final_state=True),
+    )
+    assert final_state.data_ptr() == output_state.data_ptr()
+    assert torch.equal(state, before), "initial_state was advanced anyway"
+
+
+def test_cudnn_backend_honors_output_buffer():
+    inputs = _make_inputs([384], 4, seed=13)
+    out = torch.empty_like(inputs["v"])
+    returned_out, _ = _run(inputs, output=out, **_gate_kwargs(inputs))
+    assert returned_out.data_ptr() == out.data_ptr()
+    ref_out, _ = _serial(inputs)
+    assert_rel_close("output", out, ref_out, SERIAL_TOLERANCE)
+
+
+@pytest.mark.parametrize("tensor", ["q", "k", "v", "g", "beta"])
+def test_cudnn_backend_accepts_strided_inputs(tensor):
+    """Strides are passed through, so a head-padded view must not be re-read."""
+    inputs = _make_inputs([256, 128], 4, seed=89)
+    reference = _run(inputs, **_gate_kwargs(inputs, output_final_state=True))
+    strided = dict(inputs)
+    strided[tensor] = widened_view(inputs[tensor], axis=2)
+    assert torch.equal(strided[tensor], inputs[tensor])
+    out, final_state = _run(strided, **_gate_kwargs(strided, output_final_state=True))
+    assert torch.equal(out, reference[0])
+    assert torch.equal(final_state, reference[1])
+
+
+def test_cudnn_backend_is_deterministic():
+    inputs = _make_inputs([2048, 512], 4, seed=101, initial_state=True)
+    first = _run(
+        inputs,
+        initial_state=inputs["initial_state"].clone(),
+        **_gate_kwargs(inputs, output_final_state=True),
+    )
+    second = _run(
+        inputs,
+        initial_state=inputs["initial_state"].clone(),
+        **_gate_kwargs(inputs, output_final_state=True),
+    )
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+
+
+def test_cudnn_backend_replays_under_cuda_graph_capture():
+    device = torch.device("cuda")
+    inputs = _make_inputs([512], 4, seed=103)
+    out = torch.empty_like(inputs["v"])
+    state = torch.zeros(1, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device)
+    call = _gate_kwargs(inputs, output=out, output_state=state, output_final_state=True)
+
+    capture_stream = torch.cuda.Stream(device=device)
+    capture_stream.wait_stream(torch.cuda.current_stream(device))
+    with torch.cuda.stream(capture_stream):
+        _run_direct(inputs, **call)
+    capture_stream.synchronize()
+    eager_out, eager_state = out.clone(), state.clone()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_out, captured_state = _run_direct(inputs, **call)
+    out.fill_(float("nan"))
+    state.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    assert captured_out.data_ptr() == out.data_ptr()
+    assert captured_state.data_ptr() == state.data_ptr()
+    assert torch.equal(out, eager_out)
+    assert torch.equal(state, eager_state)
+
+
+# ---------------------------------------------------------------------------
+# Routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "argument",
+    [
+        "num_spec_tokens",
+        "num_accepted_tokens",
+        "initial_state_source",
+        "initial_state_indices",
+        "seq_order",
+        "prefill_workspace",
+        "ssm_state_indices",
+        "checkpoint_every_n_tokens",
+    ],
+)
+def test_cudnn_backend_names_the_unsupported_argument(argument):
+    """Every argument cuDNN's entry point has no parameter for is named."""
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, seed=3)
+    indices = torch.zeros(1, dtype=torch.int32, device=device)
+    values = {
+        "num_spec_tokens": 2,
+        "num_accepted_tokens": indices,
+        "initial_state_source": torch.zeros(
+            4, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device
+        ),
+        "initial_state_indices": indices,
+        "seq_order": indices,
+        "prefill_workspace": RecurrentKDAPrefillWorkspace(device),
+        "ssm_state_indices": indices,
+        "checkpoint_every_n_tokens": 64,
+    }
+    kwargs = _gate_kwargs(inputs)
+    if argument == "checkpoint_every_n_tokens":
+        kwargs["state_checkpoints"] = torch.zeros(
+            4, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device
+        )
+        kwargs["checkpoint_cu_starts"] = torch.tensor(
+            [0, 4], dtype=torch.int64, device=device
+        )
+    with pytest.raises(NotImplementedError, match=argument):
+        _run(inputs, **{argument: values[argument]}, **kwargs)
+
+
+def test_cudnn_backend_names_every_unsupported_argument_at_once():
+    device = torch.device("cuda")
+    inputs = _make_inputs([256], 4, seed=9)
+    indices = torch.zeros(1, dtype=torch.int32, device=device)
+    with pytest.raises(NotImplementedError) as excinfo:
+        _run(
+            inputs,
+            num_spec_tokens=2,
+            seq_order=indices,
+            **_gate_kwargs(inputs),
+        )
+    message = str(excinfo.value)
+    assert "num_spec_tokens" in message and "seq_order" in message
+
+
+def test_backend_argument_is_validated():
+    inputs = _make_inputs([128], 4, seed=1)
+    with pytest.raises(ValueError, match="backend"):
+        recurrent_kda(
+            inputs["q"],
+            inputs["k"],
+            inputs["v"],
+            inputs["g"],
+            inputs["beta"],
+            cu_seqlens=inputs["cu_seqlens"],
+            backend="nonesuch",
+        )
+
+
+def test_cudnn_backend_requires_both_safe_gate_parameters():
+    inputs = _make_inputs([128], 4, seed=2)
+    with pytest.raises(ValueError, match="A_log and dt_bias"):
+        _run(
+            inputs,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            lower_bound=LOWER_BOUND,
+            cu_seqlens=inputs["cu_seqlens"],
+            beta_is_logit=True,
+        )
+
+
+def test_cudnn_entry_point_requires_cu_seqlens():
+    inputs = _make_inputs([128], 4, seed=4)
+    with pytest.raises(ValueError, match="cu_seqlens"):
+        cudnn_recurrent_kda(
+            inputs["q"], inputs["k"], inputs["v"], inputs["g"], inputs["beta"]
+        )

--- a/tests/kda/test_recurrent_kda_cudnn_backend.py
+++ b/tests/kda/test_recurrent_kda_cudnn_backend.py
@@ -647,6 +647,8 @@ def test_cudnn_backend_replays_under_cuda_graph_capture():
         "seq_order",
         "prefill_workspace",
         "ssm_state_indices",
+        "state_checkpoints",
+        "checkpoint_cu_starts",
         "checkpoint_every_n_tokens",
     ],
 )
@@ -655,6 +657,10 @@ def test_cudnn_backend_names_the_unsupported_argument(argument):
     device = torch.device("cuda")
     inputs = _make_inputs([256], 4, seed=3)
     indices = torch.zeros(1, dtype=torch.int32, device=device)
+    checkpoints = torch.zeros(
+        4, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    cu_starts = torch.tensor([0, 4], dtype=torch.int64, device=device)
     values = {
         "num_spec_tokens": 2,
         "num_accepted_tokens": indices,
@@ -665,16 +671,14 @@ def test_cudnn_backend_names_the_unsupported_argument(argument):
         "seq_order": indices,
         "prefill_workspace": RecurrentKDAPrefillWorkspace(device),
         "ssm_state_indices": indices,
+        "state_checkpoints": checkpoints,
+        "checkpoint_cu_starts": cu_starts,
         "checkpoint_every_n_tokens": 64,
     }
     kwargs = _gate_kwargs(inputs)
     if argument == "checkpoint_every_n_tokens":
-        kwargs["state_checkpoints"] = torch.zeros(
-            4, 4, HEAD_DIM, HEAD_DIM, dtype=torch.bfloat16, device=device
-        )
-        kwargs["checkpoint_cu_starts"] = torch.tensor(
-            [0, 4], dtype=torch.int64, device=device
-        )
+        kwargs["state_checkpoints"] = checkpoints
+        kwargs["checkpoint_cu_starts"] = cu_starts
     with pytest.raises(NotImplementedError, match=argument):
         _run(inputs, **{argument: values[argument]}, **kwargs)
 

--- a/tests/test_helpers/cudnn_linear_attention.py
+++ b/tests/test_helpers/cudnn_linear_attention.py
@@ -1,0 +1,351 @@
+"""Shared gate, oracles and metrics for the cuDNN linear-attention tests.
+
+GDN, GDN-2 and KDA run on the same cuDNN FROST engines, so they share one
+availability gate and one family of fp32 token-serial oracles. Both live here
+rather than being retyped in ``tests/gdn``, ``tests/gdn2`` and ``tests/kda``.
+
+The oracles hold the state V-major as ``[num_seqs, HO, V, K]``, which is the
+layout FlashInfer and cuDNN both use at this boundary. With ``K == V == 128``
+every shape check is blind to a transposed state, so the tests pin the
+orientation by fit instead -- see ``assert_state_orientation``.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from flashinfer.utils import get_compute_capability
+
+try:
+    import cudnn
+
+    CUDNN_AVAILABLE = True
+    CUDNN_FRONTEND_VERSION = tuple(
+        int(part) for part in cudnn.__version__.split(".")[:2]
+    )
+except Exception:
+    cudnn = None
+    CUDNN_AVAILABLE = False
+    CUDNN_FRONTEND_VERSION = (0, 0)
+
+HEAD_DIM = 128
+
+MIN_FRONTEND_VERSION = (1, 28)
+
+SUPPORTED_COMPUTE_CAPABILITIES = frozenset(
+    {(10, 0), (10, 1), (10, 2), (10, 3), (10, 7)}
+)
+
+
+def cudnn_linear_attention_unavailable_reason() -> Optional[str]:
+    """Why this host cannot run the cuDNN linear-attention engines, or ``None``.
+
+    Only the things a test can know without launching: the package, its
+    version, and the device. Everything finer -- head dims, dtypes, head-count
+    relations -- is the engine's call, so a test that wants to know whether a
+    specific call is served should make the call and read the exception.
+    """
+    if not torch.cuda.is_available():
+        return "CUDA is required"
+    if not CUDNN_AVAILABLE:
+        return "the cudnn python frontend is not installed"
+    if CUDNN_FRONTEND_VERSION < MIN_FRONTEND_VERSION:
+        want = ".".join(str(part) for part in MIN_FRONTEND_VERSION)
+        return f"cudnn-frontend >= {want} is required, found {cudnn.__version__}"
+    capability = get_compute_capability(torch.device("cuda"))
+    if capability not in SUPPORTED_COMPUTE_CAPABILITIES:
+        return (
+            "the cuDNN linear-attention engines are SM100-family only, found "
+            f"sm{capability[0]}{capability[1]}"
+        )
+    return None
+
+
+_UNAVAILABLE_REASON = cudnn_linear_attention_unavailable_reason()
+
+requires_cudnn_linear_attention = pytest.mark.skipif(
+    _UNAVAILABLE_REASON is not None,
+    reason=f"cuDNN linear attention unavailable: {_UNAVAILABLE_REASON}",
+)
+
+
+def rel_err(actual: torch.Tensor, expected: torch.Tensor) -> float:
+    """Frobenius relative error.
+
+    A recurrence accumulates over the whole sequence, so a single late token
+    can be elementwise far from the oracle while the run as a whole is right.
+    The norm ratio is the metric that survives that; elementwise
+    ``assert_close`` is kept for the same-kernel comparisons where it holds.
+    """
+    return (
+        (actual.float() - expected.float()).norm()
+        / expected.float().norm().clamp_min(1e-6)
+    ).item()
+
+
+def assert_rel_close(
+    prefix: str, actual: torch.Tensor, expected: torch.Tensor, bound: float
+):
+    assert torch.isfinite(actual).all(), f"{prefix}: non-finite values in actual"
+    assert torch.isfinite(expected).all(), f"{prefix}: non-finite values in expected"
+    error = rel_err(actual, expected)
+    assert error < bound, f"{prefix}: relative error {error:.3e} exceeds {bound:.3e}"
+
+
+def assert_state_orientation(final_state: torch.Tensor, reference_state: torch.Tensor):
+    """Pin the state's V-major orientation by fit.
+
+    ``K == V == 128`` makes every shape and stride check blind to a transposed
+    state, so the only evidence is that the transpose fits an order of
+    magnitude worse.
+    """
+    upright = rel_err(final_state, reference_state)
+    flipped = rel_err(final_state.transpose(-1, -2).contiguous(), reference_state)
+    assert flipped > 10 * upright, (
+        f"state orientation is not pinned: upright {upright:.3e} vs "
+        f"transposed {flipped:.3e}"
+    )
+
+
+def head_index_maps(num_q_heads: int, num_k_heads: int, num_v_heads: int, device):
+    """Per-output-head index maps into q, k and v.
+
+    The output lives at ``HO = max(HQ, HV)`` heads and every input is expanded
+    to it by integer division, which is how both cuDNN and FlashInfer group
+    GQA and GVA.
+    """
+    num_o_heads = max(num_q_heads, num_v_heads)
+    heads = torch.arange(num_o_heads, device=device)
+    return (
+        heads // (num_o_heads // num_q_heads),
+        heads // (num_o_heads // num_k_heads),
+        heads // (num_o_heads // num_v_heads),
+    )
+
+
+def serial_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    alpha: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    scale: float,
+    l2norm: bool = False,
+):
+    """Token-at-a-time fp32 gated delta rule, state V-major as ``[V, K]``.
+
+    One body covers GDN and KDA: ``alpha`` is per-head for GDN (``[T, HO]``)
+    and per key channel for KDA (``[T, HO, K]``), and both broadcast against
+    the state's trailing K axis once reshaped to ``[HO, 1, -1]``.
+
+    ``alpha`` is linear-space decay in both cases -- the caller converts, the
+    same way the wrappers do.
+    """
+    q_index, k_index, v_index = head_index_maps(
+        q.shape[1], k.shape[1], v.shape[1], q.device
+    )
+    num_o_heads = max(q.shape[1], v.shape[1])
+    head_dim, v_dim = q.shape[2], v.shape[2]
+    offsets = [int(x) for x in cu_seqlens.tolist()]
+
+    query = q.float()
+    key = k.float()
+    if l2norm:
+        query = F.normalize(query, dim=-1)
+        key = F.normalize(key, dim=-1)
+    value = v.float()
+
+    out = torch.empty(
+        q.shape[0], num_o_heads, v_dim, dtype=torch.float32, device=q.device
+    )
+    if initial_state is None:
+        state = torch.zeros(
+            len(offsets) - 1,
+            num_o_heads,
+            v_dim,
+            head_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        state = initial_state.float().clone()
+
+    for sequence in range(len(offsets) - 1):
+        running = state[sequence]
+        for token in range(offsets[sequence], offsets[sequence + 1]):
+            key_t = key[token, k_index]
+            if alpha is not None:
+                running = running * alpha[token].float().reshape(num_o_heads, 1, -1)
+            residual = value[token, v_index] - torch.einsum(
+                "hvk,hk->hv", running, key_t
+            )
+            if beta is not None:
+                residual = beta[token].float()[:, None] * residual
+            running = running + residual[:, :, None] * key_t[:, None, :]
+            out[token] = scale * torch.einsum(
+                "hvk,hk->hv", running, query[token, q_index]
+            )
+        state[sequence] = running
+    return out, state
+
+
+def serial_delta_product(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    num_householder: int,
+    alpha: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    scale: float,
+    l2norm: bool = False,
+):
+    """Token-at-a-time fp32 gated delta product, state V-major as ``[V, K]``.
+
+    GDP is GDN on the expanded sub-token timeline: the decay acts on
+    sub-token 0 and the readout on sub-token ``n - 1``, so this expands q and
+    ``alpha`` onto k/v/beta's timeline and defers to
+    :func:`serial_delta_rule`.
+    """
+    n = int(num_householder)
+    total = q.shape[0]
+    q_expanded = q.new_zeros(total * n, *q.shape[1:])
+    q_expanded[n - 1 :: n] = q
+    alpha_expanded = None
+    if alpha is not None:
+        alpha_expanded = alpha.new_ones(total * n, *alpha.shape[1:])
+        alpha_expanded[0::n] = alpha
+    out, state = serial_delta_rule(
+        q_expanded,
+        k,
+        v,
+        cu_seqlens * n,
+        alpha=alpha_expanded,
+        beta=beta,
+        initial_state=initial_state,
+        scale=scale,
+        l2norm=l2norm,
+    )
+    return out[n - 1 :: n], state
+
+
+def serial_delta_rule2(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens: torch.Tensor,
+    *,
+    alpha: Optional[torch.Tensor] = None,
+    beta: Optional[torch.Tensor] = None,
+    w: Optional[torch.Tensor] = None,
+    initial_state: Optional[torch.Tensor] = None,
+    scale: float,
+    l2norm: bool = False,
+):
+    """Token-at-a-time fp32 GDN-2 recurrence, state V-major as ``[V, K]``.
+
+    ``S = diag(alpha) S``; ``v_new = w * v - S (beta * k)``;
+    ``S += v_new (x) k``; ``o = scale * S q``. All three gates are per channel:
+    ``alpha`` and ``beta`` on K, ``w`` on V.
+
+    Setting all three to channel constants with ``w == beta`` recovers
+    :func:`serial_delta_rule`, which the GDN-2 tests exploit as a cross-family
+    oracle.
+    """
+    q_index, k_index, v_index = head_index_maps(
+        q.shape[1], k.shape[1], v.shape[1], q.device
+    )
+    num_o_heads = max(q.shape[1], v.shape[1])
+    head_dim, v_dim = q.shape[2], v.shape[2]
+    offsets = [int(x) for x in cu_seqlens.tolist()]
+
+    query = q.float()
+    key = k.float()
+    if l2norm:
+        query = F.normalize(query, dim=-1)
+        key = F.normalize(key, dim=-1)
+    value = v.float()
+
+    out = torch.empty(
+        q.shape[0], num_o_heads, v_dim, dtype=torch.float32, device=q.device
+    )
+    if initial_state is None:
+        state = torch.zeros(
+            len(offsets) - 1,
+            num_o_heads,
+            v_dim,
+            head_dim,
+            dtype=torch.float32,
+            device=q.device,
+        )
+    else:
+        state = initial_state.float().clone()
+
+    for sequence in range(len(offsets) - 1):
+        running = state[sequence]
+        for token in range(offsets[sequence], offsets[sequence + 1]):
+            key_t = key[token, k_index]
+            if alpha is not None:
+                running = running * alpha[token].float()[:, None, :]
+            erased = key_t if beta is None else beta[token].float() * key_t
+            written = value[token, v_index]
+            if w is not None:
+                written = w[token].float() * written
+            v_new = written - torch.einsum("hvk,hk->hv", running, erased)
+            running = running + v_new[:, :, None] * key_t[:, None, :]
+            out[token] = scale * torch.einsum(
+                "hvk,hk->hv", running, query[token, q_index]
+            )
+        state[sequence] = running
+    return out, state
+
+
+def kda_safe_gate(
+    g: torch.Tensor, A_log: torch.Tensor, dt_bias: torch.Tensor, lower_bound: float
+) -> torch.Tensor:
+    """The in-kernel safe gate, in linear space.
+
+    ``alpha = exp(lower_bound * sigmoid(exp(A_log) * (g + dt_bias)))``, the
+    transform cuDNN applies when ``safe_gate`` is on. Returned in linear space
+    so it drops straight into :func:`serial_delta_rule`'s ``alpha``.
+    """
+    return (
+        lower_bound
+        * torch.sigmoid(A_log.float().exp()[:, None] * (g.float() + dt_bias.float()))
+    ).exp()
+
+
+def packed_offsets(seq_lens, device, dtype=torch.int32) -> torch.Tensor:
+    offsets = [0]
+    for length in seq_lens:
+        offsets.append(offsets[-1] + length)
+    return torch.tensor(offsets, dtype=dtype, device=device)
+
+
+def widened_view(x: torch.Tensor, axis: int, extra: int = 4) -> torch.Tensor:
+    """A non-contiguous view of ``x`` with the same values.
+
+    Allocates a wider buffer along ``axis``, copies ``x`` into the leading
+    slice and returns that slice. The innermost dim stays stride-1, which is
+    the one layout rule the engines enforce at execute time; every other stride
+    is now larger than a contiguous tensor's, so a wrapper that dropped strides
+    and assumed compactness reads the wrong elements.
+    """
+    shape = list(x.shape)
+    shape[axis] += extra
+    wide = torch.empty(shape, dtype=x.dtype, device=x.device)
+    index = [slice(None)] * x.dim()
+    index[axis] = slice(0, x.shape[axis])
+    wide[tuple(index)] = x
+    view = wide[tuple(index)]
+    assert not view.is_contiguous()
+    return view

--- a/tests/test_helpers/cudnn_linear_attention.py
+++ b/tests/test_helpers/cudnn_linear_attention.py
@@ -34,7 +34,7 @@ except Exception:
 
 HEAD_DIM = 128
 
-MIN_FRONTEND_VERSION = (1, 28)
+MIN_FRONTEND_VERSION = (1, 29)
 
 SUPPORTED_COMPUTE_CAPABILITIES = frozenset(
     {(10, 0), (10, 1), (10, 2), (10, 3), (10, 7)}

--- a/tests/trace/example.py
+++ b/tests/trace/example.py
@@ -23,6 +23,8 @@ gdn_decode_qk4_v8_d128.json
 gdn_fused_decode_h5120_v48_d128.json
 gdn_mtp_qk4_v8_d128.json
 gdn_prefill_qk4_v8_d128.json
+gdn2_prefill_qk4_v8_d128.json
+gdp_prefill_n2_qk4_v8_d128.json
 recurrent_kda_q8_v16_d128.json
 packed_kda_decode_h12_d128.json
 fused_kda_decode_h12_d128.json
@@ -864,6 +866,51 @@ with contextlib.suppress(Exception):
     gp_v = torch.randn(gp_T, gp_HV, gp_K, dtype=torch.bfloat16, device=device)
     flashinfer.gdn_prefill.chunk_gated_delta_rule(
         gp_q, gp_k, gp_v, cu_seqlens=cu_seqlens
+    )
+
+# ── GDN-2 prefill (channel-wise gates, chunk prefill) ────────────────────────
+with contextlib.suppress(Exception):
+    import flashinfer.gdn2_prefill  # noqa: PLC0415
+
+    g2_T, g2_H, g2_HV, g2_K = 256, 4, 8, 128
+    g2_cu_seqlens = torch.tensor(
+        [0, 64, 128, 192, 256], dtype=torch.int64, device=device
+    )
+    g2_q = torch.randn(g2_T, g2_H, g2_K, dtype=torch.bfloat16, device=device)
+    g2_k = torch.randn(g2_T, g2_H, g2_K, dtype=torch.bfloat16, device=device)
+    g2_v = torch.randn(g2_T, g2_HV, g2_K, dtype=torch.bfloat16, device=device)
+    g2_g = torch.rand(g2_T, g2_HV, g2_K, dtype=torch.float32, device=device)
+    g2_beta = torch.rand(g2_T, g2_HV, g2_K, dtype=torch.bfloat16, device=device)
+    g2_w = torch.rand(g2_T, g2_HV, g2_K, dtype=torch.bfloat16, device=device)
+    flashinfer.gdn2_prefill.chunk_gated_delta_rule2(
+        g2_q, g2_k, g2_v, g2_g, g2_beta, g2_w, cu_seqlens=g2_cu_seqlens
+    )
+
+# ── GDP prefill (num_householder sub-token expansion, chunk prefill) ─────────
+with contextlib.suppress(Exception):
+    import flashinfer.gdp_prefill  # noqa: PLC0415
+
+    gp2_T, gp2_N, gp2_H, gp2_HV, gp2_K = 256, 2, 4, 8, 128
+    gp2_cu_seqlens = torch.tensor(
+        [0, 64, 128, 192, 256], dtype=torch.int64, device=device
+    )
+    gp2_q = torch.randn(gp2_T, gp2_H, gp2_K, dtype=torch.bfloat16, device=device)
+    gp2_k = torch.randn(
+        gp2_T * gp2_N, gp2_H, gp2_K, dtype=torch.bfloat16, device=device
+    )
+    gp2_v = torch.randn(
+        gp2_T * gp2_N, gp2_HV, gp2_K, dtype=torch.bfloat16, device=device
+    )
+    gp2_g = torch.rand(gp2_T, gp2_HV, dtype=torch.float32, device=device)
+    gp2_beta = torch.rand(gp2_T * gp2_N, gp2_HV, dtype=torch.float32, device=device)
+    flashinfer.gdp_prefill.chunk_gated_delta_product(
+        gp2_q,
+        gp2_k,
+        gp2_v,
+        gp2_g,
+        gp2_beta,
+        gp2_N,
+        cu_seqlens=gp2_cu_seqlens,
     )
 
 # ── GDN decode (Qwen3-Next TP=4, qk=4/v=8/d=128) ────────────────────────────

--- a/tests/trace/fi_trace_out/gdn2_prefill_qk4_v8_d128.json
+++ b/tests/trace/fi_trace_out/gdn2_prefill_qk4_v8_d128.json
@@ -1,0 +1,155 @@
+{
+  "name": "gdn2_prefill_qk4_v8_d128",
+  "description": "Gated Delta Net 2 prefill: GDN's per-head scalar forget and erase gates become per key channel and a third write gate scales the incoming value per value channel. The state is in k-last layout [N, H, V, K].",
+  "op_type": "gdn2",
+  "tags": [
+    "fi_api:flashinfer.gdn2_prefill.chunk_gated_delta_rule2",
+    "stage:prefill",
+    "status:verified"
+  ],
+  "axes": {
+    "total_seq_len": {
+      "type": "var",
+      "description": "Total number of tokens across all sequences in the batch."
+    },
+    "num_seqs": {
+      "type": "var",
+      "description": "Number of sequences in the batch."
+    },
+    "num_q_heads": {
+      "type": "const",
+      "value": 4,
+      "description": "Number of query heads."
+    },
+    "num_k_heads": {
+      "type": "const",
+      "value": 4,
+      "description": "Number of key heads."
+    },
+    "num_v_heads": {
+      "type": "const",
+      "value": 8,
+      "description": "Number of value heads (GVA: more value heads than query heads)."
+    },
+    "head_size": {
+      "type": "const",
+      "value": 128,
+      "description": "Dimension of each attention head (K in query/key space, V in value space)."
+    },
+    "len_cu_seqlens": {
+      "type": "var",
+      "description": "Length of cu_seqlens array (num_seqs + 1)."
+    }
+  },
+  "constraints": [
+    "num_v_heads >= num_q_heads",
+    "num_v_heads % num_q_heads == 0",
+    "num_k_heads == num_q_heads",
+    "len_cu_seqlens == num_seqs + 1",
+    "total_seq_len == cu_seqlens[-1].item()"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "total_seq_len",
+        "num_q_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Query tensor."
+    },
+    "k": {
+      "shape": [
+        "total_seq_len",
+        "num_k_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Key tensor."
+    },
+    "v": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Value tensor."
+    },
+    "g": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "float32",
+      "description": "Channel-wise forget gate in linear space, per key channel."
+    },
+    "beta": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Channel-wise erase gate, post-sigmoid, per key channel."
+    },
+    "w": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Channel-wise write gate, per value channel."
+    },
+    "initial_state": {
+      "shape": [
+        "num_seqs",
+        "num_v_heads",
+        "head_size",
+        "head_size"
+      ],
+      "dtype": "unknown",
+      "optional": true,
+      "description": "Incoming recurrent state in k-last layout [N, H, V, K]."
+    },
+    "cu_seqlens": {
+      "shape": [
+        "len_cu_seqlens"
+      ],
+      "dtype": "int64",
+      "description": "Cumulative sequence lengths for variable-length batching."
+    },
+    "scale": {
+      "shape": null,
+      "dtype": "float32",
+      "optional": true,
+      "description": "Scale factor. Default is 1/sqrt(head_size)."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Attention output. Shape follows num_v_heads in GVA mode."
+    },
+    "final_state": {
+      "shape": [
+        "num_seqs",
+        "num_v_heads",
+        "head_size",
+        "head_size"
+      ],
+      "dtype": "float32",
+      "description": "Outgoing recurrent state in k-last layout [N, H, V, K]."
+    }
+  },
+  "reference": "from __future__ import annotations\nimport math\nimport torch\nimport torch.nn.functional as F\n\n@torch.no_grad()\ndef _gdn2_prefill_reference(q, k, v, g, beta, w, initial_state, cu_seqlens, scale):\n    \"\"\"Gated Delta Net 2 prefill reference, state V-major as ``[N, H, V, K]``.\n\n    All three gates are per channel: ``g`` and ``beta`` on the key dimension,\n    ``w`` on the value dimension. Per token,\n\n        S = diag(g) S\n        v_new = w * v - S (beta * k)\n        S += v_new (x) k\n        o = scale * S q\n    \"\"\"\n    total_seq_len, num_q_heads, head_size = q.shape\n    num_k_heads = k.shape[1]\n    num_v_heads = v.shape[1]\n    num_sab_heads = max(num_q_heads, num_v_heads)\n    num_seqs = cu_seqlens.size(0) - 1\n    device = q.device\n\n    if scale is None or scale == 0.0:\n        scale = 1.0 / math.sqrt(head_size)\n\n    q_exp = q.float().repeat_interleave(num_sab_heads // num_q_heads, dim=1)\n    k_exp = k.float().repeat_interleave(num_sab_heads // num_k_heads, dim=1)\n    v_exp = v.float().repeat_interleave(num_sab_heads // num_v_heads, dim=1)\n    g_f32 = g.float()\n    beta_f32 = beta.float()\n    w_f32 = w.float()\n\n    output = torch.zeros(\n        (total_seq_len, num_sab_heads, head_size), dtype=q.dtype, device=device\n    )\n    final_state = torch.zeros(\n        (num_seqs, num_sab_heads, head_size, head_size),\n        dtype=torch.float32,\n        device=device,\n    )\n\n    for seq_idx in range(num_seqs):\n        start = int(cu_seqlens[seq_idx].item())\n        end = int(cu_seqlens[seq_idx + 1].item())\n        if end <= start:\n            if initial_state is not None:\n                final_state[seq_idx] = initial_state[seq_idx].float()\n            continue\n        if initial_state is not None:\n            state = initial_state[seq_idx].clone().float()  # [H, V, K]\n        else:\n            state = torch.zeros(\n                (num_sab_heads, head_size, head_size),\n                dtype=torch.float32,\n                device=device,\n            )\n        for t in range(start, end):\n            key = k_exp[t]\n            state = state * g_f32[t][:, None, :]\n            erased = beta_f32[t] * key\n            v_new = w_f32[t] * v_exp[t] - torch.einsum(\"hvk,hk->hv\", state, erased)\n            state = state + v_new[:, :, None] * key[:, None, :]\n            projected = torch.einsum(\"hvk,hk->hv\", state, q_exp[t])\n            output[t] = (scale * projected).to(q.dtype)\n        final_state[seq_idx] = state\n\n    return output, final_state\n",
+  "check": "def standard_check(\n    reference_outputs: Any,\n    actual_outputs: Any,\n    *,\n    rtol: Optional[float] = None,\n    atol: Optional[float] = None,\n    max_mismatch_pct: float = 0.0,\n    min_cos_sim: Optional[float] = 1.0 - 1e-3,\n) -> bool:\n    \"\"\"Default trace correctness check used when a template does not override it.\"\"\"\n    from flashinfer.trace import default_check\n\n    return default_check(\n        reference_outputs,\n        actual_outputs,\n        rtol=rtol,\n        atol=atol,\n        max_mismatch_pct=max_mismatch_pct,\n        min_cos_sim=min_cos_sim,\n    )\n",
+  "init": "from __future__ import annotations\nimport math\nimport torch\n\n# ----- shared init helpers -----\n# Copyright (c) 2025 by FlashInfer team.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\"\"\"Shared helpers used by ``TraceTemplate.init`` functions.\n\nThis module contains the small set of input-construction patterns that\nrecur across many templates (paged-KV cache index arrays, ragged indptr,\nRoPE pos_ids and cos/sin caches, sampling probs). Each helper is short and\ndocumented; init functions in ``templates/<category>.py`` call into here so\nthe per-template init bodies stay focused on shape/dtype, not boilerplate.\n\nThe full source of this module is **inlined into every dumped JSON's\n``\"init\"`` field** by ``flashinfer/trace/template.py:_render_init_source``,\nso downstream consumers don't need flashinfer installed to re-run the init\nsnippets.\n\"\"\"\n\n\nfrom typing import Optional, Tuple\n\nimport torch\n\n\ndef make_paged_kv_indices(\n    batch_size: int,\n    num_pages_per_seq: int,\n    page_size: int,\n    *,\n    device: str = \"cuda\",\n) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:\n    \"\"\"Return ``(kv_indptr, kv_indices, kv_last_page_len)`` for a uniform batch.\n\n    Every sequence is assigned exactly ``num_pages_per_seq`` pages, fully\n    populated (last-page length == page_size).\n\n    Invariants\n    ----------\n    - ``kv_indptr.shape == (batch_size + 1,)``, dtype int32, monotonic, [0]=0.\n    - ``kv_indices == arange(0, batch_size * num_pages_per_seq)``, int32.\n    - ``kv_last_page_len == full(batch_size, page_size)``, int32.\n    \"\"\"\n    total_pages = batch_size * num_pages_per_seq\n    kv_indptr = (\n        torch.arange(batch_size + 1, dtype=torch.int32, device=device)\n        * num_pages_per_seq\n    )\n    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)\n    kv_last_page_len = torch.full(\n        (batch_size,), page_size, dtype=torch.int32, device=device\n    )\n    return kv_indptr, kv_indices, kv_last_page_len\n\n\ndef make_ragged_indptr(\n    seg_lens,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.int32,\n) -> torch.Tensor:\n    \"\"\"Return cumulative-sum ``indptr`` of length ``len(seg_lens)+1``.\n\n    ``seg_lens`` may be a list / tuple / 1-D tensor of segment lengths.\n    \"\"\"\n    if isinstance(seg_lens, torch.Tensor):\n        lens = seg_lens.to(device=device, dtype=dtype)\n    else:\n        lens = torch.tensor(list(seg_lens), dtype=dtype, device=device)\n    indptr = torch.zeros(lens.numel() + 1, dtype=dtype, device=device)\n    indptr[1:] = torch.cumsum(lens, dim=0).to(dtype)\n    return indptr\n\n\ndef make_uniform_qo_indptr(\n    batch_size: int,\n    qo_len: int,\n    *,\n    device: str = \"cuda\",\n) -> torch.Tensor:\n    \"\"\"Return ``[0, qo_len, 2*qo_len, ..., batch_size*qo_len]`` int32.\"\"\"\n    return torch.arange(batch_size + 1, dtype=torch.int32, device=device) * qo_len\n\n\ndef make_pos_ids(\n    nnz: int,\n    max_seq_len: Optional[int] = None,\n    *,\n    device: str = \"cuda\",\n) -> torch.Tensor:\n    \"\"\"Return ``[0, 1, ..., nnz-1] (% max_seq_len)`` as int32 on ``device``.\n\n    If ``max_seq_len`` is None, no wrapping is applied.\n    \"\"\"\n    pos = torch.arange(nnz, dtype=torch.int32, device=device)\n    if max_seq_len is not None:\n        pos = pos % max_seq_len\n    return pos\n\n\ndef make_rope_cos_sin_cache(\n    max_seq_len: int,\n    rope_dim: int,\n    *,\n    base: float = 1e4,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return concatenated ``[cos | sin]`` cache of shape ``[max_seq_len, rope_dim]``.\"\"\"\n    t = torch.arange(max_seq_len, dtype=torch.float32, device=device)\n    inv = 1.0 / (\n        base\n        ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim)\n    )\n    freqs = t.unsqueeze(-1) * inv.unsqueeze(0)\n    cache = torch.cat([torch.cos(freqs), torch.sin(freqs)], dim=-1)\n    return cache.to(dtype)\n\n\ndef make_probs(\n    batch_size: int,\n    vocab_size: int,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return a ``[batch_size, vocab_size]`` probability distribution.\n\n    Uses ``softmax(randn(...))`` so each row sums to 1.0. This mirrors the\n    pattern used throughout ``tests/utils/test_sampling.py``.\n    \"\"\"\n    return torch.softmax(\n        torch.randn(batch_size, vocab_size, dtype=torch.float32, device=device),\n        dim=-1,\n    ).to(dtype)\n\n\ndef make_logits(\n    batch_size: int,\n    vocab_size: int,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return ``randn(batch_size, vocab_size)`` logits.\"\"\"\n    return torch.randn(batch_size, vocab_size, dtype=dtype, device=device)\n\n\ndef fp8_safe_randn(\n    *shape: int,\n    scale: float = 0.1,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.bfloat16,\n) -> torch.Tensor:\n    \"\"\"``randn(*shape) * scale`` \u2014 keeps values in the FP8/FP4 representable range.\n\n    Tests for fp8/fp4 paths typically multiply ``randn`` by 0.1 to avoid\n    saturation when quantizing. Use this helper to mirror that convention.\n    \"\"\"\n    return (torch.randn(*shape, dtype=dtype, device=device) * scale).to(dtype)\n\n\ndef per_tensor_fp8_quantize(\n    x: torch.Tensor,\n    *,\n    fp8_dtype: torch.dtype = torch.float8_e4m3fn,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Per-tensor FP8 quantization, mirroring ``tests/utils_fp8.py:to_float8``.\n\n    Returns ``(x_fp8, inv_scale)`` where ``inv_scale`` is the dequant\n    multiplier (``float \u2248 fp8 * inv_scale``).\n    \"\"\"\n    finfo = torch.finfo(fp8_dtype)\n    amax = x.abs().amax().clamp(min=1e-12)\n    scale = finfo.max / amax\n    x_q = (x.float() * scale).clamp(min=finfo.min, max=finfo.max).to(fp8_dtype)\n    return x_q, scale.float().reciprocal()\n\n\ndef fp8_block_quant_1d(\n    x_bf16: torch.Tensor,\n    block: int = 128,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Quantize ``[T, H]`` activations into FP8 with per-``(token, block)``\n    column-block scales. Returns ``(x_fp8, scales)`` where\n    ``scales`` has shape ``[T, H // block]``.\n\n    Mirrors ``_fp8_block_quant_1d`` in\n    ``tests/moe/test_dpsk_fused_moe_fp8.py``.\n    \"\"\"\n    assert x_bf16.dim() == 2\n    T, H = x_bf16.shape\n    assert H % block == 0\n    nb = H // block\n    finfo = torch.finfo(torch.float8_e4m3fn)\n    max_fp8 = finfo.max\n    x_f32 = x_bf16.to(torch.float32)\n    x_fp8 = torch.empty((T, H), dtype=torch.float8_e4m3fn, device=x_bf16.device)\n    scales = torch.empty((T, nb), dtype=torch.float32, device=x_bf16.device)\n    for j in range(nb):\n        sl = slice(j * block, (j + 1) * block)\n        blk = x_f32[:, sl]\n        amax = torch.amax(torch.abs(blk), dim=1)\n        s = torch.where(amax > 0, amax / max_fp8, torch.ones_like(amax))\n        x_fp8[:, sl] = (blk / s.unsqueeze(1)).to(torch.float8_e4m3fn)\n        scales[:, j] = s\n    return x_fp8, scales\n\n\ndef fp8_block_quant_2d(\n    w_bf16: torch.Tensor,\n    block: int = 128,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Quantize weights ``[..., R, C]`` with 2-D ``block \u00d7 block`` scales.\n\n    Returns ``(w_fp8, scales)`` where ``scales`` has shape\n    ``[..., R // block, C // block]``. Mirrors ``_fp8_block_quant_2d`` in\n    ``tests/moe/test_dpsk_fused_moe_fp8.py``.\n    \"\"\"\n    assert w_bf16.dim() >= 2\n    *prefix, R, C = w_bf16.shape\n    assert R % block == 0 and C % block == 0\n    nb_r, nb_c = R // block, C // block\n    finfo = torch.finfo(torch.float8_e4m3fn)\n    max_fp8 = finfo.max\n    w_f32 = w_bf16.to(torch.float32).contiguous()\n    prefix_ndim = len(prefix)\n    reshaped = w_f32.reshape(*prefix, nb_r, block, nb_c, block)\n    permute_dims = tuple(range(prefix_ndim)) + (\n        prefix_ndim,\n        prefix_ndim + 2,\n        prefix_ndim + 1,\n        prefix_ndim + 3,\n    )\n    blocks = reshaped.permute(permute_dims).contiguous()\n    amax = torch.amax(torch.abs(blocks), dim=(-1, -2))\n    scales = torch.where(\n        amax > 0, amax / max_fp8, torch.ones_like(amax, dtype=torch.float32)\n    )\n    q_blocks = (blocks / scales.unsqueeze(-1).unsqueeze(-1)).to(torch.float8_e4m3fn)\n    inv_permute = [0] * (prefix_ndim + 4)\n    for i, p in enumerate(permute_dims):\n        inv_permute[p] = i\n    w_fp8 = q_blocks.permute(*inv_permute).reshape(*prefix, R, C).contiguous()\n    return w_fp8, scales\n\n\n__all__ = [\n    \"make_paged_kv_indices\",\n    \"make_ragged_indptr\",\n    \"make_uniform_qo_indptr\",\n    \"make_pos_ids\",\n    \"make_rope_cos_sin_cache\",\n    \"make_probs\",\n    \"make_logits\",\n    \"fp8_safe_randn\",\n    \"per_tensor_fp8_quantize\",\n    \"fp8_block_quant_1d\",\n    \"fp8_block_quant_2d\",\n]\n\n# ----- init -----\ndef _gdn2_prefill_init(\n    *,\n    total_seq_len: int,\n    num_seqs: int = 4,\n    len_cu_seqlens: int = 0,  # derived\n    num_q_heads: int = 4,\n    num_k_heads: int = 4,\n    num_v_heads: int = 8,\n    head_size: int = 128,\n    device: str = \"cuda\",\n    seed: int = 0,\n):\n    \"\"\"Build inputs for ``flashinfer.gdn2_prefill.chunk_gated_delta_rule2``.\"\"\"\n    del len_cu_seqlens\n    torch.manual_seed(seed)\n    num_sab_heads = max(num_q_heads, num_v_heads)\n\n    def qkv(num_heads, normalize):\n        x = torch.randn(\n            total_seq_len, num_heads, head_size, dtype=torch.float32, device=device\n        )\n        if normalize:\n            x = torch.nn.functional.normalize(x, p=2.0, dim=-1)\n        return x.to(torch.bfloat16).contiguous()\n\n    def channel_gate(dtype):\n        return (\n            torch.empty(\n                total_seq_len,\n                num_sab_heads,\n                head_size,\n                dtype=torch.float32,\n                device=device,\n            )\n            .uniform_(0.1, 1.0)\n            .to(dtype)\n        )\n\n    base = total_seq_len // max(1, num_seqs)\n    rem = total_seq_len % max(1, num_seqs)\n    cum = [0]\n    for i in range(num_seqs):\n        cum.append(cum[-1] + base + (1 if i < rem else 0))\n    return {\n        \"q\": qkv(num_q_heads, True),\n        \"k\": qkv(num_k_heads, True),\n        \"v\": qkv(num_v_heads, False),\n        \"g\": channel_gate(torch.float32),\n        \"beta\": channel_gate(torch.bfloat16),\n        \"w\": channel_gate(torch.bfloat16),\n        \"cu_seqlens\": torch.tensor(cum, dtype=torch.int64, device=device),\n    }\n"
+}

--- a/tests/trace/fi_trace_out/gdn2_prefill_qk4_v8_d128.json
+++ b/tests/trace/fi_trace_out/gdn2_prefill_qk4_v8_d128.json
@@ -83,7 +83,7 @@
         "head_size"
       ],
       "dtype": "float32",
-      "description": "Channel-wise forget gate in linear space, per key channel."
+      "description": "Channel-wise forget gate as the natural-log decay, per key channel."
     },
     "beta": {
       "shape": [

--- a/tests/trace/fi_trace_out/gdp_prefill_n2_qk4_v8_d128.json
+++ b/tests/trace/fi_trace_out/gdp_prefill_n2_qk4_v8_d128.json
@@ -1,0 +1,162 @@
+{
+  "name": "gdp_prefill_n2_qk4_v8_d128",
+  "description": "Gated DeltaProduct prefill: num_householder beta-gated Householder updates per token with one per-head scalar decay per token. k/v/beta ride the expanded sub-token timeline; q, g and the outputs live at real-token rows. The state is in k-last layout [N, H, V, K].",
+  "op_type": "gdp",
+  "tags": [
+    "fi_api:flashinfer.gdp_prefill.chunk_gated_delta_product",
+    "stage:prefill",
+    "status:verified"
+  ],
+  "axes": {
+    "total_seq_len": {
+      "type": "var",
+      "description": "Total number of real tokens across all sequences in the batch."
+    },
+    "expanded_seq_len": {
+      "type": "var",
+      "description": "Total sub-token rows, total_seq_len * num_householder."
+    },
+    "num_seqs": {
+      "type": "var",
+      "description": "Number of sequences in the batch."
+    },
+    "num_householder": {
+      "type": "const",
+      "value": 2,
+      "description": "Householder updates per token."
+    },
+    "num_q_heads": {
+      "type": "const",
+      "value": 4,
+      "description": "Number of query heads."
+    },
+    "num_k_heads": {
+      "type": "const",
+      "value": 4,
+      "description": "Number of key heads."
+    },
+    "num_v_heads": {
+      "type": "const",
+      "value": 8,
+      "description": "Number of value heads (GVA: more value heads than query heads)."
+    },
+    "head_size": {
+      "type": "const",
+      "value": 128,
+      "description": "Dimension of each attention head (K in query/key space, V in value space)."
+    },
+    "len_cu_seqlens": {
+      "type": "var",
+      "description": "Length of cu_seqlens array (num_seqs + 1)."
+    }
+  },
+  "constraints": [
+    "expanded_seq_len == total_seq_len * num_householder",
+    "num_householder >= 1",
+    "num_k_heads == num_q_heads or num_k_heads == num_v_heads",
+    "num_v_heads >= num_q_heads",
+    "num_v_heads % num_q_heads == 0",
+    "len_cu_seqlens == num_seqs + 1",
+    "total_seq_len == cu_seqlens[-1].item()"
+  ],
+  "inputs": {
+    "q": {
+      "shape": [
+        "total_seq_len",
+        "num_q_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Query tensor at real-token rows."
+    },
+    "k": {
+      "shape": [
+        "expanded_seq_len",
+        "num_k_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Key tensor on the expanded sub-token timeline."
+    },
+    "v": {
+      "shape": [
+        "expanded_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Value tensor on the expanded sub-token timeline."
+    },
+    "g": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads"
+      ],
+      "dtype": "float32",
+      "optional": true,
+      "description": "Per-head forget gate in linear space, at real-token rows."
+    },
+    "beta": {
+      "shape": [
+        "expanded_seq_len",
+        "num_v_heads"
+      ],
+      "dtype": "float32",
+      "optional": true,
+      "description": "Per-head, per-Householder update gate, post-sigmoid."
+    },
+    "num_householder": {
+      "shape": null,
+      "dtype": "int32",
+      "description": "Householder updates per token."
+    },
+    "initial_state": {
+      "shape": [
+        "num_seqs",
+        "num_v_heads",
+        "head_size",
+        "head_size"
+      ],
+      "dtype": "unknown",
+      "optional": true,
+      "description": "Incoming recurrent state in k-last layout [N, H, V, K]."
+    },
+    "cu_seqlens": {
+      "shape": [
+        "len_cu_seqlens"
+      ],
+      "dtype": "int64",
+      "description": "Cumulative real-token sequence lengths for variable-length batching."
+    },
+    "scale": {
+      "shape": null,
+      "dtype": "float32",
+      "optional": true,
+      "description": "Scale factor. Default is 1/sqrt(head_size)."
+    }
+  },
+  "outputs": {
+    "output": {
+      "shape": [
+        "total_seq_len",
+        "num_v_heads",
+        "head_size"
+      ],
+      "dtype": "bfloat16",
+      "description": "Attention output at real-token rows. Shape follows num_v_heads in GVA mode."
+    },
+    "final_state": {
+      "shape": [
+        "num_seqs",
+        "num_v_heads",
+        "head_size",
+        "head_size"
+      ],
+      "dtype": "float32",
+      "description": "Outgoing recurrent state in k-last layout [N, H, V, K]."
+    }
+  },
+  "reference": "from __future__ import annotations\nimport math\nimport torch\nimport torch.nn.functional as F\n\n@torch.no_grad()\ndef _gdp_prefill_reference(\n    q, k, v, g, beta, initial_state, cu_seqlens, scale, num_householder\n):\n    \"\"\"Gated DeltaProduct prefill reference, state V-major as ``[N, H, V, K]``.\n\n    Per real token, with ``n = num_householder`` and sub-token rows\n    ``t*n .. t*n + n - 1`` of k/v/beta,\n\n        S = alpha_t S\n        for j in 0..n-1:\n            v_new = beta_{t,j} * (v_{t,j} - S k_{t,j})\n            S += v_new (x) k_{t,j}\n        o_t = scale * S q_t\n    \"\"\"\n    total_seq_len, num_q_heads, head_size = q.shape\n    num_k_heads = k.shape[1]\n    num_v_heads = v.shape[1]\n    num_sab_heads = max(num_q_heads, num_v_heads)\n    num_seqs = cu_seqlens.size(0) - 1\n    n = int(num_householder)\n    device = q.device\n\n    if scale is None or scale == 0.0:\n        scale = 1.0 / math.sqrt(head_size)\n\n    q_exp = q.float().repeat_interleave(num_sab_heads // num_q_heads, dim=1)\n    k_exp = k.float().repeat_interleave(num_sab_heads // num_k_heads, dim=1)\n    v_exp = v.float().repeat_interleave(num_sab_heads // num_v_heads, dim=1)\n    g_f32 = (\n        torch.ones(total_seq_len, num_sab_heads, dtype=torch.float32, device=device)\n        if g is None\n        else g.float()\n    )\n    beta_f32 = (\n        torch.ones(total_seq_len * n, num_sab_heads, dtype=torch.float32, device=device)\n        if beta is None\n        else beta.float()\n    )\n\n    output = torch.zeros(\n        (total_seq_len, num_sab_heads, v.shape[2]), dtype=q.dtype, device=device\n    )\n    final_state = torch.zeros(\n        (num_seqs, num_sab_heads, v.shape[2], head_size),\n        dtype=torch.float32,\n        device=device,\n    )\n\n    for seq_idx in range(num_seqs):\n        start = int(cu_seqlens[seq_idx].item())\n        end = int(cu_seqlens[seq_idx + 1].item())\n        if end <= start:\n            if initial_state is not None:\n                final_state[seq_idx] = initial_state[seq_idx].float()\n            continue\n        if initial_state is not None:\n            state = initial_state[seq_idx].clone().float()  # [H, V, K]\n        else:\n            state = torch.zeros(\n                (num_sab_heads, v.shape[2], head_size),\n                dtype=torch.float32,\n                device=device,\n            )\n        for t in range(start, end):\n            state = state * g_f32[t][:, None, None]\n            for j in range(t * n, t * n + n):\n                key = k_exp[j]\n                v_new = v_exp[j] - torch.einsum(\"hvk,hk->hv\", state, key)\n                v_new = beta_f32[j][:, None] * v_new\n                state = state + v_new[:, :, None] * key[:, None, :]\n            projected = torch.einsum(\"hvk,hk->hv\", state, q_exp[t])\n            output[t] = (scale * projected).to(q.dtype)\n        final_state[seq_idx] = state\n\n    return output, final_state\n",
+  "check": "def standard_check(\n    reference_outputs: Any,\n    actual_outputs: Any,\n    *,\n    rtol: Optional[float] = None,\n    atol: Optional[float] = None,\n    max_mismatch_pct: float = 0.0,\n    min_cos_sim: Optional[float] = 1.0 - 1e-3,\n) -> bool:\n    \"\"\"Default trace correctness check used when a template does not override it.\"\"\"\n    from flashinfer.trace import default_check\n\n    return default_check(\n        reference_outputs,\n        actual_outputs,\n        rtol=rtol,\n        atol=atol,\n        max_mismatch_pct=max_mismatch_pct,\n        min_cos_sim=min_cos_sim,\n    )\n",
+  "init": "from __future__ import annotations\nimport math\nimport torch\n\n# ----- shared init helpers -----\n# Copyright (c) 2025 by FlashInfer team.\n#\n# Licensed under the Apache License, Version 2.0 (the \"License\");\n# you may not use this file except in compliance with the License.\n# You may obtain a copy of the License at\n#\n#   http://www.apache.org/licenses/LICENSE-2.0\n#\n# Unless required by applicable law or agreed to in writing, software\n# distributed under the License is distributed on an \"AS IS\" BASIS,\n# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n# See the License for the specific language governing permissions and\n# limitations under the License.\n\n\"\"\"Shared helpers used by ``TraceTemplate.init`` functions.\n\nThis module contains the small set of input-construction patterns that\nrecur across many templates (paged-KV cache index arrays, ragged indptr,\nRoPE pos_ids and cos/sin caches, sampling probs). Each helper is short and\ndocumented; init functions in ``templates/<category>.py`` call into here so\nthe per-template init bodies stay focused on shape/dtype, not boilerplate.\n\nThe full source of this module is **inlined into every dumped JSON's\n``\"init\"`` field** by ``flashinfer/trace/template.py:_render_init_source``,\nso downstream consumers don't need flashinfer installed to re-run the init\nsnippets.\n\"\"\"\n\n\nfrom typing import Optional, Tuple\n\nimport torch\n\n\ndef make_paged_kv_indices(\n    batch_size: int,\n    num_pages_per_seq: int,\n    page_size: int,\n    *,\n    device: str = \"cuda\",\n) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:\n    \"\"\"Return ``(kv_indptr, kv_indices, kv_last_page_len)`` for a uniform batch.\n\n    Every sequence is assigned exactly ``num_pages_per_seq`` pages, fully\n    populated (last-page length == page_size).\n\n    Invariants\n    ----------\n    - ``kv_indptr.shape == (batch_size + 1,)``, dtype int32, monotonic, [0]=0.\n    - ``kv_indices == arange(0, batch_size * num_pages_per_seq)``, int32.\n    - ``kv_last_page_len == full(batch_size, page_size)``, int32.\n    \"\"\"\n    total_pages = batch_size * num_pages_per_seq\n    kv_indptr = (\n        torch.arange(batch_size + 1, dtype=torch.int32, device=device)\n        * num_pages_per_seq\n    )\n    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)\n    kv_last_page_len = torch.full(\n        (batch_size,), page_size, dtype=torch.int32, device=device\n    )\n    return kv_indptr, kv_indices, kv_last_page_len\n\n\ndef make_ragged_indptr(\n    seg_lens,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.int32,\n) -> torch.Tensor:\n    \"\"\"Return cumulative-sum ``indptr`` of length ``len(seg_lens)+1``.\n\n    ``seg_lens`` may be a list / tuple / 1-D tensor of segment lengths.\n    \"\"\"\n    if isinstance(seg_lens, torch.Tensor):\n        lens = seg_lens.to(device=device, dtype=dtype)\n    else:\n        lens = torch.tensor(list(seg_lens), dtype=dtype, device=device)\n    indptr = torch.zeros(lens.numel() + 1, dtype=dtype, device=device)\n    indptr[1:] = torch.cumsum(lens, dim=0).to(dtype)\n    return indptr\n\n\ndef make_uniform_qo_indptr(\n    batch_size: int,\n    qo_len: int,\n    *,\n    device: str = \"cuda\",\n) -> torch.Tensor:\n    \"\"\"Return ``[0, qo_len, 2*qo_len, ..., batch_size*qo_len]`` int32.\"\"\"\n    return torch.arange(batch_size + 1, dtype=torch.int32, device=device) * qo_len\n\n\ndef make_pos_ids(\n    nnz: int,\n    max_seq_len: Optional[int] = None,\n    *,\n    device: str = \"cuda\",\n) -> torch.Tensor:\n    \"\"\"Return ``[0, 1, ..., nnz-1] (% max_seq_len)`` as int32 on ``device``.\n\n    If ``max_seq_len`` is None, no wrapping is applied.\n    \"\"\"\n    pos = torch.arange(nnz, dtype=torch.int32, device=device)\n    if max_seq_len is not None:\n        pos = pos % max_seq_len\n    return pos\n\n\ndef make_rope_cos_sin_cache(\n    max_seq_len: int,\n    rope_dim: int,\n    *,\n    base: float = 1e4,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return concatenated ``[cos | sin]`` cache of shape ``[max_seq_len, rope_dim]``.\"\"\"\n    t = torch.arange(max_seq_len, dtype=torch.float32, device=device)\n    inv = 1.0 / (\n        base\n        ** (torch.arange(0, rope_dim, 2, dtype=torch.float32, device=device) / rope_dim)\n    )\n    freqs = t.unsqueeze(-1) * inv.unsqueeze(0)\n    cache = torch.cat([torch.cos(freqs), torch.sin(freqs)], dim=-1)\n    return cache.to(dtype)\n\n\ndef make_probs(\n    batch_size: int,\n    vocab_size: int,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return a ``[batch_size, vocab_size]`` probability distribution.\n\n    Uses ``softmax(randn(...))`` so each row sums to 1.0. This mirrors the\n    pattern used throughout ``tests/utils/test_sampling.py``.\n    \"\"\"\n    return torch.softmax(\n        torch.randn(batch_size, vocab_size, dtype=torch.float32, device=device),\n        dim=-1,\n    ).to(dtype)\n\n\ndef make_logits(\n    batch_size: int,\n    vocab_size: int,\n    *,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.float32,\n) -> torch.Tensor:\n    \"\"\"Return ``randn(batch_size, vocab_size)`` logits.\"\"\"\n    return torch.randn(batch_size, vocab_size, dtype=dtype, device=device)\n\n\ndef fp8_safe_randn(\n    *shape: int,\n    scale: float = 0.1,\n    device: str = \"cuda\",\n    dtype: torch.dtype = torch.bfloat16,\n) -> torch.Tensor:\n    \"\"\"``randn(*shape) * scale`` \u2014 keeps values in the FP8/FP4 representable range.\n\n    Tests for fp8/fp4 paths typically multiply ``randn`` by 0.1 to avoid\n    saturation when quantizing. Use this helper to mirror that convention.\n    \"\"\"\n    return (torch.randn(*shape, dtype=dtype, device=device) * scale).to(dtype)\n\n\ndef per_tensor_fp8_quantize(\n    x: torch.Tensor,\n    *,\n    fp8_dtype: torch.dtype = torch.float8_e4m3fn,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Per-tensor FP8 quantization, mirroring ``tests/utils_fp8.py:to_float8``.\n\n    Returns ``(x_fp8, inv_scale)`` where ``inv_scale`` is the dequant\n    multiplier (``float \u2248 fp8 * inv_scale``).\n    \"\"\"\n    finfo = torch.finfo(fp8_dtype)\n    amax = x.abs().amax().clamp(min=1e-12)\n    scale = finfo.max / amax\n    x_q = (x.float() * scale).clamp(min=finfo.min, max=finfo.max).to(fp8_dtype)\n    return x_q, scale.float().reciprocal()\n\n\ndef fp8_block_quant_1d(\n    x_bf16: torch.Tensor,\n    block: int = 128,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Quantize ``[T, H]`` activations into FP8 with per-``(token, block)``\n    column-block scales. Returns ``(x_fp8, scales)`` where\n    ``scales`` has shape ``[T, H // block]``.\n\n    Mirrors ``_fp8_block_quant_1d`` in\n    ``tests/moe/test_dpsk_fused_moe_fp8.py``.\n    \"\"\"\n    assert x_bf16.dim() == 2\n    T, H = x_bf16.shape\n    assert H % block == 0\n    nb = H // block\n    finfo = torch.finfo(torch.float8_e4m3fn)\n    max_fp8 = finfo.max\n    x_f32 = x_bf16.to(torch.float32)\n    x_fp8 = torch.empty((T, H), dtype=torch.float8_e4m3fn, device=x_bf16.device)\n    scales = torch.empty((T, nb), dtype=torch.float32, device=x_bf16.device)\n    for j in range(nb):\n        sl = slice(j * block, (j + 1) * block)\n        blk = x_f32[:, sl]\n        amax = torch.amax(torch.abs(blk), dim=1)\n        s = torch.where(amax > 0, amax / max_fp8, torch.ones_like(amax))\n        x_fp8[:, sl] = (blk / s.unsqueeze(1)).to(torch.float8_e4m3fn)\n        scales[:, j] = s\n    return x_fp8, scales\n\n\ndef fp8_block_quant_2d(\n    w_bf16: torch.Tensor,\n    block: int = 128,\n) -> Tuple[torch.Tensor, torch.Tensor]:\n    \"\"\"Quantize weights ``[..., R, C]`` with 2-D ``block \u00d7 block`` scales.\n\n    Returns ``(w_fp8, scales)`` where ``scales`` has shape\n    ``[..., R // block, C // block]``. Mirrors ``_fp8_block_quant_2d`` in\n    ``tests/moe/test_dpsk_fused_moe_fp8.py``.\n    \"\"\"\n    assert w_bf16.dim() >= 2\n    *prefix, R, C = w_bf16.shape\n    assert R % block == 0 and C % block == 0\n    nb_r, nb_c = R // block, C // block\n    finfo = torch.finfo(torch.float8_e4m3fn)\n    max_fp8 = finfo.max\n    w_f32 = w_bf16.to(torch.float32).contiguous()\n    prefix_ndim = len(prefix)\n    reshaped = w_f32.reshape(*prefix, nb_r, block, nb_c, block)\n    permute_dims = tuple(range(prefix_ndim)) + (\n        prefix_ndim,\n        prefix_ndim + 2,\n        prefix_ndim + 1,\n        prefix_ndim + 3,\n    )\n    blocks = reshaped.permute(permute_dims).contiguous()\n    amax = torch.amax(torch.abs(blocks), dim=(-1, -2))\n    scales = torch.where(\n        amax > 0, amax / max_fp8, torch.ones_like(amax, dtype=torch.float32)\n    )\n    q_blocks = (blocks / scales.unsqueeze(-1).unsqueeze(-1)).to(torch.float8_e4m3fn)\n    inv_permute = [0] * (prefix_ndim + 4)\n    for i, p in enumerate(permute_dims):\n        inv_permute[p] = i\n    w_fp8 = q_blocks.permute(*inv_permute).reshape(*prefix, R, C).contiguous()\n    return w_fp8, scales\n\n\n__all__ = [\n    \"make_paged_kv_indices\",\n    \"make_ragged_indptr\",\n    \"make_uniform_qo_indptr\",\n    \"make_pos_ids\",\n    \"make_rope_cos_sin_cache\",\n    \"make_probs\",\n    \"make_logits\",\n    \"fp8_safe_randn\",\n    \"per_tensor_fp8_quantize\",\n    \"fp8_block_quant_1d\",\n    \"fp8_block_quant_2d\",\n]\n\n# ----- init -----\ndef _gdp_prefill_init(\n    *,\n    total_seq_len: int,\n    expanded_seq_len: int = 0,  # derived\n    num_seqs: int = 4,\n    len_cu_seqlens: int = 0,  # derived\n    num_householder: int = 2,\n    num_q_heads: int = 4,\n    num_k_heads: int = 4,\n    num_v_heads: int = 8,\n    head_size: int = 128,\n    device: str = \"cuda\",\n    seed: int = 0,\n):\n    \"\"\"Build inputs for ``flashinfer.gdp_prefill.chunk_gated_delta_product``.\"\"\"\n    del expanded_seq_len, len_cu_seqlens\n    torch.manual_seed(seed)\n    num_sab_heads = max(num_q_heads, num_v_heads)\n    expanded = total_seq_len * num_householder\n\n    def qkv(rows, num_heads, normalize):\n        x = torch.randn(rows, num_heads, head_size, dtype=torch.float32, device=device)\n        if normalize:\n            x = torch.nn.functional.normalize(x, p=2.0, dim=-1)\n        return x.to(torch.bfloat16).contiguous()\n\n    base = total_seq_len // max(1, num_seqs)\n    rem = total_seq_len % max(1, num_seqs)\n    cum = [0]\n    for i in range(num_seqs):\n        cum.append(cum[-1] + base + (1 if i < rem else 0))\n    return {\n        \"q\": qkv(total_seq_len, num_q_heads, True),\n        \"k\": qkv(expanded, num_k_heads, True),\n        \"v\": qkv(expanded, num_v_heads, False),\n        \"g\": torch.empty(\n            total_seq_len, num_sab_heads, dtype=torch.float32, device=device\n        ).uniform_(0.1, 1.0),\n        \"beta\": torch.empty(\n            expanded, num_sab_heads, dtype=torch.float32, device=device\n        ).uniform_(0.1, 1.0),\n        \"num_householder\": num_householder,\n        \"cu_seqlens\": torch.tensor(cum, dtype=torch.int64, device=device),\n    }\n"
+}

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -66,6 +66,8 @@ _TRACE_REGISTRATION_MODULES = (
     "flashinfer.fused_moe.monomoe",
     "flashinfer.fused_moe.prepare",
     "flashinfer.fused_moe.trtllm_gen_routing",
+    "flashinfer.gdn2_prefill",
+    "flashinfer.gdp_prefill",
     "flashinfer.gdn_decode",
     "flashinfer.gdn_kernels.experimental.gdn_fused_decode",
     "flashinfer.gdn_prefill",


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Adds cuDNN as a backend for linear attention.

GDN GB200
| heads   | seqs               |  cudnn | fi flashinfer | fi/cudnn |
|---------|--------------------|-------:|--------------:|---------:|
| h16     | 1x2048             |   76.4 |          79.1 |    1.04x |
| h16     | 1x8192             |  138.4 |         130.1 |    0.94x |
| h16     | 1x32768            |  301.4 |         327.1 |    1.09x |
| h16     | 1x131072           |  907.5 |        1050.0 |    1.16x |
| h16     | 2x16384            |  296.4 |         333.0 |    1.12x |
| h16     | 6144+2048          |  130.8 |         136.6 |    1.04x |
| h16     | 4x8192             |  242.9 |         230.7 |    0.95x |
| h16     | 8x1024             |   51.3 |          44.9 |    0.88x |
| h16     | 16x2048            |  145.4 |         147.4 |    1.01x |
| h16     | 1024+7168          |  122.6 |         137.4 |    1.12x |
| h16     | 2048+6144          |  130.9 |         135.3 |    1.03x |
| h16     | 2x4096             |  118.7 |         133.1 |    1.12x |
| h16     | 4096+2048+2048     |  130.4 |         121.6 |    0.93x |
| h16     | 512+1536+2048+4096 |  150.5 |         122.5 |    0.81x |
| h16     | 7168+512+512       |  142.4 |         202.4 |    1.42x |
| h64     | 1x2048             |   84.6 |          68.8 |    0.81x |
| h64     | 1x8192             |  243.6 |         232.5 |    0.95x |
| h64     | 1x32768            |  869.9 |         883.4 |    1.02x |
| h64     | 1x131072           | 3431.4 |        3476.4 |    1.01x |
| h64     | 2x16384            |  449.8 |         478.7 |    1.06x |
| h64     | 6144+2048          |  212.0 |         185.1 |    0.87x |
| h64     | 4x8192             |  467.4 |         492.2 |    1.05x |
| h64     | 8x1024             |  154.8 |         169.0 |    1.09x |
| h64     | 16x2048            |  450.9 |         521.1 |    1.16x |
| h64     | 1024+7168          |  236.7 |         211.2 |    0.89x |
| h64     | 2048+6144          |  213.2 |         185.3 |    0.87x |
| h64     | 2x4096             |  134.6 |         137.8 |    1.02x |
| h64     | 4096+2048+2048     |  152.6 |         198.9 |    1.30x |
| h64     | 512+1536+2048+4096 |  151.0 |         185.1 |    1.23x |
| h64     | 7168+512+512       |  234.8 |         231.9 |    0.99x |
| gva2_8  | 1x2048             |   62.4 |          72.3 |    1.16x |
| gva2_8  | 1x8192             |   92.0 |         110.9 |    1.21x |
| gva2_8  | 1x32768            |  177.3 |         210.0 |    1.18x |
| gva2_8  | 1x131072           |  499.7 |         565.3 |    1.13x |
| gva2_8  | 2x16384            |  187.6 |         199.6 |    1.06x |
| gva2_8  | 6144+2048          |  101.6 |         105.7 |    1.04x |
| gva2_8  | 4x8192             |  176.0 |         215.4 |    1.22x |
| gva2_8  | 8x1024             |   57.2 |          39.8 |    0.70x |
| gva2_8  | 16x2048            |   76.3 |          70.8 |    0.93x |
| gva2_8  | 1024+7168          |  107.1 |         110.7 |    1.03x |
| gva2_8  | 2048+6144          |  101.7 |         107.9 |    1.06x |
| gva2_8  | 2x4096             |   89.4 |          98.4 |    1.10x |
| gva2_8  | 4096+2048+2048     |  102.4 |         109.4 |    1.07x |
| gva2_8  | 512+1536+2048+4096 |  100.9 |         110.9 |    1.10x |
| gva2_8  | 7168+512+512       |  107.9 |         116.4 |    1.08x |
| gva4_8  | 1x2048             |   62.6 |          73.7 |    1.18x |
| gva4_8  | 1x8192             |   92.7 |         113.0 |    1.22x |
| gva4_8  | 1x32768            |  178.9 |         211.8 |    1.18x |
| gva4_8  | 1x131072           |  503.4 |         567.7 |    1.13x |
| gva4_8  | 2x16384            |  188.9 |         202.6 |    1.07x |
| gva4_8  | 6144+2048          |  102.5 |         106.6 |    1.04x |
| gva4_8  | 4x8192             |  176.9 |         223.1 |    1.26x |
| gva4_8  | 8x1024             |   57.7 |          40.1 |    0.69x |
| gva4_8  | 16x2048            |   77.0 |          71.6 |    0.93x |
| gva4_8  | 1024+7168          |  107.8 |         112.3 |    1.04x |
| gva4_8  | 2048+6144          |  102.7 |         109.2 |    1.06x |
| gva4_8  | 2x4096             |   90.0 |         100.3 |    1.11x |
| gva4_8  | 4096+2048+2048     |  103.2 |         111.5 |    1.08x |
| gva4_8  | 512+1536+2048+4096 |  101.8 |         112.2 |    1.10x |
| gva4_8  | 7168+512+512       |  108.8 |         117.2 |    1.08x |
| gva4_16 | 1x2048             |   75.6 |          77.1 |    1.02x |
| gva4_16 | 1x8192             |  132.9 |         127.4 |    0.96x |
| gva4_16 | 1x32768            |  289.9 |         321.9 |    1.11x |
| gva4_16 | 1x131072           |  876.8 |        1036.9 |    1.18x |
| gva4_16 | 2x16384            |  286.3 |         327.7 |    1.14x |
| gva4_16 | 6144+2048          |  126.0 |         130.0 |    1.03x |
| gva4_16 | 4x8192             |  243.2 |         232.5 |    0.96x |
| gva4_16 | 8x1024             |   48.0 |          43.2 |    0.90x |
| gva4_16 | 16x2048            |  140.1 |         141.4 |    1.01x |
| gva4_16 | 1024+7168          |  118.1 |         133.2 |    1.13x |
| gva4_16 | 2048+6144          |  126.0 |         131.6 |    1.04x |
| gva4_16 | 2x4096             |  117.9 |         128.2 |    1.09x |
| gva4_16 | 4096+2048+2048     |  125.5 |         122.8 |    0.98x |
| gva4_16 | 512+1536+2048+4096 |  150.6 |         123.2 |    0.82x |
| gva4_16 | 7168+512+512       |  137.8 |         205.6 |    1.49x |

KDA GB200
| heads | seqs            |  cudnn | fi cute-dsl | fi/cudnn |
|-------|-----------------|-------:|------------:|---------:|
| h1    | 1x131072        | 1087.2 |      3615.1 |    3.33x |
| h4    | 1x32768         |  323.3 |       946.2 |    2.93x |
| h4    | 1x131072        | 1095.1 |      3732.3 |    3.41x |
| h4    | 4x32768         |  540.2 |      1071.5 |    1.98x |
| h4    | 24576+8192      |  209.4 |       725.4 |    3.46x |
| h8    | 1x32768         |  324.8 |       984.9 |    3.03x |
| h8    | 1x65536         |  582.0 |      1951.1 |    3.35x |
| h8    | 1x131072        | 1096.0 |      3886.2 |    3.55x |
| h8    | 16384+4096+4096 |  269.2 |       524.5 |    1.95x |
| h16   | 1x2048          |  102.4 |        81.3 |    0.79x |
| h16   | 1x8192          |  189.9 |       279.3 |    1.47x |
| h16   | 1x32768         |  534.5 |      1063.9 |    1.99x |
| h16   | 1x65536         |  993.0 |      2116.0 |    2.13x |
| h16   | 1x131072        | 1911.0 |      4216.3 |    2.21x |
| h16   | 2x16384         |  581.4 |       619.8 |    1.07x |
| h16   | 6144+2048       |  201.8 |       224.6 |    1.11x |
| h16   | 4x8192          |  571.0 |       400.1 |    0.70x |
| h16   | 8x1024          |  111.2 |        75.7 |    0.68x |
| h16   | 16x2048         |  293.3 |       247.8 |    0.84x |
| h16   | 1024+7168       |  194.0 |       252.4 |    1.30x |
| h16   | 4096+2048+2048  |  202.0 |       169.4 |    0.84x |
| h32   | 1x8192          |  323.7 |       318.2 |    0.98x |
| h32   | 1x32768         | 1097.8 |      1218.0 |    1.11x |
| h32   | 4x8192          |  520.4 |       463.9 |    0.89x |
| h64   | 1x2048          |  178.7 |       113.3 |    0.63x |
| h64   | 1x8192          |  571.5 |       393.7 |    0.69x |
| h64   | 1x32768         | 2065.8 |      1533.4 |    0.74x |
| h64   | 1x131072        | 7794.5 |      6158.8 |    0.79x |
| h64   | 4x8192          |  994.9 |       907.4 |    0.91x |
| h64   | 8x1024          |  304.0 |       260.2 |    0.86x |
| h64   | 16x2048         |  908.9 |       832.4 |    0.92x |
| h96   | 1x8192          |  573.8 |       461.5 |    0.80x |
| h96   | 1x32768         | 2028.1 |      1781.4 |    0.88x |
| h96   | 4x8192          | 1467.9 |      1353.6 |    0.92x |

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cuDNN-backed linear-attention APIs for GDN, GDN-2, GDP, and recurrent KDA operations.
  * Added public GDN-2 and GDP prefill APIs, with backend selection and state handling.
  * Added cuDNN backend support for existing GDN and recurrent KDA operations.
  * Added trace support and fixtures for GDN-2 and GDP operations.

* **Documentation**
  * Added API documentation covering supported operations, hardware, requirements, and constraints.

* **Tests**
  * Added extensive correctness, validation, layout, determinism, and CUDA graph coverage for cuDNN backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->