### PR TITLE
feat(moe_ep): tile-grained GEMM2 to combine overlap on the split EP path

### DIFF
--- a/benchmarks/bench_gemm2_tile_signal.py
+++ b/benchmarks/bench_gemm2_tile_signal.py
@@ -1,0 +1,446 @@
+"""Microbench: GEMM2 kernel cost of tile-ready signaling.
+
+Times the CuteDSL NVFP4 GEMM2 (finalize-fusion) kernel only — no consumer,
+no dest fingerprint, no dispatch/combine. Same problem, same MMA, same SM
+count; the only compile-time change is ``enable_tile_signal`` (destination-
+complete bulk wait + ``st.release.gpu`` of one int32 flag per CTA tile).
+
+Also reports ``store_permuted_c`` vs fused-finalize so the dense-C store is
+not confused with the flag tax.
+
+Geometry defaults to the fused-gemm2-combine reference cell on one rank:
+32 local experts, 1024 packed rows/expert (8 GPU × 128 tokens), hidden 7168,
+intermediate 2048, MMA 128×128 cluster (1,1).
+
+    python benchmarks/bench_gemm2_tile_signal.py
+    python benchmarks/bench_gemm2_tile_signal.py --world 4 --num-experts 256
+
+Submit (1 GPU):
+
+    sbatch --gpus-per-node=1 --nodes=1 \\
+        dev/cutedsl_moe/run_bench_gemm2_tile_signal.sbatch
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Optional
+
+_here = os.path.dirname(os.path.abspath(__file__))
+sys.path[:] = [p for p in sys.path if os.path.abspath(p or os.getcwd()) != _here]
+
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--num-experts", type=int, default=256)
+    p.add_argument(
+        "--num-local-experts",
+        type=int,
+        default=None,
+        help="Override local expert count (default: num_experts // world)",
+    )
+    p.add_argument(
+        "--world", type=int, default=8, help="EP world size used to size the pack"
+    )
+    p.add_argument("--tokens-per-rank", type=int, default=128)
+    p.add_argument("--hidden", type=int, default=7168)
+    p.add_argument("--intermediate", type=int, default=2048)
+    p.add_argument("--mma-m", type=int, default=128)
+    p.add_argument("--mma-n", type=int, default=128)
+    p.add_argument("--cluster-m", type=int, default=1)
+    p.add_argument("--cluster-n", type=int, default=1)
+    p.add_argument(
+        "--reserve-consumer-sms",
+        type=int,
+        default=0,
+        help="Subtract this many SMs from every GEMM2 launch. Keep 0 to isolate "
+        "the flag store from occupancy; production overlap reserves 8.",
+    )
+    p.add_argument(
+        "--include-overlap-sms",
+        action="store_true",
+        default=True,
+        help="Also time dense_c+signal with 8 SMs reserved (production occupancy).",
+    )
+    p.add_argument(
+        "--no-include-overlap-sms",
+        action="store_false",
+        dest="include_overlap_sms",
+    )
+    p.add_argument("--warmup", type=int, default=5)
+    p.add_argument("--repeat", type=int, default=20)
+    p.add_argument("--no-cuda-graph", action="store_true")
+    p.add_argument(
+        "--cupti", action="store_true", help="Time kernels with CUPTI instead of graphs"
+    )
+    p.add_argument(
+        "--epilogues",
+        default="fused,dense_c",
+        help="Comma list: fused (atomic finalize) and/or dense_c (store_permuted_c)",
+    )
+    return p.parse_args()
+
+
+@dataclass(frozen=True)
+class Problem:
+    a: Any
+    a_scale: Any
+    b: Any
+    b_scale: Any
+    alpha: Any
+    tile_idx_to_expert_idx: Any
+    num_non_exiting_tiles: Any
+    tile_idx_to_mn_limit: Any
+    permuted_idx_to_expanded_idx: Any
+    token_final_scales: Any
+    permuted_m: int
+    seq_len: int
+    n: int
+    k: int
+    num_experts: int
+    flags: int
+
+
+def _build_problem(
+    *,
+    num_local_experts: int,
+    cap: int,
+    hidden: int,
+    intermediate: int,
+    mma_tiler_mn: tuple[int, int],
+    tile_tokens_dim: int,
+    device,
+) -> Problem:
+    import torch
+
+    from flashinfer.cute_dsl.utils import convert_sf_to_mma_layout
+    from flashinfer.fp4_quantization import fp4_quantize
+    from flashinfer.fused_moe.cute_dsl.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+        gemm2_tile_ready_numel,
+    )
+    from flashinfer.fused_moe.cute_dsl.moe_utils import moe_sort
+
+    seq_len = num_local_experts * cap
+    selected = (
+        torch.arange(num_local_experts, device=device, dtype=torch.int32)
+        .repeat_interleave(cap)
+        .reshape(seq_len, 1)
+    )
+    scales = torch.ones(seq_len, 1, dtype=torch.float32, device=device)
+    (
+        tile_idx_to_expert_idx,
+        tile_idx_to_mn_limit,
+        _expanded_to_permuted,
+        permuted_idx,
+        _padded,
+        num_non_exiting_tiles,
+    ) = moe_sort(
+        token_selected_experts=selected,
+        token_final_scales=scales,
+        num_experts=num_local_experts,
+        top_k=1,
+        num_local_experts=num_local_experts,
+        tile_tokens_dim=tile_tokens_dim,
+    )
+    permuted_m = int(permuted_idx.shape[0])
+
+    gs = torch.ones(1, dtype=torch.float32, device=device)
+    act = torch.randn(permuted_m, intermediate, dtype=torch.bfloat16, device=device)
+    a, a_sf = fp4_quantize(
+        act, global_scale=gs, sf_vec_size=16, is_sf_swizzled_layout=True
+    )
+    a_scale = convert_sf_to_mma_layout(
+        a_sf, m=permuted_m, k=intermediate, num_groups=1, sf_vec_size=16
+    )
+
+    w2 = torch.randn(
+        num_local_experts, hidden, intermediate, dtype=torch.bfloat16, device=device
+    )
+    w2_q, w2_sf = fp4_quantize(
+        w2.reshape(num_local_experts * hidden, intermediate),
+        global_scale=gs,
+        sf_vec_size=16,
+        is_sf_swizzled_layout=True,
+    )
+    b = w2_q.view(num_local_experts, hidden, intermediate // 2)
+    b_scale = convert_sf_to_mma_layout(
+        w2_sf,
+        m=hidden,
+        k=intermediate,
+        num_groups=num_local_experts,
+        sf_vec_size=16,
+    )
+    alpha = torch.ones(num_local_experts, dtype=torch.float32, device=device)
+    flags = gemm2_tile_ready_numel(permuted_m, hidden, mma_tiler_mn)
+    return Problem(
+        a=a,
+        a_scale=a_scale,
+        b=b,
+        b_scale=b_scale,
+        alpha=alpha,
+        tile_idx_to_expert_idx=tile_idx_to_expert_idx,
+        num_non_exiting_tiles=num_non_exiting_tiles,
+        tile_idx_to_mn_limit=tile_idx_to_mn_limit,
+        permuted_idx_to_expanded_idx=permuted_idx,
+        token_final_scales=scales,
+        permuted_m=permuted_m,
+        seq_len=seq_len,
+        n=hidden,
+        k=intermediate,
+        num_experts=num_local_experts,
+        flags=flags,
+    )
+
+
+def _out_buf(prob: Problem, store_permuted_c: bool, device):
+    import torch
+
+    rows = prob.permuted_m if store_permuted_c else prob.seq_len
+    alloc = torch.empty if store_permuted_c else torch.zeros
+    return alloc((rows, prob.n), dtype=torch.bfloat16, device=device)
+
+
+def _aligned_sm_count(
+    sm_full: int, reserve: int, cluster_shape_mn: tuple[int, int]
+) -> int:
+    cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
+    usable = max(cluster_size, int(sm_full) - int(reserve))
+    usable = (usable // cluster_size) * cluster_size
+    return max(cluster_size, usable)
+
+
+def _launch(
+    prob: Problem,
+    *,
+    out,
+    tile_ready,
+    store_permuted_c: bool,
+    mma_tiler_mn: tuple[int, int],
+    cluster_shape_mn: tuple[int, int],
+    sm_count: int,
+):
+    from flashinfer.fused_moe.cute_dsl.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+        blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4,
+    )
+
+    return blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
+        a=prob.a,
+        b=prob.b,
+        a_scale=prob.a_scale,
+        b_scale=prob.b_scale,
+        alpha=prob.alpha,
+        tile_idx_to_expert_idx=prob.tile_idx_to_expert_idx,
+        num_non_exiting_tiles=prob.num_non_exiting_tiles,
+        tile_idx_to_mn_limit=prob.tile_idx_to_mn_limit,
+        permuted_idx_to_expanded_idx=prob.permuted_idx_to_expanded_idx,
+        token_final_scales=prob.token_final_scales,
+        out=out,
+        mma_tiler_mn=mma_tiler_mn,
+        cluster_shape_mn=cluster_shape_mn,
+        sm_count=sm_count,
+        enable_pdl=True,
+        use_fused_finalize=True,
+        tile_ready=tile_ready,
+        store_permuted_c=store_permuted_c,
+    )
+
+
+def _time_ms(
+    fn,
+    *,
+    warmup: int,
+    repeat: int,
+    use_cuda_graph: bool,
+    enable_cupti: bool,
+) -> float:
+    import numpy as np
+    import torch
+
+    from flashinfer.testing.utils import bench_gpu_time
+
+    # JIT / occupancy query live here, not in the timed region.
+    for _ in range(max(1, warmup)):
+        fn()
+    torch.cuda.synchronize()
+
+    kwargs = dict(
+        dry_run_iters=max(1, warmup),
+        repeat_iters=repeat,
+        enable_cupti=enable_cupti,
+        use_cuda_graph=False if enable_cupti else use_cuda_graph,
+        # Problem is far larger than L2; skip rotating-buffer clones.
+        cold_l2_cache=False,
+        num_iters_within_graph=10,
+    )
+    try:
+        times = bench_gpu_time(fn, **kwargs)
+    except Exception as exc:
+        if enable_cupti or not use_cuda_graph:
+            raise
+        print(
+            f"CUDA graph timing failed ({exc!r}); falling back to CUDA events",
+            flush=True,
+        )
+        kwargs["use_cuda_graph"] = False
+        times = bench_gpu_time(fn, **kwargs)
+    return float(np.median(times))
+
+
+def main() -> int:
+    args = _parse_args()
+    import torch
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10:
+        raise SystemExit("GEMM2 tile-signal microbench requires SM100+")
+
+    from flashinfer.cute_dsl.utils import get_num_sm
+
+    device = torch.device("cuda")
+    torch.cuda.set_device(0)
+    if args.num_local_experts is not None:
+        nle = int(args.num_local_experts)
+    else:
+        if args.num_experts % args.world != 0:
+            raise SystemExit(
+                f"num_experts={args.num_experts} not divisible by world={args.world}"
+            )
+        nle = args.num_experts // args.world
+    if nle < 1:
+        raise SystemExit("need at least one local expert")
+    cap = args.tokens_per_rank * args.world
+    mma_tiler_mn = (args.mma_m, args.mma_n)
+    cluster_shape_mn = (args.cluster_m, args.cluster_n)
+    sm_full = int(get_num_sm(device))
+    sm_count = _aligned_sm_count(
+        sm_full, int(args.reserve_consumer_sms), cluster_shape_mn
+    )
+    epilogues = [s.strip() for s in args.epilogues.split(",") if s.strip()]
+    for name in epilogues:
+        if name not in ("fused", "dense_c"):
+            raise SystemExit(f"unknown epilogue {name!r}; use fused and/or dense_c")
+
+    print(
+        f"geometry local_experts={nle} cap={cap} tokens={nle * cap} "
+        f"hidden={args.hidden} intermediate={args.intermediate} "
+        f"mma={mma_tiler_mn} cluster={cluster_shape_mn} "
+        f"sm={sm_count}/{sm_full} reserve={args.reserve_consumer_sms} "
+        f"cc={'.'.join(map(str, torch.cuda.get_device_capability()))}",
+        flush=True,
+    )
+    print("building problem (moe_sort + NVFP4 quantize) ...", flush=True)
+    prob = _build_problem(
+        num_local_experts=nle,
+        cap=cap,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        mma_tiler_mn=mma_tiler_mn,
+        tile_tokens_dim=args.mma_m,
+        device=device,
+    )
+    print(
+        f"permuted_m={prob.permuted_m} flags={prob.flags} "
+        f"non_exiting_tiles={int(prob.num_non_exiting_tiles.item())}",
+        flush=True,
+    )
+
+    use_graph = not args.no_cuda_graph
+    rows: list[tuple[str, bool, int, float]] = []
+    baseline_us: dict[tuple[str, int], float] = {}
+    out_bufs = {name: _out_buf(prob, name == "dense_c", device) for name in epilogues}
+
+    def _time_one(epi: str, signal: bool, sm: int) -> float:
+        store_c = epi == "dense_c"
+        out = out_bufs[epi]
+        tile_ready: Optional[torch.Tensor] = None
+        if signal:
+            tile_ready = torch.zeros(prob.flags, dtype=torch.int32, device=device)
+
+        def _fn(_out=out, _tr=tile_ready, _sc=store_c, _sm=sm):
+            _launch(
+                prob,
+                out=_out,
+                tile_ready=_tr,
+                store_permuted_c=_sc,
+                mma_tiler_mn=mma_tiler_mn,
+                cluster_shape_mn=cluster_shape_mn,
+                sm_count=_sm,
+            )
+
+        tag = f"{epi} signal={int(signal)} sm={sm}"
+        print(f"timing {tag} (JIT on first call) ...", flush=True)
+        ms = _time_ms(
+            _fn,
+            warmup=args.warmup,
+            repeat=args.repeat,
+            use_cuda_graph=use_graph,
+            enable_cupti=bool(args.cupti),
+        )
+        us = ms * 1e3
+        rows.append((epi, signal, sm, us))
+        if not signal:
+            baseline_us[(epi, sm)] = us
+        base = baseline_us.get((epi, sm), us)
+        delta = us - base
+        pct = 100.0 * delta / base if base > 0 else float("nan")
+        print(
+            f"BENCH_CSV,{epi},{int(signal)},{sm},"
+            f"{args.mma_m}x{args.mma_n},{args.cluster_m}x{args.cluster_n},"
+            f"{us:.1f},{delta:.1f},{pct:.2f},{prob.flags},{prob.permuted_m}",
+            flush=True,
+        )
+        return us
+
+    print(
+        "BENCH_CSV,epilogue,signal,sm,mma,cluster,gemm_us,delta_us,delta_pct,flags,"
+        "permuted_m"
+    )
+    for epi in epilogues:
+        for signal in (False, True):
+            _time_one(epi, signal, sm_count)
+
+    overlap_us = None
+    overlap_sm = None
+    if args.include_overlap_sms and "dense_c" in epilogues:
+        overlap_sm = _aligned_sm_count(sm_full, 8, cluster_shape_mn)
+        if overlap_sm != sm_count:
+            overlap_us = _time_one("dense_c", True, overlap_sm)
+
+    print("\nTile-signal tax (same epilogue, same SMs, same MMA):")
+    for epi, signal, sm, us in rows:
+        if not signal:
+            continue
+        base = baseline_us.get((epi, sm))
+        if base is None:
+            continue
+        print(
+            f"  {epi} sm={sm}: {base:.1f} us -> {us:.1f} us  "
+            f"({us - base:+.1f} us, {100.0 * (us - base) / base:+.2f}%)"
+        )
+    if overlap_us is not None:
+        signal_full = next(
+            (
+                us
+                for epi, signal, sm, us in rows
+                if epi == "dense_c" and signal and sm == sm_count
+            ),
+            None,
+        )
+        if signal_full is not None:
+            print(
+                f"\nOverlap SM reservation (dense_c+signal, {sm_count} -> {overlap_sm} SMs): "
+                f"{signal_full:.1f} us -> {overlap_us:.1f} us  "
+                f"({overlap_us - signal_full:+.1f} us, "
+                f"{100.0 * (overlap_us - signal_full) / signal_full:+.2f}%)"
+            )
+    print(
+        "Notes: no consumer, no dest fingerprint, no tile_ready.zero_ in the "
+        "timed path. enable_tile_signal = dest-complete bulk wait + st.release.gpu."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/bench_moe_ep.py
+++ b/benchmarks/bench_moe_ep.py
@@ -118,6 +118,14 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="time the comm-only identity path (no compute_config)",
     )
+    p.add_argument(
+        "--method",
+        choices=["split-moe", "fused-gemm2-combine"],
+        default="split-moe",
+        help="split-moe: fused-finalize GEMM2 + NCCL combine. "
+        "fused-gemm2-combine: dense C + tile-ready overlap ship (NVFP4 LL "
+        "EXPERT_MAJOR only).",
+    )
     args = p.parse_args()
     if args.reference:
         args.num_experts = _REFERENCE["num_experts"]
@@ -143,7 +151,6 @@ def _build_compute(args, *, local_num_experts, local_expert_offset, max_tokens, 
         QuantVariant,
         RoutingConfig,
         TrtllmBf16Config,
-        TrtllmFp4Config,
     )
     from flashinfer.moe_ep import MoEWeightPack
 
@@ -172,11 +179,17 @@ def _build_compute(args, *, local_num_experts, local_expert_offset, max_tokens, 
     canonical = MoEWeightPack(w13=w13, w2=w2)
 
     if args.quant == "nvfp4":
+        # Same CuteDSL compute as fused-gemm2-combine. Do not list
+        # TrtllmFp4Config: weight materialize prepares only the first backend.
+        if args.method == "fused-gemm2-combine":
+            cute = CuteDslConfig(enable_tile_signal=True, store_permuted_c=True)
+        else:
+            cute = CuteDslConfig()
         cfg = MoEConfig(
             routing=routing,
             quant=QuantConfig(variant=QuantVariant.NVFP4),
             experts=experts,
-            backend=BackendOptions(candidates=(CuteDslConfig(), TrtllmFp4Config())),
+            backend=BackendOptions(candidates=(cute,)),
             execution=execution,
         )
     else:
@@ -276,6 +289,16 @@ def main() -> int:
     else:
         compute_max_tokens = local_num_experts * per_rank * world_size
 
+    if args.method == "fused-gemm2-combine":
+        if args.quant != "nvfp4":
+            raise SystemExit("fused-gemm2-combine requires --quant nvfp4")
+        if args.algorithm != "ll":
+            raise SystemExit("fused-gemm2-combine requires --algorithm ll")
+        if args.layout != "expert_major":
+            raise SystemExit("fused-gemm2-combine requires --layout expert_major")
+        if args.baseline:
+            raise SystemExit("fused-gemm2-combine is incompatible with --baseline")
+
     comm = _comm_config(args.backend)
     if args.baseline:
         layer_backend: SplitConfig | str = SplitConfig(
@@ -297,6 +320,7 @@ def main() -> int:
         layer_backend = SplitConfig(
             comm=comm,
             kernel=FusedMoeKernelConfig(moe_config=moe_config),
+            skip_combine=(args.method == "fused-gemm2-combine"),
         )
         layer_weights = canonical_weights
 
@@ -308,13 +332,13 @@ def main() -> int:
         algorithm=ep_algorithm,
         layout=ep_layout,
     )
+    from statistics import median
+    from time import perf_counter
+
     layer = MoEEpLayer(
         bootstrap, fleet_params, weights=layer_weights, backend=layer_backend
     )
     t = MoEEpTensors(hidden_states=x, topk_ids=topk_ids, topk_weights=topk_weights)
-
-    from statistics import median
-    from time import perf_counter
 
     layer.enable_timing = True
 
@@ -368,12 +392,25 @@ def main() -> int:
     if rank == 0:
         mode = "identity" if args.baseline else args.quant
         layout_name = "ht_flat" if args.algorithm == "ht" else args.layout
+        overlap_note = ""
+        kernel = getattr(layer, "_kernel", None)
+        stats = (
+            getattr(kernel, "last_overlap_stats", None) if kernel is not None else None
+        )
+        if stats:
+            overlap_note = (
+                f" overlap_live_rows={stats.get('live_rows')} "
+                f"overlap_live_bytes={stats.get('live_bytes')} "
+                f"overlap_expected_rows={stats.get('expected_rows')}"
+            )
         print(
-            "BENCH_CSV,algo,layout,tokens,gpus,backend,quant,dispatch_us,compute_us,combine_us,e2e_us,tok_s,disp_gbps,disp_rdma_gbps,comb_gbps,comb_rdma_gbps\n"
-            f"BENCH_CSV,{args.algorithm},{layout_name},{args.tokens},{world_size},{args.backend},{mode},"
+            "BENCH_CSV,algo,layout,tokens,gpus,backend,quant,method,dispatch_us,compute_us,combine_us,e2e_us,tok_s,disp_gbps,disp_rdma_gbps,comb_gbps,comb_rdma_gbps\n"
+            f"BENCH_CSV,{args.algorithm},{layout_name},{args.tokens},{world_size},{args.backend},{mode},{args.method},"
             f"{d_us:.1f},{cp_us:.1f},{cb_us:.1f},{e2e_us:.1f},{tok_s:.1f},"
             f"{disp_gbps:.1f},{disp_rdma:.1f},{comb_gbps:.1f},{comb_rdma:.1f}"
         )
+        if overlap_note:
+            print(f"OVERLAP_STATS,{overlap_note.strip()}")
     layer.destroy()
     dist.destroy_process_group()
     return 0

--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -1314,7 +1314,19 @@ class CuteDslConfig:
     """CuteDSL FP4 backend for W4A4, W4A8, and W4A16.
 
     The underlying CuteDSL kernel throws at launch on SM120/SM121/SM130.
