### PR TITLE
perf(topk_varlen): gvr_2 dispatch rungs for 4K-8K rows, SM-count-aware register band, hint-free gvr_2 in auto

### DIFF
--- a/flashinfer/topk_varlen/__init__.py
+++ b/flashinfer/topk_varlen/__init__.py
@@ -17,5 +17,8 @@
 The CuTe-DSL kernel source (GVR and radix Top-K for Blackwell sm_100+) lives in
 ``flashinfer.topk_varlen.kernels``.  The public ``top_k_varlen`` API is defined in
 ``flashinfer.topk_varlen.topk_varlen`` and re-exported from the top-level
-``flashinfer`` namespace.
+``flashinfer`` namespace. ``release_gvr2_resources`` frees the ``gvr_2``
+backend's per-device caches (default workspace slabs, hint-free anchor tables).
 """
+
+from .topk_varlen import release_gvr2_resources as release_gvr2_resources

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -23,7 +23,11 @@ bound at the physical width and inflates only the routing value (DKG #60);
 ``validate_run_ws`` enforces the 16-byte alignment the compiled workspace
 declares; ``run_varlen`` rejects overlapping row layouts; ``run``/``run_ws``/
 ``run_varlen`` re-enter under the logits device and every compile passes an
-explicit ``--gpu-arch``. FlashInfer's ``top_k_varlen(backend="gvr_2")``
+explicit ``--gpu-arch``; ``route()`` adds two register-kernel rungs in the
+4K < n <= 8K band (VPT=2 for b <= 148, BLK=512 for 148 < b <= 296 — see the inline
+note; DKG #61); ``run_varlen`` accepts ``pre_idx=None`` and runs
+hint-free on a cached ``arange(k)`` anchor (``_hint_free_pre_idx``).
+FlashInfer's ``top_k_varlen(backend="gvr_2")``
 calls ``run_varlen`` below; the batch-uniform ``run``/``run_ws`` entries are
 kept for parity tests and benchmarking. Keep future diffs against upstream
 mechanical.
@@ -153,7 +157,11 @@ BLKC = 1024  # CTA size of the clustered register path
 
 
 def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
-    """Mirror of the CUDA gvr_topk_launch dispatch. Pure. See module doc."""
+    """Mirror of the CUDA gvr_topk_launch dispatch. Pure. See module doc.
+
+    FlashInfer-local deviations (both in the 4K < n <= 8K band, marked
+    inline): the wide VPT=2 rung and the 148 < b <= 296 BLK=512 register
+    rung."""
     if b < 1:
         raise RuntimeError(f"route requires b >= 1, got {b}")
     # 148 is the B200 SM count, baked in by the upstream CUDA dispatch (route()
@@ -171,7 +179,11 @@ def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
     DEGE = (n <= 3 * k) or (n <= 4 * k + 64)
     if DEGE and CMP < n:
         CMP = n
-    NBSEL = (2 * NB) if (n4 > 512 and not (n4 <= 1024 and not wide)) else NB
+    # FlashInfer-local: the `n4 <= 2048 and not wide` window runs the BLK=512
+    # register kernel with NBH = NB for b <= 296 (upstream: main slab, which
+    # ignores NBSEL), so the NB selector must follow (IMGOFF == NBSEL == NBH
+    # is asserted at launch).
+    NBSEL = (2 * NB) if (n4 > 512 and not (n4 <= 2048 and not wide)) else NB
     IMGOFF = NBSEL
     smem_reg = (NBSEL + 2 * CMP) * 4
 
@@ -266,6 +278,23 @@ def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
                 "ws": False,
             }
 
+    # FlashInfer-local rungs for the 4K < n <= 8K band (the upstream dispatch
+    # runs `wide` rows here on the VPT=4 kernel below and everything else on
+    # the streaming slab). Measured on B100/B200, K in {512, 1024, 2048},
+    # exact in every cell (logs/sglang_perf/force_plan*.py):
+    #   * wide (b <= 148): VPT=2 covers n4 <= 2048 exactly; the VPT=4 kernel
+    #     iterates two empty float4 slots per thread in every pass and is
+    #     ~18-20% slower (4.2 -> 3.4 us at n=8192, K=512).
+    #   * 148 < b <= 296 (one wave at MINB=2, two CTAs per SM): the
+    #     BLK=512/VPT=4 register kernel beats the main slab by 1.3-1.7x
+    #     (8.0 -> 4.9 us at b=256, n=8192, K=512). Beyond one wave the two
+    #     trade places by shape (b=512: -13%..+12%), so the slab keeps it.
+    # Reported upstream for adoption as DKG issue #61.
+    if n4 <= 2048:
+        if wide:
+            return _reg(1024, 2, 1, 2 * NB)
+        if b <= 296:
+            return _reg(512, 4, 2, NB)
     if n4 <= 4096 and wide:
         return _reg(1024, 4, 1, 2 * NB)
 
@@ -1024,6 +1053,42 @@ builder in _build_launcher; only the main family takes the workspace.
 # shape key (b, n, npad, k) -> (fn, args tuple of python ints, needs_ws)
 _LAUNCH_CACHE = {}
 _DUMMY_KV = {}
+# hint-free entry: (device index, k) -> int32[cap, k] table whose every row
+# is arange(k). Superseded tables are kept alive (captured graphs may still
+# address them).
+_HINT_FREE = {}
+_HINT_FREE_KEEP = []
+
+
+def _hint_free_pre_idx(batch, k, device):
+    """FlashInfer-local: the ``pre_idx`` stand-in for hint-free ``run_varlen``.
+
+    The kernels consume the hint only as a sampling anchor — the block-wide
+    (min, max) of ``logits[pre_idx[j]]`` — and never for exactness, so ANY k
+    distinct in-range indices are a valid hint; ``arange(k)`` is the cheapest
+    (rows shorter than k take the in-kernel identity path before the anchor
+    matters, and columns < k always lie inside the row's storage). One table
+    per (device, k), grown by doubling and reused as a contiguous row-prefix
+    view (16-byte aligned: k is a multiple of 512), so the hot path performs
+    no allocation and CUDA-graph replays see a stable address. Growth is
+    refused under capture — run one eager call (or ``warmup_varlen``) at the
+    largest batch first, like every other launcher resource.
+    """
+    key = (device.index if device.index is not None else torch.cuda.current_device(), k)
+    t = _HINT_FREE.get(key)
+    if t is None or t.shape[0] < batch:
+        if _is_capturing():
+            raise RuntimeError(
+                f"hint-free gvr_2: no pre_idx table for batch={batch}, k={k} on "
+                f"{device}; run one eager call (or warmup_varlen) at this batch "
+                "before CUDA-graph capture"
+            )
+        cap = max(batch, 64 if t is None else 2 * t.shape[0])
+        new = torch.arange(k, dtype=_I32, device=device).unsqueeze(0).expand(cap, k).contiguous()
+        if t is not None:
+            _HINT_FREE_KEEP.append(t)
+        _HINT_FREE[key] = t = new
+    return t[:batch]
 
 
 def _dummy_kv(dev_index, device):
@@ -1302,7 +1367,7 @@ def run_ws(
 
 def run_varlen(
     logits: torch.Tensor,
-    pre_idx: torch.Tensor,
+    pre_idx: torch.Tensor | None,
     kv_lens: torch.Tensor,
     indices: torch.Tensor,
     next_n: int = 1,
@@ -1311,8 +1376,15 @@ def run_varlen(
     max_seq_len: int | None = None,
     engine: str = "auto",
     workspace: torch.Tensor | None = None,
+    top_k: int | None = None,
 ) -> None:
     """Production-contract varlen entry (per-row device kv_lens).
+
+    HINT-FREE (FlashInfer-local): ``pre_idx=None`` runs with the cached
+    ``arange(k)`` stand-in of ``_hint_free_pre_idx`` and then REQUIRES
+    ``top_k`` (normally ``k = pre_idx.shape[1]``). Exact like the hinted
+    call; only the sampling anchor is weaker. When both are given they must
+    agree.
 
     Row semantics (mirror of ``heuristicTopKDecode.cu`` and the in-tree
     ``cute_dsl_gvr_topk_decode`` runner):
@@ -1360,6 +1432,7 @@ def run_varlen(
                 max_seq_len=max_seq_len,
                 engine=engine,
                 workspace=workspace,
+                top_k=top_k,
             )
     if logits.dtype is not torch.float32:
         raise RuntimeError(
@@ -1388,6 +1461,12 @@ def run_varlen(
     batch = num_rows // nn
     if kv_lens.shape[0] != batch:
         raise RuntimeError(f"kv_lens length {kv_lens.shape[0]} != num_rows/next_n = {batch}")
+    if pre_idx is None:
+        if top_k is None:
+            raise RuntimeError("run_varlen: top_k is required when pre_idx is None (hint-free)")
+        pre_idx = _hint_free_pre_idx(batch, _index(top_k), logits.device)
+    elif top_k is not None and len(pre_idx.shape) == 2 and pre_idx.shape[1] != _index(top_k):
+        raise RuntimeError(f"top_k={top_k} != pre_idx.shape[1]={pre_idx.shape[1]}")
     if len(pre_idx.shape) != 2 or pre_idx.shape[0] != batch:
         raise RuntimeError(
             f"pre_idx must be [batch={batch}, k] REQUEST-level, got {tuple(pre_idx.shape)}"
@@ -1623,6 +1702,9 @@ def warmup_varlen(
     # rows) even when CUDA-graph batch lists reach thousands of rows.
     n_env_c = max(1, int(max_seq_len) // int(compress_ratio))
     npad_c = (n_env_c + 63) // 64 * 64 if row_stride is None else int(row_stride)
+    # hint-free callers capture with the arange table: size it for the
+    # largest requested batch now (growth is refused under capture)
+    _hint_free_pre_idx(req_rows[-1] // nn, int(top_k), torch.device("cuda", dev))
     seen_keys = set()
     rows_list = []
     r = nn

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -24,8 +24,9 @@ bound at the physical width and inflates only the routing value (DKG #60);
 declares; ``run_varlen`` rejects overlapping row layouts; ``run``/``run_ws``/
 ``run_varlen`` re-enter under the logits device and every compile passes an
 explicit ``--gpu-arch``; ``route()`` adds two register-kernel rungs in the
-4K < n <= 8K band (VPT=2 for b <= 148, BLK=512 for 148 < b <= 296 — see the inline
-note; DKG #61); ``run_varlen`` accepts ``pre_idx=None`` and runs
+4K < n <= 8K band (VPT=2 for b <= sms, BLK=512 for sms < b <= 2*sms) and sizes its
+register band by the device SM count ``sms`` instead of the hard-coded 148
+(see the inline note; DKG #61); ``run_varlen`` accepts ``pre_idx=None`` and runs
 hint-free on a cached ``arange(k)`` anchor (``_hint_free_pre_idx``).
 FlashInfer's ``top_k_varlen(backend="gvr_2")``
 calls ``run_varlen`` below; the batch-uniform ``run``/``run_ws`` entries are
@@ -83,6 +84,20 @@ def _device():
             import gvr2_topk_decode as _m
         _dev_mod = _m
     return _dev_mod
+
+
+_SM_COUNT = {}
+
+
+def _sm_count() -> int:
+    """SM count of the CURRENT device (per-device cache). FlashInfer-local
+    knob of ``route()``'s register-resident band (``wide`` / one-wave tests);
+    the streaming-path constants stay at upstream's 148 — see route()."""
+    d = torch.cuda.current_device()
+    v = _SM_COUNT.get(d)
+    if v is None:
+        v = _SM_COUNT[d] = int(torch.cuda.get_device_properties(d).multi_processor_count)
+    return v
 
 
 def _arch_token() -> str:
@@ -156,26 +171,33 @@ CMPC = 4096  # crossing-bin slots per CTA, clustered register path
 BLKC = 1024  # CTA size of the clustered register path
 
 
-def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
+def route(b: int, n: int, npad: int, k: int, sms: int = 148) -> dict[str, object]:
     """Mirror of the CUDA gvr_topk_launch dispatch. Pure. See module doc.
 
-    FlashInfer-local deviations (both in the 4K < n <= 8K band, marked
-    inline): the wide VPT=2 rung and the 148 < b <= 296 BLK=512 register
-    rung."""
+    FlashInfer-local deviations, marked inline: the register-resident band
+    is sized by ``sms`` (the device SM count; upstream hard-codes 148) — the
+    ``wide`` one-wave test, QC/CURE and the one-wave cutoff of the BLK=512
+    rung — and the 4K < n <= 8K band has two extra rungs (wide VPT=2, and
+    sms < b <= 2*sms BLK=512). The streaming-path constants keep upstream's
+    148 on every part."""
     if b < 1:
         raise RuntimeError(f"route requires b >= 1, got {b}")
     # 148 is the B200 SM count, baked in by the upstream CUDA dispatch (route()
     # is a pure mirror of it). It only steers occupancy heuristics (one-wave
-    # tests, split factors, cluster sizing), never correctness: on Rubin
-    # (SM107, 208 SMs) the same constants are merely conservative. Retuning
-    # per-arch is a perf follow-up, not a functional requirement.
-    wide = b <= 148
+    # tests, split factors, cluster sizing), never correctness. FlashInfer-
+    # local: the REGISTER-band tests use the real SM count `sms` (B300 160,
+    # Rubin 208): rows in (148, sms] are one wave of 1024-thread CTAs there
+    # and the register kernels beat the slab by 1.4-1.8x (B300 12288 x 160:
+    # 7.2 -> 4.6 us; Rubin 12288 x 160-192: 5.6 -> 4.0 us; measured same-node
+    # vs sglang, DKG #61). The STREAMING constants below stay at 148: scaling
+    # them too made the 131072 x 192-256 slab cells 3-28% slower on both parts.
+    wide = b <= sms
 
     # ======================= register-resident block ========================
     n4 = n >> 2
     CMP = n if n < 2560 else 2560
-    QC = 1024 if b > 148 else QUADC
-    CURE = not (n < 2 * k and b > 148)
+    QC = 1024 if b > sms else QUADC
+    CURE = not (n < 2 * k and b > sms)
     DEGE = (n <= 3 * k) or (n <= 4 * k + 64)
     if DEGE and CMP < n:
         CMP = n
@@ -285,15 +307,19 @@ def route(b: int, n: int, npad: int, k: int) -> dict[str, object]:
     #   * wide (b <= 148): VPT=2 covers n4 <= 2048 exactly; the VPT=4 kernel
     #     iterates two empty float4 slots per thread in every pass and is
     #     ~18-20% slower (4.2 -> 3.4 us at n=8192, K=512).
-    #   * 148 < b <= 296 (one wave at MINB=2, two CTAs per SM): the
+    #   * sms < b <= 2*sms (one wave at MINB=2, two CTAs per SM): the
     #     BLK=512/VPT=4 register kernel beats the main slab by 1.3-1.7x
-    #     (8.0 -> 4.9 us at b=256, n=8192, K=512). Beyond one wave the two
-    #     trade places by shape (b=512: -13%..+12%), so the slab keeps it.
+    #     (8.0 -> 4.9 us at b=256, n=8192, K=512; Rubin 8192 x 400: 6.3 ->
+    #     4.2 us). A second wave (b <= 4*sms) still wins for the upper half
+    #     of the band (n >= 6144: B200 b=512 +11..12%, and the ragged-row
+    #     6144-8192 x 320-400 cells where the slab lost to sglang by up to
+    #     22%) but loses for the lower half (n=4160, b=512: -13%), so the
+    #     slab keeps that.
     # Reported upstream for adoption as DKG issue #61.
     if n4 <= 2048:
         if wide:
             return _reg(1024, 2, 1, 2 * NB)
-        if b <= 296:
+        if b <= 2 * sms or (b <= 4 * sms and n4 >= 1536):
             return _reg(512, 4, 2, NB)
     if n4 <= 4096 and wide:
         return _reg(1024, 4, 1, 2 * NB)
@@ -524,11 +550,11 @@ _DYN_RT = {
 _DYN_SMEM = ("reg", "regimg")  # smem depends on CMP/IMGW -> recomputed per n
 
 
-def route_static(b: int, n: int, npad: int, k: int) -> dict[str, object]:
+def route_static(b: int, n: int, npad: int, k: int, sms: int = 148) -> dict[str, object]:
     """route() with the n-continuous fields redacted (see _DYN_RT/_DYN_SMEM).
     Constant on maximal n-intervals ("bands"); every redacted field is
     reconstructible from (static, n) by route_dynamic."""
-    plan = route(b, n, npad, k)
+    plan = route(b, n, npad, k, sms=sms)
     st = {key: (dict(val) if isinstance(val, dict) else val) for key, val in plan.items()}
     for f in _DYN_RT[st["kernel"]]:
         st["rt"].pop(f)
@@ -614,10 +640,10 @@ def route_dynamic(static: dict[str, object], n: int) -> tuple[dict[str, object],
     )
 
 
-def route_split(b: int, n: int, npad: int, k: int) -> dict[str, object]:
+def route_split(b: int, n: int, npad: int, k: int, sms: int = 148) -> dict[str, object]:
     """route_static + route_dynamic recombined — must equal route() exactly
     (the factorization fuzz in the unit tests asserts this)."""
-    st = route_static(b, n, npad, k)
+    st = route_static(b, n, npad, k, sms=sms)
     dyn, smem = route_dynamic(st, n)
     plan = {key: (dict(val) if isinstance(val, dict) else val) for key, val in st.items()}
     plan["rt"].update(dyn)
@@ -763,7 +789,8 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     the universally correct fallback; specialist family tiers below.  Every
     choice here is a function of capture-stable quantities only — mirroring
     the in-tree runner's pick_tuning(graph_capture=...) discipline."""
-    key = (num_rows, npad, k, n_env, next_n, cr, _arch_token())
+    sms = _sm_count()
+    key = (num_rows, npad, k, n_env, next_n, cr, _arch_token(), sms)
     hit = _VARLEN_CACHE.get(key)
     if hit is not None:
         return hit
@@ -784,7 +811,7 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # admission window (n4 <= 32768) fits capture-frozen envelopes. The
     # choice is a pure function of this cache key, so CUDA-graph replay
     # safety is unchanged; per-row n / short-row handling lives in-kernel.
-    plan_free = route(num_rows, n_route, npad, k)
+    plan_free = route(num_rows, n_route, npad, k, sms=sms)
     if plan_free["kernel"] == "reg_clus":
         fn = dev.get_compiled__regclus(
             tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
@@ -1116,7 +1143,7 @@ _GVR_MAX_DEV = GVR_MAX_DEV
 # per-family launcher builders (cold path: once per distinct shape key)
 # ---------------------------------------------------------------------------
 def _build_launcher(b, n, npad, k):
-    rd = route(b, n, npad, k)
+    rd = route(b, n, npad, k, sms=_sm_count())
     fam = rd["kernel"]
     tpl = tuple(rd["tpl"])
     rt = rd["rt"]
@@ -1294,7 +1321,7 @@ def _run_impl(logits, pre_idx, n_valid, indices, ws, values=None):
                 values[:, n:] = torch.finfo(_F32).min  # -FLT_MAX pad
         return
 
-    key = (b, n, npad, k, _arch_token())
+    key = (b, n, npad, k, _arch_token(), _sm_count())
     lc = _LAUNCH_CACHE.get(key)
     if lc is None:
         lc = _build_launcher(b, n, npad, k)
@@ -1566,7 +1593,7 @@ def run_varlen(
             # R increment (bounded plans, bounded _VARLEN_CACHE)
             n_env = 1 << max(n_env - 1, 1).bit_length()
         n_env = min(max(n_env, 1), npad)
-        key = (num_rows, npad, k, n_env, nn, cr, _arch_token())
+        key = (num_rows, npad, k, n_env, nn, cr, _arch_token(), _sm_count())
         lc = _VARLEN_CACHE.get(key)
         if lc is None:
             if _is_capturing():
@@ -1710,7 +1737,9 @@ def warmup_varlen(
     r = nn
     r_max = req_rows[-1]
     while r <= r_max:
-        plan_free = route(r, max(min(n_env_c, npad_c), int(top_k) + 1), npad_c, int(top_k))
+        plan_free = route(
+            r, max(min(n_env_c, npad_c), int(top_k) + 1), npad_c, int(top_k), sms=_sm_count()
+        )
         if plan_free["kernel"] == "reg_clus":
             ekey = ("reg_clus", tuple(plan_free["tpl"]))
         elif plan_free["kernel"] in ("reg", "regimg"):

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -790,6 +790,44 @@ def route_streaming(
 
 _VARLEN_CACHE = {}
 
+# ---------------------------------------------------------------------------
+# first-call gate for compiled DSL kernel objects
+# ---------------------------------------------------------------------------
+# libcute_dsl_runtime's ``cuda_dialect_init_library_once`` (the per-kernel
+# CUDA init that runs inside the FIRST invocation of a compiled kernel) is a
+# double-checked once-init behind ONE process-wide spinlock. In
+# nvidia-cutlass-dsl 4.6.3, 4.7.0 and 4.7.1 the thread that acquires the lock
+# after another thread already initialised the same kernel returns WITHOUT
+# releasing it, so the next first call of ANY other kernel in the process
+# spins forever (fixed in 4.8.0.dev0 / nightlies >= 2026-08-18; reported as
+# DKG issue, see PR #4986). Until the DSL floor is past the fix, concurrent
+# first calls of one kernel object are serialized here; once the first call
+# has returned (the once-init is synchronous inside it) the wrapper costs one
+# list-element load per launch.
+_GATE_LOCK = threading.Lock()
+_GATED = {}  # id(compiled fn) -> (compiled fn kept alive, gated wrapper)
+
+
+def _gate_first_call(raw):
+    """Wrap a compiled DSL kernel object so its first invocation is exclusive."""
+    with _GATE_LOCK:
+        ent = _GATED.get(id(raw))
+        if ent is not None:
+            return ent[1]
+        lock = threading.Lock()
+        warm = [False]
+
+        def gated(*args, _raw=raw, _lock=lock, _warm=warm):
+            if _warm[0]:
+                return _raw(*args)
+            with _lock:
+                out = _raw(*args)
+                _warm[0] = True  # only after a completed first call
+            return out
+
+        _GATED[id(raw)] = (raw, gated)
+        return gated
+
 
 def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     """Capture-time varlen plan + compiled launcher.  The gvr_main port is
@@ -820,8 +858,10 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # safety is unchanged; per-row n / short-row handling lives in-kernel.
     plan_free = route(num_rows, n_route, npad, k, sms=sms)
     if plan_free["kernel"] == "reg_clus":
-        fn = dev.get_compiled__regclus(
-            tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
+        fn = _gate_first_call(
+            dev.get_compiled__regclus(
+                tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
+            )
         )
         lc = ("reg_clus", fn, n_kernel)
         _VARLEN_CACHE[key] = lc
@@ -834,8 +874,10 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # size, all safe upper bounds for every per-row n <= envelope; per-row n
     # / short-row handling lives in-kernel.
     if plan_free["kernel"] in ("reg", "regimg"):
-        fn = dev.get_compiled__reg(
-            tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
+        fn = _gate_first_call(
+            dev.get_compiled__reg(
+                tuple(plan_free["tpl"]), varlen=True, next_n=next_n, cr_shift=cr_shift
+            )
         )
         rt_f = plan_free["rt"]
         lc = (
@@ -854,13 +896,15 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # Per-row n / short-row handling in-kernel.
     if plan_free["kernel"] == "clus":
         rt_f = plan_free["rt"]
-        fn = dev.get_compiled__clus(
-            tuple(plan_free["tpl"]),
-            scap=rt_f["SCAP"],
-            cmp_=rt_f["CMP"],
-            varlen=True,
-            next_n=next_n,
-            cr_shift=cr_shift,
+        fn = _gate_first_call(
+            dev.get_compiled__clus(
+                tuple(plan_free["tpl"]),
+                scap=rt_f["SCAP"],
+                cmp_=rt_f["CMP"],
+                varlen=True,
+                next_n=next_n,
+                cr_shift=cr_shift,
+            )
         )
         lc = (
             "clus",
@@ -876,7 +920,9 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
     # TSHG (tpl[6]) is dead under varlen (the ctor compiles the TSH
     # machinery in whenever SPLIT); normalize it out of the compile key so
     # row counts differing only in that slot share one engine
-    fn = dev.get_compiled(tpl[:6] + (False,) + (next_n, cr_shift, r_const))
+    fn = _gate_first_call(
+        dev.get_compiled(tpl[:6] + (False,) + (next_n, cr_shift, r_const))
+    )
     big = num_rows * r_const <= 148
     aim_base = (
         ((4 * k if k >= 1024 else 2 * k) if r_const == 1 else 2 * k)
@@ -1078,30 +1124,52 @@ def release_cached_resources(device=None) -> int:
     """FlashInfer-local: release the lazily created per-device caches — every
     default workspace slab (one per (device, stream), 20,973,568 B each) and
     every hint-free anchor table (current and superseded) — for ``device``
-    (default: the current device). Synchronizes the device first so no
-    in-flight launch still uses them, then drops the references; the memory
-    returns to the torch caching allocator (``torch.cuda.empty_cache()``
-    hands it back to the driver). Returns the number of bytes released.
+    (default: the current device; an int, a ``torch.device`` or a device
+    string, CUDA only). Synchronizes the device, then drops the references
+    under both cache locks; the memory returns to the torch caching
+    allocator (``torch.cuda.empty_cache()`` hands it back to the driver).
+    Returns the number of bytes released.
+
+    CONTRACT — caller quiescence. The launch hot paths read the caches
+    without taking the locks (a lock there would cost every launch), so this
+    call cannot exclude a launch that is being issued concurrently: while it
+    runs, no gvr_2 call on ``device`` may be in flight or issued — no eager
+    call from any thread and no CUDA-graph replay — exactly like
+    ``torch.cuda.empty_cache()`` versus live tensors. Under that contract the
+    device sync retires every launch that could still address a cached
+    object, and the locks make the clear atomic with respect to the slow
+    paths that create objects (a creation either completes before the clear
+    or starts after it; nothing is left half-published).
 
     INVALIDATION: a CUDA graph captured against a released slab or table
     replays on freed memory. Callers release only when no such graph will be
     replayed again, and re-capture after a fresh eager warm-up on the
     capturing stream (the same rule as the first capture)."""
-    d = torch.cuda.current_device() if device is None else torch.device(device).index
-    if d is None:
+    if device is None:
         d = torch.cuda.current_device()
-    torch.cuda.synchronize(d)
+    else:
+        dev = torch.device("cuda", device) if isinstance(device, int) else torch.device(device)
+        if dev.type != "cuda":
+            raise ValueError(
+                f"release_cached_resources: expected a CUDA device, got {dev!r}"
+            )
+        d = dev.index if dev.index is not None else torch.cuda.current_device()
     freed = 0
-    with _mu:
+    with _mu, _HINT_FREE_LOCK:  # lock order: _mu -> _HINT_FREE_LOCK (never nested elsewhere)
+        torch.cuda.synchronize(d)
         for key in [k for k in _ws_keep if k[0] == d]:
             freed += _ws_keep.pop(key).numel() * 4
-    with _HINT_FREE_LOCK:
         for key in [k for k in _HINT_FREE if k[0] == d]:
             freed += _HINT_FREE.pop(key).numel() * 4
-        keep = [t for t in _HINT_FREE_KEEP if t.device.index == d]
-        for t in keep:
-            freed += t.numel() * 4
-            _HINT_FREE_KEEP.remove(t)
+        # partition by device index — never tensor equality (`in`/`remove`
+        # would compare tensor contents and raise across devices or shapes)
+        keep = []
+        for t in _HINT_FREE_KEEP:
+            if t.device.index == d:
+                freed += t.numel() * 4
+            else:
+                keep.append(t)
+        _HINT_FREE_KEEP[:] = keep
     return freed
 
 
@@ -1228,7 +1296,7 @@ def _build_launcher(b, n, npad, k):
     rt = rd["rt"]
     if fam in ("reg", "regimg"):
         dev = _device()
-        raw = dev.get_compiled__reg(tpl)
+        raw = _gate_first_call(dev.get_compiled__reg(tpl))
 
         # compiled ABI: (logits, pre_idx, kv_lens, out, n, CMP, QC,
         # smem_total) -- kv_lens is the dead varlen slot in batch-uniform
@@ -1240,7 +1308,7 @@ def _build_launcher(b, n, npad, k):
         return (fn, args, False)
     if fam == "main":
         dev = _device()
-        raw = dev.get_compiled(tpl)
+        raw = _gate_first_call(dev.get_compiled(tpl))
 
         # compiled ABI: (logits, pre_idx, out, ws, n, npad, k, SCAP_, CMP_,
         #                R, SMP, TGT, Q, SS2, TGT2,
@@ -1270,7 +1338,9 @@ def _build_launcher(b, n, npad, k):
         # ABI: (logits, pre_idx, kv_lens, out, n, npad, k, SCAP, CMP, SMP,
         #       TGT, Q, SS2, TGT2) -- NO workspace; kv_lens is the dead
         # varlen slot in batch-uniform mode (cached dummy tensor)
-        fn = dev.get_compiled__clus(tpl, scap=rt["SCAP"], cmp_=rt["CMP"])
+        fn = _gate_first_call(
+            dev.get_compiled__clus(tpl, scap=rt["SCAP"], cmp_=rt["CMP"])
+        )
         args = (
             rt["n"],
             rt["npad"],
@@ -1293,7 +1363,7 @@ def _build_launcher(b, n, npad, k):
         # compiled ABI: (logits, pre_idx, kv_lens, out, n) -- kv_lens is the
         # dead varlen slot in batch-uniform mode (cached dummy tensor);
         # smem/k derived in-module
-        fn = dev.get_compiled__regclus(tpl)
+        fn = _gate_first_call(dev.get_compiled__regclus(tpl))
         n_arg = rt["n"]
 
         def _call(lg, pi, idx, _fn=fn, _n=n_arg):

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -1074,6 +1074,37 @@ def _reset_for_tests() -> None:
         _ws_keep.clear()
 
 
+def release_cached_resources(device=None) -> int:
+    """FlashInfer-local: release the lazily created per-device caches — every
+    default workspace slab (one per (device, stream), 20,973,568 B each) and
+    every hint-free anchor table (current and superseded) — for ``device``
+    (default: the current device). Synchronizes the device first so no
+    in-flight launch still uses them, then drops the references; the memory
+    returns to the torch caching allocator (``torch.cuda.empty_cache()``
+    hands it back to the driver). Returns the number of bytes released.
+
+    INVALIDATION: a CUDA graph captured against a released slab or table
+    replays on freed memory. Callers release only when no such graph will be
+    replayed again, and re-capture after a fresh eager warm-up on the
+    capturing stream (the same rule as the first capture)."""
+    d = torch.cuda.current_device() if device is None else torch.device(device).index
+    if d is None:
+        d = torch.cuda.current_device()
+    torch.cuda.synchronize(d)
+    freed = 0
+    with _mu:
+        for key in [k for k in _ws_keep if k[0] == d]:
+            freed += _ws_keep.pop(key).numel() * 4
+    with _HINT_FREE_LOCK:
+        for key in [k for k in _HINT_FREE if k[0] == d]:
+            freed += _HINT_FREE.pop(key).numel() * 4
+        keep = [t for t in _HINT_FREE_KEEP if t.device.index == d]
+        for t in keep:
+            freed += t.numel() * 4
+            _HINT_FREE_KEEP.remove(t)
+    return freed
+
+
 # ===========================================================================
 # ==== operator entry =======================================================
 # ===========================================================================

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -38,8 +38,9 @@ Three sections:
 
 1. dispatch — the CUDA host dispatch as a pure function
    ``route(b, n, npad, k)``;
-2. workspace — one zero-initialised per-device slab (20,973,568 B) via the
-   torch caching allocator, with keep-alive + double-checked locking;
+2. workspace — one zero-initialised slab (20,973,568 B) per (device, CUDA
+   stream) via the torch caching allocator (FlashInfer-local: upstream keys
+   it per device), with keep-alive + double-checked locking, eager-only;
 3. operator entry — ``run(logits, pre_idx, n_valid, indices)`` /
    ``run_ws(..., workspace)`` DPS forms with input hardening and a
    bind-once launch cache keyed on ``(b, n, npad, k)``.
@@ -268,7 +269,13 @@ def route(b: int, n: int, npad: int, k: int, sms: int = 148) -> dict[str, object
 
     # ---- clustered register-resident path ----
     if n4 > 4096 and n4 <= 8 * BLKC * 4 and k <= BLKC:
-        av = 148 // (b if b > 0 else 1)  # truncating
+        # FlashInfer-local: cluster availability from the real SM count on
+        # parts with >= 148 SMs (Rubin 208: 4-CTA instead of 2-CTA clusters at
+        # b 38-48, and reg_clus instead of main/clus at b 80-104 / 48K-64K,
+        # 8-35% faster; B300 158-160: 12-34%); below 148 the upstream value
+        # stays — on DRIVE P2021 (68 SMs) the SM-aware rule won 34/44 measured
+        # cells but lost 10 by up to 40% (falls to clus/main at 48K-128K).
+        av = max(sms, 148) // (b if b > 0 else 1)  # truncating
         amax = 1
         while (amax << 1) <= av and amax < 8:
             amax <<= 1
@@ -898,18 +905,25 @@ def _varlen_launcher(num_rows, npad, k, n_env, next_n, cr):
 
 
 def route_bands(
-    b: int, npad: int, k: int, n_lo: int | None = None, n_hi: int | None = None
+    b: int,
+    npad: int,
+    k: int,
+    n_lo: int | None = None,
+    n_hi: int | None = None,
+    sms: int = 148,
 ) -> list[tuple[int, int, dict[str, object]]]:
     """Enumerate maximal n-intervals on which route_static is constant.
     Dense O(n_hi - n_lo) scan of the pure host dispatch — an offline /
     engine-init tool (seconds for the 262144-token envelope), NOT a hot
-    path. Returns [(n_lo, n_hi, static_plan), ...]."""
+    path. Returns [(n_lo, n_hi, static_plan), ...]. Pass the target part's
+    SM count as ``sms`` (``_sm_count()`` on the device) or the bands describe
+    the B200 dispatch."""
     lo = k + 1 if n_lo is None else max(n_lo, k + 1)
     hi = npad if n_hi is None else min(n_hi, npad)
     bands = []
     cur_key, cur_lo, cur_plan = None, lo, None
     for n in range(lo, hi + 1):
-        st = route_static(b, n, npad, k)
+        st = route_static(b, n, npad, k, sms=sms)
         key = repr(st)
         if key != cur_key:
             if cur_key is not None:
@@ -960,7 +974,18 @@ WS_BYTES = _GVR_WS_BUF_OFF + _MAXC * _GCAP * 8  # 20,973,568
 assert WS_BYTES == 20_973_568
 
 _mu = threading.Lock()  # slow-path mutex
-_ws_keep = {}  # device index -> keep-alive int32 view
+# FlashInfer-local: one slab per (device index, CUDA stream) instead of one
+# per device. The SPLIT slab is mutable scratch (publish counters + candidate
+# buffer, restored by the kernel), so two launches that can overlap in time —
+# concurrent streams, or graphs captured on different streams and replayed
+# together — must not share it (measured 17/5120 corrupted rows through a
+# device-wide slab; see test_topk_varlen_serving). Keyed by the raw stream
+# handle; the tensor refcount is the keep-alive.
+_ws_keep = {}  # (device index, cuda stream handle) -> keep-alive int32 view
+
+
+def _ws_key(d: int) -> tuple[int, int]:
+    return (d, torch.cuda.current_stream(d).cuda_stream)
 
 
 def workspace_bytes() -> int:
@@ -969,26 +994,37 @@ def workspace_bytes() -> int:
 
 
 def default_workspace(ref: torch.Tensor) -> torch.Tensor:
-    """Per-device cached workspace slab.
+    """Cached workspace slab for (ref's device, the CURRENT stream).
 
     Returns the kernel-facing 1-D int32 view (zero-initialised on first use;
     the kernel restores the zeros it consumes, so one zeroing suffices for
-    the lifetime of the cache entry)."""
+    the lifetime of the cache entry). Allocation is eager-only: under
+    CUDA-graph capture a slab would come from the graph's private pool and
+    its zero-fill would be part of the graph, so a capture on a stream that
+    has never run an eager gvr_2 call raises instead (same warm-up rule as
+    the launcher cache)."""
     d = ref.get_device()
     if not (0 <= d < GVR_MAX_DEV):
         raise RuntimeError(f"device index out of range: {d}")
-    ws = _ws_keep.get(d)  # hot path: one (GIL-atomic) load
+    key = _ws_key(d)
+    ws = _ws_keep.get(key)  # hot path: one (GIL-atomic) load
     if ws is not None:
         return ws
     with _mu:  # slow path: double-checked
-        ws = _ws_keep.get(d)
+        ws = _ws_keep.get(key)
         if ws is not None:
             return ws
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "gvr_2 default workspace: no slab for this stream yet; run one "
+                "eager gvr_2 call on the stream that captures the graph (or pass "
+                "workspace={'gvr2_workspace': ...}) before CUDA-graph capture"
+            )
         # lazy zeros via the torch caching allocator, viewed int32 for the
         # DSL launch signature.
         buf = torch.zeros(WS_BYTES, dtype=torch.uint8, device=ref.device)
         ws = buf.view(torch.int32)
-        _ws_keep[d] = ws  # keep-alive (ws_keep[d] = tensor)
+        _ws_keep[key] = ws  # keep-alive
         return ws
 
 
@@ -1082,9 +1118,13 @@ _LAUNCH_CACHE = {}
 _DUMMY_KV = {}
 # hint-free entry: (device index, k) -> int32[cap, k] table whose every row
 # is arange(k). Superseded tables are kept alive (captured graphs may still
-# address them).
+# address them). Growth is serialized by _HINT_FREE_LOCK (locked re-check,
+# capacity only grows) and the producing stream is synchronized before a
+# table is published, so any thread/stream that sees the pointer sees a
+# complete table.
 _HINT_FREE = {}
 _HINT_FREE_KEEP = []
+_HINT_FREE_LOCK = threading.Lock()
 
 
 def _hint_free_pre_idx(batch, k, device):
@@ -1102,20 +1142,28 @@ def _hint_free_pre_idx(batch, k, device):
     largest batch first, like every other launcher resource.
     """
     key = (device.index if device.index is not None else torch.cuda.current_device(), k)
-    t = _HINT_FREE.get(key)
-    if t is None or t.shape[0] < batch:
-        if _is_capturing():
-            raise RuntimeError(
-                f"hint-free gvr_2: no pre_idx table for batch={batch}, k={k} on "
-                f"{device}; run one eager call (or warmup_varlen) at this batch "
-                "before CUDA-graph capture"
-            )
+    t = _HINT_FREE.get(key)  # hot path: one (GIL-atomic) load
+    if t is not None and t.shape[0] >= batch:
+        return t[:batch]
+    if _is_capturing():
+        raise RuntimeError(
+            f"hint-free gvr_2: no pre_idx table for batch={batch}, k={k} on "
+            f"{device}; run one eager call (or warmup_varlen) at this batch "
+            "before CUDA-graph capture"
+        )
+    with _HINT_FREE_LOCK:  # slow path: locked re-check, monotonic capacity
+        t = _HINT_FREE.get(key)
+        if t is not None and t.shape[0] >= batch:
+            return t[:batch]
         cap = max(batch, 64 if t is None else 2 * t.shape[0])
         new = torch.arange(k, dtype=_I32, device=device).unsqueeze(0).expand(cap, k).contiguous()
+        # the fill ran on the caller's stream; make it complete before any
+        # other stream/thread can see the pointer (eager-only, rare: doubling)
+        torch.cuda.current_stream(device).synchronize()
         if t is not None:
             _HINT_FREE_KEEP.append(t)
-        _HINT_FREE[key] = t = new
-    return t[:batch]
+        _HINT_FREE[key] = new
+        return new[:batch]
 
 
 def _dummy_kv(dev_index, device):
@@ -1368,7 +1416,7 @@ def run(
     d = logits.get_device()
     if not 0 <= d < _GVR_MAX_DEV:  # checked on EVERY call
         raise RuntimeError(f"device index out of range: {d}")
-    ws = _ws_hot.get(d)
+    ws = _ws_hot.get(_ws_key(d))
     if ws is None:
         ws = default_workspace(logits)
     _run_impl(logits, pre_idx, n_valid, indices, ws, values)
@@ -1492,8 +1540,15 @@ def run_varlen(
         if top_k is None:
             raise RuntimeError("run_varlen: top_k is required when pre_idx is None (hint-free)")
         pre_idx = _hint_free_pre_idx(batch, _index(top_k), logits.device)
-    elif top_k is not None and len(pre_idx.shape) == 2 and pre_idx.shape[1] != _index(top_k):
-        raise RuntimeError(f"top_k={top_k} != pre_idx.shape[1]={pre_idx.shape[1]}")
+    else:
+        if top_k is not None and len(pre_idx.shape) == 2 and pre_idx.shape[1] != _index(top_k):
+            raise RuntimeError(f"top_k={top_k} != pre_idx.shape[1]={pre_idx.shape[1]}")
+        if len(pre_idx.shape) == 2 and not _is_capturing():
+            # hint mode is NOT a warm-up dimension: a hinted eager call at this
+            # geometry also sizes the hint-free anchor table, so a later
+            # hint-free capture of the same geometry finds it (dict hit once
+            # sized; allocation only on growth)
+            _hint_free_pre_idx(batch, pre_idx.shape[1], logits.device)
     if len(pre_idx.shape) != 2 or pre_idx.shape[0] != batch:
         raise RuntimeError(
             f"pre_idx must be [batch={batch}, k] REQUEST-level, got {tuple(pre_idx.shape)}"
@@ -1507,9 +1562,10 @@ def run_varlen(
         validate_run_ws(workspace, logits)
         ws = kernel_view(workspace)
     else:
-        ws = _ws_hot.get(d)
-        if ws is None:
-            ws = default_workspace(logits)
+        # resolved lazily: only the streaming `main` family takes the slab, so
+        # register/cluster plans never need one (and can be captured on any
+        # stream without an eager launch there)
+        ws = None
 
     if engine == "auto":
         # ---- per-row in-kernel engine (gvr_main varlen port) ----------------
@@ -1620,6 +1676,10 @@ def run_varlen(
             lc[1](lg, pre_idx, kv_lens, idx, *lc[2])
         else:
             _, fn, pre, tail = lc
+            if ws is None:
+                ws = _ws_hot.get(_ws_key(d))
+                if ws is None:
+                    ws = default_workspace(logits)  # raises under capture
             fn(lg, pre_idx, idx, ws, *pre, kv_lens, *tail)
         if vals is not None:
             idx64 = idx.to(torch.int64)
@@ -1648,6 +1708,8 @@ def run_varlen(
     if vals is not None and vals.shape[1] != k:
         vals = vals.reshape(-1)[: num_rows * k].view(num_rows, k)
     kl = kv_lens.tolist()  # the ONE documented D2H sync of this engine
+    if ws is None:
+        ws = default_workspace(logits)
     for r in range(num_rows):
         # production graph slots can carry kv_len < next_n (padded / evicted
         # requests): clamp to the empty row, emitting all -1 — the same
@@ -1730,8 +1792,12 @@ def warmup_varlen(
     n_env_c = max(1, int(max_seq_len) // int(compress_ratio))
     npad_c = (n_env_c + 63) // 64 * 64 if row_stride is None else int(row_stride)
     # hint-free callers capture with the arange table: size it for the
-    # largest requested batch now (growth is refused under capture)
+    # largest requested batch now (growth is refused under capture), and
+    # create THIS stream's default workspace slab (the band launches below may
+    # all land on register/cluster plans while a requested row count routes
+    # to the slab-using `main` family; both are refused under capture)
     _hint_free_pre_idx(req_rows[-1] // nn, int(top_k), torch.device("cuda", dev))
+    default_workspace(torch.empty(0, dtype=torch.uint8, device=torch.device("cuda", dev)))
     seen_keys = set()
     rows_list = []
     r = nn

--- a/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
+++ b/flashinfer/topk_varlen/kernels/gvr2_topk_host.py
@@ -983,11 +983,12 @@ def route_bands(
 # ===========================================================================
 # ==== workspace ============================================================
 # ===========================================================================
-"""Per-device workspace slab for the multi-CTA SPLIT path.
+"""Default workspace slabs for the multi-CTA SPLIT path.
 
 Semantics:
-  * ONE zero-initialised slab workspace per device, lazily allocated through
-    the torch caching allocator;
+  * ONE zero-initialised slab per (device index, raw CUDA stream handle),
+    lazily allocated through the torch caching allocator by the first EAGER
+    slab-using launch on that stream (never under CUDA-graph capture);
   * keep-alive store: module dict `_ws_keep` (tensor refcount = keep-alive);
   * double-checked locking: lock-free hot-path load (a GIL-atomic dict get
     plays an acquire load), slow path re-checks under a mutex;
@@ -996,8 +997,16 @@ Semantics:
     input checks, so a CPU logits tensor dies here with "device index out of
     range: -1").
 
-Concurrent STREAMS on one device that may both take the multi-CTA SPLIT path
-must pass their own workspace via run_ws().
+Concurrent streams on one device each get their own slab, so launches that
+overlap in time (distinct streams, graphs captured on different streams and
+replayed together) never share mutable scratch; a caller-provided workspace
+(run_ws() / `workspace=`) is optional, not required for concurrency. Two
+graphs captured on the SAME stream share that stream's slab and are correct
+as long as they replay in stream order. The number of slabs equals the number
+of distinct stream handles that have run an eager slab-using launch:
+`torch.cuda.Stream()` recycles handles from a fixed pool (32 per device and
+priority), but externally created / foreign stream handles are not bounded by
+that pool; `release_cached_resources()` frees them all.
 
 Size: workspace_bytes() = GVR_WS_BUF_OFF + MAXC*GCAP*sizeof(int2)
     = 2048 + 160*16384*8 = 20,973,568 B.

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -45,8 +45,9 @@ Backend choices
                        accepted and ignored (the kernel takes no hint).
 ``"auto"``           — shape/dtype-aware ranking that tracks the measured
                        per-config winner (see ``_top_k_varlen_heuristic``):
-                       gvr_2 for hinted fp32; radix_filter for hint-free
-                       fp32 from 32K columns up and for the mid/large bf16 and
+                       gvr_2 for fp32, hinted or hint-free (one tiny
+                       single-row K>=2048 cell excepted); radix_filter for
+                       the rest of hint-free fp32 and for the mid/large bf16 and
                        fp16 regions; gvr only for large hinted batches of
                        mid/long rows; radix otherwise, with radix_cutlass
                        preferred in its fp32 big-batch/long-row corner and as
@@ -272,12 +273,13 @@ def _gvr2_top_k_varlen_check(
 
     Mirrors the TRT-LLM ``run_varlen`` hard contract so backend="auto" (and an
     explicit backend="gvr_2") never reaches a kernel-side RuntimeError.
+
+    ``pre_idx`` is NOT a requirement (FlashInfer-local): the kernels use the
+    hint only as a sampling anchor, so the host runs hint-free with a cached
+    ``arange(k)`` stand-in when it is absent — or malformed, in which case the
+    API body discards it with a RuntimeWarning first.
     """
-    if not (
-        _cute_dsl_ready(logits.device)
-        and pre_idx is not None
-        and _hint_problem(pre_idx, logits, seq_lens, top_k) is None
-    ):
+    if not _cute_dsl_ready(logits.device):
         return False
     # fp32 only: the upstream self-sampling kernels declare bf16/fp16 a
     # follow-up (run_varlen raises on any other dtype).
@@ -327,8 +329,15 @@ def _top_k_varlen_heuristic(
     cr in {1, 4}, next_n in {1, 2}; see PR #4811). Decision rules, using only
     capture-stable host facts (dtype, logits width N, request count B):
 
-    1. fp32 + pre_idx: gvr_2 first — it won 211/213 measured cells (geomean
-       2.1-3.8x over every other backend) and ~1.00x vs its TRT-LLM origin.
+    1. fp32: gvr_2 first, hinted or not — hinted it won 211/213 measured
+       cells (geomean 2.1-3.8x over every other backend) and ~1.00x vs its
+       TRT-LLM origin; HINT-FREE (FlashInfer-local arange anchor, see
+       ``gvr2_topk_host._hint_free_pre_idx``) it stays within ~10% of the
+       hinted time on most cells and beats the best hint-free radix backend
+       by 1.5-5x on every measured cell (B100, K in {512, 1024, 2048}, N in
+       [4K, 512K], B in [1, 256], cr 1 and 4, uniform and mixed lengths)
+       except one: K >= 2048 with N <= 4096 at B == 1, where radix_filter is
+       ~1.3x faster (3.0 vs 3.9 us) — that cell is carved out.
     2. gvr vs radix (when a hint is given but gvr_2 is unsuitable, and for
        every bf16/fp16 hinted call): gvr only pays off when the batch is
        large AND rows are long — B*N >= 2^22 (fp32) / 2^23 (bf16/fp16).
@@ -392,8 +401,14 @@ def _top_k_varlen_heuristic(
         )
         gvr_first = batch >= 256 and 32768 <= n_cols <= 524288
     cutlass_first = fp32 and n_cols >= 65536 and elems >= (1 << 23)
+    # the one measured cell where hint-free radix_filter beats gvr_2 (rule 1);
+    # hinted gvr_2 is still ahead there, so the carve-out is hint-free only
+    hinted = (
+        pre_idx is not None and _hint_problem(pre_idx, logits, seq_lens, top_k) is None
+    )
+    gvr2_tiny_loss = (not hinted) and top_k >= 2048 and n_cols <= 4096 and batch == 1
 
-    order = ["gvr_2"]
+    order = [] if gvr2_tiny_loss else ["gvr_2"]
     if fp32:
         # radix_filter beats gvr in every measured fp32 cell (1.2-3x)
         if rf_first:
@@ -413,6 +428,11 @@ def _top_k_varlen_heuristic(
     if "gvr" not in order:
         # small-problem fallback rank: radix > gvr > radix_cutlass
         order.insert(order.index("radix") + 1, "gvr")
+    if gvr2_tiny_loss:
+        # radix_filter (the cell's winner) first, gvr_2 right behind it
+        order = ["radix_filter", "gvr_2"] + [
+            b for b in order if b not in ("radix_filter", "gvr_2")
+        ]
     return [b for b in order if b in suitable_backends]
 
 
@@ -1038,7 +1058,7 @@ def _run_gvr(
 
 def _run_gvr2(
     logits: torch.Tensor,
-    pre_idx: torch.Tensor,
+    pre_idx: Optional[torch.Tensor],
     seq_lens: torch.Tensor,
     top_k: int,
     next_n: int,
@@ -1057,6 +1077,9 @@ def _run_gvr2(
     the launcher for this shape has been compiled (warm up before capture).
     The kernel reads each request's ``seq_lens`` on device and re-derives its
     sampling ladder per row, so no LJF sort or prepare kernel is needed.
+    ``pre_idx=None`` runs hint-free: the host substitutes a cached
+    ``arange(top_k)`` table as the sampling anchor (exact, no per-call
+    allocation, CUDA-graph safe once sized by an eager call).
     """
     from .kernels import gvr2_topk_host
 
@@ -1070,6 +1093,7 @@ def _run_gvr2(
         values=out_values if return_output_values else None,
         max_seq_len=logits.shape[1] * compress_ratio,
         workspace=workspace.get("gvr2_workspace") if workspace else None,
+        top_k=top_k,
     )
     return out_indices, (out_values if return_output_values else None)
 
@@ -1436,8 +1460,9 @@ def top_k_varlen(
     Backend selection
     -----------------
     ``backend="auto"`` (default) ranks the backends that can run the call by
-    shape and dtype (see ``_top_k_varlen_heuristic``): ``gvr_2`` for hinted
-    fp32 on datacentre Blackwell-class GPUs, ``radix_filter`` in the
+    shape and dtype (see ``_top_k_varlen_heuristic``): ``gvr_2`` for fp32 on
+    datacentre Blackwell-class GPUs, with or without a hint (a missing hint
+    costs ~10% on most shapes), ``radix_filter`` in the
     measured large-N regions, ``gvr`` for large hinted half-precision
     batches of mid-length rows, otherwise the CuTe DSL ``radix`` backend on
     Blackwell, with the ``radix_cutlass`` masked fallback in its fp32 big
@@ -1473,12 +1498,14 @@ def top_k_varlen(
         internally applies a ``+1`` offset (DSv3.2) so the previous step's
         indices land correctly in the current step's grown KV-cache space.
         ``pre_idx[:, 0]`` must be the argmax index.
-        Required by the ``"gvr"`` and ``"gvr_2"`` backends; ignored by the
-        radix backends. Must be a contiguous, 16-byte-aligned int32 CUDA
-        tensor on ``logits.device`` of shape ``[seq_lens.shape[0], top_k]``:
-        a hint that violates this is **discarded with a RuntimeWarning** and
-        the call runs hint-free (``auto`` picks a hint-free backend; an
-        explicit ``"gvr"`` / ``"gvr_2"`` request is refused).
+        Required by the ``"gvr"`` backend; optional for ``"gvr_2"`` (the
+        kernels use it only as a sampling anchor, so a hint-free call is
+        exact and only somewhat slower); ignored by the radix backends. Must
+        be a contiguous, 16-byte-aligned int32 CUDA tensor on
+        ``logits.device`` of shape ``[seq_lens.shape[0], top_k]``: a hint
+        that violates this is **discarded with a RuntimeWarning** and the
+        call runs hint-free (``gvr_2`` with its synthetic anchor; an explicit
+        ``"gvr"`` request is refused).
     compress_ratio : int, optional
         KV-index compression factor (``1`` for DSv3.2, ``4`` for DSv4).
         Default ``1``.
@@ -1511,9 +1538,10 @@ def top_k_varlen(
                               sample-calibrated threshold ladders, exact
                               tie-interchangeable top-K, one launch per batch.
                               Datacentre Blackwell-class only (sm_100/103, or
-                              Rubin sm_107); requires
-                              ``pre_idx`` (hints steer sampling, never
-                              exactness) and fp32 logits;
+                              Rubin sm_107); fp32 logits; ``pre_idx``
+                              optional (hints steer sampling, never
+                              exactness — without one the host supplies a
+                              cached ``arange`` anchor);
                               ``top_k`` in {512, 1024, 2048}. ``load_balance``
                               is ignored (the kernel families load-balance
                               internally). CUDA graphs: warm up each
@@ -1539,8 +1567,11 @@ def top_k_varlen(
                               hint), as for ``"radix"`` and
                               ``"radix_cutlass"``.
         ``"auto"``          — shape/dtype-aware selection tracking the
-                              measured per-config winner: gvr_2 for hinted
-                              fp32; radix_filter for hint-free fp32 from 32K
+                              measured per-config winner: gvr_2 for fp32,
+                              hinted or hint-free (except hint-free
+                              ``top_k >= 2048`` at ``N <= 4096`` for a single
+                              row, where radix_filter wins); radix_filter
+                              for the remaining hint-free fp32 cells from 32K
                               columns up (all N once ``batch >= 256``) and
                               for the bf16/fp16 mid/large regions; gvr for
                               fp32 when ``batch * max_seq_len >= 2^22`` and
@@ -1612,7 +1643,7 @@ def top_k_varlen(
     ------
     BackendSupportedError
         If the requested backend is not supported on the current device, or
-        an explicit ``"gvr"`` / ``"gvr_2"`` request has no usable ``pre_idx``.
+        an explicit ``"gvr"`` request has no usable ``pre_idx``.
     ValueError
         If ``logits`` / ``seq_lens`` / ``next_n`` violate the shape, dtype or
         grouping contract, an ``out_indices`` / ``out_values`` buffer is
@@ -1698,13 +1729,17 @@ def top_k_varlen(
     if pre_idx is not None:
         problem = _hint_problem(pre_idx, logits, seq_lens, top_k)
         if problem is not None:
-            tail = (
-                "Fix the caller: with a well-formed hint auto can use the gvr_2 / "
-                "gvr paths, which are several times faster on hinted fp32 shapes."
-                if backend == "auto"
-                else f"backend={backend!r} never consumes the hint; the result is "
-                "unaffected, but fix the caller."
-            )
+            if backend in ("auto", "gvr_2"):
+                tail = (
+                    "Fix the caller: gvr_2 falls back to a synthetic sampling anchor "
+                    "(exact, but slower than with a real previous-step hint) and "
+                    "gvr cannot run at all without a well-formed hint."
+                )
+            else:
+                tail = (
+                    f"backend={backend!r} never consumes the hint; the result is "
+                    "unaffected, but fix the caller."
+                )
             warnings.warn(
                 f"top_k_varlen: pre_idx is malformed ({problem}); the hint is "
                 f"DISCARDED and this call runs hint-free (int32[{seq_lens.shape[0]}, "
@@ -1752,10 +1787,10 @@ def top_k_varlen(
 
     if backend == "auto":
         backend = top_k_varlen.suitable_auto_backends[0]
-    if pre_idx is None and backend in ("gvr", "gvr_2"):
+    if pre_idx is None and backend == "gvr":
         # reachable under skip_check=True (the checkers did not run) with a
         # missing or just-discarded hint: refuse here instead of handing None
-        # to a kernel host
+        # to a kernel host (gvr_2 runs hint-free, see _run_gvr2)
         raise BackendSupportedError(
             f"backend={backend!r} requires a well-formed pre_idx hint "
             f"(int32[{seq_lens.shape[0]}, {top_k}] contiguous CUDA tensor on "

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -59,6 +59,7 @@ Backend choices
 
 import functools
 import math
+import sys
 import warnings
 from typing import Literal, Optional, Tuple
 
@@ -1105,9 +1106,12 @@ def release_gvr2_resources(device=None) -> int:
     """Release the ``gvr_2`` backend's lazily created per-device caches.
 
     ``top_k_varlen(backend="gvr_2")`` keeps, per device, one default workspace
-    slab per CUDA stream it has run on (20,973,568 bytes each, at most 32 per
-    device) and one hint-free anchor table per ``top_k`` (grown by doubling).
-    They are created by eager launches and live for the process. This call
+    slab per raw CUDA stream handle it has run on (20,973,568 bytes each; as
+    many as there are distinct stream handles that ran an eager slab-using
+    launch) and one hint-free anchor table per ``top_k`` (grown by doubling).
+    They are created by eager launches and live for the process. Returns 0
+    without importing the kernel modules if the ``gvr_2`` host was never
+    loaded in this process (nothing can be cached then). This call
     synchronizes ``device`` (default: the current device; an int, a
     ``torch.device`` or a device string — CUDA only, anything else raises
     ``ValueError``), drops them all and returns the number of bytes released
@@ -1127,9 +1131,25 @@ def release_gvr2_resources(device=None) -> int:
     same warm-up rule as the first capture. Explicit ``workspace=`` buffers
     passed by the caller are never touched.
     """
-    from .kernels import gvr2_topk_host
-
-    return gvr2_topk_host.release_cached_resources(device)
+    if device is not None:  # same argument contract whether or not the host is loaded
+        dev = (
+            torch.device("cuda", device)
+            if isinstance(device, int)
+            else torch.device(device)
+        )
+        if dev.type != "cuda":
+            raise ValueError(
+                f"release_gvr2_resources: expected a CUDA device, got {dev!r}"
+            )
+    # The caches live in the gvr_2 host module; if it was never imported in
+    # this process no gvr_2 launch has happened and nothing can be cached.
+    # Looking it up in sys.modules (instead of importing `.kernels`, whose
+    # package __init__ eagerly imports the optional CuTe-DSL kernel modules)
+    # keeps this a no-op on installations without nvidia-cutlass-dsl.
+    host = sys.modules.get(f"{__package__}.kernels.gvr2_topk_host")
+    if host is None:
+        return 0
+    return host.release_cached_resources(device)
 
 
 # ---------------------------------------------------------------------------
@@ -1676,12 +1696,15 @@ def top_k_varlen(
             the graph pool. Graphs captured on the SAME stream share that
             stream's slab and must not be replayed concurrently with each
             other; pass a private ``"gvr2_workspace"`` for that pattern.
-            Slabs are keyed by the raw CUDA stream handle, and PyTorch hands
-            out ``torch.cuda.Stream()`` objects from a pool of 32 per
-            priority, so the default slabs are bounded at 32 x 21 MB per
-            device (and two ``Stream`` objects may share one slab when the
-            pool wraps — they also share the raw stream, so their launches
-            are ordered). The slabs and the hint-free anchor tables live for
+            Slabs are keyed by the raw CUDA stream handle: there is one 21 MB
+            slab per distinct handle that has run an eager slab-using launch.
+            PyTorch hands out ``torch.cuda.Stream()`` objects from a fixed
+            pool per device and priority (two ``Stream`` objects may share one
+            slab when the pool wraps — they also share the raw stream, so
+            their launches are ordered), but stream handles created outside
+            that pool (external streams, other priorities) each add a slab,
+            so the total is not bounded by the pool size. The slabs and the
+            hint-free anchor tables live for
             the process unless released with
             ``flashinfer.topk_varlen.release_gvr2_resources(device)``, which
             synchronizes the device, drops them and returns the bytes freed;

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1101,6 +1101,28 @@ def _run_gvr2(
     return out_indices, (out_values if return_output_values else None)
 
 
+def release_gvr2_resources(device=None) -> int:
+    """Release the ``gvr_2`` backend's lazily created per-device caches.
+
+    ``top_k_varlen(backend="gvr_2")`` keeps, per device, one default workspace
+    slab per CUDA stream it has run on (20,973,568 bytes each, at most 32 per
+    device) and one hint-free anchor table per ``top_k`` (grown by doubling).
+    They are created by eager launches and live for the process. This call
+    synchronizes ``device`` (default: the current device), drops them all and
+    returns the number of bytes released to the torch caching allocator
+    (``torch.cuda.empty_cache()`` returns that memory to the driver).
+
+    Any CUDA graph captured against a released slab or table would replay on
+    freed memory: release only when no such graph will be replayed again, and
+    re-capture after one eager ``gvr_2`` launch on the capturing stream, the
+    same warm-up rule as the first capture. Explicit ``workspace=`` buffers
+    passed by the caller are never touched.
+    """
+    from .kernels import gvr2_topk_host
+
+    return gvr2_topk_host.release_cached_resources(device)
+
+
 # ---------------------------------------------------------------------------
 # Internal: radix_cutlass (masked-radix CUTLASS) backend implementation
 # ---------------------------------------------------------------------------
@@ -1650,7 +1672,12 @@ def top_k_varlen(
             priority, so the default slabs are bounded at 32 x 21 MB per
             device (and two ``Stream`` objects may share one slab when the
             pool wraps — they also share the raw stream, so their launches
-            are ordered).
+            are ordered). The slabs and the hint-free anchor tables live for
+            the process unless released with
+            ``flashinfer.topk_varlen.release_gvr2_resources(device)``, which
+            synchronizes the device, drops them and returns the bytes freed;
+            graphs captured against them must then be re-captured after a
+            fresh eager warm-up.
 
     Returns
     -------

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -33,7 +33,10 @@ Backend choices
 ``"gvr_2"``          — self-sampling GVR V2 (sample-calibrated threshold
                        ladders; TRT-LLM PR #17821 port). Requires a datacentre
                        Blackwell-class GPU (sm_100/103, or Rubin sm_107),
-                       nvidia-cutlass-dsl, ``pre_idx``, and fp32 logits.
+                       nvidia-cutlass-dsl and fp32 logits; ``pre_idx`` is
+                       optional (a cached synthetic anchor is used when it is
+                       absent — exact either way, the hint only steers
+                       sampling).
 ``"radix_cutlass"``  — masked-radix fallback; masks logits to ``seq_lens`` then
                        calls the FlashInfer CUTLASS radix top-K.  Runs on any GPU.
 ``"radix_filter"``   — filtered-radix (coarse histogram → filter → on-chip
@@ -1546,9 +1549,16 @@ def top_k_varlen(
                               is ignored (the kernel families load-balance
                               internally). CUDA graphs: warm up each
                               (num_rows, N, top_k, next_n, compress_ratio)
-                              geometry with one eager call before capture
-                              (an uncompiled launcher raises loudly under
-                              capture); replays may change ``seq_lens``
+                              geometry with one eager call, ON THE STREAM
+                              THAT WILL CAPTURE, before capture: the eager
+                              call compiles the launcher, sizes the
+                              hint-free anchor table (hinted or not, so hint
+                              mode is not a warm-up dimension) and creates
+                              that stream's default workspace slab (one per
+                              device and stream, so graphs captured on
+                              different streams never share scratch); any
+                              of the three missing raises loudly under
+                              capture; replays may change ``seq_lens``
                               CONTENTS freely in either direction. All finite
                               values, ``+inf`` and ``-inf`` are tie-aware
                               exact (TRT-LLM #18501/#18625 ported); NaN
@@ -1614,7 +1624,7 @@ def top_k_varlen(
         (CUDA tensor of at least
         ``flashinfer.topk_varlen.kernels.gvr2_topk_host.workspace_bytes()``
         = 20,973,568 bytes, zero-initialized before first use, 16-byte
-        aligned) overrides the per-device cached slab.
+        aligned) overrides the cached default slab.
 
         .. warning::
             Do **not** share the same workspace dict across concurrent CUDA
@@ -1622,15 +1632,19 @@ def top_k_varlen(
             on the device tensors.  For the ``"gvr"`` backend, ``workspace=None``
             (default) allocates per call and is safe for any concurrency.
             For ``"gvr_2"``, ``workspace=None`` resolves to **one slab per
-            device**, shared by every launch on that device: it holds the
-            cross-CTA counters, offsets and candidate buffer of the multi-CTA
-            streaming path (selected by the kernel's ``route()`` from row
-            count, envelope and ``top_k``; small batches with long rows), so
-            two such launches in flight at once — two eager streams, or two
-            CUDA graphs replayed concurrently — race on it. Every concurrently
-            active stream, and every CUDA graph that may replay concurrently
-            with another launch, must pass its own ``"gvr2_workspace"``;
-            stream-ordered use needs nothing.
+            device and CUDA stream**: it holds the cross-CTA counters,
+            offsets and candidate buffer of the multi-CTA streaming path
+            (selected by the kernel's ``route()`` from row count, envelope
+            and ``top_k``; small batches with long rows), so launches that
+            can overlap must not share it — and with per-stream slabs, two
+            eager streams or two CUDA graphs captured on different streams
+            and replayed concurrently do not. The slab is created by the
+            first **eager** launch on a stream; a graph captured on a stream
+            that has never run an eager ``gvr_2`` launch (and whose plan
+            needs the slab) raises under capture instead of allocating from
+            the graph pool. Graphs captured on the SAME stream share that
+            stream's slab and must not be replayed concurrently with each
+            other; pass a private ``"gvr2_workspace"`` for that pattern.
 
     Returns
     -------

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1108,9 +1108,18 @@ def release_gvr2_resources(device=None) -> int:
     slab per CUDA stream it has run on (20,973,568 bytes each, at most 32 per
     device) and one hint-free anchor table per ``top_k`` (grown by doubling).
     They are created by eager launches and live for the process. This call
-    synchronizes ``device`` (default: the current device), drops them all and
-    returns the number of bytes released to the torch caching allocator
-    (``torch.cuda.empty_cache()`` returns that memory to the driver).
+    synchronizes ``device`` (default: the current device; an int, a
+    ``torch.device`` or a device string — CUDA only, anything else raises
+    ``ValueError``), drops them all and returns the number of bytes released
+    to the torch caching allocator (``torch.cuda.empty_cache()`` returns that
+    memory to the driver).
+
+    The caller must be quiescent on ``device`` for the duration of the call:
+    no ``gvr_2`` call in flight or being issued from any thread, eager or
+    CUDA-graph replay — the same rule as ``torch.cuda.empty_cache()`` versus
+    live tensors. The launch hot paths do not take the cache locks, so a
+    launch issued concurrently could otherwise address a slab this call has
+    just released.
 
     Any CUDA graph captured against a released slab or table would replay on
     freed memory: release only when no such graph will be replayed again, and

--- a/flashinfer/topk_varlen/topk_varlen.py
+++ b/flashinfer/topk_varlen/topk_varlen.py
@@ -1645,6 +1645,12 @@ def top_k_varlen(
             the graph pool. Graphs captured on the SAME stream share that
             stream's slab and must not be replayed concurrently with each
             other; pass a private ``"gvr2_workspace"`` for that pattern.
+            Slabs are keyed by the raw CUDA stream handle, and PyTorch hands
+            out ``torch.cuda.Stream()`` objects from a pool of 32 per
+            priority, so the default slabs are bounded at 32 x 21 MB per
+            device (and two ``Stream`` objects may share one slab when the
+            pool wraps — they also share the raw stream, so their launches
+            are ordered).
 
     Returns
     -------

--- a/tests/topk_varlen/test_topk_varlen.py
+++ b/tests/topk_varlen/test_topk_varlen.py
@@ -1317,6 +1317,31 @@ def test_backend_heuristic_priority():
         "radix",
         "radix_cutlass",
     ]
+    # hint-free fp32 (gvr_2 runs on its synthetic anchor): gvr_2 still first
+    # everywhere except the one measured loss — K >= 2048, N <= 4096, single
+    # row — where radix_filter leads and gvr_2 follows; a real hint restores
+    # gvr_2 to the front there.
+    all5 = all4 + ["radix_filter"]
+
+    def order_k(suitable, batch, n_cols, top_k, hinted):
+        logits = torch.empty(batch, n_cols, dtype=torch.float32, device="meta")
+        seq_lens = torch.empty(batch, dtype=torch.int32, device="meta")
+        pre_idx = (
+            torch.empty(batch, top_k, dtype=torch.int32, device="meta")
+            if hinted
+            else None
+        )
+        return _top_k_varlen_heuristic(suitable, logits, seq_lens, top_k, pre_idx)
+
+    assert order_k(all5, 16, 32768, 512, False)[0] == "gvr_2"
+    assert order_k(all5, 1, 4096, 1024, False)[0] == "gvr_2"
+    assert order_k(all5, 2, 4096, 2048, False)[0] == "gvr_2"
+    assert order_k(all5, 1, 4096, 2048, False)[:2] == ["radix_filter", "gvr_2"]
+    assert order_k(all4, 1, 4096, 2048, False)[0] == "gvr_2"  # no radix_filter
+    # (a meta pre_idx fails the CUDA-device check and counts as absent; a hint
+    # on the logits device is exercised by the GPU tests)
+    assert order_k(all5, 1, 4096, 2048, True)[:2] == ["radix_filter", "gvr_2"]
+
     # None tensors (skip_check / doc examples): static fallback order.
     assert _top_k_varlen_heuristic(all4, None, None, None) == [
         "gvr_2",
@@ -1423,9 +1448,10 @@ def _malformed_hints(batch, top_k):
 def test_malformed_hint_is_discarded_with_warning(kind):
     """A malformed ``pre_idx`` (wrong shape, dtype, device, layout or
     alignment) is dropped with a RuntimeWarning and the call runs hint-free
-    and exact, under ``auto`` and under an explicit hint-free backend. The
-    hint-consuming backends refuse the call up front instead of failing
-    inside the kernel (they cannot run without a hint)."""
+    and exact, under ``auto``, under an explicit hint-free backend, and under
+    ``gvr_2`` (which runs on its synthetic anchor). ``gvr`` cannot run
+    without a hint and refuses the call up front instead of failing inside
+    the kernel."""
     from flashinfer.utils import BackendSupportedError
 
     batch, n, top_k = 4, 8192, 1024
@@ -1453,31 +1479,37 @@ def test_malformed_hint_is_discarded_with_warning(kind):
         )
     assert bool(((indices >= 0) & (indices < n)).all()), "index out of range"
     assert torch.equal(torch.sort(logits.gather(1, indices.long()), dim=1).values, ref)
-    # explicit hint-consuming backends: refused by their checker up front
-    # (the @backend_requirement decorator reports a failed explicit-backend
-    # check as ValueError("Problem size is not supported ..."))
-    for backend in ("gvr", "gvr_2"):
-        if flashinfer.top_k_varlen.is_backend_supported(backend, major * 10 + minor):
-            with pytest.raises(
-                (BackendSupportedError, ValueError), match="not supported"
-            ):
-                flashinfer.top_k_varlen(
-                    logits, seq_lens, top_k, pre_idx=bad, backend=backend
-                )
-            # skip_check=True bypasses the checkers: the body must still refuse
-            # instead of handing the discarded hint (None) to the kernel host
-            with (
-                pytest.warns(RuntimeWarning, match="pre_idx"),
-                pytest.raises(BackendSupportedError, match="well-formed"),
-            ):
-                flashinfer.top_k_varlen(
+    # gvr_2: the hint is dropped with the warning and the call runs exact on
+    # the host's synthetic anchor (checked and skip_check paths alike)
+    if flashinfer.top_k_varlen.is_backend_supported("gvr_2", cc):
+        for skip in (False, True):
+            with pytest.warns(RuntimeWarning, match="synthetic sampling anchor"):
+                indices, _ = flashinfer.top_k_varlen(
                     logits,
                     seq_lens,
                     top_k,
                     pre_idx=bad,
-                    backend=backend,
-                    skip_check=True,
+                    backend="gvr_2",
+                    skip_check=skip,
                 )
+            assert torch.equal(
+                torch.sort(logits.gather(1, indices.long()), dim=1).values, ref
+            )
+    # gvr (V1) consumes the hint: refused by its checker up front (the
+    # @backend_requirement decorator reports a failed explicit-backend check
+    # as ValueError("Problem size is not supported ..."))
+    if flashinfer.top_k_varlen.is_backend_supported("gvr", cc):
+        with pytest.raises((BackendSupportedError, ValueError), match="not supported"):
+            flashinfer.top_k_varlen(logits, seq_lens, top_k, pre_idx=bad, backend="gvr")
+        # skip_check=True bypasses the checkers: the body must still refuse
+        # instead of handing the discarded hint (None) to the kernel host
+        with (
+            pytest.warns(RuntimeWarning, match="pre_idx"),
+            pytest.raises(BackendSupportedError, match="well-formed"),
+        ):
+            flashinfer.top_k_varlen(
+                logits, seq_lens, top_k, pre_idx=bad, backend="gvr", skip_check=True
+            )
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="no CUDA")

--- a/tests/topk_varlen/test_topk_varlen_concurrency.py
+++ b/tests/topk_varlen/test_topk_varlen_concurrency.py
@@ -138,6 +138,7 @@ def _split_inputs(copies, rows=16, n=131072, k=512, seed=0):
         pre = torch.full((rows, k), -1, dtype=torch.int32, device=_DEV)
         out = torch.full((rows, k), -7, dtype=torch.int32, device=_DEV)
         work.append((logits, seq, pre, out))
+    torch.cuda.synchronize()  # inputs are consumed on side streams: complete them first
     return k, work
 
 
@@ -173,6 +174,7 @@ def test_gvr2_eager_slab_launches_overlap_across_threads_and_streams(hint):
     outs = [
         [torch.full_like(w[3], -7) for _ in range(launches)] for w in work
     ]  # one buffer per launch so every result is checked
+    torch.cuda.synchronize()  # the -7 fills complete before any side stream writes
     barrier = _barrier(threads_n)
     errors = []
 
@@ -213,6 +215,7 @@ def test_gvr2_graph_replay_races_eager_launches_on_other_streams():
     k, work = _split_inputs(n_graphs + 1, seed=21)
     streams = [torch.cuda.Stream() for _ in range(n_graphs + 1)]
     outs = [[torch.full_like(w[3], -7) for _ in range(launches)] for w in work]
+    torch.cuda.synchronize()  # the -7 fills complete before any side stream writes
     graphs = []
     for i in range(n_graphs):  # captures are serialized (one per process at a time)
         with torch.cuda.stream(streams[i]):
@@ -324,6 +327,7 @@ def test_gvr2_hint_free_graph_survives_table_growth_by_others():
     logits = torch.randn(8, n, generator=gen, device=_DEV)
     seq = torch.randint(600, n, (8,), generator=gen, device=_DEV, dtype=torch.int32)
     out = torch.full((8, k), -7, dtype=torch.int32, device=_DEV)
+    torch.cuda.synchronize()  # default-stream initialisation before the side-stream launch
     s = torch.cuda.Stream()
     with torch.cuda.stream(s):
         _launch((logits, seq, None, out), k, hint=False)
@@ -338,6 +342,7 @@ def test_gvr2_hint_free_graph_survives_table_growth_by_others():
     big_logits = torch.randn(1024, n, generator=gen, device=_DEV)
     big_seq = torch.full((1024,), n, dtype=torch.int32, device=_DEV)
     big_out = torch.empty(1024, k, dtype=torch.int32, device=_DEV)
+    torch.cuda.synchronize()  # default-stream initialisation before the side-stream launches
     other = torch.cuda.Stream()
     for b in (100, 300, 1024):
         with torch.cuda.stream(other):
@@ -373,6 +378,7 @@ def test_gvr2_hint_free_table_grown_on_one_stream_is_complete_when_published():
     logits = torch.randn(512, n, generator=gen, device=_DEV)
     seq = torch.full((512,), n, dtype=torch.int32, device=_DEV)
     outs = [torch.full((512, k), -7, dtype=torch.int32, device=_DEV) for _ in range(2)]
+    torch.cuda.synchronize()  # default-stream initialisation before the side-stream launch
     a, b = torch.cuda.Stream(), torch.cuda.Stream()
     with torch.cuda.stream(b):  # compile the launcher for 512 rows on B, hinted
         _launch(

--- a/tests/topk_varlen/test_topk_varlen_concurrency.py
+++ b/tests/topk_varlen/test_topk_varlen_concurrency.py
@@ -18,20 +18,32 @@ they cannot see the class of defect that review round 1 of PR #4986 found:
 lazily created resources shared across launches that may overlap (the gvr_2
 SPLIT workspace slab and the hint-free anchor table). Every test here drives
 the API the way a serving engine does — several host threads, several CUDA
-streams, CUDA graphs captured and replayed while other work is in flight —
-and asserts exactness per row, so a race shows up as a wrong result rather
-than as a note in a docstring.
+streams, CUDA graphs replayed while other work is in flight — and asserts the
+invariant directly (exactness per row, or the contents of the shared object),
+so a race shows up as a wrong result rather than as a note in a docstring.
+
+Ground rules the tests themselves obey (each was a review finding):
+
+* CUDA-graph captures are serialized — PyTorch allows one capture per process
+  at a time; only the REPLAYS are concurrent;
+* GPU-side overlap comes from graph replays and single-thread multi-stream
+  issue; Python threads serialize on the GIL and exercise host thread-safety;
+* every host write to a buffer a stream will read is issued on that stream or
+  ordered before it with a synchronize;
+* ``torch.cuda.Stream()`` hands out one of 32 pooled raw streams, so a "fresh"
+  stream may carry a slab cached by an earlier test — the tests clear the
+  cache entry for that raw handle before relying on its absence;
+* every test carries ``pytest.mark.timeout(300, method="thread")`` (the
+  repository's pytest-timeout convention): a hang dumps every thread's stack
+  and terminates the process instead of stalling the suite. Healthy runs take
+  1-6 s per test on every part measured.
 
 Inputs are chosen so gvr_2 lands on the streaming ``main`` family with a
 multi-CTA SPLIT (the only family that touches the slab); tests skip on parts
 that route the shape elsewhere.
 """
 
-import faulthandler
-import functools
-import sys
 import threading
-import time
 
 import pytest
 import torch
@@ -45,10 +57,15 @@ try:
 except ImportError:
     _FLASHINFER_AVAILABLE = False
 
-pytestmark = pytest.mark.skipif(
-    not (_FLASHINFER_AVAILABLE and torch.cuda.is_available()),
-    reason="flashinfer + CUDA required",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not (_FLASHINFER_AVAILABLE and torch.cuda.is_available()),
+        reason="flashinfer + CUDA required",
+    ),
+    # > cold-cache JIT compile + the longest test by 50x; a real hang is
+    # immediate. "thread" mode dumps all stacks and terminates the process.
+    pytest.mark.timeout(300, method="thread"),
+]
 _DEV = "cuda"
 
 
@@ -61,9 +78,24 @@ def _barrier(parties):
 def _forget_table(k):
     """Drop the cached hint-free anchor table for k (cold start for a test)."""
     key = (torch.cuda.current_device(), k)
-    lock = getattr(_host, "_HINT_FREE_LOCK", None) or threading.Lock()
-    with lock:
+    # getattr: lets the file run against a host without the growth lock (the
+    # teeth check runs these tests on the pre-fix tree)
+    with getattr(_host, "_HINT_FREE_LOCK", None) or threading.Lock():
         _host._HINT_FREE.pop(key, None)
+
+
+def _slab_key(stream):
+    return (torch.cuda.current_device(), stream.cuda_stream)
+
+
+def _forget_slab(stream):
+    """Drop the cached default workspace slab of ``stream``'s RAW handle.
+    torch.cuda.Stream() recycles 32 pooled streams, so a stream object that is
+    new to this test may map to a handle an earlier test already gave a slab;
+    the tests below establish 'no slab yet' explicitly instead of assuming it."""
+    torch.cuda.synchronize()
+    with _host._mu:
+        _host._ws_keep.pop(_slab_key(stream), None)
 
 
 def _cc() -> int:
@@ -77,80 +109,6 @@ requires_gvr2 = pytest.mark.skipif(
     or not flashinfer.top_k_varlen.is_backend_supported("gvr_2", _cc()),
     reason="gvr_2 unsupported on this device",
 )
-
-
-# ---------------------------------------------------------------------------
-# deadline: a hung concurrency test must fail, not stall the suite
-# ---------------------------------------------------------------------------
-
-_CALIBRATION = {}
-
-
-def _per_launch_seconds():
-    """Wall time of one eager slab-family launch + sync on this device (warm),
-    measured once per process; the deadline budgets scale with it so a slow
-    part or a cold JIT cache does not produce false timeouts."""
-    if "t" not in _CALIBRATION:
-        rows, n, k = 16, 131072, 512
-        gen = torch.Generator(device=_DEV).manual_seed(999)
-        logits = torch.randn(rows, n, generator=gen, device=_DEV)
-        seq = torch.full((rows,), n, dtype=torch.int32, device=_DEV)
-        pre = torch.full((rows, k), -1, dtype=torch.int32, device=_DEV)
-        out = torch.empty(rows, k, dtype=torch.int32, device=_DEV)
-        for _ in range(3):  # compile + warm
-            flashinfer.top_k_varlen(
-                logits, seq, k, pre_idx=pre, out_indices=out, backend="gvr_2"
-            )
-        torch.cuda.synchronize()
-        t0 = time.perf_counter()
-        for _ in range(20):
-            flashinfer.top_k_varlen(
-                logits, seq, k, pre_idx=pre, out_indices=out, backend="gvr_2"
-            )
-        torch.cuda.synchronize()
-        _CALIBRATION["t"] = max((time.perf_counter() - t0) / 20, 1e-4)
-    return _CALIBRATION["t"]
-
-
-def _deadline(launches, slack_s=60.0, factor=200.0):
-    """Run the test body in a worker thread and fail if it exceeds
-    ``slack_s + factor * launches * per_launch_seconds`` — generous enough
-    (200x the measured eager launch cost per launch, plus a minute for JIT,
-    checks and graph capture) that a healthy run never trips it, small enough
-    that a deadlock surfaces as a failure with every thread's stack printed.
-    The body runs in a thread so the main thread can enforce the budget; CUDA
-    graph capture is per-thread and unaffected."""
-
-    def wrap(fn):
-        @functools.wraps(fn)
-        def run(*args, **kwargs):
-            budget = slack_s + factor * launches * _per_launch_seconds()
-            result = {}
-
-            def body():
-                try:
-                    fn(*args, **kwargs)
-                except BaseException as e:  # noqa: BLE001
-                    result["error"] = e
-
-            t = threading.Thread(target=body, name=f"{fn.__name__}-body", daemon=True)
-            t.start()
-            t.join(budget)
-            if t.is_alive():
-                sys.stderr.write(
-                    f"\n=== {fn.__name__}: deadline {budget:.0f}s exceeded; thread stacks: ===\n"
-                )
-                faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
-                pytest.fail(
-                    f"{fn.__name__} exceeded its deadline of {budget:.0f}s "
-                    f"({launches} launches x {_per_launch_seconds() * 1e3:.2f} ms + {slack_s:.0f}s slack): probable hang"
-                )
-            if "error" in result:
-                raise result["error"]
-
-        return run
-
-    return wrap
 
 
 def _exact(logits, seq, out, k, who=""):
@@ -197,13 +155,12 @@ def _launch(w, k, hint=True, out=None, workspace=None):
 
 
 # ---------------------------------------------------------------------------
-# 1. eager launches overlapping across streams and host threads
+# 1. launches overlapping across streams (and host threads)
 # ---------------------------------------------------------------------------
 
 
 @requires_gvr2
 @pytest.mark.parametrize("hint", [True, False], ids=["hinted", "hint_free"])
-@_deadline(launches=328)
 def test_gvr2_eager_slab_launches_overlap_across_threads_and_streams(hint):
     """Eight host threads, each on its own stream, hammer the SPLIT family with
     workspace=None for 40 launches each while the others do the same: the
@@ -242,23 +199,22 @@ def test_gvr2_eager_slab_launches_overlap_across_threads_and_streams(hint):
 
 
 @requires_gvr2
-@_deadline(launches=524)
 def test_gvr2_graph_replay_races_eager_launches_on_other_streams():
     """Four graphs (eight slab-using launches each, one output buffer per
-    launch) captured on streams A..D are replayed back to back while stream E
-    receives eight eager slab-using launches (default workspace), all issued
-    from ONE host thread with no synchronization until the round ends —
-    captured decode steps overlapping with eager work. Issuing from one thread
-    is what produces real GPU-side overlap (Python threads serialize on the
-    GIL); the four-graph replay is the pattern that measured 2-17 corrupted
-    rows per run through a device-wide slab. Each stream owns a slab, so
-    every replayed and eager result stays exact."""
+    launch) captured one after another on streams A..D are replayed back to
+    back while stream E receives eight eager slab-using launches (default
+    workspace), all issued from ONE host thread with no synchronization until
+    the round ends — captured decode steps overlapping with eager work.
+    Issuing from one thread is what produces real GPU-side overlap (Python
+    threads serialize on the GIL); the four-graph replay is the pattern that
+    measured 2-17 corrupted rows per run through a device-wide slab. Each
+    stream owns a slab, so every replayed and eager result stays exact."""
     n_graphs, launches, rounds = 4, 8, 12
     k, work = _split_inputs(n_graphs + 1, seed=21)
     streams = [torch.cuda.Stream() for _ in range(n_graphs + 1)]
     outs = [[torch.full_like(w[3], -7) for _ in range(launches)] for w in work]
     graphs = []
-    for i in range(n_graphs):
+    for i in range(n_graphs):  # captures are serialized (one per process at a time)
         with torch.cuda.stream(streams[i]):
             _launch(work[i], k)
         torch.cuda.synchronize()
@@ -275,7 +231,7 @@ def test_gvr2_graph_replay_races_eager_launches_on_other_streams():
         for os_ in outs:
             for o in os_:
                 o.fill_(-7)
-        torch.cuda.synchronize()
+        torch.cuda.synchronize()  # fills ordered before every stream's work
         for i in range(n_graphs):
             with torch.cuda.stream(streams[i]):
                 graphs[i].replay()
@@ -290,48 +246,26 @@ def test_gvr2_graph_replay_races_eager_launches_on_other_streams():
 
 
 @requires_gvr2
-@_deadline(launches=84)
-def test_gvr2_graphs_captured_concurrently_from_threads_replay_exact():
-    """Four threads capture graphs on four streams at the same time (a serving
-    engine capturing per-batch-size graphs in parallel), after a per-stream
-    eager warm-up; every graph replays exact, including when all four replay
-    together."""
+def test_gvr2_graphs_captured_sequentially_replay_concurrently_exact():
+    """A serving engine captures its per-batch-size graphs one at a time (only
+    one CUDA-graph capture may be underway per process) and later replays them
+    concurrently on their streams. Four graphs, each captured on its own
+    stream after a per-stream eager warm-up, replay together for several
+    rounds; every result stays exact."""
     k, work = _split_inputs(4, seed=31)
     streams = [torch.cuda.Stream() for _ in range(4)]
+    graphs = []
     for i in range(4):
         with torch.cuda.stream(streams[i]):
             _launch(work[i], k)
+        torch.cuda.synchronize()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(streams[i]), torch.cuda.graph(g, stream=streams[i]):
+            for _ in range(4):
+                _launch(work[i], k)
+        graphs.append(g)
     torch.cuda.synchronize()
-    graphs = [None] * 4
-    barrier = _barrier(4)
-    errors = []
-
-    def capture(i):
-        try:
-            g = torch.cuda.CUDAGraph()
-            barrier.wait()
-            # thread-local capture mode: other threads' CUDA calls must not
-            # invalidate this thread's capture (the default "global" mode does)
-            with (
-                torch.cuda.stream(streams[i]),
-                torch.cuda.graph(
-                    g, stream=streams[i], capture_error_mode="thread_local"
-                ),
-            ):
-                for _ in range(4):
-                    _launch(work[i], k)
-            graphs[i] = g
-        except Exception as e:  # noqa: BLE001
-            errors.append(e)
-
-    ts = [threading.Thread(target=capture, args=(i,)) for i in range(4)]
-    for t in ts:
-        t.start()
-    for t in ts:
-        t.join()
-    torch.cuda.synchronize()
-    assert not errors, errors
-    for _ in range(4):
+    for _ in range(6):
         for w in work:
             w[3].fill_(-7)
         torch.cuda.synchronize()
@@ -344,7 +278,6 @@ def test_gvr2_graphs_captured_concurrently_from_threads_replay_exact():
 
 
 @requires_gvr2
-@_deadline(launches=58)
 def test_gvr2_same_stream_graphs_share_a_slab_and_replay_sequentially():
     """Two graphs captured on the SAME stream share that stream's slab. That is
     the documented allowed pattern as long as they replay in stream order —
@@ -380,7 +313,6 @@ def test_gvr2_same_stream_graphs_share_a_slab_and_replay_sequentially():
 
 
 @requires_gvr2
-@_deadline(launches=8)
 def test_gvr2_hint_free_graph_survives_table_growth_by_others():
     """A hint-free graph captured against the anchor table at capacity C keeps
     replaying exactly after other callers grow the table past C (the graph
@@ -402,7 +334,7 @@ def test_gvr2_hint_free_graph_survives_table_growth_by_others():
         _launch((logits, seq, None, out), k, hint=False)
     torch.cuda.synchronize()
     # grow the table well past the captured capacity, several times, from
-    # another stream, and scribble over freshly grown tables' *views*
+    # another stream
     big_logits = torch.randn(1024, n, generator=gen, device=_DEV)
     big_seq = torch.full((1024,), n, dtype=torch.int32, device=_DEV)
     big_out = torch.empty(1024, k, dtype=torch.int32, device=_DEV)
@@ -412,56 +344,104 @@ def test_gvr2_hint_free_graph_survives_table_growth_by_others():
             _launch((big_logits[:b], big_seq[:b], None, big_out[:b]), k, hint=False)
     torch.cuda.synchronize()
     assert _host._HINT_FREE[key] is not old and _host._HINT_FREE[key].shape[0] >= 1024
-    assert old in _host._HINT_FREE_KEEP
+    assert any(t is old for t in _host._HINT_FREE_KEEP), (
+        "superseded table not kept alive"
+    )
     assert bool((old == torch.arange(k, dtype=torch.int32, device=_DEV)).all())
     for _ in range(3):
-        out.fill_(-7)
-        with torch.cuda.stream(s):
+        with torch.cuda.stream(s):  # the fill is ordered before the replay on s
+            out.fill_(-7)
             g.replay()
         torch.cuda.synchronize()
         _exact(logits, seq, out, k, who="graph on the superseded table")
 
 
 @requires_gvr2
-@_deadline(launches=3)
-def test_gvr2_hint_free_table_grown_on_one_stream_used_at_once_on_another():
-    """Grow the table on stream A and, without any host synchronization,
-    launch hint-free on stream B at the new capacity from another thread; the
-    published table must already be complete (the producer stream is
-    synchronized before publication)."""
+def test_gvr2_hint_free_table_grown_on_one_stream_is_complete_when_published():
+    """Publication ordering of the anchor table: the producer on stream A queues
+    a long busy-wait kernel and then grows the table (the arange fill sits
+    behind the busy-wait in A's queue); the consumer on stream B, without any
+    synchronization with A, snapshots the published table the moment the
+    pointer is visible. The snapshot must equal arange(k): the host must
+    synchronize the producing stream before publishing. (Exactness of the
+    consumer's top-k is NOT the observable — gvr_2 is exact for any hint
+    contents — so the table itself is compared.) Fails on a host that
+    publishes before the fill completes."""
     k, n = 1024, 8192
-    _forget_table(k)
+    key = (torch.cuda.current_device(), k)
     gen = torch.Generator(device=_DEV).manual_seed(61)
     logits = torch.randn(512, n, generator=gen, device=_DEV)
     seq = torch.full((512,), n, dtype=torch.int32, device=_DEV)
     outs = [torch.full((512, k), -7, dtype=torch.int32, device=_DEV) for _ in range(2)]
     a, b = torch.cuda.Stream(), torch.cuda.Stream()
-    with torch.cuda.stream(
-        b
-    ):  # compile the launcher for 512 rows on B, hinted (table untouched)
+    with torch.cuda.stream(b):  # compile the launcher for 512 rows on B, hinted
         _launch(
             (logits, seq, torch.zeros(512, k, dtype=torch.int32, device=_DEV), outs[1]),
             k,
         )
     torch.cuda.synchronize()
-    _forget_table(k)
+    _forget_table(k)  # the hinted call pre-sized it; go cold again
+    # the freed table's block would be handed back by the caching allocator
+    # with arange(k) still in it, which would mask a publish-before-fill bug:
+    # release cached blocks, then poison a same-sized block ON STREAM A (the
+    # allocator reuses blocks per stream) so the new table's memory does not
+    # start out holding the right answer
+    torch.cuda.empty_cache()
+    with torch.cuda.stream(a):
+        # Walk the growth's exact allocation path once on stream A and free the
+        # result, so the real growth reuses cached blocks: any cudaMalloc
+        # inside the growth would block the host behind the busy-wait and make
+        # even a publish-before-fill host look ordered (measured). The block
+        # is left holding -1, so a table published before its fill reads -1.
+        warm = (
+            torch.arange(k, dtype=torch.int32, device=_DEV)
+            .unsqueeze(0)
+            .expand(512, k)
+            .contiguous()
+        )
+        warm.fill_(-1)
+    torch.cuda.synchronize()
+    del warm
+    ref = torch.arange(k, dtype=torch.int32, device=_DEV)
     grown = threading.Event()
+    snapshot = {}
     errors = []
+
+    orig_arange = torch.arange
+
+    def slow_arange(*args, **kwargs):
+        # The growth builds the table as arange(k).expand(...).contiguous():
+        # queue a ~2 s GPU busy-wait on the producing stream right AFTER the
+        # arange and BEFORE the expand/contiguous copy, so the fill sits behind
+        # the busy-wait in stream A's queue. (Queuing the busy-wait before the
+        # growth does not work: torch.arange itself blocks the host until the
+        # stream drains, which closes the window even on a publish-early host.)
+        t = orig_arange(*args, **kwargs)
+        torch.cuda._sleep(4_000_000_000)
+        return t
 
     def producer():
         try:
             with torch.cuda.stream(a):
-                _host._hint_free_pre_idx(512, k, torch.device(_DEV))  # grows 0 -> 512
+                torch.arange = slow_arange
+                try:
+                    _host._hint_free_pre_idx(
+                        512, k, torch.device(_DEV)
+                    )  # grows 0 -> 512
+                finally:
+                    torch.arange = orig_arange
                 grown.set()
                 _launch((logits, seq, None, outs[0]), k, hint=False)
         except Exception as e:  # noqa: BLE001
             errors.append(e)
+            grown.set()
 
     def consumer():
         try:
             grown.wait()
-            with torch.cuda.stream(b):
-                _launch((logits, seq, None, outs[1]), k, hint=False)  # no sync with A
+            with torch.cuda.stream(b):  # no synchronization with A
+                snapshot["table"] = _host._HINT_FREE[key].clone()
+                _launch((logits, seq, None, outs[1]), k, hint=False)
         except Exception as e:  # noqa: BLE001
             errors.append(e)
 
@@ -472,12 +452,16 @@ def test_gvr2_hint_free_table_grown_on_one_stream_used_at_once_on_another():
         t.join()
     torch.cuda.synchronize()
     assert not errors, errors
+    snap = snapshot["table"]
+    bad_rows = int((snap != ref).any(dim=1).sum())
+    assert bad_rows == 0, (
+        f"{bad_rows}/{snap.shape[0]} table rows were not arange(k) when published"
+    )
     _exact(logits, seq, outs[0], k, who="producer stream")
     _exact(logits, seq, outs[1], k, who="consumer stream")
 
 
 @requires_gvr2
-@_deadline(launches=12)
 def test_gvr2_hint_free_tables_for_different_k_grow_independently():
     """Interleaved growth of the k=512 and k=2048 tables from two threads keeps
     each table's rows equal to arange(k) and its capacity monotonic."""
@@ -518,28 +502,31 @@ def test_gvr2_hint_free_tables_for_different_k_grow_independently():
 
 
 @requires_gvr2
-@_deadline(launches=8)
 def test_gvr2_warmup_varlen_on_stream_enables_capture_on_that_stream_only():
     """warmup_varlen run on stream A creates A's slab and sizes the anchor
     table; a hint-free slab-using capture on A then succeeds, while the same
-    capture on a stream that never saw an eager launch raises (never allocates
-    from the graph pool)."""
+    capture on a stream with no slab raises (never allocates from the graph
+    pool). The 'no slab' precondition is established explicitly, since
+    stream B's pooled raw handle may have been given a slab by an earlier
+    test."""
     k, work = _split_inputs(1, seed=71)
     logits, seq, _, out = work[0]
     rows, n = logits.shape
     a, b = torch.cuda.Stream(), torch.cuda.Stream()
+    assert a.cuda_stream != b.cuda_stream
     with torch.cuda.stream(a):
         _host.warmup_varlen(k, n, num_rows_list=(rows,))
     torch.cuda.synchronize()
+    assert _slab_key(a) in _host._ws_keep, "warmup_varlen did not create A's slab"
     g = torch.cuda.CUDAGraph()
     with torch.cuda.stream(a), torch.cuda.graph(g, stream=a):
         _launch((logits, seq, None, out), k, hint=False)
-    out.fill_(-7)
-    torch.cuda.synchronize()
     with torch.cuda.stream(a):
+        out.fill_(-7)
         g.replay()
     torch.cuda.synchronize()
     _exact(logits, seq, out, k, who="captured after warmup on A")
+    _forget_slab(b)
     g2 = torch.cuda.CUDAGraph()
     with (
         pytest.raises(RuntimeError, match="no slab for this stream"),
@@ -548,14 +535,17 @@ def test_gvr2_warmup_varlen_on_stream_enables_capture_on_that_stream_only():
     ):
         _launch((logits, seq, None, out), k, hint=False)
     torch.cuda.synchronize()
+    assert _slab_key(b) not in _host._ws_keep, "a failed capture must not leave a slab"
 
 
 @requires_gvr2
-@_deadline(launches=5)
 def test_gvr2_register_family_capture_needs_no_slab_on_a_fresh_stream():
     """The rule is scoped to slab-using plans: a register-family shape warmed
-    on the default stream captures on a fresh stream without any eager launch
-    there (hinted or hint-free) and replays exact."""
+    on the default stream captures on a stream WITHOUT a slab (cleared
+    explicitly) with no eager launch there, hinted or hint-free, replays
+    exact, and the capture does not create a slab for that stream — so a
+    regression that made register plans consult the workspace would fail
+    here instead of being masked by a slab cached on a recycled stream."""
     k, n, rows = 512, 8192, 4
     lc = _host._varlen_launcher(rows, n, k, n, 1, 1)
     assert lc[0] in ("reg", "reg_clus"), lc[0]
@@ -568,12 +558,16 @@ def test_gvr2_register_family_capture_needs_no_slab_on_a_fresh_stream():
     torch.cuda.synchronize()
     for hint in (True, False):
         fresh = torch.cuda.Stream()
+        _forget_slab(fresh)
         g = torch.cuda.CUDAGraph()
         with torch.cuda.stream(fresh), torch.cuda.graph(g, stream=fresh):
             _launch((logits, seq, pre, out), k, hint=hint)
-        out.fill_(-7)
-        torch.cuda.synchronize()
+        assert _slab_key(fresh) not in _host._ws_keep, (
+            "a register-family capture must not touch the workspace slab"
+        )
         with torch.cuda.stream(fresh):
+            out.fill_(-7)
             g.replay()
         torch.cuda.synchronize()
         _exact(logits, seq, out, k, who=f"register family, hint={hint}")
+        assert _slab_key(fresh) not in _host._ws_keep

--- a/tests/topk_varlen/test_topk_varlen_concurrency.py
+++ b/tests/topk_varlen/test_topk_varlen_concurrency.py
@@ -1,0 +1,579 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Adversarial concurrency tests for ``top_k_varlen`` (gvr_2-centred).
+
+The shape suites run one launch at a time on one stream from one thread, so
+they cannot see the class of defect that review round 1 of PR #4986 found:
+lazily created resources shared across launches that may overlap (the gvr_2
+SPLIT workspace slab and the hint-free anchor table). Every test here drives
+the API the way a serving engine does — several host threads, several CUDA
+streams, CUDA graphs captured and replayed while other work is in flight —
+and asserts exactness per row, so a race shows up as a wrong result rather
+than as a note in a docstring.
+
+Inputs are chosen so gvr_2 lands on the streaming ``main`` family with a
+multi-CTA SPLIT (the only family that touches the slab); tests skip on parts
+that route the shape elsewhere.
+"""
+
+import faulthandler
+import functools
+import sys
+import threading
+import time
+
+import pytest
+import torch
+
+try:
+    import flashinfer
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+    from flashinfer.utils import get_compute_capability
+
+    _FLASHINFER_AVAILABLE = True
+except ImportError:
+    _FLASHINFER_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(
+    not (_FLASHINFER_AVAILABLE and torch.cuda.is_available()),
+    reason="flashinfer + CUDA required",
+)
+_DEV = "cuda"
+
+
+def _barrier(parties):
+    """Barrier with a timeout: a thread that fails before reaching it must not
+    hang the whole test (the others then see BrokenBarrierError and report)."""
+    return threading.Barrier(parties, timeout=120)
+
+
+def _forget_table(k):
+    """Drop the cached hint-free anchor table for k (cold start for a test)."""
+    key = (torch.cuda.current_device(), k)
+    lock = getattr(_host, "_HINT_FREE_LOCK", None) or threading.Lock()
+    with lock:
+        _host._HINT_FREE.pop(key, None)
+
+
+def _cc() -> int:
+    major, minor = get_compute_capability(torch.device(_DEV))
+    return major * 10 + minor
+
+
+requires_gvr2 = pytest.mark.skipif(
+    not _FLASHINFER_AVAILABLE
+    or not torch.cuda.is_available()
+    or not flashinfer.top_k_varlen.is_backend_supported("gvr_2", _cc()),
+    reason="gvr_2 unsupported on this device",
+)
+
+
+# ---------------------------------------------------------------------------
+# deadline: a hung concurrency test must fail, not stall the suite
+# ---------------------------------------------------------------------------
+
+_CALIBRATION = {}
+
+
+def _per_launch_seconds():
+    """Wall time of one eager slab-family launch + sync on this device (warm),
+    measured once per process; the deadline budgets scale with it so a slow
+    part or a cold JIT cache does not produce false timeouts."""
+    if "t" not in _CALIBRATION:
+        rows, n, k = 16, 131072, 512
+        gen = torch.Generator(device=_DEV).manual_seed(999)
+        logits = torch.randn(rows, n, generator=gen, device=_DEV)
+        seq = torch.full((rows,), n, dtype=torch.int32, device=_DEV)
+        pre = torch.full((rows, k), -1, dtype=torch.int32, device=_DEV)
+        out = torch.empty(rows, k, dtype=torch.int32, device=_DEV)
+        for _ in range(3):  # compile + warm
+            flashinfer.top_k_varlen(
+                logits, seq, k, pre_idx=pre, out_indices=out, backend="gvr_2"
+            )
+        torch.cuda.synchronize()
+        t0 = time.perf_counter()
+        for _ in range(20):
+            flashinfer.top_k_varlen(
+                logits, seq, k, pre_idx=pre, out_indices=out, backend="gvr_2"
+            )
+        torch.cuda.synchronize()
+        _CALIBRATION["t"] = max((time.perf_counter() - t0) / 20, 1e-4)
+    return _CALIBRATION["t"]
+
+
+def _deadline(launches, slack_s=60.0, factor=200.0):
+    """Run the test body in a worker thread and fail if it exceeds
+    ``slack_s + factor * launches * per_launch_seconds`` — generous enough
+    (200x the measured eager launch cost per launch, plus a minute for JIT,
+    checks and graph capture) that a healthy run never trips it, small enough
+    that a deadlock surfaces as a failure with every thread's stack printed.
+    The body runs in a thread so the main thread can enforce the budget; CUDA
+    graph capture is per-thread and unaffected."""
+
+    def wrap(fn):
+        @functools.wraps(fn)
+        def run(*args, **kwargs):
+            budget = slack_s + factor * launches * _per_launch_seconds()
+            result = {}
+
+            def body():
+                try:
+                    fn(*args, **kwargs)
+                except BaseException as e:  # noqa: BLE001
+                    result["error"] = e
+
+            t = threading.Thread(target=body, name=f"{fn.__name__}-body", daemon=True)
+            t.start()
+            t.join(budget)
+            if t.is_alive():
+                sys.stderr.write(
+                    f"\n=== {fn.__name__}: deadline {budget:.0f}s exceeded; thread stacks: ===\n"
+                )
+                faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+                pytest.fail(
+                    f"{fn.__name__} exceeded its deadline of {budget:.0f}s "
+                    f"({launches} launches x {_per_launch_seconds() * 1e3:.2f} ms + {slack_s:.0f}s slack): probable hang"
+                )
+            if "error" in result:
+                raise result["error"]
+
+        return run
+
+    return wrap
+
+
+def _exact(logits, seq, out, k, who=""):
+    for r in range(out.shape[0]):
+        idx = out[r].long()
+        n = int(seq[r])
+        assert bool(((idx >= 0) & (idx < n)).all()), f"{who} row {r}: index range"
+        assert torch.equal(
+            torch.sort(logits[r][idx]).values,
+            torch.sort(torch.topk(logits[r, :n], k).values).values,
+        ), f"{who} row {r}: value multiset differs from torch.topk"
+
+
+def _split_inputs(copies, rows=16, n=131072, k=512, seed=0):
+    """`copies` independent problems that gvr_2 routes to the SPLIT slab family
+    on this device (skip otherwise); each gets its own output buffer."""
+    lc = _host._varlen_launcher(rows, n, k, n, 1, 1)
+    if not (lc[0] == "main" and lc[2][5] > 1):
+        pytest.skip(f"shape routes to {lc[0]} (no workspace use) on this device")
+    gen = torch.Generator(device=_DEV).manual_seed(seed)
+    work = []
+    for _ in range(copies):
+        logits = torch.randn(rows, n, generator=gen, device=_DEV)
+        seq = torch.randint(
+            40000, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+        )
+        pre = torch.full((rows, k), -1, dtype=torch.int32, device=_DEV)
+        out = torch.full((rows, k), -7, dtype=torch.int32, device=_DEV)
+        work.append((logits, seq, pre, out))
+    return k, work
+
+
+def _launch(w, k, hint=True, out=None, workspace=None):
+    logits, seq, pre, o = w
+    flashinfer.top_k_varlen(
+        logits,
+        seq,
+        k,
+        pre_idx=pre if hint else None,
+        out_indices=out if out is not None else o,
+        backend="gvr_2",
+        workspace=workspace,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. eager launches overlapping across streams and host threads
+# ---------------------------------------------------------------------------
+
+
+@requires_gvr2
+@pytest.mark.parametrize("hint", [True, False], ids=["hinted", "hint_free"])
+@_deadline(launches=328)
+def test_gvr2_eager_slab_launches_overlap_across_threads_and_streams(hint):
+    """Eight host threads, each on its own stream, hammer the SPLIT family with
+    workspace=None for 40 launches each while the others do the same: the
+    host-thread-safety exercise of the per-stream slab lookup/creation path
+    (GIL-serialized launches give little GPU overlap; the graph tests below
+    cover that). Every row must be exact and no launch may raise."""
+    threads_n, launches = 8, 40
+    k, work = _split_inputs(threads_n, seed=11)
+    streams = [torch.cuda.Stream() for _ in range(threads_n)]
+    outs = [
+        [torch.full_like(w[3], -7) for _ in range(launches)] for w in work
+    ]  # one buffer per launch so every result is checked
+    barrier = _barrier(threads_n)
+    errors = []
+
+    def worker(i):
+        try:
+            with torch.cuda.stream(streams[i]):
+                _launch(work[i], k, hint)  # compile / create this stream's slab
+                barrier.wait()
+                for j in range(launches):
+                    _launch(work[i], k, hint, out=outs[i][j])
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    ts = [threading.Thread(target=worker, args=(i,)) for i in range(threads_n)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    torch.cuda.synchronize()
+    assert not errors, errors
+    for i, w in enumerate(work):
+        for j in range(launches):
+            _exact(w[0], w[1], outs[i][j], k, who=f"stream {i} launch {j}")
+
+
+@requires_gvr2
+@_deadline(launches=524)
+def test_gvr2_graph_replay_races_eager_launches_on_other_streams():
+    """Four graphs (eight slab-using launches each, one output buffer per
+    launch) captured on streams A..D are replayed back to back while stream E
+    receives eight eager slab-using launches (default workspace), all issued
+    from ONE host thread with no synchronization until the round ends —
+    captured decode steps overlapping with eager work. Issuing from one thread
+    is what produces real GPU-side overlap (Python threads serialize on the
+    GIL); the four-graph replay is the pattern that measured 2-17 corrupted
+    rows per run through a device-wide slab. Each stream owns a slab, so
+    every replayed and eager result stays exact."""
+    n_graphs, launches, rounds = 4, 8, 12
+    k, work = _split_inputs(n_graphs + 1, seed=21)
+    streams = [torch.cuda.Stream() for _ in range(n_graphs + 1)]
+    outs = [[torch.full_like(w[3], -7) for _ in range(launches)] for w in work]
+    graphs = []
+    for i in range(n_graphs):
+        with torch.cuda.stream(streams[i]):
+            _launch(work[i], k)
+        torch.cuda.synchronize()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(streams[i]), torch.cuda.graph(g, stream=streams[i]):
+            for o in outs[i]:
+                _launch(work[i], k, out=o)
+        graphs.append(g)
+    ew = work[n_graphs]
+    with torch.cuda.stream(streams[n_graphs]):
+        _launch(ew, k)  # slab for the eager stream
+    torch.cuda.synchronize()
+    for _ in range(rounds):
+        for os_ in outs:
+            for o in os_:
+                o.fill_(-7)
+        torch.cuda.synchronize()
+        for i in range(n_graphs):
+            with torch.cuda.stream(streams[i]):
+                graphs[i].replay()
+        with torch.cuda.stream(streams[n_graphs]):
+            for o in outs[n_graphs]:
+                _launch(ew, k, out=o)
+        torch.cuda.synchronize()
+        for i, w in enumerate(work):
+            for j, o in enumerate(outs[i]):
+                who = f"graph {i} launch {j}" if i < n_graphs else f"eager launch {j}"
+                _exact(w[0], w[1], o, k, who=who)
+
+
+@requires_gvr2
+@_deadline(launches=84)
+def test_gvr2_graphs_captured_concurrently_from_threads_replay_exact():
+    """Four threads capture graphs on four streams at the same time (a serving
+    engine capturing per-batch-size graphs in parallel), after a per-stream
+    eager warm-up; every graph replays exact, including when all four replay
+    together."""
+    k, work = _split_inputs(4, seed=31)
+    streams = [torch.cuda.Stream() for _ in range(4)]
+    for i in range(4):
+        with torch.cuda.stream(streams[i]):
+            _launch(work[i], k)
+    torch.cuda.synchronize()
+    graphs = [None] * 4
+    barrier = _barrier(4)
+    errors = []
+
+    def capture(i):
+        try:
+            g = torch.cuda.CUDAGraph()
+            barrier.wait()
+            # thread-local capture mode: other threads' CUDA calls must not
+            # invalidate this thread's capture (the default "global" mode does)
+            with (
+                torch.cuda.stream(streams[i]),
+                torch.cuda.graph(
+                    g, stream=streams[i], capture_error_mode="thread_local"
+                ),
+            ):
+                for _ in range(4):
+                    _launch(work[i], k)
+            graphs[i] = g
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    ts = [threading.Thread(target=capture, args=(i,)) for i in range(4)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    torch.cuda.synchronize()
+    assert not errors, errors
+    for _ in range(4):
+        for w in work:
+            w[3].fill_(-7)
+        torch.cuda.synchronize()
+        for i in range(4):
+            with torch.cuda.stream(streams[i]):
+                graphs[i].replay()
+        torch.cuda.synchronize()
+        for i, w in enumerate(work):
+            _exact(w[0], w[1], w[3], k, who=f"graph {i}")
+
+
+@requires_gvr2
+@_deadline(launches=58)
+def test_gvr2_same_stream_graphs_share_a_slab_and_replay_sequentially():
+    """Two graphs captured on the SAME stream share that stream's slab. That is
+    the documented allowed pattern as long as they replay in stream order —
+    alternating replays on the one stream must be exact (the slab is restored
+    to zeros by every launch)."""
+    k, work = _split_inputs(2, seed=41)
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
+        for w in work:
+            _launch(w, k)
+    torch.cuda.synchronize()
+    graphs = []
+    for w in work:
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(s), torch.cuda.graph(g, stream=s):
+            for _ in range(4):
+                _launch(w, k)
+        graphs.append(g)
+    torch.cuda.synchronize()
+    with torch.cuda.stream(s):
+        for _ in range(6):
+            for w, g in zip(work, graphs, strict=True):
+                w[3].fill_(-7)
+                g.replay()
+    torch.cuda.synchronize()
+    for i, w in enumerate(work):
+        _exact(w[0], w[1], w[3], k, who=f"same-stream graph {i}")
+
+
+# ---------------------------------------------------------------------------
+# 2. the hint-free anchor table under growth, cross-stream use and capture
+# ---------------------------------------------------------------------------
+
+
+@requires_gvr2
+@_deadline(launches=8)
+def test_gvr2_hint_free_graph_survives_table_growth_by_others():
+    """A hint-free graph captured against the anchor table at capacity C keeps
+    replaying exactly after other callers grow the table past C (the graph
+    holds the OLD table's address, which must stay alive and intact)."""
+    k, n = 512, 8192
+    key = (torch.cuda.current_device(), k)
+    _forget_table(k)
+    gen = torch.Generator(device=_DEV).manual_seed(51)
+    logits = torch.randn(8, n, generator=gen, device=_DEV)
+    seq = torch.randint(600, n, (8,), generator=gen, device=_DEV, dtype=torch.int32)
+    out = torch.full((8, k), -7, dtype=torch.int32, device=_DEV)
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(s):
+        _launch((logits, seq, None, out), k, hint=False)
+    torch.cuda.synchronize()
+    old = _host._HINT_FREE[key]
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.stream(s), torch.cuda.graph(g, stream=s):
+        _launch((logits, seq, None, out), k, hint=False)
+    torch.cuda.synchronize()
+    # grow the table well past the captured capacity, several times, from
+    # another stream, and scribble over freshly grown tables' *views*
+    big_logits = torch.randn(1024, n, generator=gen, device=_DEV)
+    big_seq = torch.full((1024,), n, dtype=torch.int32, device=_DEV)
+    big_out = torch.empty(1024, k, dtype=torch.int32, device=_DEV)
+    other = torch.cuda.Stream()
+    for b in (100, 300, 1024):
+        with torch.cuda.stream(other):
+            _launch((big_logits[:b], big_seq[:b], None, big_out[:b]), k, hint=False)
+    torch.cuda.synchronize()
+    assert _host._HINT_FREE[key] is not old and _host._HINT_FREE[key].shape[0] >= 1024
+    assert old in _host._HINT_FREE_KEEP
+    assert bool((old == torch.arange(k, dtype=torch.int32, device=_DEV)).all())
+    for _ in range(3):
+        out.fill_(-7)
+        with torch.cuda.stream(s):
+            g.replay()
+        torch.cuda.synchronize()
+        _exact(logits, seq, out, k, who="graph on the superseded table")
+
+
+@requires_gvr2
+@_deadline(launches=3)
+def test_gvr2_hint_free_table_grown_on_one_stream_used_at_once_on_another():
+    """Grow the table on stream A and, without any host synchronization,
+    launch hint-free on stream B at the new capacity from another thread; the
+    published table must already be complete (the producer stream is
+    synchronized before publication)."""
+    k, n = 1024, 8192
+    _forget_table(k)
+    gen = torch.Generator(device=_DEV).manual_seed(61)
+    logits = torch.randn(512, n, generator=gen, device=_DEV)
+    seq = torch.full((512,), n, dtype=torch.int32, device=_DEV)
+    outs = [torch.full((512, k), -7, dtype=torch.int32, device=_DEV) for _ in range(2)]
+    a, b = torch.cuda.Stream(), torch.cuda.Stream()
+    with torch.cuda.stream(
+        b
+    ):  # compile the launcher for 512 rows on B, hinted (table untouched)
+        _launch(
+            (logits, seq, torch.zeros(512, k, dtype=torch.int32, device=_DEV), outs[1]),
+            k,
+        )
+    torch.cuda.synchronize()
+    _forget_table(k)
+    grown = threading.Event()
+    errors = []
+
+    def producer():
+        try:
+            with torch.cuda.stream(a):
+                _host._hint_free_pre_idx(512, k, torch.device(_DEV))  # grows 0 -> 512
+                grown.set()
+                _launch((logits, seq, None, outs[0]), k, hint=False)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    def consumer():
+        try:
+            grown.wait()
+            with torch.cuda.stream(b):
+                _launch((logits, seq, None, outs[1]), k, hint=False)  # no sync with A
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    ts = [threading.Thread(target=producer), threading.Thread(target=consumer)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    torch.cuda.synchronize()
+    assert not errors, errors
+    _exact(logits, seq, outs[0], k, who="producer stream")
+    _exact(logits, seq, outs[1], k, who="consumer stream")
+
+
+@requires_gvr2
+@_deadline(launches=12)
+def test_gvr2_hint_free_tables_for_different_k_grow_independently():
+    """Interleaved growth of the k=512 and k=2048 tables from two threads keeps
+    each table's rows equal to arange(k) and its capacity monotonic."""
+    dev = torch.cuda.current_device()
+    for k in (512, 2048):
+        _forget_table(k)
+    seen = {512: [], 2048: []}
+    errors = []
+    barrier = _barrier(2)
+
+    def grow(k):
+        try:
+            barrier.wait()
+            for b in (8, 70, 20, 300, 9, 600):
+                t = _host._hint_free_pre_idx(b, k, torch.device(_DEV))
+                seen[k].append(_host._HINT_FREE[(dev, k)].shape[0])
+                assert t.shape == (b, k)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    ts = [threading.Thread(target=grow, args=(k,)) for k in (512, 2048)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    assert not errors, errors
+    for k in (512, 2048):
+        caps = seen[k]
+        assert caps == sorted(caps), f"k={k}: capacity shrank: {caps}"
+        table = _host._HINT_FREE[(dev, k)]
+        assert table.shape[0] >= 600
+        assert bool((table == torch.arange(k, dtype=torch.int32, device=_DEV)).all())
+
+
+# ---------------------------------------------------------------------------
+# 3. warm-up on one stream, capture on another: loud, not silent
+# ---------------------------------------------------------------------------
+
+
+@requires_gvr2
+@_deadline(launches=8)
+def test_gvr2_warmup_varlen_on_stream_enables_capture_on_that_stream_only():
+    """warmup_varlen run on stream A creates A's slab and sizes the anchor
+    table; a hint-free slab-using capture on A then succeeds, while the same
+    capture on a stream that never saw an eager launch raises (never allocates
+    from the graph pool)."""
+    k, work = _split_inputs(1, seed=71)
+    logits, seq, _, out = work[0]
+    rows, n = logits.shape
+    a, b = torch.cuda.Stream(), torch.cuda.Stream()
+    with torch.cuda.stream(a):
+        _host.warmup_varlen(k, n, num_rows_list=(rows,))
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.stream(a), torch.cuda.graph(g, stream=a):
+        _launch((logits, seq, None, out), k, hint=False)
+    out.fill_(-7)
+    torch.cuda.synchronize()
+    with torch.cuda.stream(a):
+        g.replay()
+    torch.cuda.synchronize()
+    _exact(logits, seq, out, k, who="captured after warmup on A")
+    g2 = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(RuntimeError, match="no slab for this stream"),
+        torch.cuda.stream(b),
+        torch.cuda.graph(g2, stream=b),
+    ):
+        _launch((logits, seq, None, out), k, hint=False)
+    torch.cuda.synchronize()
+
+
+@requires_gvr2
+@_deadline(launches=5)
+def test_gvr2_register_family_capture_needs_no_slab_on_a_fresh_stream():
+    """The rule is scoped to slab-using plans: a register-family shape warmed
+    on the default stream captures on a fresh stream without any eager launch
+    there (hinted or hint-free) and replays exact."""
+    k, n, rows = 512, 8192, 4
+    lc = _host._varlen_launcher(rows, n, k, n, 1, 1)
+    assert lc[0] in ("reg", "reg_clus"), lc[0]
+    gen = torch.Generator(device=_DEV).manual_seed(81)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    seq = torch.randint(600, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32)
+    pre = torch.zeros(rows, k, dtype=torch.int32, device=_DEV)
+    out = torch.full((rows, k), -7, dtype=torch.int32, device=_DEV)
+    _launch((logits, seq, pre, out), k)  # default stream, hinted (also sizes the table)
+    torch.cuda.synchronize()
+    for hint in (True, False):
+        fresh = torch.cuda.Stream()
+        g = torch.cuda.CUDAGraph()
+        with torch.cuda.stream(fresh), torch.cuda.graph(g, stream=fresh):
+            _launch((logits, seq, pre, out), k, hint=hint)
+        out.fill_(-7)
+        torch.cuda.synchronize()
+        with torch.cuda.stream(fresh):
+            g.replay()
+        torch.cuda.synchronize()
+        _exact(logits, seq, out, k, who=f"register family, hint={hint}")

--- a/tests/topk_varlen/test_topk_varlen_concurrency.py
+++ b/tests/topk_varlen/test_topk_varlen_concurrency.py
@@ -545,6 +545,61 @@ def test_gvr2_warmup_varlen_on_stream_enables_capture_on_that_stream_only():
 
 
 @requires_gvr2
+def test_gvr2_release_between_quiescent_multithreaded_phases_is_exact():
+    """`release_gvr2_resources` under its documented contract in a threaded
+    program: eight threads launch on eight streams, all of them park at a
+    barrier (quiescent: nothing in flight, nothing being issued), the main
+    thread releases the device's slabs and anchor tables, and the threads
+    resume with hint-free launches on the same streams. Every result stays
+    exact, every slab and the table are recreated, and a second release frees
+    at least the same number of slabs."""
+    from flashinfer.topk_varlen import release_gvr2_resources
+
+    threads_n = 8
+    k, work = _split_inputs(threads_n, seed=91)
+    dev = torch.cuda.current_device()
+    streams = [torch.cuda.Stream() for _ in range(threads_n)]
+    outs = [[torch.full_like(w[3], -7) for _ in range(2)] for w in work]
+    torch.cuda.synchronize()
+    b_quiet, b_resume = _barrier(threads_n + 1), _barrier(threads_n + 1)
+    errors = []
+
+    def worker(i):
+        try:
+            with torch.cuda.stream(streams[i]):
+                _launch(work[i], k, False, out=outs[i][0])  # slab + table
+                streams[i].synchronize()
+                b_quiet.wait()  # main releases while everyone is parked here
+                b_resume.wait()
+                _launch(work[i], k, False, out=outs[i][1])  # recreates them
+                streams[i].synchronize()
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    ts = [threading.Thread(target=worker, args=(i,)) for i in range(threads_n)]
+    for t in ts:
+        t.start()
+    b_quiet.wait()
+    n_slabs = sum(1 for key in _host._ws_keep if key[0] == dev)
+    assert n_slabs >= threads_n
+    freed = release_gvr2_resources()
+    assert freed >= threads_n * _host.workspace_bytes(), (freed, n_slabs)
+    assert not any(key[0] == dev for key in _host._ws_keep)
+    assert (dev, k) not in _host._HINT_FREE
+    b_resume.wait()
+    for t in ts:
+        t.join()
+    torch.cuda.synchronize()
+    assert not errors, errors
+    assert sum(1 for key in _host._ws_keep if key[0] == dev) >= threads_n
+    assert (dev, k) in _host._HINT_FREE
+    for i, w in enumerate(work):
+        for j in range(2):
+            _exact(w[0], w[1], outs[i][j], k, who=f"stream {i} phase {j}")
+    assert release_gvr2_resources() >= threads_n * _host.workspace_bytes()
+
+
+@requires_gvr2
 def test_gvr2_register_family_capture_needs_no_slab_on_a_fresh_stream():
     """The rule is scoped to slab-using plans: a register-family shape warmed
     on the default stream captures on a stream WITHOUT a slab (cleared

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -521,7 +521,16 @@ def test_gvr2_workspace_override():
 
 def _assert_family(rows, msl_c, top_k, next_n, cr, want):
     """The varlen launcher must admit the same family the free route picks."""
-    key = (rows, msl_c, top_k, msl_c, next_n, cr, _host._arch_token())
+    key = (
+        rows,
+        msl_c,
+        top_k,
+        msl_c,
+        next_n,
+        cr,
+        _host._arch_token(),
+        _host._sm_count(),
+    )
     lc = _host._VARLEN_CACHE.get(key)
     assert lc is not None, f"launcher not cached for {key}"
     assert lc[0] == want, f"family {lc[0]} != {want} for {key}"
@@ -1317,8 +1326,12 @@ def test_gvr2_route_local_rungs():
             )
             assert p["rt"]["IMGOFF"] == p["tpl"][7] == _host.NB
             assert _host.route(296, n, _round64(n), k)["tpl"][:3] == (512, 4, 2)
-            assert _host.route(297, n, _round64(n), k)["kernel"] == "main"
-            assert _host.route(512, n, _round64(n), k)["kernel"] == "main"
+            # second wave only for the upper half of the band (n4 >= 1536)
+            second = "reg" if n >= 6144 else "main"
+            assert _host.route(297, n, _round64(n), k)["kernel"] == second
+            assert _host.route(512, n, _round64(n), k)["kernel"] == second
+            assert _host.route(592, n, _round64(n), k)["kernel"] == second
+            assert _host.route(593, n, _round64(n), k)["kernel"] == "main"
         p = _host.route(8, 12288, 12288, k)
         assert p["kernel"] == "reg" and p["tpl"][:3] == (1024, 4, 1)
         p = _host.route(256, 12288, 12288, k)
@@ -1328,3 +1341,64 @@ def test_gvr2_route_local_rungs():
         assert _host.route_split(b, n, _round64(n), 512) == _host.route(
             b, n, _round64(n), 512
         )
+
+
+def test_gvr2_route_sm_count_aware():
+    """FlashInfer-local: the register band is sized by the device SM count
+    (`sms`; B200 148, B300 160, Rubin 208) — rows in (148, sms] are one wave
+    of 1024-thread CTAs there — while the streaming constants stay at
+    upstream's 148, so plans outside the register band are identical for
+    every sms. Default sms=148 reproduces the B200 dispatch exactly."""
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+
+    for k in (512, 1024, 2048):
+        for sms in (160, 208):
+            # rows between 148 and sms: wide on this part -> register rungs
+            p = _host.route(sms, 8192, 8192, k, sms=sms)
+            assert p["kernel"] == "reg" and p["tpl"][:3] == (1024, 2, 1), (
+                k,
+                sms,
+                p["tpl"],
+            )
+            assert p["rt"]["QC"] == _host.QUADC  # the b > sms flag follows sms too
+            p = _host.route(sms, 12288, 12288, k, sms=sms)
+            assert p["kernel"] == "reg" and p["tpl"][:3] == (1024, 4, 1), (
+                k,
+                sms,
+                p["tpl"],
+            )
+            assert (
+                _host.route(sms, 12288, 12288, k)["kernel"] == "main"
+            )  # default 148: slab
+            # wave cutoffs of the BLK=512 rung scale with sms: one wave for the
+            # whole band, a second wave (<= 4*sms) only from n=6144 up
+            for n_, b_, want in (
+                (8192, 2 * sms, "reg"),
+                (6140, 2 * sms, "reg"),
+                (8192, 4 * sms, "reg"),
+                (6144, 4 * sms, "reg"),
+                (8192, 4 * sms + 1, "main"),
+                (6140, 2 * sms + 1, "main"),
+            ):
+                p = _host.route(b_, n_, n_, k, sms=sms)
+                assert p["kernel"] == want, (k, sms, n_, b_, p["kernel"])
+                if want == "reg":
+                    assert p["tpl"][:3] == (512, 4, 2)
+            # streaming half untouched by sms (b > sms, n outside the register band)
+            for b, n in ((sms + 1, 131072), (192, 131072), (256, 32768), (400, 65536)):
+                assert _host.route(b, n, n, k, sms=sms) == _host.route(b, n, n, k)
+            # the lossless static/dynamic factorization holds for every sms
+            for b, n in ((sms, 8192), (sms + 8, 8192), (2 * sms, 6144), (192, 131072)):
+                assert _host.route_split(b, n, _round64(n), k, sms=sms) == _host.route(
+                    b, n, _round64(n), k, sms=sms
+                )
+    # sms is part of the launcher cache key (a heterogeneous process must not
+    # reuse a plan sized for another part's SM count)
+    assert (
+        _host._sm_count()
+        == torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).multi_processor_count
+        if torch.cuda.is_available()
+        else True
+    )

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -532,7 +532,10 @@ def _assert_family(rows, msl_c, top_k, next_n, cr, want):
     "rows,msl_c,top_k,next_n,cr,family",
     [
         (8, 131072, 1024, 4, 4, "reg_clus"),  # clustered register-resident
-        (8, 6144, 512, 1, 4, "reg"),  # register-resident
+        (8, 6144, 512, 1, 4, "reg"),  # register-resident (local VPT=2 rung)
+        (8, 8192, 512, 1, 1, "reg"),  # local VPT=2 rung, top of its band
+        (256, 8192, 512, 1, 1, "reg"),  # local b > 148 BLK=512 rung (upstream: main)
+        (8, 12288, 512, 1, 1, "reg"),  # upstream VPT=4 rung, unchanged
         (8, 3072, 512, 1, 4, "reg"),  # regimg flavor (cached as "reg")
         (64, 131072, 1024, 1, 1, "clus"),  # CS=2 cluster split
         (32, 131072, 1024, 1, 1, "clus"),  # CS=4 cluster split
@@ -697,6 +700,33 @@ def test_gvr2_auto_selects_gvr2():
     assert order[0] == "gvr_2"
     assert "gvr" in order
     _check_varlen_rows(logits, indices, [8192] * 4, 512)
+
+
+@requires_gvr2
+def test_gvr2_auto_selects_gvr2_hint_free():
+    """fp32 WITHOUT pre_idx: auto still picks gvr_2 (hint-free it beats every
+    radix backend 1.5-5x on the measured grid) and never admits gvr (V1
+    needs the hint); the one carved-out cell (K >= 2048, N <= 4096, one row)
+    ranks radix_filter first where it is available, gvr_2 right behind, and a
+    real hint puts gvr_2 back in front."""
+    logits = torch.randn(4, 8192, dtype=torch.float32, device=_DEV)
+    seq_lens = torch.full((4,), 8192, dtype=torch.int32, device=_DEV)
+    indices, _ = flashinfer.top_k_varlen(logits, seq_lens, 512, backend="auto")
+    order = flashinfer.top_k_varlen.suitable_auto_backends
+    assert order[0] == "gvr_2" and "gvr" not in order
+    _check_varlen_rows(logits, indices, [8192] * 4, 512)
+    tiny = torch.randn(1, 4096, dtype=torch.float32, device=_DEV)
+    one = torch.full((1,), 4096, dtype=torch.int32, device=_DEV)
+    indices, _ = flashinfer.top_k_varlen(tiny, one, 2048, backend="auto")
+    order = flashinfer.top_k_varlen.suitable_auto_backends
+    if "radix_filter" in order:
+        assert order[:2] == ["radix_filter", "gvr_2"]
+    else:
+        assert order[0] == "gvr_2"
+    _check_varlen_rows(tiny, indices, [4096], 2048)
+    hint = torch.zeros(1, 2048, dtype=torch.int32, device=_DEV)
+    flashinfer.top_k_varlen(tiny, one, 2048, pre_idx=hint, backend="auto")
+    assert flashinfer.top_k_varlen.suitable_auto_backends[0] == "gvr_2"
 
 
 @requires_gvr2
@@ -1145,3 +1175,156 @@ def test_gvr2_route_pure_and_total():
                 assert plan["kernel"] in ("main", "reg", "regimg", "clus", "reg_clus")
                 assert plan["block"] >= 128
                 assert plan["grid"][0] >= 1
+
+
+# ---------------------------------------------------------------------------
+# hint-free gvr_2 (FlashInfer-local: pre_idx=None runs on a cached arange
+# anchor) + the FlashInfer-local route() rungs in the 4K < n <= 8K band
+# ---------------------------------------------------------------------------
+
+
+@requires_gvr2
+@pytest.mark.parametrize(
+    "kv,next_n,cr,top_k",
+    [
+        ([8192, 5000, 300, 1], 1, 1, 512),  # reg VPT=2 rung + short rows
+        ([8192 * 4, 6000 * 4, 2048 * 4], 2, 4, 512),  # MTP rows, cr=4
+        ([65536, 40000, 1000], 1, 1, 1024),  # reg_clus band
+        ([262144, 100000, 2047], 1, 1, 2048),  # main/clus band, K=2048
+        ([4096] * 200 + [100] * 56, 1, 1, 512),  # b > 148 BLK=512 rung
+    ],
+)
+def test_gvr2_hint_free_exact(kv, next_n, cr, top_k):
+    """pre_idx=None is exact on every family (the hint only steers sampling);
+    short rows take the identity path, tails are -1, poisoned padding is
+    never read."""
+    logits, seq_lens, _, n_r, _ = _make_varlen_case(kv, next_n, cr, top_k, seed=7)
+    indices, values = _run_gvr2(
+        logits,
+        seq_lens,
+        top_k,
+        None,
+        next_n=next_n,
+        compress_ratio=cr,
+        return_values=True,
+    )
+    _check_varlen_rows(logits, indices, n_r, top_k, values)
+
+
+@requires_gvr2
+def test_gvr2_hint_free_cuda_graph_replay():
+    """Hint-free calls replay under CUDA graphs: the arange table is a stable
+    per-(device, k) address, growth happens only eagerly (refused under
+    capture), and seq_lens contents may change between replays."""
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+
+    top_k, n = 512, 8192
+    kv_a = [8192, 4096, 700, 8192]
+    logits, seq_lens, _, n_r_a, _ = _make_varlen_case(
+        kv_a, 1, 1, top_k, seed=3, msl_c=n
+    )
+    out = torch.empty(len(kv_a), top_k, dtype=torch.int32, device=_DEV)
+    # eager call: compiles the launcher and sizes the table
+    _run_gvr2(logits, seq_lens, top_k, None, out_indices=out)
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s), torch.cuda.graph(g, stream=s):
+        _run_gvr2(logits, seq_lens, top_k, None, out_indices=out)
+    torch.cuda.current_stream().wait_stream(s)
+    g.replay()
+    torch.cuda.synchronize()
+    _check_varlen_rows(logits, out, n_r_a, top_k)
+    # grow / shrink rows between replays
+    kv_b = [3000, 8192, 8192, 100]
+    seq_lens.copy_(torch.tensor(kv_b, dtype=torch.int32, device=_DEV))
+    n_r_b = _row_valid_lens(kv_b, len(kv_b), 1, 1, n)
+    for r in range(len(kv_b)):
+        logits[r, n_r_b[r] :] = 3e38
+        logits[r, : n_r_b[r]] = torch.randn(n_r_b[r], device=_DEV) - 2.0
+    g.replay()
+    torch.cuda.synchronize()
+    _check_varlen_rows(logits, out, n_r_b, top_k)
+    # table growth under capture is refused: warm the launcher at a larger
+    # batch WITH a hint (table untouched), then capture hint-free
+    big = (
+        4 * len(kv_a) + _host._HINT_FREE[(torch.cuda.current_device(), top_k)].shape[0]
+    )
+    logits_b = torch.randn(big, n, device=_DEV)
+    seq_b = torch.full((big,), n, dtype=torch.int32, device=_DEV)
+    hint = torch.zeros(big, top_k, dtype=torch.int32, device=_DEV)
+    out_b = torch.empty(big, top_k, dtype=torch.int32, device=_DEV)
+    _run_gvr2(logits_b, seq_b, top_k, hint, out_indices=out_b)
+    torch.cuda.synchronize()
+    g2 = torch.cuda.CUDAGraph()
+    s.wait_stream(torch.cuda.current_stream())
+    with (
+        pytest.raises(RuntimeError, match="hint-free gvr_2"),
+        torch.cuda.stream(s),
+        torch.cuda.graph(g2, stream=s),
+    ):
+        _run_gvr2(logits_b, seq_b, top_k, None, out_indices=out_b)
+    torch.cuda.synchronize()
+    # warmup_varlen sizes the table for its largest batch, so the same
+    # capture then succeeds
+    _host.warmup_varlen(top_k, n, num_rows_list=(big,))
+    g3 = torch.cuda.CUDAGraph()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s), torch.cuda.graph(g3, stream=s):
+        _run_gvr2(logits_b, seq_b, top_k, None, out_indices=out_b)
+    torch.cuda.current_stream().wait_stream(s)
+    g3.replay()
+    torch.cuda.synchronize()
+    _check_varlen_rows(logits_b, out_b, [n] * big, top_k)
+
+
+@requires_gvr2
+def test_gvr2_hint_free_host_requires_top_k():
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+
+    logits = torch.randn(2, 4096, device=_DEV)
+    kv = torch.full((2,), 4096, dtype=torch.int32, device=_DEV)
+    out = torch.empty(2, 512, dtype=torch.int32, device=_DEV)
+    with pytest.raises(RuntimeError, match="top_k is required"):
+        _host.run_varlen(logits, None, kv, out)
+    hint = torch.zeros(2, 1024, dtype=torch.int32, device=_DEV)
+    with pytest.raises(RuntimeError, match="top_k=512 != pre_idx"):
+        _host.run_varlen(logits, hint, kv, out, top_k=512)
+
+
+def test_gvr2_route_local_rungs():
+    """The two FlashInfer-local rungs (4K < n <= 8K): VPT=2 for b <= 148,
+    BLK=512/VPT=4/MINB=2 for 148 < b <= 296 (one wave) — with NBH == IMGOFF
+    (asserted at launch) — the main slab beyond one wave, and the upstream
+    VPT=4 rung untouched above 8K."""
+    from flashinfer.topk_varlen.kernels import gvr2_topk_host as _host
+
+    for k in (512, 1024, 2048):
+        for n in (4100, 6144, 8192):
+            p = _host.route(8, n, _round64(n), k)
+            assert p["kernel"] == "reg" and p["tpl"][:3] == (1024, 2, 1), (
+                n,
+                k,
+                p["tpl"],
+            )
+            assert p["rt"]["IMGOFF"] == p["tpl"][7]
+            p = _host.route(256, n, _round64(n), k)
+            assert p["kernel"] == "reg" and p["tpl"][:3] == (512, 4, 2), (
+                n,
+                k,
+                p["tpl"],
+            )
+            assert p["rt"]["IMGOFF"] == p["tpl"][7] == _host.NB
+            assert _host.route(296, n, _round64(n), k)["tpl"][:3] == (512, 4, 2)
+            assert _host.route(297, n, _round64(n), k)["kernel"] == "main"
+            assert _host.route(512, n, _round64(n), k)["kernel"] == "main"
+        p = _host.route(8, 12288, 12288, k)
+        assert p["kernel"] == "reg" and p["tpl"][:3] == (1024, 4, 1)
+        p = _host.route(256, 12288, 12288, k)
+        assert p["kernel"] == "main"
+    # the lossless static/dynamic factorization must still hold on the new rungs
+    for b, n in ((8, 8192), (256, 8192), (149, 5000), (148, 5000)):
+        assert _host.route_split(b, n, _round64(n), 512) == _host.route(
+            b, n, _round64(n), 512
+        )

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -1544,3 +1544,64 @@ def test_gvr2_route_bands_follow_sm_count():
     assert _host.route_bands(b, npad, k, 4097, 16384) == _host.route_bands(
         b, npad, k, 4097, 16384, sms=148
     )
+
+
+@requires_gvr2
+def test_gvr2_release_cached_resources():
+    """flashinfer.topk_varlen.release_gvr2_resources(): drops every default
+    workspace slab and hint-free anchor table of the device, returns the bytes
+    released (at least one slab + the tables), and the allocator's footprint
+    falls by that much; the next eager launch recreates its stream's slab and
+    the table, and a slab-using capture right after a release (no warm-up on
+    that stream) raises the documented error instead of allocating."""
+    from flashinfer.topk_varlen import release_gvr2_resources
+
+    rows, n, k = 16, 131072, 512
+    lc = _host._varlen_launcher(rows, n, k, n, 1, 1)
+    if not (lc[0] == "main" and lc[2][5] > 1):
+        pytest.skip(f"shape routes to {lc[0]} (no workspace use) on this device")
+    dev = torch.cuda.current_device()
+    gen = torch.Generator(device=_DEV).manual_seed(91)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    seq = torch.randint(
+        50000, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    out = torch.empty(rows, k, dtype=torch.int32, device=_DEV)
+    s = torch.cuda.Stream()
+    with torch.cuda.stream(
+        s
+    ):  # creates s's slab and the k=512 anchor table (hint-free)
+        _run_gvr2(logits, seq, k, None, out_indices=out)
+    torch.cuda.synchronize()
+    assert (dev, s.cuda_stream) in _host._ws_keep and (dev, k) in _host._HINT_FREE
+    slab_bytes = _host.workspace_bytes()
+    table_bytes = _host._HINT_FREE[(dev, k)].numel() * 4
+    before = torch.cuda.memory_allocated(dev)
+    freed = release_gvr2_resources()
+    assert freed >= slab_bytes + table_bytes, (freed, slab_bytes, table_bytes)
+    assert not any(key[0] == dev for key in _host._ws_keep)
+    assert not any(key[0] == dev for key in _host._HINT_FREE)
+    assert not any(t.device.index == dev for t in _host._HINT_FREE_KEEP)
+    assert before - torch.cuda.memory_allocated(dev) >= freed - 1024, (
+        before,
+        torch.cuda.memory_allocated(dev),
+        freed,
+    )
+    # capture without a fresh warm-up on s: loud, not a silent allocation
+    g = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(RuntimeError, match="no slab for this stream|hint-free gvr_2"),
+        torch.cuda.stream(s),
+        torch.cuda.graph(g, stream=s),
+    ):
+        _run_gvr2(logits, seq, k, None, out_indices=out)
+    torch.cuda.synchronize()
+    # eager launch recreates both, and the result is exact
+    with torch.cuda.stream(s):
+        _run_gvr2(logits, seq, k, None, out_indices=out)
+    torch.cuda.synchronize()
+    assert (dev, s.cuda_stream) in _host._ws_keep and (dev, k) in _host._HINT_FREE
+    _check_varlen_rows(logits, out, seq.tolist(), k)
+    # releasing when nothing is cached is a no-op returning 0
+    release_gvr2_resources(torch.device(_DEV, dev))
+    assert release_gvr2_resources() == 0

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -1587,21 +1587,174 @@ def test_gvr2_release_cached_resources():
         torch.cuda.memory_allocated(dev),
         freed,
     )
-    # capture without a fresh warm-up on s: loud, not a silent allocation
+    # capture without a fresh warm-up on s: loud, not a silent allocation.
+    # Hinted capture (a valid pre_idx, so the anchor-table check cannot fire):
+    # the WORKSPACE guard must be the one that raises, and it must not have
+    # allocated a slab from the graph pool.
+    pre = (
+        torch.arange(k, dtype=torch.int32, device=_DEV)
+        .unsqueeze(0)
+        .expand(rows, k)
+        .contiguous()
+    )
     g = torch.cuda.CUDAGraph()
     with (
-        pytest.raises(RuntimeError, match="no slab for this stream|hint-free gvr_2"),
+        pytest.raises(RuntimeError, match="no slab for this stream"),
+        torch.cuda.stream(s),
+        torch.cuda.graph(g, stream=s),
+    ):
+        _run_gvr2(logits, seq, k, pre, out_indices=out)
+    torch.cuda.synchronize()
+    assert not any(key[0] == dev for key in _host._ws_keep), "capture allocated a slab"
+    # hint-free capture after release: the anchor-table guard fires first
+    g = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(RuntimeError, match="hint-free gvr_2: no pre_idx table"),
         torch.cuda.stream(s),
         torch.cuda.graph(g, stream=s),
     ):
         _run_gvr2(logits, seq, k, None, out_indices=out)
     torch.cuda.synchronize()
+    assert not any(key[0] == dev for key in _host._HINT_FREE)
     # eager launch recreates both, and the result is exact
     with torch.cuda.stream(s):
         _run_gvr2(logits, seq, k, None, out_indices=out)
     torch.cuda.synchronize()
     assert (dev, s.cuda_stream) in _host._ws_keep and (dev, k) in _host._HINT_FREE
     _check_varlen_rows(logits, out, seq.tolist(), k)
-    # releasing when nothing is cached is a no-op returning 0
+    # releasing when nothing is cached is a no-op returning 0; int / device /
+    # string spellings of the same CUDA device are all accepted
     release_gvr2_resources(torch.device(_DEV, dev))
+    assert release_gvr2_resources(dev) == 0
+    assert release_gvr2_resources(f"cuda:{dev}") == 0
     assert release_gvr2_resources() == 0
+
+
+@requires_gvr2
+def test_gvr2_release_rejects_non_cuda_device():
+    """A non-CUDA device argument must raise, never redirect the cleanup to a
+    CUDA device: "cpu" is not "the current CUDA device" and "cpu:1" is not
+    CUDA device 1. The caches stay intact."""
+    from flashinfer.topk_varlen import release_gvr2_resources
+
+    rows, n, k = 16, 131072, 512
+    lc = _host._varlen_launcher(rows, n, k, n, 1, 1)
+    if not (lc[0] == "main" and lc[2][5] > 1):
+        pytest.skip(f"shape routes to {lc[0]} (no workspace use) on this device")
+    dev = torch.cuda.current_device()
+    gen = torch.Generator(device=_DEV).manual_seed(92)
+    logits = torch.randn(rows, n, generator=gen, device=_DEV)
+    seq = torch.randint(
+        50000, n, (rows,), generator=gen, device=_DEV, dtype=torch.int32
+    )
+    out = torch.empty(rows, k, dtype=torch.int32, device=_DEV)
+    _run_gvr2(logits, seq, k, None, out_indices=out)
+    torch.cuda.synchronize()
+    slabs = sum(1 for key in _host._ws_keep if key[0] == dev)
+    tables = sum(1 for key in _host._HINT_FREE if key[0] == dev)
+    assert slabs and tables
+    for bad in ("cpu", "cpu:1", torch.device("cpu"), torch.device("cpu", 1)):
+        with pytest.raises(ValueError, match="expected a CUDA device"):
+            release_gvr2_resources(bad)
+        assert sum(1 for key in _host._ws_keep if key[0] == dev) == slabs
+        assert sum(1 for key in _host._HINT_FREE if key[0] == dev) == tables
+
+
+@requires_gvr2
+def test_gvr2_release_partitions_kept_tables_without_tensor_equality():
+    """The superseded-table list is partitioned by device index. Tensor
+    equality (`in` / `list.remove`) would compare contents and raise on
+    entries of different shapes or devices; this interleaves superseded tables
+    of two shapes (and, with two GPUs, of two devices) and releases one device
+    at a time."""
+    from flashinfer.topk_varlen import release_gvr2_resources
+
+    dev = torch.cuda.current_device()
+    devices = [dev]
+    if torch.cuda.device_count() > 1:
+        devices.append((dev + 1) % torch.cuda.device_count())
+    with _host._HINT_FREE_LOCK:
+        for d in devices:
+            _host._HINT_FREE.pop((d, 512), None)
+            _host._HINT_FREE.pop((d, 1024), None)
+    for d in devices:
+        for k in (512, 1024):
+            # capacities 8 -> 64 -> 128 -> 256: two superseded tables per k per
+            # device, of different shapes, interleaved across k and devices
+            for b in (8, 100, 200):
+                _host._hint_free_pre_idx(b, k, torch.device("cuda", d))
+    before = {
+        d: sum(1 for t in _host._HINT_FREE_KEEP if t.device.index == d) for d in devices
+    }
+    assert all(v >= 4 for v in before.values()), before
+    freed = release_gvr2_resources(torch.device("cuda", dev))
+    assert freed > 0
+    assert not any(t.device.index == dev for t in _host._HINT_FREE_KEEP)
+    assert not any(key[0] == dev for key in _host._HINT_FREE)
+    for d in devices[1:]:  # the other device's entries are untouched
+        assert sum(1 for t in _host._HINT_FREE_KEEP if t.device.index == d) == before[d]
+        assert (d, 512) in _host._HINT_FREE and (d, 1024) in _host._HINT_FREE
+        release_gvr2_resources(d)
+        assert not any(t.device.index == d for t in _host._HINT_FREE_KEEP)
+
+
+def test_gvr2_first_call_gate_serializes_only_the_first_call():
+    """`_gate_first_call` wraps a compiled kernel object so concurrent FIRST
+    calls are exclusive (the CuTe DSL runtime's once-init lock leak,
+    nvidia-cutlass-dsl <= 4.7.1, needs two threads inside the first call of one
+    kernel to trigger) and later calls run unserialized; a failed first call
+    does not mark the object warm; the same object gets the same wrapper."""
+    import threading
+    import time
+
+    inside = [0]
+    peak = [0]
+    calls = [0]
+    guard = threading.Lock()
+
+    def raw(*args):
+        with guard:
+            inside[0] += 1
+            peak[0] = max(peak[0], inside[0])
+            calls[0] += 1
+            n = calls[0]
+        if n == 1:
+            raise RuntimeError("first attempt fails")
+        time.sleep(0.05)
+        with guard:
+            inside[0] -= 1
+        return n
+
+    gated = _host._gate_first_call(raw)
+    assert _host._gate_first_call(raw) is gated
+    with pytest.raises(RuntimeError, match="first attempt fails"):
+        gated()
+    with guard:
+        inside[0] = 0  # the failed attempt never decremented
+    barrier = threading.Barrier(8, timeout=30)
+    results = []
+
+    def worker():
+        barrier.wait()
+        results.append(gated("a", 1))
+
+    ts = [threading.Thread(target=worker) for _ in range(8)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join(30)
+    assert len(results) == 8 and not any(t.is_alive() for t in ts)
+    # the first completed call ran alone (peak 1 while it was the only one
+    # allowed in); after it returned the remaining callers were released
+    first_peak = peak[0]
+    assert first_peak >= 1
+    # warm now: another concurrent round is NOT serialized (several inside at once)
+    inside[0] = 0
+    peak[0] = 0
+    barrier = threading.Barrier(8, timeout=30)
+    ts = [threading.Thread(target=worker) for _ in range(8)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join(30)
+    assert peak[0] > 1, "warm calls must not be serialized"

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -1630,6 +1630,44 @@ def test_gvr2_release_cached_resources():
     assert release_gvr2_resources() == 0
 
 
+def test_gvr2_release_without_loaded_host_is_a_no_op():
+    """`release_gvr2_resources` in a process that never ran gvr_2: returns 0
+    without importing the gvr_2 host module (and so without importing the
+    optional CuTe-DSL kernel modules on installations that lack them), while
+    the device-argument contract still holds ("cpu" raises). Runs in a fresh
+    interpreter because this process has the host loaded."""
+    import os
+    import subprocess
+    import sys
+
+    import flashinfer
+
+    code = (
+        "import sys; import flashinfer.topk_varlen as t\n"
+        "H = 'flashinfer.topk_varlen.kernels.gvr2_topk_host'\n"
+        "assert H not in sys.modules\n"
+        "assert t.release_gvr2_resources() == 0\n"
+        "assert t.release_gvr2_resources(0) == 0\n"
+        "assert H not in sys.modules, 'release imported the gvr_2 host'\n"
+        "try:\n    t.release_gvr2_resources('cpu')\nexcept ValueError as e:\n"
+        "    assert 'expected a CUDA device' in str(e)\nelse:\n    raise SystemExit('cpu accepted')\n"
+        "print('OK')\n"
+    )
+    root = os.path.dirname(os.path.dirname(os.path.abspath(flashinfer.__file__)))
+    r = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        timeout=300,
+        env={**os.environ, "PYTHONPATH": root},
+    )
+    assert r.returncode == 0 and r.stdout.strip().endswith("OK"), (
+        r.stdout,
+        r.stderr[-2000:],
+    )
+
+
 @requires_gvr2
 def test_gvr2_release_rejects_non_cuda_device():
     """A non-CUDA device argument must raise, never redirect the cleanup to a

--- a/tests/topk_varlen/test_topk_varlen_gvr2.py
+++ b/tests/topk_varlen/test_topk_varlen_gvr2.py
@@ -495,7 +495,7 @@ def test_gvr2_logits_on_non_current_device():
 @requires_gvr2
 def test_gvr2_workspace_override():
     """Caller-provided workspace (multi-stream escape hatch) must agree with
-    the default per-device slab."""
+    the default per-(device, stream) slab."""
     kv, top_k = [131075, 32800, 2000], 512
     logits, seq_lens, pre_idx, n_r, _ = _make_varlen_case(kv, 1, 1, top_k, seed=17)
     idx_default, _ = _run_gvr2(logits, seq_lens, top_k, pre_idx)
@@ -1200,14 +1200,19 @@ def test_gvr2_route_pure_and_total():
         ([8192 * 4, 6000 * 4, 2048 * 4], 2, 4, 512),  # MTP rows, cr=4
         ([65536, 40000, 1000], 1, 1, 1024),  # reg_clus band
         ([262144, 100000, 2047], 1, 1, 2048),  # main/clus band, K=2048
-        ([4096] * 200 + [100] * 56, 1, 1, 512),  # b > 148 BLK=512 rung
+        ([8192] * 200 + [100] * 56, 1, 1, 512),  # b > sms BLK=512/VPT=4 rung
     ],
 )
 def test_gvr2_hint_free_exact(kv, next_n, cr, top_k):
     """pre_idx=None is exact on every family (the hint only steers sampling);
     short rows take the identity path, tails are -1, poisoned padding is
-    never read."""
-    logits, seq_lens, _, n_r, _ = _make_varlen_case(kv, next_n, cr, top_k, seed=7)
+    never read. The 256-row case must land on the FlashInfer-local BLK=512
+    rung (asserted through the launcher cache), not the pre-existing
+    n4 <= 1024 branch."""
+    logits, seq_lens, _, n_r, msl_c = _make_varlen_case(kv, next_n, cr, top_k, seed=7)
+    if len(kv) == 256:
+        want = _host.route(256, msl_c, msl_c, top_k, sms=_host._sm_count())
+        assert want["kernel"] == "reg" and want["tpl"][:3] == (512, 4, 2), want["tpl"]
     indices, values = _run_gvr2(
         logits,
         seq_lens,
@@ -1233,11 +1238,12 @@ def test_gvr2_hint_free_cuda_graph_replay():
         kv_a, 1, 1, top_k, seed=3, msl_c=n
     )
     out = torch.empty(len(kv_a), top_k, dtype=torch.int32, device=_DEV)
+    s = torch.cuda.Stream()  # every eager warm-up below runs on the capturing stream
     # eager call: compiles the launcher and sizes the table
-    _run_gvr2(logits, seq_lens, top_k, None, out_indices=out)
+    with torch.cuda.stream(s):
+        _run_gvr2(logits, seq_lens, top_k, None, out_indices=out)
     torch.cuda.synchronize()
     g = torch.cuda.CUDAGraph()
-    s = torch.cuda.Stream()
     s.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(s), torch.cuda.graph(g, stream=s):
         _run_gvr2(logits, seq_lens, top_k, None, out_indices=out)
@@ -1255,37 +1261,59 @@ def test_gvr2_hint_free_cuda_graph_replay():
     g.replay()
     torch.cuda.synchronize()
     _check_varlen_rows(logits, out, n_r_b, top_k)
-    # table growth under capture is refused: warm the launcher at a larger
-    # batch WITH a hint (table untouched), then capture hint-free
-    big = (
-        4 * len(kv_a) + _host._HINT_FREE[(torch.cuda.current_device(), top_k)].shape[0]
-    )
+    # hint mode is not a warm-up dimension: a HINTED eager call at a larger
+    # batch also sizes the anchor table, so a hint-free capture of the same
+    # geometry succeeds without any hint-free eager call
+    cap0 = _host._HINT_FREE[(torch.cuda.current_device(), top_k)].shape[0]
+    big = 4 * len(kv_a) + cap0
     logits_b = torch.randn(big, n, device=_DEV)
     seq_b = torch.full((big,), n, dtype=torch.int32, device=_DEV)
     hint = torch.zeros(big, top_k, dtype=torch.int32, device=_DEV)
     out_b = torch.empty(big, top_k, dtype=torch.int32, device=_DEV)
-    _run_gvr2(logits_b, seq_b, top_k, hint, out_indices=out_b)
+    with torch.cuda.stream(s):  # hinted eager warm-up, on the capturing stream
+        _run_gvr2(logits_b, seq_b, top_k, hint, out_indices=out_b)
     torch.cuda.synchronize()
+    assert _host._HINT_FREE[(torch.cuda.current_device(), top_k)].shape[0] >= big
     g2 = torch.cuda.CUDAGraph()
     s.wait_stream(torch.cuda.current_stream())
-    with (
-        pytest.raises(RuntimeError, match="hint-free gvr_2"),
-        torch.cuda.stream(s),
-        torch.cuda.graph(g2, stream=s),
-    ):
+    with torch.cuda.stream(s), torch.cuda.graph(g2, stream=s):
         _run_gvr2(logits_b, seq_b, top_k, None, out_indices=out_b)
+    torch.cuda.current_stream().wait_stream(s)
+    g2.replay()
+    torch.cuda.synchronize()
+    _check_varlen_rows(logits_b, out_b, [n] * big, top_k)
+    # table growth under capture is refused: a batch no eager call has seen
+    huge = 2 * _host._HINT_FREE[(torch.cuda.current_device(), top_k)].shape[0] + 8
+    logits_h = torch.randn(huge, n, device=_DEV)
+    seq_h = torch.full((huge,), n, dtype=torch.int32, device=_DEV)
+    out_h = torch.empty(huge, top_k, dtype=torch.int32, device=_DEV)
+    # compile the launcher for this row count on the capturing stream, but
+    # with a hint from a table-free path: legacy warmup_varlen cannot help here
+    # since it would size the table too, so capture straight away
+    g3 = torch.cuda.CUDAGraph()
+    s.wait_stream(torch.cuda.current_stream())
+    with (
+        pytest.raises(
+            RuntimeError, match="hint-free gvr_2|varlen launcher not compiled"
+        ),
+        torch.cuda.stream(s),
+        torch.cuda.graph(g3, stream=s),
+    ):
+        _run_gvr2(logits_h, seq_h, top_k, None, out_indices=out_h)
     torch.cuda.synchronize()
     # warmup_varlen sizes the table for its largest batch, so the same
     # capture then succeeds
-    _host.warmup_varlen(top_k, n, num_rows_list=(big,))
-    g3 = torch.cuda.CUDAGraph()
-    s.wait_stream(torch.cuda.current_stream())
-    with torch.cuda.stream(s), torch.cuda.graph(g3, stream=s):
-        _run_gvr2(logits_b, seq_b, top_k, None, out_indices=out_b)
-    torch.cuda.current_stream().wait_stream(s)
-    g3.replay()
+    with torch.cuda.stream(s):
+        _host.warmup_varlen(top_k, n, num_rows_list=(huge,))
     torch.cuda.synchronize()
-    _check_varlen_rows(logits_b, out_b, [n] * big, top_k)
+    g4 = torch.cuda.CUDAGraph()
+    s.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(s), torch.cuda.graph(g4, stream=s):
+        _run_gvr2(logits_h, seq_h, top_k, None, out_indices=out_h)
+    torch.cuda.current_stream().wait_stream(s)
+    g4.replay()
+    torch.cuda.synchronize()
+    _check_varlen_rows(logits_h, out_h, [n] * huge, top_k)
 
 
 @requires_gvr2
@@ -1401,4 +1429,118 @@ def test_gvr2_route_sm_count_aware():
         ).multi_processor_count
         if torch.cuda.is_available()
         else True
+    )
+
+
+@requires_gvr2
+def test_gvr2_hint_free_table_growth_is_serialized_and_stream_ordered():
+    """Concurrent cold-start / growth of the hint-free anchor table from several
+    threads on several streams: the published capacity is the maximum ever
+    requested (never a smaller table overwriting a larger one), every row of
+    the published table reads arange(k) from any stream, and hint-free calls
+    on every stream are exact afterwards."""
+    import threading
+
+    top_k, n = 1024, 8192
+    key = (torch.cuda.current_device(), top_k)
+    with _host._HINT_FREE_LOCK:
+        _host._HINT_FREE.pop(key, None)  # cold start for this k
+    batches = [8, 200, 64, 512, 16, 300, 128, 40]
+    streams = [torch.cuda.Stream() for _ in batches]
+    errors = []
+    barrier = threading.Barrier(len(batches))
+
+    def grow(i, b):
+        try:
+            with torch.cuda.stream(streams[i]):
+                barrier.wait()
+                t = _host._hint_free_pre_idx(b, top_k, torch.device("cuda"))
+                assert t.shape == (b, top_k)
+        except Exception as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [
+        threading.Thread(target=grow, args=(i, b)) for i, b in enumerate(batches)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errors, errors
+    table = _host._HINT_FREE[key]
+    assert table.shape[0] >= max(batches), table.shape
+    ref = torch.arange(top_k, dtype=torch.int32, device=_DEV)
+    for s in streams:  # complete contents visible from every stream
+        with torch.cuda.stream(s):
+            assert bool((table == ref).all())
+    torch.cuda.synchronize()
+    logits = torch.randn(max(batches), n, device=_DEV)
+    seq = torch.full((max(batches),), n, dtype=torch.int32, device=_DEV)
+    for s, b in zip(streams, batches, strict=True):
+        with torch.cuda.stream(s):
+            idx, _ = _run_gvr2(logits[:b], seq[:b], top_k, None)
+        torch.cuda.synchronize()
+        _check_varlen_rows(logits[:b], idx, [n] * b, top_k)
+
+
+def test_gvr2_route_reg_clus_sm_count_aware():
+    """The clustered-register admission (`av`) follows the SM count on parts with
+    >= 148 SMs (Rubin/B300: bigger clusters, reg_clus where B200 falls to the
+    slab) and keeps upstream's 148 below it (DRIVE P2021 measured mixed)."""
+    r = _host.route
+    # Rubin: 4-CTA clusters instead of 2-CTA at b 38-48, 16K-32K
+    for n in (16388, 24576, 32768):
+        assert r(40, n, _round64(n), 512)["tpl"] == (1024, 4, 2)
+        assert r(40, n, _round64(n), 512, sms=208)["tpl"] == (1024, 2, 4)
+        # reg_clus instead of main at b 80-104
+        assert r(96, n, _round64(n), 512)["kernel"] == "main"
+        assert r(96, n, _round64(n), 512, sms=208)["kernel"] == "reg_clus"
+    # Rubin/B300: reg_clus instead of main/clus at 48K-64K, b 38-48
+    for sms in (158, 160, 208):
+        assert r(38, 49152, 49152, 512, sms=sms)["kernel"] == "reg_clus"
+        assert r(38, 65536, 65536, 1024, sms=sms)["kernel"] == "reg_clus"
+    assert r(38, 49152, 49152, 512)["kernel"] == "main"
+    assert r(38, 65536, 65536, 1024)["kernel"] == "clus"
+    # below 148 SMs the upstream admission is kept
+    for n in (16388, 65536, 131072):
+        for b in (9, 12, 24, 48):
+            assert r(b, n, _round64(n), 512, sms=68) == r(b, n, _round64(n), 512)
+    # the factorization stays lossless with the extra rung selections
+    for b, n, sms in ((40, 16388, 208), (96, 32768, 208), (38, 65536, 160)):
+        assert _host.route_split(b, n, _round64(n), 512, sms=sms) == r(
+            b, n, _round64(n), 512, sms=sms
+        )
+
+
+def test_gvr2_route_bands_follow_sm_count():
+    """route_bands(sms=...) enumerates the bands of the part it is given: at
+    b=160 the 148-SM bands put 8K<n<=16K on the slab (one BLK=512 wave covers
+    only n<=8K there), the 208-SM bands keep all of 4K<n<=16K on the register
+    kernels (b=160 is `wide`), and every band's plan equals route_static at
+    both ends."""
+    b, npad, k = 160, 16384, 512
+    for sms in (148, 208):
+        bands = _host.route_bands(b, npad, k, n_lo=4097, n_hi=16384, sms=sms)
+        assert bands and bands[0][0] == 4097 and bands[-1][1] == 16384
+        for lo, hi, plan in bands:
+            assert plan == _host.route_static(b, lo, npad, k, sms=sms)
+            assert plan == _host.route_static(b, hi, npad, k, sms=sms)
+    kinds_148 = {
+        p["kernel"] for _, _, p in _host.route_bands(b, npad, k, 4097, 16384, sms=148)
+    }
+    kinds_208 = {
+        p["kernel"] for _, _, p in _host.route_bands(b, npad, k, 4097, 16384, sms=208)
+    }
+    # (n=4097..4099 still has n4 == 1024: the regimg flavour where b=160 is
+    # `wide`, i.e. on the 208-SM part only)
+    assert kinds_148 == {"reg", "main"} and kinds_208 == {"reg", "regimg"}
+    # the 148-SM slab band starts at the first n with n4 = n >> 2 > 2048
+    slab = [
+        (lo, hi)
+        for lo, hi, p in _host.route_bands(b, npad, k, 4097, 16384, sms=148)
+        if p["kernel"] == "main"
+    ]
+    assert slab and slab[0][0] == 8196 and slab[-1][1] == 16384
+    assert _host.route_bands(b, npad, k, 4097, 16384) == _host.route_bands(
+        b, npad, k, 4097, 16384, sms=148
     )

--- a/tests/topk_varlen/test_topk_varlen_serving.py
+++ b/tests/topk_varlen/test_topk_varlen_serving.py
@@ -19,7 +19,7 @@ model here) drives the top-k differently, and several review findings on this
 API were only visible under those patterns:
 
 * several CUDA streams / CUDA graphs in flight on one device (the gvr_2
-  default workspace is one slab per device);
+  default workspace is one slab per device and stream, created eagerly);
 * a top-k issued on a side stream with ``wait_stream`` hand-offs (dual-stream
   indexer overlap);
 * CUDA graphs captured at a padded batch and replayed with fewer live rows,
@@ -167,8 +167,11 @@ def _concurrent_graph_replays(private_workspace, streams=4, launches=8, rounds=6
             workspace={"gvr2_workspace": ws} if private_workspace else None,
         )
 
-    for w in work:  # compile eagerly before capture
-        launch(w, w[3][0])
+    # compile eagerly before capture, on the stream that will capture: the
+    # eager call also creates that stream's default workspace slab
+    for s, w in enumerate(work):
+        with torch.cuda.stream(cuda_streams[s]):
+            launch(w, w[3][0])
     torch.cuda.synchronize()
     graphs = []
     for s, w in enumerate(work):
@@ -222,16 +225,67 @@ def test_gvr2_concurrent_graph_replays_private_workspaces():
     or not flashinfer.top_k_varlen.is_backend_supported("gvr_2", _cc()),
     reason="gvr_2 unsupported on this device",
 )
-@pytest.mark.xfail(
-    strict=False,
-    reason="DOCUMENTED HAZARD: workspace=None resolves to one gvr_2 slab per "
-    "device, so concurrently replayed graphs race on its counters and candidate "
-    "buffer (measured 17/5120 corrupted rows on B100). Flips to XPASS if a "
-    "per-stream/per-graph default ever lands; callers must pass a workspace.",
-)
-def test_gvr2_default_workspace_shared_across_concurrent_graphs():
+def test_gvr2_default_workspace_per_stream_across_concurrent_graphs():
+    """workspace=None: the default slab is per (device, stream), so four graphs
+    captured on four streams, each warmed eagerly on its own stream, replay
+    concurrently without sharing scratch. (A device-wide default slab measured
+    17/5120 corrupted rows here.)"""
     bad, total = _concurrent_graph_replays(private_workspace=False)
-    assert bad == 0, f"{bad}/{total} rows corrupted through the shared default slab"
+    assert bad == 0, (
+        f"{bad}/{total} rows corrupted through the per-stream default slabs"
+    )
+
+
+@pytest.mark.skipif(
+    not _FLASHINFER_AVAILABLE
+    or not flashinfer.top_k_varlen.is_backend_supported("gvr_2", _cc()),
+    reason="gvr_2 unsupported on this device",
+)
+def test_gvr2_default_workspace_capture_needs_eager_launch_on_stream():
+    """A slab-using plan captured on a stream that never ran an eager gvr_2
+    launch raises loudly instead of allocating the slab from the graph pool;
+    one eager launch on that stream makes the same capture succeed."""
+    rows, k, work = _split_case(1, 1)
+    logits, seq, pre, outs, _ = work[0]
+    fresh = torch.cuda.Stream()
+    # compile the launcher on the default stream (does not create fresh's slab)
+    flashinfer.top_k_varlen(
+        logits, seq, k, pre_idx=pre, out_indices=outs[0], backend="gvr_2"
+    )
+    torch.cuda.synchronize()
+    g = torch.cuda.CUDAGraph()
+    with (
+        pytest.raises(RuntimeError, match="default workspace: no slab for this stream"),
+        torch.cuda.stream(fresh),
+        torch.cuda.graph(g, stream=fresh),
+    ):
+        flashinfer.top_k_varlen(
+            logits, seq, k, pre_idx=pre, out_indices=outs[0], backend="gvr_2"
+        )
+    torch.cuda.synchronize()
+    with torch.cuda.stream(fresh):  # eager launch on the capturing stream
+        flashinfer.top_k_varlen(
+            logits, seq, k, pre_idx=pre, out_indices=outs[0], backend="gvr_2"
+        )
+    torch.cuda.synchronize()
+    g2 = torch.cuda.CUDAGraph()
+    with torch.cuda.stream(fresh), torch.cuda.graph(g2, stream=fresh):
+        flashinfer.top_k_varlen(
+            logits, seq, k, pre_idx=pre, out_indices=outs[0], backend="gvr_2"
+        )
+    outs[0].fill_(-7)
+    torch.cuda.synchronize()
+    with torch.cuda.stream(fresh):
+        g2.replay()
+    torch.cuda.synchronize()
+    for r in range(rows):
+        idx = outs[0][r].long()
+        n = int(seq[r])
+        assert bool(((idx >= 0) & (idx < n)).all())
+        assert torch.equal(
+            torch.sort(logits[r][idx]).values,
+            torch.sort(torch.topk(logits[r, :n], k).values).values,
+        )
 
 
 def test_side_stream_handoff_every_backend():

--- a/tests/topk_varlen/test_topk_varlen_serving.py
+++ b/tests/topk_varlen/test_topk_varlen_serving.py
@@ -253,6 +253,10 @@ def test_gvr2_default_workspace_capture_needs_eager_launch_on_stream():
         logits, seq, k, pre_idx=pre, out_indices=outs[0], backend="gvr_2"
     )
     torch.cuda.synchronize()
+    # torch.cuda.Stream() recycles 32 pooled raw streams: establish 'no slab
+    # for this handle' explicitly instead of assuming the stream is new
+    with _host._mu:
+        _host._ws_keep.pop((torch.cuda.current_device(), fresh.cuda_stream), None)
     g = torch.cuda.CUDAGraph()
     with (
         pytest.raises(RuntimeError, match="default workspace: no slab for this stream"),

--- a/tests/topk_varlen/test_topk_varlen_serving.py
+++ b/tests/topk_varlen/test_topk_varlen_serving.py
@@ -168,8 +168,11 @@ def _concurrent_graph_replays(private_workspace, streams=4, launches=8, rounds=6
         )
 
     # compile eagerly before capture, on the stream that will capture: the
-    # eager call also creates that stream's default workspace slab
+    # eager call also creates that stream's default workspace slab. The
+    # inputs were initialised on the default stream, so each side stream
+    # waits for it first.
     for s, w in enumerate(work):
+        cuda_streams[s].wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(cuda_streams[s]):
             launch(w, w[3][0])
     torch.cuda.synchronize()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Follow-up to #4811 (these two commits were pushed to its branch after the squash-merge, so they never landed). Both are host-side changes to the `gvr_2` self-sampling top-k backend; no kernel code changes.

**1. `gvr_2` dispatch rungs for compressed widths 4K < n <= 8K (`c7f9075f`).** An SGLang report ("gvr_v2 slower than `topk_transform_512_v2` at 32K with c4") reproduced with their input recipe held in exactly one band: compressed width 6144-8192, where `gvr_2` was 3-7% slower at bs <= 128 and 13-21% slower at bs 256, while already 8-45% faster at every other width from 4096 to 131072. The cause is the dispatch, not the kernels: for `1024 < n4 <= 4096` the upstream `route()` runs every `wide` row on the VPT=4 register kernel (two empty float4 slots per thread up to n = 8192) and sends b > 148 to the streaming slab. Two FlashInfer-local rungs (marked inline, reported to the kernel owner as internal DKG issue #61): `n4 <= 2048` and `wide` -> `_reg(1024, 2, 1, 2*NB)` (18-20% faster for K in {512, 1024, 2048}); `n4 <= 2048` and one wave of `MINB=2` CTAs -> `_reg(512, 4, 2, NB)` instead of the slab (1.3-1.7x), with `NBSEL` following so `IMGOFF == NBH`.

**Hint-free `gvr_2` (same commit).** `pre_idx` is now optional for `gvr_2`: `run_varlen(pre_idx=None, top_k=K)` runs on a cached `arange(k)` table (`_hint_free_pre_idx`, per (device, k), grown eagerly, refused under CUDA-graph capture, pre-sized by `warmup_varlen`). The kernels use the hint only as a sampling anchor, so the result is exact; hint-free is within ~10% of the hinted time on most cells and 1.5-5x ahead of `radix` / `radix_filter` everywhere except K >= 2048, N <= 4096, B = 1 (radix_filter 1.3x faster). `auto` ranks `gvr_2` first for fp32 with or without a hint, with that one cell carved out to `radix_filter`; a malformed hint on `backend="gvr_2"` is discarded with the existing RuntimeWarning and the call still runs on `gvr_2`; the "requires pre_idx" refusal now applies to `gvr` only.

**2. SM-count-aware register band (`4cb98eab`).** `route()` hard-codes 148 (the B200 SM count). Tuning the same band on B300 (160 SMs) and Rubin (208 SMs) showed the remaining losses sat exactly where that constant mis-sizes a wave: rows in (148, sms] are one wave of 1024-thread CTAs there and the register kernels beat the slab by 1.4-1.8x (B300 12288 x 160: 7.2 -> 4.6 us; Rubin 12288 x 160-192: 5.6 -> 4.0 us). `route(b, n, npad, k, sms=148)` takes the device SM count (`_sm_count()`, part of both launcher cache keys) for the register-band tests only: `wide`, the `QC`/`CURE` flags, and the BLK=512 rung's wave cutoffs (`b <= 2*sms`, plus a second wave `b <= 4*sms` from n = 6144 up). The streaming constants stay at 148 on every part: scaling them made the 131072 x 192-256 slab cells 3-28% slower on B300 and Rubin.

**Measured** (same-node, one process per node, isolated computelab B200 / B300 nodes and Rubin; sglang `topk_v2` vs `gvr_2` with the upstream dispatch vs with this PR; K = 512, perfect hint, CUDA-graph replay medians; 84 uniform cells = 7 widths 4096-131072 x 12 batch sizes 1-512, 48 ragged cells = 4 widths x 12 batch sizes, per-row lengths uniform in [1, width]). `gvr_2` faster-or-equal than sglang:

| GPU | uniform, upstream dispatch | uniform, this PR | ragged, upstream | ragged, this PR |
|---|---|---|---|---|
| B200 (148 SMs) | 65 / 84 | 83 / 84 | 35 / 48 | 45 / 48 |
| B300 (160 SMs) | 62 / 84 | 82 / 84 | 31 / 48 | 43 / 48 |
| Rubin (208 SMs) | 58 / 84 | 84 / 84 | 31 / 48 | 46 / 48 |

At the reported cell (width 8192, B200): sglang 4.27-4.48 us vs `gvr_2` 3.62-3.76 us for bs 1-128 (was 4.46-4.58); 6.77 vs 4.89 us at bs 256 (was 8.04). Every `gvr_2` cell in every run was value-multiset exact. What sglang still wins: 1-4 randomly short rows at width 4096 (~1 us calls; its short-row early exit is 0.3-0.5 us cheaper), the second CTA wave at width 12288 (B200 bs 160 0.99; B300 bs 256-320 0.91-0.97), and a few B300 ragged cells within 7%. Note sglang's kernel fuses the page-table transform, so it does slightly more work per call.

Tried and rejected (measured, same-node): swapping the `regimg` flavour for plain `reg` at n <= 4K (+5%..-12% by cell and hint quality); clustered-register configs for 8K < n <= 16K at b > sms (2-4x slower); `_reg(1024, 4, 1)` for the second wave of 8K-16K (mixed); scaling the streaming constants (see above).

## 🔍 Related Issues

Follow-up to #4811. Dispatch findings reported to the TRT-LLM kernel owner as internal DKG issue #61 (the DSL host in TensorRT-LLM has the same rungs).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New tests: hint-free exactness on every kernel family incl. short/MTP/cr=4 rows; hint-free CUDA-graph replay with table-growth refusal; host `top_k` contract; the rungs (tuple, `NBH == IMGOFF`, wave cutoffs, `route_split` parity); SM-count-aware dispatch (rungs at sms / 2*sms / 4*sms for sms in {160, 208}, streaming half identical for every sms); `auto` order with and without a hint; per-backend malformed-hint behaviour; family-parity key carries the SM count. `tests/topk_varlen` on the final code: A100, L40S, H100, RTX 5080 (74-78 passed, `gvr_2` skips), B100, DRIVE P2021, isolated computelab B200 and B300, Rubin (323-324 passed, 2 known xfails).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Both commits are FlashInfer-local deviations from the vendored TRT-LLM host dispatch (`route()` is otherwise a pure mirror); each deviation is marked inline with its measurement. The `logs/`-style benchmark scripts are not part of the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GVR2 varlen top-k execution supports workloads without a precomputed index hint.
  * Backend selection adapts to hint availability, top-k values, workload size, and GPU resources.
  * Workspace management supports separate allocations per device and CUDA stream.

* **Bug Fixes**
  * Improved validation and warnings for malformed hints and missing or invalid top-k values.
  * Improved CUDA Graph reliability through stream-specific warmup and workspace requirements.
  * Improved correctness for concurrent multi-stream and multi-device execution.

* **Performance**
  * Expanded SM-aware optimization coverage across GPU configurations and larger top-k ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->