### PR TITLE
fix(trtllm-gen): write the empty-KV identity for MLA decode rows with seq_lens == 0

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -448,10 +448,13 @@ void trtllm_paged_attention_launcher(
 
   // Only callers that request the LSE merge partial attention states, and only a merge can
   // observe an empty-KV row, so the fixup is skipped (zero cost) on the plain decode path.
-  // Block-sparse attention carries per-head lengths and sparse MLA has no empty-row contract, so
-  // both are left untouched.
-  if (mode == TllmPagedAttentionMode::ForGen && lse != nullptr && seq_lens != nullptr &&
-      !enable_block_sparse_attention && sparse_mla_top_k <= 0) {
+  // Scope: dense MLA decode without attention sinks. A sink contributes to the softmax
+  // denominator, so an empty-KV row with sinks has a finite LSE that must not be overwritten with
+  // -inf. Block-sparse attention carries per-head lengths and sparse MLA has no empty-row
+  // contract, so both are left untouched as well.
+  if (mode == TllmPagedAttentionMode::ForGen && is_mla_decode && lse != nullptr &&
+      seq_lens != nullptr && attention_sinks == nullptr && !enable_block_sparse_attention &&
+      sparse_mla_top_k <= 0) {
     int64_t const out_row_bytes = num_qo_heads * head_dim_vo * get_size_in_bits(o_data_type) / 8;
     int64_t const q_len_per_request = cum_seq_lens_q == nullptr ? sum_seq_q / batch_size : 0;
     launch_fixup_empty_kv_rows(out, out_row_bytes, lse, lse_stride_tokens, lse_stride_heads,

--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -41,6 +41,71 @@ namespace {
 
 constexpr int32_t kDsv4SparseMlaSlidingWindowTopK = 128;
 
+// Empty-KV rows (seqLensKv[b] == 0) are the attention identity: out = 0, lse = -inf, so that a
+// caller merging partial states (decode context parallelism, chunked KV) can ignore them. The
+// generation cubins export lse = -inf for those rows but never write `out`, which leaves stale
+// memory (possibly NaN/Inf) that poisons the merge even with a zero weight. This kernel
+// materializes the identity after the main launch. It is sync-free and CUDA-graph safe: every
+// (row, query token) gets a block that exits immediately unless the row is empty.
+//
+// grid = (max_q_len, batch_size), block = kFixupEmptyKvRowsThreads.
+constexpr int32_t kFixupEmptyKvRowsThreads = 256;
+
+__global__ void FixupEmptyKvRowsKernel(uint8_t* out, int64_t out_row_bytes, float* lse,
+                                       int64_t lse_stride_tokens, int64_t lse_stride_heads,
+                                       int32_t num_heads, int32_t const* seq_lens_kv,
+                                       int32_t const* cum_seq_lens_q, int32_t q_len_per_request) {
+  int32_t const batch_idx = blockIdx.y;
+  if (seq_lens_kv[batch_idx] != 0) {
+    return;
+  }
+  int32_t token_begin, token_end;
+  if (cum_seq_lens_q != nullptr) {
+    token_begin = cum_seq_lens_q[batch_idx];
+    token_end = cum_seq_lens_q[batch_idx + 1];
+  } else {
+    token_begin = batch_idx * q_len_per_request;
+    token_end = token_begin + q_len_per_request;
+  }
+  int32_t const token = token_begin + static_cast<int32_t>(blockIdx.x);
+  if (token >= token_end) {
+    return;
+  }
+  uint8_t* row = out + static_cast<int64_t>(token) * out_row_bytes;
+  if ((reinterpret_cast<uintptr_t>(row) & 15) == 0 && (out_row_bytes & 15) == 0) {
+    uint4* row_vec = reinterpret_cast<uint4*>(row);
+    int64_t const num_vec = out_row_bytes / 16;
+    for (int64_t i = threadIdx.x; i < num_vec; i += blockDim.x) {
+      row_vec[i] = make_uint4(0u, 0u, 0u, 0u);
+    }
+  } else {
+    for (int64_t i = threadIdx.x; i < out_row_bytes; i += blockDim.x) {
+      row[i] = 0;
+    }
+  }
+  if (lse != nullptr) {
+    for (int32_t h = threadIdx.x; h < num_heads; h += blockDim.x) {
+      lse[static_cast<int64_t>(token) * lse_stride_tokens + h * lse_stride_heads] = -INFINITY;
+    }
+  }
+}
+
+void launch_fixup_empty_kv_rows(void* out, int64_t out_row_bytes, float* lse,
+                                int64_t lse_stride_tokens, int64_t lse_stride_heads,
+                                int64_t num_heads, int32_t const* seq_lens_kv,
+                                int32_t const* cum_seq_lens_q, int64_t q_len_per_request,
+                                int64_t max_q_len, int64_t batch_size, cudaStream_t stream) {
+  if (batch_size <= 0 || max_q_len <= 0) {
+    return;
+  }
+  dim3 const grid(static_cast<uint32_t>(max_q_len), static_cast<uint32_t>(batch_size));
+  FixupEmptyKvRowsKernel<<<grid, kFixupEmptyKvRowsThreads, 0, stream>>>(
+      static_cast<uint8_t*>(out), out_row_bytes, lse, lse_stride_tokens, lse_stride_heads,
+      static_cast<int32_t>(num_heads), seq_lens_kv, cum_seq_lens_q,
+      static_cast<int32_t>(q_len_per_request));
+  FLASHINFER_CUDA_CHECK(cudaGetLastError());
+}
+
 __global__ void RemapDsv4SparseMlaIndicesKernel(int32_t const* input, int32_t* output,
                                                 int64_t num_indices, int32_t sparse_mla_top_k,
                                                 int32_t primary_page_size,
@@ -380,6 +445,19 @@ void trtllm_paged_attention_launcher(
   }
 
   fmha_runner->run(runner_params);
+
+  // Only callers that request the LSE merge partial attention states, and only a merge can
+  // observe an empty-KV row, so the fixup is skipped (zero cost) on the plain decode path.
+  // Block-sparse attention carries per-head lengths and sparse MLA has no empty-row contract, so
+  // both are left untouched.
+  if (mode == TllmPagedAttentionMode::ForGen && lse != nullptr && seq_lens != nullptr &&
+      !enable_block_sparse_attention && sparse_mla_top_k <= 0) {
+    int64_t const out_row_bytes = num_qo_heads * head_dim_vo * get_size_in_bits(o_data_type) / 8;
+    int64_t const q_len_per_request = cum_seq_lens_q == nullptr ? sum_seq_q / batch_size : 0;
+    launch_fixup_empty_kv_rows(out, out_row_bytes, lse, lse_stride_tokens, lse_stride_heads,
+                               num_qo_heads, seq_lens, cum_seq_lens_q, q_len_per_request, max_q_len,
+                               batch_size, stream);
+  }
 }
 
 inline Data_type dl_dtype_to_tllm_data_type(const DLDataType dtype) {

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -3046,7 +3046,11 @@ def trtllm_batch_decode_with_kv_cache_mla(
     seq_lens : Optional[torch.Tensor]
         Per-request physical KV sequence lengths for dense and TRTLLM-GEN
         paths. With DCP these are rank-local lengths and continue to control
-        paging, memory bounds, and split-KV. For
+        paging, memory bounds, and split-KV. A request with ``seq_lens == 0``
+        (for example a DCP rank that owns no KV slice of it) is the attention
+        identity: when ``return_lse=True`` the ``trtllm-gen`` and ``cute-dsl``
+        backends write ``out = 0`` and ``lse = -inf`` for its query rows so a
+        downstream merge ignores them. For
         SM120/SM121 sparse v32/GLM, pass ``[batch_size, q_len_per_request]`` or
         flattened ``[batch_size * q_len_per_request]`` active top-k lengths; if
         ``None``, every column in ``block_tables`` is active.
@@ -3131,7 +3135,10 @@ def trtllm_batch_decode_with_kv_cache_mla(
     return_lse : bool = False
         Whether to return LSE values. Supported by ``trtllm-gen``,
         ``cute-dsl``, and ``sparse`` backends. When True, the function
-        returns ``(out, lse)``. With compact variable Q, LSE is currently
+        returns ``(out, lse)``, and rows with ``seq_lens == 0`` are
+        guaranteed to hold the empty-attention identity (``out = 0``,
+        ``lse = -inf``); without the LSE their ``out`` rows are left
+        undefined. With compact variable Q, LSE is currently
         supported only by monolithic CuTeDSL.
     cute_dsl_impl : str = "auto"
         Which cute-dsl implementation to use. Honored when

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -3048,8 +3048,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         paths. With DCP these are rank-local lengths and continue to control
         paging, memory bounds, and split-KV. A request with ``seq_lens == 0``
         (for example a DCP rank that owns no KV slice of it) is the attention
-        identity: when ``return_lse=True`` the ``trtllm-gen`` and ``cute-dsl``
-        backends write ``out = 0`` and ``lse = -inf`` for its query rows so a
+        identity: for dense MLA decode without attention sinks, the
+        ``trtllm-gen`` and ``cute-dsl`` backends write ``out = 0`` and
+        ``lse = -inf`` for its query rows when ``return_lse=True`` so a
         downstream merge ignores them. For
         SM120/SM121 sparse v32/GLM, pass ``[batch_size, q_len_per_request]`` or
         flattened ``[batch_size * q_len_per_request]`` active top-k lengths; if
@@ -3135,10 +3136,12 @@ def trtllm_batch_decode_with_kv_cache_mla(
     return_lse : bool = False
         Whether to return LSE values. Supported by ``trtllm-gen``,
         ``cute-dsl``, and ``sparse`` backends. When True, the function
-        returns ``(out, lse)``, and rows with ``seq_lens == 0`` are
-        guaranteed to hold the empty-attention identity (``out = 0``,
-        ``lse = -inf``); without the LSE their ``out`` rows are left
-        undefined. With compact variable Q, LSE is currently
+        returns ``(out, lse)``. For dense MLA decode without attention
+        sinks on the ``trtllm-gen`` and ``cute-dsl`` backends, rows with
+        ``seq_lens == 0`` then hold the empty-attention identity
+        (``out = 0``, ``lse = -inf``); without the LSE their ``out`` rows
+        are left undefined, and sparse MLA / block-sparse decode make no
+        such guarantee. With compact variable Q, LSE is currently
         supported only by monolithic CuTeDSL.
     cute_dsl_impl : str = "auto"
         Which cute-dsl implementation to use. Honored when

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1714,3 +1714,108 @@ def test_trtllm_batch_decode_mla_use_fp16_softmax(
         uses_shared_paged_kv_idx=True,
         use_fp16_softmax=True,
     )
+
+
+@pytest.mark.parametrize("num_heads", [16, 128])
+@pytest.mark.parametrize("q_len_per_request", [1, 2])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_trtllm_batch_decode_mla_empty_kv_rows_are_neutral(
+    num_heads: int, q_len_per_request: int, dtype: torch.dtype
+):
+    """Rows with ``seq_lens == 0`` must come back as ``out = 0`` / ``lse = -inf``.
+
+    A decode-context-parallel rank that owns no KV slice of a request, or a
+    chunked-KV merge, feeds such rows into ``merge_state``; stale ``out`` memory
+    would poison the merge even with a zero weight.
+    """
+    compute_capability = get_compute_capability(torch.device(device="cuda"))
+    if compute_capability[0] != 10:
+        pytest.skip("TRTLLM-GEN MLA only supports SM100 and SM103 GPUs")
+
+    torch.manual_seed(0)
+    device = "cuda:0"
+    page_size = 64
+    kv_lora_rank = 512
+    qk_nope_head_dim = 128
+    qk_rope_head_dim = 64
+    seq_lens = torch.tensor(
+        [130, 0, 5, 0, 0, 300, 64, 0], dtype=torch.int32, device=device
+    )
+    batch_size = seq_lens.numel()
+    max_seq_len = int(seq_lens.max().item())
+    max_pages_per_seq = (max_seq_len + page_size - 1) // page_size
+    num_pages = batch_size * max_pages_per_seq
+    block_tables = (
+        torch.randperm(num_pages, device=device)
+        .view(batch_size, max_pages_per_seq)
+        .to(torch.int32)
+    )
+    kv_cache = torch.randn(
+        num_pages, 1, page_size, kv_lora_rank + qk_rope_head_dim, device=device
+    ).to(dtype)
+    query = torch.randn(
+        batch_size,
+        q_len_per_request,
+        num_heads,
+        kv_lora_rank + qk_rope_head_dim,
+        device=device,
+    ).to(dtype)
+    workspace = torch.zeros(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+    bmm1_scale = 1.0 / ((qk_nope_head_dim + qk_rope_head_dim) ** 0.5)
+
+    def run(query, block_tables, seq_lens, out=None, lse=None):
+        return flashinfer.decode.trtllm_batch_decode_with_kv_cache_mla(
+            query=query,
+            kv_cache=kv_cache,
+            workspace_buffer=workspace,
+            qk_nope_head_dim=qk_nope_head_dim,
+            kv_lora_rank=kv_lora_rank,
+            qk_rope_head_dim=qk_rope_head_dim,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            max_seq_len=max_seq_len,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=1.0,
+            backend="trtllm-gen",
+            out=out,
+            lse=lse,
+            return_lse=True,
+        )
+
+    # Sentinels: the kernel must overwrite both buffers for the empty rows.
+    out = torch.full(
+        (batch_size, q_len_per_request, num_heads, kv_lora_rank),
+        7.0,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    lse = torch.full(
+        (batch_size * q_len_per_request, num_heads),
+        3.0,
+        dtype=torch.float32,
+        device=device,
+    )
+    out_ret, lse_ret = run(query, block_tables, seq_lens, out=out, lse=lse)
+    assert out_ret is out
+    assert lse_ret is lse
+    torch.cuda.synchronize()
+
+    empty = seq_lens == 0
+    lse_rows = lse.view(batch_size, q_len_per_request, num_heads)
+    assert torch.all(out[empty] == 0), "empty-KV rows must produce out = 0"
+    assert torch.isneginf(lse_rows[empty]).all(), (
+        "empty-KV rows must produce lse = -inf"
+    )
+
+    # Active rows must match the same batch with the empty rows removed.
+    active = torch.nonzero(~empty, as_tuple=False).flatten()
+    out_active, lse_active = run(query[active], block_tables[active], seq_lens[active])
+    torch.testing.assert_close(
+        out[active].float(), out_active.float(), atol=2e-2, rtol=2e-2
+    )
+    torch.testing.assert_close(
+        lse_rows[active],
+        lse_active.view(-1, q_len_per_request, num_heads),
+        atol=2e-2,
+        rtol=2e-2,
+    )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`trtllm_batch_decode_with_kv_cache_mla(backend="trtllm-gen")` leaves the output rows of a request with `seq_lens == 0` untouched. The generation cubin exports `lse = -inf` for such rows but never writes `out`, so the caller sees whatever was in the buffer (`torch.empty` when FlashInfer allocates it). Rows like this are legal and common in decode context parallelism (a rank that owns no KV slice of a request) and in chunked-KV merging: the caller combines rank/chunk partial states with `merge_state`, and a stale `NaN`/`Inf` in `out` poisons the merged result even though its weight is `exp(-inf) = 0`. sglang currently works around it with its own post-launch kernel (`fixup_zero_kv_rows`, sgl-project/sglang#22688, #33881).

This PR materializes the empty-attention identity (`out = 0`, `lse = -inf`) inside the trtllm-gen launcher, right after the generation kernel:

- `csrc/trtllm_fmha_kernel_launcher.cu`: add `FixupEmptyKvRowsKernel`, a tiny kernel with one block per `(request, query token)` that returns immediately unless `seq_lens[b] == 0`, and zeroes that token's `out` row (16-byte stores when aligned) and writes `-inf` to its LSE. It reads `seq_lens` / `cum_seq_lens_q` on the device only, so it is sync-free and CUDA-graph safe (the decode path is graph-replayed by every serving engine).
- Scope: dense MLA decode (`is_mla_decode`) without attention sinks, and only when the caller requests the LSE (`lse != nullptr`), because only a merge can observe an empty row. Plain decode (`return_lse=False`) launches nothing extra, so its cost is unchanged. Generic MHA/GQA decode is not touched: with attention sinks an empty-KV row has a finite LSE (the sink is in the denominator), so the `-inf` identity would be wrong there. Block-sparse attention (per-head `seq_lens`) and sparse MLA are left untouched as well.
- `flashinfer/mla/_core.py`: document the contract on `seq_lens` and `return_lse`, limited to dense MLA decode without sinks on `trtllm-gen` / `cute-dsl`. `cute-dsl` already satisfies it (#4719); this PR brings `trtllm-gen` in line.

The ragged prefill wrapper (`trtllm_ragged_attention_deepseek`) handles the same class of rows by host-side compaction (#3779), which cannot run under CUDA-graph capture (#4703 now skips it there). Extending this device-side fixup to the context kernel so that captured ragged prefill is also well defined is a possible follow-up; not done here to keep the change scoped.

## 🔍 Related Issues

- Follow-up to #3047 / #3779 (the TRTLLM-GEN empty-KV case, decode side).
- Motivated by sgl-project/sglang#33881 (discussion on whether sglang's `fixup_zero_kv` workaround can be removed).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New test `tests/attention/test_trtllm_gen_mla.py::test_trtllm_batch_decode_mla_empty_kv_rows_are_neutral` (bf16 and fp8 KV, 16/128 heads, q_len 1/2): pre-fills `out`/`lse` with sentinels, runs a batch with `seq_lens = [130, 0, 5, 0, 0, 300, 64, 0]`, asserts the empty rows are `0` / `-inf` and the active rows match the same batch with the empty rows removed.

Validation on GB300 (SM103, CUDA 13.0, torch 2.13):

- New test: 8/8 passed (`-k empty_kv_rows`), re-run after narrowing the scope to `is_mla_decode && attention_sinks == nullptr` (8/8, MLA bf16 regression 3168 passed again).
- Existing `test_trtllm_batch_decode_mla` (bf16, trtllm-gen, all parametrizations; the LSE-checking subset asserts finite LSE and an untouched workspace guard): 3168 passed. Other trtllm-gen MLA decode entry points (`q1_mla`, `grouped_mla*`, `non_power_of_two_heads*`, `fixed_q_batch_stride`, `variable_q_lengths`, `multi_ctas*`): 104 passed, 1 skipped.
- Generic (non-MLA) trtllm-gen decode, which the fixup must not touch: full `tests/attention/test_trtllm_gen_attention_decode.py` decode matrix including `enable_sink=True`, `test_trtllm_batch_decode_lse_contract` and the gpt-oss counter test: 62841 passed, 29136 skipped.
- Before/after (this branch with and without the launcher change, same cubins), 128 heads, q_len 1, seq_len 4096, page 64, bf16, CUDA-graph replay of 20 calls, median per call:

| batch | `return_lse=False` before → after | `return_lse=True` before → after |
|---|---|---|
| 8 | 17.8 → 17.7 µs | 19.0 → 22.0 µs |
| 64 | 66.1 → 65.6 µs | 67.8 → 70.2 µs |
| 256 | 261.0 → 259.7 µs | 262.9 → 266.0 µs |

The plain decode path is unchanged; the LSE path pays one extra ~3 µs launch per call, which is what a caller would otherwise spend on its own post-launch fixup (sglang's `fixup_zero_kv_rows` measures about the same).

## Reviewer Notes

- The extra launch is gated on `lse != nullptr`. If you would rather always run it (one ~2 µs launch per attention call on the plain decode path), or gate it on an explicit flag instead, happy to change.
- `out` is assumed contiguous `[sum_seq_q, num_heads, head_dim_o]`, matching what the Python wrapper allocates/validates today; the row byte count is derived from `num_qo_heads * head_dim_vo * bits(o_dtype)`.
- Ideally the cubin itself would write the identity; this is a wrapper-level fix because the kernel is closed source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty key-value rows during MLA decoding now produce neutral attention results (`out = 0`, `LSE = -inf`) when log-sum-exp output is requested.
  - Prevents empty rows from affecting downstream attention result merges.

- **Documentation**
  - Clarified behavior for empty attention rows, including backend-specific guarantees and behavior when LSE output is not requested.

- **Tests**
  - Added coverage for empty-row handling in decode-context-parallel and chunked-KV merge scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->