+
+    Parameters
+    ----------
+    enable_tile_signal : bool
+        GEMM2 writes per-CTA ``tile_ready`` flags after each output tile lands
+        in HBM. Used by the fused-gemm2-combine overlap path.
+    store_permuted_c : bool
+        GEMM2 writes dense ``C[permuted_m, H]`` (identity store, routing
+        scale 1.0) instead of fused-finalize scatter into token rows.
     """
+
+    enable_tile_signal: bool = False
+    store_permuted_c: bool = False
 
     @classmethod
     def supported(cls, arch: int) -> bool:
@@ -1351,7 +1363,13 @@ class CuteDslConfig:
         )
 
     def __repr__(self) -> str:
-        return "CuteDslConfig()"
+        parts = []
+        if self.enable_tile_signal:
+            parts.append(f"enable_tile_signal={self.enable_tile_signal!r}")
+        if self.store_permuted_c:
+            parts.append(f"store_permuted_c={self.store_permuted_c!r}")
+        inner = ", ".join(parts)
+        return f"CuteDslConfig({inner})"
 
 
 @dataclass(frozen=True)

--- a/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blackwell/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -367,6 +367,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         enable_pdl: bool = True,
         use_a_per_token_scale: bool = False,
         use_fused_finalize: bool = True,
+        enable_tile_signal: bool = False,
+        store_permuted_c: bool = False,
     ):
         """Initializes the configuration for a Blackwell blockscaled dense GEMM kernel.
 
@@ -390,6 +392,8 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         self.enable_pdl = enable_pdl
         self.use_a_per_token_scale = use_a_per_token_scale
         self.use_fused_finalize = use_fused_finalize
+        self.enable_tile_signal = enable_tile_signal
+        self.store_permuted_c = store_permuted_c
         self.acc_dtype = cutlass.Float32
         self.use_2cta_instrs = mma_tiler_mn[0] == 256
         self.cluster_shape_mn = cluster_shape_mn
@@ -647,6 +651,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         permuted_idx_to_expanded_idx: cute.Tensor,
         token_final_scales: cute.Tensor,
         a_per_token_scale: Optional[cute.Tensor],
+        tile_ready: Optional[cute.Tensor],
         epilogue_op: cutlass.Constexpr = lambda x: x,
     ):
         """Execute the GEMM operation in steps:
@@ -974,6 +979,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             permuted_idx_to_expanded_idx,
             token_final_scales,
             a_per_token_scale,
+            tile_ready,
             self.cluster_layout_vmnk,
             self.cluster_layout_sfb_vmnk,
             self.a_smem_layout_staged,
@@ -1062,6 +1068,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         permuted_idx_to_expanded_idx: cute.Tensor,
         token_final_scales: cute.Tensor,
         a_per_token_scale: Optional[cute.Tensor],
+        tile_ready: Optional[cute.Tensor],
         cluster_layout_vmnk: cute.Layout,
         cluster_layout_sfb_vmnk: cute.Layout,
         a_smem_layout_staged: cute.ComposedLayout,
@@ -1993,7 +2000,12 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                     gather_tok = token_idx * is_valid_row
                     token_scale = token_final_scales[(gather_tok, topk_idx)]
                     output_idx = token_idx
-                    if cutlass.const_expr(not self.use_fused_finalize):
+                    if cutlass.const_expr(self.store_permuted_c):
+                        # Dense GEMM-M C: identity store, no routing scale
+                        # (dest combine applies topk_weights).
+                        token_scale = self.final_scale_dtype(1.0)
+                        output_idx = permuted_row
+                    elif cutlass.const_expr(not self.use_fused_finalize):
                         token_scale = self.final_scale_dtype(1.0)
                         output_idx = safe_idx
                     if cutlass.const_expr(self.use_a_per_token_scale):
@@ -2197,7 +2209,12 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                         # is_valid_tensor_alignment requires each output row to
                         # end on a 16-byte boundary, matching the bulk-copy
                         # instruction's size and address requirements.
-                        if cutlass.const_expr(not self.use_fused_finalize):
+                        # Both dense permuted C and deterministic finalize write
+                        # each output row exactly once, so they store rather
+                        # than reduce.
+                        if cutlass.const_expr(
+                            self.store_permuted_c or not self.use_fused_finalize
+                        ):
                             blk_copy(
                                 scatter_out_offset,
                                 sC[reduce_row, None, 0],
@@ -2223,8 +2240,26 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
                             )
 
                 cute.arch.cp_async_bulk_commit_group()
-                cute.arch.cp_async_bulk_wait_group(0, read=True)
+                if cutlass.const_expr(self.enable_tile_signal):
+                    # Destination-complete wait: C rows are visible in HBM
+                    # before the release flag store.
+                    cute.arch.cp_async_bulk_wait_group(0, read=False)
+                else:
+                    cute.arch.cp_async_bulk_wait_group(0, read=True)
                 self.epilog_sync_barrier.arrive_and_wait()
+
+                if cutlass.const_expr(self.enable_tile_signal):
+                    if epi_tidx == 0:
+                        num_n = (
+                            out.shape[1] + self.cta_tile_shape_mnk[1] - 1
+                        ) // self.cta_tile_shape_mnk[1]
+                        flag_idx = tile_info[0] * num_n + tile_info[1]
+                        cute.arch.store(
+                            tile_ready.iterator + flag_idx,
+                            cutlass.Int32(1),
+                            sem="release",
+                            scope="gpu",
+                        )
 
                 # Release the prefetched metadata slot for this tile.
                 meta_pipeline.consumer_release(meta_consumer_state)
@@ -2885,6 +2920,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
         num_non_exiting_tiles_ptr: cute.Pointer,
         token_final_scales_ptr: cute.Pointer,
         a_per_token_scale_ptr: Optional[cute.Pointer],
+        tile_ready_ptr: Optional[cute.Pointer],
         m: cutlass.Int64,
         n: cutlass.Int64,
         k: cutlass.Int64,
@@ -2918,7 +2954,9 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             ),
         )
         output_rows = num_tokens
-        if cutlass.const_expr(not self.use_fused_finalize):
+        if cutlass.const_expr(self.store_permuted_c):
+            output_rows = m
+        elif cutlass.const_expr(not self.use_fused_finalize):
             output_rows = num_tokens * top_k
         c = cute.make_tensor(
             c_ptr, layout=cute.make_ordered_layout((output_rows, n, 1), order=(1, 0, 2))
@@ -2946,6 +2984,19 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             if cutlass.const_expr(a_per_token_scale_ptr is not None)
             else None
         )
+        tile_ready = (
+            cute.make_tensor(
+                tile_ready_ptr,
+                layout=cute.make_layout(
+                    (
+                        ((m + self.mma_tiler[0] - 1) // self.mma_tiler[0])
+                        * ((n + self.mma_tiler[1] - 1) // self.mma_tiler[1]),
+                    )
+                ),
+            )
+            if cutlass.const_expr(self.enable_tile_signal)
+            else None
+        )
 
         return self(
             a,
@@ -2962,6 +3013,7 @@ class Sm100BlockScaledContiguousGroupedGemmFinalizeFusionKernel:
             permuted_idx_to_expanded_idx=permuted_idx_to_expanded_idx,
             token_final_scales=token_final_scales,
             a_per_token_scale=a_per_token_scale,
+            tile_ready=tile_ready,
             epilogue_op=epilogue_op,
         )
 

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_grouped_gemm_finalize_fusion.py
@@ -42,7 +42,7 @@ Key features:
 
 import functools
 import warnings
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import cutlass
 import cutlass.cute as cute
@@ -176,6 +176,32 @@ def create_finalize_fusion_tensors(
     return permuted_idx_to_expanded_idx, token_final_scales
 
 
+def gemm2_cta_tile_mn(mma_tiler_mn: Tuple[int, int]) -> Tuple[int, int]:
+    """CTA output tile ``(M, N)`` matching GEMM2's ``tile_ready`` layout.
+
+    MMA-M 256 uses two CTAs along M, so the flag's M-tile is 128 rows.
+    """
+    cta_m = mma_tiler_mn[0] // (2 if mma_tiler_mn[0] == 256 else 1)
+    cta_n = mma_tiler_mn[1]
+    return cta_m, cta_n
+
+
+def gemm2_tile_ready_numel(
+    permuted_m: int,
+    n: int,
+    mma_tiler_mn: Tuple[int, int],
+) -> int:
+    """Number of int32 flags GEMM2 writes, one per CTA output tile.
+
+    Index is ``m_tile * num_n_tiles + n_tile``. The buffer must be zeroed on
+    the GEMM stream before each launch.
+    """
+    cta_m, cta_n = gemm2_cta_tile_mn(mma_tiler_mn)
+    num_m = (permuted_m + cta_m - 1) // cta_m
+    num_n = (n + cta_n - 1) // cta_n
+    return num_m * num_n
+
+
 # Kernel cache for compiled kernels (class-level to persist across calls)
 _finalize_kernel_cache: Dict[Tuple, Any] = {}
 
@@ -201,6 +227,7 @@ def _get_compiled_finalize_kernel(
     num_tiles_ptr,
     token_scales_ptr,
     a_per_token_scale_ptr,
+    tile_ready_ptr,
     max_active_clusters: int,
     stream,
     # Tactic parameters (compile-time - IN cache key)
@@ -222,6 +249,8 @@ def _get_compiled_finalize_kernel(
     enable_pdl: bool = True,
     use_a_per_token_scale: bool = False,
     use_fused_finalize: bool = True,
+    enable_tile_signal: bool = False,
+    store_permuted_c: bool = False,
 ):
     """Get or compile the grouped GEMM with finalize fusion kernel.
 
@@ -257,6 +286,9 @@ def _get_compiled_finalize_kernel(
         enable_pdl,
         use_a_per_token_scale,
         use_fused_finalize,
+        enable_tile_signal,
+        store_permuted_c,
+        max_active_clusters,
     )
 
     if cache_key not in _finalize_kernel_cache:
@@ -279,6 +311,11 @@ def _get_compiled_finalize_kernel(
                     "use_fused_finalize=False is not supported by the Rubin "
                     "(SM107) finalize grouped GEMM kernel: it always performs "
                     "the fused atomic scatter-add."
+                )
+            if enable_tile_signal or store_permuted_c:
+                raise NotImplementedError(
+                    "enable_tile_signal and store_permuted_c are not supported "
+                    "by the Rubin (SM107) finalize grouped GEMM kernel."
                 )
             if final_scale_dtype is not cutlass.Float32:
                 # The Rubin kernel hardcodes self.final_scale_dtype =
@@ -307,6 +344,8 @@ def _get_compiled_finalize_kernel(
                 enable_pdl=enable_pdl,
                 use_a_per_token_scale=use_a_per_token_scale,
                 use_fused_finalize=use_fused_finalize,
+                enable_tile_signal=enable_tile_signal,
+                store_permuted_c=store_permuted_c,
             )
             wrapper_fn = gemm_bw.wrapper
 
