### PR TITLE
feat(attention): FA3 kernels for a 16-bit query with an FP8 KV cache

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -227,15 +227,15 @@ def gen_fa3(
     use_sliding_window: bool,
     use_logits_soft_cap: bool,
 ) -> Iterator[JitSpec]:
-    if dtype_q != dtype_kv:
-        return  # fa3 template do not support mixed precision
+    if dtype_q != dtype_kv and not (dtype_q.itemsize == 2 and dtype_kv.itemsize == 1):
+        return  # fa3 supports mixed precision only as a 16-bit query with an fp8 KV cache
     if dtype_q.itemsize == 2:
         if dtype_q != dtype_o:
-            return  # for fp16, dtype_o must be the same as dtype_q/dtype_kv
+            return  # for fp16, dtype_o must be the same as dtype_q
 
-    if dtype_kv.itemsize == 1:
+    if dtype_q.itemsize == 1:
         if head_dim_qk == 192 or head_dim_qk == 64:
-            return  # (192, 128) & (64, 64) not supported for fp8 yet.
+            return  # (192, 128) & (64, 64) not supported for fp8 query yet.
 
     yield gen_batch_prefill_module(
         backend="fa3",
@@ -345,6 +345,29 @@ def gen_attention(
                 dtype_q=dtype_qkv,
                 dtype_kv=dtype_qkv,
                 dtype_o=dtype_o,
+                head_dim_qk=head_dim_qk,
+                head_dim_vo=head_dim_vo,
+                use_sliding_window=use_sliding_window,
+                use_logits_soft_cap=use_logits_soft_cap,
+            )
+        # FA3 with a 16-bit query and an fp8 KV cache (K/V dequantized in the kernel)
+        for (
+            (head_dim_qk, head_dim_vo),
+            dtype_qo,
+            dtype_kv,
+            use_sliding_window,
+            use_logits_soft_cap,
+        ) in product(
+            fa3_head_dim_,
+            f16_dtype_,
+            f8_dtype_,
+            use_sliding_window_,
+            use_logits_soft_cap_,
+        ):
+            yield from gen_fa3(
+                dtype_q=dtype_qo,
+                dtype_kv=dtype_kv,
+                dtype_o=dtype_qo,
                 head_dim_qk=head_dim_qk,
                 head_dim_vo=head_dim_vo,
                 use_sliding_window=use_sliding_window,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -1206,10 +1206,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 module = self._jit_module
             else:
                 if backend == "auto":
-                    if {
-                        torch.float8_e4m3fn,
-                        torch.float8_e5m2,
-                    } & {q_data_type, kv_data_type}:
+                    # Decode tiles are far shorter than the fa3 query tile, so the
+                    # fa2 tensor-core kernel is the faster choice whenever it
+                    # supports the dtypes; only an FP8 query needs fa3.
+                    if q_data_type in {torch.float8_e4m3fn, torch.float8_e5m2}:
                         backend = determine_attention_backend(
                             self.device,
                             PosEncodingMode[pos_encoding_mode].value,
@@ -1821,10 +1821,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 self._cached_module = self._jit_module
             else:
                 if self._backend == "auto":
-                    if {
-                        torch.float8_e4m3fn,
-                        torch.float8_e5m2,
-                    } & {q_data_type, kv_data_type}:
+                    # See workspace_size(): fa2 is the faster tensor-core decode
+                    # kernel unless the query itself is FP8.
+                    if q_data_type in {torch.float8_e4m3fn, torch.float8_e5m2}:
                         self._backend = determine_attention_backend(
                             self.device,
                             PosEncodingMode[pos_encoding_mode].value,

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -468,10 +468,13 @@ def is_fa3_backend_supported(
         return False
     if use_fp16_qk_reductions:
         return False
-    # FA3 FP8 KV cache currently requires FP8 query.
+    # FA3 supports an FP8 KV cache with either an FP8 query (FP8 tensor cores) or a
+    # 16-bit query (K/V dequantized to the query dtype in the kernel).
     if dtype_kv in {torch.float8_e4m3fn, torch.float8_e5m2} and dtype_q not in {
         torch.float8_e4m3fn,
         torch.float8_e5m2,
+        torch.float16,
+        torch.bfloat16,
     }:
         return False
     # FA3 does not support NVFP4 KV cache (uint8 packed FP4).

--- a/include/flashinfer/attention/hopper/dequant_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/dequant_mainloop.cuh
@@ -67,8 +67,10 @@ struct StagingPipelinesFor<CollectiveMainloop, true> {
 
 // Exact FP8 -> 16-bit conversion of 16 packed elements (four 32-bit words holding four FP8
 // values each). Every finite FP8 value is representable in both fp16 and bf16, so all variants
-// produce the same values as vec_cast (and hence the FA2 mixed-precision kernels); the bit
-// tricks are the ones from fast_dequant_f8f16x4 with the byte placement folded into one PRMT.
+// produce the same values as vec_cast (and hence the FA2 mixed-precision kernels) and use the
+// same per-path instructions on sm_90 (hardware cvt for e4m3 -> fp16, byte placement for
+// e5m2 -> fp16, the fast_dequant_f8f16x4 bit trick for bf16 with the byte placement folded into
+// one PRMT); non-finite codes therefore also match vec_cast path by path.
 template <typename DTypeKV, typename DTypeKVMma>
 struct Fp8x16Dequantizer {
   static constexpr bool kE5M2 = std::is_same_v<DTypeKV, cutlass::float_e5m2_t>;
@@ -471,6 +473,9 @@ struct DequantCollectiveMainloop {
     return num_kv_tiles;
   }
 
+  // The multi-item-scoring arguments only exist so that the kernel can call every FP8-KV
+  // mainloop the same way; dense K/V has no multi-item-scoring mode. TMA zero-fills the rows
+  // past kv_len of a partial tile, so maybe_partial is not needed either.
   template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
             typename SharedStorage>
   CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
@@ -480,8 +485,8 @@ struct DequantCollectiveMainloop {
                            typename Scheduler::Params const& scheduler_params,
                            typename Scheduler::WorkTileInfo& work_tile_info,
                            BlockCoord const& block_coord, int work_idx,
-                           const int num_kv_tiles_outside_items_window = 0,
-                           const int num_kv_tiles_prefix = 0) {
+                           const int /*num_kv_tiles_outside_items_window*/ = 0,
+                           const int /*num_kv_tiles_prefix*/ = 0) {
     const int thread_idx = threadIdx.x;
     Tensor sQ = make_tensor(make_smem_ptr(shared_storage.smem_q.data()), SmemLayoutQ{});
     Tensor sK =
@@ -578,7 +583,11 @@ struct DequantCollectiveMainloop {
 };
 
 // Paged K/V: the staging buffers are filled by a cp.async gather through the page table, issued
-// by all producer threads. The gather mirrors SparseCollectiveMainloop (sparse_mainloop.cuh).
+// by all producer threads. The gather mirrors SparseCollectiveMainloop (sparse_mainloop.cuh),
+// except that the page-table offsets are recomputed for K and V (they are staged at different
+// times) and that the last V tile staged is V(first_tile) rather than V(0). With a sliding
+// window both are fully masked, so either choice is correct; the former keeps the schedule
+// uniform.
 template <typename AdditionalParams, typename Ktraits, bool CAUSAL, bool MULTIITEMSCORING = false>
 struct SparseDequantCollectiveMainloop {
   using DTypeQ = typename Ktraits::DTypeQ;
@@ -824,6 +833,8 @@ struct SparseDequantCollectiveMainloop {
     constexpr int THREADS_PER_GROUP = NUM_COPY_THREADS / NUM_GROUPS;
     constexpr int NUM_ITERS_PER_GROUP = NUM_KV_PER_ITER;
     static_assert(NUM_ITERS_PER_GROUP <= THREADS_PER_GROUP);
+    // The page offsets are exchanged with __shfl_sync, so a group must stay inside one warp.
+    static_assert(THREADS_PER_GROUP <= cutlass::NumThreadsPerWarp);
 
     const int group_id = thread_idx / THREADS_PER_GROUP;
     const int thread_in_group = thread_idx % THREADS_PER_GROUP;

--- a/include/flashinfer/attention/hopper/dequant_mainloop.cuh
+++ b/include/flashinfer/attention/hopper/dequant_mainloop.cuh
@@ -1,0 +1,927 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FLASHINFER_ATTENTION_HOPPER_DEQUANT_MAINLOOP_CUH_
+#define FLASHINFER_ATTENTION_HOPPER_DEQUANT_MAINLOOP_CUH_
+
+// Producer-side mainloops for a 16-bit query attending to an FP8 KV cache.
+//
+// The MMA warpgroups run the unmodified 16-bit consumer (mainloop_mma.cuh): they wait on the
+// 16-bit K/V pipelines and read smem_k / smem_v exactly as for a 16-bit KV cache. The producer
+// warpgroup fills those buffers in two steps:
+//
+//   1. K/V tiles are loaded as FP8 into small staging buffers (TMA for dense K/V, cp.async gather
+//      for paged K/V), gated by the staging pipelines.
+//   2. All 128 producer threads dequantize a staged tile into the 16-bit swizzled K/V layout
+//      (exact conversion, the same values the FA2 mixed-precision kernel computes), publish it
+//      on the 16-bit pipeline and release the staging stage.
+//
+// Because the staging buffers are separate from smem_k / smem_v, staging loads run ahead of the
+// dequantization by NUM_STAGES_KV_STAGING tiles, and the V loads no longer wait for the epilogue
+// (only the 16-bit V writes do, since smem_v aliases smem_o).
+
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+
+#include <type_traits>
+
+#include "../../fastdiv.cuh"
+#include "cute/tensor.hpp"
+#include "cutlass/gemm/collective/collective_builder.hpp"
+#include "cutlass/pipeline/pipeline.hpp"
+#include "named_barrier.cuh"
+#include "utils.cuh"
+
+namespace flashinfer {
+
+using namespace cute;
+
+// Empty stand-in for the staging pipelines of the 16-bit KV mainloops, so that the kernel can
+// declare the staging state unconditionally.
+struct NoStagingPipelines {
+  template <typename SharedStorage>
+  CUTLASS_DEVICE NoStagingPipelines(SharedStorage&, int) {}
+};
+
+template <typename CollectiveMainloop, bool KV_DEQUANT>
+struct StagingPipelinesFor {
+  using type = NoStagingPipelines;
+};
+template <typename CollectiveMainloop>
+struct StagingPipelinesFor<CollectiveMainloop, true> {
+  using type = typename CollectiveMainloop::StagingPipelines;
+};
+
+// Exact FP8 -> 16-bit conversion of 16 packed elements (four 32-bit words holding four FP8
+// values each). Every finite FP8 value is representable in both fp16 and bf16, so all variants
+// produce the same values as vec_cast (and hence the FA2 mixed-precision kernels); the bit
+// tricks are the ones from fast_dequant_f8f16x4 with the byte placement folded into one PRMT.
+template <typename DTypeKV, typename DTypeKVMma>
+struct Fp8x16Dequantizer {
+  static constexpr bool kE5M2 = std::is_same_v<DTypeKV, cutlass::float_e5m2_t>;
+  static constexpr bool kHalf = std::is_same_v<DTypeKVMma, cutlass::half_t>;
+  static_assert(kE5M2 || std::is_same_v<DTypeKV, cutlass::float_e4m3_t>);
+  static_assert(kHalf || std::is_same_v<DTypeKVMma, cutlass::bfloat16_t>);
+
+  // Elements keep their order: out[2*i] holds elements 0 and 1 of in[i] (low and high half),
+  // out[2*i+1] holds elements 2 and 3.
+  CUTLASS_DEVICE static void convert(const uint32_t (&in)[4], uint32_t (&out)[8]) {
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      const uint32_t q = in[i];
+      if constexpr (kE5M2 && kHalf) {
+        // e5m2 is the top byte of an fp16: place the bytes and zero the low bytes.
+        out[2 * i] = __byte_perm(q, 0, 0x1404);
+        out[2 * i + 1] = __byte_perm(q, 0, 0x3424);
+      } else if constexpr (!kE5M2 && kHalf) {
+        // Hardware e4m3x2 -> f16x2 conversion (sm_89+); the low byte lands in the low half.
+        asm("cvt.rn.f16x2.e4m3x2 %0, %1;"
+            : "=r"(out[2 * i])
+            : "h"(static_cast<uint16_t>(q & 0xFFFFu)));
+        asm("cvt.rn.f16x2.e4m3x2 %0, %1;"
+            : "=r"(out[2 * i + 1])
+            : "h"(static_cast<uint16_t>(q >> 16)));
+      } else {
+        // bf16 target: keep the sign, move the 7 exponent/mantissa bits of the FP8 value
+        // (at bits [14:8] after the byte placement) down to the bf16 exponent/mantissa fields
+        // and fix up the exponent bias with one multiply, which also handles subnormals.
+        constexpr int FP8_EXPONENT = kE5M2 ? 5 : 4;
+        constexpr int BIAS_OFFSET = (1 << (8 - 1)) - (1 << (FP8_EXPONENT - 1));
+        constexpr uint32_t BIAS_BITS = static_cast<uint32_t>(BIAS_OFFSET + 127)
+                                       << 7;  // bf16 2^BIAS
+        constexpr uint32_t BIAS2 = BIAS_BITS | (BIAS_BITS << 16);
+        constexpr int SHIFT = 8 - FP8_EXPONENT;
+        constexpr uint32_t PAYLOAD = (0x7F00u >> SHIFT) * 0x10001u;
+        const uint32_t x01 = __byte_perm(q, 0, 0x1404);  // bytes 0, 1 -> high bytes of the halves
+        const uint32_t x23 = __byte_perm(q, 0, 0x3424);  // bytes 2, 3
+        const uint32_t y01 = (x01 & 0x80008000u) | ((x01 >> SHIFT) & PAYLOAD);
+        const uint32_t y23 = (x23 & 0x80008000u) | ((x23 >> SHIFT) & PAYLOAD);
+        asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(out[2 * i]) : "r"(y01), "r"(BIAS2));
+        asm("mul.rn.bf16x2 %0, %1, %2;" : "=r"(out[2 * i + 1]) : "r"(y23), "r"(BIAS2));
+      }
+    }
+  }
+};
+
+// The part of the producer schedule shared by the dense and paged FP8-KV mainloops: the
+// dequantization of staged tiles and the order in which tiles are staged and published.
+template <typename Ktraits>
+struct DequantKVSchedule {
+  using DTypeKV = typename Ktraits::DTypeKV;
+  using DTypeKVMma = typename Ktraits::DTypeKVMma;
+  using MainloopPipeline = typename Ktraits::MainloopPipeline;
+  using PipelineState = typename Ktraits::PipelineState;
+  using StagingPipeline = typename Ktraits::StagingPipeline;
+  using StagingPipelineState = typename Ktraits::StagingPipelineState;
+  using SmemLayoutK = typename Ktraits::SmemLayoutK;
+  using SmemLayoutV = typename Ktraits::SmemLayoutV;
+  using SmemLayoutKStaging = typename Ktraits::SmemLayoutKStaging;
+  using SmemLayoutVStaging = typename Ktraits::SmemLayoutVStaging;
+
+  static constexpr int NUM_STAGES_KV_STAGING = Ktraits::NUM_STAGES_KV_STAGING;
+  static constexpr int NUM_MMA_THREADS = Ktraits::NUM_MMA_THREADS;
+  static constexpr int NUM_PRODUCER_THREADS = Ktraits::NUM_PRODUCER_THREADS;
+  static constexpr int HEAD_DIM_QK = Ktraits::HEAD_DIM_QK;
+  static constexpr int HEAD_DIM_VO = Ktraits::HEAD_DIM_VO;
+  static constexpr int CTA_KV = Ktraits::CTA_KV;
+  // 16 FP8 elements per 16-byte vector: one shared-memory load, one conversion, two 16-byte
+  // stores (the 16-bit swizzle permutes 16-byte chunks, so the two halves are stored separately).
+  static constexpr int VEC = 16;
+  static_assert(NUM_PRODUCER_THREADS == cutlass::NumThreadsPerWarpGroup,
+                "the whole producer warpgroup dequantizes");
+
+  CUTLASS_DEVICE static uint32_t smem_addr(void const* ptr) {
+    return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
+  }
+  CUTLASS_DEVICE static void lds128(uint32_t addr, uint32_t (&v)[4]) {
+    asm volatile("ld.shared.v4.b32 {%0, %1, %2, %3}, [%4];"
+                 : "=r"(v[0]), "=r"(v[1]), "=r"(v[2]), "=r"(v[3])
+                 : "r"(addr));
+  }
+  CUTLASS_DEVICE static void sts128(uint32_t addr, uint32_t v0, uint32_t v1, uint32_t v2,
+                                    uint32_t v3) {
+    asm volatile("st.shared.v4.b32 [%0], {%1, %2, %3, %4};"
+                 :
+                 : "r"(addr), "r"(v0), "r"(v1), "r"(v2), "r"(v3));
+  }
+
+  // Dequantizes one (CTA_KV, HEAD_DIM) tile from the 8-bit staging layout into the 16-bit
+  // swizzled K/V layout.
+  //
+  // Thread mapping: consecutive threads take consecutive rows of the same 16-byte column, so
+  // the 8 threads of a quarter warp hit 8 different rows of a swizzle atom, i.e. 8 different
+  // 16-byte bank groups, for both the 8-bit loads and the 16-bit stores. Each thread then
+  // walks its column in steps of ROWS_PER_PASS rows. Both layouts stack 8-row swizzle atoms
+  // along the row mode and ROWS_PER_PASS is a multiple of 8, so a step is a constant byte
+  // offset that leaves the XOR pattern unchanged: the swizzled addresses are resolved once per
+  // tile and the passes use immediate offsets. ROWS_PER_PASS is the largest multiple of 8 whose
+  // pass fits in the warpgroup; head_dim 64 / 128 / 256 use all 128 threads, head_dim 192 uses
+  // 96 (12 columns of 8 rows).
+  template <int HEAD_DIM, typename TensorSrc, typename TensorDst>
+  CUTLASS_DEVICE static void convert_tile(TensorSrc& sSrc, TensorDst& sDst, int src_stage,
+                                          int dst_stage, int thread_idx) {
+    constexpr int THREADS_PER_ROW = HEAD_DIM / VEC;
+    constexpr int ROWS_PER_PASS = (NUM_PRODUCER_THREADS / THREADS_PER_ROW) / 8 * 8;
+    constexpr int ACTIVE_THREADS = ROWS_PER_PASS * THREADS_PER_ROW;
+    constexpr int NUM_PASSES = CTA_KV / ROWS_PER_PASS;
+    static_assert(HEAD_DIM % VEC == 0 && ROWS_PER_PASS >= 8);
+    static_assert(ACTIVE_THREADS <= NUM_PRODUCER_THREADS && CTA_KV % ROWS_PER_PASS == 0);
+    if constexpr (ACTIVE_THREADS < NUM_PRODUCER_THREADS) {
+      if (thread_idx >= ACTIVE_THREADS) {
+        return;
+      }
+    }
+    const int row = thread_idx % ROWS_PER_PASS;
+    const int col = (thread_idx / ROWS_PER_PASS) * VEC;
+    const uint32_t src = smem_addr(&sSrc(row, col, src_stage));
+    const uint32_t dst_lo = smem_addr(&sDst(row, col, dst_stage));
+    const uint32_t dst_hi = smem_addr(&sDst(row, col + VEC / 2, dst_stage));
+    const uint32_t src_step = smem_addr(&sSrc(row + ROWS_PER_PASS, col, src_stage)) - src;
+    const uint32_t dst_step = smem_addr(&sDst(row + ROWS_PER_PASS, col, dst_stage)) - dst_lo;
+
+    // Software pipelined in groups of up to four passes: issue the loads of a group, then
+    // convert and store. NUM_PASSES is 3..8 for the supported tiles.
+    constexpr int GROUP = NUM_PASSES % 4 == 0 ? 4 : (NUM_PASSES % 3 == 0 ? 3 : 2);
+    static_assert(NUM_PASSES % GROUP == 0);
+#pragma unroll
+    for (int g = 0; g < NUM_PASSES; g += GROUP) {
+      uint32_t in[GROUP][4];
+#pragma unroll
+      for (int i = 0; i < GROUP; ++i) {
+        lds128(src + (g + i) * src_step, in[i]);
+      }
+#pragma unroll
+      for (int i = 0; i < GROUP; ++i) {
+        uint32_t out[8];
+        Fp8x16Dequantizer<DTypeKV, DTypeKVMma>::convert(in[i], out);
+        const uint32_t off = (g + i) * dst_step;
+        sts128(dst_lo + off, out[0], out[1], out[2], out[3]);
+        sts128(dst_hi + off, out[4], out[5], out[6], out[7]);
+      }
+    }
+  }
+
+  // Waits for the next staged tile, dequantizes it into the next 16-bit stage and publishes it.
+  template <int HEAD_DIM, typename TensorSrc, typename TensorDst>
+  CUTLASS_DEVICE static void convert(TensorSrc& sSrc, TensorDst& sDst, StagingPipeline& staging,
+                                     StagingPipelineState& staging_read, MainloopPipeline& pipeline,
+                                     PipelineState& write, int thread_idx) {
+    staging.consumer_wait(staging_read);
+    pipeline.producer_acquire(write);
+    convert_tile<HEAD_DIM>(sSrc, sDst, staging_read.index(), write.index(), thread_idx);
+    // The 16-bit tile is written by the generic proxy and read by the GMMAs (async proxy).
+    cutlass::arch::fence_view_async_shared();
+    pipeline.producer_commit(write);
+    staging.consumer_release(staging_read);
+    ++staging_read;
+    ++write;
+  }
+
+  // Runs the producer schedule for one work tile. Tiles are visited from last_tile down to
+  // first_tile through next_tile(), and published in the order the consumer waits for them:
+  // K(last), K(last-1), V(last), K(last-2), V(last-1), ..., K(first), V(first+1), V(first).
+  // Each staging ring is kept NUM_STAGES_KV_STAGING tiles ahead of the dequantization: a tile is
+  // staged as soon as the stage that the previous occupant released becomes free.
+  //
+  // issue_k / issue_v stage one tile (tile index, whether the tile may be partial), issue_q loads
+  // Q, and all of them advance their pipeline state on every thread.
+  template <typename SharedStorage, typename StagingPipelines, typename IssueQ, typename IssueK,
+            typename IssueV, typename NextTile>
+  CUTLASS_DEVICE static void run(SharedStorage& shared_storage, StagingPipelines& staging,
+                                 MainloopPipeline& pipeline_k, MainloopPipeline& pipeline_v,
+                                 PipelineState& smem_pipe_write_k, PipelineState& smem_pipe_write_v,
+                                 int thread_idx, int work_idx, int last_tile, int first_tile,
+                                 IssueQ&& issue_q, IssueK&& issue_k, IssueV&& issue_v,
+                                 NextTile&& next_tile) {
+    Tensor sKStaging =
+        make_tensor(make_smem_ptr(shared_storage.smem_k_staging.data()), SmemLayoutKStaging{});
+    Tensor sVStaging =
+        make_tensor(make_smem_ptr(shared_storage.smem_v_staging.data()), SmemLayoutVStaging{});
+    Tensor sK = make_tensor(make_smem_ptr(shared_storage.smem_k.data()), SmemLayoutK{});
+    Tensor sV = make_tensor(make_smem_ptr(shared_storage.smem_v.data()), SmemLayoutV{});
+
+    int k_cursor = last_tile, v_cursor = last_tile;
+    auto stage_next_k = [&] {
+      if (k_cursor >= first_tile) {
+        issue_k(k_cursor, /*maybe_partial=*/k_cursor == last_tile);
+        k_cursor = next_tile(k_cursor);
+      }
+    };
+    auto stage_next_v = [&] {
+      if (v_cursor >= first_tile) {
+        issue_v(v_cursor, /*maybe_partial=*/v_cursor == last_tile);
+        v_cursor = next_tile(v_cursor);
+      }
+    };
+    auto convert_k = [&] {
+      convert<HEAD_DIM_QK>(sKStaging, sK, staging.k, staging.read_k, pipeline_k, smem_pipe_write_k,
+                           thread_idx);
+    };
+    auto convert_v = [&] {
+      convert<HEAD_DIM_VO>(sVStaging, sV, staging.v, staging.read_v, pipeline_v, smem_pipe_write_v,
+                           thread_idx);
+    };
+
+#pragma unroll
+    for (int i = 0; i < NUM_STAGES_KV_STAGING; ++i) {
+      stage_next_k();
+    }
+
+    // Wait for the MMA warpgroups to say that smem_q is ready.
+    cutlass::arch::NamedBarrier::sync(NUM_MMA_THREADS + NUM_PRODUCER_THREADS,
+                                      static_cast<int>(NamedBarriers::kQueryEmpty));
+    issue_q();
+
+    // The staging buffers do not alias smem_o, so V can be staged before the epilogue of the
+    // previous work tile has drained.
+#pragma unroll
+    for (int i = 0; i < NUM_STAGES_KV_STAGING; ++i) {
+      stage_next_v();
+    }
+
+    convert_k();
+    stage_next_k();
+
+    // smem_v aliases smem_o: wait until the MMA warpgroups have written O of the previous work
+    // tile before dequantizing V into it. See mainloop.cuh for why this is a cluster barrier.
+    shared_storage.barrier_O.wait((work_idx + 1) % 2);
+
+#pragma unroll 1
+    for (int tile = last_tile;; tile = next_tile(tile)) {
+      const int tile_next = next_tile(tile);
+      if (tile_next >= first_tile) {
+        convert_k();
+        stage_next_k();
+      }
+      convert_v();
+      stage_next_v();
+      if (tile_next < first_tile) {
+        break;
+      }
+    }
+  }
+};
+
+// Dense (ragged or single) K/V: the staging buffers are filled by TMA, issued by one thread.
+template <typename AdditionalParams, typename Ktraits, bool CAUSAL>
+struct DequantCollectiveMainloop {
+  using DTypeQ = typename Ktraits::DTypeQ;
+  using DTypeKV = typename Ktraits::DTypeKV;
+  using TileShape_QKD = typename Ktraits::TileShape_QKD;
+  using TileShape_PDV = typename Ktraits::TileShape_PDV;
+  static constexpr int CTA_Q = get<0>(TileShape_QKD{});
+  static constexpr int CTA_KV = get<1>(TileShape_QKD{});
+
+  static constexpr int NUM_STAGES = Ktraits::NUM_STAGES;
+  static constexpr int NUM_STAGES_KV_STAGING = Ktraits::NUM_STAGES_KV_STAGING;
+  static constexpr int NUM_MMA_THREADS = Ktraits::NUM_MMA_THREADS;
+  static constexpr int NUM_PRODUCER_THREADS = Ktraits::NUM_PRODUCER_THREADS;
+  static constexpr int HEAD_DIM_QK = Ktraits::HEAD_DIM_QK;
+  static constexpr int HEAD_DIM_VO = Ktraits::HEAD_DIM_VO;
+  static_assert(Ktraits::KV_DEQUANT && Ktraits::USE_TMA_LOAD_KV_STAGING);
+
+  using GmemTiledCopyQ = cute::SM90_TMA_LOAD;
+  using GmemTiledCopyKV = cute::SM90_TMA_LOAD;
+
+  using SmemLayoutQ = typename Ktraits::SmemLayoutQ;
+  using SmemLayoutKStaging = typename Ktraits::SmemLayoutKStaging;
+  using SmemLayoutVStaging = typename Ktraits::SmemLayoutVStaging;
+
+  using ShapeT = cute::Shape<int32_t, int32_t, int32_t>;
+  using StrideT = cute::Shape<int64_t, _1, int64_t>;  // (N, D, H)
+  using LayoutT = cute::Layout<ShapeT, StrideT>;
+
+  using TMA_Q = decltype(make_tma_copy(
+      GmemTiledCopyQ{},
+      make_tensor(make_gmem_ptr(static_cast<DTypeQ const*>(nullptr)),
+                  repeat_like(StrideT{}, int32_t(0)), StrideT{}),
+      SmemLayoutQ{}, select<0, 2>(TileShape_QKD{}), _1{}));  // no mcast for Q
+
+  using TMA_K = decltype(make_tma_copy(
+      GmemTiledCopyKV{},
+      make_tensor(make_gmem_ptr(static_cast<DTypeKV const*>(nullptr)),
+                  repeat_like(StrideT{}, int32_t(0)), StrideT{}),
+      take<0, 2>(SmemLayoutKStaging{}), select<1, 2>(TileShape_QKD{}), _1{}));  // no mcast
+
+  using TMA_V = decltype(make_tma_copy(
+      GmemTiledCopyKV{},
+      make_tensor(make_gmem_ptr(static_cast<DTypeKV const*>(nullptr)),
+                  repeat_like(StrideT{}, int32_t(0)), StrideT{}),
+      take<0, 2>(SmemLayoutVStaging{}), select<2, 1>(TileShape_PDV{}), _1{}));  // no mcast
+
+  // The 16-bit K/V pipelines are signaled by the producer threads, not by the TMA unit.
+  static constexpr bool USE_TMA_LOAD_KV = false;
+  static constexpr bool KV_DEQUANT = true;
+  using MainloopPipeline = typename Ktraits::MainloopPipeline;
+  using PipelineParams = typename MainloopPipeline::Params;
+  using PipelineState = typename MainloopPipeline::PipelineState;
+  using StagingPipeline = typename Ktraits::StagingPipeline;
+  using StagingPipelineState = typename Ktraits::StagingPipelineState;
+
+  static constexpr uint32_t TmaTransactionBytesQ =
+      static_cast<uint32_t>(size(SmemLayoutQ{}) * cutlass::sizeof_bits_v<DTypeQ> / 8);
+  static constexpr uint32_t TmaTransactionBytesKStaging = static_cast<uint32_t>(
+      size(take<0, 2>(SmemLayoutKStaging{})) * cutlass::sizeof_bits_v<DTypeKV> / 8);
+  static constexpr uint32_t TmaTransactionBytesVStaging = static_cast<uint32_t>(
+      size(take<0, 2>(SmemLayoutVStaging{})) * cutlass::sizeof_bits_v<DTypeKV> / 8);
+
+  // Same heuristic as the 16-bit mainloops (the GEMMs run in DTypeQ).
+  static constexpr bool UseSchedulerBarrier = HEAD_DIM_VO <= 128;
+  using WarpScheduler = WarpScheduler<Ktraits, UseSchedulerBarrier>;
+
+  // Staging pipelines and their states; constructed by the producer warpgroup, which is both the
+  // producer (the TMA-issuing thread) and the consumer (all 128 dequantizing threads).
+  struct StagingPipelines {
+    StagingPipeline k, v;
+    StagingPipelineState write_k, read_k, write_v, read_v;
+
+    template <typename SharedStorage>
+    CUTLASS_DEVICE StagingPipelines(SharedStorage& shared_storage, int warp_group_thread_idx)
+        : k(shared_storage.pipeline_k_staging,
+            make_params(warp_group_thread_idx, TmaTransactionBytesKStaging),
+            /*cluster_shape=*/Shape<_1, _1, _1>{}),
+          v(shared_storage.pipeline_v_staging,
+            make_params(warp_group_thread_idx, TmaTransactionBytesVStaging),
+            /*cluster_shape=*/Shape<_1, _1, _1>{}),
+          write_k(cutlass::make_producer_start_state<StagingPipeline>()),
+          write_v(cutlass::make_producer_start_state<StagingPipeline>()) {}
+
+    CUTLASS_DEVICE static typename StagingPipeline::Params make_params(int warp_group_thread_idx,
+                                                                       uint32_t transaction_bytes) {
+      typename StagingPipeline::Params params;
+      params.role = StagingPipeline::ThreadCategory::ProducerConsumer;
+      params.is_leader = warp_group_thread_idx == 0;
+      params.num_consumers = NUM_PRODUCER_THREADS;
+      params.transaction_bytes = transaction_bytes;
+      return params;
+    }
+  };
+
+  // Host side kernel arguments
+  struct Arguments {
+    DTypeQ const* Q_ptr;
+    LayoutT layout_Q;
+    DTypeKV const* K_ptr;
+    LayoutT layout_K;
+    DTypeKV const* V_ptr;
+    LayoutT layout_V;
+    int window_left;
+    AdditionalParams additional_params;
+  };
+
+  // Device side kernel params
+  struct Params {
+    LayoutT layout_Q;
+    LayoutT layout_K;
+    LayoutT layout_V;
+    TMA_Q tma_load_Q;
+    TMA_K tma_load_K;
+    TMA_V tma_load_V;
+    int window_left;
+    AdditionalParams additional_params;
+  };
+
+  static Params to_underlying_arguments(Arguments const& args) {
+    Tensor mQ = make_tensor(make_gmem_ptr(args.Q_ptr), args.layout_Q);
+    TMA_Q tma_load_Q = make_tma_copy(GmemTiledCopyQ{}, mQ, SmemLayoutQ{},
+                                     select<0, 2>(TileShape_QKD{}), _1{});  // no mcast for Q
+    Tensor mK = make_tensor(make_gmem_ptr(args.K_ptr), args.layout_K);
+    TMA_K tma_load_K = make_tma_copy(GmemTiledCopyKV{}, mK, SmemLayoutKStaging{}(_, _, _0{}),
+                                     select<1, 2>(TileShape_QKD{}), _1{});  // no mcast
+    Tensor mV = make_tensor(make_gmem_ptr(args.V_ptr), args.layout_V);
+    TMA_V tma_load_V = make_tma_copy(GmemTiledCopyKV{}, mV, SmemLayoutVStaging{}(_, _, _0{}),
+                                     select<2, 1>(TileShape_PDV{}), _1{});  // no mcast
+    return {args.layout_Q, args.layout_K, args.layout_V,    tma_load_Q,
+            tma_load_K,    tma_load_V,    args.window_left, args.additional_params};
+  }
+
+  /// Issue Tma Descriptor Prefetch -- ideally from a single thread for best performance
+  CUTLASS_DEVICE
+  static void prefetch_tma_descriptors(Params const& mainloop_params) {
+    cute::prefetch_tma_descriptor(mainloop_params.tma_load_Q.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(mainloop_params.tma_load_K.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(mainloop_params.tma_load_V.get_tma_descriptor());
+  }
+
+  CUTLASS_DEVICE
+  int get_num_kv_tiles(Params const& mainloop_params, int q_tile_idx, const int qo_len,
+                       const int kv_len) {
+    // Function-local copies: cute::ceil_div takes references, and ODR-using the class-scope
+    // constants from device code trips nvcc.
+    static constexpr int CTA_Q = get<0>(TileShape_QKD{});
+    static constexpr int CTA_KV = get<1>(TileShape_QKD{});
+    int num_kv_tiles = cute::ceil_div(kv_len, CTA_KV);
+    if constexpr (CAUSAL) {
+      num_kv_tiles = std::min(num_kv_tiles,
+                              cute::ceil_div((q_tile_idx + 1) * CTA_Q + kv_len - qo_len, CTA_KV));
+    }
+    return num_kv_tiles;
+  }
+
+  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
+            typename SharedStorage>
+  CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
+                           MainloopPipeline pipeline_v, PipelineState& smem_pipe_write_k,
+                           PipelineState& smem_pipe_write_v, StagingPipelines& staging,
+                           SharedStorage& shared_storage, Scheduler& scheduler,
+                           typename Scheduler::Params const& scheduler_params,
+                           typename Scheduler::WorkTileInfo& work_tile_info,
+                           BlockCoord const& block_coord, int work_idx,
+                           const int num_kv_tiles_outside_items_window = 0,
+                           const int num_kv_tiles_prefix = 0) {
+    const int thread_idx = threadIdx.x;
+    Tensor sQ = make_tensor(make_smem_ptr(shared_storage.smem_q.data()), SmemLayoutQ{});
+    Tensor sK =
+        make_tensor(make_smem_ptr(shared_storage.smem_k_staging.data()), SmemLayoutKStaging{});
+    Tensor sV =
+        make_tensor(make_smem_ptr(shared_storage.smem_v_staging.data()), SmemLayoutVStaging{});
+
+    Tensor mQ = mainloop_params.tma_load_Q.get_tma_tensor(mainloop_params.layout_Q.shape());
+    Tensor mK = mainloop_params.tma_load_K.get_tma_tensor(mainloop_params.layout_K.shape());
+    Tensor mV = mainloop_params.tma_load_V.get_tma_tensor(mainloop_params.layout_V.shape());
+
+    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
+        block_coord;
+
+    // Prepare the TMA loads
+    Tensor gQ = get_local_tile_tensor(mQ, select<0, 2>(TileShape_QKD{}), qo_head_idx, qo_indptr,
+                                      qo_len)(_, _, q_tile_idx);  // (Q, D)
+    Tensor gK = get_local_tile_tensor(mK, select<1, 2>(TileShape_QKD{}), kv_head_idx, kv_indptr,
+                                      kv_len);  // (K, D, _)
+    Tensor gV = get_local_tile_tensor(mV, select<2, 1>(TileShape_PDV{}), kv_head_idx, kv_indptr,
+                                      kv_len);  // (K, D, _)
+
+    Tensor sQ_x = make_tensor(sQ.data(), make_layout(sQ.layout(), Layout<_1>{}));
+    Tensor gQ_x = make_tensor(gQ.data(), make_layout(gQ.layout(), Layout<_1>{}));
+    auto [tQgQ, tQsQ] =
+        tma_partition(mainloop_params.tma_load_Q, _0{}, Layout<_1>{}, group_modes<0, 2>(sQ_x),
+                      group_modes<0, 2>(gQ_x));  // (TMA), (TMA)
+    auto [tKgK, tKsK] =
+        tma_partition(mainloop_params.tma_load_K, _0{}, Layout<_1>{}, group_modes<0, 2>(sK),
+                      group_modes<0, 2>(gK));  // (TMA, k), (TMA, PIPE)
+    auto [tVgV, tVsV] =
+        tma_partition(mainloop_params.tma_load_V, _0{}, Layout<_1>{}, group_modes<0, 2>(sV),
+                      group_modes<0, 2>(gV));  // (TMA, k), (TMA, PIPE)
+
+    const int num_kv_tiles = get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
+    const int last_tile = num_kv_tiles - 1;
+    int first_tile = 0;
+    if constexpr (LEFT_SLIDING_WINDOW) {
+      first_tile = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left, q_tile_idx,
+                                                            qo_len, kv_len);
+    }
+
+    // One thread issues the TMA loads; every thread advances the staging write states.
+    const int lane_predicate = cute::elect_one_sync();
+    const int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (thread_idx / 32) % 4, 0);
+    const bool issue_thread = warp_idx_in_warpgroup == 0 && lane_predicate;
+
+    auto issue_q = [&] {
+      if (issue_thread) {
+        shared_storage.barrier_Q.arrive_and_expect_tx(TmaTransactionBytesQ);
+        copy(mainloop_params.tma_load_Q.with(
+                 reinterpret_cast<cutlass::arch::ClusterTransactionBarrier::ValueType&>(
+                     shared_storage.barrier_Q),
+                 /*mcast_mask=*/0),
+             tQgQ, tQsQ);
+      }
+    };
+    auto issue_k = [&](int tile, bool /*maybe_partial*/) {
+      if (issue_thread) {
+        staging.k.producer_acquire(staging.write_k);
+        copy(mainloop_params.tma_load_K.with(*staging.k.producer_get_barrier(staging.write_k),
+                                             /*mcast_mask=*/0),
+             tKgK(_, tile), tKsK(_, staging.write_k.index()));
+      }
+      ++staging.write_k;
+    };
+    auto issue_v = [&](int tile, bool /*maybe_partial*/) {
+      if (issue_thread) {
+        staging.v.producer_acquire(staging.write_v);
+        copy(mainloop_params.tma_load_V.with(*staging.v.producer_get_barrier(staging.write_v),
+                                             /*mcast_mask=*/0),
+             tVgV(_, tile), tVsV(_, staging.write_v.index()));
+      }
+      ++staging.write_v;
+    };
+    auto next_tile = [](int tile) { return tile - 1; };
+
+    DequantKVSchedule<Ktraits>::run(shared_storage, staging, pipeline_k, pipeline_v,
+                                    smem_pipe_write_k, smem_pipe_write_v, thread_idx, work_idx,
+                                    last_tile, first_tile, issue_q, issue_k, issue_v, next_tile);
+
+    scheduler.prefetch_next_work(scheduler_params, work_tile_info);
+    scheduler.broadcast_next_work(work_tile_info);
+  }
+
+  CUTLASS_DEVICE void load_tail(MainloopPipeline pipeline_k, MainloopPipeline pipeline_v,
+                                PipelineState& smem_pipe_write_k, PipelineState& smem_pipe_write_v,
+                                StagingPipelines& staging) {
+    pipeline_k.producer_tail(smem_pipe_write_k);
+    pipeline_v.producer_tail(smem_pipe_write_v);
+    // Every staged tile has been dequantized (and its stage released) by this warpgroup, so the
+    // staging pipelines are already drained.
+  }
+};
+
+// Paged K/V: the staging buffers are filled by a cp.async gather through the page table, issued
+// by all producer threads. The gather mirrors SparseCollectiveMainloop (sparse_mainloop.cuh).
+template <typename AdditionalParams, typename Ktraits, bool CAUSAL, bool MULTIITEMSCORING = false>
+struct SparseDequantCollectiveMainloop {
+  using DTypeQ = typename Ktraits::DTypeQ;
+  using DTypeKV = typename Ktraits::DTypeKV;
+  using IdType = typename Ktraits::IdType;
+  using TileShape_QKD = typename Ktraits::TileShape_QKD;
+  using TileShape_PDV = typename Ktraits::TileShape_PDV;
+  static constexpr int CTA_Q = get<0>(TileShape_QKD{});
+  static constexpr int CTA_KV = get<1>(TileShape_QKD{});
+
+  static constexpr int NUM_STAGES = Ktraits::NUM_STAGES;
+  static constexpr int NUM_STAGES_KV_STAGING = Ktraits::NUM_STAGES_KV_STAGING;
+  static constexpr int HEAD_DIM_QK = Ktraits::HEAD_DIM_QK;
+  static constexpr int HEAD_DIM_VO = Ktraits::HEAD_DIM_VO;
+  static_assert(HEAD_DIM_QK == HEAD_DIM_VO);
+  static constexpr int NUM_COPY_THREADS = cutlass::NumThreadsPerWarpGroup;
+  static_assert(Ktraits::KV_DEQUANT && !Ktraits::USE_TMA_LOAD_KV_STAGING);
+  static_assert(Ktraits::NUM_PRODUCER_THREADS == NUM_COPY_THREADS,
+                "NUM_PRODUCER_THREADS must equal NUM_COPY_THREADS for sparse/paged KV loading");
+
+  using GmemTiledCopyQ = cute::SM90_TMA_LOAD;
+  static constexpr auto AlignmentKV = 128 / cutlass::sizeof_bits<DTypeKV>::value;
+  using AlignmentTypeKV = cute::uint_byte_t<static_cast<int>(sizeof(DTypeKV)) * AlignmentKV>;
+  // NOTE(Zihao): use SM80_CP_ASYNC for sparse loading of KV-cache
+  using GmemCopyAtomKV = cute::Copy_Atom<SM80_CP_ASYNC_CACHEGLOBAL_ZFILL<AlignmentTypeKV>, DTypeKV>;
+  using GmemTiledCopyK =
+      decltype(cutlass::gemm::collective::detail::make_simt_gmem_tiled_copy<
+               GmemCopyAtomKV, NUM_COPY_THREADS, AlignmentKV,
+               cutlass::detail::TagToStrideB_t<cutlass::layout::ColumnMajor>,
+               decltype(cute::get<1>(TileShape_QKD{})), decltype(cute::get<2>(TileShape_QKD{}))>());
+  using GmemTiledCopyV =
+      decltype(cutlass::gemm::collective::detail::make_simt_gmem_tiled_copy<
+               GmemCopyAtomKV, NUM_COPY_THREADS, AlignmentKV,
+               cutlass::detail::TagToStrideB_t<cutlass::layout::ColumnMajor>,
+               decltype(cute::get<2>(TileShape_PDV{})), decltype(cute::get<1>(TileShape_PDV{}))>());
+
+  using SmemLayoutQ = typename Ktraits::SmemLayoutQ;
+  using SmemLayoutKStaging = typename Ktraits::SmemLayoutKStaging;
+  using SmemLayoutVStaging = typename Ktraits::SmemLayoutVStaging;
+
+  using ShapeT = cute::Shape<int32_t, int32_t, int32_t>;
+  using StrideT = cute::Shape<int64_t, _1, int64_t>;  // (N, D, H)
+  using LayoutT = cute::Layout<ShapeT, StrideT>;
+
+  using TMA_Q = decltype(make_tma_copy(
+      GmemTiledCopyQ{},
+      make_tensor(make_gmem_ptr(static_cast<DTypeQ const*>(nullptr)),
+                  repeat_like(StrideT{}, int32_t(0)), StrideT{}),
+      SmemLayoutQ{}, select<0, 2>(TileShape_QKD{}), _1{}));  // no mcast for Q
+
+  static constexpr bool USE_TMA_LOAD_KV = false;
+  static constexpr bool KV_DEQUANT = true;
+  static constexpr int NUM_MMA_THREADS = Ktraits::NUM_MMA_THREADS;
+  static constexpr int NUM_PRODUCER_THREADS = Ktraits::NUM_PRODUCER_THREADS;
+  using MainloopPipeline = typename Ktraits::MainloopPipeline;
+  using PipelineParams = typename MainloopPipeline::Params;
+  using PipelineState = typename MainloopPipeline::PipelineState;
+  using StagingPipeline = typename Ktraits::StagingPipeline;
+  using StagingPipelineState = typename Ktraits::StagingPipelineState;
+
+  static constexpr uint32_t TmaTransactionBytesQ =
+      static_cast<uint32_t>(size(SmemLayoutQ{}) * cutlass::sizeof_bits_v<DTypeQ> / 8);
+
+  static constexpr bool UseSchedulerBarrier = HEAD_DIM_VO <= 128;
+  using WarpScheduler = WarpScheduler<Ktraits, UseSchedulerBarrier>;
+
+  // Staging pipelines and their states; every producer thread issues cp.async into a stage
+  // (producer) and dequantizes it (consumer).
+  struct StagingPipelines {
+    StagingPipeline k, v;
+    StagingPipelineState write_k, read_k, write_v, read_v;
+
+    template <typename SharedStorage>
+    CUTLASS_DEVICE StagingPipelines(SharedStorage& shared_storage, int /*warp_group_thread_idx*/)
+        : k(shared_storage.pipeline_k_staging, make_params()),
+          v(shared_storage.pipeline_v_staging, make_params()),
+          write_k(cutlass::make_producer_start_state<StagingPipeline>()),
+          write_v(cutlass::make_producer_start_state<StagingPipeline>()) {}
+
+    CUTLASS_DEVICE static typename StagingPipeline::Params make_params() {
+      typename StagingPipeline::Params params;
+      params.role = StagingPipeline::ThreadCategory::ProducerConsumer;
+      params.producer_arv_count = NUM_COPY_THREADS;
+      params.consumer_arv_count = NUM_COPY_THREADS;
+      return params;
+    }
+  };
+
+  // Host side kernel arguments
+  struct Arguments {
+    DTypeQ const* Q_ptr;
+    LayoutT layout_Q;
+    DTypeKV const* K_ptr;
+    LayoutT layout_K;
+    DTypeKV const* V_ptr;
+    LayoutT layout_V;
+    IdType const* kv_indices;
+    int window_left;
+    int64_t k_page_stride;  // Stride between pages for K (paged_k.stride(0))
+    int64_t v_page_stride;  // Stride between pages for V (paged_v.stride(0))
+    uint32_t page_size;     // Size of each page
+    AdditionalParams additional_params;
+  };
+
+  // Device side kernel params
+  struct Params {
+    LayoutT layout_Q;
+    LayoutT layout_K;
+    LayoutT layout_V;
+    TMA_Q tma_load_Q;
+    DTypeKV* K_ptr;
+    DTypeKV* V_ptr;
+    IdType* kv_indices;
+    int window_left;
+    int64_t k_page_stride;   // Stride between pages for K
+    int64_t v_page_stride;   // Stride between pages for V
+    uint_fastdiv page_size;  // Size of each page (as fastdiv for efficient divmod)
+    AdditionalParams additional_params;
+  };
+
+  static Params to_underlying_arguments(Arguments const& args) {
+    Tensor mQ = make_tensor(make_gmem_ptr(args.Q_ptr), args.layout_Q);
+    TMA_Q tma_load_Q =
+        make_tma_copy(GmemTiledCopyQ{}, mQ, SmemLayoutQ{}, select<0, 2>(TileShape_QKD{}), _1{});
+    return {args.layout_Q,
+            args.layout_K,
+            args.layout_V,
+            tma_load_Q,
+            const_cast<DTypeKV*>(args.K_ptr),
+            const_cast<DTypeKV*>(args.V_ptr),
+            const_cast<IdType*>(args.kv_indices),
+            args.window_left,
+            args.k_page_stride,
+            args.v_page_stride,
+            uint_fastdiv(args.page_size),
+            args.additional_params};
+  }
+
+  CUTLASS_DEVICE
+  static void prefetch_tma_descriptors(Params const& mainloop_params) {
+    cute::prefetch_tma_descriptor(mainloop_params.tma_load_Q.get_tma_descriptor());
+  }
+
+  CUTLASS_DEVICE
+  int get_num_kv_tiles(Params const& mainloop_params, int q_tile_idx, const int qo_len,
+                       const int kv_len) {
+    // Function-local copies: cute::ceil_div takes references, and ODR-using the class-scope
+    // constants from device code trips nvcc.
+    static constexpr int CTA_Q = get<0>(TileShape_QKD{});
+    static constexpr int CTA_KV = get<1>(TileShape_QKD{});
+    int num_kv_tiles = cute::ceil_div(kv_len, CTA_KV);
+    if constexpr (CAUSAL || MULTIITEMSCORING) {
+      num_kv_tiles = std::min(num_kv_tiles,
+                              cute::ceil_div((q_tile_idx + 1) * CTA_Q + kv_len - qo_len, CTA_KV));
+    }
+    return num_kv_tiles;
+  }
+
+  template <bool LEFT_SLIDING_WINDOW, typename BlockCoord, typename Scheduler,
+            typename SharedStorage>
+  CUTLASS_DEVICE void load(Params const& mainloop_params, MainloopPipeline pipeline_k,
+                           MainloopPipeline pipeline_v, PipelineState& smem_pipe_write_k,
+                           PipelineState& smem_pipe_write_v, StagingPipelines& staging,
+                           SharedStorage& shared_storage, Scheduler& scheduler,
+                           typename Scheduler::Params const& scheduler_params,
+                           typename Scheduler::WorkTileInfo& work_tile_info,
+                           BlockCoord const& block_coord, int work_idx,
+                           const int num_kv_tiles_outside_items_window = 0,
+                           const int num_kv_tiles_prefix = 0) {
+    const int thread_idx = threadIdx.x;
+    const int warp_idx_in_warpgroup = __shfl_sync(0xffffffff, (thread_idx / 32) % 4, 0);
+    Tensor sQ = make_tensor(make_smem_ptr(shared_storage.smem_q.data()), SmemLayoutQ{});
+    Tensor sK =
+        make_tensor(make_smem_ptr(shared_storage.smem_k_staging.data()), SmemLayoutKStaging{});
+    Tensor sV =
+        make_tensor(make_smem_ptr(shared_storage.smem_v_staging.data()), SmemLayoutVStaging{});
+
+    Tensor mQ = mainloop_params.tma_load_Q.get_tma_tensor(mainloop_params.layout_Q.shape());
+
+    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
+        block_coord;
+
+    // Prepare the TMA loads
+    Tensor gQ = get_local_tile_tensor(mQ, select<0, 2>(TileShape_QKD{}), qo_head_idx, qo_indptr,
+                                      qo_len)(_, _, q_tile_idx);  // (Q, D)
+
+    Tensor sQ_x = make_tensor(sQ.data(), make_layout(sQ.layout(), Layout<_1>{}));
+    Tensor gQ_x = make_tensor(gQ.data(), make_layout(gQ.layout(), Layout<_1>{}));
+    auto [tQgQ, tQsQ] =
+        tma_partition(mainloop_params.tma_load_Q, _0{}, Layout<_1>{}, group_modes<0, 2>(sQ_x),
+                      group_modes<0, 2>(gQ_x));  // (TMA), (TMA)
+
+    const int num_kv_tiles = get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
+    const int last_tile = num_kv_tiles - 1;
+    int first_tile = 0;
+    if constexpr (LEFT_SLIDING_WINDOW) {
+      first_tile = get_swa_begin_kv_tile_idx<CTA_Q, CTA_KV>(mainloop_params.window_left, q_tile_idx,
+                                                            qo_len, kv_len);
+    }
+
+    // Store base pointers and indices for manual page table lookup
+    DTypeKV* K_ptr_base = mainloop_params.K_ptr + kv_head_idx * stride<2>(mainloop_params.layout_K);
+    DTypeKV* V_ptr_base = mainloop_params.V_ptr + kv_head_idx * stride<2>(mainloop_params.layout_V);
+    IdType const* kv_indices_ptr = mainloop_params.kv_indices + kv_indptr;
+    // Use the page stride (stride between pages) and stride within page
+    const int64_t k_page_stride = mainloop_params.k_page_stride;
+    const int64_t k_stride_n = stride<0>(mainloop_params.layout_K);
+
+    // Create dummy tensors for partitioning with contiguous column-major layout
+    // NOTE: We use a virtual contiguous layout for correct partitioning,
+    // actual addressing uses page table lookup
+    Tensor gK =
+        make_tensor(make_gmem_ptr(static_cast<DTypeKV*>(nullptr)), make_shape(CTA_KV, HEAD_DIM_QK),
+                    make_stride(HEAD_DIM_QK, _1{}));  // Column-major: (KV, D)
+    Tensor gK_tiled =
+        local_tile(gK, select<1, 2>(TileShape_QKD{}), make_coord(_, _0{}));  // (KV, D_K, kv)
+    Tensor gV =
+        make_tensor(make_gmem_ptr(static_cast<DTypeKV*>(nullptr)), make_shape(CTA_KV, HEAD_DIM_VO),
+                    make_stride(HEAD_DIM_VO, _1{}));  // Column-major: (KV, D)
+    Tensor gV_tiled =
+        local_tile(gV, select<2, 1>(TileShape_PDV{}), make_coord(_, _0{}));  // (KV, D_V, kv)
+    Tensor cK = cute::make_identity_tensor(gK_tiled.shape());
+    Tensor cV = cute::make_identity_tensor(gV_tiled.shape());
+
+    GmemTiledCopyK gmem_tiled_copy_k;
+    GmemTiledCopyV gmem_tiled_copy_v;
+    auto gmem_thr_copy_k = gmem_tiled_copy_k.get_slice(thread_idx);
+    auto gmem_thr_copy_v = gmem_tiled_copy_v.get_slice(thread_idx);
+
+    Tensor tKgK = gmem_thr_copy_k.partition_S(gK_tiled);  // (CPY, CPY_KV, CPY_D, kv)
+    Tensor tKsK = gmem_thr_copy_k.partition_D(sK);        // (CPY, CPY_KV, CPY_D, PIPE)
+    Tensor tVgV = gmem_thr_copy_v.partition_S(gV_tiled);  // (CPY, CPY_KV, CPY_D, kv)
+    Tensor tVsV = gmem_thr_copy_v.partition_D(sV);        // (CPY, CPY_KV, CPY_D, PIPE)
+    Tensor tKcK = gmem_thr_copy_k.partition_D(cK);        // (CPY, CPY_KV, CPY_D, kv)
+    Tensor tVcV = gmem_thr_copy_v.partition_D(cV);        // (CPY, CPY_KV, CPY_D, kv)
+
+    // Group organization based on partition strategy (see SparseCollectiveMainloop). Each thread
+    // of a group looks up the page-table offset of one KV row; the rows a thread copies all live
+    // in its own group, so the offsets are exchanged with warp shuffles.
+    constexpr int NUM_KV_PER_ITER = decltype(size<1>(tKcK))::value;
+    constexpr int KV_STRIDE = CTA_KV / NUM_KV_PER_ITER;
+    constexpr int NUM_GROUPS = KV_STRIDE;
+    constexpr int THREADS_PER_GROUP = NUM_COPY_THREADS / NUM_GROUPS;
+    constexpr int NUM_ITERS_PER_GROUP = NUM_KV_PER_ITER;
+    static_assert(NUM_ITERS_PER_GROUP <= THREADS_PER_GROUP);
+
+    const int group_id = thread_idx / THREADS_PER_GROUP;
+    const int thread_in_group = thread_idx % THREADS_PER_GROUP;
+
+    // K and V of a tile are staged at different times, so the offset is recomputed for each
+    // (one divmod and one page-table load per thread; K and V share strides, checked on the host).
+    auto kv_offset_of_tile = [&](int kv_tile_idx, bool use_predicate) -> int64_t {
+      const int kv_idx_read = kv_tile_idx * CTA_KV + group_id + thread_in_group * KV_STRIDE;
+      const bool valid_read =
+          thread_in_group < NUM_ITERS_PER_GROUP && (!use_predicate || kv_idx_read < kv_len);
+      if (!valid_read) {
+        return 0;
+      }
+      uint32_t page_iter, entry_idx;
+      mainloop_params.page_size.divmod(kv_idx_read, page_iter, entry_idx);
+      const IdType page_idx = kv_indices_ptr[page_iter];
+      return page_idx * k_page_stride + entry_idx * k_stride_n;
+    };
+
+    auto load_kv_with_gather = [&](auto&& tXsX, auto&& tXcX, DTypeKV* base_ptr, int kv_tile_idx,
+                                   int stage_idx, bool use_predicate, int64_t my_kv_offset) {
+      using Vec = AlignmentTypeKV;
+      constexpr int VecSize = sizeof(Vec) / sizeof(DTypeKV);
+      const int kv_base_idx = kv_tile_idx * CTA_KV;
+      auto dst = recast<Vec>(flatten(tXsX(_, _, _, stage_idx)));
+      auto c = flatten(tXcX(_, _, _, kv_tile_idx));
+      constexpr unsigned FULL_MASK = 0xffffffff;
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(dst); ++i) {
+        auto coord = c(VecSize * i);
+        const int kv_offset = get<0>(coord);
+        const int d_idx = get<1>(coord);
+        const int kv_idx = kv_base_idx + kv_offset;
+        const bool guard = !use_predicate || kv_idx < kv_len;
+        const int src_thread = group_id * THREADS_PER_GROUP + kv_offset / KV_STRIDE;
+        const int64_t base_offset = __shfl_sync(FULL_MASK, my_kv_offset, src_thread);
+        Vec const* src_ptr = reinterpret_cast<Vec const*>(base_ptr + base_offset + d_idx);
+        cutlass::arch::cp_async_zfill<sizeof(Vec), cutlass::arch::CacheOperation::Global>(
+            &dst(i), src_ptr, guard);
+      }
+    };
+
+    auto issue_q = [&] {
+      if (warp_idx_in_warpgroup == 0) {
+        const int lane_predicate = cute::elect_one_sync();
+        if (lane_predicate) {
+          shared_storage.barrier_Q.arrive_and_expect_tx(TmaTransactionBytesQ);
+          copy(mainloop_params.tma_load_Q.with(
+                   reinterpret_cast<cutlass::arch::ClusterTransactionBarrier::ValueType&>(
+                       shared_storage.barrier_Q),
+                   /*mcast_mask=*/0),
+               tQgQ, tQsQ);
+        }
+      }
+    };
+    auto issue_k = [&](int tile, bool maybe_partial) {
+      const int64_t my_kv_offset = kv_offset_of_tile(tile, maybe_partial);
+      staging.k.producer_acquire(staging.write_k);
+      load_kv_with_gather(tKsK, tKcK, K_ptr_base, tile, staging.write_k.index(), maybe_partial,
+                          my_kv_offset);
+      staging.k.producer_commit(staging.write_k, cutlass::arch::cpasync_barrier_arrive);
+      ++staging.write_k;
+    };
+    auto issue_v = [&](int tile, bool maybe_partial) {
+      const int64_t my_kv_offset = kv_offset_of_tile(tile, maybe_partial);
+      staging.v.producer_acquire(staging.write_v);
+      load_kv_with_gather(tVsV, tVcV, V_ptr_base, tile, staging.write_v.index(), maybe_partial,
+                          my_kv_offset);
+      staging.v.producer_commit(staging.write_v, cutlass::arch::cpasync_barrier_arrive);
+      ++staging.write_v;
+    };
+    auto next_tile = [&](int kv_tile_idx) {
+      int result = kv_tile_idx - 1;
+      if constexpr (MULTIITEMSCORING) {
+        if ((kv_tile_idx == num_kv_tiles_outside_items_window) &
+            (kv_tile_idx >= num_kv_tiles_prefix)) {
+          result = num_kv_tiles_prefix - 1;
+        }
+      }
+      return result;
+    };
+
+    DequantKVSchedule<Ktraits>::run(shared_storage, staging, pipeline_k, pipeline_v,
+                                    smem_pipe_write_k, smem_pipe_write_v, thread_idx, work_idx,
+                                    last_tile, first_tile, issue_q, issue_k, issue_v, next_tile);
+
+    scheduler.prefetch_next_work(scheduler_params, work_tile_info);
+    scheduler.broadcast_next_work(work_tile_info);
+  }
+
+  CUTLASS_DEVICE void load_tail(MainloopPipeline pipeline_k, MainloopPipeline pipeline_v,
+                                PipelineState& smem_pipe_write_k, PipelineState& smem_pipe_write_v,
+                                StagingPipelines& staging) {
+    pipeline_k.producer_tail(smem_pipe_write_k);
+    pipeline_v.producer_tail(smem_pipe_write_v);
+  }
+};
+
+}  // namespace flashinfer
+
+#endif  // FLASHINFER_ATTENTION_HOPPER_DEQUANT_MAINLOOP_CUH_

--- a/include/flashinfer/attention/hopper/kernel_traits.cuh
+++ b/include/flashinfer/attention/hopper/kernel_traits.cuh
@@ -209,6 +209,14 @@ struct DequantAttentionKernelTraits
                                DTypeKVMma, DTypeO_, typename Base::SmemLayoutQ,
                                typename Base::SmemLayoutK, typename Base::SmemLayoutV,
                                typename Base::SmemLayoutO, SmemLayoutKStaging, SmemLayoutVStaging>;
+  // The dense head_dim 128 and 256 configurations sit 2 KB under the SM90 limit.
+  static_assert(sizeof(SharedStorage) <= 227 * 1024, "shared storage exceeds the SM90 limit");
+  // The dequantizer (DequantKVSchedule::convert_tile) steps through a tile in multiples of 8
+  // rows and relies on every swizzle atom spanning exactly 8 rows, so that the step is a
+  // constant offset that leaves the XOR pattern unchanged.
+  static_assert(size<0>(SmemLayoutAtomKStaging{}) == 8 && size<0>(SmemLayoutAtomVStaging{}) == 8);
+  static_assert(size<0>(typename Base::SmemLayoutAtomK{}) == 8 &&
+                size<0>(typename Base::SmemLayoutAtomV{}) == 8);
 };
 
 }  // namespace flashinfer

--- a/include/flashinfer/attention/hopper/kernel_traits.cuh
+++ b/include/flashinfer/attention/hopper/kernel_traits.cuh
@@ -47,9 +47,14 @@ struct AttentionKernelTraits {
 
   using DTypeQ = DTypeQ_;
   using DTypeKV = DTypeKV_;
+  // Element type of the K/V tiles in shared memory, i.e. the B operands of the two GEMMs and the
+  // type P is converted to. Equal to DTypeKV here; DequantAttentionKernelTraits (FP8 KV cache with
+  // a 16-bit query) dequantizes K/V to DTypeQ on load and overrides it.
+  using DTypeKVMma = DTypeKV_;
   using DTypeO = DTypeO_;
   using IdType = IdType_;
   using DTypeQKAccum = float;
+  static constexpr bool KV_DEQUANT = false;
 
   static constexpr int CTA_Q = CTA_Q_;
   static_assert(CTA_Q % 64 == 0);
@@ -117,6 +122,93 @@ struct AttentionKernelTraits {
 
   using SharedStorage = SharedStorageQKVO<MainloopPipeline, DTypeQ, DTypeKV, DTypeO, IdType, CTA_KV,
                                           SmemLayoutQ, SmemLayoutK, SmemLayoutV, SmemLayoutO>;
+};
+
+// Shared storage of the FP8-KV kernels: the 16-bit Q/K/V/O buffers of SharedStorageQKVO plus the
+// 8-bit staging buffers that K/V tiles are loaded into before the producer warpgroup dequantizes
+// them into smem_k / smem_v. smem_v aliases smem_o exactly as in SharedStorageQKVO; the staging
+// buffers alias nothing, so staging loads never have to wait for the epilogue.
+template <typename MainloopPipeline, typename StagingPipeline, class DTypeQ, class DTypeKV,
+          class DTypeKVMma, class DTypeOut, class SmemLayoutQ, class SmemLayoutK, class SmemLayoutV,
+          class SmemLayoutO, class SmemLayoutKStaging, class SmemLayoutVStaging>
+struct SharedStorageQKVODequant {
+  cute::array_aligned<DTypeQ, cute::cosize_v<SmemLayoutQ>> smem_q;
+  cute::array_aligned<DTypeKVMma, cute::cosize_v<SmemLayoutK>> smem_k;
+  union {
+    cute::array_aligned<DTypeKVMma, cute::cosize_v<SmemLayoutV>> smem_v;
+    cute::array_aligned<DTypeOut, cute::cosize_v<SmemLayoutO>> smem_o;
+  };
+  cute::array_aligned<DTypeKV, cute::cosize_v<SmemLayoutKStaging>, 1024> smem_k_staging;
+  cute::array_aligned<DTypeKV, cute::cosize_v<SmemLayoutVStaging>, 1024> smem_v_staging;
+  struct {
+    cutlass::arch::ClusterTransactionBarrier barrier_Q;
+    cutlass::arch::ClusterBarrier barrier_O;
+    typename MainloopPipeline::SharedStorage pipeline_k;
+    typename MainloopPipeline::SharedStorage pipeline_v;
+    typename StagingPipeline::SharedStorage pipeline_k_staging;
+    typename StagingPipeline::SharedStorage pipeline_v_staging;
+  };
+};
+
+// Kernel traits for a 16-bit query attending to an FP8 (e4m3 / e5m2) KV cache.
+//
+// The GEMMs run on the 16-bit tensor cores with K/V dequantized to DTypeQ, so everything the MMA
+// warpgroups see (TiledMma*, SmemLayout{K,V,Vt}, smem_k, smem_v) is inherited from the 16-bit
+// traits with DTypeKV := DTypeQ. What this struct adds is the 8-bit side: the staging layouts the
+// K/V tiles are loaded into and the pipelines that hand staged tiles to the dequantizer.
+//
+// USE_TMA_LOAD_KV selects how the staging buffers are filled (TMA for dense K/V, cp.async gather
+// for paged K/V). The kernel sees USE_TMA_LOAD_KV == false through the base: the 16-bit K/V
+// pipelines are always thread-signaled (PipelineAsync) because the producer warpgroup, not the TMA
+// unit, writes smem_k / smem_v, and all four producer warps take part in the load.
+template <bool USE_TMA_LOAD_KV, int HEAD_DIM_QK_, int HEAD_DIM_VO_, int CTA_Q_, int CTA_KV_,
+          int NUM_STAGES_, int NUM_STAGES_KV_STAGING_, typename DTypeQ_, typename DTypeKV_,
+          typename DTypeO_, typename IdType_, typename AttentionVariant_>
+struct DequantAttentionKernelTraits
+    : AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK_, HEAD_DIM_VO_, CTA_Q_, CTA_KV_,
+                            NUM_STAGES_, DTypeQ_, /*DTypeKV_=*/DTypeQ_, DTypeO_, IdType_,
+                            AttentionVariant_> {
+  using Base =
+      AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK_, HEAD_DIM_VO_, CTA_Q_, CTA_KV_,
+                            NUM_STAGES_, DTypeQ_, DTypeQ_, DTypeO_, IdType_, AttentionVariant_>;
+  static_assert(cutlass::sizeof_bits_v<DTypeQ_> == 16, "the query must be 16-bit");
+  static_assert(cutlass::sizeof_bits_v<DTypeKV_> == 8, "the KV cache must be 8-bit");
+
+  using DTypeKV = DTypeKV_;    // KV cache element type in global memory and the staging buffers
+  using DTypeKVMma = DTypeQ_;  // K/V (and P) element type fed to the GEMMs
+  static constexpr bool KV_DEQUANT = true;
+  static constexpr bool USE_TMA_LOAD_KV_STAGING = USE_TMA_LOAD_KV;
+  static constexpr int NUM_STAGES_KV_STAGING = NUM_STAGES_KV_STAGING_;
+  static_assert(NUM_STAGES_KV_STAGING >= 1);
+
+  using TileShape_QKD = typename Base::TileShape_QKD;
+  using TileShape_PDV = typename Base::TileShape_PDV;
+
+  using SmemLayoutAtomKStaging =
+      decltype(cutlass::gemm::collective::detail::ss_smem_selector<
+               GMMA::Major::K, DTypeKV, decltype(cute::get<1>(TileShape_QKD{})),
+               decltype(cute::get<2>(TileShape_QKD{}))>());
+  using SmemLayoutKStaging = decltype(tile_to_shape(
+      SmemLayoutAtomKStaging{}, make_shape(shape<1>(TileShape_QKD{}), shape<2>(TileShape_QKD{}),
+                                           Int<NUM_STAGES_KV_STAGING>{})));
+  using SmemLayoutAtomVStaging =
+      decltype(cutlass::gemm::collective::detail::ss_smem_selector<
+               GMMA::Major::K, DTypeKV, decltype(cute::get<2>(TileShape_PDV{})),
+               decltype(cute::get<1>(TileShape_PDV{}))>());
+  using SmemLayoutVStaging = decltype(tile_to_shape(
+      SmemLayoutAtomVStaging{},
+      make_shape(get<2>(TileShape_PDV{}), get<1>(TileShape_PDV{}), Int<NUM_STAGES_KV_STAGING>{})));
+
+  using StagingPipeline =
+      std::conditional_t<USE_TMA_LOAD_KV, cutlass::PipelineTmaAsync<NUM_STAGES_KV_STAGING>,
+                         cutlass::PipelineAsync<NUM_STAGES_KV_STAGING>>;
+  using StagingPipelineState = cutlass::PipelineState<NUM_STAGES_KV_STAGING>;
+
+  using SharedStorage =
+      SharedStorageQKVODequant<typename Base::MainloopPipeline, StagingPipeline, DTypeQ_, DTypeKV,
+                               DTypeKVMma, DTypeO_, typename Base::SmemLayoutQ,
+                               typename Base::SmemLayoutK, typename Base::SmemLayoutV,
+                               typename Base::SmemLayoutO, SmemLayoutKStaging, SmemLayoutVStaging>;
 };
 
 }  // namespace flashinfer

--- a/include/flashinfer/attention/hopper/mainloop_mma.cuh
+++ b/include/flashinfer/attention/hopper/mainloop_mma.cuh
@@ -30,7 +30,9 @@ CUTLASS_DEVICE void mma_f16(
     uint16_t* token_pos_in_items, const int num_kv_tiles_outside_items_window = 0,
     const int num_kv_tiles_prefix = 0) {
   using DTypeQ = typename Ktraits::DTypeQ;
-  using DTypeKV = typename Ktraits::DTypeKV;
+  // P is the A operand of the PV GEMM, so it is converted to the element type of the V tile in
+  // shared memory (DTypeKV for 16-bit KV, DTypeQ when an FP8 KV cache is dequantized on load).
+  using DTypeKVMma = typename Ktraits::DTypeKVMma;
   using IdType = typename Ktraits::IdType;
   using TileShape_QKD = typename Ktraits::TileShape_QKD;
   static constexpr int NUM_MMA_THREADS = Ktraits::NUM_MMA_THREADS;
@@ -172,7 +174,7 @@ CUTLASS_DEVICE void mma_f16(
   }
 
   attention_updater.update</*init=*/true>(tSrS);
-  Tensor tOrP = make_tensor(convert_type<DTypeKV>(tSrS).data(),
+  Tensor tOrP = make_tensor(convert_type<DTypeKVMma>(tSrS).data(),
                             convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout()));
 
   constexpr int n_masking_steps = MULTIITEMSCORING ? (cute::ceil_div(CTA_Q, CTA_KV) + 1)
@@ -222,7 +224,7 @@ CUTLASS_DEVICE void mma_f16(
     pipeline_v.consumer_release(smem_pipe_read_v);  // release V
     ++smem_pipe_read_k;
     ++smem_pipe_read_v;
-    cute::copy(make_tensor(convert_type<DTypeKV>(tSrS).data(),
+    cute::copy(make_tensor(convert_type<DTypeKVMma>(tSrS).data(),
                            convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout())),
                tOrP);
   }
@@ -268,7 +270,7 @@ CUTLASS_DEVICE void mma_f16(
     pipeline_v.consumer_release(smem_pipe_read_v);  // release V
     ++smem_pipe_read_k;
     ++smem_pipe_read_v;
-    cute::copy(make_tensor(convert_type<DTypeKV>(tSrS).data(),
+    cute::copy(make_tensor(convert_type<DTypeKVMma>(tSrS).data(),
                            convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout())),
                tOrP);
   }
@@ -305,7 +307,7 @@ CUTLASS_DEVICE void mma_f16(
       pipeline_v.consumer_release(smem_pipe_read_v);  // release V
       ++smem_pipe_read_k;
       ++smem_pipe_read_v;
-      cute::copy(make_tensor(convert_type<DTypeKV>(tSrS).data(),
+      cute::copy(make_tensor(convert_type<DTypeKVMma>(tSrS).data(),
                              convert_layout_acc_Aregs<typename Ktraits::TiledMmaPV>(tSrS.layout())),
                  tOrP);
     }

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -23,6 +23,7 @@
 #include "../mask.cuh"
 #include "cute/tensor.hpp"
 #include "cutlass/pipeline/pipeline.hpp"
+#include "dequant_mainloop.cuh"
 #include "epilogue.cuh"
 #include "kernel_traits.cuh"
 #include "mainloop.cuh"
@@ -156,6 +157,16 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
     if (!use_tma_load_kv || warp_idx_in_warpgroup == 0) {  // Load Q, K, V
       PipelineState smem_pipe_write_k = cutlass::make_producer_start_state<MainloopPipeline>();
       PipelineState smem_pipe_write_v = cutlass::make_producer_start_state<MainloopPipeline>();
+      // FP8 KV cache: the staging pipelines are owned by this warpgroup alone (it both stages and
+      // dequantizes), so they are set up here rather than with the K/V pipelines above. Empty for
+      // the 16-bit kernels.
+      typename StagingPipelinesFor<CollectiveMainloop, Ktraits::KV_DEQUANT>::type staging(
+          shared_storage, warp_group_thread_idx);
+      if constexpr (Ktraits::KV_DEQUANT) {
+        // Make the barrier initialization by warp 0 visible to the whole producer warpgroup.
+        cutlass::arch::NamedBarrier::sync(NUM_COPY_THREADS,
+                                          static_cast<int>(NamedBarriers::kProducerWG));
+      }
 
       int work_idx = 0;
 
@@ -188,7 +199,12 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           num_kv_tiles_outside_items_window = valid_items_window_len / CTA_KV;
           num_kv_tiles_prefix = cute::ceil_div(prefix_len, CTA_KV);
         }
-        if constexpr (MULTIITEMSCORING) {
+        if constexpr (Ktraits::KV_DEQUANT) {
+          collective_mainloop.template load<LEFT_SLIDING_WINDOW>(
+              mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
+              staging, shared_storage, scheduler, scheduler_params, work_tile_info, block_coord,
+              work_idx, num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
+        } else if constexpr (MULTIITEMSCORING) {
           collective_mainloop.load<LEFT_SLIDING_WINDOW>(
               mainloop_params, pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
               shared_storage, scheduler, scheduler_params, work_tile_info, block_coord, work_idx,
@@ -200,7 +216,12 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
         }
         ++work_idx;
       }
-      collective_mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v);
+      if constexpr (Ktraits::KV_DEQUANT) {
+        collective_mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v,
+                                      staging);
+      } else {
+        collective_mainloop.load_tail(pipeline_k, pipeline_v, smem_pipe_write_k, smem_pipe_write_v);
+      }
     }
   } else {  // Consumer
     if constexpr (use_tma_load_kv) {
@@ -295,8 +316,10 @@ cudaError_t SinglePrefillWithKVCacheKernelTraitsDispatched(Params& params, cudaS
   using DTypeKV = typename KernelTraits::DTypeKV;
   using DTypeO = typename KernelTraits::DTypeO;
 
-  using CollectiveMainloop =
-      CollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>;
+  using CollectiveMainloop = std::conditional_t<
+      KernelTraits::KV_DEQUANT,
+      DequantCollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>,
+      CollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler = SingleTileScheduler;
   typename CollectiveMainloop::Params mainloop_params = CollectiveMainloop::to_underlying_arguments(
@@ -360,8 +383,12 @@ cudaError_t BatchPrefillWithPagedKVCacheKernelTraitsDispatched(Params& params,
   using DTypeO = typename KernelTraits::DTypeO;
   using IdType = typename KernelTraits::IdType;
 
-  using CollectiveMainloop = SparseCollectiveMainloop<typename Params::AdditionalParams,
-                                                      KernelTraits, CAUSAL, MULTIITEMSCORING>;
+  using CollectiveMainloop =
+      std::conditional_t<KernelTraits::KV_DEQUANT,
+                         SparseDequantCollectiveMainloop<typename Params::AdditionalParams,
+                                                         KernelTraits, CAUSAL, MULTIITEMSCORING>,
+                         SparseCollectiveMainloop<typename Params::AdditionalParams, KernelTraits,
+                                                  CAUSAL, MULTIITEMSCORING>>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler =
       std::conditional_t<SAME_SCHEDULE_FOR_ALL_HEADS, BatchPrefillTileScheduler<IdType>,
@@ -437,8 +464,10 @@ cudaError_t BatchPrefillWithRaggedKVCacheKernelTraitsDispatched(Params& params,
   using DTypeO = typename KernelTraits::DTypeO;
   using IdType = typename KernelTraits::IdType;
 
-  using CollectiveMainloop =
-      CollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>;
+  using CollectiveMainloop = std::conditional_t<
+      KernelTraits::KV_DEQUANT,
+      DequantCollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>,
+      CollectiveMainloop<typename Params::AdditionalParams, KernelTraits, CAUSAL>>;
   using CollectiveEpilogue = CollectiveEpilogue<KernelTraits>;
   using Scheduler =
       std::conditional_t<SAME_SCHEDULE_FOR_ALL_HEADS, BatchPrefillTileScheduler<IdType>,
@@ -524,6 +553,30 @@ constexpr auto getCTATileSize() {
   }
 }
 
+// Tile configuration (CTA_Q, CTA_KV, NUM_STAGES_KV_STAGING) of the dense FP8-KV kernels, whose
+// shared memory holds the 16-bit K/V stages of getCTATileSize plus the 8-bit staging buffers:
+// CTA_KV is capped at 128 (the non-causal head_dim 128 tile of 192 does not fit next to its
+// staging buffers), head_dim 256 keeps a single staging stage, and the DeepSeek prefill pair
+// halves CTA_KV.
+template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO>
+constexpr auto getDequantCTATileSize() {
+  if constexpr (HEAD_DIM_QK == HEAD_DIM_VO) {
+    if constexpr (HEAD_DIM_QK == 64) {
+      return std::make_tuple(192, 128, 2);
+    } else if constexpr (HEAD_DIM_QK == 128) {
+      return std::make_tuple(128, 128, 2);
+    } else {
+      return std::make_tuple(128, 64, 1);
+    }
+  } else {
+    static_assert(HEAD_DIM_QK == 192 && HEAD_DIM_VO == 128);
+    return std::make_tuple(128, 64, 2);
+  }
+}
+
+template <typename Params>
+constexpr bool kv_cache_is_fp8_v = cutlass::sizeof_bits_v<typename Params::DTypeKV> == 8;
+
 template <uint32_t HEAD_DIM_QK, uint32_t HEAD_DIM_VO, MaskMode MASK_MODE, bool LEFT_SLIDING_WINDOW,
           typename AttentionVariant, typename Params>
 cudaError_t SinglePrefillWithKVCacheDispatched(Params& params, cudaStream_t stream) {
@@ -532,14 +585,28 @@ cudaError_t SinglePrefillWithKVCacheDispatched(Params& params, cudaStream_t stre
     return cudaErrorNotSupported;  // Not supported yet.
   }
   constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
-  constexpr auto CTA_TILE_SIZE = getCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO, CAUSAL>();
-  SinglePrefillWithKVCacheKernelTraitsDispatched<
-      AttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
-                            /*CTA_Q_=*/get<0>(CTA_TILE_SIZE),
-                            /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
-                            /*NUM_STAGES_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
-                            typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
-      LEFT_SLIDING_WINDOW, CAUSAL>(params, stream);
+  if constexpr (kv_cache_is_fp8_v<Params>) {
+    constexpr auto CTA_TILE_SIZE = getDequantCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO>();
+    SinglePrefillWithKVCacheKernelTraitsDispatched<
+        DequantAttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
+                                     /*CTA_Q_=*/get<0>(CTA_TILE_SIZE),
+                                     /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
+                                     /*NUM_STAGES_=*/2,
+                                     /*NUM_STAGES_KV_STAGING_=*/get<2>(CTA_TILE_SIZE),
+                                     typename Params::DTypeQ, typename Params::DTypeKV,
+                                     typename Params::DTypeO, typename Params::IdType,
+                                     AttentionVariant>,
+        LEFT_SLIDING_WINDOW, CAUSAL>(params, stream);
+  } else {
+    constexpr auto CTA_TILE_SIZE = getCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO, CAUSAL>();
+    SinglePrefillWithKVCacheKernelTraitsDispatched<
+        AttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
+                              /*CTA_Q_=*/get<0>(CTA_TILE_SIZE),
+                              /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
+                              /*NUM_STAGES_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
+                              typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
+        LEFT_SLIDING_WINDOW, CAUSAL>(params, stream);
+  }
   cudaError_t status = cudaGetLastError();
   return status;
 }
@@ -553,14 +620,28 @@ cudaError_t BatchPrefillWithRaggedKVCacheDispatched(Params& params, bool enable_
     return cudaErrorNotSupported;  // Not supported yet.
   }
   constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
-  constexpr auto CTA_TILE_SIZE = getCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO, CAUSAL>();
-  BatchPrefillWithRaggedKVCacheKernelTraitsDispatched<
-      AttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
-                            /*CTA_Q_=*/get<0>(CTA_TILE_SIZE),
-                            /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
-                            /*NUM_STAGES_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
-                            typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
-      LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+  if constexpr (kv_cache_is_fp8_v<Params>) {
+    constexpr auto CTA_TILE_SIZE = getDequantCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO>();
+    BatchPrefillWithRaggedKVCacheKernelTraitsDispatched<
+        DequantAttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
+                                     /*CTA_Q_=*/get<0>(CTA_TILE_SIZE),
+                                     /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
+                                     /*NUM_STAGES_=*/2,
+                                     /*NUM_STAGES_KV_STAGING_=*/get<2>(CTA_TILE_SIZE),
+                                     typename Params::DTypeQ, typename Params::DTypeKV,
+                                     typename Params::DTypeO, typename Params::IdType,
+                                     AttentionVariant>,
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+  } else {
+    constexpr auto CTA_TILE_SIZE = getCTATileSize<HEAD_DIM_QK, HEAD_DIM_VO, CAUSAL>();
+    BatchPrefillWithRaggedKVCacheKernelTraitsDispatched<
+        AttentionKernelTraits</*USE_TMA_LOAD_KV=*/true, HEAD_DIM_QK, HEAD_DIM_VO,
+                              /*CTA_Q_=*/get<0>(CTA_TILE_SIZE),
+                              /*CTA_KV_=*/get<1>(CTA_TILE_SIZE),
+                              /*NUM_STAGES_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
+                              typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
+        LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS>(params, stream);
+  }
   cudaError_t status = cudaGetLastError();
   return status;
 }
@@ -576,7 +657,19 @@ cudaError_t BatchPrefillWithPagedKVCacheDispatched(Params& params, bool enable_p
   constexpr bool CAUSAL = MASK_MODE == MaskMode::kCausal;
   constexpr bool MULTIITEMSCORING = MASK_MODE == MaskMode::kMultiItemScoring;
   if constexpr (HEAD_DIM_QK == HEAD_DIM_VO) {
-    if constexpr (HEAD_DIM_VO == 64) {
+    if constexpr (kv_cache_is_fp8_v<Params>) {
+      // Same 16-bit tiles as below; the 8-bit staging buffers fit next to them at every head dim.
+      constexpr int CTA_Q = HEAD_DIM_VO == 64 ? 192 : 128;
+      constexpr int CTA_KV = HEAD_DIM_VO == 256 ? 32 : 96;
+      // Two staging stages: deeper staging (3, 4) measured within noise of 2 on a GH200.
+      BatchPrefillWithPagedKVCacheKernelTraitsDispatched<
+          DequantAttentionKernelTraits<
+              /*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK, HEAD_DIM_VO, CTA_Q, CTA_KV, /*NUM_STAGES_=*/2,
+              /*NUM_STAGES_KV_STAGING_=*/2, typename Params::DTypeQ, typename Params::DTypeKV,
+              typename Params::DTypeO, typename Params::IdType, AttentionVariant>,
+          LEFT_SLIDING_WINDOW, CAUSAL, SAME_SCHEDULE_FOR_ALL_HEADS, Params, MULTIITEMSCORING>(
+          params, stream);
+    } else if constexpr (HEAD_DIM_VO == 64) {
       // NOTE(Zihao): CTA_KV not tuned for HEAD_DIM == 64, need to optimize later
       BatchPrefillWithPagedKVCacheKernelTraitsDispatched<
           AttentionKernelTraits</*USE_TMA_LOAD_KV=*/false, HEAD_DIM_QK, HEAD_DIM_VO,

--- a/tests/attention/test_hopper_fp8_kv.py
+++ b/tests/attention/test_hopper_fp8_kv.py
@@ -281,7 +281,13 @@ def test_batch_paged_prefill_fp8_kv(
     qo_indptr_t = torch.tensor(qo_indptr, dtype=torch.int32, device="cuda")
 
     outs = {}
-    for backend in ["fa3", "fa2"]:
+    for name, backend, (kc, vc) in [
+        ("fa3", "fa3", (k_cache, v_cache)),
+        ("fa2", "fa2", (k_cache, v_cache)),
+        # The paged fp8-KV kernel uses the tiles of the 16-bit kernel, so on the dequantized
+        # cache the two must agree bit for bit.
+        ("fa3_16bit", "fa3", (k_cache.to(q_dtype), v_cache.to(q_dtype))),
+    ]:
         wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
             _workspace(), kv_layout, backend=backend
         )
@@ -296,11 +302,13 @@ def test_batch_paged_prefill_fp8_kv(
             page_size,
             causal=causal,
             q_data_type=q_dtype,
-            kv_data_type=kv_dtype,
+            kv_data_type=kc.dtype,
         )
-        outs[backend] = wrapper.run_return_lse(q, (k_cache, v_cache))
+        outs[name] = wrapper.run_return_lse(q, (kc, vc))
     o_ref = _reference(q, k, v, qo_indptr, kv_indptr_tokens, causal)
 
+    torch.testing.assert_close(outs["fa3"][1], outs["fa3_16bit"][1], rtol=0, atol=0)
+    torch.testing.assert_close(outs["fa3"][0], outs["fa3_16bit"][0], rtol=0, atol=0)
     torch.testing.assert_close(outs["fa3"][1], outs["fa2"][1], **_lse_tol(q_dtype))
     torch.testing.assert_close(outs["fa3"][0], outs["fa2"][0], **_tol(q_dtype))
     torch.testing.assert_close(outs["fa3"][0].float(), o_ref, **_tol(q_dtype))
@@ -429,9 +437,11 @@ def test_fp8_kv_sliding_window_and_soft_cap(
         torch.testing.assert_close(outs["fa3"], outs["fa2"], **_tol(q_dtype))
 
 
-@pytest.mark.parametrize("paged", [False, True])
+# The ragged wrapper only applies k_scale / v_scale for an NVFP4 cache (issue #4979), so the
+# ragged path is not covered here.
+@pytest.mark.parametrize("mode", ["single", "paged"])
 @pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
-def test_fp8_kv_calibration_scale(paged, kv_dtype):
+def test_fp8_kv_calibration_scale(mode, kv_dtype):
     """k_scale / v_scale keep their fa2 semantics: fp8 attention over a scaled cache
     matches 16-bit attention over the unscaled one."""
     _skip_unless_sm90a()
@@ -463,7 +473,8 @@ def test_fp8_kv_calibration_scale(paged, kv_dtype):
         "f16": (k16, v16, {}),
         "fp8": (k8, v8, dict(k_scale=k_scale, v_scale=v_scale)),
     }.items():
-        if paged:
+        qo_indptr = torch.tensor([0, qo_len], dtype=torch.int32, device="cuda")
+        if mode == "paged":
             k_cache, v_cache, kv_indptr, kv_indices, last_page_len = _paged_cache(
                 kk, vv, [0, kv_len], page_size, "NHD", gen
             )
@@ -471,7 +482,7 @@ def test_fp8_kv_calibration_scale(paged, kv_dtype):
                 _workspace(), "NHD", backend="fa3"
             )
             wrapper.plan(
-                torch.tensor([0, qo_len], dtype=torch.int32, device="cuda"),
+                qo_indptr,
                 kv_indptr,
                 kv_indices,
                 last_page_len,
@@ -484,6 +495,21 @@ def test_fp8_kv_calibration_scale(paged, kv_dtype):
                 kv_data_type=kk.dtype,
             )
             outs[name] = wrapper.run(q, (k_cache, v_cache), **scales)
+        elif mode == "ragged":
+            wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+                _workspace(), "NHD", backend="fa3"
+            )
+            wrapper.plan(
+                qo_indptr,
+                torch.tensor([0, kv_len], dtype=torch.int32, device="cuda"),
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                causal=True,
+                q_data_type=q_dtype,
+                kv_data_type=kk.dtype,
+            )
+            outs[name] = wrapper.run(q, kk, vv, **scales)
         else:
             outs[name] = flashinfer.single_prefill_with_kv_cache(
                 q, kk, vv, causal=True, backend="fa3", **scales
@@ -691,12 +717,14 @@ def test_fp8_kv_multi_item_scoring(page_size, num_qo_heads, q_dtype, kv_dtype):
     the consumer visits."""
     _skip_unless_sm90a()
     torch.manual_seed(0)
-    kv_len, qo_len, num_kv_heads, head_dim = 97, 81, 4, 128
+    # kv_len - qo_len - max_item_len = 50 gives a non-empty outside-items window, so the
+    # producer's tile cursor has to take the same jump the consumer takes.
+    kv_len, qo_len, num_kv_heads, head_dim = 1000, 900, 4, 128
     prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr = (
-        16,
-        list(range(80)) + [0],
-        97,
-        79,
+        100,
+        (list(range(50)) * 18)[:900] + [0],
+        1000,
+        50,
     )
     q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
     num_pages = (kv_len + page_size - 1) // page_size

--- a/tests/attention/test_hopper_fp8_kv.py
+++ b/tests/attention/test_hopper_fp8_kv.py
@@ -1,0 +1,747 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+# FA3 (SM90) attention with a 16-bit query and an FP8 KV cache.
+#
+# The kernels dequantize K/V to the query dtype while loading them and then run
+# the 16-bit tensor-core mainloop, which is also what the FA2 mixed-precision
+# kernels do. Every test therefore checks the fa3 output against fa2 and against
+# an fp32 reference computed from the dequantized KV cache.
+
+import functools
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.utils import determine_attention_backend, is_sm90a_supported
+
+# (head_dim, q_dtype, kv_dtype). Every dtype pair exercises a different conversion path, so
+# all four are covered at head_dim 128; the other head dims (different tile shapes and
+# staging depths) use one pair to bound the number of JIT modules.
+CONFIGS = [
+    (128, torch.bfloat16, torch.float8_e4m3fn),
+    (128, torch.float16, torch.float8_e4m3fn),
+    (128, torch.bfloat16, torch.float8_e5m2),
+    (128, torch.float16, torch.float8_e5m2),
+    (64, torch.bfloat16, torch.float8_e4m3fn),
+    (256, torch.bfloat16, torch.float8_e4m3fn),
+]
+# The single-prefill kernel shares the dense mainloop with ragged prefill.
+SINGLE_CONFIGS = [
+    (128, torch.bfloat16, torch.float8_e4m3fn),
+    (128, torch.float16, torch.float8_e5m2),
+    (64, torch.bfloat16, torch.float8_e4m3fn),
+    (256, torch.bfloat16, torch.float8_e4m3fn),
+]
+
+
+def _skip_unless_sm90a():
+    if not is_sm90a_supported(torch.device("cuda")):
+        pytest.skip("SM90A is not supported")
+
+
+@functools.lru_cache(maxsize=1)
+def _workspace():
+    return torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+
+def _tol(q_dtype):
+    # fa3 and fa2 see the same dequantized operands and both accumulate in fp32, so they
+    # only differ by accumulation order and the rounding of P and O to q_dtype.
+    if q_dtype == torch.bfloat16:
+        return dict(rtol=1e-2, atol=2e-2)
+    return dict(rtol=1e-2, atol=5e-3)
+
+
+def _lse_tol(q_dtype):
+    if q_dtype == torch.bfloat16:
+        return dict(rtol=5e-3, atol=5e-3)
+    return dict(rtol=1e-3, atol=1e-3)
+
+
+def _reference(
+    q,
+    k,
+    v,
+    qo_indptr,
+    kv_indptr,
+    causal,
+    window_left=-1,
+    logits_soft_cap=0.0,
+):
+    """fp32 attention over the dequantized KV cache, one request at a time.
+
+    q: [total_q, H, D]; k, v: [total_kv, HKV, D] (any dtype). Query positions are aligned
+    to the end of the KV sequence, as in the kernels.
+    """
+    H = q.shape[1]
+    HKV = k.shape[1]
+    D = q.shape[2]
+    sm_scale = 1.0 / math.sqrt(D)
+    outs = []
+    for b in range(len(qo_indptr) - 1):
+        qb = q[qo_indptr[b] : qo_indptr[b + 1]].float()
+        kb = k[kv_indptr[b] : kv_indptr[b + 1]].float().repeat_interleave(H // HKV, 1)
+        vb = v[kv_indptr[b] : kv_indptr[b + 1]].float().repeat_interleave(H // HKV, 1)
+        qo_len, kv_len = qb.shape[0], kb.shape[0]
+        s = torch.einsum("qhd,khd->hqk", qb, kb) * sm_scale
+        if logits_soft_cap > 0:
+            s = torch.tanh(s / logits_soft_cap) * logits_soft_cap
+        q_pos = torch.arange(qo_len, device=q.device)[:, None] + kv_len - qo_len
+        k_pos = torch.arange(kv_len, device=q.device)[None, :]
+        mask = torch.ones(qo_len, kv_len, dtype=torch.bool, device=q.device)
+        if causal:
+            mask &= k_pos <= q_pos
+        if window_left >= 0:
+            mask &= k_pos >= q_pos - window_left
+        s = s.masked_fill(~mask[None], float("-inf"))
+        outs.append(torch.einsum("hqk,khd->qhd", torch.softmax(s, -1), vb))
+    return torch.cat(outs, 0)
+
+
+def _paged_cache(k, v, kv_indptr_tokens, page_size, kv_layout, generator):
+    """Scatter per-request [tokens, HKV, D] K/V into a page table with shuffled pages.
+
+    Returns (k_cache, v_cache, kv_indptr, kv_indices, last_page_len).
+    """
+    HKV, D = k.shape[1], k.shape[2]
+    lens = [
+        int(kv_indptr_tokens[b + 1] - kv_indptr_tokens[b])
+        for b in range(len(kv_indptr_tokens) - 1)
+    ]
+    pages_per_req = [(n + page_size - 1) // page_size for n in lens]
+    total_pages = sum(pages_per_req)
+    perm = torch.randperm(total_pages, generator=generator)
+    k_cache = torch.zeros(
+        total_pages, page_size, HKV, D, dtype=k.dtype, device=k.device
+    )
+    v_cache = torch.zeros_like(k_cache)
+    kv_indptr = [0]
+    kv_indices = []
+    last_page_len = []
+    page = 0
+    for b, (n, num_pages) in enumerate(zip(lens, pages_per_req, strict=True)):
+        kb = k[kv_indptr_tokens[b] : kv_indptr_tokens[b + 1]]
+        vb = v[kv_indptr_tokens[b] : kv_indptr_tokens[b + 1]]
+        for p in range(num_pages):
+            phys = int(perm[page + p])
+            rows = slice(p * page_size, min((p + 1) * page_size, n))
+            k_cache[phys, : rows.stop - rows.start] = kb[rows]
+            v_cache[phys, : rows.stop - rows.start] = vb[rows]
+            kv_indices.append(phys)
+        page += num_pages
+        kv_indptr.append(page)
+        last_page_len.append(n - (num_pages - 1) * page_size)
+    if kv_layout == "HND":
+        k_cache = k_cache.transpose(1, 2).contiguous()
+        v_cache = v_cache.transpose(1, 2).contiguous()
+    to_i32 = lambda x: torch.tensor(x, dtype=torch.int32, device=k.device)
+    return (
+        k_cache,
+        v_cache,
+        to_i32(kv_indptr),
+        to_i32(kv_indices),
+        to_i32(last_page_len),
+    )
+
+
+@pytest.mark.parametrize("seq_len", [11, 99, 1763, 4097])
+@pytest.mark.parametrize("num_qo_heads, num_kv_heads", [(1, 1), (8, 2)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("head_dim, q_dtype, kv_dtype", SINGLE_CONFIGS)
+def test_single_prefill_fp8_kv(
+    seq_len, num_qo_heads, num_kv_heads, causal, head_dim, q_dtype, kv_dtype
+):
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    q = torch.randn(seq_len, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(seq_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    v = torch.randn(seq_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+
+    o_fa3, lse_fa3 = flashinfer.single_prefill_with_kv_cache_return_lse(
+        q, k, v, causal=causal, backend="fa3"
+    )
+    o_fa2, lse_fa2 = flashinfer.single_prefill_with_kv_cache_return_lse(
+        q, k, v, causal=causal, backend="fa2"
+    )
+    indptr = [0, seq_len]
+    o_ref = _reference(q, k, v, indptr, indptr, causal)
+
+    assert o_fa3.dtype == q_dtype
+    torch.testing.assert_close(lse_fa3, lse_fa2, **_lse_tol(q_dtype))
+    torch.testing.assert_close(o_fa3, o_fa2, **_tol(q_dtype))
+    torch.testing.assert_close(o_fa3.float(), o_ref, **_tol(q_dtype))
+
+
+@pytest.mark.parametrize("batch_size", [1, 7])
+@pytest.mark.parametrize("seq_len", [12, 99, 1763])
+@pytest.mark.parametrize("num_qo_heads, num_kv_heads", [(4, 4), (8, 1)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("head_dim, q_dtype, kv_dtype", CONFIGS)
+def test_batch_ragged_prefill_fp8_kv(
+    batch_size, seq_len, num_qo_heads, num_kv_heads, causal, head_dim, q_dtype, kv_dtype
+):
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    total = batch_size * seq_len
+    q = torch.randn(total, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(total, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    v = torch.randn(total, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    indptr = torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda") * seq_len
+
+    outs = {}
+    for backend in ["fa3", "fa2"]:
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            _workspace(), "NHD", backend=backend
+        )
+        wrapper.plan(
+            indptr,
+            indptr,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            causal=causal,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+        )
+        outs[backend] = wrapper.run_return_lse(q, k, v)
+    o_ref = _reference(q, k, v, indptr.tolist(), indptr.tolist(), causal)
+
+    torch.testing.assert_close(outs["fa3"][1], outs["fa2"][1], **_lse_tol(q_dtype))
+    torch.testing.assert_close(outs["fa3"][0], outs["fa2"][0], **_tol(q_dtype))
+    torch.testing.assert_close(outs["fa3"][0].float(), o_ref, **_tol(q_dtype))
+
+
+@pytest.mark.parametrize("batch_size", [1, 5])
+@pytest.mark.parametrize("qo_len, kv_len", [(1, 54), (37, 37), (300, 4097)])
+@pytest.mark.parametrize("page_size", [1, 5, 16])
+@pytest.mark.parametrize("kv_layout", ["NHD", "HND"])
+@pytest.mark.parametrize("num_qo_heads, num_kv_heads", [(8, 2)])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("head_dim, q_dtype, kv_dtype", CONFIGS)
+def test_batch_paged_prefill_fp8_kv(
+    batch_size,
+    qo_len,
+    kv_len,
+    page_size,
+    kv_layout,
+    num_qo_heads,
+    num_kv_heads,
+    causal,
+    head_dim,
+    q_dtype,
+    kv_dtype,
+):
+    _skip_unless_sm90a()
+    if causal and qo_len > kv_len:
+        pytest.skip("causal requires qo_len <= kv_len")
+    torch.manual_seed(0)
+    gen = torch.Generator().manual_seed(0)
+    # Requests of different lengths, with the last one at the parametrized size.
+    qo_lens = [max(1, qo_len - 3 * b) for b in range(batch_size)]
+    kv_lens = [max(n, kv_len - 5 * b) for b, n in enumerate(qo_lens)]
+    qo_indptr = [0]
+    kv_indptr_tokens = [0]
+    for a, b in zip(qo_lens, kv_lens, strict=True):
+        qo_indptr.append(qo_indptr[-1] + a)
+        kv_indptr_tokens.append(kv_indptr_tokens[-1] + b)
+    q = torch.randn(qo_indptr[-1], num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(
+        kv_indptr_tokens[-1], num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    v = torch.randn(
+        kv_indptr_tokens[-1], num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    k_cache, v_cache, kv_indptr, kv_indices, last_page_len = _paged_cache(
+        k, v, kv_indptr_tokens, page_size, kv_layout, gen
+    )
+    qo_indptr_t = torch.tensor(qo_indptr, dtype=torch.int32, device="cuda")
+
+    outs = {}
+    for backend in ["fa3", "fa2"]:
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            _workspace(), kv_layout, backend=backend
+        )
+        wrapper.plan(
+            qo_indptr_t,
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=causal,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+        )
+        outs[backend] = wrapper.run_return_lse(q, (k_cache, v_cache))
+    o_ref = _reference(q, k, v, qo_indptr, kv_indptr_tokens, causal)
+
+    torch.testing.assert_close(outs["fa3"][1], outs["fa2"][1], **_lse_tol(q_dtype))
+    torch.testing.assert_close(outs["fa3"][0], outs["fa2"][0], **_tol(q_dtype))
+    torch.testing.assert_close(outs["fa3"][0].float(), o_ref, **_tol(q_dtype))
+
+
+@pytest.mark.parametrize("seq_len", [99, 1763])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(torch.bfloat16, torch.float8_e4m3fn)])
+def test_deepseek_prefill_fp8_kv(seq_len, causal, q_dtype, kv_dtype):
+    """The (192, 128) head-dim pair of the DeepSeek prefill kernel, ragged KV.
+
+    The fa2 mixed-precision kernel returns wrong results for this head-dim pair with an
+    fp8 KV cache (issue #4976), so the comparison is against the 16-bit fa3 kernel on the
+    dequantized cache (bit-identical operands) and the fp32 reference instead."""
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    num_heads, head_dim_qk, head_dim_vo = 16, 192, 128
+    q = torch.randn(seq_len, num_heads, head_dim_qk, dtype=q_dtype, device="cuda")
+    k = torch.randn(seq_len, num_heads, head_dim_qk, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    v = torch.randn(seq_len, num_heads, head_dim_vo, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    indptr = torch.tensor([0, seq_len], dtype=torch.int32, device="cuda")
+
+    outs = {}
+    for name, (kk, vv) in {
+        "fp8": (k, v),
+        "16bit": (k.to(q_dtype), v.to(q_dtype)),
+    }.items():
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            _workspace(), "NHD", backend="fa3"
+        )
+        wrapper.plan(
+            indptr,
+            indptr,
+            num_heads,
+            num_heads,
+            head_dim_qk,
+            head_dim_vo=head_dim_vo,
+            causal=causal,
+            q_data_type=q_dtype,
+            kv_data_type=kk.dtype,
+        )
+        outs[name] = wrapper.run_return_lse(q, kk, vv)
+    o_ref = _reference(q, k, v, [0, seq_len], [0, seq_len], causal)
+
+    torch.testing.assert_close(outs["fp8"][1], outs["16bit"][1], **_lse_tol(q_dtype))
+    torch.testing.assert_close(outs["fp8"][0], outs["16bit"][0], **_tol(q_dtype))
+    torch.testing.assert_close(outs["fp8"][0].float(), o_ref, **_tol(q_dtype))
+
+
+@pytest.mark.parametrize("paged", [False, True])
+@pytest.mark.parametrize("qo_len, kv_len", [(300, 4097), (1024, 1024)])
+@pytest.mark.parametrize("window_left", [64, 333])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("logits_soft_cap", [0.0, 30.0])
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(torch.bfloat16, torch.float8_e4m3fn)])
+def test_fp8_kv_sliding_window_and_soft_cap(
+    paged, qo_len, kv_len, window_left, causal, logits_soft_cap, q_dtype, kv_dtype
+):
+    """window_left and logits_soft_cap through the fp8-KV mainloops, head_dim 128."""
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    gen = torch.Generator().manual_seed(0)
+    num_qo_heads, num_kv_heads, head_dim, page_size = 8, 2, 128, 16
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    v = torch.randn(kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    qo_indptr = torch.tensor([0, qo_len], dtype=torch.int32, device="cuda")
+    plan_kwargs = dict(
+        causal=causal,
+        window_left=window_left,
+        logits_soft_cap=logits_soft_cap,
+        q_data_type=q_dtype,
+        kv_data_type=kv_dtype,
+    )
+    outs = {}
+    for backend in ["fa3", "fa2"]:
+        if paged:
+            k_cache, v_cache, kv_indptr, kv_indices, last_page_len = _paged_cache(
+                k, v, [0, kv_len], page_size, "NHD", gen
+            )
+            wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+                _workspace(), "NHD", backend=backend
+            )
+            wrapper.plan(
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                last_page_len,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                **plan_kwargs,
+            )
+            outs[backend] = wrapper.run(q, (k_cache, v_cache))
+        else:
+            kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda")
+            wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+                _workspace(), "NHD", backend=backend
+            )
+            wrapper.plan(
+                qo_indptr,
+                kv_indptr,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                **plan_kwargs,
+            )
+            outs[backend] = wrapper.run(q, k, v)
+    o_ref = _reference(
+        q, k, v, [0, qo_len], [0, kv_len], causal, window_left, logits_soft_cap
+    )
+
+    torch.testing.assert_close(outs["fa3"].float(), o_ref, **_tol(q_dtype))
+    if causal:
+        # The fa2 non-causal sliding window is wrong (issue #4972), so fa2 is only a
+        # reference for the causal cases.
+        torch.testing.assert_close(outs["fa3"], outs["fa2"], **_tol(q_dtype))
+
+
+@pytest.mark.parametrize("paged", [False, True])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_fp8_kv_calibration_scale(paged, kv_dtype):
+    """k_scale / v_scale keep their fa2 semantics: fp8 attention over a scaled cache
+    matches 16-bit attention over the unscaled one."""
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    gen = torch.Generator().manual_seed(0)
+    q_dtype = torch.float16
+    qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim, page_size = (
+        53,
+        97,
+        32,
+        4,
+        128,
+        8,
+    )
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k16 = 0.05 * torch.randn(
+        kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    )
+    v16 = 0.05 * torch.randn(
+        kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    )
+    k_scale = k16.abs().amax().item() / 256
+    v_scale = v16.abs().amax().item() / 256
+    k8 = (k16 / k_scale).to(kv_dtype)
+    v8 = (v16 / v_scale).to(kv_dtype)
+
+    outs = {}
+    for name, (kk, vv, scales) in {
+        "f16": (k16, v16, {}),
+        "fp8": (k8, v8, dict(k_scale=k_scale, v_scale=v_scale)),
+    }.items():
+        if paged:
+            k_cache, v_cache, kv_indptr, kv_indices, last_page_len = _paged_cache(
+                kk, vv, [0, kv_len], page_size, "NHD", gen
+            )
+            wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+                _workspace(), "NHD", backend="fa3"
+            )
+            wrapper.plan(
+                torch.tensor([0, qo_len], dtype=torch.int32, device="cuda"),
+                kv_indptr,
+                kv_indices,
+                last_page_len,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim,
+                page_size,
+                causal=True,
+                q_data_type=q_dtype,
+                kv_data_type=kk.dtype,
+            )
+            outs[name] = wrapper.run(q, (k_cache, v_cache), **scales)
+        else:
+            outs[name] = flashinfer.single_prefill_with_kv_cache(
+                q, kk, vv, causal=True, backend="fa3", **scales
+            )
+
+    torch.testing.assert_close(outs["f16"], outs["fp8"], atol=1e-2, rtol=2e-1)
+
+
+@pytest.mark.parametrize(
+    "q_dtype, kv_dtype",
+    [(torch.bfloat16, torch.float8_e4m3fn), (torch.float16, torch.float8_e5m2)],
+)
+def test_fp8_kv_backend_selection(q_dtype, kv_dtype):
+    """backend="auto" routes 16-bit-query / fp8-KV prefill to fa3 on SM90, while
+    tensor-core decode stays on fa2; an explicit fa3 decode still works."""
+    _skip_unless_sm90a()
+    device = torch.device("cuda")
+    assert (
+        determine_attention_backend(device, 0, False, False, q_dtype, kv_dtype) == "fa3"
+    )
+
+    torch.manual_seed(0)
+    gen = torch.Generator().manual_seed(0)
+    batch_size, kv_len, num_qo_heads, num_kv_heads, head_dim, page_size = (
+        4,
+        333,
+        8,
+        2,
+        128,
+        16,
+    )
+    q = torch.randn(batch_size, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    v = torch.randn(
+        batch_size * kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    kv_indptr_tokens = [b * kv_len for b in range(batch_size + 1)]
+    k_cache, v_cache, kv_indptr, kv_indices, last_page_len = _paged_cache(
+        k, v, kv_indptr_tokens, page_size, "NHD", gen
+    )
+    qo_indptr = torch.arange(0, batch_size + 1, dtype=torch.int32, device="cuda")
+
+    prefill = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace(), "NHD", backend="auto"
+    )
+    prefill.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        q_data_type=q_dtype,
+        kv_data_type=kv_dtype,
+    )
+    assert prefill._backend == "fa3"
+    o_prefill = prefill.run(q, (k_cache, v_cache))
+
+    outs = {}
+    for backend in ["auto", "fa3"]:
+        decode = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            _workspace(), "NHD", use_tensor_cores=True, backend=backend
+        )
+        decode.plan(
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+        )
+        outs[backend] = decode.run(q, (k_cache, v_cache))
+        assert decode._backend == ("fa2" if backend == "auto" else "fa3")
+    o_ref = _reference(q, k, v, qo_indptr.tolist(), kv_indptr_tokens, causal=False)
+
+    for o in [o_prefill, outs["auto"], outs["fa3"]]:
+        torch.testing.assert_close(o.float(), o_ref, **_tol(q_dtype))
+
+
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(torch.bfloat16, torch.float8_e4m3fn)])
+def test_fp8_kv_block_sparse_wrapper(q_dtype, kv_dtype):
+    """BlockSparseAttentionWrapper resolves backend="auto" through the same selector and
+    runs the paged kernel with page_size = C."""
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    M, N, R, C, num_qo_heads, num_kv_heads, head_dim = 512, 2048, 16, 32, 8, 2, 128
+    MB, NB = M // R, N // C
+    block_mask = torch.rand(MB, NB) < 0.3
+    indptr = [0]
+    indices = []
+    for r in range(MB):
+        indices += block_mask[r].nonzero().flatten().tolist()
+        indptr.append(len(indices))
+    indptr = torch.tensor(indptr, dtype=torch.int32, device="cuda")
+    indices = torch.tensor(indices, dtype=torch.int32, device="cuda")
+    q = torch.randn(M, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(N, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+    v = torch.randn(N, num_kv_heads, head_dim, dtype=q_dtype, device="cuda").to(
+        kv_dtype
+    )
+
+    outs = {}
+    for backend in ["fa3", "fa2", "auto"]:
+        wrapper = flashinfer.sparse.BlockSparseAttentionWrapper(
+            _workspace(), backend=backend
+        )
+        wrapper.plan(
+            indptr,
+            indices,
+            M,
+            N,
+            R,
+            C,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+            o_data_type=q_dtype,
+        )
+        outs[backend] = wrapper.run(q, k, v)
+        assert wrapper._backend == ("fa2" if backend == "fa2" else "fa3")
+
+    torch.testing.assert_close(outs["fa3"], outs["fa2"], **_tol(q_dtype))
+    torch.testing.assert_close(outs["auto"], outs["fa3"], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(torch.bfloat16, torch.float8_e4m3fn)])
+def test_fp8_kv_attention_sink_wrapper(q_dtype, kv_dtype):
+    """The attention-sink variant of the paged kernel with an fp8 KV cache."""
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    gen = torch.Generator().manual_seed(0)
+    batch_size, kv_len, num_qo_heads, num_kv_heads, head_dim, page_size = (
+        3,
+        333,
+        8,
+        2,
+        128,
+        16,
+    )
+    q = torch.randn(
+        batch_size * kv_len, num_qo_heads, head_dim, dtype=q_dtype, device="cuda"
+    )
+    k = torch.randn(
+        batch_size * kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    v = torch.randn(
+        batch_size * kv_len, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    kv_indptr_tokens = [b * kv_len for b in range(batch_size + 1)]
+    k_cache, v_cache, kv_indptr, kv_indices, last_page_len = _paged_cache(
+        k, v, kv_indptr_tokens, page_size, "NHD", gen
+    )
+    qo_indptr = torch.tensor(kv_indptr_tokens, dtype=torch.int32, device="cuda")
+    sink = torch.rand(num_qo_heads, dtype=torch.float32, device="cuda") * 5
+
+    outs = {}
+    for backend in ["fa3", "fa2", "auto"]:
+        wrapper = flashinfer.BatchAttentionWithAttentionSinkWrapper(
+            _workspace(),
+            kv_layout="NHD",
+            backend=backend,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+            head_dim_qk=head_dim,
+            head_dim_vo=head_dim,
+        )
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=True,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+        )
+        outs[backend] = wrapper.run(
+            q, (k_cache, v_cache), sink, 1.0 / math.sqrt(head_dim)
+        )
+        assert wrapper._backend == ("fa2" if backend == "fa2" else "fa3")
+
+    torch.testing.assert_close(outs["fa3"], outs["fa2"], **_tol(q_dtype))
+    torch.testing.assert_close(outs["auto"], outs["fa3"], rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("page_size", [1, 5, 16])
+@pytest.mark.parametrize("num_qo_heads", [4, 32])
+@pytest.mark.parametrize("q_dtype, kv_dtype", [(torch.float16, torch.float8_e4m3fn)])
+def test_fp8_kv_multi_item_scoring(page_size, num_qo_heads, q_dtype, kv_dtype):
+    """Multi-item scoring skips KV tiles; fa3 must stage and dequantize the same tiles
+    the consumer visits."""
+    _skip_unless_sm90a()
+    torch.manual_seed(0)
+    kv_len, qo_len, num_kv_heads, head_dim = 97, 81, 4, 128
+    prefix_len_ptr, token_pos_in_items_ptr, token_pos_in_items_len, max_item_len_ptr = (
+        16,
+        list(range(80)) + [0],
+        97,
+        79,
+    )
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=q_dtype, device="cuda")
+    num_pages = (kv_len + page_size - 1) // page_size
+    kv_data = torch.randn(
+        num_pages, 2, page_size, num_kv_heads, head_dim, dtype=q_dtype, device="cuda"
+    ).to(kv_dtype)
+    qo_indptr = torch.tensor([0, qo_len], dtype=torch.int32, device="cuda")
+    kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device="cuda")
+    kv_indices = torch.arange(0, num_pages, dtype=torch.int32, device="cuda")
+    last_page_len = torch.tensor(
+        [(kv_len - 1) % page_size + 1], dtype=torch.int32, device="cuda"
+    )
+    mis_kwargs = dict(
+        prefix_len_ptr=torch.tensor(
+            [prefix_len_ptr], dtype=torch.uint32, device="cuda"
+        ),
+        token_pos_in_items_ptr=torch.tensor(
+            token_pos_in_items_ptr, dtype=torch.uint16, device="cuda"
+        ),
+        token_pos_in_items_len=token_pos_in_items_len,
+        max_item_len_ptr=torch.tensor(
+            [max_item_len_ptr], dtype=torch.uint16, device="cuda"
+        ),
+    )
+
+    outs = {}
+    for backend in ["fa3", "fa2"]:
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            _workspace(), "NHD", backend=backend
+        )
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=True,
+            q_data_type=q_dtype,
+            kv_data_type=kv_dtype,
+            **mis_kwargs,
+        )
+        outs[backend] = wrapper.run_return_lse(q, kv_data)
+
+    torch.testing.assert_close(outs["fa3"][1], outs["fa2"][1], **_lse_tol(q_dtype))
+    torch.testing.assert_close(outs["fa3"][0], outs["fa2"][0], **_tol(q_dtype))


### PR DESCRIPTION
## Description

FA3 (SM90) attention for a 16-bit query (`bfloat16` / `float16`) with an FP8 (`e4m3` / `e5m2`) KV cache, for `single_prefill_with_kv_cache`, `BatchPrefillWithRaggedKVCacheWrapper` and `BatchPrefillWithPagedKVCacheWrapper`. Until now FA3 rejected this dtype pair, so `backend="auto"` on H100/H200 fell back to the FA2 mixed-precision kernel, which is slower than FA2 with a 16-bit cache.

**Kernel.** The MMA warpgroups run the unchanged 16-bit consumer. Only the producer side is new (`hopper/dequant_mainloop.cuh`): K/V tiles are loaded as FP8 into small staging buffers (TMA for dense K/V, the existing cp.async page-table gather for paged K/V), and all 128 producer threads dequantize each staged tile into the 16-bit swizzled K/V layout the consumer already reads. The conversion is exact, so the kernel computes the same values as the FA2 mixed-precision kernel and is bit-identical to the 16-bit FA3 kernel on the dequantized cache.

Tile shapes are those of the 16-bit kernels, except that dense head_dim 128 keeps `CTA_KV = 128` for the non-causal kernel and head_dim 256 keeps one staging stage so the staging buffers fit in shared memory. ptxas reports no spills.

**Python.** `backend="auto"` selects fa3 for this dtype pair on SM90 for prefill (also through the block-sparse and attention-sink wrappers). Tensor-core decode keeps fa2, whose short query tiles are 4-5x faster than fa3 for decode. `k_scale` / `v_scale` keep their semantics (the ragged wrapper's pre-existing gap is #4979). `aot.py` generates the new modules.

**Performance.** GH200 480GB, CUDA 12.8, `benchmarks/flashinfer_benchmark.py`, bf16 query, e4m3 KV cache, 32/8 heads, head_dim 128, page size 16, median of 50 iterations. `fa2` is what `backend="auto"` selected before this PR; the last column is the 16-bit fa3 kernel on the same shapes.

| kernel | mask | batch x qo_len / kv_len | fa2, fp8 KV (before) | fa3, fp8 KV (this PR) | speedup | fa3, bf16 KV |
|---|---|---|---|---|---|---|
| paged | causal | 4 x 4096 / 4096 | 2.195 ms | 1.699 ms | 1.29x | 1.242 ms |
| paged | causal | 8 x 1024 / 8192 | 3.767 ms | 2.912 ms | 1.29x | 2.174 ms |
| paged | causal | 1 x 16384 / 16384 | 8.120 ms | 5.974 ms | 1.36x | 4.402 ms |
| paged | non-causal | 4 x 4096 / 4096 | 4.007 ms | 3.120 ms | 1.28x | 2.267 ms |
| paged | non-causal | 8 x 1024 / 8192 | 3.954 ms | 3.065 ms | 1.29x | 2.260 ms |
| paged | non-causal | 1 x 16384 / 16384 | 15.549 ms | 11.900 ms | 1.31x | 8.649 ms |
| ragged | causal | 4 x 4096 / 4096 | 2.008 ms | 1.234 ms | 1.63x | 0.842 ms |
| ragged | causal | 8 x 1024 / 8192 | 3.547 ms | 2.157 ms | 1.64x | 1.438 ms |
| ragged | causal | 1 x 16384 / 16384 | 7.551 ms | 4.473 ms | 1.69x | 2.950 ms |
| ragged | non-causal | 4 x 4096 / 4096 | 3.702 ms | 2.295 ms | 1.61x | 1.568 ms |
| ragged | non-causal | 8 x 1024 / 8192 | 3.676 ms | 2.254 ms | 1.63x | 1.483 ms |
| ragged | non-causal | 1 x 16384 / 16384 | 14.414 ms | 8.906 ms | 1.62x | 6.121 ms |

FA2 with a bf16 cache takes 1.751 ms (paged) and 1.554 ms (ragged) on the first row's shape, so the fp8 cache is now faster than the 16-bit FA2 path as well. The remaining gap to the 16-bit fa3 kernel is the dequantization competing with the consumer warps for issue slots.

**Prior art.** The same staging-plus-dequantization idea is used by the SM90 FP8-KV kernel @qixiang-99 added to vLLM's flash-attention fork (vllm-project/flash-attention#147, CuTe DSL, dequantization in the consumer warpgroups); thanks to @jhaotingc for the pointer. This is an independent implementation for FlashInfer's C++ FA3 kernels that also covers the paged and single-prefill paths.

## Related Issues

Closes the FlashInfer side of #3327. Resolves the SM90 part of #1753. Found on the way and filed separately: #4976 (fa2 with an fp8 cache is wrong for the (192, 128) head-dim pair), #4979 (the ragged wrapper ignores `k_scale` / `v_scale` for an fp8 cache) and a wider scope for #4972 (fa2 non-causal sliding window).

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New file `tests/attention/test_hopper_fp8_kv.py`, 690 cases, all passing on GH200: single, ragged and paged prefill for every `{bf16, fp16} x {e4m3, e5m2}` pair at head_dim 128 (each pair is a different conversion path) and at head_dim 64 / 256, page sizes 1 / 5 / 16, NHD and HND, chunked prefill, causal and non-causal, sliding window, logits soft cap, `k_scale` / `v_scale`, the (192, 128) head-dim pair, multi-item scoring, the block-sparse and attention-sink wrappers, `backend="auto"` routing, and tensor-core decode through fa3. Every case is checked against an fp32 reference over the dequantized cache and, where fa2 is correct, against fa2. The 16-bit and fp8-query subsets of `tests/attention/test_hopper.py` and `test_hopper_fp8_attention.py` still pass.

## Experimental Track

Not applicable.

## Reviewer Notes

- `DequantKVSchedule::run` publishes tiles in the order the consumer waits for them and keeps each staging ring `NUM_STAGES_KV_STAGING` tiles ahead; the comments there give the ordering argument, including why the V staging loads no longer wait for `barrier_O` while the 16-bit V writes still do.
- `benchmarks/flashinfer_benchmark.py --refcheck` compares fa2 against fa3. With the benchmark's fp8 data (values scaled to the fp8 range, near one-hot softmax) the two disagree on a few elements in 67M; the unmodified 16-bit fa2 and fa3 kernels disagree on exactly the same elements when fed the dequantized values, so this is accumulation-order sensitivity of that data, not a kernel difference.
- Pre-existing, unchanged: multi-item scoring with `prefix_len == 0` and a non-empty outside-items window makes the consumer wait for KV tile -1 (the old paged loader reads the page table out of bounds there; the new one does not stage that tile).

Developed in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Hopper FA3 attention with FP16 or BF16 queries and FP8 key-value caches.
  - Extended support across prefill modes, paged and ragged batches, sliding windows, soft caps, calibration scales, block-sparse attention, attention sinks, and multi-item scoring.
  - Automatic backend selection now routes supported FP8-cache workloads appropriately.

- **Bug Fixes**
  - Corrected backend selection for FP8 KV caches when queries use non-FP8 16-bit dtypes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->