### PR TITLE
fix: apply calibration scales to ragged FP8 KV prefill

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -4438,12 +4438,16 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             logits_soft_cap = 0.0
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(q.size(-1))
-        # For NVFP4 KV, fuse q_scale and k_scale into sm_scale
+        # FA2/FA3 with a 16-bit query consumes unscaled FP8 KV values.
+        # Full-FP8 and other backends handle their scales separately.
+        apply_kv_scales = kv_cache_sf is not None or (
+            self._backend in ("fa2", "fa3") and is_float8(k) and not is_float8(q)
+        )
         if kv_cache_sf is not None:
             if q_scale is not None:
                 sm_scale *= q_scale
-            if k_scale is not None:
-                sm_scale *= k_scale
+        if apply_kv_scales and k_scale is not None:
+            sm_scale *= k_scale
         if rope_scale is None:
             rope_scale = 1.0
         if rope_theta is None:
@@ -4809,9 +4813,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         assert self._cached_module is not None, "cached module is not initialized"
         self._cached_module.ragged_run(*run_args)
 
-        # Apply V scaling for NVFP4 ragged KV if v_scale is provided and not equal to 1.0
+        # Apply global V calibration after attention, without changing the LSE.
         is_float_one = isinstance(v_scale, float) and v_scale == 1.0
-        if kv_cache_sf is not None and v_scale is not None and not is_float_one:
+        if apply_kv_scales and v_scale is not None and not is_float_one:
             out *= v_scale
 
         return (out, lse) if return_lse else out