@@ -319,7 +358,7 @@ def _get_compiled_finalize_kernel(
         # (a_ptr, b_ptr, a_sf_ptr, b_sf_ptr, c_ptr, alpha_ptr,
         #  tile_idx_to_group_idx_ptr, tile_idx_to_mn_limit_ptr,
         #  permuted_idx_to_expanded_idx_ptr, num_non_exiting_tiles_ptr,
-        #  token_final_scales_ptr, [a_per_token_scale_ptr],
+        #  token_final_scales_ptr, [a_per_token_scale_ptr, tile_ready_ptr],
         #  m, n, k, l, num_tokens, top_k,
         #  tile_size, scaling_vector_size, max_active_clusters, stream)
         compiled_gemm = cute.compile(
@@ -335,7 +374,7 @@ def _get_compiled_finalize_kernel(
             permuted_idx_ptr,
             num_tiles_ptr,
             token_scales_ptr,
-            *([] if is_rubin else [a_per_token_scale_ptr]),
+            *([] if is_rubin else [a_per_token_scale_ptr, tile_ready_ptr]),
             permuted_m,
             n,
             k,
@@ -381,6 +420,10 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
     mma_inst_shape: Optional[Tuple[int, int, int]] = None,
     enable_pdl: bool = True,
     use_fused_finalize: bool = True,
+    tile_ready: Optional[torch.Tensor] = None,
+    store_permuted_c: bool = False,
+    before_launch: Optional[Callable[[], None]] = None,
+    after_launch: Optional[Callable[[], None]] = None,
 ) -> torch.Tensor:
     """Blockscaled contiguous grouped GEMM for MoE GEMM2 workloads.
 
@@ -417,6 +460,18 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         sm_count: Number of SMs to use. Default: max available.
         use_fused_finalize: Use atomic fused finalize; otherwise write expanded
              rows for deterministic reduction. Default: True.
+        tile_ready: Optional int32 flag buffer, one flag per CTA output tile.
+             When provided, GEMM2 release-stores 1 after each tile's store has
+             landed in HBM. Must be zeroed before launch; size at least
+             :func:`gemm2_tile_ready_numel`.
+        store_permuted_c: Write dense ``C[permuted_m, H]`` via ``blk_copy``
+             (identity row index, routing scale 1.0). Skips fused scatter.
+             Dest combine applies ``topk_weights``. Default: False.
+        before_launch: Optional callback after ``cute.compile`` and before the
+             GEMM2 grid is queued. Use this to JIT overlapping kernels without
+             launching a flag-waiter.
+        after_launch: Optional callback after the GEMM2 host launch returns.
+             Use this to queue a second-stream consumer that waits on flags.
 
     Returns:
         out: Output tensor with dtype out_dtype. The shape is ``(seq_len, n)``
@@ -574,11 +629,19 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
             f"cluster_shape_mn={cluster_shape_mn}, shape=({permuted_m}, {n}, {k}, {num_experts})"
         )
 
-    output_rows = seq_len if use_fused_finalize else seq_len * topk
+    if store_permuted_c:
+        output_rows = permuted_m
+    elif use_fused_finalize:
+        output_rows = seq_len
+    else:
+        output_rows = seq_len * topk
 
     # Atomic fused finalize requires zero-initialized output.
+    # store_permuted_c and deterministic mode write each row once.
     if out is None:
-        allocator = torch.zeros if use_fused_finalize else torch.empty
+        allocator = (
+            torch.empty if (store_permuted_c or not use_fused_finalize) else torch.zeros
+        )
         out = allocator(
             (output_rows, n),
             dtype=cutlass_to_torch_dtype(out_dtype_cutlass),
@@ -595,14 +658,14 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
                 f"out must have dtype {expected_out_dtype}, got {out.dtype}"
             )
 
-    # Get SM count
+    cluster_size = cluster_shape_mn[0] * cluster_shape_mn[1]
+    max_active_clusters = get_max_active_clusters(cluster_size)
     if sm_count is None:
         sm_count = get_num_sm(a.device)
-
-    # Compute max active clusters (cached to avoid expensive HardwareInfo queries)
-    max_active_clusters = get_max_active_clusters(
-        cluster_shape_mn[0] * cluster_shape_mn[1]
-    )
+    else:
+        max_from_sm = max(1, int(sm_count) // cluster_size)
+        if max_from_sm < max_active_clusters:
+            max_active_clusters = max_from_sm
 
     tile_size = mma_tiler[0] if is_rubin else mma_tiler_mn[0]
 
@@ -653,6 +716,30 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
     else:
         a_per_token_scale_ptr = None
 
+    enable_tile_signal = tile_ready is not None
+    if enable_tile_signal:
+        if tile_ready.dtype != torch.int32 or not tile_ready.is_contiguous():
+            raise ValueError("tile_ready must be a contiguous int32 CUDA tensor")
+        if tile_ready.device.type != "cuda":
+            raise ValueError("tile_ready must be on CUDA")
+        needed = gemm2_tile_ready_numel(permuted_m, n, mma_tiler_mn)
+        if int(tile_ready.numel()) < needed:
+            raise ValueError(
+                f"tile_ready must have at least {needed} flags "
+                f"(permuted_m={permuted_m}, n={n}, mma_tiler_mn={mma_tiler_mn}), "
+                f"got {int(tile_ready.numel())}"
+            )
+        tile_ready_ptr = make_ptr(
+            cutlass.Int32, tile_ready.data_ptr(), cute.AddressSpace.gmem
+        )
+    else:
+        tile_ready_ptr = None
+    if (enable_tile_signal or store_permuted_c) and is_rubin:
+        raise NotImplementedError(
+            "enable_tile_signal and store_permuted_c require the Blackwell "
+            "finalize kernel; Rubin is not supported."
+        )
+
     # Get CUDA stream
     torch_stream = torch.cuda.current_stream()
     stream = cuda.CUstream(torch_stream.cuda_stream)
@@ -676,6 +763,7 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         num_tiles_ptr=num_tiles_ptr,
         token_scales_ptr=token_scales_ptr,
         a_per_token_scale_ptr=a_per_token_scale_ptr,
+        tile_ready_ptr=tile_ready_ptr,
         max_active_clusters=max_active_clusters,
         stream=stream,
         sf_vec_size=sf_vec_size,
@@ -693,15 +781,21 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
         use_a_per_token_scale=use_a_per_token_scale,
+        enable_tile_signal=enable_tile_signal,
+        store_permuted_c=store_permuted_c,
     )
+
+    # Compile (above) may device-sync. JIT overlapping kernels here, then
+    # queue GEMM2, then launch any flag-waiter (after_launch).
+    if before_launch is not None:
+        before_launch()
 
     # Execute kernel with runtime parameters.
     # Order must match the wrapper signature; the Rubin SM107 wrapper has no
-    # a_per_token_scale_ptr parameter (see the arity note at the compile site),
-    # so on Rubin the extra pointer must be omitted here too.
+    # a_per_token_scale_ptr / tile_ready_ptr parameters.
     # (a_ptr, b_ptr, a_sf_ptr, b_sf_ptr, c_ptr, alpha_ptr, tile_idx_ptr,
     #  mn_limit_ptr, permuted_idx_ptr, num_tiles_ptr, token_scales_ptr,
-    #  [a_per_token_scale_ptr], m, n, k, l, num_tokens, top_k, stream)
+    #  [a_per_token_scale_ptr, tile_ready_ptr], m, n, k, l, num_tokens, top_k, stream)
     compiled_gemm(
         a_ptr,
         b_ptr,
@@ -714,7 +808,7 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         permuted_idx_ptr,
         num_tiles_ptr,
         token_scales_ptr,
-        *([] if is_rubin else [a_per_token_scale_ptr]),
+        *([] if is_rubin else [a_per_token_scale_ptr, tile_ready_ptr]),
         permuted_m,
         n,
         k,
@@ -723,6 +817,8 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion(
         topk,
         stream=stream,
     )
+    if after_launch is not None:
+        after_launch()
 
     return out
 
@@ -755,6 +851,10 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
     sm_count: Optional[int] = None,
     enable_pdl: bool = True,
     use_fused_finalize: bool = True,
+    tile_ready: Optional[torch.Tensor] = None,
+    store_permuted_c: bool = False,
+    before_launch: Optional[Callable[[], None]] = None,
+    after_launch: Optional[Callable[[], None]] = None,
 ) -> torch.Tensor:
     """Run the existing homogeneous NVFP4 GEMM2 finalize kernel."""
     warnings.warn(
@@ -790,6 +890,10 @@ def blockscaled_contiguous_grouped_gemm_finalize_fusion_nvfp4(
         sm_count=sm_count,
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
+        tile_ready=tile_ready,
+        store_permuted_c=store_permuted_c,
+        before_launch=before_launch,
+        after_launch=after_launch,
     )
 
 

--- a/flashinfer/fused_moe/cute_dsl/fused_moe.py
+++ b/flashinfer/fused_moe/cute_dsl/fused_moe.py
@@ -70,8 +70,8 @@ from ...tllm_enums import (
     DEFAULT_SWIGLU_BETA,
     DEFAULT_SWIGLU_LIMIT,
 )
-from ...autotuner import AutoTuner
-from ...cute_dsl.utils import convert_sf_to_mma_layout
+from ...autotuner import AutoTuner, is_in_profile_measurement
+from ...cute_dsl.utils import convert_sf_to_mma_layout, get_num_sm
 from ...cute_dsl.utils import require_cute_dsl_arch as _require_cute_dsl_arch_for
 from ...quantization.kernels.nvfp4_quantize import (
     SF_LAYOUT_128x4,
@@ -144,6 +144,94 @@ def _get_cuda_graph_resources() -> Dict[str, Any]:
 # =============================================================================
 # Core Implementation (Shared by Functional and Wrapper APIs)
 # =============================================================================
+
+# Must match TileReadyConsumerKernel default max_ctas. fused_moe cannot import moe_ep.
+_OVERLAP_CONSUMER_SMS = 8
+
+
+def _overlap_gemm2_sm_count(
+    device: torch.device, cluster_shape_mn: Tuple[int, int]
+) -> int:
+    """SMs left for GEMM2 after reserving persistent consumer CTAs."""
+    cluster_size = int(cluster_shape_mn[0]) * int(cluster_shape_mn[1])
+    if cluster_size < 1:
+        raise ValueError(f"invalid GEMM2 cluster_shape_mn={cluster_shape_mn}")
+    usable = int(get_num_sm(device)) - _OVERLAP_CONSUMER_SMS
+    usable = (usable // cluster_size) * cluster_size
+    return max(cluster_size, usable)
+
+
+def _publish_tile_signal_state(
+    tile_signal_state: Optional[Dict[str, Any]],
+    tile_ready: Optional[torch.Tensor],
+    permuted_idx: torch.Tensor,
+    gemm2_c: torch.Tensor,
+    gemm2_mma_tiler_mn: Tuple[int, int],
+    gemm2_cluster_shape_mn: Tuple[int, int],
+    num_non_exiting_tiles: torch.Tensor,
+) -> None:
+    """Zero flags, record gemm2_ready_event, stash maps for the consumer.
+
+    Compile the consumer after GEMM2 ``cute.compile`` (no launch). Queue GEMM2
+    next, then launch the consumer so a flag-waiter is never live across a
+    GEMM2 host sync or a persistent-grid occupancy check.
+    """
+    if tile_signal_state is None:
+        return
+    if tile_ready is None and tile_signal_state.get("on_gemm2_ready") is None:
+        return
+    if tile_ready is not None:
+        tile_ready.zero_()
+    event = tile_signal_state.get("gemm2_ready_event")
+    if event is None:
+        event = torch.cuda.Event()
+        tile_signal_state["gemm2_ready_event"] = event
+    event.record()
+    tile_signal_state["tile_ready"] = tile_ready
+    tile_signal_state["permuted_idx"] = permuted_idx
+    tile_signal_state["gemm2_c"] = gemm2_c
+    tile_signal_state["gemm2_mma_tiler_mn"] = gemm2_mma_tiler_mn
+    tile_signal_state["gemm2_cluster_shape_mn"] = gemm2_cluster_shape_mn
+    tile_signal_state["num_non_exiting_tiles"] = num_non_exiting_tiles
+    tile_signal_state["permuted_m"] = int(gemm2_c.shape[0])
+
+
+def _overlap_consumer_armed(tile_signal_state: Optional[Dict[str, Any]]) -> bool:
+    return (
+        tile_signal_state is not None
+        and tile_signal_state.get("on_gemm2_ready") is not None
+    )
+
+
+def _compile_overlap_consumer(tile_signal_state: Optional[Dict[str, Any]]) -> None:
+    """JIT the consumer without launching it. Skip CUDA-graph capture."""
+    if not _overlap_consumer_armed(tile_signal_state):
+        return
+    if torch.cuda.is_current_stream_capturing():
+        return
+    assert tile_signal_state is not None
+    tile_signal_state["consumer_compile_only"] = True
+    try:
+        tile_signal_state["on_gemm2_ready"](tile_signal_state)
+    finally:
+        tile_signal_state["consumer_compile_only"] = False
+
+
+def _launch_overlap_consumer(tile_signal_state: Optional[Dict[str, Any]]) -> None:
+    """Launch the second-stream consumer if armed.
+
+    Skip CUDA-graph capture and autotune tactic profiling so ``shipped_rows``
+    counts one winner launch, not every profile replay.
+    """
+    if not _overlap_consumer_armed(tile_signal_state):
+        return
+    if torch.cuda.is_current_stream_capturing():
+        return
+    if is_in_profile_measurement():
+        return
+    assert tile_signal_state is not None
+    tile_signal_state["consumer_compile_only"] = False
+    tile_signal_state["on_gemm2_ready"](tile_signal_state)
 
 
 def validate_w4a8_inputs(
@@ -235,6 +323,10 @@ def _moe_core_impl(
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
     situ_beta: Optional[float] = None,
     situ_linear_beta: Optional[float] = None,
+    tile_ready: Optional[torch.Tensor] = None,
+    tile_signal_state: Optional[Dict[str, Any]] = None,
+    store_permuted_c: bool = False,
+    gemm2_c: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Core MoE implementation shared by functional and wrapper APIs.
 
@@ -290,6 +382,11 @@ def _moe_core_impl(
         swiglu_limit: SwiGLU clamp limit.
         situ_beta: When set with ActivationType.Swiglu, use the SiTU gate.
         situ_linear_beta: Optional SiTU tanh clamp for the up branch.
+        tile_ready: Optional GEMM2 per-tile ready flags (int32).
+        tile_signal_state: Optional dict stashed for a second-stream consumer.
+        store_permuted_c: Write dense ``C[permuted_m, H]`` instead of fused
+            finalize scatter. Dest combine applies routing weights.
+        gemm2_c: Optional preallocated dense C workspace when store_permuted_c.
 
     Returns:
         Output tensor [num_tokens, hidden_size].
@@ -344,7 +441,9 @@ def _moe_core_impl(
         )
 
     # Fused finalize overlaps output zeroing with GEMM1.
-    if use_async_memset and use_fused_finalize:
+    # store_permuted_c writes dense C and does not touch moe_output.
+    do_fused_memset = use_async_memset and use_fused_finalize and not store_permuted_c
+    if do_fused_memset:
         if aux_stream is None or main_event is None or memset_event is None:
             resources = _get_cuda_graph_resources()
             aux_stream = aux_stream or resources["aux_stream"]
@@ -382,7 +481,7 @@ def _moe_core_impl(
         kernel_num_non_exiting_tiles = num_non_exiting_tiles
 
     # Record event for async memset synchronization
-    if use_async_memset and use_fused_finalize:
+    if do_fused_memset:
         main_event.record()
         moe_output.record_stream(aux_stream)
 
@@ -456,8 +555,19 @@ def _moe_core_impl(
         )
 
     # Atomic finalize requires a zeroed token output. Deterministic finalize
-    # writes each route to a unique expanded row.
-    if use_fused_finalize:
+    # writes each route to a unique expanded row. store_permuted_c writes
+    # dense C[permuted_m, H] for a second-stream dest combine.
+    permuted_m = int(permuted_idx_to_expanded_idx.shape[0])
+    if store_permuted_c:
+        if gemm2_c is None or int(gemm2_c.shape[0]) < permuted_m:
+            gemm2_output = torch.empty(
+                (permuted_m, hidden_size),
+                dtype=output_dtype,
+                device=x.device,
+            )
+        else:
+            gemm2_output = gemm2_c[:permuted_m]
+    elif use_fused_finalize:
         if use_async_memset:
             with torch.cuda.stream(aux_stream):
                 main_event.wait()
@@ -474,7 +584,22 @@ def _moe_core_impl(
             device=x.device,
         )
 
-    # Step 3: GEMM2 with optional atomic finalize
+    _publish_tile_signal_state(
+        tile_signal_state,
+        tile_ready,
+        permuted_idx_to_expanded_idx,
+        gemm2_output,
+        gemm2_mma_tiler_mn,
+        gemm2_cluster_shape_mn,
+        kernel_num_non_exiting_tiles,
+    )
+
+    # Step 3: GEMM2 with optional atomic finalize.
+    # Overlap: compile consumer after GEMM2 JIT, queue GEMM2, then launch
+    # the spinner. Leave consumer SMs out of the persistent GEMM2 grid.
+    gemm2_sm_count = None
+    if _overlap_consumer_armed(tile_signal_state):
+        gemm2_sm_count = _overlap_gemm2_sm_count(x.device, gemm2_cluster_shape_mn)
     blockscaled_contiguous_grouped_gemm_finalize_fusion(
         a=intermediate,
         b=w2_weight,
@@ -497,12 +622,17 @@ def _moe_core_impl(
         mma_tiler=gemm2_mma_tiler,
         mma_inst_shape=gemm2_mma_inst_shape,
         cluster_shape_mn=gemm2_cluster_shape_mn,
+        sm_count=gemm2_sm_count,
         enable_pdl=enable_pdl,
         use_fused_finalize=use_fused_finalize,
+        tile_ready=tile_ready,
+        store_permuted_c=store_permuted_c,
+        before_launch=lambda: _compile_overlap_consumer(tile_signal_state),
+        after_launch=lambda: _launch_overlap_consumer(tile_signal_state),
     )
 
     # Step 4: Deterministic routing-weight reduction
-    if not use_fused_finalize:
+    if not use_fused_finalize and not store_permuted_c:
         moe_unpermute(
             permuted_input=gemm2_output,
             output=moe_output,
@@ -855,6 +985,7 @@ class CuteDslMoEWrapper:
             swiglu_limit=self.swiglu_limit,
             situ_beta=self.situ_beta,
             situ_linear_beta=self.situ_linear_beta,
+            **kwargs,
         )
 
     @flashinfer_api(trace=cute_dsl_moe_wrapper_run_trace)
@@ -1076,6 +1207,10 @@ def _cute_dsl_fused_moe_impl(
     swiglu_limit: float = DEFAULT_SWIGLU_LIMIT,
     situ_beta: Optional[float] = None,
     situ_linear_beta: Optional[float] = None,
+    tile_ready: Optional[torch.Tensor] = None,
+    tile_signal_state: Optional[Dict[str, Any]] = None,
+    store_permuted_c: bool = False,
+    gemm2_c: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Internal implementation called by auto-tuner for functional API."""
     return _moe_core_impl(
@@ -1116,6 +1251,10 @@ def _cute_dsl_fused_moe_impl(
         swiglu_limit=swiglu_limit,
         situ_beta=situ_beta,
         situ_linear_beta=situ_linear_beta,
+        tile_ready=tile_ready,
+        tile_signal_state=tile_signal_state,
+        store_permuted_c=store_permuted_c,
+        gemm2_c=gemm2_c,
     )
 
 

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -505,6 +505,8 @@ class CuteDslFusedMoERunner(TunableRunner):
         situ_linear_beta: Optional[float] = None,
         use_per_token_activation: bool = False,
         quant_mode: str = "w4a4",
+        enable_tile_signal: bool = False,
+        store_permuted_c: bool = False,
     ):
         activation_type, gated = normalize_cute_dsl_moe_activation_type(activation_type)
         validate_cute_dsl_moe_situ_config(activation_type, situ_beta, situ_linear_beta)
@@ -530,6 +532,11 @@ class CuteDslFusedMoERunner(TunableRunner):
         self.situ_linear_beta = situ_linear_beta
         self.use_per_token_activation = use_per_token_activation
         self.quant_mode = quant_mode
+        self.enable_tile_signal = enable_tile_signal
+        self.store_permuted_c = store_permuted_c
+        self.tile_signal_state: Optional[Dict[str, Any]] = None
+        self.tile_ready: Optional[torch.Tensor] = None
+        self.gemm2_c: Optional[torch.Tensor] = None
 
         # Helper that builds a deterministic balanced approx-max-load
         # assignment for token_selected_experts during autotune profiling.
@@ -660,6 +667,8 @@ class CuteDslFusedMoERunner(TunableRunner):
                 self.situ_linear_beta,
                 self.use_per_token_activation,
                 self.quant_mode,
+                self.enable_tile_signal,
+                self.store_permuted_c,
             )
         )
 
@@ -677,6 +686,8 @@ class CuteDslFusedMoERunner(TunableRunner):
             self.use_fused_finalize,
             self.output_dtype,
             self.enable_pdl,
+            self.enable_tile_signal,
+            self.store_permuted_c,
         )
 
     def get_valid_tactics(  # type: ignore[override]
@@ -734,6 +745,14 @@ class CuteDslFusedMoERunner(TunableRunner):
 
         def _tactic_ok(tactic):
             tile_size, gemm1_tactic, gemm2_tactic = tactic
+            if self.enable_tile_signal or self.store_permuted_c:
+                if _is_rubin_tactic(tactic):
+                    return False
+                if tile_size != 128:
+                    return False
+                gemm2_mma_tiler_mn, gemm2_cluster_shape_mn, _ = gemm2_tactic
+                if gemm2_mma_tiler_mn != (128, 128) or gemm2_cluster_shape_mn != (1, 1):
+                    return False
             permuted_m = get_max_num_permuted_tokens(
                 num_tokens, self.top_k, self.num_local_experts, tile_size
             )
@@ -964,6 +983,10 @@ class CuteDslFusedMoERunner(TunableRunner):
             swiglu_limit=self.swiglu_limit,
             situ_beta=self.situ_beta,
             situ_linear_beta=self.situ_linear_beta,
+            tile_ready=kwargs.pop("tile_ready", self.tile_ready),
+            tile_signal_state=kwargs.pop("tile_signal_state", self.tile_signal_state),
+            store_permuted_c=kwargs.pop("store_permuted_c", self.store_permuted_c),
+            gemm2_c=kwargs.pop("gemm2_c", self.gemm2_c),
             **kwargs,
         )
 

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -68,6 +68,7 @@ from .api import (
     SwiGLUStep,
     # Unified config and pack types
     ActivationType,
+    CuteDslConfig,
     MoEActivationPack,
     MoEConfig,
     MoEWeightPack,
@@ -3850,6 +3851,16 @@ class CuteDslRunner(MoERunner):
         self.device = torch.device(device)
         self._inner: Any = None
         self.tuning_config = TuningConfig()
+        self._enable_tile_signal = False
+        self._store_permuted_c = False
+        for candidate in config.backend:
+            if isinstance(candidate, CuteDslConfig):
+                self._enable_tile_signal = bool(candidate.enable_tile_signal)
+                self._store_permuted_c = bool(candidate.store_permuted_c)
+                break
+        self.tile_signal_state: dict[str, Any] = {}
+        self._tile_ready: torch.Tensor | None = None
+        self._gemm2_c: torch.Tensor | None = None
 
     def _build(self) -> None:
         """Create the shape-independent CuTe DSL tuning runner."""
@@ -3882,8 +3893,11 @@ class CuteDslRunner(MoERunner):
                     if self.config.quant.variant is QuantVariant.MXFP4
                     else "w4a4"
                 ),
