### PR TITLE
bench: compare DeepSeek MoE against pure TRTLLM BF16

### DIFF
--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -696,32 +696,37 @@ def bench_cutlass(
     )
 
 
-def _trtllm_routing_inputs(n, dev, routing_input_mode, distributions):
-    """Use the same pre-routed workload for the TRTLLM FP4 and BF16 cases."""
+def _trtllm_routing_inputs(inputs, routing_input_mode, distributions):
+    """Cache one pre-routed workload per input row for both TRTLLM dtypes."""
     from flashinfer.fused_moe.da_tuner import (
         RoutingRealizationFactory,
         RoutingRealizationKey,
     )
 
-    routing_ids = None
-    routing_weights = None
-    if routing_input_mode == "routed":
-        realized = RoutingRealizationFactory().get_or_create(
-            RoutingRealizationKey(
-                device=torch.device(dev),
-                num_tokens=n,
-                distribution=distributions[0],
-                sample_index=0,
-                local_expert_offset=0,
-                num_local_experts=CFG.num_experts,
-                top_k=CFG.top_k,
-                routing_rule_fingerprint="bench_moe_deepseek:renormalize",
-                routed_scaling_factor=1.0,
-            )
+    if routing_input_mode != "routed":
+        return None, None
+    # A factory caches by the complete realization key, including distribution.
+    # Keep it with this row's inputs so FP4/BF16 reuse identical tensors even
+    # after autotuning advances the RNG, and release it with the input row.
+    factory = inputs.get("_trtllm_routing_factory")
+    if factory is None:
+        factory = RoutingRealizationFactory()
+        inputs["_trtllm_routing_factory"] = factory
+    router_logits = inputs["router_logits"]
+    realized = factory.get_or_create(
+        RoutingRealizationKey(
+            device=torch.device(router_logits.device),
+            num_tokens=router_logits.shape[0],
+            distribution=distributions[0],
+            sample_index=0,
+            local_expert_offset=0,
+            num_local_experts=CFG.num_experts,
+            top_k=CFG.top_k,
+            routing_rule_fingerprint="bench_moe_deepseek:renormalize",
+            routed_scaling_factor=1.0,
         )
-        routing_ids = realized.expert_ids
-        routing_weights = realized.routing_weights
-    return routing_ids, routing_weights
+    )
+    return realized.expert_ids, realized.routing_weights
 
 
 def bench_trtllm(
@@ -845,7 +850,7 @@ def bench_trtllm(
     sc = torch.ones(num_local_experts, device=dev, dtype=torch.float32)
 
     routing_ids, routing_weights = _trtllm_routing_inputs(
-        n, dev, routing_input_mode, distributions
+        inputs, routing_input_mode, distributions
     )
 
     def run(routing_logits, routing_bias, hidden_states, hidden_states_scale):
@@ -969,7 +974,7 @@ def bench_trtllm_bf16(
 
     if num_local_experts is None:
         num_local_experts = CFG.num_experts
-    n, dev = inputs["router_logits"].shape[0], inputs["router_logits"].device
+    dev = inputs["router_logits"].device
     expert_end = local_expert_offset + num_local_experts
     # Canonical [up, gate] weights need both the gated row reorder and
     # BlockMajorK shuffle. The public helper preserves their BF16 values.
@@ -982,7 +987,7 @@ def bench_trtllm_bf16(
         device=dev,
     )
     routing_ids, routing_weights = _trtllm_routing_inputs(
-        n, dev, routing_input_mode, distributions
+        inputs, routing_input_mode, distributions
     )
     moe_kwargs = dict(
         gemm1_weights=weights["gemm1_weights"],

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -5,7 +5,7 @@ Compares NVFP4 and BF16 MoE backends on DeepSeek-V3 configuration:
 - CuteDSL W4A4: NVFP4 activations and weights
 - CuteDSL W4A16: BF16 activations with NVFP4 weights decoded online
 - CUTLASS: NVIDIA CUTLASS-based implementation
-- TRTLLM: TensorRT-LLM's NVFP4 implementation
+- TRTLLM NVFP4: TensorRT-LLM's NVFP4 implementation
 - TRTLLM BF16: unquantized BF16 activations and weights
 
 Usage:
@@ -31,6 +31,9 @@ Usage:
 
     # Compare CuTe DSL W4A4/W4A16 against pure BF16 TRTLLM MoE
     python bench_moe_deepseek.py --backends cutedsl,trtllm-bf16
+
+    # Compare TRTLLM NVFP4 and BF16
+    python bench_moe_deepseek.py --backends trtllm-nvfp4,trtllm-bf16
 
     # Disable CUDA graph (useful for debugging or profiling)
     python bench_moe_deepseek.py --no-cuda-graph
@@ -745,156 +748,161 @@ def bench_trtllm(
     autotune_cache=None,
     routing_input_mode="logits",
     distributions=("uniform",),
+    precision="nvfp4",
 ):
-    """Benchmark TRT-LLM-Gen MoE.
+    """Benchmark TRTLLM NVFP4 or pure BF16 MoE with native finalize.
 
     Args:
         do_autotune: See ``bench_cute_dsl`` for the autotune-scope rationale.
+        precision: ``"nvfp4"`` or ``"bf16"``. Both modes prepare the same
+            source weights outside timing. BF16 preserves the activations
+            and weights without quantization; FP4 activation flags do not
+            affect it.
     """
-    from flashinfer import SfLayout, nvfp4_quantize
-    from flashinfer.fused_moe import (
-        RoutingMethodType,
-        trtllm_fp4_block_scale_moe,
-        trtllm_fp4_block_scale_routed_moe,
-    )
-    from flashinfer.fused_moe.core import (
-        _maybe_get_cached_w3_w1_permute_indices,
-        get_w2_permute_indices_with_cache,
-    )
-    from flashinfer.fp4_quantization import fp4_quantize, block_scale_interleave
-    from flashinfer.quantization.nvfp4_quantization_utils import (
-        current_nvfp4_4over6_config,
-        make_nvfp4_global_scale,
-    )
+    from flashinfer.fused_moe import RoutingMethodType
 
+    if precision not in ("nvfp4", "bf16"):
+        raise ValueError(f"Unsupported TRTLLM precision: {precision}")
     if num_local_experts is None:
         num_local_experts = CFG.num_experts
 
     n, dev = inputs["router_logits"].shape[0], inputs["router_logits"].device
-    sv, etm, cache = 16, 128, {}
-
-    # Expert range for this EP partition
     expert_start = local_expert_offset
     expert_end = local_expert_offset + num_local_experts
+    input_kwargs = {
+        "routing_logits": inputs["router_logits"],
+        "routing_bias": inputs["routing_bias"],
+        "hidden_states": inputs["hidden_bf16"],
+    }
+    moe_kwargs = dict(
+        num_experts=CFG.num_experts,
+        top_k=CFG.top_k,
+        n_group=CFG.n_group,
+        topk_group=CFG.topk_group,
+        intermediate_size=CFG.intermediate_size,
+        local_expert_offset=local_expert_offset,
+        local_num_experts=num_local_experts,
+        do_finalize=True,
+    )
 
-    hidden_global_scale = inputs["hidden_gs"]
-    if use_per_token_activation:
-        hidden_global_scale = make_nvfp4_global_scale(
-            inputs["hidden_bf16"],
-            per_token_activation=True,
-            nvfp4_4over6_config=current_nvfp4_4over6_config(),
+    if precision == "bf16":
+        from flashinfer.fused_moe import (
+            TrtllmBf16Config,
+            trtllm_bf16_moe,
+            trtllm_bf16_routed_moe,
         )
 
-    def quantize_hidden(hidden_states):
+        # Canonical [up, gate] weights need both the gated row reorder and
+        # BlockMajorK shuffle. The public helper preserves their BF16 values.
+        weights = TrtllmBf16Config.prepare_weights(
+            inputs["w1_bf16"][expert_start:expert_end],
+            inputs["w2_bf16"][expert_start:expert_end],
+            num_local_experts=num_local_experts,
+            hidden_size=CFG.hidden_size,
+            intermediate_size=CFG.intermediate_size,
+            device=dev,
+        )
+        moe_kwargs.update(
+            gemm1_weights=weights["gemm1_weights"],
+            gemm2_weights=weights["gemm2_weights"],
+        )
+        logits_moe, routed_moe = trtllm_bf16_moe, trtllm_bf16_routed_moe
+    else:
+        from flashinfer import SfLayout, nvfp4_quantize
+        from flashinfer.fused_moe import (
+            trtllm_fp4_block_scale_moe,
+            trtllm_fp4_block_scale_routed_moe,
+        )
+        from flashinfer.fused_moe.core import (
+            _maybe_get_cached_w3_w1_permute_indices,
+            get_w2_permute_indices_with_cache,
+        )
+        from flashinfer.fp4_quantization import fp4_quantize, block_scale_interleave
+        from flashinfer.quantization.nvfp4_quantization_utils import (
+            current_nvfp4_4over6_config,
+            make_nvfp4_global_scale,
+        )
+
+        sv, etm, cache = 16, 128, {}
+        hidden_global_scale = inputs["hidden_gs"]
         if use_per_token_activation:
-            hidden_states, hidden_states_scale, per_token_scale = nvfp4_quantize(
-                hidden_states,
-                hidden_global_scale,
-                sfLayout=SfLayout.layout_linear,
+            hidden_global_scale = make_nvfp4_global_scale(
+                inputs["hidden_bf16"],
                 per_token_activation=True,
-                backend="cute-dsl",
+                nvfp4_4over6_config=current_nvfp4_4over6_config(),
             )
-        else:
-            hidden_states, hidden_states_scale = fp4_quantize(
-                hidden_states, hidden_global_scale, sv, False, True
+
+        def quantize_hidden(hidden_states):
+            if use_per_token_activation:
+                hidden_states, hidden_states_scale, per_token_scale = nvfp4_quantize(
+                    hidden_states,
+                    hidden_global_scale,
+                    sfLayout=SfLayout.layout_linear,
+                    per_token_activation=True,
+                    backend="cute-dsl",
+                )
+            else:
+                hidden_states, hidden_states_scale = fp4_quantize(
+                    hidden_states, hidden_global_scale, sv, False, True
+                )
+                per_token_scale = None
+            hidden_states = hidden_states.view(torch.uint8).reshape(
+                n, CFG.hidden_size // 2
             )
-            per_token_scale = None
-        hidden_states = hidden_states.view(torch.uint8).reshape(n, CFG.hidden_size // 2)
-        hidden_states_scale = (
-            hidden_states_scale.view(torch.float8_e4m3fn)
-            .flatten()[: n * CFG.hidden_size // sv]
-            .reshape(n, CFG.hidden_size // sv)
+            hidden_states_scale = (
+                hidden_states_scale.view(torch.float8_e4m3fn)
+                .flatten()[: n * CFG.hidden_size // sv]
+                .reshape(n, CFG.hidden_size // sv)
+            )
+            return hidden_states, hidden_states_scale, per_token_scale
+
+        hfp, hsc, hidden_per_token_scale = quantize_hidden(inputs["hidden_bf16"])
+
+        def prep(bf16, gs, M, K):
+            """Prepare weights for LOCAL experts only."""
+            fl, sl = [], []
+            for e in range(expert_start, expert_end):
+                q, s = fp4_quantize(bf16[e], gs[e], sv, False, False)
+                fl.append(q.view(torch.uint8).reshape(M, K // 2))
+                sl.append(s.view(torch.float8_e4m3fn).reshape(M, K // sv))
+            return torch.stack(fl), torch.stack(sl)
+
+        w1f, w1s = prep(
+            inputs["w1_bf16"],
+            inputs["w1_gs"],
+            2 * CFG.intermediate_size,
+            CFG.hidden_size,
         )
-        return hidden_states, hidden_states_scale, per_token_scale
+        w2f, w2s = prep(
+            inputs["w2_bf16"], inputs["w2_gs"], CFG.hidden_size, CFG.intermediate_size
+        )
 
-    hfp, hsc, hidden_per_token_scale = quantize_hidden(inputs["hidden_bf16"])
+        def shuf(fp4, sf, perm_fn):
+            """Shuffle weights for LOCAL experts only."""
+            fsh, ssh = [], []
+            for i in range(num_local_experts):
+                p = perm_fn(cache, fp4[i], etm)
+                fsh.append(fp4[i][p.to(dev)].contiguous())
+                ps = perm_fn(cache, sf[i].view(torch.uint8), etm, sv)
+                ssh.append(
+                    block_scale_interleave(
+                        sf[i].view(torch.uint8)[ps.to(dev)].contiguous()
+                    )
+                )
+            return torch.stack(fsh), torch.stack(ssh)
 
-    def prep(bf16, gs, M, K):
-        """Prepare weights for LOCAL experts only."""
-        fl, sl = [], []
-        for e in range(expert_start, expert_end):
-            q, s = fp4_quantize(bf16[e], gs[e], sv, False, False)
-            fl.append(q.view(torch.uint8).reshape(M, K // 2))
-            sl.append(s.view(torch.float8_e4m3fn).reshape(M, K // sv))
-        return torch.stack(fl), torch.stack(sl)
+        w1f, w1s = shuf(w1f, w1s, _maybe_get_cached_w3_w1_permute_indices)
+        w2f, w2s = shuf(w2f, w2s, get_w2_permute_indices_with_cache)
+        w1s = w1s.view(torch.float8_e4m3fn).reshape(
+            num_local_experts, 2 * CFG.intermediate_size, CFG.hidden_size // sv
+        )
+        w2s = w2s.view(torch.float8_e4m3fn).reshape(
+            num_local_experts, CFG.hidden_size, CFG.intermediate_size // sv
+        )
 
-    w1f, w1s = prep(
-        inputs["w1_bf16"], inputs["w1_gs"], 2 * CFG.intermediate_size, CFG.hidden_size
-    )
-    w2f, w2s = prep(
-        inputs["w2_bf16"], inputs["w2_gs"], CFG.hidden_size, CFG.intermediate_size
-    )
-
-    def shuf(fp4, sf, perm_fn):
-        """Shuffle weights for LOCAL experts only."""
-        fsh, ssh = [], []
-        for i in range(num_local_experts):
-            p = perm_fn(cache, fp4[i], etm)
-            fsh.append(fp4[i][p.to(dev)].contiguous())
-            ps = perm_fn(cache, sf[i].view(torch.uint8), etm, sv)
-            ssh.append(
-                block_scale_interleave(sf[i].view(torch.uint8)[ps.to(dev)].contiguous())
-            )
-        return torch.stack(fsh), torch.stack(ssh)
-
-    w1f, w1s = shuf(w1f, w1s, _maybe_get_cached_w3_w1_permute_indices)
-    w2f, w2s = shuf(w2f, w2s, get_w2_permute_indices_with_cache)
-    w1s = w1s.view(torch.float8_e4m3fn).reshape(
-        num_local_experts, 2 * CFG.intermediate_size, CFG.hidden_size // sv
-    )
-    w2s = w2s.view(torch.float8_e4m3fn).reshape(
-        num_local_experts, CFG.hidden_size, CFG.intermediate_size // sv
-    )
-
-    # Scale tensors sized for LOCAL experts only
-    sc = torch.ones(num_local_experts, device=dev, dtype=torch.float32)
-
-    routing_ids, routing_weights = _trtllm_routing_inputs(
-        inputs, routing_input_mode, distributions
-    )
-
-    def run(routing_logits, routing_bias, hidden_states, hidden_states_scale):
-        """Invoke the selected logits or pre-routed TRTLLM public entry point."""
-        per_token_scale = hidden_per_token_scale
-        if include_activation_quant:
-            hidden_states, hidden_states_scale, per_token_scale = quantize_hidden(
-                hidden_states
-            )
-        if routing_input_mode == "routed":
-            return trtllm_fp4_block_scale_routed_moe(
-                topk_ids=(routing_ids, routing_weights),
-                routing_bias=None,
-                hidden_states=hidden_states,
-                hidden_states_scale=hidden_states_scale,
-                gemm1_weights=w1f,
-                gemm1_weights_scale=w1s,
-                gemm1_bias=None,
-                gemm1_alpha=None,
-                gemm1_beta=None,
-                gemm1_clamp_limit=None,
-                gemm2_weights=w2f,
-                gemm2_weights_scale=w2s,
-                gemm2_bias=None,
-                output1_scale_scalar=sc,
-                output1_scale_gate_scalar=sc,
-                output2_scale_scalar=sc,
-                num_experts=CFG.num_experts,
-                top_k=CFG.top_k,
-                n_group=CFG.n_group,
-                topk_group=CFG.topk_group,
-                intermediate_size=CFG.intermediate_size,
-                local_expert_offset=local_expert_offset,
-                local_num_experts=num_local_experts,
-                routed_scaling_factor=1.0,
-                routing_method_type=RoutingMethodType.Renormalize.value,
-                per_token_scale=per_token_scale,
-                do_finalize=True,
-            )
-        return trtllm_fp4_block_scale_moe(
-            routing_logits=routing_logits,
-            routing_bias=routing_bias,
-            hidden_states=hidden_states,
-            hidden_states_scale=hidden_states_scale,
+        # Scale tensors sized for LOCAL experts only
+        sc = torch.ones(num_local_experts, device=dev, dtype=torch.float32)
+        moe_kwargs.update(
             gemm1_weights=w1f,
             gemm1_weights_scale=w1s,
             gemm1_bias=None,
@@ -907,124 +915,56 @@ def bench_trtllm(
             output1_scale_scalar=sc,
             output1_scale_gate_scalar=sc,
             output2_scale_scalar=sc,
-            num_experts=CFG.num_experts,
-            top_k=CFG.top_k,
-            n_group=CFG.n_group,
-            topk_group=CFG.topk_group,
-            intermediate_size=CFG.intermediate_size,
-            local_expert_offset=local_expert_offset,
-            local_num_experts=num_local_experts,
-            routed_scaling_factor=CFG.routed_scaling_factor,
-            routing_method_type=RoutingMethodType.DeepSeekV3,
-            per_token_scale=per_token_scale,
-            do_finalize=True,
         )
+        input_kwargs.update(
+            hidden_states=inputs["hidden_bf16"] if include_activation_quant else hfp,
+            hidden_states_scale=None if include_activation_quant else hsc,
+        )
+        logits_moe = trtllm_fp4_block_scale_moe
+        routed_moe = trtllm_fp4_block_scale_routed_moe
 
-    input_kwargs = {
-        "routing_logits": inputs["router_logits"],
-        "routing_bias": inputs["routing_bias"],
-        "hidden_states": inputs["hidden_bf16"] if include_activation_quant else hfp,
-        "hidden_states_scale": None if include_activation_quant else hsc,
-    }
-
-    # Pre-warm under autotune; measurement runs outside (see bench_cute_dsl).
-    with _autotune_context(do_autotune, autotune_cache):
-        run(**input_kwargs)
-        torch.cuda.synchronize()
-
-    return _measure_or_profile(
-        run,
-        input_kwargs,
-        warmup,
-        iters,
-        use_cuda_graph,
-        use_cupti,
-        profile_cuda,
-        profile_iters,
-    )
-
-
-def bench_trtllm_bf16(
-    inputs,
-    warmup=10,
-    iters=100,
-    num_local_experts=None,
-    local_expert_offset=0,
-    use_cuda_graph=True,
-    use_cupti=True,
-    do_autotune=True,
-    profile_cuda=False,
-    profile_iters=10,
-    autotune_cache=None,
-    routing_input_mode="logits",
-    distributions=("uniform",),
-):
-    """Benchmark pure BF16 TRTLLM MoE with its native finalize.
-
-    Repack the same source weights outside timing; activations and both
-    GEMMs remain BF16. CuTe DSL finalize and FP4 activation-quantization
-    flags do not change this baseline.
-    """
-    from flashinfer.fused_moe import (
-        RoutingMethodType,
-        TrtllmBf16Config,
-        trtllm_bf16_moe,
-        trtllm_bf16_routed_moe,
-    )
-
-    if num_local_experts is None:
-        num_local_experts = CFG.num_experts
-    dev = inputs["router_logits"].device
-    expert_end = local_expert_offset + num_local_experts
-    # Canonical [up, gate] weights need both the gated row reorder and
-    # BlockMajorK shuffle. The public helper preserves their BF16 values.
-    weights = TrtllmBf16Config.prepare_weights(
-        inputs["w1_bf16"][local_expert_offset:expert_end],
-        inputs["w2_bf16"][local_expert_offset:expert_end],
-        num_local_experts=num_local_experts,
-        hidden_size=CFG.hidden_size,
-        intermediate_size=CFG.intermediate_size,
-        device=dev,
-    )
     routing_ids, routing_weights = _trtllm_routing_inputs(
         inputs, routing_input_mode, distributions
     )
-    moe_kwargs = dict(
-        gemm1_weights=weights["gemm1_weights"],
-        gemm2_weights=weights["gemm2_weights"],
-        num_experts=CFG.num_experts,
-        top_k=CFG.top_k,
-        n_group=CFG.n_group,
-        topk_group=CFG.topk_group,
-        intermediate_size=CFG.intermediate_size,
-        local_expert_offset=local_expert_offset,
-        local_num_experts=num_local_experts,
-        do_finalize=True,
+    is_routed = routing_input_mode == "routed"
+    moe = routed_moe if is_routed else logits_moe
+    moe_kwargs.update(
+        routed_scaling_factor=1.0 if is_routed else CFG.routed_scaling_factor,
+        routing_method_type=(
+            RoutingMethodType.Renormalize.value
+            if is_routed
+            else RoutingMethodType.DeepSeekV3
+        ),
     )
 
-    def run(routing_logits, routing_bias, hidden_states):
-        if routing_input_mode == "routed":
-            return trtllm_bf16_routed_moe(
-                topk_ids=(routing_ids, routing_weights),
-                hidden_states=hidden_states,
-                routed_scaling_factor=1.0,
-                routing_method_type=RoutingMethodType.Renormalize.value,
-                **moe_kwargs,
+    def run(routing_logits, routing_bias, hidden_states, hidden_states_scale=None):
+        activation_kwargs = {}
+        if precision == "nvfp4":
+            per_token_scale = hidden_per_token_scale
+            if include_activation_quant:
+                hidden_states, hidden_states_scale, per_token_scale = quantize_hidden(
+                    hidden_states
+                )
+            activation_kwargs.update(
+                hidden_states_scale=hidden_states_scale,
+                per_token_scale=per_token_scale,
             )
-        return trtllm_bf16_moe(
-            routing_logits=routing_logits,
-            routing_bias=routing_bias,
+        if is_routed:
+            routing_kwargs = {"topk_ids": (routing_ids, routing_weights)}
+            if precision == "nvfp4":
+                routing_kwargs["routing_bias"] = None
+        else:
+            routing_kwargs = dict(
+                routing_logits=routing_logits, routing_bias=routing_bias
+            )
+        return moe(
             hidden_states=hidden_states,
-            routed_scaling_factor=CFG.routed_scaling_factor,
-            routing_method_type=RoutingMethodType.DeepSeekV3,
+            **routing_kwargs,
+            **activation_kwargs,
             **moe_kwargs,
         )
 
-    input_kwargs = {
-        "routing_logits": inputs["router_logits"],
-        "routing_bias": inputs["routing_bias"],
-        "hidden_states": inputs["hidden_bf16"],
-    }
+    # Pre-warm under autotune; measurement runs outside (see bench_cute_dsl).
     with _autotune_context(do_autotune, autotune_cache):
         run(**input_kwargs)
         torch.cuda.synchronize()
@@ -1229,7 +1169,7 @@ def _benchmark_single(
     inputs = create_inputs(n, routing_bias_scale=routing_bias_scale)
     histogram_record = _collect_expert_histogram(inputs, num_local, local_offset)
 
-    selected = set(backends or ("cutedsl", "cutlass", "trtllm", "trtllm-bf16"))
+    selected = set(backends or ("cutedsl", "cutlass", "trtllm-nvfp4", "trtllm-bf16"))
     run_cute_dsl_w4a4 = "cutedsl" in selected and profile_backend in (
         None,
         "cute-dsl",
@@ -1239,7 +1179,10 @@ def _benchmark_single(
         "cute-dsl-w4a16",
     )
     run_cutlass = "cutlass" in selected and profile_backend in (None, "cutlass")
-    run_trtllm = "trtllm" in selected and profile_backend in (None, "trtllm")
+    run_trtllm_nvfp4 = "trtllm-nvfp4" in selected and profile_backend in (
+        None,
+        "trtllm-nvfp4",
+    )
 
     run_trtllm_bf16 = "trtllm-bf16" in selected and profile_backend in (
         None,
@@ -1300,41 +1243,29 @@ def _benchmark_single(
             profile_iters=profile_iters,
             autotune_cache=autotune_cache,
         )
-    if run_trtllm:
-        lat["TRTLLM"] = bench_trtllm(
-            inputs,
-            warmup,
-            iters,
-            num_local,
-            local_offset,
-            use_cuda_graph,
-            use_cupti,
-            do_autotune=do_autotune,
-            use_per_token_activation=use_per_token_activation,
-            include_activation_quant=include_activation_quant,
-            profile_cuda=profile_cuda,
-            profile_iters=profile_iters,
-            autotune_cache=autotune_cache,
-            routing_input_mode=routing_input_mode,
-            distributions=distributions,
-        )
-
-    if run_trtllm_bf16:
-        lat["TRTLLM BF16"] = bench_trtllm_bf16(
-            inputs,
-            warmup,
-            iters,
-            num_local,
-            local_offset,
-            use_cuda_graph,
-            use_cupti,
-            do_autotune=do_autotune,
-            profile_cuda=profile_cuda,
-            profile_iters=profile_iters,
-            autotune_cache=autotune_cache,
-            routing_input_mode=routing_input_mode,
-            distributions=distributions,
-        )
+    for precision, enabled in (
+        ("nvfp4", run_trtllm_nvfp4),
+        ("bf16", run_trtllm_bf16),
+    ):
+        if enabled:
+            lat[f"TRTLLM {precision.upper()}"] = bench_trtllm(
+                inputs,
+                warmup,
+                iters,
+                num_local,
+                local_offset,
+                use_cuda_graph,
+                use_cupti,
+                do_autotune=do_autotune,
+                use_per_token_activation=use_per_token_activation,
+                include_activation_quant=include_activation_quant,
+                profile_cuda=profile_cuda,
+                profile_iters=profile_iters,
+                autotune_cache=autotune_cache,
+                routing_input_mode=routing_input_mode,
+                distributions=distributions,
+                precision=precision,
+            )
 
     # Build results
     results = []
@@ -1411,9 +1342,9 @@ def _print_header(
             f"{'Tokens':>6} | "
             f"{'CuteDSL W4A4':^15} | "
             f"{'CuteDSL W4A16':^15} | "
-            f"{'TRTLLM':^15} | "
+            f"{'TRTLLM NVFP4':^15} | "
             f"{'TRTLLM BF16':^15} | "
-            f"{'Speedup vs TRTLLM':^18} | "
+            f"{'Speedup vs NVFP4':^18} | "
             f"{'Speedup vs BF16':^18} | "
             f"{'Winner':^8} | "
             f"{'Active':^7} | "
@@ -1437,10 +1368,10 @@ def _print_header(
             f"{'CuteDSL W4A4':^15} | "
             f"{'CuteDSL W4A16':^15} | "
             f"{'CUTLASS':^15} | "
-            f"{'TRTLLM':^15} | "
+            f"{'TRTLLM NVFP4':^15} | "
             f"{'TRTLLM BF16':^15} | "
             f"{'Speedup vs CUTLASS':^18} | "
-            f"{'Speedup vs TRTLLM':^18} | "
+            f"{'Speedup vs NVFP4':^18} | "
             f"{'Speedup vs BF16':^18} | "
             f"{'Winner':^8} | "
             f"{'Active':^7} | "
@@ -1467,18 +1398,18 @@ def _print_row(results, histogram_record):
     """Print a single row of benchmark results."""
     # Extract values by backend
     r = {r.backend: r for r in results}
-    w4a4, w4a16, trtllm = (
+    w4a4, w4a16, nvfp4 = (
         r["CuteDSL W4A4"],
         r["CuteDSL W4A16"],
-        r["TRTLLM"],
+        r["TRTLLM NVFP4"],
     )
     cutlass = r.get("CUTLASS")
     bf16 = r["TRTLLM BF16"]
 
     # Calculate speedups (> 1.0 means CuteDSL is faster)
-    trtllm_speedups = (
-        trtllm.latency_ms / w4a4.latency_ms,
-        trtllm.latency_ms / w4a16.latency_ms,
+    nvfp4_speedups = (
+        nvfp4.latency_ms / w4a4.latency_ms,
+        nvfp4.latency_ms / w4a16.latency_ms,
     )
 
     bf16_speedups = (
@@ -1492,6 +1423,7 @@ def _print_row(results, histogram_record):
     winner = {
         "CuteDSL W4A4": "W4A4",
         "CuteDSL W4A16": "W4A16",
+        "TRTLLM NVFP4": "NVFP4",
         "TRTLLM BF16": "BF16",
     }.get(winner, winner)
 
@@ -1502,12 +1434,12 @@ def _print_row(results, histogram_record):
         f"{histogram_record['median_count']:>7.2f}"
     )
     if cutlass is None:
-        speedups = f"{trtllm_speedups[0]:>7.2f}x {trtllm_speedups[1]:>7.2f}x"
+        speedups = f"{nvfp4_speedups[0]:>7.2f}x {nvfp4_speedups[1]:>7.2f}x"
         print(
             f"{w4a4.tokens:>6} | "
             f"{w4a4.latency_ms:>7.3f} {w4a4.tflops:>7.1f} | "
             f"{w4a16.latency_ms:>7.3f} {w4a16.tflops:>7.1f} | "
-            f"{trtllm.latency_ms:>7.3f} {trtllm.tflops:>7.1f} | "
+            f"{nvfp4.latency_ms:>7.3f} {nvfp4.tflops:>7.1f} | "
             f"{bf16.latency_ms:>7.3f} {bf16.tflops:>7.1f} | "
             f"{speedups:>18} | "
             f"{bf16_speedups_text:>18} | "
@@ -1523,18 +1455,16 @@ def _print_row(results, histogram_record):
         cutlass_speedups_text = (
             f"{cutlass_speedups[0]:>7.2f}x {cutlass_speedups[1]:>7.2f}x"
         )
-        trtllm_speedups_text = (
-            f"{trtllm_speedups[0]:>7.2f}x {trtllm_speedups[1]:>7.2f}x"
-        )
+        nvfp4_speedups_text = f"{nvfp4_speedups[0]:>7.2f}x {nvfp4_speedups[1]:>7.2f}x"
         print(
             f"{w4a4.tokens:>6} | "
             f"{w4a4.latency_ms:>7.3f} {w4a4.tflops:>7.1f} | "
             f"{w4a16.latency_ms:>7.3f} {w4a16.tflops:>7.1f} | "
             f"{cutlass.latency_ms:>7.3f} {cutlass.tflops:>7.1f} | "
-            f"{trtllm.latency_ms:>7.3f} {trtllm.tflops:>7.1f} | "
+            f"{nvfp4.latency_ms:>7.3f} {nvfp4.tflops:>7.1f} | "
             f"{bf16.latency_ms:>7.3f} {bf16.tflops:>7.1f} | "
             f"{cutlass_speedups_text:>18} | "
-            f"{trtllm_speedups_text:>18} | "
+            f"{nvfp4_speedups_text:>18} | "
             f"{bf16_speedups_text:>18} | "
             f"{winner:^8} | "
             f"{active_experts:>7} | "
@@ -1628,7 +1558,7 @@ def main():
     parser.add_argument(
         "--backends",
         type=str,
-        help="Comma-separated subset of cutedsl,cutlass,trtllm,trtllm-bf16 (default: all)",
+        help="Comma-separated subset of cutedsl,cutlass,trtllm-nvfp4,trtllm-bf16 (default: all)",
     )
     parser.add_argument(
         "--distributions",
@@ -1704,7 +1634,13 @@ def main():
     )
     parser.add_argument(
         "--profile-backend",
-        choices=["cute-dsl", "cute-dsl-w4a16", "cutlass", "trtllm", "trtllm-bf16"],
+        choices=[
+            "cute-dsl",
+            "cute-dsl-w4a16",
+            "cutlass",
+            "trtllm-nvfp4",
+            "trtllm-bf16",
+        ],
         help="Backend captured by --profile-cuda.",
     )
     parser.add_argument(
@@ -1727,7 +1663,7 @@ def main():
             item.strip() for item in args.backends.split(",") if item.strip()
         )
         unknown = sorted(
-            set(backends) - {"cutedsl", "cutlass", "trtllm", "trtllm-bf16"}
+            set(backends) - {"cutedsl", "cutlass", "trtllm-nvfp4", "trtllm-bf16"}
         )
         if unknown:
             parser.error(f"unknown --backends value(s): {', '.join(unknown)}")

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -1286,16 +1286,16 @@ def _print_header(
     use_fused_finalize=True,
 ):
     """Print benchmark header."""
-    table_width = 159 if use_per_token_activation else 198
+    table_width = 173 if use_per_token_activation else 212
     print("\n" + "=" * table_width)
     if use_per_token_activation:
         print(
-            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4/BF16 "
+            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4 / TRTLLM BF16 "
             f"(EP={ep_config}, TP={tp_config})"
         )
     else:
         print(
-            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM NVFP4/BF16 "
+            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM NVFP4 / TRTLLM BF16 "
             f"(EP={ep_config}, TP={tp_config})"
         )
     print("=" * table_width)
@@ -1326,7 +1326,9 @@ def _print_header(
         "CuteDSL finalize: "
         f"{'atomic fused' if use_fused_finalize else 'deterministic two-stage'}"
     )
-    print("TRTLLM NVFP4/BF16 finalize: native (unaffected by --no-fused-finalize).")
+    print(
+        "TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize)."
+    )
     if use_per_token_activation:
         print("CUTLASS omitted: it does not consume the per-token activation scale.")
     print("-" * table_width)
@@ -1337,11 +1339,11 @@ def _print_header(
             f"{'CuteDSL W4A16':^15} | "
             f"{'TRTLLM NVFP4':^15} | "
             f"{'TRTLLM BF16':^15} | "
-            f"{'Speedup vs NVFP4':^18} | "
-            f"{'Speedup vs BF16':^18} | "
-            f"{'Winner':^8} | "
+            f"{'Speedup vs TRTLLM NVFP4':^23} | "
+            f"{'Speedup vs TRTLLM BF16':^23} | "
+            f"{'Winner':^12} | "
             f"{'Active':^7} | "
-            f"{'Stats':^14}"
+            f"{'Stats':^15}"
         )
         print(
             f"{'':>6} | "
@@ -1349,11 +1351,11 @@ def _print_header(
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
-            f"{'W4A4':>8}  {'W4A16':>8} | "
-            f"{'W4A4':>8}  {'W4A16':>8} | "
-            f"{'':^8} | "
+            f"{'W4A4':>11} {'W4A16':>11} | "
+            f"{'W4A4':>11} {'W4A16':>11} | "
+            f"{'':^12} | "
             f"{'experts':^7} | "
-            f"{'min/max/median':^14}"
+            f"{'min/max/median':^15}"
         )
     else:
         print(
@@ -1364,11 +1366,11 @@ def _print_header(
             f"{'TRTLLM NVFP4':^15} | "
             f"{'TRTLLM BF16':^15} | "
             f"{'Speedup vs CUTLASS':^18} | "
-            f"{'Speedup vs NVFP4':^18} | "
-            f"{'Speedup vs BF16':^18} | "
-            f"{'Winner':^8} | "
+            f"{'Speedup vs TRTLLM NVFP4':^23} | "
+            f"{'Speedup vs TRTLLM BF16':^23} | "
+            f"{'Winner':^12} | "
             f"{'Active':^7} | "
-            f"{'Stats':^14}"
+            f"{'Stats':^15}"
         )
         print(
             f"{'':>6} | "
@@ -1378,11 +1380,11 @@ def _print_header(
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'W4A4':>8}  {'W4A16':>8} | "
-            f"{'W4A4':>8}  {'W4A16':>8} | "
-            f"{'W4A4':>8}  {'W4A16':>8} | "
-            f"{'':^8} | "
+            f"{'W4A4':>11} {'W4A16':>11} | "
+            f"{'W4A4':>11} {'W4A16':>11} | "
+            f"{'':^12} | "
             f"{'experts':^7} | "
-            f"{'min/max/median':^14}"
+            f"{'min/max/median':^15}"
         )
     print("-" * table_width)
 
@@ -1416,8 +1418,6 @@ def _print_row(results, histogram_record):
     winner = {
         "CuteDSL W4A4": "W4A4",
         "CuteDSL W4A16": "W4A16",
-        "TRTLLM NVFP4": "NVFP4",
-        "TRTLLM BF16": "BF16",
     }.get(winner, winner)
 
     active_experts = f"{histogram_record['active_local_experts']:>3}"
@@ -1434,11 +1434,11 @@ def _print_row(results, histogram_record):
             f"{w4a16.latency_ms:>7.3f} {w4a16.tflops:>7.1f} | "
             f"{nvfp4.latency_ms:>7.3f} {nvfp4.tflops:>7.1f} | "
             f"{bf16.latency_ms:>7.3f} {bf16.tflops:>7.1f} | "
-            f"{speedups:>18} | "
-            f"{bf16_speedups_text:>18} | "
-            f"{winner:^8} | "
+            f"{speedups:>23} | "
+            f"{bf16_speedups_text:>23} | "
+            f"{winner:^12} | "
             f"{active_experts:>7} | "
-            f"{stats:>14}"
+            f"{stats:>15}"
         )
     else:
         cutlass_speedups = (
@@ -1457,17 +1457,17 @@ def _print_row(results, histogram_record):
             f"{nvfp4.latency_ms:>7.3f} {nvfp4.tflops:>7.1f} | "
             f"{bf16.latency_ms:>7.3f} {bf16.tflops:>7.1f} | "
             f"{cutlass_speedups_text:>18} | "
-            f"{nvfp4_speedups_text:>18} | "
-            f"{bf16_speedups_text:>18} | "
-            f"{winner:^8} | "
+            f"{nvfp4_speedups_text:>23} | "
+            f"{bf16_speedups_text:>23} | "
+            f"{winner:^12} | "
             f"{active_experts:>7} | "
-            f"{stats:>14}"
+            f"{stats:>15}"
         )
 
 
 def _print_footer(use_per_token_activation):
     """Print benchmark footer."""
-    table_width = 159 if use_per_token_activation else 198
+    table_width = 173 if use_per_token_activation else 212
     print("-" * table_width)
     print(
         "Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend"
@@ -1712,7 +1712,7 @@ def main():
     print(f"CuteDSL API: {'Functional' if args.functional_api else 'Wrapper'}")
     print(f"Per-token activation: {args.use_per_token_activation}")
     print(f"Initial activation quantization: {args.include_activation_quant}")
-    print("CuteDSL modes: W4A4 and W4A16; TRTLLM baselines: NVFP4 and BF16")
+    print("CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4 and TRTLLM BF16")
     print(f"Tensor parallelism simulation: TP={args.tp}")
     print(f"CUDA profiler capture: {args.profile_cuda}")
     print(
@@ -1720,7 +1720,9 @@ def main():
         f"{'atomic fused' if args.use_fused_finalize else 'deterministic two-stage'}"
     )
 
-    print("TRTLLM NVFP4/BF16 finalize: native (unaffected by --no-fused-finalize).")
+    print(
+        "TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize)."
+    )
 
     run_benchmark(
         token_counts=tokens,

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -732,8 +732,6 @@ def bench_trtllm(
         RoutingRealizationKey,
     )
 
-    if precision not in ("nvfp4", "bf16"):
-        raise ValueError(f"Unsupported TRTLLM precision: {precision}")
     if num_local_experts is None:
         num_local_experts = CFG.num_experts
 
@@ -778,7 +776,7 @@ def bench_trtllm(
             gemm2_weights=weights["gemm2_weights"],
         )
         logits_moe, routed_moe = trtllm_bf16_moe, trtllm_bf16_routed_moe
-    else:
+    elif precision == "nvfp4":
         from flashinfer import SfLayout, nvfp4_quantize
         from flashinfer.fused_moe import (
             trtllm_fp4_block_scale_moe,
@@ -893,6 +891,8 @@ def bench_trtllm(
         )
         logits_moe = trtllm_fp4_block_scale_moe
         routed_moe = trtllm_fp4_block_scale_routed_moe
+    else:
+        raise ValueError(f"Unsupported TRTLLM precision: {precision}")
 
     routing_ids = None
     routing_weights = None

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -1675,6 +1675,16 @@ def main():
         parser.error("--profile-iters must be positive")
     if args.profile_cuda != (args.profile_backend is not None):
         parser.error("--profile-cuda and --profile-backend must be specified together")
+    if backends and args.profile_backend is not None:
+        profile_backend = (
+            "cutedsl"
+            if args.profile_backend in ("cute-dsl", "cute-dsl-w4a16")
+            else args.profile_backend
+        )
+        if profile_backend not in backends:
+            parser.error(
+                f"--profile-backend {args.profile_backend} is excluded by --backends"
+            )
     if args.profile_backend == "cutlass" and args.use_per_token_activation:
         parser.error("CUTLASS does not consume the per-token activation scale")
     if not is_sm100_family():

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -699,39 +699,6 @@ def bench_cutlass(
     )
 
 
-def _trtllm_routing_inputs(inputs, routing_input_mode, distributions):
-    """Cache one pre-routed workload per input row for both TRTLLM dtypes."""
-    from flashinfer.fused_moe.da_tuner import (
-        RoutingRealizationFactory,
-        RoutingRealizationKey,
-    )
-
-    if routing_input_mode != "routed":
-        return None, None
-    # A factory caches by the complete realization key, including distribution.
-    # Keep it with this row's inputs so FP4/BF16 reuse identical tensors even
-    # after autotuning advances the RNG, and release it with the input row.
-    factory = inputs.get("_trtllm_routing_factory")
-    if factory is None:
-        factory = RoutingRealizationFactory()
-        inputs["_trtllm_routing_factory"] = factory
-    router_logits = inputs["router_logits"]
-    realized = factory.get_or_create(
-        RoutingRealizationKey(
-            device=torch.device(router_logits.device),
-            num_tokens=router_logits.shape[0],
-            distribution=distributions[0],
-            sample_index=0,
-            local_expert_offset=0,
-            num_local_experts=CFG.num_experts,
-            top_k=CFG.top_k,
-            routing_rule_fingerprint="bench_moe_deepseek:renormalize",
-            routed_scaling_factor=1.0,
-        )
-    )
-    return realized.expert_ids, realized.routing_weights
-
-
 def bench_trtllm(
     inputs,
     warmup=10,
@@ -760,6 +727,10 @@ def bench_trtllm(
             affect it.
     """
     from flashinfer.fused_moe import RoutingMethodType
+    from flashinfer.fused_moe.da_tuner import (
+        RoutingRealizationFactory,
+        RoutingRealizationKey,
+    )
 
     if precision not in ("nvfp4", "bf16"):
         raise ValueError(f"Unsupported TRTLLM precision: {precision}")
@@ -923,10 +894,32 @@ def bench_trtllm(
         logits_moe = trtllm_fp4_block_scale_moe
         routed_moe = trtllm_fp4_block_scale_routed_moe
 
-    routing_ids, routing_weights = _trtllm_routing_inputs(
-        inputs, routing_input_mode, distributions
-    )
+    routing_ids = None
+    routing_weights = None
     is_routed = routing_input_mode == "routed"
+    if is_routed:
+        # Share this row's cached routes across precisions, including after
+        # autotuning advances the RNG. Release the cache with the input row.
+        factory = inputs.get("_trtllm_routing_factory")
+        if factory is None:
+            factory = RoutingRealizationFactory()
+            inputs["_trtllm_routing_factory"] = factory
+        realized = factory.get_or_create(
+            RoutingRealizationKey(
+                device=torch.device(dev),
+                num_tokens=n,
+                distribution=distributions[0],
+                sample_index=0,
+                local_expert_offset=0,
+                num_local_experts=CFG.num_experts,
+                top_k=CFG.top_k,
+                routing_rule_fingerprint="bench_moe_deepseek:renormalize",
+                routed_scaling_factor=1.0,
+            )
+        )
+        routing_ids = realized.expert_ids
+        routing_weights = realized.routing_weights
+
     moe = routed_moe if is_routed else logits_moe
     moe_kwargs.update(
         routed_scaling_factor=1.0 if is_routed else CFG.routed_scaling_factor,

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """DeepSeek-V3 MoE Performance Benchmark - CuteDSL vs CUTLASS vs TRTLLM.
 
-Compares NVFP4 MoE backends on DeepSeek-V3 configuration:
+Compares NVFP4 and BF16 MoE backends on DeepSeek-V3 configuration:
 - CuteDSL W4A4: NVFP4 activations and weights
 - CuteDSL W4A16: BF16 activations with NVFP4 weights decoded online
 - CUTLASS: NVIDIA CUTLASS-based implementation
-- TRTLLM: TensorRT-LLM's implementation
+- TRTLLM: TensorRT-LLM's NVFP4 implementation
+- TRTLLM BF16: unquantized BF16 activations and weights
 
 Usage:
     # Throughput benchmark (large batches: 128-4096 tokens)
@@ -28,6 +29,9 @@ Usage:
     # Include activation quantization for FP4-activation backends
     python bench_moe_deepseek.py --include-activation-quant
 
+    # Compare CuTe DSL W4A4/W4A16 against pure BF16 TRTLLM MoE
+    python bench_moe_deepseek.py --backends cutedsl,trtllm-bf16
+
     # Disable CUDA graph (useful for debugging or profiling)
     python bench_moe_deepseek.py --no-cuda-graph
 
@@ -38,7 +42,7 @@ Usage:
     python bench_moe_deepseek.py --num-tokens 128 \
         --profile-cuda --profile-backend cute-dsl
 
-    # CuTe DSL finalize modes
+    # CuTe DSL finalize modes (TRTLLM keeps its native finalize)
     python bench_moe_deepseek.py --functional-api  # atomic fused (default)
     python bench_moe_deepseek.py --functional-api --no-fused-finalize  # deterministic
 
@@ -692,6 +696,34 @@ def bench_cutlass(
     )
 
 
+def _trtllm_routing_inputs(n, dev, routing_input_mode, distributions):
+    """Use the same pre-routed workload for the TRTLLM FP4 and BF16 cases."""
+    from flashinfer.fused_moe.da_tuner import (
+        RoutingRealizationFactory,
+        RoutingRealizationKey,
+    )
+
+    routing_ids = None
+    routing_weights = None
+    if routing_input_mode == "routed":
+        realized = RoutingRealizationFactory().get_or_create(
+            RoutingRealizationKey(
+                device=torch.device(dev),
+                num_tokens=n,
+                distribution=distributions[0],
+                sample_index=0,
+                local_expert_offset=0,
+                num_local_experts=CFG.num_experts,
+                top_k=CFG.top_k,
+                routing_rule_fingerprint="bench_moe_deepseek:renormalize",
+                routed_scaling_factor=1.0,
+            )
+        )
+        routing_ids = realized.expert_ids
+        routing_weights = realized.routing_weights
+    return routing_ids, routing_weights
+
+
 def bench_trtllm(
     inputs,
     warmup=10,
@@ -719,10 +751,6 @@ def bench_trtllm(
         RoutingMethodType,
         trtllm_fp4_block_scale_moe,
         trtllm_fp4_block_scale_routed_moe,
-    )
-    from flashinfer.fused_moe.da_tuner import (
-        RoutingRealizationFactory,
-        RoutingRealizationKey,
     )
     from flashinfer.fused_moe.core import (
         _maybe_get_cached_w3_w1_permute_indices,
@@ -816,24 +844,9 @@ def bench_trtllm(
     # Scale tensors sized for LOCAL experts only
     sc = torch.ones(num_local_experts, device=dev, dtype=torch.float32)
 
-    routing_ids = None
-    routing_weights = None
-    if routing_input_mode == "routed":
-        realized = RoutingRealizationFactory().get_or_create(
-            RoutingRealizationKey(
-                device=torch.device(dev),
-                num_tokens=n,
-                distribution=distributions[0],
-                sample_index=0,
-                local_expert_offset=0,
-                num_local_experts=CFG.num_experts,
-                top_k=CFG.top_k,
-                routing_rule_fingerprint="bench_moe_deepseek:renormalize",
-                routed_scaling_factor=1.0,
-            )
-        )
-        routing_ids = realized.expert_ids
-        routing_weights = realized.routing_weights
+    routing_ids, routing_weights = _trtllm_routing_inputs(
+        n, dev, routing_input_mode, distributions
+    )
 
     def run(routing_logits, routing_bias, hidden_states, hidden_states_scale):
         """Invoke the selected logits or pre-routed TRTLLM public entry point."""
@@ -910,6 +923,103 @@ def bench_trtllm(
     }
 
     # Pre-warm under autotune; measurement runs outside (see bench_cute_dsl).
+    with _autotune_context(do_autotune, autotune_cache):
+        run(**input_kwargs)
+        torch.cuda.synchronize()
+
+    return _measure_or_profile(
+        run,
+        input_kwargs,
+        warmup,
+        iters,
+        use_cuda_graph,
+        use_cupti,
+        profile_cuda,
+        profile_iters,
+    )
+
+
+def bench_trtllm_bf16(
+    inputs,
+    warmup=10,
+    iters=100,
+    num_local_experts=None,
+    local_expert_offset=0,
+    use_cuda_graph=True,
+    use_cupti=True,
+    do_autotune=True,
+    profile_cuda=False,
+    profile_iters=10,
+    autotune_cache=None,
+    routing_input_mode="logits",
+    distributions=("uniform",),
+):
+    """Benchmark pure BF16 TRTLLM MoE with its native finalize.
+
+    Repack the same source weights outside timing; activations and both
+    GEMMs remain BF16. CuTe DSL finalize and FP4 activation-quantization
+    flags do not change this baseline.
+    """
+    from flashinfer.fused_moe import (
+        RoutingMethodType,
+        TrtllmBf16Config,
+        trtllm_bf16_moe,
+        trtllm_bf16_routed_moe,
+    )
+
+    if num_local_experts is None:
+        num_local_experts = CFG.num_experts
+    n, dev = inputs["router_logits"].shape[0], inputs["router_logits"].device
+    expert_end = local_expert_offset + num_local_experts
+    # Canonical [up, gate] weights need both the gated row reorder and
+    # BlockMajorK shuffle. The public helper preserves their BF16 values.
+    weights = TrtllmBf16Config.prepare_weights(
+        inputs["w1_bf16"][local_expert_offset:expert_end],
+        inputs["w2_bf16"][local_expert_offset:expert_end],
+        num_local_experts=num_local_experts,
+        hidden_size=CFG.hidden_size,
+        intermediate_size=CFG.intermediate_size,
+        device=dev,
+    )
+    routing_ids, routing_weights = _trtllm_routing_inputs(
+        n, dev, routing_input_mode, distributions
+    )
+    moe_kwargs = dict(
+        gemm1_weights=weights["gemm1_weights"],
+        gemm2_weights=weights["gemm2_weights"],
+        num_experts=CFG.num_experts,
+        top_k=CFG.top_k,
+        n_group=CFG.n_group,
+        topk_group=CFG.topk_group,
+        intermediate_size=CFG.intermediate_size,
+        local_expert_offset=local_expert_offset,
+        local_num_experts=num_local_experts,
+        do_finalize=True,
+    )
+
+    def run(routing_logits, routing_bias, hidden_states):
+        if routing_input_mode == "routed":
+            return trtllm_bf16_routed_moe(
+                topk_ids=(routing_ids, routing_weights),
+                hidden_states=hidden_states,
+                routed_scaling_factor=1.0,
+                routing_method_type=RoutingMethodType.Renormalize.value,
+                **moe_kwargs,
+            )
+        return trtllm_bf16_moe(
+            routing_logits=routing_logits,
+            routing_bias=routing_bias,
+            hidden_states=hidden_states,
+            routed_scaling_factor=CFG.routed_scaling_factor,
+            routing_method_type=RoutingMethodType.DeepSeekV3,
+            **moe_kwargs,
+        )
+
+    input_kwargs = {
+        "routing_logits": inputs["router_logits"],
+        "routing_bias": inputs["routing_bias"],
+        "hidden_states": inputs["hidden_bf16"],
+    }
     with _autotune_context(do_autotune, autotune_cache):
         run(**input_kwargs)
         torch.cuda.synchronize()
@@ -1114,7 +1224,7 @@ def _benchmark_single(
     inputs = create_inputs(n, routing_bias_scale=routing_bias_scale)
     histogram_record = _collect_expert_histogram(inputs, num_local, local_offset)
 
-    selected = set(backends or ("cutedsl", "cutlass", "trtllm"))
+    selected = set(backends or ("cutedsl", "cutlass", "trtllm", "trtllm-bf16"))
     run_cute_dsl_w4a4 = "cutedsl" in selected and profile_backend in (
         None,
         "cute-dsl",
@@ -1125,6 +1235,11 @@ def _benchmark_single(
     )
     run_cutlass = "cutlass" in selected and profile_backend in (None, "cutlass")
     run_trtllm = "trtllm" in selected and profile_backend in (None, "trtllm")
+
+    run_trtllm_bf16 = "trtllm-bf16" in selected and profile_backend in (
+        None,
+        "trtllm-bf16",
+    )
 
     lat = {}
     if run_cute_dsl_w4a4:
@@ -1199,6 +1314,23 @@ def _benchmark_single(
             distributions=distributions,
         )
 
+    if run_trtllm_bf16:
+        lat["TRTLLM BF16"] = bench_trtllm_bf16(
+            inputs,
+            warmup,
+            iters,
+            num_local,
+            local_offset,
+            use_cuda_graph,
+            use_cupti,
+            do_autotune=do_autotune,
+            profile_cuda=profile_cuda,
+            profile_iters=profile_iters,
+            autotune_cache=autotune_cache,
+            routing_input_mode=routing_input_mode,
+            distributions=distributions,
+        )
+
     # Build results
     results = []
     for backend, latency in lat.items():
@@ -1225,16 +1357,16 @@ def _print_header(
     use_fused_finalize=True,
 ):
     """Print benchmark header."""
-    table_width = 120 if use_per_token_activation else 159
+    table_width = 159 if use_per_token_activation else 198
     print("\n" + "=" * table_width)
     if use_per_token_activation:
         print(
-            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM "
+            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4/BF16 "
             f"(EP={ep_config}, TP={tp_config})"
         )
     else:
         print(
-            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM "
+            "DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM NVFP4/BF16 "
             f"(EP={ep_config}, TP={tp_config})"
         )
     print("=" * table_width)
@@ -1259,12 +1391,13 @@ def _print_header(
     print(
         "Timed initial activation quantization for FP4-activation backends: "
         f"{'included' if include_activation_quant else 'excluded'}; "
-        "W4A16 consumes BF16 directly"
+        "W4A16 and TRTLLM BF16 consume BF16 directly"
     )
     print(
         "CuteDSL finalize: "
         f"{'atomic fused' if use_fused_finalize else 'deterministic two-stage'}"
     )
+    print("TRTLLM NVFP4/BF16 finalize: native (unaffected by --no-fused-finalize).")
     if use_per_token_activation:
         print("CUTLASS omitted: it does not consume the per-token activation scale.")
     print("-" * table_width)
@@ -1274,7 +1407,9 @@ def _print_header(
             f"{'CuteDSL W4A4':^15} | "
             f"{'CuteDSL W4A16':^15} | "
             f"{'TRTLLM':^15} | "
+            f"{'TRTLLM BF16':^15} | "
             f"{'Speedup vs TRTLLM':^18} | "
+            f"{'Speedup vs BF16':^18} | "
             f"{'Winner':^8} | "
             f"{'Active':^7} | "
             f"{'Stats':^14}"
@@ -1284,6 +1419,8 @@ def _print_header(
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
+            f"{'ms':>7} {'TFLOPS':>7} | "
+            f"{'W4A4':>8}  {'W4A16':>8} | "
             f"{'W4A4':>8}  {'W4A16':>8} | "
             f"{'':^8} | "
             f"{'experts':^7} | "
@@ -1296,8 +1433,10 @@ def _print_header(
             f"{'CuteDSL W4A16':^15} | "
             f"{'CUTLASS':^15} | "
             f"{'TRTLLM':^15} | "
+            f"{'TRTLLM BF16':^15} | "
             f"{'Speedup vs CUTLASS':^18} | "
             f"{'Speedup vs TRTLLM':^18} | "
+            f"{'Speedup vs BF16':^18} | "
             f"{'Winner':^8} | "
             f"{'Active':^7} | "
             f"{'Stats':^14}"
@@ -1308,6 +1447,8 @@ def _print_header(
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
             f"{'ms':>7} {'TFLOPS':>7} | "
+            f"{'ms':>7} {'TFLOPS':>7} | "
+            f"{'W4A4':>8}  {'W4A16':>8} | "
             f"{'W4A4':>8}  {'W4A16':>8} | "
             f"{'W4A4':>8}  {'W4A16':>8} | "
             f"{'':^8} | "
@@ -1327,6 +1468,7 @@ def _print_row(results, histogram_record):
         r["TRTLLM"],
     )
     cutlass = r.get("CUTLASS")
+    bf16 = r["TRTLLM BF16"]
 
     # Calculate speedups (> 1.0 means CuteDSL is faster)
     trtllm_speedups = (
@@ -1334,11 +1476,18 @@ def _print_row(results, histogram_record):
         trtllm.latency_ms / w4a16.latency_ms,
     )
 
+    bf16_speedups = (
+        bf16.latency_ms / w4a4.latency_ms,
+        bf16.latency_ms / w4a16.latency_ms,
+    )
+    bf16_speedups_text = f"{bf16_speedups[0]:>7.2f}x {bf16_speedups[1]:>7.2f}x"
+
     # Find winner
     winner = min(r.values(), key=lambda x: x.latency_ms).backend
     winner = {
         "CuteDSL W4A4": "W4A4",
         "CuteDSL W4A16": "W4A16",
+        "TRTLLM BF16": "BF16",
     }.get(winner, winner)
 
     active_experts = f"{histogram_record['active_local_experts']:>3}"
@@ -1354,7 +1503,9 @@ def _print_row(results, histogram_record):
             f"{w4a4.latency_ms:>7.3f} {w4a4.tflops:>7.1f} | "
             f"{w4a16.latency_ms:>7.3f} {w4a16.tflops:>7.1f} | "
             f"{trtllm.latency_ms:>7.3f} {trtllm.tflops:>7.1f} | "
+            f"{bf16.latency_ms:>7.3f} {bf16.tflops:>7.1f} | "
             f"{speedups:>18} | "
+            f"{bf16_speedups_text:>18} | "
             f"{winner:^8} | "
             f"{active_experts:>7} | "
             f"{stats:>14}"
@@ -1376,8 +1527,10 @@ def _print_row(results, histogram_record):
             f"{w4a16.latency_ms:>7.3f} {w4a16.tflops:>7.1f} | "
             f"{cutlass.latency_ms:>7.3f} {cutlass.tflops:>7.1f} | "
             f"{trtllm.latency_ms:>7.3f} {trtllm.tflops:>7.1f} | "
+            f"{bf16.latency_ms:>7.3f} {bf16.tflops:>7.1f} | "
             f"{cutlass_speedups_text:>18} | "
             f"{trtllm_speedups_text:>18} | "
+            f"{bf16_speedups_text:>18} | "
             f"{winner:^8} | "
             f"{active_experts:>7} | "
             f"{stats:>14}"
@@ -1386,7 +1539,7 @@ def _print_row(results, histogram_record):
 
 def _print_footer(use_per_token_activation):
     """Print benchmark footer."""
-    table_width = 120 if use_per_token_activation else 159
+    table_width = 159 if use_per_token_activation else 198
     print("-" * table_width)
     print(
         "Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend"
@@ -1470,7 +1623,7 @@ def main():
     parser.add_argument(
         "--backends",
         type=str,
-        help="Comma-separated subset of cutedsl,cutlass,trtllm",
+        help="Comma-separated subset of cutedsl,cutlass,trtllm,trtllm-bf16 (default: all)",
     )
     parser.add_argument(
         "--distributions",
@@ -1525,7 +1678,7 @@ def main():
     parser.add_argument(
         "--include-activation-quant",
         action="store_true",
-        help="Include initial activation FP4 quantization in each backend's timing.",
+        help="Include initial activation quantization for FP4-activation backends; BF16 is unaffected.",
     )
     parser.add_argument(
         "--no-fused-finalize",
@@ -1546,7 +1699,7 @@ def main():
     )
     parser.add_argument(
         "--profile-backend",
-        choices=["cute-dsl", "cute-dsl-w4a16", "cutlass", "trtllm"],
+        choices=["cute-dsl", "cute-dsl-w4a16", "cutlass", "trtllm", "trtllm-bf16"],
         help="Backend captured by --profile-cuda.",
     )
     parser.add_argument(
@@ -1568,7 +1721,9 @@ def main():
         backends = tuple(
             item.strip() for item in args.backends.split(",") if item.strip()
         )
-        unknown = sorted(set(backends) - {"cutedsl", "cutlass", "trtllm"})
+        unknown = sorted(
+            set(backends) - {"cutedsl", "cutlass", "trtllm", "trtllm-bf16"}
+        )
         if unknown:
             parser.error(f"unknown --backends value(s): {', '.join(unknown)}")
     distributions = tuple(
@@ -1613,13 +1768,15 @@ def main():
     print(f"CuteDSL API: {'Functional' if args.functional_api else 'Wrapper'}")
     print(f"Per-token activation: {args.use_per_token_activation}")
     print(f"Initial activation quantization: {args.include_activation_quant}")
-    print("CuteDSL modes: W4A4 and W4A16")
+    print("CuteDSL modes: W4A4 and W4A16; TRTLLM baselines: NVFP4 and BF16")
     print(f"Tensor parallelism simulation: TP={args.tp}")
     print(f"CUDA profiler capture: {args.profile_cuda}")
     print(
         "CuteDSL finalize: "
         f"{'atomic fused' if args.use_fused_finalize else 'deterministic two-stage'}"
     )
+
+    print("TRTLLM NVFP4/BF16 finalize: native (unaffected by --no-fused-finalize).")
 
     run_benchmark(
         token_counts=tokens,

--- a/benchmarks/bench_moe_deepseek.py
+++ b/benchmarks/bench_moe_deepseek.py
@@ -45,6 +45,13 @@ Usage:
     python bench_moe_deepseek.py --num-tokens 128 \
         --profile-cuda --profile-backend cute-dsl
 
+    # Nsight Systems: trace individual graph kernels after tuning/warmup.
+    # The moe NVTX range excludes the separately labeled cold-L2 flush.
+    nsys profile --trace=cuda,nvtx --cuda-graph-trace=node --sample=none \
+        --cpuctxsw=none --capture-range=cudaProfilerApi --capture-range-end=stop \
+        -o moe_bf16 python bench_moe_deepseek.py --num-tokens 32 --ep 8 \
+        --profile-cuda --profile-backend trtllm-bf16 --profile-iters 20
+
     # CuTe DSL finalize modes (TRTLLM keeps its native finalize)
     python bench_moe_deepseek.py --functional-api  # atomic fused (default)
     python bench_moe_deepseek.py --functional-api --no-fused-finalize  # deterministic
@@ -311,10 +318,12 @@ def _measure_or_profile(
     l2_flush = torch.empty(2 * get_l2_cache_size(), device="cuda", dtype=torch.int8)
     torch.cuda.cudart().cudaProfilerStart()
     for _ in range(profile_iters):
-        l2_flush.zero_()
-        torch.cuda.synchronize()
-        runner()
-        torch.cuda.synchronize()
+        with torch.cuda.nvtx.range("l2_flush"):
+            l2_flush.zero_()
+            torch.cuda.synchronize()
+        with torch.cuda.nvtx.range("moe"):
+            runner()
+            torch.cuda.synchronize()
     torch.cuda.cudart().cudaProfilerStop()
     if use_cuda_graph:
         torch.cuda.synchronize()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

@humansand

Compare CuTe DSL W4A16/W4A4 MoE against pure TRTLLM BF16 using the same DeepSeek-V3 source inputs. Extend `benchmarks/bench_moe_deepseek.py` with BF16 and NVFP4 precision modes in the existing `bench_trtllm` helper.

- **BF16 contract:** BF16 activations and expert weights; public `TrtllmBf16Config.prepare_weights` applies gated row reorder and BlockMajorK layout outside timing, with no quantization.
- **Integration:** `TRTLLM NVFP4` / `TRTLLM BF16` output and `trtllm-nvfp4` / `trtllm-bf16` selectors for benchmarking/profiling; shared routing, autotuning and measurement setup with explicit precision branches. Both precisions reuse the same cached routed realization per input row.
- **Finalize:** `--no-fused-finalize` applies to CuTe. TRTLLM retains native finalize; FP4 activation flags do not affect pure BF16.
- **Scope:** benchmark script only; no kernel or distributed-script changes. Three configurations below: inference per-tensor, inference per-token, and the deterministic RL configuration from #4048.

### Source and environment

- **Measured source:** `1ac2233d43df747af455ed4a8406d7439d686d9f` (FlashInfer 0.6.18), used for all nine sweeps. **Implementation head:** `2079fa00c4a2a0fb2e95bb284978a703653a4830`. The nine sweeps precede the shared-helper/name/CLI-validation updates. Separate diagnostic measurements below identify their own source commits; they do not replace the original sweeps. Paired refactor correctness validation is linked in Tests.
- **Hardware:** retained C2 devbox, one B300 SXM6 AC (`CUDA_VISIBLE_DEVICES=0`, SM103, 148 SMs, 267.7 GiB) on an eight-B300 host; driver 590.48.01 and image CUDA compatibility library 595.58.03.
- **Image:** `nvcr.io/nvidia/pytorch:26.05-py3`; digest `nvcr.io/nvidia/pytorch@sha256:222d8b18e671be5c3ef91cb41727a2572a0b23f59ded6c39f373a96946f6f2ba`.
- **Software:** CUDA toolkit 13.2 (`nvcc V13.2.78`), PyTorch `2.12.0a0+5aff3928d8.nv26.05`, Python 3.12.3, CuTe DSL `[cu13]==4.7.0`, `cupti-python==13.2.0`, `nvidia-cuda-cupti==13.2.86`, `apache-tvm-ffi==0.1.13.post3`; `nvidia-cuda-nvdisasm==13.3.73` is the DSL disassembler dependency, while compiler/runtime remain CUDA 13.2.
- **Provenance:** editable metadata still reports initial commit `e713467f`; the measured Git checkout is `1ac2233d`. Their difference only shares routed benchmark inputs across TRTLLM precisions. Warm compilation caches are retained.

### Reproduction and configuration

Run inside the image above. Setup the exact measured source; the optional EP-transport build is disabled because no communication is performed.

```sh
set -euo pipefail
mkdir -p /workspace/flashinfer-moe-bf16-benchmark/artifacts
cd /workspace/flashinfer-moe-bf16-benchmark
git clone --branch zianglih/bench-deepseek-moe-bf16 https://github.com/zianglih/flashinfer.git flashinfer
cd flashinfer
git checkout --detach 1ac2233d43df747af455ed4a8406d7439d686d9f
git submodule update --init --recursive
export BUILD_NVEP=0 FLASHINFER_BUILD_NO_PIP=1 MAX_JOBS=8
python3 -m pip install 'setuptools>=77' 'apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2'
python3 -m pip install 'nvidia-cutlass-dsl[cu13]==4.7.0' 'cupti-python==13.2.0' 'nvidia-cuda-cupti==13.2.86' 'nvidia-cuda-nvdisasm==13.3.73' ninja einops pytest pytest-timeout
python3 -m pip install --no-build-isolation --no-deps -e .
python3 -m flashinfer.collect_env > ../artifacts/environment.txt
python3 -m pip freeze > ../artifacts/pip-freeze.txt
nvcc --version >> ../artifacts/environment.txt
nvidia-smi --query-gpu=name,uuid,driver_version,memory.total --format=csv >> ../artifacts/environment.txt
```

Run each command below from that checkout. All commands use logits routing, wrapper API, TP1, initial activation quantization included, CUDA graphs, CUPTI and autotuning. The existing order was per-token 1, RL 1, per-token 2, RL 2, per-token 3, RL 3. Only the added per-tensor variant was subsequently run three times consecutively. Every repetition starts a fresh Python process.

**Inference per-tensor — `Per-token activation: False`:** omit `--use-per-token-activation`; use the existing global-scale path, 4over6 disabled, FP4 quantization fast math enabled, CuTe fused atomic finalize. The default CLI includes CUTLASS NVFP4 in this configuration.

```sh
env \
  -u FLASHINFER_NVFP4_4OVER6 \
  -u FLASHINFER_NVFP4_4OVER6_E4M3_USE_256 \
  -u FLASHINFER_NVFP4_4OVER6_ERR_MODE \
  -u FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH \
  -u FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH \
  CUDA_VISIBLE_DEVICES=0 FLASHINFER_DISABLE_VERSION_CHECK=1 MAX_JOBS=8 \
  python3 benchmarks/bench_moe_deepseek.py \
    --num-tokens 1,2,4,8,16,32,64,128,256,512,1024,2048,4096 \
    --ep 8 --warmup 10 --iters 100 --routing-input-mode logits \
    --include-activation-quant
```

**Inference per-token — `Per-token activation: True`:** per-token activation scaling, 4over6 disabled, FP4 quantization fast math enabled, CuTe fused atomic finalize. CUTLASS is omitted because it does not consume per-token scales.

```sh
env \
  -u FLASHINFER_NVFP4_4OVER6 \
  -u FLASHINFER_NVFP4_4OVER6_E4M3_USE_256 \
  -u FLASHINFER_NVFP4_4OVER6_ERR_MODE \
  -u FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH \
  -u FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH \
  CUDA_VISIBLE_DEVICES=0 FLASHINFER_DISABLE_VERSION_CHECK=1 MAX_JOBS=8 \
  python3 benchmarks/bench_moe_deepseek.py \
    --num-tokens 1,2,4,8,16,32,64,128,256,512,1024,2048,4096 \
    --ep 8 --warmup 10 --iters 100 --routing-input-mode logits \
    --include-activation-quant --use-per-token-activation
```

**Deterministic RL — `Per-token activation: True`:** per-token 4over6 MSE, E4M3 max 256, error fast math enabled, FP4 quantization fast math disabled, CuTe two-stage finalize. This is the requested configuration name, not a full-model determinism claim; CUTLASS is omitted.

```sh
env \
  -u FLASHINFER_NVFP4_4OVER6 \
  -u FLASHINFER_NVFP4_4OVER6_E4M3_USE_256 \
  -u FLASHINFER_NVFP4_4OVER6_ERR_MODE \
  -u FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH \
  -u FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH \
  CUDA_VISIBLE_DEVICES=0 FLASHINFER_DISABLE_VERSION_CHECK=1 MAX_JOBS=8 \
  FLASHINFER_NVFP4_4OVER6=1 \
  FLASHINFER_NVFP4_4OVER6_E4M3_USE_256=1 \
  FLASHINFER_NVFP4_4OVER6_ERR_MODE=MSE \
  FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH=1 \
  FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH=1 \
  python3 benchmarks/bench_moe_deepseek.py \
    --num-tokens 1,2,4,8,16,32,64,128,256,512,1024,2048,4096 \
    --ep 8 --warmup 10 --iters 100 --routing-input-mode logits \
    --include-activation-quant --use-per-token-activation --no-fused-finalize
```

- **Timing:** 10 warmups, 100 iterations/case, cold L2; each run reports median iteration latency. Routing, expert computation, finalize and initial FP4 activation quantization are timed. W4A16/BF16 consume BF16 directly. Weight preparation, compilation and autotuning are outside measurement.
- **Workload:** H=7168, I=2048, E=256, 32 local experts (EP8 simulation), top-k=8, 8 groups/top-4 groups, routed scale=2.5, bias scale=0.01, seed 42, tokens 1–4096 in powers of two. All arms share source BF16 inputs and logits within each row. TFLOPS uses expected uniform local work fraction 32/256; printed routing statistics show actual local routes.
- **Capture:** an outer wrapper serializes returned `BenchResult` records after measurement; original CLI/timing functions are unchanged. All nine processes exited 0. All 507 captured latencies (6×13×4 + 3×13×5) were checked against the printed values before aggregation.

### Complete raw performance results

All nine complete result tables follow. Backend names and table spacing are normalized for display; decorative divider lines are omitted. Original logs and captures remain unchanged, as do every result value and column. Identical printed configuration headers are shown once per three-run group. Raw latency prints to 0.001 ms; raw speedups use unrounded values. The existing six per-token/RL measurements remain unchanged; only the three per-tensor runs were added.

**Inference per-tensor — printed configuration for all three runs:**

```text
DeepSeek-V3 MoE Performance Benchmark
GPU: NVIDIA B300 SXM6 AC
CuteDSL API: Wrapper
Per-token activation: False
Initial activation quantization: True
CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4 and TRTLLM BF16
Tensor parallelism simulation: TP=1
CUDA profiler capture: False
CuteDSL finalize: atomic fused
TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize).
DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs CUTLASS vs TRTLLM NVFP4 / TRTLLM BF16 (EP=8, TP=1)
Model: hidden=7168, intermediate=2048, experts=256, top_k=8
EP Config: 32 local experts (simulating 8-way parallelism)
TP Config: intermediate size 2048 (simulating 1-way parallelism)
CUDA Graph: enabled, CUPTI: enabled
Routing bias scale: 0.01 (larger values tend to create expert imbalance)
Timed initial activation quantization for FP4-activation backends: included; W4A16 and TRTLLM BF16 consume BF16 directly
CuteDSL finalize: atomic fused
TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize).
```

<details>
<summary>Inference per-tensor run 1 — 13 token counts, 5 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | CUTLASS       | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs CUTLASS | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16     | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.031     2.8 | 0.040     2.2 | 0.048     1.8 | 0.026     3.4 | 0.051     1.7 | 1.53x    1.21x     | 0.82x    0.65x          | 1.63x    1.29x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.040     4.4 | 0.046     3.9 | 0.058     3.1 | 0.036     4.9 | 0.079     2.2 | 1.43x    1.26x     | 0.89x    0.79x          | 1.95x    1.72x         | TRTLLM NVFP4 | 4       | 0/  1/   0.00
4      | 0.057     6.2 | 0.063     5.6 | 0.070     5.0 | 0.051     6.9 | 0.117     3.0 | 1.24x    1.12x     | 0.89x    0.81x          | 2.05x    1.85x         | TRTLLM NVFP4 | 7       | 0/  1/   0.00
8      | 0.073     9.7 | 0.079     8.9 | 0.086     8.2 | 0.064    11.0 | 0.157     4.5 | 1.18x    1.10x     | 0.88x    0.81x          | 2.15x    1.99x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.083    17.0 | 0.085    16.5 | 0.097    14.5 | 0.076    18.7 | 0.192     7.3 | 1.17x    1.14x     | 0.91x    0.89x          | 2.32x    2.25x         | TRTLLM NVFP4 | 13      | 0/  2/   0.00
32     | 0.113    24.8 | 0.119    23.8 | 0.127    22.1 | 0.106    26.5 | 0.285     9.9 | 1.12x    1.07x     | 0.94x    0.90x          | 2.52x    2.41x         | TRTLLM NVFP4 | 21      | 0/  3/   1.00
64     | 0.146    38.5 | 0.153    36.9 | 0.159    35.6 | 0.139    40.6 | 0.388    14.5 | 1.08x    1.04x     | 0.95x    0.91x          | 2.65x    2.54x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.150    75.3 | 0.158    71.5 | 0.164    68.8 | 0.144    78.3 | 0.399    28.3 | 1.10x    1.04x     | 0.96x    0.91x          | 2.66x    2.53x         | TRTLLM NVFP4 | 30      | 0/  8/   3.00
256    | 0.158   142.8 | 0.164   137.2 | 0.173   130.0 | 0.154   146.7 | 0.427    52.8 | 1.10x    1.06x     | 0.97x    0.94x          | 2.71x    2.60x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.160   282.2 | 0.169   267.2 | 0.179   251.4 | 0.164   275.3 | 0.435   103.7 | 1.12x    1.06x     | 1.03x    0.97x          | 2.72x    2.58x         | W4A4         | 32      | 7/ 23/  14.00
1024   | 0.165   545.5 | 0.189   476.0 | 0.197   458.2 | 0.295   305.4 | 0.444   203.3 | 1.19x    1.04x     | 1.79x    1.56x          | 2.68x    2.34x         | W4A4         | 32      | 17/ 42/  28.50
2048   | 0.177  1018.3 | 0.233   773.7 | 0.223   810.3 | 0.299   602.6 | 0.475   379.4 | 1.26x    0.95x     | 1.69x    1.28x          | 2.68x    2.04x         | W4A4         | 32      | 38/ 74/  57.50
4096   | 0.219  1646.7 | 0.363   993.0 | 0.281  1282.8 | 0.309  1167.4 | 0.529   682.5 | 1.28x    0.77x     | 1.41x    0.85x          | 2.41x    1.45x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

<details>
<summary>Inference per-tensor run 2 — 13 token counts, 5 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | CUTLASS       | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs CUTLASS | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16     | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.031     2.8 | 0.039     2.2 | 0.048     1.8 | 0.026     3.4 | 0.051     1.7 | 1.53x    1.21x     | 0.82x    0.65x          | 1.63x    1.29x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.040     4.4 | 0.046     3.8 | 0.058     3.1 | 0.036     4.9 | 0.079     2.2 | 1.43x    1.26x     | 0.89x    0.79x          | 1.95x    1.72x         | TRTLLM NVFP4 | 4       | 0/  1/   0.00
4      | 0.057     6.2 | 0.063     5.6 | 0.070     5.0 | 0.051     6.9 | 0.117     3.0 | 1.24x    1.12x     | 0.89x    0.81x          | 2.05x    1.85x         | TRTLLM NVFP4 | 7       | 0/  1/   0.00
8      | 0.073     9.7 | 0.079     9.0 | 0.086     8.2 | 0.064    11.0 | 0.157     4.5 | 1.18x    1.10x     | 0.88x    0.81x          | 2.15x    1.99x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.083    17.0 | 0.088    16.0 | 0.097    14.5 | 0.076    18.6 | 0.192     7.3 | 1.17x    1.10x     | 0.91x    0.86x          | 2.32x    2.17x         | TRTLLM NVFP4 | 13      | 0/  2/   0.00
32     | 0.114    24.8 | 0.118    23.8 | 0.127    22.1 | 0.106    26.6 | 0.285     9.9 | 1.12x    1.08x     | 0.93x    0.90x          | 2.51x    2.41x         | TRTLLM NVFP4 | 21      | 0/  3/   1.00
64     | 0.147    38.4 | 0.151    37.4 | 0.159    35.5 | 0.140    40.3 | 0.388    14.5 | 1.08x    1.05x     | 0.95x    0.93x          | 2.64x    2.57x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.150    75.3 | 0.158    71.3 | 0.164    68.8 | 0.144    78.2 | 0.399    28.2 | 1.09x    1.04x     | 0.96x    0.91x          | 2.67x    2.53x         | TRTLLM NVFP4 | 30      | 0/  8/   3.00
256    | 0.158   143.0 | 0.164   137.1 | 0.173   130.2 | 0.154   146.5 | 0.428    52.7 | 1.10x    1.05x     | 0.98x    0.94x          | 2.71x    2.60x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.160   281.9 | 0.169   267.3 | 0.179   251.3 | 0.164   275.4 | 0.435   103.8 | 1.12x    1.06x     | 1.02x    0.97x          | 2.72x    2.58x         | W4A4         | 32      | 7/ 23/  14.00
1024   | 0.165   546.4 | 0.190   475.7 | 0.197   458.4 | 0.295   305.4 | 0.443   203.6 | 1.19x    1.04x     | 1.79x    1.56x          | 2.68x    2.34x         | W4A4         | 32      | 17/ 42/  28.50
2048   | 0.177  1018.2 | 0.233   772.9 | 0.223   810.6 | 0.299   603.6 | 0.476   379.1 | 1.26x    0.95x     | 1.69x    1.28x          | 2.69x    2.04x         | W4A4         | 32      | 38/ 74/  57.50
4096   | 0.217  1661.9 | 0.363   994.3 | 0.281  1283.9 | 0.309  1166.6 | 0.530   680.7 | 1.29x    0.77x     | 1.42x    0.85x          | 2.44x    1.46x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

<details>
<summary>Inference per-tensor run 3 — 13 token counts, 5 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | CUTLASS       | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs CUTLASS | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16     | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.031     2.8 | 0.040     2.2 | 0.048     1.8 | 0.026     3.4 | 0.051     1.7 | 1.53x    1.21x     | 0.82x    0.65x          | 1.64x    1.29x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.043     4.1 | 0.046     3.9 | 0.058     3.1 | 0.036     4.9 | 0.078     2.2 | 1.34x    1.26x     | 0.83x    0.79x          | 1.82x    1.71x         | TRTLLM NVFP4 | 4       | 0/  1/   0.00
4      | 0.057     6.2 | 0.063     5.6 | 0.071     5.0 | 0.051     6.9 | 0.117     3.0 | 1.24x    1.12x     | 0.90x    0.81x          | 2.05x    1.85x         | TRTLLM NVFP4 | 7       | 0/  1/   0.00
8      | 0.073     9.7 | 0.079     9.0 | 0.086     8.2 | 0.064    11.0 | 0.156     4.5 | 1.18x    1.10x     | 0.88x    0.81x          | 2.15x    1.99x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.083    17.0 | 0.085    16.5 | 0.097    14.5 | 0.076    18.6 | 0.189     7.5 | 1.17x    1.14x     | 0.91x    0.89x          | 2.28x    2.22x         | TRTLLM NVFP4 | 13      | 0/  2/   0.00
32     | 0.114    24.8 | 0.118    23.8 | 0.127    22.1 | 0.106    26.6 | 0.286     9.9 | 1.12x    1.08x     | 0.93x    0.89x          | 2.52x    2.41x         | TRTLLM NVFP4 | 21      | 0/  3/   1.00
64     | 0.147    38.5 | 0.151    37.3 | 0.158    35.6 | 0.140    40.3 | 0.387    14.6 | 1.08x    1.05x     | 0.95x    0.93x          | 2.64x    2.56x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.150    75.4 | 0.156    72.1 | 0.164    68.9 | 0.144    78.2 | 0.399    28.3 | 1.09x    1.05x     | 0.96x    0.92x          | 2.67x    2.55x         | TRTLLM NVFP4 | 30      | 0/  8/   3.00
256    | 0.158   142.7 | 0.165   136.7 | 0.173   130.0 | 0.154   146.9 | 0.428    52.7 | 1.10x    1.05x     | 0.97x    0.93x          | 2.70x    2.59x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.160   282.0 | 0.169   267.2 | 0.179   251.4 | 0.164   275.1 | 0.435   103.7 | 1.12x    1.06x     | 1.03x    0.97x          | 2.72x    2.58x         | W4A4         | 32      | 7/ 23/  14.00
1024   | 0.165   546.2 | 0.190   475.9 | 0.195   463.0 | 0.296   304.9 | 0.443   203.5 | 1.18x    1.03x     | 1.79x    1.56x          | 2.68x    2.34x         | W4A4         | 32      | 17/ 42/  28.50
2048   | 0.177  1019.1 | 0.233   774.0 | 0.223   810.6 | 0.299   603.0 | 0.477   378.4 | 1.26x    0.95x     | 1.69x    1.28x          | 2.69x    2.05x         | W4A4         | 32      | 38/ 74/  57.50
4096   | 0.217  1661.4 | 0.363   993.5 | 0.280  1288.5 | 0.309  1168.4 | 0.529   681.8 | 1.29x    0.77x     | 1.42x    0.85x          | 2.44x    1.46x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

**Inference per-token — printed configuration for all three runs:**

```text
DeepSeek-V3 MoE Performance Benchmark
GPU: NVIDIA B300 SXM6 AC
CuteDSL API: Wrapper
Per-token activation: True
Initial activation quantization: True
CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4 and TRTLLM BF16
Tensor parallelism simulation: TP=1
CUDA profiler capture: False
CuteDSL finalize: atomic fused
TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize).
DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4 / TRTLLM BF16 (EP=8, TP=1)
Model: hidden=7168, intermediate=2048, experts=256, top_k=8
EP Config: 32 local experts (simulating 8-way parallelism)
TP Config: intermediate size 2048 (simulating 1-way parallelism)
CUDA Graph: enabled, CUPTI: enabled
Routing bias scale: 0.01 (larger values tend to create expert imbalance)
Timed initial activation quantization for FP4-activation backends: included; W4A16 and TRTLLM BF16 consume BF16 directly
CuteDSL finalize: atomic fused
TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize).
CUTLASS omitted: it does not consume the per-token activation scale.
```

<details>
<summary>Inference per-token run 1 — 13 token counts, 4 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.042     2.1 | 0.040     2.2 | 0.034     2.6 | 0.053     1.7 | 0.82x    0.87x          | 1.26x    1.34x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.053     3.3 | 0.046     3.9 | 0.046     3.8 | 0.079     2.2 | 0.87x    1.01x          | 1.49x    1.72x         | W4A16        | 4       | 0/  1/   0.00
4      | 0.072     4.9 | 0.062     5.7 | 0.060     5.9 | 0.116     3.0 | 0.83x    0.97x          | 1.61x    1.87x         | TRTLLM NVFP4 | 7       | 0/  1/   0.00
8      | 0.088     8.0 | 0.078     9.0 | 0.074     9.5 | 0.157     4.5 | 0.84x    0.95x          | 1.79x    2.01x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.097    14.6 | 0.084    16.8 | 0.086    16.3 | 0.190     7.4 | 0.89x    1.03x          | 1.97x    2.27x         | W4A16        | 13      | 0/  2/   0.00
32     | 0.132    21.4 | 0.120    23.5 | 0.116    24.3 | 0.287     9.8 | 0.88x    0.97x          | 2.18x    2.39x         | TRTLLM NVFP4 | 21      | 0/  3/   1.00
64     | 0.165    34.2 | 0.153    36.8 | 0.148    38.0 | 0.386    14.6 | 0.90x    0.97x          | 2.34x    2.52x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.170    66.5 | 0.157    71.8 | 0.154    73.2 | 0.398    28.3 | 0.91x    0.98x          | 2.34x    2.53x         | TRTLLM NVFP4 | 30      | 0/  8/   3.00
256    | 0.178   126.8 | 0.164   137.3 | 0.164   137.9 | 0.427    52.8 | 0.92x    1.00x          | 2.40x    2.60x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.182   247.3 | 0.169   267.6 | 0.174   259.3 | 0.436   103.5 | 0.95x    1.03x          | 2.39x    2.58x         | W4A16        | 32      | 7/ 23/  14.00
1024   | 0.192   470.5 | 0.190   475.4 | 0.316   285.6 | 0.443   203.8 | 1.65x    1.66x          | 2.31x    2.33x         | W4A16        | 32      | 17/ 42/  28.50
2048   | 0.213   848.8 | 0.233   774.5 | 0.326   553.7 | 0.477   378.2 | 1.53x    1.40x          | 2.24x    2.05x         | W4A4         | 32      | 38/ 74/  57.50
4096   | 0.268  1346.3 | 0.362   997.3 | 0.338  1066.3 | 0.529   681.8 | 1.26x    0.94x          | 1.97x    1.46x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

<details>
<summary>Inference per-token run 2 — 13 token counts, 4 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.048     1.8 | 0.039     2.2 | 0.035     2.5 | 0.051     1.7 | 0.73x    0.88x          | 1.06x    1.28x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.053     3.3 | 0.046     3.9 | 0.046     3.8 | 0.079     2.2 | 0.87x    1.01x          | 1.49x    1.73x         | W4A16        | 4       | 0/  1/   0.00
4      | 0.072     4.9 | 0.062     5.7 | 0.060     5.9 | 0.117     3.0 | 0.83x    0.97x          | 1.62x    1.90x         | TRTLLM NVFP4 | 7       | 0/  1/   0.00
8      | 0.088     8.0 | 0.078     9.0 | 0.074     9.5 | 0.156     4.5 | 0.84x    0.95x          | 1.78x    2.00x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.097    14.6 | 0.087    16.3 | 0.087    16.3 | 0.190     7.4 | 0.90x    1.00x          | 1.96x    2.19x         | W4A16        | 13      | 0/  2/   0.00
32     | 0.132    21.4 | 0.120    23.5 | 0.116    24.3 | 0.287     9.8 | 0.88x    0.97x          | 2.18x    2.39x         | TRTLLM NVFP4 | 21      | 0/  3/   1.00
64     | 0.165    34.2 | 0.153    36.8 | 0.149    37.9 | 0.387    14.6 | 0.90x    0.97x          | 2.34x    2.53x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.170    66.4 | 0.157    71.7 | 0.154    73.1 | 0.398    28.3 | 0.91x    0.98x          | 2.34x    2.53x         | TRTLLM NVFP4 | 30      | 0/  8/   3.00
256    | 0.178   126.7 | 0.164   137.2 | 0.164   137.8 | 0.427    52.8 | 0.92x    1.00x          | 2.40x    2.60x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.183   247.1 | 0.169   267.4 | 0.174   259.2 | 0.436   103.5 | 0.95x    1.03x          | 2.39x    2.58x         | W4A16        | 32      | 7/ 23/  14.00
1024   | 0.191   471.0 | 0.190   475.1 | 0.317   284.7 | 0.442   203.9 | 1.65x    1.67x          | 2.31x    2.33x         | W4A16        | 32      | 17/ 42/  28.50
2048   | 0.213   848.6 | 0.233   774.4 | 0.326   553.2 | 0.477   378.4 | 1.53x    1.40x          | 2.24x    2.05x         | W4A4         | 32      | 38/ 74/  57.50
4096   | 0.268  1345.8 | 0.363   994.6 | 0.339  1065.5 | 0.528   683.5 | 1.26x    0.93x          | 1.97x    1.46x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

<details>
<summary>Inference per-token run 3 — 13 token counts, 4 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.048     1.8 | 0.040     2.2 | 0.034     2.6 | 0.051     1.7 | 0.72x    0.87x          | 1.06x    1.28x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.053     3.3 | 0.046     3.9 | 0.046     3.8 | 0.079     2.2 | 0.87x    1.01x          | 1.49x    1.73x         | W4A16        | 4       | 0/  1/   0.00
4      | 0.072     4.9 | 0.064     5.5 | 0.060     5.9 | 0.116     3.0 | 0.83x    0.94x          | 1.61x    1.83x         | TRTLLM NVFP4 | 7       | 0/  1/   0.00
8      | 0.088     8.0 | 0.078     9.0 | 0.074     9.5 | 0.156     4.5 | 0.84x    0.95x          | 1.78x    2.00x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.097    14.6 | 0.087    16.3 | 0.086    16.4 | 0.190     7.4 | 0.89x    0.99x          | 1.97x    2.20x         | TRTLLM NVFP4 | 13      | 0/  2/   0.00
32     | 0.132    21.4 | 0.120    23.5 | 0.116    24.3 | 0.287     9.8 | 0.88x    0.97x          | 2.18x    2.39x         | TRTLLM NVFP4 | 21      | 0/  3/   1.00
64     | 0.165    34.1 | 0.153    36.8 | 0.149    37.8 | 0.387    14.6 | 0.90x    0.97x          | 2.34x    2.53x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.170    66.4 | 0.157    71.8 | 0.154    73.2 | 0.400    28.2 | 0.91x    0.98x          | 2.36x    2.55x         | TRTLLM NVFP4 | 30      | 0/  8/   3.00
256    | 0.178   126.9 | 0.164   137.2 | 0.163   138.0 | 0.427    52.8 | 0.92x    0.99x          | 2.40x    2.60x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.182   247.7 | 0.168   267.7 | 0.174   258.9 | 0.436   103.4 | 0.96x    1.03x          | 2.39x    2.59x         | W4A16        | 32      | 7/ 23/  14.00
1024   | 0.192   470.6 | 0.190   475.5 | 0.316   285.5 | 0.443   203.8 | 1.65x    1.67x          | 2.31x    2.33x         | W4A16        | 32      | 17/ 42/  28.50
2048   | 0.212   848.9 | 0.233   774.4 | 0.326   554.0 | 0.477   378.1 | 1.53x    1.40x          | 2.25x    2.05x         | W4A4         | 32      | 38/ 74/  57.50
4096   | 0.268  1346.0 | 0.362   997.1 | 0.338  1066.0 | 0.529   682.3 | 1.26x    0.94x          | 1.97x    1.46x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

**Deterministic RL — printed configuration for all three runs:**

```text
DeepSeek-V3 MoE Performance Benchmark
GPU: NVIDIA B300 SXM6 AC
CuteDSL API: Wrapper
Per-token activation: True
Initial activation quantization: True
CuteDSL modes: W4A4 and W4A16; baselines: TRTLLM NVFP4 and TRTLLM BF16
Tensor parallelism simulation: TP=1
CUDA profiler capture: False
CuteDSL finalize: deterministic two-stage
TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize).
DeepSeek-V3 MoE Benchmark: CuteDSL W4A4/W4A16 vs TRTLLM NVFP4 / TRTLLM BF16 (EP=8, TP=1)
Model: hidden=7168, intermediate=2048, experts=256, top_k=8
EP Config: 32 local experts (simulating 8-way parallelism)
TP Config: intermediate size 2048 (simulating 1-way parallelism)
CUDA Graph: enabled, CUPTI: enabled
Routing bias scale: 0.01 (larger values tend to create expert imbalance)
Timed initial activation quantization for FP4-activation backends: included; W4A16 and TRTLLM BF16 consume BF16 directly
CuteDSL finalize: deterministic two-stage
TRTLLM NVFP4 / TRTLLM BF16 finalize: native (unaffected by --no-fused-finalize).
CUTLASS omitted: it does not consume the per-token activation scale.
```

<details>
<summary>Deterministic RL run 1 — 13 token counts, 4 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.048     1.8 | 0.039     2.2 | 0.036     2.5 | 0.051     1.7 | 0.74x    0.91x          | 1.05x    1.29x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.059     3.0 | 0.046     3.8 | 0.047     3.7 | 0.078     2.3 | 0.80x    1.03x          | 1.32x    1.70x         | W4A16        | 4       | 0/  1/   0.00
4      | 0.078     4.5 | 0.061     5.8 | 0.061     5.7 | 0.117     3.0 | 0.79x    1.01x          | 1.51x    1.93x         | W4A16        | 7       | 0/  1/   0.00
8      | 0.093     7.6 | 0.076     9.3 | 0.076     9.3 | 0.157     4.5 | 0.82x    1.00x          | 1.69x    2.07x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.104    13.6 | 0.084    16.9 | 0.087    16.3 | 0.191     7.4 | 0.83x    1.04x          | 1.83x    2.28x         | W4A16        | 13      | 0/  2/   0.00
32     | 0.138    20.4 | 0.117    24.1 | 0.117    24.0 | 0.286     9.9 | 0.85x    1.01x          | 2.07x    2.45x         | W4A16        | 21      | 0/  3/   1.00
64     | 0.175    32.3 | 0.150    37.5 | 0.150    37.5 | 0.386    14.6 | 0.86x    1.00x          | 2.21x    2.57x         | W4A16        | 29      | 0/  5/   2.00
128    | 0.180    62.8 | 0.155    72.9 | 0.156    72.1 | 0.398    28.3 | 0.87x    1.01x          | 2.21x    2.57x         | W4A16        | 30      | 0/  8/   3.00
256    | 0.188   119.6 | 0.167   134.7 | 0.166   136.0 | 0.427    52.8 | 0.88x    0.99x          | 2.26x    2.55x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.194   232.1 | 0.167   270.1 | 0.177   254.2 | 0.435   103.6 | 0.91x    1.06x          | 2.24x    2.61x         | W4A16        | 32      | 7/ 23/  14.00
1024   | 0.208   433.7 | 0.185   487.7 | 0.319   282.7 | 0.443   203.7 | 1.53x    1.73x          | 2.13x    2.39x         | W4A16        | 32      | 17/ 42/  28.50
2048   | 0.238   758.6 | 0.224   807.1 | 0.334   540.8 | 0.477   378.0 | 1.40x    1.49x          | 2.01x    2.14x         | W4A16        | 32      | 38/ 74/  57.50
4096   | 0.311  1160.4 | 0.328  1098.6 | 0.350  1030.2 | 0.529   681.9 | 1.13x    1.07x          | 1.70x    1.61x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

<details>
<summary>Deterministic RL run 2 — 13 token counts, 4 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.048     1.8 | 0.039     2.2 | 0.036     2.5 | 0.053     1.7 | 0.74x    0.91x          | 1.10x    1.35x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.059     3.0 | 0.046     3.8 | 0.047     3.7 | 0.079     2.2 | 0.80x    1.03x          | 1.34x    1.71x         | W4A16        | 4       | 0/  1/   0.00
4      | 0.077     4.5 | 0.060     5.8 | 0.061     5.7 | 0.116     3.0 | 0.79x    1.02x          | 1.50x    1.92x         | W4A16        | 7       | 0/  1/   0.00
8      | 0.093     7.6 | 0.075     9.4 | 0.075     9.4 | 0.160     4.4 | 0.81x    1.00x          | 1.72x    2.13x         | TRTLLM NVFP4 | 10      | 0/  2/   0.00
16     | 0.104    13.5 | 0.083    16.9 | 0.087    16.3 | 0.190     7.4 | 0.83x    1.04x          | 1.83x    2.28x         | W4A16        | 13      | 0/  2/   0.00
32     | 0.138    20.4 | 0.115    24.5 | 0.117    24.1 | 0.287     9.8 | 0.85x    1.02x          | 2.08x    2.49x         | W4A16        | 21      | 0/  3/   1.00
64     | 0.175    32.3 | 0.150    37.5 | 0.150    37.6 | 0.386    14.6 | 0.86x    1.00x          | 2.21x    2.57x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.180    62.8 | 0.153    73.5 | 0.156    72.1 | 0.400    28.2 | 0.87x    1.02x          | 2.23x    2.61x         | W4A16        | 30      | 0/  8/   3.00
256    | 0.189   119.6 | 0.167   134.7 | 0.165   136.3 | 0.427    52.8 | 0.88x    0.99x          | 2.26x    2.55x         | TRTLLM NVFP4 | 32      | 1/ 11/   7.00
512    | 0.194   232.2 | 0.167   270.2 | 0.177   254.4 | 0.436   103.5 | 0.91x    1.06x          | 2.24x    2.61x         | W4A16        | 32      | 7/ 23/  14.00
1024   | 0.208   433.7 | 0.185   487.9 | 0.320   282.2 | 0.443   203.5 | 1.54x    1.73x          | 2.13x    2.40x         | W4A16        | 32      | 17/ 42/  28.50
2048   | 0.238   759.1 | 0.224   807.1 | 0.333   542.0 | 0.477   378.2 | 1.40x    1.49x          | 2.01x    2.13x         | W4A16        | 32      | 38/ 74/  57.50
4096   | 0.311  1160.6 | 0.328  1098.4 | 0.350  1029.4 | 0.528   682.8 | 1.13x    1.07x          | 1.70x    1.61x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

<details>
<summary>Deterministic RL run 3 — 13 token counts, 4 backends</summary>

```text
Tokens | CuteDSL W4A4  | CuteDSL W4A16 | TRTLLM NVFP4  | TRTLLM BF16   | Speedup vs TRTLLM NVFP4 | Speedup vs TRTLLM BF16 | Winner       | Active  | Stats
       | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | ms  TFLOPS    | W4A4     W4A16          | W4A4     W4A16         |              | experts | min/max/median
1      | 0.048     1.8 | 0.040     2.2 | 0.036     2.4 | 0.053     1.7 | 0.75x    0.90x          | 1.09x    1.31x         | TRTLLM NVFP4 | 2       | 0/  1/   0.00
2      | 0.059     3.0 | 0.046     3.8 | 0.047     3.7 | 0.079     2.2 | 0.81x    1.03x          | 1.34x    1.71x         | W4A16        | 4       | 0/  1/   0.00
4      | 0.077     4.6 | 0.060     5.8 | 0.061     5.7 | 0.117     3.0 | 0.79x    1.01x          | 1.51x    1.93x         | W4A16        | 7       | 0/  1/   0.00
8      | 0.093     7.6 | 0.075     9.4 | 0.075     9.4 | 0.157     4.5 | 0.81x    1.00x          | 1.68x    2.09x         | W4A16        | 10      | 0/  2/   0.00
16     | 0.104    13.6 | 0.083    16.9 | 0.087    16.3 | 0.190     7.4 | 0.84x    1.04x          | 1.83x    2.28x         | W4A16        | 13      | 0/  2/   0.00
32     | 0.139    20.3 | 0.117    24.1 | 0.117    24.1 | 0.287     9.8 | 0.84x    1.00x          | 2.07x    2.46x         | W4A16        | 21      | 0/  3/   1.00
64     | 0.175    32.3 | 0.152    37.0 | 0.150    37.5 | 0.386    14.6 | 0.86x    0.99x          | 2.21x    2.54x         | TRTLLM NVFP4 | 29      | 0/  5/   2.00
128    | 0.180    62.8 | 0.155    72.8 | 0.156    72.2 | 0.398    28.4 | 0.87x    1.01x          | 2.21x    2.57x         | W4A16        | 30      | 0/  8/   3.00
256    | 0.189   119.5 | 0.162   139.1 | 0.166   136.0 | 0.427    52.8 | 0.88x    1.02x          | 2.26x    2.63x         | W4A16        | 32      | 1/ 11/   7.00
512    | 0.194   232.3 | 0.167   270.1 | 0.177   254.3 | 0.436   103.3 | 0.91x    1.06x          | 2.25x    2.61x         | W4A16        | 32      | 7/ 23/  14.00
1024   | 0.208   433.5 | 0.185   487.5 | 0.322   280.3 | 0.443   203.4 | 1.55x    1.74x          | 2.13x    2.40x         | W4A16        | 32      | 17/ 42/  28.50
2048   | 0.238   759.5 | 0.223   807.2 | 0.333   542.3 | 0.477   378.1 | 1.40x    1.49x          | 2.01x    2.14x         | W4A16        | 32      | 38/ 74/  57.50
4096   | 0.311  1159.4 | 0.329  1097.9 | 0.351  1029.3 | 0.528   683.4 | 1.13x    1.07x          | 1.70x    1.61x         | W4A4         | 32      | 81/147/ 117.00
Speedup > 1.0 means that CuTe DSL mode is faster than the comparison backend
```

</details>

### Derived performance summary

Latencies are **medians of three fresh-process runs**, calculated from unrounded captures and displayed in milliseconds to three decimal places. Each **W4A16 speedup** is the named TRTLLM baseline's median latency divided by the CuTe DSL W4A16 median latency at that token count. These are ratios of medians; values above 1 mean W4A16 is faster; values below 1 mean W4A16 is slower. Both NVFP4 and pure BF16 comparisons are explicit.

**Inference per-tensor — median of three runs**

| Tokens | CuTe W4A4 (ms) | CuTe W4A16 (ms) | CUTLASS NVFP4 (ms) | TRTLLM NVFP4 (ms) | TRTLLM BF16 (ms) | W4A16 speedup over TRTLLM NVFP4 | W4A16 speedup over TRTLLM BF16 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 0.031 | 0.040 | 0.048 | 0.026 | 0.051 | 0.65x | 1.29x |
| 2 | 0.040 | 0.046 | 0.058 | 0.036 | 0.079 | 0.79x | 1.72x |
| 4 | 0.057 | 0.063 | 0.070 | 0.051 | 0.117 | 0.81x | 1.85x |
| 8 | 0.073 | 0.079 | 0.086 | 0.064 | 0.157 | 0.81x | 1.99x |
| 16 | 0.083 | 0.085 | 0.097 | 0.076 | 0.192 | 0.89x | 2.25x |
| 32 | 0.114 | 0.118 | 0.127 | 0.106 | 0.285 | 0.89x | 2.41x |
| 64 | 0.147 | 0.151 | 0.159 | 0.140 | 0.388 | 0.92x | 2.56x |
| 128 | 0.150 | 0.158 | 0.164 | 0.144 | 0.399 | 0.91x | 2.53x |
| 256 | 0.158 | 0.164 | 0.173 | 0.154 | 0.428 | 0.93x | 2.60x |
| 512 | 0.160 | 0.169 | 0.179 | 0.164 | 0.435 | 0.97x | 2.58x |
| 1024 | 0.165 | 0.190 | 0.197 | 0.295 | 0.443 | 1.56x | 2.34x |
| 2048 | 0.177 | 0.233 | 0.223 | 0.299 | 0.476 | 1.28x | 2.04x |
| 4096 | 0.217 | 0.363 | 0.281 | 0.309 | 0.529 | 0.85x | 1.46x |

**Inference per-token — median of three runs**

| Tokens | CuTe W4A4 (ms) | CuTe W4A16 (ms) | TRTLLM NVFP4 (ms) | TRTLLM BF16 (ms) | W4A16 speedup over TRTLLM NVFP4 | W4A16 speedup over TRTLLM BF16 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 0.048 | 0.040 | 0.034 | 0.051 | 0.87x | 1.28x |
| 2 | 0.053 | 0.046 | 0.046 | 0.079 | 1.01x | 1.73x |
| 4 | 0.072 | 0.062 | 0.060 | 0.116 | 0.97x | 1.88x |
| 8 | 0.088 | 0.078 | 0.074 | 0.156 | 0.95x | 2.00x |
| 16 | 0.097 | 0.087 | 0.086 | 0.190 | 1.00x | 2.20x |
| 32 | 0.132 | 0.120 | 0.116 | 0.287 | 0.97x | 2.39x |
| 64 | 0.165 | 0.153 | 0.149 | 0.387 | 0.97x | 2.52x |
| 128 | 0.170 | 0.157 | 0.154 | 0.398 | 0.98x | 2.53x |
| 256 | 0.178 | 0.164 | 0.164 | 0.427 | 1.00x | 2.60x |
| 512 | 0.182 | 0.169 | 0.174 | 0.436 | 1.03x | 2.58x |
| 1024 | 0.192 | 0.190 | 0.316 | 0.443 | 1.66x | 2.33x |
| 2048 | 0.213 | 0.233 | 0.326 | 0.477 | 1.40x | 2.05x |
| 4096 | 0.268 | 0.362 | 0.338 | 0.529 | 0.94x | 1.46x |

**Deterministic RL — median of three runs**

| Tokens | CuTe W4A4 (ms) | CuTe W4A16 (ms) | TRTLLM NVFP4 (ms) | TRTLLM BF16 (ms) | W4A16 speedup over TRTLLM NVFP4 | W4A16 speedup over TRTLLM BF16 |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 0.048 | 0.039 | 0.036 | 0.053 | 0.91x | 1.34x |
| 2 | 0.059 | 0.046 | 0.047 | 0.079 | 1.03x | 1.71x |
| 4 | 0.077 | 0.060 | 0.061 | 0.117 | 1.01x | 1.93x |
| 8 | 0.093 | 0.075 | 0.075 | 0.157 | 1.00x | 2.09x |
| 16 | 0.104 | 0.083 | 0.087 | 0.190 | 1.04x | 2.28x |
| 32 | 0.138 | 0.117 | 0.117 | 0.287 | 1.00x | 2.46x |
| 64 | 0.175 | 0.150 | 0.150 | 0.386 | 1.00x | 2.57x |
| 128 | 0.180 | 0.155 | 0.156 | 0.398 | 1.01x | 2.57x |
| 256 | 0.189 | 0.167 | 0.166 | 0.427 | 0.99x | 2.55x |
| 512 | 0.194 | 0.167 | 0.177 | 0.436 | 1.06x | 2.61x |
| 1024 | 0.208 | 0.185 | 0.320 | 0.443 | 1.73x | 2.40x |
| 2048 | 0.238 | 0.224 | 0.333 | 0.477 | 1.49x | 2.13x |
| 4096 | 0.311 | 0.328 | 0.350 | 0.528 | 1.07x | 1.61x |

- **Inference per-tensor:** W4A16 speedup 0.65–1.56x over TRTLLM NVFP4 (2/13 faster); 1.29–2.60x over TRTLLM BF16 (13/13 faster).
- **Inference per-token:** W4A16 speedup 0.87–1.66x over TRTLLM NVFP4 (4/13 faster); 1.28–2.60x over TRTLLM BF16 (13/13 faster).
- **Deterministic RL:** W4A16 speedup 0.91–1.73x over TRTLLM NVFP4 (9/13 faster); 1.34–2.61x over TRTLLM BF16 (13/13 faster).

### BF16 performance investigation

**Finding:** the W4A16 advantage is present in GPU expert computation. TRTLLM BF16 tuning is active; exhaustive native-tactic checks on the actual inputs do not close the gap. Preparation, tuning, L2 flushing and host dispatch are outside the reported CUPTI GPU span. Independent single-call graph events reproduce the ordering. These diagnostics supplement the unchanged nine sweeps.

**Provenance:** profiles, actual-input tactic sweep and event controls use `2079fa00c4a2a0fb2e95bb284978a703653a4830` on the same retained B300/CUDA 13.2 image above. Nsight Systems 2026.2.1, GPU 0; tactic diagnostics GPU 1, serialized with GPU 0 work. Initial cache/default audit uses `a3fce87d5beec29775e9bc3917df99ba6bc4db9c`. Naming commit `d0caa842` and profiling-only commit `2079fa00` are separate; normal benchmark functions/timing remain unchanged from the refactor validation source.

**Autotuning:** 2,852 successful native candidate profiles across 21 token buckets, zero failures; all ten measured warmup/capture dispatches used nonfallback cache hits with tuning disabled. The selected tactic reaches the native launcher. At 32 tokens, all 352 actual-input candidates give a best 284.5635 µs versus 287.3155 µs for the selected baseline (about 1%, single sweep). At 4096, the selected `(128,0)` is also the exhaustive eight-candidate winner at 529.3520 µs. Default `-1` is ~15% slower there. The v1 tuner's synthetic routing activates 11/30 local experts at 32/4096, versus 21/32 on actual inputs; shorter synthetic probe times therefore are not the final benchmark latency. The exhaustive actual-input sweep checks this selection concern directly.

TRTLLM BF16 tuned/default controls (µs; each cell is a 100-iteration median; 3 alternating pairs):

```csv
tokens,tuned_tactic,repeat,tuned_us,default_us
32,8:92,1,286.9315,287.1400
32,8:92,2,287.1560,287.0915
32,8:92,3,287.0440,287.0440
4096,128:0,1,528.9665,609.1280
4096,128:0,2,530.0870,610.4075
4096,128:0,3,531.5110,611.6720
```

All actual-input native candidates (median of 100 iterations, µs; one sample each). Each CSV row lists latencies in ascending contiguous config-ID order; `(tileN, config)` is the native tactic. This includes every 352/8 enumerated candidate plus default.

```text
tokens=32; default(-1)=286.8350
tile=8; config=0..143
295.8595,286.0840,297.8440,285.7475,299.2360,285.5240,295.9080,297.4760,286.0515,299.2035,286.1795,285.4120,297.0920,287.0435,298.6920,286.5315,300.6760,286.2120,296.9640,298.5000,286.8360,300.1955,286.5155,286.3720,295.2840,285.3795,296.8685,285.3000,299.1075,284.6115,295.2520,296.9475,285.4115,299.1080,284.8520,284.5635,296.2920,286.4840,298.1160,286.3075,300.0350,285.9240,296.1640,298.5960,286.8840,300.0355,286.2435,285.6995,297.1560,286.8360,298.8200,286.7560,300.6760,286.3080,296.5795,298.5475,286.8035,300.8355,286.7235,286.1800,296.7555,286.9640,298.3240,287.0435,300.3080,286.3885,296.9475,297.9720,287.0115,300.1160,286.6915,286.4990,296.2600,285.9395,297.4600,285.8280,299.6360,285.6360,295.9720,297.3800,286.1155,299.5075,285.6360,285.3955,297.2680,287.2360,298.4360,286.8200,300.6600,286.3555,297.1070,298.7720,286.9630,301.0115,286.7235,286.4840,295.3160,285.2355,296.7560,285.2200,299.2040,284.9795,295.3315,296.9640,285.4600,299.2995,285.0440,284.5800,296.3880,286.6440,297.8755,286.3395,299.7320,285.7800,296.1955,297.9715,287.1240,300.1160,286.1960,285.9715,297.1395,287.0595,299.0280,286.9150,300.9635,286.3720,297.1560,298.4520,286.9155,300.9960,286.6755,286.5800,296.9000,287.0920,298.2125,287.1080,300.1795,286.5635,296.5800,298.5800,287.0280,300.3085,286.8520,286.2920
tile=16; config=0..143
292.6915,294.5480,285.8280,296.8680,285.6355,285.1880,292.8355,285.6040,294.7075,296.8840,285.6200,285.3160,293.3160,295.2365,286.3875,297.7965,286.3235,286.0680,293.0440,286.6600,295.0760,297.4760,286.4200,286.2920,291.9400,293.9885,285.0910,296.1645,285.0600,284.7080,292.0835,284.9640,293.8280,296.4360,285.1070,284.7230,292.6760,294.9800,285.9240,297.1880,286.2595,285.3320,292.7240,285.9880,294.7080,296.8680,286.0040,285.5075,293.7630,295.8605,287.0440,298.0835,287.0920,286.5960,293.5720,286.7880,295.6520,297.4760,287.0120,286.1800,293.2840,295.4600,286.8670,297.9560,286.6115,286.2115,293.0435,286.3720,295.3805,297.2840,286.9325,286.0675,292.2435,294.4520,285.6040,296.4360,285.8760,285.1560,292.7245,285.5240,294.7560,296.9000,285.7320,285.3005,293.2845,295.3000,286.3245,297.5245,286.4360,286.5000,293.1080,286.4680,295.2520,297.5875,286.7240,286.1480,291.8760,294.1960,285.1080,296.0360,284.9640,284.8200,291.6040,285.1235,294.0360,296.2920,285.3160,284.7555,292.6440,294.8200,285.8920,296.9640,286.0520,285.1880,292.7560,285.9550,294.5955,297.2520,286.0840,285.7315,293.7000,295.8920,286.8520,298.2760,286.9000,286.9320,293.7320,286.8520,295.3640,297.7485,287.1720,286.6755,293.3965,295.4440,286.3725,297.3800,286.9160,286.1795,293.5725,286.5480,295.1400,297.5710,286.5950,286.2915
tile=32; config=0..63
292.4360,286.0520,295.0600,285.7955,292.2285,295.1080,285.5555,286.2440,294.3400,287.7800,297.5880,287.7320,294.1960,297.2200,287.8120,287.8920,293.0760,286.9160,296.5960,286.7720,292.8675,296.4680,286.8035,286.7240,293.6680,287.7165,297.1715,287.5720,293.5565,296.9160,287.6040,287.4920,292.1795,286.2110,295.2680,285.7475,292.1635,295.4600,286.0200,286.0675,294.1480,288.0195,297.5405,287.7955,294.1480,297.2200,287.6845,288.0680,293.2840,286.9160,296.1320,286.7075,293.0920,296.3240,286.9320,286.9800,293.8600,287.7960,296.7075,287.4290,293.5720,296.9160,287.3000,287.6835
tokens=4096; default(-1)=609.7365
tile=64; config=0..3
611.4960,611.9765,610.2970,611.5760
tile=128; config=0..3
529.3520,529.5590,530.8710,530.3430
```

**Nsight Systems complete device breakdown (µs):** 20 cold-L2, one-call graph replays per case after tuning and three uncaptured replays. Every non-dash activity cell is the mean of 20 instances; both temporary-zero kernels are shown separately. All target kernels/memsets are accounted for inside synchronized `moe` NVTX ranges; each contains one `cudaGraphLaunch`. The 20 separately labeled L2 flushes are excluded. Kernel sums are diagnostic, not latency: [programmatic dependent launch](https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/programmatic-dependent-launch.html) allows dependent kernel intervals to overlap. GPU span measures the first activity start through last activity end; uncovered gaps use the union of intervals. Inference profiles cover both inference activation variants because those flags do not change W4A16 or TRTLLM BF16; RL is separately profiled.

**Inference:**

| Activity / metric | CuTe W4A16 / 32 | TRTLLM BF16 / 32 | CuTe W4A16 / 4096 | TRTLLM BF16 / 4096 |
| --- | ---: | ---: | ---: | ---: |
| Top-k routing | 3.150 | 3.346 | 9.635 | 9.214 |
| Temporary zero 1 | 0.587 | — | 0.672 | — |
| Temporary zero 2 | 0.628 | — | 0.702 | — |
| Route map | 3.709 | 3.171 | 6.832 | 6.339 |
| BF16 permute | 4.648 | — | 22.986 | — |
| GEMM1 + SwiGLU | 67.812 | 189.739 | 164.956 | 331.377 |
| Output zero | 0.906 | — | 9.722 | — |
| GEMM2 | 36.946 | 89.677 | 147.033 | 150.361 |
| Finalize | — | 5.779 | — | 38.018 |
| GPU activity sum | 118.386 | 291.712 | 362.538 | 535.309 |
| GPU span | 118.522 | 285.562 | 359.142 | 527.871 |
| Uncovered GPU gaps | 0.668 | 0.000 | 0.644 | 0.000 |
| Graph launch CPU API (excluded) | 9.867 | 8.062 | 7.405 | 8.048 |
| L2 flush (excluded) | 67.826 | 67.925 | 67.882 | 67.810 |

**Deterministic RL:**

| Activity / metric | CuTe W4A16 / 32 | TRTLLM BF16 / 32 | CuTe W4A16 / 4096 | TRTLLM BF16 / 4096 |
| --- | ---: | ---: | ---: | ---: |
| Top-k routing | 3.094 | 3.283 | 9.622 | 9.283 |
| Temporary zero 1 | 0.592 | — | 0.677 | — |
| Temporary zero 2 | 0.590 | — | 0.694 | — |
| Route map | 3.578 | 3.014 | 7.237 | 6.586 |
| BF16 permute | 4.526 | — | 23.088 | — |
| GEMM1 + SwiGLU | 68.505 | 188.811 | 165.900 | 331.810 |
| Output zero | — | — | — | — |
| GEMM2 | 43.343 | 89.194 | 110.439 | 150.190 |
| Finalize | 5.880 | 5.755 | 31.789 | 38.095 |
| GPU activity sum | 130.108 | 290.058 | 349.446 | 535.964 |
| GPU span | 114.262 | 284.682 | 326.137 | 528.484 |
| Uncovered GPU gaps | 0.365 | 0.000 | 0.329 | 0.000 |
| Graph launch CPU API (excluded) | 7.163 | 6.141 | 10.132 | 8.223 |
| L2 flush (excluded) | 67.928 | 67.817 | 67.880 | 67.842 |

Kernel mapping: top-k=`deepseek_v3_topk_kernel` / `routingMainKernel`; route map=`routingIndicesClusterKernel` / `routingIndicesCoopKernel`; temporary zeros=`vectorized_elementwise_kernel`; permute/unpermute=`moePermuteKernel` / `moeUnpermuteKernel`; CuTe GEMMs=`Sm100W4A16GroupedGemmKernel` in launch order; TRTLLM BF16 GEMMs=`bmm_Bfloat16_Bfloat16Bfloat16...` (FC1 has `swiGlu`); native finalize=`finalizeKernel` / `finalizeKernelVecLoad`. CuTe inference GEMM2 includes atomic finalize; RL uses the separate unpermute row. At 32 tokens both GEMMs explain the gap; at 4096 the largest difference is GEMM1, with native finalize also contributing. TRTLLM BF16 has no uncovered device gaps in these traces.

**Independent timer control:** same tuned callable, one call per graph, 100 samples after 10 warmups; zero a 2×L2 byte buffer and synchronize before each start event, then `start.record(); graph.replay(); end.record(); end.synchronize()`. CUPTI separately measures the same prepared callable. Every case passed with finite outputs. Table contains every case's median in µs. Event intervals add roughly 4–6 µs but retain the gap; host submission cannot explain the BF16 slowdown. Warm-cache results are sequential diagnostics, not an isolated cache speedup claim. Ordinary `--no-cupti` is not this control: it uses ten-call graphs and rotates only input kwargs, leaving closure-held weights unrotated.

| Config | Tokens | Backend | Cold CUPTI | Cold events | Warm events |
| --- | ---: | --- | ---: | ---: | ---: |
| inference | 1 | CuTe W4A16 | 38.9440 | 42.9440 | 39.8240 |
| inference | 1 | TRTLLM BF16 | 50.7525 | 56.8640 | 46.5280 |
| inference | 32 | CuTe W4A16 | 118.9450 | 124.4480 | 113.4080 |
| inference | 32 | TRTLLM BF16 | 286.0665 | 292.3360 | 276.1920 |
| inference | 4096 | CuTe W4A16 | 361.9550 | 366.7200 | 378.1440 |
| inference | 4096 | TRTLLM BF16 | 528.9640 | 533.6480 | 543.2800 |
| rl | 1 | CuTe W4A16 | 40.1280 | 45.8080 | 42.1760 |
| rl | 1 | TRTLLM BF16 | 53.0885 | 58.8960 | 48.0480 |
| rl | 32 | CuTe W4A16 | 115.0410 | 120.3360 | 112.3520 |
| rl | 32 | TRTLLM BF16 | 286.5785 | 292.5920 | 276.2240 |
| rl | 4096 | CuTe W4A16 | 327.4590 | 333.0560 | 355.2640 |
| rl | 4096 | TRTLLM BF16 | 528.6275 | 533.4560 | 542.9120 |

### Nsight Compute: fixed normal-tuned tactics

- **Scope:** inference per-token, EP8/TP1, B300 GPU 0, NCU 2026.1.1, source `2079fa00`. Tactics were recorded during normal tuning before NCU injection, then fixed by a diagnostic helper; all captured calls had tuning disabled. Each report contains exactly FC1 (with SwiGLU) and FC2, nine replay passes each. Node replay flushes caches and isolates PDL kernels: these durations are diagnostics, not additive end-to-end latency.
- **Tactics:** TRTLLM BF16: `(8, 37)` at 32; `(128, 1)` at 4096. CuteDSL W4A16 uses the same tactic for both GEMMs: `((128, 8, 256), (2, 1), True)` at 32; `((256, 128, 256), (2, 1), True)` at 4096.

Raw counters below: R/W = DRAM bytes; D/T/S = DRAM throughput / tensor-pipe activity / SM throughput (% of sustained elapsed peak); LD/ST = local-memory sectors; warps = active warps per active SM cycle; A/T = achieved/theoretical occupancy (%).

| Tokens | Backend | GEMM | R bytes | W bytes | ns | D/T/S % | LD/ST | Warps | Occupancy A/T % | Registers/thread | Shared bytes/block |
| ---: | --- | --- | ---: | ---: | ---: | --- | --- | ---: | --- | ---: | ---: |
| 32 | TRTLLM BF16 | FC1 | 1233656832 | 3507200 | 176896 | 91.17/2.42/25.37 | 0/0 | 11.33 | 17.70/18.75 | 168 | 181904 |
| 32 | TRTLLM BF16 | FC2 | 616784896 | 4100096 | 93760 | 86.35/2.27/23.87 | 0/0 | 7.95 | 12.42/12.50 | 255 | 216720 |
| 4096 | TRTLLM BF16 | FC1 | 2064285184 | 17972224 | 323040 | 84.03/40.83/45.78 | 0/0 | 10.84 | 16.94/18.75 | 168 | 187032 |
| 4096 | TRTLLM BF16 | FC2 | 960271104 | 50072064 | 152864 | 86.17/44.00/48.40 | 0/0 | 6.98 | 10.91/12.50 | 255 | 219800 |
| 32 | CuteDSL W4A16 | FC1 | 349258752 | 3499264 | 65632 | 70.11/6.61/53.35 | 0/0 | 15.86 | 24.77/25.00 | 128 | 215040 |
| 32 | CuteDSL W4A16 | FC2 | 174409728 | 3022592 | 37504 | 61.78/5.74/49.50 | 0/0 | 15.61 | 24.39/25.00 | 128 | 206880 |
| 4096 | CuteDSL W4A16 | FC1 | 637545728 | 13989120 | 165696 | 51.26/87.20/87.81 | 0/0 | 15.84 | 24.75/25.00 | 128 | 223232 |
| 4096 | CuteDSL W4A16 | FC2 | 322100992 | 7225344 | 148096 | 28.99/44.90/46.44 | 0/0 | 15.06 | 23.53/25.00 | 128 | 215168 |

Remaining launch counters (all eight kernels): occupancy limits = 32 blocks, 1 block by registers, 1 by shared memory; warp limit = 5/8 blocks for BF16 FC1/FC2 and 4 for W4A16. Cluster dimensions = `(2,1,1)`, except BF16 at 32 uses `(1,1,1)`. `occupancy_cluster_pct` = 3.12%; `occupancy_cluster_gpu_pct` = 0.59/0.39% for BF16 FC1/FC2 and 0.78% for both W4A16 kernels (launch estimates, not measured GPU activity). Full raw CSV/report metadata is retained.

**Interpretation:** at 4096, BF16 still reaches 84–86% DRAM throughput with 41–44% tensor activity; W4A16 FC1 reaches 87% tensor activity. BF16 reads 3.025 GB versus W4A16's 0.960 GB. EP8 leaves 3715 local assignments across 32 experts (116/expert); 4096 is not each expert's GEMM M. No local load/store traffic was measured in any kernel. Registers and shared memory both limit residency to one block/SM; low occupancy alone does not establish an avoidable defect. These counters support a bandwidth explanation and do not demonstrate a spilling or launch-overhead bug.

Public CLI equivalent on `2079fa00`: TRTLLM BF16 at 32 passed normal cache save then fresh-process `--no-autotune` load (both exit 0, target cache hit, no retuning, unchanged cache hash). The measured counters above used the helper-frozen tactics, not this smoke cache. Run in the same inference environment with NVFP4 overrides unset. Require a target-operation `Config cache hit`; missing/incompatible caches can otherwise fall back.

```bash
export CUDA_VISIBLE_DEVICES=0 FLASHINFER_DISABLE_VERSION_CHECK=1 MAX_JOBS=8 FLASHINFER_LOGGING_LEVEL=info
m=(dram__bytes_{read,write}.sum {dram__throughput,sm__throughput,sm__pipe_tensor_cycles_active}.avg.pct_of_peak_sustained_elapsed gpu__time_duration.sum l1tex__t_sectors_pipe_lsu_mem_local_op_{ld,st}.sum sm__warps_active.avg.{per_cycle_active,pct_of_peak_sustained_active} sm__maximum_warps_per_active_cycle_pct launch__{registers_per_thread,shared_mem_per_block,occupancy_limit_{blocks,registers,shared_mem,warps},cluster_dim_{x,y,z},occupancy_cluster_pct,occupancy_cluster_gpu_pct})
for n in 32 4096; do
  for b in cute-dsl-w4a16 trtllm-bf16; do
    a=(benchmarks/bench_moe_deepseek.py --num-tokens "$n" --ep 8 --tp 1 --routing-input-mode logits --use-per-token-activation --include-activation-quant --profile-cuda --profile-backend "$b" --profile-iters 1 --cache "$b-$n.json")
    python "${a[@]}"
    test -s "$b-$n.json" || exit 1
    ncu --profile-from-start off --replay-mode kernel --graph-profiling node --nvtx --nvtx-include moe/ --kernel-name-base demangled --rename-kernels off --kernel-name 'regex:.*(Sm100W4A16GroupedGemmKernel|bmm_Bfloat16_Bfloat16Bfloat16_).*' --launch-count 2 --cache-control all --clock-control none --metrics "$(IFS=,; echo "${m[*]}")" --csv --page raw --print-units base --export "$b-$n" python "${a[@]}" --no-autotune
  done
done
```

**Why 4096 remains bandwidth-sensitive:** the actual EP8 routing has 3715/32 = 116.09 rows per expert. Useful BF16 GEMM FLOPs divided by unique weight bytes give 116.09 FLOP/byte; including minimum activation traffic gives about 108–112. The advertised dense BF16 rate is 36 PFLOPS/node ÷ 2 ÷ 8 = 2.25 PFLOPS/GPU ([NVIDIA HGX specifications](https://www.nvidia.com/en-us/data-center/hgx/)); with [8 TB/s HBM](https://docs.nvidia.com/enterprise-reference-architectures/hgx-ai-factory/latest/components.html), the ideal crossover is about 281 FLOP/byte. These are analytical peak bounds, supported here by the measured DRAM counters. Tile128 pads to 40 tiles/5120 slots (72.56% useful rows). The 3.025 GB measured BF16 reads are close to 2.819 GB unique weights and below 3.523 GB if every token tile reread them. Compression moves W4A16 GEMM1 toward compute saturation; equal tensor-core input precision does not give equal memory traffic.

**Reproduce the eight Nsight traces** from the implementation checkout and image above. Output files remain on the retained devbox; no compilation caches are removed.

```bash
git checkout 2079fa00c4a2a0fb2e95bb284978a703653a4830
export CUDA_VISIBLE_DEVICES=0 FLASHINFER_DISABLE_VERSION_CHECK=1 MAX_JOBS=8
for mode in inference rl; do
  unset FLASHINFER_NVFP4_4OVER6 FLASHINFER_NVFP4_4OVER6_E4M3_USE_256
  unset FLASHINFER_NVFP4_4OVER6_ERR_MODE FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH
  unset FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH
  extra=()
  if [[ $mode == rl ]]; then
    export FLASHINFER_NVFP4_4OVER6=1 FLASHINFER_NVFP4_4OVER6_E4M3_USE_256=1
    export FLASHINFER_NVFP4_4OVER6_ERR_MODE=MSE FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH=1
    export FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH=1
    extra=(--no-fused-finalize)
  fi
  for n in 32 4096; do
    for backend in cute-dsl-w4a16 trtllm-bf16; do
      nsys profile --sample=none --cpuctxsw=none --trace=cuda,nvtx \
        --cuda-graph-trace=node --capture-range=cudaProfilerApi \
        --capture-range-end=stop -o "$mode-$backend-t$n" \
        python3 benchmarks/bench_moe_deepseek.py --num-tokens "$n" --ep 8 \
        --warmup 10 --iters 100 --use-per-token-activation --include-activation-quant \
        --profile-cuda --profile-backend "$backend" --profile-iters 20 "${extra[@]}"
      nsys export --type=sqlite -o "$mode-$backend-t$n.sqlite" "$mode-$backend-t$n.nsys-rep"
    done
  done
done
```

Aggregate all GPU activities contained by each synchronized `moe` NVTX range, including target memsets; verify 20 ranges and one graph launch per range. Report per-kernel `sum(end-start)/20`, per-range GPU `max(end)-min(start)`, and CPU graph-launch duration separately. Exclude `l2_flush`; do not sum kernel durations as wall-clock latency. These are single-GPU local-expert diagnostics, not distributed or full-model speedups.

### Interpretation and limits

- Single-GPU EP8 shard shapes: no dispatch/combine, all-gather, all-reduce, network or full-model runtime is timed.
- Both TRTLLM arms use native finalize in every configuration. Native logits routing stores selected weights in BF16; CuTe route weights are FP32. This is not a numerical-parity claim between BF16/quantized paths or proof of RL-training determinism.
- New per-tensor runs also remeasure the unaffected W4A16/BF16 paths. Differences across separate sweeps are not attributed solely to activation scaling. Coverage is B300/SM103 and the stated shapes; other architectures and distributed execution were not tested.

## 🔍 Related Issues

Related implementation and benchmark configurations: #4048.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

- **Original measured source:** seven existing BF16 GPU tests passed (310 deselected); eight independent reference cases passed with unchanged `rtol=atol=0.03`, three exact eager repeats and three exact CUDA-graph replays per case. BF16 CLI/profiler smoke passed. [Complete original test output, helper and commands](https://github.com/flashinfer-ai/flashinfer/pull/4985#issuecomment-5549485234).
- **Shared-helper refactor `a3fce87d`:** 43 paired GPU cases matched measured source `1ac2233d` for public entry points, bound kernel arguments, finalized output bytes and timing inputs; renamed selectors and NVFP4 profiler smoke passed; an excluded profiling backend is rejected with exit 2. Autotuning was disabled for these bounded equivalence checks. [Complete refactor validation and reproduction](https://github.com/flashinfer-ai/flashinfer/pull/4985#issuecomment-5549433238).
- **Later head `2079fa00`:** printed-name fixtures and external-profiler NVTX ranges are validated separately; the five benchmark functions and non-profile timing branch remain AST-identical to the 43-case refactor source. Those 43 cases are attributed to the refactor commit above.
- **Static scope:** file-scoped pre-commit hooks, Ruff, formatting, Python compilation and `git diff --check` passed. Mypy is skipped by the configured hook because this benchmark is outside its `flashinfer/` scope. No upstream test files were changed; all-files hooks and the full repository test suite were not run. These correctness checks do not replace the nine performance sweeps.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please review the precision-specific TRTLLM weight/scale arguments, shared routing and timing boundary, explicit backend/finalize labels, and the three configuration definitions. All nine raw tables and both W4A16 baseline speedup columns are above; complete validation output is linked in Tests. Unchecked all-files/full-suite items reflect the stated scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified TensorRT-LLM benchmarking for NVFP4 and BF16 precision modes.
  * Added support for logits and pre-routed execution scenarios.
  * Added the `trtllm-bf16` backend to benchmark selection, validation, tables, speedup reporting, and command-line help.
  * Improved consistency for routed workload comparisons across TensorRT-LLM precision modes.

* **Bug Fixes**
  * Profile-backend selection now rejects values not included in the selected backend list.
  * Benchmark status and winner labels now clearly distinguish NVFP4 and BF16 results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