--- a/tests/attention/test_fp8_prefill.py
+++ b/tests/attention/test_fp8_prefill.py
@@ -148,7 +148,7 @@ def test_batch_prefill_with_ragged_kv_cache_fp8(
     # Validates the ragged FP8 KV dequant kernel path (BF16 repack for hd128/256,
     # in-loop dequant for the k64B hd64 case) against the equivalent 16-bit kernel
     # run on the *same* dequantized values -- so no dependence on k/v scale
-    # plumbing (the fa2 ragged wrapper does not apply k_scale/v_scale).
+    # plumbing (calibration scales are tested separately below).
     if qo_len > kv_len and causal:
         pytest.skip("qo_len > kv_len and causal is not supported")
     torch.manual_seed(42)
@@ -426,6 +426,69 @@ def test_single_prefill_fp8_h512_long_q():
     )
     o_fp8 = flashinfer.single_prefill_with_kv_cache(q, k_fp8, v_fp8)
     torch.testing.assert_close(o_fp8.to(torch.float16), o_ref, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("q_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize(
+    "k_scale,v_scale",
+    [(None, None), (1.0, 1.0), (0.25, None), (None, 0.5), (0.25, 0.5)],
+)
+def test_ragged_fp8_calibration_scales(q_dtype, kv_dtype, causal, k_scale, v_scale):
+    # Regression for #4979: compare against the actual quantized values, so
+    # quantization error cannot hide missing K/V calibration.
+    torch.manual_seed(0)
+    batch, qo_len, kv_len, heads, kv_heads, dim = 2, 53, 97, 8, 2, 128
+    q = torch.randn(batch * qo_len, heads, dim, dtype=q_dtype, device="cuda")
+    k = torch.randn(batch * kv_len, kv_heads, dim, device="cuda").to(kv_dtype)
+    v = torch.randn(batch * kv_len, kv_heads, dim, device="cuda").to(kv_dtype)
+    qo_indptr = torch.arange(batch + 1, dtype=torch.int32, device="cuda") * qo_len
+    kv_indptr = torch.arange(batch + 1, dtype=torch.int32, device="cuda") * kv_len
+    workspace = torch.empty(32 << 20, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace, "NHD", backend="fa2"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        heads,
+        kv_heads,
+        dim,
+        causal=causal,
+        q_data_type=q_dtype,
+        kv_data_type=kv_dtype,
+        logits_soft_cap=3.0,
+    )
+    out = torch.empty_like(q)
+    lse = torch.empty(q.shape[:2], dtype=torch.float32, device="cuda")
+    actual, actual_lse = wrapper.run(
+        q, k, v, k_scale=k_scale, v_scale=v_scale, out=out, lse=lse, return_lse=True
+    )
+    assert actual.data_ptr() == out.data_ptr()
+    assert actual_lse.data_ptr() == lse.data_ptr()
+
+    q_ref = q.float().reshape(batch, qo_len, heads, dim).transpose(1, 2)
+    k_ref = k.float().reshape(batch, kv_len, kv_heads, dim).transpose(1, 2)
+    v_ref = v.float().reshape(batch, kv_len, kv_heads, dim).transpose(1, 2)
+    k_ref = k_ref.repeat_interleave(heads // kv_heads, dim=1)
+    v_ref = v_ref.repeat_interleave(heads // kv_heads, dim=1)
+    logits = (q_ref @ k_ref.transpose(-1, -2)) * (
+        (1.0 if k_scale is None else k_scale) / dim**0.5
+    )
+    logits = 3.0 * torch.tanh(logits / 3.0)
+    if causal:
+        mask = torch.arange(kv_len, device="cuda")[None, :] > (
+            torch.arange(qo_len, device="cuda")[:, None] + kv_len - qo_len
+        )
+        logits.masked_fill_(mask, float("-inf"))
+    expected = (logits.softmax(-1) @ v_ref) * (1.0 if v_scale is None else v_scale)
+    expected = expected.transpose(1, 2).reshape_as(actual)
+    expected_lse = logits.logsumexp(-1).transpose(1, 2).reshape_as(actual_lse)
+    assert torch.isfinite(actual).all()
+    assert torch.isfinite(actual_lse).all()
+    torch.testing.assert_close(actual.float(), expected, atol=3e-3, rtol=1e-2)
+    torch.testing.assert_close(actual_lse, expected_lse, atol=1e-3, rtol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/attention/test_fp8_prefill.py
+++ b/tests/attention/test_fp8_prefill.py
@@ -18,7 +18,7 @@ import pytest
 import torch
 
 import flashinfer
-from flashinfer.utils import get_compute_capability
+from flashinfer.utils import get_compute_capability, log2e
 
 
 def head_dim_512_supported() -> bool:
@@ -484,7 +484,8 @@ def test_ragged_fp8_calibration_scales(q_dtype, kv_dtype, causal, k_scale, v_sca
         logits.masked_fill_(mask, float("-inf"))
     expected = (logits.softmax(-1) @ v_ref) * (1.0 if v_scale is None else v_scale)
     expected = expected.transpose(1, 2).reshape_as(actual)
-    expected_lse = logits.logsumexp(-1).transpose(1, 2).reshape_as(actual_lse)
+    # FlashInfer returns base-2 LSE; torch.logsumexp uses natural logarithms.
+    expected_lse = logits.logsumexp(-1).transpose(1, 2).reshape_as(actual_lse) * log2e
     assert torch.isfinite(actual).all()
     assert torch.isfinite(actual_lse).all()
     torch.testing.assert_close(actual.float(), expected, atol=3e-3, rtol=1e-2)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Apply global `k_scale` / `v_scale` calibration in ragged FA2/FA3 prefill with a 16-bit query and FP8 KV cache. Previously, the wrapper gated both operations on the presence of NVFP4 block scale factors, silently ignoring the documented calibration arguments for FP8 KV.

Fold K calibration into the softmax scale before logits soft capping, and apply V calibration to the output without changing LSE. Leave the existing NVFP4, full-FP8, and other backend paths unchanged.

Add a focused regression matrix checking outputs and base-2 LSE against an FP32 reference over the actual quantized KV values. Thanks @SamMausberg for the report and reproducer.

## 🔍 Related Issues

Fixes #4979. Related to #4977, which adds mixed-precision FA3 support and explicitly leaves this wrapper issue separate; this PR does not implement that FA3 kernel work.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Ran the official hooks on the changed files with `uvx pre-commit run --files flashinfer/prefill.py tests/attention/test_fp8_prefill.py`; all applicable hooks passed, including mypy and Ruff. The full-repository hook run was not performed.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

The checked result refers to the targeted tests below, not the entire repository suite.

Validated on one B200 (SM100), using clean source-bound checkouts and isolated source-JIT execution:

```sh
python -m pytest -q tests/attention/test_fp8_prefill.py::test_ragged_fp8_calibration_scales
```

- Candidate: **40 passed, 0 failed, 0 skipped**, exit 0. Covers FP16/BF16 queries, e4m3/e5m2 KV, causal/noncausal attention, omitted/unit/K-only/V-only/both scales, soft capping, finite output/LSE, and caller-provided buffer aliasing.
- Test-only baseline: the first selected CUDA case fails the output assertion (97.4% mismatched elements, max absolute error 0.495196), exit 1. This is a numerical failure, not an import or collection failure.
- Original reported shape: B=2, Q=KV=512, H=8, HKV=2, D=128, BF16 query/e4m3 KV, causal, no soft cap, K scale 0.25 and V scale 0.5: exit 0. Output max absolute error **0.000460476**, relative L2 **0.00280250**; LSE max absolute error **0.000430107**, relative L2 **0.0000116672**. All values finite; output/LSE buffers retain their aliases.

The initial test reference incorrectly used natural-log LSE. It was corrected to FlashInfer's base-2 convention, with no runtime-source or tolerance changes. The earlier failed run is retained as a test-reference error, not reported as passing. The baseline output failure remains valid.

Validated commit: `2f253e0ba7111caf8d2d8ccf832f76678a2bb51a`. FA3/Hopper execution and the full attention suite have not been validated locally.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable on `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please review the calibration boundary: 16-bit-query FP8-KV FA2/FA3 uses the global scales here, while full-FP8 and other backends retain their separate handling. Maintainer CI covering the other attention backends would be appreciated.

Developed with Codex assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FP8 prefill attention scaling across supported backends and data types.
  - Ensured key and value calibration scales are applied consistently, including when scale factors are supplied through backend configuration.
  - Improved numerical accuracy for FP8 attention outputs and log-sum-exp results.

- **Tests**
  - Added comprehensive coverage for FP8 calibration scales across data types, execution modes, scaling combinations, and output configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->