+                enable_tile_signal=self._enable_tile_signal,
+                store_permuted_c=self._store_permuted_c,
                 **_cute_dsl_activation_kwargs(self.config.activation),
             )
+            self._inner.tile_signal_state = self.tile_signal_state
         elif self.config.quant.variant is QuantVariant.W4A16:
             self._inner = CuteDslFusedMoEW4A16Runner(
                 num_experts=routing.num_experts,
@@ -3911,7 +3925,47 @@ class CuteDslRunner(MoERunner):
         return super()._cache_key_extras() + (
             bool(self._inner.use_fused_finalize),
             bool(self._inner.enable_pdl),
+            bool(self._enable_tile_signal),
+            bool(self._store_permuted_c),
         )
+
+    def _ensure_tile_ready(self, num_tokens: int, hidden_size: int) -> torch.Tensor:
+        from .cute_dsl.blockscaled_contiguous_grouped_gemm_finalize_fusion import (
+            gemm2_tile_ready_numel,
+        )
+        from .cute_dsl.moe_utils import get_max_num_permuted_tokens
+
+        nle = self.config.experts.local_num_experts or self.config.routing.num_experts
+        permuted_m = get_max_num_permuted_tokens(
+            num_tokens, self._inner.top_k, nle, tile_size=128
+        )
+        needed = gemm2_tile_ready_numel(permuted_m, hidden_size, (128, 128))
+        buf = self._tile_ready
+        if buf is None or int(buf.numel()) < needed:
+            buf = torch.zeros(needed, dtype=torch.int32, device=self.device)
+            self._tile_ready = buf
+        return buf
+
+    def _ensure_gemm2_c(self, num_tokens: int, hidden_size: int) -> torch.Tensor:
+        from .cute_dsl.moe_utils import get_max_num_permuted_tokens
+
+        nle = self.config.experts.local_num_experts or self.config.routing.num_experts
+        permuted_m = get_max_num_permuted_tokens(
+            num_tokens, self._inner.top_k, nle, tile_size=128
+        )
+        buf = self._gemm2_c
+        if (
+            buf is None
+            or int(buf.shape[0]) < permuted_m
+            or int(buf.shape[1]) != hidden_size
+        ):
+            buf = torch.empty(
+                (permuted_m, hidden_size),
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+            self._gemm2_c = buf
+        return buf
 
     def forward(
         self,
@@ -3921,8 +3975,20 @@ class CuteDslRunner(MoERunner):
         **kwargs: Any,
     ) -> torch.Tensor:
         self._require_built()
+        extra: dict[str, Any] = {
+            "store_permuted_c": self._store_permuted_c,
+            "tile_signal_state": self.tile_signal_state,
+        }
+        if self.config.quant.variant is QuantVariant.NVFP4 and (
+            self._enable_tile_signal or self._store_permuted_c
+        ):
+            num_tokens = int(inputs[0].shape[0])
+            hidden_size = int(inputs[0].shape[1]) * 2  # NVFP4 packed
+            extra["tile_ready"] = self._ensure_tile_ready(num_tokens, hidden_size)
+            extra["gemm2_c"] = self._ensure_gemm2_c(num_tokens, hidden_size)
+        extra.update(kwargs)
         return self._inner.forward(
-            inputs, tactic=tactic, do_preparation=do_preparation, **kwargs
+            inputs, tactic=tactic, do_preparation=do_preparation, **extra
         )
 
     def pack_inputs(

--- a/flashinfer/moe_ep/backends/split/kernel/fused_moe/backend.py
+++ b/flashinfer/moe_ep/backends/split/kernel/fused_moe/backend.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+import torch.distributed as dist
 
 from .....config import BootstrapConfig, EpAlgorithm, EpLayout, FleetParams
 from .....core.kernel.base import SplitKernelBackend, SplitKernelContext
@@ -21,6 +24,19 @@ from .weights import materialize_fused_moe_weights
 
 if TYPE_CHECKING:
     from ......fused_moe.layer import MoELayer
+    from ...overlap import CombineInboxWorkspace
+
+
+_TILE_SIGNAL_STATE_KEYS = (
+    "tile_ready",
+    "permuted_idx",
+    "gemm2_c",
+    "gemm2_mma_tiler_mn",
+    "gemm2_cluster_shape_mn",
+    "num_non_exiting_tiles",
+    "permuted_m",
+    "gemm2_ready_event",
+)
 
 
 @register_split_kernel("fused_moe")
@@ -34,7 +50,17 @@ class FusedMoeSplitKernelBackend(SplitKernelBackend):
             )
         self._moe_config = config.moe_config
         self._mxfp8_dispatch = config.mxfp8_dispatch
+        self._overlap_combine_fn = config.overlap_combine_fn
         self._compute: Optional["MoELayer"] = None
+        self._overlap_enabled = False
+        self._inbox: Optional["CombineInboxWorkspace"] = None
+        self._consumer_stream: Optional[torch.cuda.Stream] = None
+        self._topk_all: Optional[torch.Tensor] = None
+        self._dest_fp: Optional[torch.Tensor] = None
+        self._src_info: Optional[torch.Tensor] = None
+        self._shipped_rows: Optional[torch.Tensor] = None
+        self._src_rank = 0
+        self.last_overlap_stats: dict[str, Any] = {}
 
     @classmethod
     def kernel_name(cls) -> str:
@@ -75,6 +101,210 @@ class FusedMoeSplitKernelBackend(SplitKernelBackend):
         )
         return self._transformed_weights
 
+    def _cute_dsl_flags(self) -> tuple[bool, bool]:
+        from ......fused_moe.api import CuteDslConfig
+
+        enable = False
+        store_c = False
+        for candidate in self._moe_config.backend:
+            if isinstance(candidate, CuteDslConfig):
+                enable = bool(candidate.enable_tile_signal)
+                store_c = bool(candidate.store_permuted_c)
+                break
+        return enable, store_c
+
+    def _overlap_wanted(self, fleet_params: FleetParams) -> bool:
+        from ......fused_moe.api import QuantVariant
+
+        enable, store_c = self._cute_dsl_flags()
+        if not (enable and store_c):
+            return False
+        if self._moe_config.quant.variant is not QuantVariant.NVFP4:
+            return False
+        if fleet_params.algorithm is not EpAlgorithm.LOW_LATENCY:
+            return False
+        if fleet_params.layout is not EpLayout.EXPERT_MAJOR:
+            return False
+        return True
+
+    def _cute_dsl_runner(self, layer: "MoELayer"):
+        for runner in layer.runners:
+            if getattr(runner, "backend_key", None) == "cute_dsl":
+                return runner
+        return None
+
+    def _ensure_overlap(self, ctx: SplitKernelContext) -> None:
+        from ...overlap import CombineInboxWorkspace, basic_overlap_combine
+
+        fleet = ctx.fleet_params
+        device = ctx.expert_tensors.device
+        world = dist.get_world_size() if dist.is_initialized() else 1
+        nle = int(
+            self._moe_config.experts.local_num_experts
+            or self._moe_config.routing.num_experts
+        )
+        tokens_per_rank = int(fleet.max_tokens_per_rank)
+        hidden = int(fleet.token_hidden_size)
+        if self._inbox is None:
+            self._inbox = CombineInboxWorkspace(
+                world_size=world,
+                num_local_experts=nle,
+                tokens_per_rank=tokens_per_rank,
+                hidden=hidden,
+                device=device,
+            )
+            self._consumer_stream = torch.cuda.Stream(device=device)
+            dest_k = (
+                int(ctx.dest_topk_ids.shape[1]) if ctx.dest_topk_ids is not None else 1
+            )
+            self._topk_all = torch.empty(
+                (world, tokens_per_rank, dest_k),
+                dtype=torch.int32,
+                device=device,
+            )
+            self._dest_fp = torch.empty(
+                (world, tokens_per_rank),
+                dtype=torch.int64,
+                device=device,
+            )
+            self._src_info = torch.full(
+                (nle, world * tokens_per_rank),
+                -1,
+                dtype=torch.int32,
+                device=device,
+            )
+            self._shipped_rows = torch.zeros(1, dtype=torch.int32, device=device)
+            self._src_rank = dist.get_rank() if dist.is_initialized() else 0
+            if self._overlap_combine_fn is None:
+                self._overlap_combine_fn = basic_overlap_combine
+        assert self._inbox is not None and self._shipped_rows is not None
+        self._inbox.zero()
+        self._shipped_rows.zero_()
+
+    def _arm_overlap(self, ctx: SplitKernelContext, layer: "MoELayer") -> None:
+        runner = self._cute_dsl_runner(layer)
+        if runner is None:
+            raise RuntimeError(
+                "fused-gemm2-combine requires the cute_dsl runner; "
+                "none is configured on MoELayer."
+            )
+        if ctx.dest_topk_ids is None:
+            raise RuntimeError(
+                "overlap combine requires dest topk_ids on SplitKernelContext"
+            )
+        if ctx.dest_hidden_states is None:
+            raise RuntimeError(
+                "overlap combine requires dest hidden_states on SplitKernelContext"
+            )
+        self._ensure_overlap(ctx)
+        fleet = ctx.fleet_params
+        tokens_per_rank = int(fleet.max_tokens_per_rank)
+        dest_ids = ctx.dest_topk_ids
+        if dest_ids.shape[0] > tokens_per_rank:
+            raise ValueError(
+                f"dest topk_ids tokens={int(dest_ids.shape[0])} exceeds "
+                f"max_tokens_per_rank={tokens_per_rank}"
+            )
+        local = torch.full(
+            (tokens_per_rank, int(dest_ids.shape[1])),
+            -1,
+            dtype=torch.int32,
+            device=dest_ids.device,
+        )
+        local[: dest_ids.shape[0]].copy_(dest_ids.to(dtype=torch.int32))
+        world = int(self._topk_all.shape[0])
+        topk_all_flat = self._topk_all.view(world * tokens_per_rank, -1)
+        consumer = self._consumer_stream
+        nle = int(
+            self._moe_config.experts.local_num_experts
+            or self._moe_config.routing.num_experts
+        )
+        offset = int(self._moe_config.experts.local_expert_offset)
+        from ...overlap import (
+            ROW_FP_UNUSED,
+            combine_src_info_from_packed,
+            row_fingerprint,
+        )
+
+        dest_h = ctx.dest_hidden_states
+        n_tok = min(int(dest_h.shape[0]), tokens_per_rank)
+        local_fp = torch.full(
+            (tokens_per_rank,),
+            ROW_FP_UNUSED,
+            dtype=torch.int64,
+            device=dest_h.device,
+        )
+        if n_tok > 0:
+            local_fp[:n_tok] = row_fingerprint(dest_h[:n_tok])
+
+        consumer.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(consumer):
+            if dist.is_initialized() and world > 1:
+                dist.all_gather_into_tensor(topk_all_flat, local)
+                dist.all_gather_into_tensor(self._dest_fp.view(-1), local_fp)
+            else:
+                self._topk_all[0].copy_(local)
+                self._dest_fp[0].copy_(local_fp)
+            combine_src_info_from_packed(
+                ctx.expert_tensors,
+                self._dest_fp,
+                self._topk_all,
+                local_expert_offset=offset,
+                num_local_experts=nle,
+                out=self._src_info,
+            )
+
+        state = runner.tile_signal_state
+        state["on_gemm2_ready"] = self._on_gemm2_ready
+        self._overlap_enabled = True
+
+    def _on_gemm2_ready(self, state: dict[str, Any]) -> None:
+        from ...overlap import launch_tile_ready_consumer
+
+        missing = [
+            k for k in _TILE_SIGNAL_STATE_KEYS if k not in state or state[k] is None
+        ]
+        if missing:
+            raise RuntimeError(f"tile_signal_state missing keys: {missing}")
+        inbox = self._inbox
+        consumer = self._consumer_stream
+        src_info = self._src_info
+        shipped_rows = self._shipped_rows
+        if (
+            inbox is None
+            or consumer is None
+            or src_info is None
+            or shipped_rows is None
+        ):
+            raise RuntimeError("overlap workspace was not armed in _arm_overlap")
+        compile_only = bool(state.get("consumer_compile_only"))
+        if not compile_only:
+            consumer.wait_event(state["gemm2_ready_event"])
+        nle = int(
+            self._moe_config.experts.local_num_experts
+            or self._moe_config.routing.num_experts
+        )
+        with torch.cuda.stream(consumer):
+            if not compile_only:
+                shipped_rows.zero_()
+            launch_tile_ready_consumer(
+                tile_ready=state["tile_ready"],
+                gemm2_c=state["gemm2_c"],
+                permuted_idx_to_expanded_idx=state["permuted_idx"],
+                mma_tiler_mn=state["gemm2_mma_tiler_mn"],
+                tokens_per_rank=int(inbox.tokens_per_rank),
+                world_size=int(inbox.world_size),
+                num_local_experts=nle,
+                num_non_exiting_tiles=state["num_non_exiting_tiles"],
+                permuted_m=int(state["permuted_m"]),
+                src_info=src_info,
+                peer_ptrs=inbox.peer_ptrs,
+                src_rank=self._src_rank,
+                shipped_rows=shipped_rows,
+                stream=consumer,
+                compile_only=compile_only,
+            )
+
     def _ensure_compute(self, fleet_params: FleetParams) -> "MoELayer":
         if self._compute is None:
             from ......fused_moe.layer import MoELayer
@@ -102,6 +332,9 @@ class FusedMoeSplitKernelBackend(SplitKernelBackend):
 
         fleet_params = ctx.fleet_params
         is_ht = fleet_params.algorithm is EpAlgorithm.HIGH_THROUGHPUT
+        layer = self._ensure_compute(fleet_params)
+        if self._overlap_wanted(fleet_params):
+            self._arm_overlap(ctx, layer)
         if is_ht or fleet_params.layout is EpLayout.RANK_MAJOR:
             if ctx.recv_topk_idx is None or ctx.recv_topk_weights is None:
                 raise RuntimeError(
@@ -129,5 +362,78 @@ class FusedMoeSplitKernelBackend(SplitKernelBackend):
                 hidden_size=fleet_params.token_hidden_size,
             )
 
-        out_2d = self._ensure_compute(fleet_params)(act_pack, self._transformed_weights)
+        out_2d = layer(act_pack, self._transformed_weights)
         return reshape_for_combine(out_2d, dim0, dim1)
+
+    def wait_overlap(self) -> None:
+        if not self._overlap_enabled or self._consumer_stream is None:
+            return
+        torch.cuda.current_stream().wait_stream(self._consumer_stream)
+
+    def collect_overlap_combine(
+        self,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> torch.Tensor:
+        if self._inbox is None or self._overlap_combine_fn is None:
+            raise RuntimeError("overlap combine was not armed for this iteration")
+        hidden = int(hidden_states.shape[-1])
+        live_rows = (
+            int(self._shipped_rows.item()) if self._shipped_rows is not None else 0
+        )
+        live_bytes = live_rows * hidden * 2
+        expected = 0
+        if self._topk_all is not None:
+            offset = int(self._moe_config.experts.local_expert_offset)
+            nle = int(
+                self._moe_config.experts.local_num_experts
+                or self._moe_config.routing.num_experts
+            )
+            expected = int(
+                ((self._topk_all >= offset) & (self._topk_all < offset + nle))
+                .sum()
+                .item()
+            )
+        pack_rows = (
+            int(self._inbox.num_local_experts)
+            * int(self._inbox.tokens_per_rank)
+            * int(self._inbox.world_size)
+        )
+        pack_bytes = pack_rows * hidden * 2
+        self.last_overlap_stats = {
+            "live_rows": live_rows,
+            "live_bytes": live_bytes,
+            "expected_rows": expected,
+            "pack_bytes": pack_bytes,
+        }
+        # Abort only if the consumer shipped the padded pack, or many more
+        # rows than dest-local top-k hits. Do not use pack/4: occupancy is
+        # topk/num_experts (50% on the 16-expert correctness geometry).
+        # live != expected is stats-only: autotune/graph can skip or replay
+        # the consumer. The pytest path asserts equality separately.
+        if pack_rows > 0 and live_rows >= pack_rows:
+            raise RuntimeError(
+                f"overlap ship live_rows={live_rows} is the full padded pack "
+                f"(pack_rows={pack_rows}); sparse live filter is not working"
+            )
+        if expected > 0 and live_rows > 2 * expected:
+            raise RuntimeError(
+                f"overlap ship live_rows={live_rows} >> expected_rows={expected} "
+                f"(pack_rows={pack_rows})"
+            )
+        return self._overlap_combine_fn(
+            self._inbox, hidden_states, topk_ids, topk_weights
+        )
+
+    def destroy(self) -> None:
+        if self._inbox is not None:
+            self._inbox.destroy()
+            self._inbox = None
+        self._consumer_stream = None
+        self._topk_all = None
+        self._dest_fp = None
+        self._src_info = None
+        self._shipped_rows = None
+        self._overlap_enabled = False
+        self._compute = None

--- a/flashinfer/moe_ep/backends/split/kernel/fused_moe/config.py
+++ b/flashinfer/moe_ep/backends/split/kernel/fused_moe/config.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from ......fused_moe.api import MoEConfig
+    from ...overlap.combine import OverlapCombineFn
 
 
 @dataclass
@@ -16,3 +17,4 @@ class FusedMoeKernelConfig:
     moe_config: "MoEConfig"
     kernel_name: str = "fused_moe"
     mxfp8_dispatch: bool = False
+    overlap_combine_fn: Optional["OverlapCombineFn"] = None

--- a/flashinfer/moe_ep/backends/split/overlap/__init__.py
+++ b/flashinfer/moe_ep/backends/split/overlap/__init__.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compute → combine overlap for the split EP path.
+
+This package is the seam between GEMM2 ``tile_ready`` flags and combine, not
+a fused-MoE GEMM and not an NCCL-EP handle. Launch the consumer on a second
+stream.
+
+The ship lives in its own kernel rather than in the GEMM2 epilogue because
+the epilogue-fused variant (peer stores issued straight from the epilogue)
+was tried first on the TRT-LLM NVFP4 MoE backend and performed badly there.
+Splitting it out makes tile completion an explicit, measurable signal. Folding
+it back into the GEMM2 warps is still worth retrying on this path — it would
+drop both the consumer's SM reservation and the flag round-trip — but keep the
+separate kernel as the baseline to beat.
+"""
+
+from .combine import OverlapCombineFn, basic_overlap_combine, weighted_reduce_inbox
+from .peer_inbox import CombineInboxWorkspace
+from .tile_ready_consumer import (
+    combine_src_info_from_packed,
+    expert_major_dest,
+    gemm2_cta_tile_mn,
+    gemm2_tile_ready_numel,
+    launch_tile_ready_consumer,
+    peer_ptrs_from_peer_out,
+    row_fingerprint,
+    ROW_FP_UNUSED,
+)
+
+__all__ = [
+    "CombineInboxWorkspace",
+    "OverlapCombineFn",
+    "basic_overlap_combine",
+    "combine_src_info_from_packed",
+    "expert_major_dest",
+    "gemm2_cta_tile_mn",
+    "gemm2_tile_ready_numel",
+    "launch_tile_ready_consumer",
+    "peer_ptrs_from_peer_out",
+    "row_fingerprint",
+    "ROW_FP_UNUSED",
+    "weighted_reduce_inbox",
+]

--- a/flashinfer/moe_ep/backends/split/overlap/combine.py
+++ b/flashinfer/moe_ep/backends/split/overlap/combine.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dest-side overlap combine algorithms.
+
+The tile-ready consumer ships GEMM2 rows into each dest rank's inbox. Combine
+turns that inbox into ``[tokens, hidden]`` like NCCL combine. Swap the
+callable on :class:`FusedMoeKernelConfig.overlap_combine_fn` (or pass it to
+:meth:`SplitKernelBackend.collect_overlap_combine` via the kernel) to try
+another algorithm without touching ship or GEMM2.
+
+Inbox layout is ``[world, num_local_experts, tokens_per_rank, hidden]``.
+Source rank ``S`` wrote dest ``D`` at ``inbox_D[S, local_expert, slot]``.
+Global expert id ``e`` maps to ``src = e // nle``, ``local_expert = e % nle``.
+Slot is the original token index on the home GPU. The consumer looks up that
+home GPU and index from the dispatch payload; it must not infer them from the
+dispatch-buffer column.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+import torch
+
+from .peer_inbox import CombineInboxWorkspace
+
+
+class OverlapCombineFn(Protocol):
+    """Dest-side combine after the tile-ready consumer has shipped.
+
+    Must return ``[tokens, hidden]`` with ``hidden_states`` dtype.
+    """
+
+    def __call__(
+        self,
+        inbox: CombineInboxWorkspace,
+        hidden_states: torch.Tensor,
+        topk_ids: torch.Tensor,
+        topk_weights: torch.Tensor,
+    ) -> torch.Tensor: ...
+
+
+def weighted_reduce_inbox(
+    inbox: CombineInboxWorkspace,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Weighted sum of EXPERT_MAJOR inbox rows into ``[tokens, hidden]``.
+
+    ``inbox`` is ``[world, num_local_experts, tokens_per_rank, hidden]``.
+    ``topk_ids`` are global expert ids. Does not wait for peers; the caller
+    must have already established visibility of shipped rows.
+    """
+    buf = inbox.inbox
+    if buf.dim() != 4:
+        raise ValueError(
+            "inbox must be [world, num_local_experts, tokens_per_rank, hidden], "
+            f"got {tuple(buf.shape)}"
+        )
+    world, nle, tokens_per_rank, hidden = buf.shape
+    if topk_ids.dim() != 2:
+        raise ValueError(
+            f"topk_ids must be [tokens, topk], got {tuple(topk_ids.shape)}"
+        )
+    tokens = int(topk_ids.shape[0])
+    if tokens > tokens_per_rank:
+        raise ValueError(
+            f"topk_ids tokens={tokens} exceeds inbox tokens_per_rank={tokens_per_rank}"
+        )
+    if int(hidden_states.shape[-1]) != hidden:
+        raise ValueError(
+            f"hidden_states hidden={int(hidden_states.shape[-1])} != inbox hidden={hidden}"
+        )
+    if tuple(topk_weights.shape) != tuple(topk_ids.shape):
+        raise ValueError(
+            f"topk_weights shape {tuple(topk_weights.shape)} != topk_ids {tuple(topk_ids.shape)}"
+        )
+
+    ids = topk_ids.to(dtype=torch.int64)
+    weights = topk_weights.to(dtype=torch.float32)
+    src = torch.div(ids, nle, rounding_mode="floor").clamp(0, world - 1)
+    local_e = (ids % nle).clamp(0, nle - 1)
+    slot = torch.arange(tokens, device=ids.device).unsqueeze(1).expand_as(ids)
+    contrib = buf[src, local_e, slot].to(dtype=torch.float32) * weights.unsqueeze(-1)
+    return contrib.sum(dim=1).to(dtype=hidden_states.dtype)
+
+
+def basic_overlap_combine(
+    inbox: CombineInboxWorkspace,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Default overlap combine: quorum all-reduce, then weighted inbox reduce.
+
+    The all-reduce is a device-ordered stand-in so dest sees every source's
+    stores after the consumer's ``fence.sys``. Replace this callable for
+    credit/arrival or a fused reduce kernel.
+    """
+    inbox.wait_peers()
+    return weighted_reduce_inbox(inbox, hidden_states, topk_ids, topk_weights)

--- a/flashinfer/moe_ep/backends/split/overlap/peer_inbox.py
+++ b/flashinfer/moe_ep/backends/split/overlap/peer_inbox.py
@@ -1,0 +1,184 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-rank MNNVL inboxes for the tile-ready combine ship path.
+
+Each rank owns ``inbox[src, local_expert, slot, hidden]``. The consumer on
+source rank ``S`` stores a finished GEMM2 row into dest rank ``D`` at
+``inbox_D[S, expert, slot]``. Dest-side reduce lives in :mod:`.combine`.
+
+Multi-rank buffers are fabric-mapped via :class:`MnnvlMemory` (GB200 MNNVL).
+Classic ``cudaIpcOpenMemHandle`` is same-node only and fails on Blyris 2-node
+with ``invalid resource handle``. World-size 1 keeps a local ``cudaMalloc``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import List
+
+import torch
+import torch.distributed as dist
+
+from flashinfer.comm.dlpack_utils import pack_strided_memory
+
+
+def _gpus_per_node() -> int:
+    raw = os.environ.get("LOCAL_WORLD_SIZE")
+    if raw is not None:
+        return max(1, int(raw))
+    n = torch.cuda.device_count()
+    return max(1, int(n) if n else 1)
+
+
+def _wrap_bf16(
+    ptr: int, nbytes: int, shape: tuple[int, ...], dev_id: int
+) -> torch.Tensor:
+    wrapped = pack_strided_memory(ptr, nbytes, nbytes, 1, torch.bfloat16, dev_id)
+    flat = wrapped.view(torch.bfloat16)
+    inbox = flat.reshape(shape)
+    inbox._capsule_wrapper = getattr(wrapped, "_capsule_wrapper", None)
+    return inbox
+
+
+def _alloc_mnnvl(nbytes: int) -> tuple[object, List[int]]:
+    from flashinfer.comm.comm_backend import TorchDistBackend
+    from flashinfer.comm.mapping import Mapping
+    from flashinfer.comm.mnnvl import MnnvlConfig, MnnvlMemory
+
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    group = dist.group.WORLD
+    MnnvlMemory.initialize()
+    mapping = Mapping(
+        world_size=world_size,
+        rank=rank,
+        gpus_per_node=_gpus_per_node(),
+        tp_size=world_size,
+    )
+    backend = TorchDistBackend(group)
+    MnnvlMemory.set_comm_from_config(mapping, MnnvlConfig(comm_backend=backend))
+    mem = MnnvlMemory(mapping, nbytes)
+    pointers = [int(mem.ptr + i * mem.rank_stride) for i in range(world_size)]
+    return mem, pointers
+
+
+class CombineInboxWorkspace:
+    """MNNVL-mapped ``[world, nle, tokens_per_rank, hidden]`` bf16 inbox."""
+
+    def __init__(
+        self,
+        world_size: int,
+        num_local_experts: int,
+        tokens_per_rank: int,
+        hidden: int,
+        device: torch.device,
+    ) -> None:
+        if world_size <= 0 or num_local_experts <= 0:
+            raise ValueError("world_size and num_local_experts must be positive")
+        if tokens_per_rank <= 0 or hidden <= 0:
+            raise ValueError("tokens_per_rank and hidden must be positive")
+        if hidden % 2 != 0:
+            raise ValueError(f"hidden must be even for 4-byte copies, got {hidden}")
+
+        self.world_size = int(world_size)
+        self.num_local_experts = int(num_local_experts)
+        self.tokens_per_rank = int(tokens_per_rank)
+        self.hidden = int(hidden)
+        self.device = device
+
+        shape = (
+            self.world_size,
+            self.num_local_experts,
+            self.tokens_per_rank,
+            self.hidden,
+        )
+        nbytes = int(
+            self.world_size
+            * self.num_local_experts
+            * self.tokens_per_rank
+            * self.hidden
+            * 2
+        )
+        self._group = dist.group.WORLD if dist.is_initialized() else None
+        self._mnnvl = None
+        self._local_malloc_ptr = None
+        self._pointers: List[int] = []
+        self._keepalive: list[object] = []
+
+        if dist.is_initialized() and self.world_size > 1:
+            mem, pointers = _alloc_mnnvl(nbytes)
+            self._mnnvl = mem
+            self._pointers = pointers
+            self._keepalive.append(mem)
+            rank = dist.get_rank()
+            local_ptr = pointers[rank]
+            dev_id = int(
+                device.index
+                if device.index is not None
+                else torch.cuda.current_device()
+            )
+            local = _wrap_bf16(local_ptr, nbytes, shape, dev_id)
+            self._keepalive.append(local)
+            self.inbox = local
+        else:
+            from flashinfer.comm.cuda_ipc import cudart
+
+            local_ptr = cudart.cudaMalloc(nbytes)
+            self._local_malloc_ptr = local_ptr
+            ptr = int(local_ptr.value)
+            self._pointers = [ptr]
+            dev_id = int(
+                device.index
+                if device.index is not None
+                else torch.cuda.current_device()
+            )
+            local = _wrap_bf16(ptr, nbytes, shape, dev_id)
+            self._keepalive.append(local)
+            self.inbox = local
+
+        self.inbox.zero_()
+        self.peer_ptrs = torch.tensor(self._pointers, device=device, dtype=torch.int64)
+        self._quorum = torch.ones(1, device=device, dtype=torch.int32)
+
+    def zero(self) -> None:
+        self.inbox.zero_()
+
+    def wait_peers(self) -> None:
+        """Device-ordered quorum so dest sees every source's sys stores."""
+        if not dist.is_initialized() or dist.get_world_size() <= 1:
+            return
+        self._quorum.fill_(1)
+        dist.all_reduce(self._quorum, group=self._group)
+
+    def destroy(self) -> None:
+        self.inbox = None  # type: ignore[assignment]
+        self.peer_ptrs = None  # type: ignore[assignment]
+        self._quorum = None
+        self._keepalive = []
+        self._pointers = []
+        mem = self._mnnvl
+        self._mnnvl = None
+        if mem is not None:
+            from flashinfer.comm.mnnvl import MnnvlMemory
+
+            ptr = getattr(mem, "ptr", None)
+            if ptr is not None:
+                MnnvlMemory.close_mnnvl_memory(ptr)
+        if self._local_malloc_ptr is not None:
+            import ctypes
+
+            from flashinfer.comm.cuda_ipc import cudart
+
+            cudart.cudaFree(ctypes.c_void_p(int(self._local_malloc_ptr.value)))
+            self._local_malloc_ptr = None

--- a/flashinfer/moe_ep/backends/split/overlap/tile_ready_consumer.py
+++ b/flashinfer/moe_ep/backends/split/overlap/tile_ready_consumer.py
@@ -1,0 +1,881 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GEMM2 ``tile_ready`` consumer: wait flags, then ship dense permuted ``C``.
+
+Producer contract (GEMM2 epilogue, opt-in ``tile_ready``)
+---------------------------------------------------------
+* One ``int32`` flag per CTA output tile, index ``m_tile * num_n_tiles + n_tile``.
+* ``cta_m`` / ``cta_n`` follow :func:`gemm2_cta_tile_mn` (pinned 128 x 128
+  on the fused-gemm2-combine path). A band is ``cta_m`` **permuted** rows.
+* Store is ``st.release.gpu`` of ``1``. This kernel pairs it with
+  ``ld.acquire.gpu``. The caller zeros the buffer before each GEMM2 launch.
+* Flags live in permuted GEMM M-space. Payload is dense ``C[p, :]``.
+
+Wait rule (Finding 009)
+-----------------------
+A band is hidden-complete only after **every** column tile is flagged.
+Wait only GEMM2's live M-tiles (``num_non_exiting_tiles``).
+
+Combine dest
+------------
+Each GEMM row is one expert output for one dispatched token. Combine sends it
+back to that token's **home GPU** at that token's **original index**.
+
+``permuted_idx[p]`` is only the dispatch-buffer row (which local expert).
+Home GPU and original index live in ``src_info`` from
+:func:`combine_src_info_from_packed` (packed as
+``home_rank * tokens_per_rank + token_index``, ``-1`` unused). Skip
+``expanded < 0`` and ``src_info < 0``. Do not infer the home GPU from the
+dispatch-buffer column.
+
+Ship is ``m02_ship<K>``: 16-byte ``ld.global.v4.u32`` / ``st.global.v4.u32``,
+K loads issued before any store, one ``fence.sys`` per CTA at kernel exit.
+Default ``K=8``, ``threads=256``, ``max_ctas=8``. Consecutive live ``p`` with
+contiguous inbox addresses become one bulk put (in-kernel RLE).
+
+Launch on a **second stream** after GEMM2 is queued; do not PDL-wait on GEMM2.
+JIT with ``compile_only=True`` before the GEMM2 host launch so a flag-waiter
+is never live across that invoke.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import torch
+from cutlass import BFloat16, Int32, Int64
+from cutlass._mlir.dialects import llvm
+from cutlass.cutlass_dsl import dsl_user_op
+
+from flashinfer.cute_dsl.fp4_common import (
+    get_ptr_as_int64,
+    ld_global_v4_u32,
+    st_global_v4_u32,
+)
+from flashinfer.cute_dsl.utils import make_ptr
+
+# Re-exported so the consumer and the GEMM2 producer can never disagree on the
+# flag-buffer geometry.
+from flashinfer.fused_moe.cute_dsl.blockscaled_contiguous_grouped_gemm_finalize_fusion import (  # noqa: E501
+    gemm2_cta_tile_mn,
+    gemm2_tile_ready_numel,
+)
+
+_SHIP_UNROLLS = (1, 2, 4, 8)
+
+
+def expert_major_dest(
+    expanded: int, tokens_per_rank: int, world_size: int
+) -> Tuple[int, int, int]:
+    """Map an EXPERT_MAJOR pack row to ``(expert, dest_rank, window_slot)``.
+
+    ``window_slot`` is the dense index inside the dest-rank window, not the
+    dest token index. Use :func:`combine_src_info_from_packed` for the token.
+    """
+    cap = tokens_per_rank * world_size
+    expert = expanded // cap
+    local_slot = expanded % cap
+    dest_rank = local_slot // tokens_per_rank
+    window_slot = local_slot % tokens_per_rank
+    return expert, dest_rank, window_slot
+
+
+# Unused dest / padding fingerprint. Chosen so a live bf16 row cannot match it
+# via :func:`_row_fingerprint` (4x int16 packed into int64).
+_FP_UNUSED = torch.iinfo(torch.int64).max
+
+
+def _row_fingerprint(x: torch.Tensor) -> torch.Tensor:
+    """Pack the first four bf16 bit-patterns of each row into ``int64``."""
+    if x.shape[-1] < 4:
+        raise ValueError(
+            f"fingerprint needs hidden >= 4, got hidden={int(x.shape[-1])}"
+        )
+    head = x[..., :4].contiguous().view(torch.int16).to(torch.int64) & 0xFFFF
+    return (
+        head[..., 0]
+        | (head[..., 1] << 16)
+        | (head[..., 2] << 32)
+        | (head[..., 3] << 48)
+    )
+
+
+row_fingerprint = _row_fingerprint
+ROW_FP_UNUSED = _FP_UNUSED
+
+
+def combine_src_info_from_packed(
+    packed: torch.Tensor,
+    dest_fp_all: torch.Tensor,
+    topk_all: torch.Tensor,
+    *,
+    local_expert_offset: int,
+    num_local_experts: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Build combine ``src_info`` from the dispatch payload permutation.
+
+    Combine is: send this expert output back to the GPU that owned the token,
+    at that token's original index. Dispatch does not keep tokens in home-GPU
+    order, so this matches packed activations to dest hidden states.
+
+    Stored value is ``home_rank * tokens_per_rank + token_index`` (``-1`` unused).
+
+    ``packed`` is ``[num_local_experts, world * tpr, hidden]``. ``dest_fp_all``
+    is ``[world, tpr]`` int64 from :func:`_row_fingerprint` on dest hidden
+    states. ``topk_all`` is ``[world, tpr, dest_top_k]``. Returns
+    ``int32 [num_local_experts, world * tpr]``; unused slots are ``-1``.
+    """
+    if packed.dim() != 3:
+        raise ValueError(
+            "packed must be [num_local_experts, world * tpr, hidden], "
+            f"got {tuple(packed.shape)}"
+        )
+    if dest_fp_all.dim() != 2 or dest_fp_all.dtype != torch.int64:
+        raise ValueError(
+            "dest_fp_all must be int64 [world, tpr], "
+            f"got {dest_fp_all.dtype} {tuple(dest_fp_all.shape)}"
+        )
+    if topk_all.dim() != 3:
+        raise ValueError(
+            "topk_all must be [world, tokens_per_rank, dest_top_k], "
+            f"got {tuple(topk_all.shape)}"
+        )
+    world, tpr, _k = (int(s) for s in topk_all.shape)
+    cap = world * tpr
+    if int(packed.shape[0]) != num_local_experts or int(packed.shape[1]) != cap:
+        raise ValueError(
+            f"packed shape {tuple(packed.shape)} does not match "
+            f"num_local_experts={num_local_experts} cap={cap}"
+        )
+    if tuple(dest_fp_all.shape) != (world, tpr):
+        raise ValueError(
+            f"dest_fp_all shape {tuple(dest_fp_all.shape)} != ({world}, {tpr})"
+        )
+    if out is None:
+        src_info = torch.full(
+            (num_local_experts, cap),
+            -1,
+            dtype=torch.int32,
+            device=packed.device,
+        )
+    else:
+        if out.shape != (num_local_experts, cap) or out.dtype != torch.int32:
+            raise ValueError(
+                f"out must be int32 [{num_local_experts}, {cap}], got "
+                f"{out.dtype} {tuple(out.shape)}"
+            )
+        src_info = out
+        src_info.fill_(-1)
+
+    packed_fp = _row_fingerprint(packed)
+    device = packed.device
+    unused = torch.tensor(_FP_UNUSED, dtype=torch.int64, device=device)
+    neg1 = torch.tensor(-1, dtype=torch.int32, device=device)
+    home = (
+        torch.arange(world, device=device, dtype=torch.int64)
+        .unsqueeze(1)
+        .expand(world, tpr)
+    )
+    token = (
+        torch.arange(tpr, device=device, dtype=torch.int64)
+        .unsqueeze(0)
+        .expand(world, tpr)
+    )
+    loc = (home * tpr + token).reshape(-1)
+    nloc = world * tpr
+    for e in range(num_local_experts):
+        selected = topk_all.eq(local_expert_offset + e).any(dim=-1)
+        cand_fp = torch.where(selected, dest_fp_all, unused).reshape(-1)
+        order = torch.argsort(cand_fp)
+        sorted_fp = cand_fp[order]
+        sorted_loc = loc[order]
+        p_fp = packed_fp[e]
+        pos = torch.searchsorted(sorted_fp, p_fp).clamp(max=nloc - 1)
+        hit = (sorted_fp[pos] == p_fp) & (p_fp != unused)
+        src_info[e] = torch.where(hit, sorted_loc[pos].to(dtype=torch.int32), neg1)
+    return src_info
+
+
+def peer_ptrs_from_peer_out(peer_out: torch.Tensor) -> torch.Tensor:
+    """Build ``int64[world]`` bases from a contiguous 4-D peer tensor.
+
+    ``peer_out`` shape is ``[world, num_local_experts, tokens_per_rank, hidden]``.
+    """
+    if peer_out.dim() != 4:
+        raise ValueError(
+            "peer_out must be [world, num_local_experts, tokens_per_rank, hidden], "
+            f"got shape {tuple(peer_out.shape)}"
+        )
+    if not peer_out.is_contiguous():
+        raise ValueError("peer_out must be contiguous")
+    world = peer_out.shape[0]
+    rank_stride_bytes = peer_out.stride(0) * peer_out.element_size()
+    base = peer_out.data_ptr()
+    return (
+        torch.arange(world, device=peer_out.device, dtype=torch.int64)
+        * rank_stride_bytes
+        + base
+    )
+
+
+@dsl_user_op
+def _fence_sys(*, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [],
+        "fence.sys;",
+        "",
+        has_side_effects=True,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def _nanosleep(n: Int32, *, loc=None, ip=None) -> None:
+    llvm.inline_asm(
+        None,
+        [Int32(n).ir_value(loc=loc, ip=ip)],
+        "nanosleep.u32 $0;",
+        "r",
+        has_side_effects=True,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _m02_ship(
+    src_ptr: Int64,
+    dst_ptr: Int64,
+    n_uint4: Int32,
+    tid: Int32,
+    stride: Int32,
+    unroll: cutlass.Constexpr,
+) -> None:
+    """Copy ``n_uint4`` 16-byte words. K=8 issues 8 loads before any store."""
+    w = tid
+    word = Int64(16)
+    if cutlass.const_expr(unroll == 8):
+        last = stride * Int32(7)
+        step = stride * Int32(8)
+        while w + last < n_uint4:
+            a00, a01, a02, a03 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(0)) * word
+            )
+            a10, a11, a12, a13 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(1)) * word
+            )
+            a20, a21, a22, a23 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(2)) * word
+            )
+            a30, a31, a32, a33 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(3)) * word
+            )
+            a40, a41, a42, a43 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(4)) * word
+            )
+            a50, a51, a52, a53 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(5)) * word
+            )
+            a60, a61, a62, a63 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(6)) * word
+            )
+            a70, a71, a72, a73 = ld_global_v4_u32(
+                src_ptr + Int64(w + stride * Int32(7)) * word
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(0)) * word, a00, a01, a02, a03
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(1)) * word, a10, a11, a12, a13
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(2)) * word, a20, a21, a22, a23
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(3)) * word, a30, a31, a32, a33
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(4)) * word, a40, a41, a42, a43
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(5)) * word, a50, a51, a52, a53
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(6)) * word, a60, a61, a62, a63
+            )
+            st_global_v4_u32(
+                dst_ptr + Int64(w + stride * Int32(7)) * word, a70, a71, a72, a73
+            )
+            w += step
+    while w < n_uint4:
+        v0, v1, v2, v3 = ld_global_v4_u32(src_ptr + Int64(w) * word)
+        st_global_v4_u32(dst_ptr + Int64(w) * word, v0, v1, v2, v3)
+        w += stride
+
+
+def _smem_i32(smem, n: int):
+    ptr = smem.allocate_array(cutlass.Int32, n, byte_alignment=4)
+    return cute.make_tensor(ptr, cute.make_layout((n,)))
+
+
+class TileReadyConsumerKernel:
+    def __init__(
+        self,
+        *,
+        cta_m: int,
+        threads: int,
+        unroll: int,
+        no_wait: bool,
+        no_ship: bool,
+        max_ctas: int,
+    ):
+        self.cta_m = cta_m
+        self.threads = threads
+        self.unroll = unroll
+        self.no_wait = no_wait
+        self.no_ship = no_ship
+        self.max_ctas = max_ctas
+
+    @cute.kernel
+    def kernel(
+        self,
+        tile_ready: cute.Tensor,
+        gemm2_c: cute.Tensor,
+        permuted_idx: cute.Tensor,
+        peer_ptrs: cute.Tensor,
+        src_info: cute.Tensor,
+        num_non_exiting_tiles: cute.Tensor,
+        shipped_rows: cute.Tensor,
+        permuted_m: cutlass.Int32,
+        hidden: cutlass.Int32,
+        tokens_per_rank: cutlass.Int32,
+        world: cutlass.Int32,
+        num_local_experts: cutlass.Int32,
+        src_rank: cutlass.Int32,
+        num_n: cutlass.Int32,
+    ):
+        tidx, _, _ = cute.arch.thread_idx()
+        bidx, _, _ = cute.arch.block_idx()
+        gdx, _, _ = cute.arch.grid_dim()
+
+        smem = cutlass.utils.SmemAllocator()
+        s_start = _smem_i32(smem, self.cta_m)
+        s_n = _smem_i32(smem, self.cta_m)
+        s_dest = _smem_i32(smem, self.cta_m)
+        s_expert = _smem_i32(smem, self.cta_m)
+        s_slot = _smem_i32(smem, self.cta_m)
+        s_nruns = _smem_i32(smem, 1)
+        cute.arch.sync_threads()
+
+        nne = cute.arch.make_warp_uniform(cutlass.Int32(num_non_exiting_tiles[0]))
+        row_bytes = Int64(hidden) * Int64(2)
+        uint4_per_row = hidden // 8
+        cap = tokens_per_rank * world
+        inbox_src_stride = Int64(num_local_experts) * Int64(tokens_per_rank) * row_bytes
+
+        band = bidx
+        while band < nne:
+            if cutlass.const_expr(not self.no_wait):
+                col = tidx
+                while col < num_n:
+                    flag_idx = band * num_n + col
+                    ready = cutlass.Int32(0)
+                    while ready == 0:
+                        ready = cute.arch.load(
+                            tile_ready.iterator + flag_idx,
+                            cutlass.Int32,
+                            sem="acquire",
+                            scope="gpu",
+                        )
+                        if ready == 0:
+                            _nanosleep(Int32(32))
+                    col += Int32(self.threads)
+            cute.arch.sync_threads()
+
+            if cutlass.const_expr(not self.no_ship):
+                band_start = band * Int32(self.cta_m)
+                if tidx == 0:
+                    nruns = Int32(0)
+                    active = Int32(0)
+                    run_start = Int32(0)
+                    run_n = Int32(0)
+                    run_dest = Int32(0)
+                    run_expert = Int32(0)
+                    run_slot = Int32(0)
+                    for i in cutlass.range(self.cta_m, unroll_full=True):
+                        p = band_start + i
+                        live = Int32(0)
+                        dest_rank = Int32(0)
+                        expert = Int32(0)
+                        slot = Int32(0)
+                        if p < permuted_m:
+                            expanded = permuted_idx[p]
+                            if expanded >= 0:
+                                expert = expanded // cap
+                                local_slot = expanded % cap
+                                in_bounds = (
+                                    (expert >= 0)
+                                    & (expert < num_local_experts)
+                                    & (local_slot >= 0)
+                                    & (local_slot < cap)
+                                )
+                                if in_bounds:
+                                    loc = src_info[(expert, local_slot)]
+                                    if loc >= 0:
+                                        dest_rank = loc // tokens_per_rank
+                                        slot = loc % tokens_per_rank
+                                        live = (
+                                            Int32(dest_rank >= 0)
+                                            & Int32(dest_rank < world)
+                                            & Int32(slot >= 0)
+                                            & Int32(slot < tokens_per_rank)
+                                        )
+                        if live != 0:
+                            cont = (
+                                (active != 0)
+                                & (dest_rank == run_dest)
+                                & (expert == run_expert)
+                                & (slot == run_slot + run_n)
+                            )
+                            if cont:
+                                run_n = run_n + Int32(1)
+                            else:
+                                if active != 0:
+                                    s_start[nruns] = run_start
+                                    s_n[nruns] = run_n
+                                    s_dest[nruns] = run_dest
+                                    s_expert[nruns] = run_expert
+                                    s_slot[nruns] = run_slot
+                                    nruns = nruns + Int32(1)
+                                run_start = p
+                                run_n = Int32(1)
+                                run_dest = dest_rank
+                                run_expert = expert
+                                run_slot = slot
+                                active = Int32(1)
+                        else:
+                            if active != 0:
+                                s_start[nruns] = run_start
+                                s_n[nruns] = run_n
+                                s_dest[nruns] = run_dest
+                                s_expert[nruns] = run_expert
+                                s_slot[nruns] = run_slot
+                                nruns = nruns + Int32(1)
+                                active = Int32(0)
+                    if active != 0:
+                        s_start[nruns] = run_start
+                        s_n[nruns] = run_n
+                        s_dest[nruns] = run_dest
+                        s_expert[nruns] = run_expert
+                        s_slot[nruns] = run_slot
+                        nruns = nruns + Int32(1)
+                    s_nruns[0] = nruns
+                cute.arch.sync_threads()
+
+                nruns = s_nruns[0]
+                shipped = Int32(0)
+                for r in cutlass.range(self.cta_m):
+                    if r < nruns:
+                        p0 = s_start[r]
+                        n_run = s_n[r]
+                        dest_rank = s_dest[r]
+                        expert = s_expert[r]
+                        slot = s_slot[r]
+                        dst = (
+                            peer_ptrs[dest_rank]
+                            + Int64(src_rank) * inbox_src_stride
+                            + (Int64(expert) * Int64(tokens_per_rank) + Int64(slot))
+                            * row_bytes
+                        )
+                        src = (
+                            get_ptr_as_int64(gemm2_c, Int64(0)) + Int64(p0) * row_bytes
+                        )
+                        _m02_ship(
+                            src,
+                            dst,
+                            n_run * uint4_per_row,
+                            tidx,
+                            Int32(self.threads),
+                            self.unroll,
+                        )
+                        if tidx == 0:
+                            shipped += n_run
+                cute.arch.sync_threads()
+                if tidx == 0 and shipped != 0:
+                    cute.arch.atomic_add(shipped_rows.iterator, shipped)
+            band += gdx
+
+        if cutlass.const_expr(not self.no_ship):
+            _fence_sys()
+
+    @cute.jit
+    def wrapper(
+        self,
+        tile_ready_ptr: cute.Pointer,
+        gemm2_c_ptr: cute.Pointer,
+        permuted_idx_ptr: cute.Pointer,
+        peer_ptrs_ptr: cute.Pointer,
+        src_info_ptr: cute.Pointer,
+        num_non_exiting_tiles_ptr: cute.Pointer,
+        shipped_rows_ptr: cute.Pointer,
+        permuted_m: cutlass.Int32,
+        hidden: cutlass.Int32,
+        tokens_per_rank: cutlass.Int32,
+        world: cutlass.Int32,
+        num_local_experts: cutlass.Int32,
+        src_rank: cutlass.Int32,
+        num_n: cutlass.Int32,
+        stream: cuda.CUstream,
+    ):
+        tile_ready = cute.make_tensor(
+            tile_ready_ptr,
+            layout=cute.make_layout((permuted_m * num_n,)),
+        )
+        gemm2_c = cute.make_tensor(
+            gemm2_c_ptr,
+            layout=cute.make_ordered_layout((permuted_m, hidden), order=(1, 0)),
+        )
+        permuted_idx = cute.make_tensor(
+            permuted_idx_ptr, layout=cute.make_layout((permuted_m,))
+        )
+        peer_ptrs = cute.make_tensor(peer_ptrs_ptr, layout=cute.make_layout((world,)))
+        cap = tokens_per_rank * world
+        src_info = cute.make_tensor(
+            src_info_ptr,
+            layout=cute.make_ordered_layout((num_local_experts, cap), order=(1, 0)),
+        )
+        num_non_exiting_tiles = cute.make_tensor(
+            num_non_exiting_tiles_ptr, layout=cute.make_layout((1,))
+        )
+        shipped_rows = cute.make_tensor(shipped_rows_ptr, layout=cute.make_layout((1,)))
+        self.kernel(
+            tile_ready,
+            gemm2_c,
+            permuted_idx,
+            peer_ptrs,
+            src_info,
+            num_non_exiting_tiles,
+            shipped_rows,
+            permuted_m,
+            hidden,
+            tokens_per_rank,
+            world,
+            num_local_experts,
+            src_rank,
+            num_n,
+        ).launch(
+            grid=[self.max_ctas, 1, 1],
+            block=[self.threads, 1, 1],
+            stream=stream,
+            min_blocks_per_mp=1,
+        )
+
+
+_kernel_cache: Dict[Tuple, Any] = {}
+_cached_dummy_peer_ptrs: Optional[torch.Tensor] = None
+_cached_dummy_src_info: Optional[torch.Tensor] = None
+
+
+def _dummy_peer_ptrs(device: torch.device) -> torch.Tensor:
+    global _cached_dummy_peer_ptrs
+    if _cached_dummy_peer_ptrs is None or _cached_dummy_peer_ptrs.device != device:
+        _cached_dummy_peer_ptrs = torch.zeros(1, dtype=torch.int64, device=device)
+    return _cached_dummy_peer_ptrs
+
+
+def _dummy_src_info(device: torch.device) -> torch.Tensor:
+    global _cached_dummy_src_info
+    if _cached_dummy_src_info is None or _cached_dummy_src_info.device != device:
+        _cached_dummy_src_info = torch.full(
+            (1, 1), -1, dtype=torch.int32, device=device
+        )
+    return _cached_dummy_src_info
+
+
+def _get_compiled_consumer(
+    *,
+    cta_m: int,
+    threads: int,
+    unroll: int,
+    no_wait: bool,
+    no_ship: bool,
+    max_ctas: int,
+    tile_ready_ptr,
+    gemm2_c_ptr,
+    permuted_idx_ptr,
+    peer_ptrs_ptr,
+    src_info_ptr,
+    num_tiles_ptr,
+    shipped_ptr,
+    permuted_m: int,
+    hidden: int,
+    tokens_per_rank: int,
+    world: int,
+    num_local_experts: int,
+    src_rank: int,
+    num_n: int,
+    stream,
+):
+    cache_key = (cta_m, threads, unroll, no_wait, no_ship, max_ctas)
+    if cache_key not in _kernel_cache:
+        gemm = TileReadyConsumerKernel(
+            cta_m=cta_m,
+            threads=threads,
+            unroll=unroll,
+            no_wait=no_wait,
+            no_ship=no_ship,
+            max_ctas=max_ctas,
+        )
+        compiled = cute.compile(
+            gemm.wrapper,
+            tile_ready_ptr,
+            gemm2_c_ptr,
+            permuted_idx_ptr,
+            peer_ptrs_ptr,
+            src_info_ptr,
+            num_tiles_ptr,
+            shipped_ptr,
+            permuted_m,
+            hidden,
+            tokens_per_rank,
+            world,
+            num_local_experts,
+            src_rank,
+            num_n,
+            stream,
+        )
+        _kernel_cache[cache_key] = compiled
+    return _kernel_cache[cache_key]
+
+
+def launch_tile_ready_consumer(
+    tile_ready: torch.Tensor,
+    gemm2_c: torch.Tensor,
+    permuted_idx_to_expanded_idx: torch.Tensor,
+    mma_tiler_mn: Tuple[int, int],
+    tokens_per_rank: int,
+    world_size: int,
+    num_local_experts: int,
+    num_non_exiting_tiles: torch.Tensor,
+    permuted_m: int,
+    src_info: Optional[torch.Tensor] = None,
+    *,
+    peer_ptrs: Optional[torch.Tensor] = None,
+    peer_out: Optional[torch.Tensor] = None,
+    src_rank: int = 0,
+    shipped_rows: Optional[torch.Tensor] = None,
+    no_ship: bool = False,
+    no_wait: bool = False,
+    threads: int = 256,
+    unroll: int = 8,
+    max_ctas: int = 8,
+    stream: Optional[torch.cuda.Stream] = None,
+    compile_only: bool = False,
+) -> None:
+    """Launch the tile-ready consumer on ``stream`` (default: current stream).
+
+    ``compile_only=True`` runs ``cute.compile`` (or a cache hit) and returns
+    without queuing the kernel. Use that to keep a flag-waiter off the GPU
+    across a later GEMM2 host launch.
+
+    ``src_info`` is ``[num_local_experts, world * tokens_per_rank]`` int32
+    home locations ``home_rank * tokens_per_rank + token_index`` (``-1``
+    unused). Build it with :func:`combine_src_info_from_packed`.
+    """
+    if gemm2_c.dim() != 2:
+        raise ValueError(
+            f"gemm2_c must be 2-D [rows, hidden], got {tuple(gemm2_c.shape)}"
+        )
+    if gemm2_c.dtype != torch.bfloat16:
+        raise ValueError(f"gemm2_c must be torch.bfloat16, got {gemm2_c.dtype}")
+    if not gemm2_c.is_contiguous() or gemm2_c.device.type != "cuda":
+        raise ValueError("gemm2_c must be a contiguous CUDA tensor")
+    if tile_ready.dtype != torch.int32 or not tile_ready.is_contiguous():
+        raise ValueError("tile_ready must be contiguous int32")
+    if tile_ready.device.type != "cuda":
+        raise ValueError("tile_ready must be on CUDA")
+    if permuted_idx_to_expanded_idx.dtype != torch.int32:
+        raise ValueError(
+            f"permuted_idx_to_expanded_idx must be int32, got {permuted_idx_to_expanded_idx.dtype}"
+        )
+    if permuted_idx_to_expanded_idx.device.type != "cuda":
+        raise ValueError("permuted_idx_to_expanded_idx must be on CUDA")
+    if not permuted_idx_to_expanded_idx.is_contiguous():
+        raise ValueError("permuted_idx_to_expanded_idx must be contiguous")
+    if num_non_exiting_tiles.dtype != torch.int32:
+        raise ValueError(
+            f"num_non_exiting_tiles must be int32, got {num_non_exiting_tiles.dtype}"
+        )
+    if num_non_exiting_tiles.device.type != "cuda":
+        raise ValueError("num_non_exiting_tiles must be on CUDA")
+    if not num_non_exiting_tiles.is_contiguous():
+        raise ValueError("num_non_exiting_tiles must be contiguous")
+    if num_non_exiting_tiles.numel() < 1:
+        raise ValueError("num_non_exiting_tiles must hold at least one int32")
+
+    hidden = int(gemm2_c.shape[1])
+    if hidden % 8 != 0:
+        raise ValueError(
+            f"hidden must be a multiple of 8 for 16-byte (uint4) copies, got {hidden}"
+        )
+    if unroll not in _SHIP_UNROLLS:
+        raise ValueError(f"unroll must be one of {_SHIP_UNROLLS}, got {unroll}")
+    if tokens_per_rank <= 0 or world_size <= 0 or num_local_experts <= 0:
+        raise ValueError(
+            "tokens_per_rank, world_size, and num_local_experts must be positive"
+        )
+    if max_ctas <= 0:
+        raise ValueError(f"max_ctas must be positive, got {max_ctas}")
+    if src_rank < 0 or src_rank >= world_size:
+        raise ValueError(
+            f"src_rank must be in [0, world_size), got {src_rank} vs {world_size}"
+        )
+    if int(gemm2_c.shape[0]) < permuted_m:
+        raise ValueError(
+            f"gemm2_c.shape[0]={int(gemm2_c.shape[0])} < permuted_m={permuted_m}"
+        )
+    if permuted_m > int(permuted_idx_to_expanded_idx.numel()):
+        raise ValueError(
+            f"permuted_m={permuted_m} exceeds permuted_idx_to_expanded_idx "
+            f"numel={int(permuted_idx_to_expanded_idx.numel())}"
+        )
+
+    cap = tokens_per_rank * world_size
+    if no_ship:
+        if src_info is None:
+            src_info = _dummy_src_info(gemm2_c.device)
+    else:
+        if src_info is None:
+            raise ValueError("src_info is required unless no_ship=True")
+        if src_info.dim() != 2:
+            raise ValueError(
+                "src_info must be [num_local_experts, world * tokens_per_rank], "
+                f"got {tuple(src_info.shape)}"
+            )
+        if int(src_info.shape[0]) != num_local_experts or int(src_info.shape[1]) != cap:
+            raise ValueError(
+                f"src_info shape {tuple(src_info.shape)} does not match "
+                f"nle={num_local_experts} cap={cap}"
+            )
+        if src_info.dtype != torch.int32:
+            raise ValueError(f"src_info must be int32, got {src_info.dtype}")
+        if not src_info.is_contiguous() or src_info.device.type != "cuda":
+            raise ValueError("src_info must be a contiguous CUDA tensor")
+
+    cta_m, cta_n = gemm2_cta_tile_mn(mma_tiler_mn)
+    needed = gemm2_tile_ready_numel(permuted_m, hidden, mma_tiler_mn)
+    if int(tile_ready.numel()) < needed:
+        raise ValueError(
+            f"tile_ready must have at least {needed} flags (permuted_m={permuted_m}, "
+            f"hidden={hidden}, mma_tiler_mn={mma_tiler_mn}), got {int(tile_ready.numel())}"
+        )
+    num_n = (hidden + cta_n - 1) // cta_n
+
+    if no_ship:
+        if peer_ptrs is None:
+            peer_ptrs = _dummy_peer_ptrs(gemm2_c.device)
+    else:
+        if peer_ptrs is None:
+            if peer_out is None:
+                raise ValueError(
+                    "peer_ptrs or peer_out is required unless no_ship=True"
+                )
+            peer_ptrs = peer_ptrs_from_peer_out(peer_out)
+        if peer_ptrs.dtype != torch.int64 or not peer_ptrs.is_contiguous():
+            raise ValueError("peer_ptrs must be contiguous int64")
+        if int(peer_ptrs.numel()) < world_size:
+            raise ValueError(
+                f"peer_ptrs numel={int(peer_ptrs.numel())} < world_size={world_size}"
+            )
+
+    if shipped_rows is None:
+        shipped_rows = torch.zeros(1, dtype=torch.int32, device=gemm2_c.device)
+    elif shipped_rows.dtype != torch.int32 or shipped_rows.numel() < 1:
+        raise ValueError("shipped_rows must be a 1-element int32 tensor")
+
+    torch_stream = stream or torch.cuda.current_stream()
+    cu_stream = cuda.CUstream(torch_stream.cuda_stream)
+
+    tile_ready_ptr = make_ptr(
+        cutlass.Int32, tile_ready.data_ptr(), cute.AddressSpace.gmem
+    )
+    gemm2_c_ptr = make_ptr(
+        BFloat16, gemm2_c.data_ptr(), cute.AddressSpace.gmem, assumed_align=16
+    )
+    permuted_idx_ptr = make_ptr(
+        cutlass.Int32,
+        permuted_idx_to_expanded_idx.data_ptr(),
+        cute.AddressSpace.gmem,
+    )
+    peer_ptrs_ptr = make_ptr(
+        cutlass.Int64, peer_ptrs.data_ptr(), cute.AddressSpace.gmem
+    )
+    src_info_ptr = make_ptr(cutlass.Int32, src_info.data_ptr(), cute.AddressSpace.gmem)
+    num_tiles_ptr = make_ptr(
+        cutlass.Int32, num_non_exiting_tiles.data_ptr(), cute.AddressSpace.gmem
+    )
+    shipped_ptr = make_ptr(
+        cutlass.Int32, shipped_rows.data_ptr(), cute.AddressSpace.gmem
+    )
+
+    compiled = _get_compiled_consumer(
+        cta_m=cta_m,
+        threads=threads,
+        unroll=unroll,
+        no_wait=no_wait,
+        no_ship=no_ship,
+        max_ctas=max_ctas,
+        tile_ready_ptr=tile_ready_ptr,
+        gemm2_c_ptr=gemm2_c_ptr,
+        permuted_idx_ptr=permuted_idx_ptr,
+        peer_ptrs_ptr=peer_ptrs_ptr,
+        src_info_ptr=src_info_ptr,
+        num_tiles_ptr=num_tiles_ptr,
+        shipped_ptr=shipped_ptr,
+        permuted_m=permuted_m,
+        hidden=hidden,
+        tokens_per_rank=tokens_per_rank,
+        world=world_size,
+        num_local_experts=num_local_experts,
+        src_rank=src_rank,
+        num_n=num_n,
+        stream=cu_stream,
+    )
+
+    if compile_only:
+        return
+
+    compiled(
+        tile_ready_ptr,
+        gemm2_c_ptr,
+        permuted_idx_ptr,
+        peer_ptrs_ptr,
+        src_info_ptr,
+        num_tiles_ptr,
+        shipped_ptr,
+        permuted_m,
+        hidden,
+        tokens_per_rank,
+        world_size,
+        num_local_experts,
+        src_rank,
+        num_n,
+        stream=cu_stream,
+    )

--- a/flashinfer/moe_ep/core/kernel/base.py
+++ b/flashinfer/moe_ep/core/kernel/base.py
@@ -23,6 +23,9 @@ class SplitKernelContext:
     fleet_params: "FleetParams"
     recv_topk_idx: Optional["torch.Tensor"] = None
     recv_topk_weights: Optional["torch.Tensor"] = None
+    dest_topk_ids: Optional["torch.Tensor"] = None
+    dest_topk_weights: Optional["torch.Tensor"] = None
+    dest_hidden_states: Optional["torch.Tensor"] = None
 
 
 class SplitKernelBackend(ABC):
@@ -69,6 +72,23 @@ class SplitKernelBackend(ABC):
 
     @abstractmethod
     def compute(self, ctx: SplitKernelContext) -> "torch.Tensor": ...
+
+    def wait_overlap(self) -> None:  # noqa: B027 - intentional no-op default
+        """Wait for an overlapping second-stream consumer, if any."""
+
+    def collect_overlap_combine(
+        self,
+        hidden_states: "torch.Tensor",
+        topk_ids: "torch.Tensor",
+        topk_weights: "torch.Tensor",
+    ) -> "torch.Tensor":
+        """Dest-side combine after overlap ship. Default: unused."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement overlap combine"
+        )
+
+    def destroy(self) -> None:  # noqa: B027 - intentional no-op default
+        """Release kernel-owned workspace (inbox, streams)."""
 
 
 class MegaKernelBackend(ABC):

--- a/flashinfer/moe_ep/modes/config.py
+++ b/flashinfer/moe_ep/modes/config.py
@@ -20,6 +20,7 @@ class SplitConfig:
 
     comm: object = field(default_factory=NcclEpConfig)
     kernel: object = field(default_factory=IdentityConfig)
+    skip_combine: bool = False
 
 
 @dataclass

--- a/flashinfer/moe_ep/modes/split_layer.py
+++ b/flashinfer/moe_ep/modes/split_layer.py
@@ -69,9 +69,11 @@ class MoEEpSplitLayer(nn.Module):
         if isinstance(backend, SplitConfig):
             self._comm_backend = backend.comm
             self._kernel_config = backend.kernel
+            self.skip_combine = bool(backend.skip_combine)
         else:
             self._comm_backend = backend
             self._kernel_config = IdentityConfig()
+            self.skip_combine = False
 
         self._kernel: SplitKernelBackend = create_split_kernel(self._kernel_config)
 
@@ -151,15 +153,39 @@ class MoEEpSplitLayer(nn.Module):
             )
         return self._fleet
 
-    def _inner_compute(self, dispatch: DispatchOutput) -> torch.Tensor:
+    def _inner_compute(
+        self, dispatch: DispatchOutput, t: "MoEEpTensors"
+    ) -> torch.Tensor:
         ctx = SplitKernelContext(
             expert_tensors=dispatch.expert_tensors,
             num_tokens=dispatch.get_num_tokens(),
             fleet_params=self._fleet_params,
             recv_topk_idx=dispatch.recv_topk_idx,
             recv_topk_weights=dispatch.recv_topk_weights,
+            dest_topk_ids=t.topk_ids,
+            dest_topk_weights=t.topk_weights,
+            dest_hidden_states=t.hidden_states,
         )
         return self._kernel.compute(ctx)
+
+    def _combine_or_overlap(
+        self,
+        handle,
+        expert_out: torch.Tensor,
+        t: "MoEEpTensors",
+    ) -> torch.Tensor:
+        if self.skip_combine:
+            self._kernel.wait_overlap()
+            return self._kernel.collect_overlap_combine(
+                t.hidden_states, t.topk_ids, t.topk_weights
+            )
+        combine = handle.combine(
+            CombineInputParams(
+                x=[expert_out],
+                out=torch.empty_like(t.hidden_states),
+            )
+        )
+        return combine.x
 
     def forward(self, t: "MoEEpTensors") -> torch.Tensor:
         ensure_bootstrap_dist_validated(self._bootstrap)
@@ -186,14 +212,8 @@ class MoEEpSplitLayer(nn.Module):
                         x=[self._kernel.pack_dispatch_payload(t.hidden_states)]
                     )
                 )
