### PR TITLE
fix(comm): check cp_size in the auto_parallel guard

### DIFF
--- a/flashinfer/comm/mapping.py
+++ b/flashinfer/comm/mapping.py
@@ -164,7 +164,7 @@ class Mapping(object):
             )
 
         if auto_parallel:
-            if tp_size != 1 or pp_size != 1 or tp_size != 1:
+            if tp_size != 1 or pp_size != 1 or cp_size != 1:
                 raise ValueError(
                     f"When auto parallel is enabled, tp_size, pp_size, cp_size must be 1, but got {tp_size}, {pp_size}, {cp_size}."
                 )


### PR DESCRIPTION
### Problem

`Mapping.__init__` validates the `auto_parallel` case in `flashinfer/comm/mapping.py`:

```python
if auto_parallel:
    if tp_size != 1 or pp_size != 1 or tp_size != 1:
        raise ValueError(
            f"When auto parallel is enabled, tp_size, pp_size, cp_size must be 1, "
            f"but got {tp_size}, {pp_size}, {cp_size}."
        )
```

`tp_size != 1` appears twice and `cp_size` is never tested. The error message right below is the spec — it says all three "must be 1" and interpolates all three — so the third operand was meant to be `cp_size != 1`.

### Impact

With `auto_parallel=True`, a `Mapping(tp_size=1, pp_size=1, cp_size=N)` for `N > 1` passes validation instead of being rejected. Note the `else` branch is the one that enforces `tp_size * pp_size * cp_size == world_size`, so under `auto_parallel` nothing else catches a non-unit `cp_size` either.

### Fix

```python
    if tp_size != 1 or pp_size != 1 or cp_size != 1:
```

### Verification

I lifted the real condition out of the file before and after the patch (`git show HEAD:…` vs the working copy) and evaluated both over the full 2×2×2 truth table:

```
tp   pp   cp   raises(before)  raises(after)
1    1    1    False           False
1    1    2    False           True     <== CHANGED
1    2    1    True            True
1    2    2    True            True
2    1    1    True            True
2    1    2    True            True
2    2    1    True            True
2    2    2    True            True

changed cells: 1 / 8
```

The all-ones case still passes and every case that was already rejected stays rejected; the only change is that `cp_size != 1` is now caught, which is what the message promises.

`ruff check` and `ruff format --check` pass on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected `auto_parallel` validation to properly validate the context-parallel size configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->