-                expert_out = self._inner_compute(dispatch)
-                combine = handle.combine(
-                    CombineInputParams(
-                        x=[expert_out],
-                        out=torch.empty_like(t.hidden_states),
-                    )
-                )
-                result = combine.x
+                expert_out = self._inner_compute(dispatch, t)
+                result = self._combine_or_overlap(handle, expert_out, t)
             else:
                 ev = {
                     k: (
@@ -210,27 +230,22 @@ class MoEEpSplitLayer(nn.Module):
                 )
                 ev["dispatch"][1].record()
                 ev["compute"][0].record()
-                expert_out = self._inner_compute(dispatch)
+                expert_out = self._inner_compute(dispatch, t)
                 ev["compute"][1].record()
                 ev["combine"][0].record()
-                combine = handle.combine(
-                    CombineInputParams(
-                        x=[expert_out],
-                        out=torch.empty_like(t.hidden_states),
-                    )
-                )
+                result = self._combine_or_overlap(handle, expert_out, t)
                 ev["combine"][1].record()
                 torch.cuda.synchronize()
                 self.last_timings_ms = {
                     k: start.elapsed_time(end) for k, (start, end) in ev.items()
                 }
-                result = combine.x
         finally:
             handle.complete()
             handle.destroy()
         return result
 
     def destroy(self) -> None:
+        self._kernel.destroy()
         if self._fleet is not None:
             self._fleet.destroy()
             self._fleet = None

--- a/tests/moe_ep/run_tests.sh
+++ b/tests/moe_ep/run_tests.sh
@@ -10,6 +10,7 @@
 #   bash tests/moe_ep/run_tests.sh sm90_push     # 2-GPU Hopper sm90_fp8_fp8_bf16_push_cuda kernel + backend
 #   bash tests/moe_ep/run_tests.sh split_path_correctness_bf16   # 4-GPU bf16 split-path numerics
 #   bash tests/moe_ep/run_tests.sh split_path_correctness_nvfp4  # 4-GPU NVFP4 split-path numerics
+#   bash tests/moe_ep/run_tests.sh split_path_correctness_fused_gemm2_combine  # 4-GPU NVFP4 overlap combine
 #   bash tests/moe_ep/run_tests.sh split_path_correctness_ht     # 4-GPU HT (FLAT) split-path numerics
 #   bash tests/moe_ep/run_tests.sh oracle        # 1-GPU torch-oracle correctness (all paths)
 #   bash tests/moe_ep/run_tests.sh oracle_sm90   # 1-GPU Hopper sm90_fp8_fp8_bf16_pull_cutedsl vs drop reference
@@ -196,6 +197,16 @@ run_split_path_correctness_nvfp4() {
   "${TORCHRUN}" --nproc_per_node="${NPROC_CORRECTNESS}" -m pytest \
     "${MOE_EP_PYTEST_FLAGS[@]}" \
     tests/moe_ep/test_moe_ep_compute_correctness_nvfp4.py -v \
+    -m "nvep and gpu_4 and arch_blackwell" --backend=nccl_ep
+}
+
+run_split_path_correctness_fused_gemm2_combine() {
+  require_nccl_ep || return 1
+
+  NPROC_CORRECTNESS="${NPROC_CORRECTNESS:-4}"
+  "${TORCHRUN}" --nproc_per_node="${NPROC_CORRECTNESS}" -m pytest \
+    "${MOE_EP_PYTEST_FLAGS[@]}" \
+    tests/moe_ep/test_moe_ep_fused_gemm2_combine_correctness.py -v -s \
     -m "nvep and gpu_4 and arch_blackwell" --backend=nccl_ep
 }
 
@@ -398,6 +409,7 @@ run_all() {
   run_section "split-path multirank (NCCL-EP)" run_multirank
   run_section "split_path_correctness_bf16 (4 GPU)" run_split_path_correctness_bf16
   run_section "split_path_correctness_nvfp4 (4 GPU)" run_split_path_correctness_nvfp4
+  run_section "split_path_correctness_fused_gemm2_combine (4 GPU)" run_split_path_correctness_fused_gemm2_combine
   run_section "split_path_correctness_ht (4 GPU)" run_split_path_correctness_ht
   run_section "mega multirank (Blackwell)" run_mega
   run_section "smoke scripts" run_smoke
@@ -413,6 +425,7 @@ case "${1:-all}" in
   multirank) run_section "split-path multirank (NCCL-EP)" run_multirank; print_summary ;;
   split_path_correctness_bf16) run_section "split_path_correctness_bf16 (4 GPU)" run_split_path_correctness_bf16; print_summary ;;
   split_path_correctness_nvfp4) run_section "split_path_correctness_nvfp4 (4 GPU)" run_split_path_correctness_nvfp4; print_summary ;;
+  split_path_correctness_fused_gemm2_combine) run_section "split_path_correctness_fused_gemm2_combine (4 GPU)" run_split_path_correctness_fused_gemm2_combine; print_summary ;;
   split_path_correctness_ht) run_section "split_path_correctness_ht (4 GPU)" run_split_path_correctness_ht; print_summary ;;
   mega) run_section "mega multirank (Blackwell)" run_mega; print_summary ;;
   mega_sm90) run_section "sm90_fp8_fp8_bf16_pull_cutedsl mega multirank (Hopper)" run_mega_sm90; print_summary ;;
@@ -422,7 +435,7 @@ case "${1:-all}" in
   ft) run_section "fault tolerance (4 GPU)" run_ft; print_summary ;;
   all) run_all ;;
   *)
-    echo "Usage: $0 [unit|oracle|oracle_sm90|multirank|sm90_push|split_path_correctness_bf16|split_path_correctness_nvfp4|split_path_correctness_ht|mega|mega_sm90|mega_sm120|smoke|ft|all]" >&2
+    echo "Usage: $0 [unit|oracle|oracle_sm90|multirank|sm90_push|split_path_correctness_bf16|split_path_correctness_nvfp4|split_path_correctness_fused_gemm2_combine|split_path_correctness_ht|mega|mega_sm90|mega_sm120|smoke|ft|all]" >&2
     exit 1
     ;;
 esac

--- a/tests/moe_ep/test_moe_ep_fused_gemm2_combine_correctness.py
+++ b/tests/moe_ep/test_moe_ep_fused_gemm2_combine_correctness.py
@@ -1,0 +1,284 @@
+"""Multi-GPU correctness for fused-gemm2-combine (NVFP4 LL EXPERT_MAJOR).
+
+Clone of ``test_moe_ep_compute_correctness_nvfp4.py`` for the overlap path:
+CuteDSL GEMM2 ``tile_ready`` + dense permuted-C ship + dest-side combine
+(``skip_combine=True``). Isolates that path against split-moe on the same
+CuteDSL compute family (plain ``CuteDslConfig()``, NCCL combine).
+
+Launch (4 GPU, SM100+):
+    torchrun --nproc_per_node=4 -m pytest \\
+        tests/moe_ep/test_moe_ep_fused_gemm2_combine_correctness.py -v -s \\
+        -m "nvep and gpu_4 and arch_blackwell"
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import timedelta
+
+import pytest
+
+# First-use JIT compile of CuteDSL kernels can exceed torch's 10-min default
+# watchdog while other ranks wait in a collective; a cold cache is not a hang.
+_PG_TIMEOUT = timedelta(minutes=60)
+
+NUM_EXPERTS = 16
+TOP_K = 8
+TOKENS_PER_RANK = 128
+HIDDEN = 8192
+INTERMEDIATE = 2048
+RTOL = 5e-2
+ATOL = 5e-2
+
+
+def _build_nvfp4_cute_moe_config(
+    *, offset, local_num_experts, max_tokens, tile_signal: bool
+):
+    from flashinfer.fused_moe.api import (
+        BackendOptions,
+        CuteDslConfig,
+        ExecutionConfig,
+        ExpertConfig,
+        MoEConfig,
+        QuantConfig,
+        QuantVariant,
+        RoutingConfig,
+    )
+
+    cute = CuteDslConfig(
+        enable_tile_signal=tile_signal,
+        store_permuted_c=tile_signal,
+    )
+    return MoEConfig(
+        routing=RoutingConfig(num_experts=NUM_EXPERTS, top_k=TOP_K),
+        quant=QuantConfig(variant=QuantVariant.NVFP4),
+        experts=ExpertConfig(
+            intermediate_size=INTERMEDIATE,
+            local_expert_offset=offset,
+            local_num_experts=local_num_experts,
+        ),
+        backend=BackendOptions(candidates=(cute,)),
+        execution=ExecutionConfig(tune_max_num_tokens=max_tokens),
+    )
+
+
+def _local_weight_pack(w1_full, w2_full, offset, local_num_experts):
+    from flashinfer.moe_ep import MoEWeightPack
+
+    return MoEWeightPack(
+        w13=w1_full[offset : offset + local_num_experts].contiguous().clone(),
+        w2=w2_full[offset : offset + local_num_experts].contiguous().clone(),
+    )
+
+
+def _forward_ep(
+    *,
+    x,
+    topk_ids,
+    topk_weights,
+    weights,
+    moe_config,
+    fleet_params,
+    bootstrap,
+    skip_combine: bool,
+    expect_overlap_stats: bool = False,
+):
+    import torch
+
+    from flashinfer.moe_ep import (
+        FusedMoeKernelConfig,
+        MoEEpLayer,
+        MoEEpTensors,
+        NcclEpConfig,
+        SplitConfig,
+    )
+
+    layer = MoEEpLayer(
+        bootstrap,
+        fleet_params,
+        weights=weights,
+        backend=SplitConfig(
+            comm=NcclEpConfig(),
+            kernel=FusedMoeKernelConfig(moe_config=moe_config),
+            skip_combine=skip_combine,
+        ),
+    )
+    t = MoEEpTensors(
+        hidden_states=x,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+    )
+    y = layer.forward(t)
+    torch.cuda.synchronize()
+    assert y.shape == x.shape
+
+    stats = None
+    if expect_overlap_stats:
+        kernel = getattr(layer, "_kernel", None)
+        stats = (
+            getattr(kernel, "last_overlap_stats", None) if kernel is not None else None
+        )
+        if not stats:
+            raise AssertionError(
+                "fused-gemm2-combine did not populate last_overlap_stats"
+            )
+        live = int(stats.get("live_rows", -1))
+        expected = int(stats.get("expected_rows", -2))
+        assert live == expected, (
+            f"overlap live_rows={live} != expected_rows={expected} (stats={stats})"
+        )
+    layer.destroy()
+    return y, stats
+
+
+def _run_fused_gemm2_combine_vs_split_moe():
+    import torch
+    import torch.distributed as dist
+
+    from flashinfer.fused_moe.api import CuteDslConfig
+    from flashinfer.moe_ep import (
+        BootstrapConfig,
+        EpAlgorithm,
+        EpLayout,
+        FleetParams,
+    )
+
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    local_rank = int(os.environ.get("LOCAL_RANK", rank))
+    torch.cuda.set_device(local_rank)
+
+    major, minor = torch.cuda.get_device_capability()
+    arch = major * 10 + minor
+    if not CuteDslConfig.supported(arch):
+        pytest.skip(
+            f"CuteDSL NVFP4 fused-gemm2-combine requires SM100/103/107, got sm{arch}"
+        )
+
+    local_num_experts = NUM_EXPERTS // world_size
+    offset = rank * local_num_experts
+    max_tokens = local_num_experts * TOKENS_PER_RANK * world_size
+
+    gw = torch.Generator(device="cuda").manual_seed(2024)
+    w1_full = (
+        torch.randn(NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN, device="cuda", generator=gw)
+        * (HIDDEN**-0.5)
+    ).to(torch.bfloat16)
+    w2_full = (
+        torch.randn(NUM_EXPERTS, HIDDEN, INTERMEDIATE, device="cuda", generator=gw)
+        * (INTERMEDIATE**-0.5)
+    ).to(torch.bfloat16)
+
+    g = torch.Generator(device="cuda").manual_seed(1000 + rank)
+    x = torch.randn(TOKENS_PER_RANK, HIDDEN, device="cuda", generator=g).to(
+        torch.bfloat16
+    )
+    scores = torch.randn(TOKENS_PER_RANK, NUM_EXPERTS, device="cuda", generator=g)
+    topk_ids = scores.topk(TOP_K, dim=-1).indices.to(torch.int64)
+    topk_weights = torch.softmax(
+        torch.randn(TOKENS_PER_RANK, TOP_K, device="cuda", generator=g), dim=-1
+    )
+
+    fleet_params = FleetParams(
+        num_experts=NUM_EXPERTS,
+        max_tokens_per_rank=TOKENS_PER_RANK,
+        token_hidden_size=HIDDEN,
+        dtype_bytes=2,
+        algorithm=EpAlgorithm.LOW_LATENCY,
+        layout=EpLayout.EXPERT_MAJOR,
+    )
+
+    def _bootstrap():
+        return BootstrapConfig(
+            world_size=world_size,
+            rank=rank,
+            stream=torch.cuda.current_stream().cuda_stream,
+            nccl_comm=None,
+        )
+
+    y_overlap, stats = _forward_ep(
+        x=x,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        weights=_local_weight_pack(w1_full, w2_full, offset, local_num_experts),
+        moe_config=_build_nvfp4_cute_moe_config(
+            offset=offset,
+            local_num_experts=local_num_experts,
+            max_tokens=max_tokens,
+            tile_signal=True,
+        ),
+        fleet_params=fleet_params,
+        bootstrap=_bootstrap(),
+        skip_combine=True,
+        expect_overlap_stats=True,
+    )
+
+    expected_rows = int(stats["expected_rows"])
+    totals = torch.tensor([expected_rows], device="cuda", dtype=torch.int64)
+    dist.all_reduce(totals, op=dist.ReduceOp.SUM)
+    assert int(totals.item()) > 0, (
+        "overlap expected_rows summed to 0 across ranks; routing never hit a "
+        "local expert, so an empty inbox could pass assert_close"
+    )
+
+    dist.barrier()
+
+    y_split, _ = _forward_ep(
+        x=x.clone(),
+        topk_ids=topk_ids.clone(),
+        topk_weights=topk_weights.clone(),
+        weights=_local_weight_pack(w1_full, w2_full, offset, local_num_experts),
+        moe_config=_build_nvfp4_cute_moe_config(
+            offset=offset,
+            local_num_experts=local_num_experts,
+            max_tokens=max_tokens,
+            tile_signal=False,
+        ),
+        fleet_params=fleet_params,
+        bootstrap=_bootstrap(),
+        skip_combine=False,
+    )
+
+    yf, rf = y_overlap.float(), y_split.float()
+
+    def _rel(a, b):
+        return (a - b).abs().amax().item() / b.abs().amax().clamp_min(1e-6).item()
+
+    overlap_vs_split = _rel(yf, rf)
+    if rank == 0:
+        print(
+            f"[nvfp4 fused-gemm2-combine] overlap-vs-split-moe rel-err="
+            f"{overlap_vs_split:.4f} live_rows={stats['live_rows']} "
+            f"expected_rows={stats['expected_rows']}"
+        )
+
+    torch.testing.assert_close(yf, rf, rtol=RTOL, atol=ATOL)
+    return rank, overlap_vs_split, stats
+
+
+@pytest.mark.nvep
+@pytest.mark.gpu_4
+@pytest.mark.arch_blackwell
+def test_moe_ep_fused_gemm2_combine_matches_split_moe():
+    import torch
+
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("NVFP4 fused-gemm2-combine requires SM100+")
+
+    import torch.distributed as dist
+
+    if not dist.is_initialized():
+        dist.init_process_group(backend="nccl", timeout=_PG_TIMEOUT)
+    world_size = dist.get_world_size()
+    if NUM_EXPERTS % world_size != 0:
+        pytest.skip(
+            f"num_experts={NUM_EXPERTS} not divisible by world_size={world_size}"
+        )
+
+    rank, rel_err, stats = _run_fused_gemm2_combine_vs_split_moe()
+    dist.barrier()
+    print(
+        f"rank {rank}: fused-gemm2-combine==split-moe OK "
+        f"(rel-err={rel_err:.4f}, live_rows={stats['live_rows']}, "
+        f"expected_rows={stats['expected_rows']})"
+    )


### PR DESCRIPTION
## 📌 Description

**Draft — the mechanism works and is numerically correct, but end-to-end performance is not there yet. Opening it early to get feedback on the design and on where the remaining time is going.**

The point of this PR is to introduce **GEMM2+combine** as a concept in FlashInfer and to settle on the seam between the GEMM2 epilogue and combine. The implementation here is one point in that design space (explicit per-tile flags, ship from a separate kernel) chosen because it is the most measurable one — not because it is the end state. See the reviewer notes on epilogue fusion.

### The idea

On the split EP path, GEMM2 and combine are fully serialized: the CuteDSL NVFP4 GEMM2 finishes *every* output tile and scatters through fused finalize, and only then does NCCL combine start moving bytes. The GEMM is compute-bound and the combine is network-bound, so there is a whole combine's worth of egress that could have been in flight while the tail of the GEMM was still running.

This PR makes the overlap **tile-grained** rather than kernel-grained. Instead of waiting on the whole GEMM, a consumer waits on individual GEMM2 output tiles and ships each finished row to its destination rank as soon as that row is complete, while GEMM2 is still working on the remaining tiles.

### How it works

GEMM2 gains two compile-time options on `CuteDslConfig`:

- **`enable_tile_signal`** — the epilogue release-stores one `int32` flag per CTA output tile, indexed `m_tile * num_n_tiles + n_tile`. The bulk-copy wait is switched from `read=True` to `read=False` (destination-complete) so the tile's C rows are visible in HBM *before* the flag store becomes visible. The store is `st.release.gpu`; the consumer pairs it with `ld.acquire.gpu`.
- **`store_permuted_c`** — GEMM2 writes dense `C[permuted_m, hidden]` with an identity row index and routing scale 1.0, instead of scattering into token rows. The destination applies `topk_weights` during combine. This is what makes a finished tile shippable: rows are contiguous in permuted GEMM-M space, so consecutive live rows coalesce into one bulk transfer.

A second-stream CuteDSL consumer (`flashinfer/moe_ep/backends/split/overlap/`) then:

1. Acquires flags for an M-band. A band is only shipped once **every** column tile of that band is flagged — a row is not hidden-complete until the last N-tile lands, so waiting per-tile rather than per-band would ship torn rows.
2. Resolves each permuted row to its home rank and original token index, run-length-encodes consecutive rows with contiguous destination addresses, and pushes them into the destination rank's inbox with 16-byte `ld.global.v4.u32` / `st.global.v4.u32`, 8 loads issued before any store, one `fence.sys` per CTA at exit.
3. The destination reduces its `[world, local_experts, tokens_per_rank, hidden]` inbox into `[tokens, hidden]`.

Inboxes are fabric-mapped through `MnnvlMemory` rather than `cudaIpcOpenMemHandle`, since the latter is same-node only and fails across a 2-node NVL domain.

Wired into `MoEEpSplitLayer` behind `SplitConfig(skip_combine=True)`, which swaps `handle.combine()` for the overlap collect. Gated to NVFP4 + low-latency + `EXPERT_MAJOR` + Blackwell with a 128×128 MMA tile (the autotuner drops non-conforming tactics); **every other configuration keeps the existing fused-finalize + NCCL-combine path byte-for-byte.**

### Performance: where it stands

**GEMM2 kernel in isolation** — `benchmarks/bench_gemm2_tile_signal.py`, 1× GB200 (152 SMs), 32 local experts, 1024 packed rows/expert, hidden 7168, intermediate 2048, MMA 128×128, `permuted_m=36736`, 16072 flags:

| epilogue | tile signal | SMs | GEMM2 |
| --- | --- | --- | --- |
| dense C | off | 152 | 271.2 µs |
| dense C | on | 152 | 356.0 µs |
| dense C | on | 144 | 367.4 µs |
| fused finalize (baseline) | off | 152 | 425.6 µs |

The flag store costs **+31%** on the dense-C epilogue (271 → 356 µs), and reserving 8 SMs for the consumer costs another **+3%** (356 → 367 µs). So the producer side is not where the problem is — dense C + signalling + the SM reservation still lands below the fused-finalize baseline on this geometry, because it skips the atomic scatter.

One anomaly I have not chased: with fused finalize, enabling the flag store *lowers* the measured time (425.6 → 282.3 µs). I suspect it is the `read=False` bulk wait interacting with the atomic-scatter barrier traffic, but I have not confirmed it and I am not claiming it as a win.

**End to end** — `benchmarks/bench_moe_ep.py --reference --algorithm ll --backend nccl_ep --quant nvfp4 --layout expert_major`, 4× GB200, 256 experts, top-k 8, hidden 7168, intermediate 2048, 128 tokens/rank:

| method | dispatch | compute | combine | e2e |
| --- | --- | --- | --- | --- |
| `split-moe` (fused finalize + NCCL combine) | 79.6 µs | 1787.9 µs | 44.9 µs | **2076.0 µs** |
| `fused-gemm2-combine` (this PR) | 61.2 µs | 18348.1 µs | 3060.6 µs | **21761.4 µs** |

About 10× slower than the path it is meant to beat. The cost is not in the kernels — it is in two pieces that are deliberately placeholders, both of which run as per-iteration PyTorch work:

1. **The destination reduce** (`basic_overlap_combine`, 3060 µs vs 45 µs for NCCL combine) is a quorum `all_reduce` for visibility followed by an advanced-indexing gather and weighted sum over the inbox. It wants to be a fused reduce kernel, and the all-reduce wants to be credit/arrival-based.
2. **The `src_info` build** inside `compute` (which is most of the 1788 → 18348 µs regression) matches packed activation rows back to their home GPU and token index by fingerprinting the first four `bf16` values of each row and doing a per-expert `argsort` + `searchsorted`. This exists only because LL dispatch does not hand back a slot → source-token map. Getting that map out of the transport instead would delete this step entirely; that is the next thing I plan to do.

The remaining `.item()` calls in `collect_overlap_combine` also force two device syncs per forward, which I left in for now because the correctness test asserts on them.

Also worth flagging: on the 4-GPU reference geometry the consumer ships 1017 live rows where 1016 are expected. That extra row is a fingerprint collision — two rows sharing their leading four `bf16` values — which is an inherent weakness of the fingerprint placeholder above, not of the ship path. The correctness test's geometry does not collide and asserts exact equality.

### One change that touches shared code

`_get_compiled_finalize_kernel` now includes `max_active_clusters` in its compile cache key. It is baked into the compiled kernel, so a caller that varied `sm_count` between calls could previously get back a kernel compiled for a different cluster count. The overlap path needs this to be correct because it reserves SMs; it is a fix for the existing path too, at the cost of one extra compile per distinct `sm_count`.

## 🔍 Related Issues

None that I could find.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

`tests/moe_ep/test_moe_ep_fused_gemm2_combine_correctness.py` runs the overlap path and the fused-finalize + NCCL-combine path over the same weights and routing and compares outputs, and asserts that the consumer shipped exactly the number of rows that dest-local top-k selects (so an empty inbox cannot pass `assert_close`).

```
bash tests/moe_ep/run_tests.sh split_path_correctness_fused_gemm2_combine
```

It needs 4 Blackwell GPUs and a built `nccl_ep`, so it is not something CI will pick up. It passes locally on 4× GB200. I have not run the full suite on this rebase yet — hence the unchecked box.

## Reviewer Notes

What I would most like feedback on:

- **The producer contract.** Is `st.release.gpu` of one flag per CTA tile, paired with a destination-complete bulk wait, the right way to expose tile completion out of the CuteDSL epilogue? The `before_launch` / `after_launch` callbacks on the GEMM2 wrapper exist because `cute.compile` can device-sync, so the consumer has to be JIT'd *before* GEMM2 is queued and launched *after* — otherwise a flag-waiter sits live across a host sync. That is workable but not pretty, and I would take a better suggestion.
- **Where the ship should live: separate kernel vs. GEMM2 epilogue.** This PR ships from a separate kernel on a second stream, with 8 SMs carved out of GEMM2's persistent grid. That is not because epilogue fusion is off the table — it is where I started. I first tried doing the peer stores directly from the GEMM2 epilogue in the TRT-LLM NVFP4 MoE backend, and it performed badly there, which is what pushed me to pull the ship out into its own kernel and make tile completion an explicit signal instead. I do intend to try epilogue fusion again on the CuteDSL path: now that the flag contract and the ship path are separated, the fused variant has something to be measured against, and folding the ship into the epilogue warps would remove both the SM reservation and the flag round-trip. Treat the current split as the deliberately conservative starting point rather than a verdict on fusion.
- **The slot → source-token map.** The fingerprint hack is the single biggest thing standing between this and a real speedup, and it is a workaround for missing transport metadata. If there is an existing or planned way to get a receive-slot → source-token map out of LL dispatch, that changes the shape of this PR substantially.
- I have deliberately kept the destination reduce swappable via `FusedMoeKernelConfig.overlap_combine_fn` so a fused kernel can be dropped in without touching the ship path or GEMM2.

Everything is behind opt-in flags that default to off, so the existing paths should be unaffected; I would appreciate a check that I have not perturbed them.
