### PR TITLE
feat(attention): add skip softmax to PrimTS context (prefill) kernels

### DIFF
--- a/benchmarks/bench_prims_ts_skip_softmax.py
+++ b/benchmarks/bench_prims_ts_skip_softmax.py
@@ -1,0 +1,219 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Benchmark skip softmax in the PrimTS context (prefill) kernel.
+
+Times the dense PrimTS context kernel against its skip-softmax specialization
+at several thresholds on one fixed-shape problem per configuration. Random
+N(0, 0.2) inputs keep every K/V tile's scaled score gap to the running maximum
+inside roughly exp(gap) in [0.7, 1.4], so ``threshold=0`` measures the cost of
+the skip machinery without any skipping, ``threshold=1`` skips a data-dependent
+subset of tiles, and ``threshold=2`` skips every tile after a query group's
+first one, which bounds the attainable speedup.
+
+Example:
+    python benchmarks/bench_prims_ts_skip_softmax.py --iters 30
+"""
+
+import argparse
+import math
+import statistics
+
+import torch
+
+from flashinfer.attention.prims_ts import BatchPrefillTSWrapper
+from flashinfer.testing import bench_gpu_time
+
+
+def _dtype(name: str) -> torch.dtype:
+    return {
+        "bf16": torch.bfloat16,
+        "fp16": torch.float16,
+        "fp8": torch.float8_e4m3fn,
+    }[name]
+
+
+def bench_config(
+    *,
+    batch_size: int,
+    seq_len_q: int,
+    seq_len_kv: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    mask_type: str,
+    thresholds: tuple[float, ...],
+    iters: int,
+) -> None:
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    q = (
+        0.2 * torch.randn(batch_size, seq_len_q, num_qo_heads, head_dim, device=device)
+    ).to(dtype)
+    k = (
+        0.2 * torch.randn(batch_size, seq_len_kv, num_kv_heads, head_dim, device=device)
+    ).to(dtype)
+    v = (0.2 * torch.randn_like(k.float())).to(dtype)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    out_dtype = torch.bfloat16 if dtype == torch.float8_e4m3fn else dtype
+    out = torch.empty(q.shape, device=device, dtype=out_dtype)
+
+    dense = BatchPrefillTSWrapper()
+    dense.plan(q, k, v, mask_type=mask_type, sm_scale=sm_scale, out_dtype=out_dtype)
+    dense_out = dense.run(q, k, v)
+
+    causal_fraction = 0.5 if mask_type == "causal" else 1.0
+    flops = (
+        4.0
+        * batch_size
+        * num_qo_heads
+        * seq_len_q
+        * seq_len_kv
+        * head_dim
+        * causal_fraction
+    )
+    print(
+        f"\nB={batch_size} Sq={seq_len_q} Sk={seq_len_kv} Hq={num_qo_heads} "
+        f"Hkv={num_kv_heads} D={head_dim} {str(dtype).split('.')[-1]} {mask_type}"
+    )
+    print(
+        f"{'threshold':>10} {'median_us':>10} {'TFLOP/s':>9} {'speedup':>8} {'max|out-dense|':>15}"
+    )
+    baseline_us = None
+    for threshold in (None, *thresholds):
+        wrapper = BatchPrefillTSWrapper()
+        wrapper.plan(
+            q,
+            k,
+            v,
+            mask_type=mask_type,
+            sm_scale=sm_scale,
+            out_dtype=out_dtype,
+            skip_softmax_threshold=threshold,
+        )
+        wrapper.run(q, k, v, out=out)
+        torch.cuda.synchronize()
+        times_ms = bench_gpu_time(
+            lambda: wrapper.run(q, k, v, out=out),
+            dry_run_iters=5,
+            repeat_iters=iters,
+            enable_cupti=True,
+        )
+        median_us = statistics.median(times_ms) * 1e3
+        if baseline_us is None:
+            baseline_us = median_us
+        max_abs = (out.float() - dense_out.float()).abs().max().item()
+        label = "dense" if threshold is None else f"{threshold:g}"
+        print(
+            f"{label:>10} {median_us:10.1f} {flops / median_us / 1e6:9.1f} "
+            f"{baseline_us / median_us:8.2f} {max_abs:15.4g}"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument(
+        "--thresholds",
+        type=float,
+        nargs="+",
+        default=(0.0, 1.0, 2.0),
+        help="Skip-softmax thresholds in the ordinary softmax domain.",
+    )
+    parser.add_argument(
+        "--head-dim",
+        type=int,
+        choices=(128, 256),
+        default=None,
+        help="Only run the configurations with this head dimension.",
+    )
+    args = parser.parse_args()
+    thresholds = tuple(args.thresholds)
+    configs = (
+        dict(
+            batch_size=1,
+            seq_len_q=8192,
+            seq_len_kv=8192,
+            num_qo_heads=24,
+            num_kv_heads=24,
+            head_dim=128,
+            dtype="bf16",
+            mask_type="dense",
+        ),
+        dict(
+            batch_size=1,
+            seq_len_q=8192,
+            seq_len_kv=8192,
+            num_qo_heads=32,
+            num_kv_heads=8,
+            head_dim=128,
+            dtype="bf16",
+            mask_type="causal",
+        ),
+        dict(
+            batch_size=1,
+            seq_len_q=8192,
+            seq_len_kv=8192,
+            num_qo_heads=24,
+            num_kv_heads=24,
+            head_dim=128,
+            dtype="fp8",
+            mask_type="dense",
+        ),
+        dict(
+            batch_size=1,
+            seq_len_q=4096,
+            seq_len_kv=4096,
+            num_qo_heads=16,
+            num_kv_heads=16,
+            head_dim=256,
+            dtype="bf16",
+            mask_type="dense",
+        ),
+        dict(
+            batch_size=1,
+            seq_len_q=4096,
+            seq_len_kv=4096,
+            num_qo_heads=16,
+            num_kv_heads=16,
+            head_dim=256,
+            dtype="fp8",
+            mask_type="dense",
+        ),
+        dict(
+            batch_size=1,
+            seq_len_q=4096,
+            seq_len_kv=4096,
+            num_qo_heads=8,
+            num_kv_heads=2,
+            head_dim=128,
+            dtype="bf16",
+            mask_type="causal",
+        ),
+    )
+    for config in configs:
+        if args.head_dim is not None and config["head_dim"] != args.head_dim:
+            continue
+        bench_config(
+            **{**config, "dtype": _dtype(config["dtype"])},
+            thresholds=thresholds,
+            iters=args.iters,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bench_prims_ts_skip_softmax.py
+++ b/benchmarks/bench_prims_ts_skip_softmax.py
@@ -21,7 +21,7 @@ at several thresholds on one fixed-shape problem per configuration. Random
 N(0, 0.2) inputs keep every K/V tile's scaled score gap to the running maximum
 inside roughly exp(gap) in [0.7, 1.4], so ``threshold=0`` measures the cost of
 the skip machinery without any skipping, ``threshold=1`` skips a data-dependent
-subset of tiles, and ``threshold=2`` skips every tile after a query group's
+subset of tiles, and ``threshold=2`` skips every tile after a softmax warp's
 first one, which bounds the attainable speedup.
 
 Example:

--- a/flashinfer/attention/prims_ts/README.md
+++ b/flashinfer/attention/prims_ts/README.md
@@ -23,7 +23,7 @@ The component guides define supported shapes, layouts, metadata lifetime,
 output/workspace ownership, examples, limitations, and validation commands.
 
 The FMHA context APIs accept an optional `skip_softmax_threshold`. It selects a
-skip-softmax specialization that bypasses the softmax and PV work of K/V tiles
+skip-softmax specialization that skips the softmax and PV MMA of K/V tiles
 whose scores cannot contribute more than the threshold relative to the running
 maximum; see the context guide for the exact contract, the scalar versus
 per-request tensor forms, and their CUDA Graph semantics.

--- a/flashinfer/attention/prims_ts/README.md
+++ b/flashinfer/attention/prims_ts/README.md
@@ -22,6 +22,12 @@ Import all entries below from `flashinfer.attention.prims_ts`.
 The component guides define supported shapes, layouts, metadata lifetime,
 output/workspace ownership, examples, limitations, and validation commands.
 
+The FMHA context APIs accept an optional `skip_softmax_threshold`. It selects a
+skip-softmax specialization that bypasses the softmax and PV work of K/V tiles
+whose scores cannot contribute more than the threshold relative to the running
+maximum; see the context guide for the exact contract, the scalar versus
+per-request tensor forms, and their CUDA Graph semantics.
+
 For `BlockSparsePagedTSWrapper`, `plan` freezes only the compact fixed-Q
 geometry, dtypes, sparse-route capacity, and `max_seq_len_kv`; it retains no
 request metadata. Every `run` reads live paged-KV row offsets, physical page

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -39,7 +39,7 @@ import itertools
 import math
 import numbers
 import struct
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import torch
 
@@ -99,6 +99,7 @@ class _ContextGeometry:
     has_q_offset: bool
     causal_single_kv_tile: bool
     packed_dense_k_mask: bool
+    skip_softmax: bool
     q_shape: tuple[int, ...]
     kv_shape: tuple[int, ...]
 
@@ -127,6 +128,7 @@ class _PagedContextGeometry:
     uniform_packed_lengths: bool
     has_q_offset: bool
     packed_dense_k_mask: bool
+    skip_softmax: bool
     q_shape: tuple[int, ...]
     kv_shape: tuple[int, ...]
 
@@ -176,6 +178,7 @@ class _ContextCompileSpec:
     has_q_offset: bool
     causal_single_kv_tile: bool
     packed_dense_k_mask: bool
+    skip_softmax: bool
     scheduler: _ContextScheduler
 
 
@@ -199,6 +202,7 @@ class _PagedContextCompileSpec:
     uniform_packed_lengths: bool
     has_q_offset: bool
     packed_dense_k_mask: bool
+    skip_softmax: bool
     scheduler: _ContextScheduler
 
 
@@ -217,6 +221,7 @@ def _make_context_kernel(
     scheduler: _ContextScheduler,
     page_size: int | None = None,
     max_num_pages_per_seq_kv: int | None = None,
+    skip_softmax: bool = False,
 ):
     """Build one context kernel from its batch-independent static topology."""
 
@@ -261,6 +266,7 @@ def _make_context_kernel(
         h_r=num_qo_heads // num_kv_heads,
         enable_skip_correction=True,
         causal_single_kv_tile=(causal_single_kv_tile and not use_paged_kv),
+        skip_softmax=skip_softmax,
         **paged_kwargs,
     )
 
@@ -456,6 +462,50 @@ def _validate_scale(value: object, name: str) -> float:
     if not math.isfinite(as_float32) or as_float32 <= 0.0:
         raise ValueError(f"{name} must be representable as a positive float32")
     return as_float32
+
+
+def _resolve_skip_softmax_threshold(
+    value: Optional[Union[float, torch.Tensor]],
+    *,
+    batch_size: int,
+    device: torch.device,
+) -> Optional[torch.Tensor]:
+    """Return the per-request ``float32[B]`` skip-softmax threshold tensor.
+
+    ``None`` selects the dense kernel. A Python scalar is expanded into a
+    plan-owned tensor, so its value is fixed for the plan and for any CUDA
+    graph that captures it. A caller-owned tensor is retained as a live input:
+    the caller may update its values in place between runs or replays while
+    keeping its storage stable. Finite, non-negative element values are a
+    caller contract; they are not validated to avoid host synchronization.
+    """
+    if value is None:
+        return None
+    if isinstance(value, torch.Tensor):
+        _validate_tensor(value, "skip_softmax_threshold")
+        if _device_index(value.device) != _device_index(device):
+            raise ValueError(
+                f"skip_softmax_threshold must be on {device}, got {value.device}"
+            )
+        if value.dtype != torch.float32:
+            raise TypeError("skip_softmax_threshold must have dtype torch.float32")
+        if tuple(value.shape) != (batch_size,):
+            raise ValueError(
+                "skip_softmax_threshold must have shape "
+                f"[{batch_size}], got {tuple(value.shape)}"
+            )
+        _validate_compact(value, "skip_softmax_threshold", "[B]")
+        _validate_alignment(value, "skip_softmax_threshold", 4)
+        return value
+    if isinstance(value, bool) or not isinstance(value, numbers.Real):
+        raise TypeError(
+            "skip_softmax_threshold must be None, a non-negative Python scalar, "
+            "or a float32 CUDA tensor"
+        )
+    as_float = float(value)
+    if not math.isfinite(as_float) or as_float < 0.0:
+        raise ValueError("skip_softmax_threshold must be finite and non-negative")
+    return torch.full((batch_size,), as_float, dtype=torch.float32, device=device)
 
 
 def _validate_extent(value: int, name: str) -> int:
@@ -792,6 +842,7 @@ def _resolve_geometry(
     mask_type: str,
     window_left: int,
     output_dtype: torch.dtype,
+    skip_softmax: bool = False,
 ) -> _ContextGeometry:
     """Validate a plan and derive its semantic and storage geometry.
 
@@ -922,6 +973,7 @@ def _resolve_geometry(
         has_q_offset=has_q_offset,
         causal_single_kv_tile=causal_single_kv_tile,
         packed_dense_k_mask=packed_dense_k_mask,
+        skip_softmax=skip_softmax,
         q_shape=q_shape,
         kv_shape=kv_shape,
     )
@@ -940,6 +992,7 @@ def _resolve_paged_geometry(
     mask_type: str,
     window_left: int,
     output_dtype: torch.dtype,
+    skip_softmax: bool = False,
 ) -> tuple[_PagedContextGeometry, _PagedContextMetadata]:
     """Validate packed-Q paged-KV inputs and materialize their static ABI."""
 
@@ -1118,6 +1171,7 @@ def _resolve_paged_geometry(
         uniform_packed_lengths=uniform_packed_lengths,
         has_q_offset=has_q_offset,
         packed_dense_k_mask=packed_dense_k_mask,
+        skip_softmax=skip_softmax,
         q_shape=tuple(q.shape),
         kv_shape=tuple(k_cache.shape),
     )
@@ -1160,6 +1214,7 @@ def _make_context_scheduler_probe(
         scheduler="static_persistent",
         page_size=page_size,
         max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
+        skip_softmax=geometry.skip_softmax,
     )
     with torch.cuda.device(geometry.device_index):
         max_active_clusters = int(utils.HardwareInfo().get_max_active_clusters(1))
@@ -1257,6 +1312,7 @@ def _context_compile_spec(geometry: _ContextGeometry) -> _ContextCompileSpec:
         has_q_offset=geometry.has_q_offset,
         causal_single_kv_tile=geometry.causal_single_kv_tile,
         packed_dense_k_mask=geometry.packed_dense_k_mask,
+        skip_softmax=geometry.skip_softmax,
         scheduler=_resolve_context_scheduler(geometry),
     )
 
@@ -1281,6 +1337,7 @@ def _paged_context_compile_spec(
         uniform_packed_lengths=geometry.uniform_packed_lengths,
         has_q_offset=geometry.has_q_offset,
         packed_dense_k_mask=geometry.packed_dense_k_mask,
+        skip_softmax=geometry.skip_softmax,
         scheduler=_resolve_paged_context_scheduler(geometry),
     )
 
@@ -1307,6 +1364,7 @@ def _get_compiled_context(
     has_q_offset = compile_spec.has_q_offset
     causal_single_kv_tile = compile_spec.causal_single_kv_tile
     packed_dense_k_mask = compile_spec.packed_dense_k_mask
+    skip_softmax = compile_spec.skip_softmax
     scheduler = compile_spec.scheduler
 
     import cutlass
@@ -1336,6 +1394,7 @@ def _get_compiled_context(
         has_q_offset=has_q_offset,
         causal_single_kv_tile=causal_single_kv_tile,
         scheduler=scheduler,
+        skip_softmax=skip_softmax,
     )
     fmha.cfg.has_varlen = packed
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths
@@ -1366,14 +1425,21 @@ def _get_compiled_context(
         variable_window_token_starts: cute.Tensor,
         variable_window_token_ends: cute.Tensor,
         variable_window_cta_starts: cute.Tensor,
+        skip_softmax_threshold: cute.Tensor,
         stream: cuda_drv.CUstream,
         static_max_active_clusters: cutlass.Constexpr[int],
         static_packed: cutlass.Constexpr[bool],
         static_max_seq_len_q: cutlass.Constexpr[int],
         static_max_seq_len_k: cutlass.Constexpr[int],
+        static_skip_softmax: cutlass.Constexpr[bool],
     ) -> None:
         """Adapt torch TVM-FFI tensors to the FmhaTs host entry point."""
 
+        # The dense specialization receives a one-element placeholder and
+        # never reads it.
+        threshold = (
+            skip_softmax_threshold if cutlass.const_expr(static_skip_softmax) else None
+        )
         if cutlass.const_expr(static_packed):
             fmha(
                 q,
@@ -1391,6 +1457,7 @@ def _get_compiled_context(
                 variable_window_token_starts=variable_window_token_starts,
                 variable_window_token_ends=variable_window_token_ends,
                 variable_window_cta_starts=variable_window_cta_starts,
+                skip_softmax_threshold=threshold,
             )
         else:
             fmha(
@@ -1405,6 +1472,7 @@ def _get_compiled_context(
                 variable_window_token_starts=variable_window_token_starts,
                 variable_window_token_ends=variable_window_token_ends,
                 variable_window_cta_starts=variable_window_cta_starts,
+                skip_softmax_threshold=threshold,
             )
 
     def fake_compact(dtype, shape, assumed_align):
@@ -1463,6 +1531,7 @@ def _get_compiled_context(
     variable_window_cta_starts_fake = fake_compact(
         cutlass.Int32, variable_window_cta_shape, 4
     )
+    skip_softmax_threshold_fake = fake_compact(cutlass.Float32, (cute.sym_int(),), 4)
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     # Task objects carry loop-local state through generated control flow, so
@@ -1481,11 +1550,13 @@ def _get_compiled_context(
             variable_window_starts_fake,
             variable_window_ends_fake,
             variable_window_cta_starts_fake,
+            skip_softmax_threshold_fake,
             stream_fake,
             max_active_clusters,
             packed,
             max_seq_len_q,
             max_seq_len_k,
+            skip_softmax,
             options=_COMPILE_OPTIONS,
         )
     policy = (
@@ -1494,6 +1565,7 @@ def _get_compiled_context(
         ("uniform_packed_lengths", uniform_packed_lengths),
         ("causal_single_kv_tile", causal_single_kv_tile),
         ("packed_dense_k_mask", packed_dense_k_mask),
+        ("skip_softmax", skip_softmax),
     )
     return compiled, policy
 
@@ -1520,6 +1592,7 @@ def _get_compiled_paged_context(
     uniform_packed_lengths = compile_spec.uniform_packed_lengths
     has_q_offset = compile_spec.has_q_offset
     packed_dense_k_mask = compile_spec.packed_dense_k_mask
+    skip_softmax = compile_spec.skip_softmax
     scheduler = compile_spec.scheduler
 
     import cutlass
@@ -1550,6 +1623,7 @@ def _get_compiled_paged_context(
         scheduler=scheduler,
         page_size=page_size,
         max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
+        skip_softmax=skip_softmax,
     )
     fmha.cfg.has_varlen = True
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths
@@ -1577,11 +1651,18 @@ def _get_compiled_paged_context(
         kv_indptr: cute.Tensor,
         page_idx_kv: cute.Tensor,
         seq_lens_kv: cute.Tensor,
+        skip_softmax_threshold: cute.Tensor,
         stream: cuda_drv.CUstream,
         static_max_active_clusters: cutlass.Constexpr[int],
         static_max_seq_len_q: cutlass.Constexpr[int],
         static_max_seq_len_k: cutlass.Constexpr[int],
+        static_skip_softmax: cutlass.Constexpr[bool],
     ) -> None:
+        # The dense specialization receives a one-element placeholder and
+        # never reads it.
+        threshold = (
+            skip_softmax_threshold if cutlass.const_expr(static_skip_softmax) else None
+        )
         fmha(
             q,
             k_cache,
@@ -1597,6 +1678,7 @@ def _get_compiled_paged_context(
             cutlass.Int32(static_max_seq_len_k),
             page_idx_kv,
             seq_lens_kv,
+            skip_softmax_threshold=threshold,
         )
 
     def fake_compact(dtype, shape, assumed_align):
@@ -1632,6 +1714,7 @@ def _get_compiled_paged_context(
         4,
     )
     seq_lens_fake = fake_compact(cutlass.Int32, (batch_size,), 4)
+    skip_softmax_threshold_fake = fake_compact(cutlass.Float32, (cute.sym_int(),), 4)
     stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
     with torch.cuda.device(device_index):
@@ -1647,10 +1730,12 @@ def _get_compiled_paged_context(
             kv_indptr_fake,
             page_idx_fake,
             seq_lens_fake,
+            skip_softmax_threshold_fake,
             stream_fake,
             max_active_clusters,
             max_seq_len_q,
             max_seq_len_k,
+            skip_softmax,
             options=_COMPILE_OPTIONS,
         )
     policy = (
@@ -1660,6 +1745,7 @@ def _get_compiled_paged_context(
         ("page_size", page_size),
         ("causal_single_kv_tile", False),
         ("packed_dense_k_mask", packed_dense_k_mask),
+        ("skip_softmax", skip_softmax),
     )
     return compiled, policy
 
@@ -1783,6 +1869,7 @@ class BatchPrefillTSWrapper:
         sm_scale: Optional[float] = None,
         output_scale: float = 1.0,
         out_dtype: Optional[torch.dtype] = None,
+        skip_softmax_threshold: Optional[Union[float, torch.Tensor]] = None,
     ) -> None:
         """Validate semantics, establish Q/K capacities, and compile once.
 
@@ -1810,6 +1897,21 @@ class BatchPrefillTSWrapper:
             Scale applied to the attention output.
         out_dtype : torch.dtype, optional
             Output dtype; defaults to the query dtype.
+        skip_softmax_threshold : float or torch.Tensor, optional
+            Skip-softmax threshold in the ordinary softmax domain. ``None``
+            selects the dense kernel. Any provided value, including zero,
+            selects the skip-enabled kernel: a 128-key K/V tile is skipped for
+            a 32-row query group when every row of the group satisfies
+            ``exp(sm_scale * (tile_max - running_max)) < threshold``. Skipped
+            tiles contribute zero probability mass and leave the running
+            maximum unchanged, and the PV MMA is bypassed once all four groups
+            of a 128-row query tile skip. A scalar applies to every request
+            and is fixed for the plan and for any CUDA graph that captures
+            it. A contiguous CUDA ``float32[B]`` tensor gives request ``b``
+            its own threshold and is retained as a live input: its storage
+            must stay valid and stable, while its values may be updated in
+            place between runs or graph replays. Values must be finite and
+            non-negative; tensor contents are not validated.
         """
 
         if out_dtype is None:
@@ -1827,6 +1929,7 @@ class BatchPrefillTSWrapper:
             mask_type=mask_type,
             window_left=window_left,
             output_dtype=resolved_out_dtype,
+            skip_softmax=skip_softmax_threshold is not None,
         )
         if mask_type == "variable_window":
             validated_window_starts, validated_window_ends = (
@@ -1874,6 +1977,17 @@ class BatchPrefillTSWrapper:
         output_scale_tensor = torch.tensor(
             [output_scale], dtype=torch.float32, device=geometry.device
         )
+        planned_skip_softmax_threshold = _resolve_skip_softmax_threshold(
+            skip_softmax_threshold,
+            batch_size=geometry.batch_size,
+            device=geometry.device,
+        )
+        if planned_skip_softmax_threshold is None:
+            # Uniform TVM-FFI signature; the dense specialization never reads
+            # this placeholder.
+            planned_skip_softmax_threshold = torch.empty(
+                1, dtype=torch.float32, device=geometry.device
+            )
         if geometry.packed:
             assert qo_indptr is not None and kv_indptr is not None
             planned_qo_indptr = qo_indptr
@@ -1902,6 +2016,7 @@ class BatchPrefillTSWrapper:
         self._variable_window_token_starts = planned_window_starts
         self._variable_window_token_ends = planned_window_ends
         self._variable_window_cta_starts = planned_window_cta_starts
+        self._skip_softmax_threshold = planned_skip_softmax_threshold
         self._compiled = compiled
         self._policy = policy
         self._planned = True
@@ -1943,6 +2058,7 @@ class BatchPrefillTSWrapper:
                 ("variable_window_token_starts", self._variable_window_token_starts),
                 ("variable_window_token_ends", self._variable_window_token_ends),
                 ("variable_window_cta_starts", self._variable_window_cta_starts),
+                ("skip_softmax_threshold", self._skip_softmax_threshold),
             )
         self._compiled(
             q,
@@ -1956,6 +2072,7 @@ class BatchPrefillTSWrapper:
             self._variable_window_token_starts,
             self._variable_window_token_ends,
             self._variable_window_cta_starts,
+            self._skip_softmax_threshold,
         )
         return out
 
@@ -2019,6 +2136,7 @@ class BatchPrefillPagedTSWrapper:
         sm_scale: Optional[float] = None,
         output_scale: float = 1.0,
         out_dtype: Optional[torch.dtype] = None,
+        skip_softmax_threshold: Optional[Union[float, torch.Tensor]] = None,
     ) -> None:
         """Snapshot K/V metadata, retain live Q offsets, and compile once.
 
@@ -2047,6 +2165,12 @@ class BatchPrefillPagedTSWrapper:
             Scale applied to the attention output.
         out_dtype : torch.dtype, optional
             Output dtype; defaults to the query dtype.
+        skip_softmax_threshold : float or torch.Tensor, optional
+            Skip-softmax threshold in the ordinary softmax domain; see
+            :meth:`BatchPrefillTSWrapper.plan`. ``None`` selects the dense
+            kernel. A scalar is fixed for the plan; a contiguous CUDA
+            ``float32[B]`` tensor is retained live and may be updated in
+            place between runs or graph replays.
         """
 
         if out_dtype is None:
@@ -2067,6 +2191,7 @@ class BatchPrefillPagedTSWrapper:
             mask_type=mask_type,
             window_left=window_left,
             output_dtype=resolved_out_dtype,
+            skip_softmax=skip_softmax_threshold is not None,
         )
         if sm_scale is None:
             sm_scale = 1.0 / math.sqrt(geometry.head_dim)
@@ -2081,6 +2206,17 @@ class BatchPrefillPagedTSWrapper:
         output_scale_tensor = torch.tensor(
             [output_scale], dtype=torch.float32, device=geometry.device
         )
+        planned_skip_softmax_threshold = _resolve_skip_softmax_threshold(
+            skip_softmax_threshold,
+            batch_size=geometry.batch_size,
+            device=geometry.device,
+        )
+        if planned_skip_softmax_threshold is None:
+            # Uniform TVM-FFI signature; the dense specialization never reads
+            # this placeholder.
+            planned_skip_softmax_threshold = torch.empty(
+                1, dtype=torch.float32, device=geometry.device
+            )
         logical_kv_indptr = torch.tensor(
             metadata.kv_indptr, dtype=torch.int32, device=geometry.device
         )
@@ -2114,6 +2250,7 @@ class BatchPrefillPagedTSWrapper:
         self._dense_page_idx_kv = dense_page_idx_kv
         self._scale_softmax_log2 = scale_tensor
         self._output_scale = output_scale_tensor
+        self._skip_softmax_threshold = planned_skip_softmax_threshold
         self._compiled = compiled
         self._policy = policy
         self._planned = True
@@ -2159,6 +2296,7 @@ class BatchPrefillPagedTSWrapper:
                 ("dense_page_idx_kv", self._dense_page_idx_kv),
                 ("scale_softmax_log2", self._scale_softmax_log2),
                 ("output_scale", self._output_scale),
+                ("skip_softmax_threshold", self._skip_softmax_threshold),
             )
         self._compiled(
             q,
@@ -2171,6 +2309,7 @@ class BatchPrefillPagedTSWrapper:
             self._logical_kv_indptr,
             self._dense_page_idx_kv,
             self._seq_lens_kv,
+            self._skip_softmax_threshold,
         )
         return out
 
@@ -2190,6 +2329,7 @@ def batch_prefill(
     sm_scale: Optional[float] = None,
     output_scale: float = 1.0,
     out_dtype: Optional[torch.dtype] = None,
+    skip_softmax_threshold: Optional[Union[float, torch.Tensor]] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Run one-shot fixed or packed-ragged task-scheduled context attention.
@@ -2223,6 +2363,9 @@ def batch_prefill(
         Scale applied to the attention output.
     out_dtype : torch.dtype, optional
         Requested output dtype.
+    skip_softmax_threshold : float or torch.Tensor, optional
+        Skip-softmax threshold in the ordinary softmax domain; see
+        :meth:`BatchPrefillTSWrapper.plan`. ``None`` selects the dense kernel.
     out : torch.Tensor, optional
         Caller-owned output tensor.
     """
@@ -2244,6 +2387,7 @@ def batch_prefill(
         sm_scale=sm_scale,
         output_scale=output_scale,
         out_dtype=resolved_out_dtype,
+        skip_softmax_threshold=skip_softmax_threshold,
     )
     return wrapper.run(q, k, v, out=out)
 
@@ -2265,6 +2409,7 @@ def batch_prefill_with_paged_kv_cache(
     sm_scale: Optional[float] = None,
     output_scale: float = 1.0,
     out_dtype: Optional[torch.dtype] = None,
+    skip_softmax_threshold: Optional[Union[float, torch.Tensor]] = None,
     out: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Run one-shot packed-Q context attention over separate HND page pools.
@@ -2300,6 +2445,9 @@ def batch_prefill_with_paged_kv_cache(
         Scale applied to the attention output.
     out_dtype : torch.dtype, optional
         Requested output dtype.
+    skip_softmax_threshold : float or torch.Tensor, optional
+        Skip-softmax threshold in the ordinary softmax domain; see
+        :meth:`BatchPrefillTSWrapper.plan`. ``None`` selects the dense kernel.
     out : torch.Tensor, optional
         Caller-owned output tensor.
     """
@@ -2322,6 +2470,7 @@ def batch_prefill_with_paged_kv_cache(
         sm_scale=sm_scale,
         output_scale=output_scale,
         out_dtype=resolved_out_dtype,
+        skip_softmax_threshold=skip_softmax_threshold,
     )
     return wrapper.run(q, k_cache, v_cache, out=out)
 

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -1901,11 +1901,11 @@ class BatchPrefillTSWrapper:
             Skip-softmax threshold in the ordinary softmax domain. ``None``
             selects the dense kernel. Any provided value, including zero,
             selects the skip-enabled kernel: a 128-key K/V tile is skipped for
-            a 32-row query group when every row of the group satisfies
+            the 32 Q rows owned by one softmax warp when every valid row satisfies
             ``exp(sm_scale * (tile_max - running_max)) < threshold``. Skipped
             tiles contribute zero probability mass and leave the running
-            maximum unchanged, and the PV MMA is bypassed once all four groups
-            of a 128-row query tile skip. A scalar applies to every request
+            maximum unchanged, and the PV MMA is skipped once all four softmax
+            warps of a Q/KV instance skip. A scalar applies to every request
             and is fixed for the plan and for any CUDA graph that captures
             it. A contiguous CUDA ``float32[B]`` tensor gives request ``b``
             its own threshold and is retained as a live input: its storage

--- a/flashinfer/attention/prims_ts/context.py
+++ b/flashinfer/attention/prims_ts/context.py
@@ -221,7 +221,7 @@ def _make_context_kernel(
     scheduler: _ContextScheduler,
     page_size: int | None = None,
     max_num_pages_per_seq_kv: int | None = None,
-    skip_softmax: bool = False,
+    enable_skip_softmax: bool = False,
 ):
     """Build one context kernel from its batch-independent static topology."""
 
@@ -266,7 +266,7 @@ def _make_context_kernel(
         h_r=num_qo_heads // num_kv_heads,
         enable_skip_correction=True,
         causal_single_kv_tile=(causal_single_kv_tile and not use_paged_kv),
-        skip_softmax=skip_softmax,
+        enable_skip_softmax=enable_skip_softmax,
         **paged_kwargs,
     )
 
@@ -1214,7 +1214,7 @@ def _make_context_scheduler_probe(
         scheduler="static_persistent",
         page_size=page_size,
         max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
-        skip_softmax=geometry.skip_softmax,
+        enable_skip_softmax=geometry.skip_softmax,
     )
     with torch.cuda.device(geometry.device_index):
         max_active_clusters = int(utils.HardwareInfo().get_max_active_clusters(1))
@@ -1394,7 +1394,7 @@ def _get_compiled_context(
         has_q_offset=has_q_offset,
         causal_single_kv_tile=causal_single_kv_tile,
         scheduler=scheduler,
-        skip_softmax=skip_softmax,
+        enable_skip_softmax=skip_softmax,
     )
     fmha.cfg.has_varlen = packed
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths
@@ -1623,7 +1623,7 @@ def _get_compiled_paged_context(
         scheduler=scheduler,
         page_size=page_size,
         max_num_pages_per_seq_kv=max_num_pages_per_seq_kv,
-        skip_softmax=skip_softmax,
+        enable_skip_softmax=skip_softmax,
     )
     fmha.cfg.has_varlen = True
     fmha.cfg.has_uniform_varlen = uniform_packed_lengths

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
@@ -81,10 +81,10 @@ remain internal to the kernel.
 `skip_softmax_threshold` selects the skip-softmax specialization of the same
 kernel. `None` compiles the dense kernel. Any provided value, including zero,
 compiles the skip-enabled kernel, whose decision runs once per 128-key K/V
-tile for each 32-row query group of a softmax warp:
+tile for the 32 Q rows owned by one softmax warp:
 
 ```text
-skip the tile for the group  <=>  for every row of the group,
+skip the tile for the warp  <=>  for every valid row of the warp,
     exp(sm_scale * (tile_max - running_max)) < skip_softmax_threshold
 ```
 
@@ -93,12 +93,12 @@ converts it to the log2 domain once per work tile. `tile_max` is the row's
 largest masked score in the tile and `running_max` is the row's current
 softmax maximum, so a row that has not met a valid key yet never votes to
 skip, and a zero threshold never skips. Only the rows inside the request
-vote; the TMA padding rows of a partial query tile abstain. A skipped tile
+vote; the TMA padding rows of a partial Q tile abstain. A skipped tile
 contributes zero probability mass: the warp publishes an all-zero P tile
-without exponentiation, keeps its running maximum and denominator, and votes
-in shared memory. When all four softmax warps of a 128-row query tile skip,
+without exp2, keeps its running maximum and denominator, and votes
+in SMEM. When all four softmax warps of a Q/KV instance skip,
 the MMA task also skips that tile's PV MMA. K and V tiles are still loaded, so
-the saving is in softmax and tensor-core work rather than in memory traffic.
+the saving is in softmax and PV MMA work rather than in memory traffic.
 Skipping is an approximation chosen by the caller: larger thresholds skip
 more tiles and deviate further from dense attention.
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
@@ -190,10 +190,11 @@ Q + contiguous or paged K/V
 
 The TS graph assigns load, MMA, softmax, correction, epilogue, page-offset,
 and scheduling work to cooperating tasks. Resources own the corresponding
-SMEM/TMEM buffers and pipeline state. Skip-softmax specializations add one
-SMEM vote word per S/P stage and Q/KV instance, one byte per softmax warp: the
-softmax warp writes its byte before publishing P, and the MMA task reads the
-word after the P-ready wait to decide whether to issue the PV MMA.
+SMEM/TMEM buffers and pipeline state. Skip-softmax specializations add a
+pipeline-less `SmemSkipVoteResource` per Q/KV instance that owns the request
+threshold and one SMEM vote word per softmax warp and S/P stage: the softmax
+warp writes its word before publishing P, and the MMA task reads the four words
+of the stage after the P-ready wait to decide whether to issue the PV MMA.
 
 Paged D256 uses topology-derived page-ID staging. For a dense static domain
 that is divisible by the complete staged window and whose exact SMEM footprint

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
@@ -191,10 +191,9 @@ Q + contiguous or paged K/V
 The TS graph assigns load, MMA, softmax, correction, epilogue, page-offset,
 and scheduling work to cooperating tasks. Resources own the corresponding
 SMEM/TMEM buffers and pipeline state. Skip-softmax specializations add one
-shared-memory vote word per softmax warp, S/P stage, and Q/KV instance: the
-softmax warp writes its vote before publishing P, and the MMA task reads the
-four words of an instance after the P-ready wait to decide whether to issue
-the PV MMA.
+SMEM vote word per S/P stage and Q/KV instance, one byte per softmax warp: the
+softmax warp writes its byte before publishing P, and the MMA task reads the
+word after the P-ready wait to decide whether to issue the PV MMA.
 
 Paged D256 uses topology-derived page-ID staging. For a dense static domain
 that is divisible by the complete staged window and whose exact SMEM footprint

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/README.md
@@ -54,6 +54,7 @@ against the K/V lengths and page table translated and snapshotted by `plan()`.
 | Page size | 16, 32, 64, or 128 tokens |
 | Mask | Dense or bottom-right causal |
 | Sliding window | Positive causal left window; `window_left=-1` disables it |
+| Skip softmax | Optional `skip_softmax_threshold`: `None` (dense), a scalar, or a live `float32[B]` tensor |
 | Scheduling | Automatic nonpersistent, static-persistent, or CLC-persistent selection; no public tuning knob |
 | Accumulation | FP32 QK/PV and softmax state |
 
@@ -74,6 +75,42 @@ least 4-byte aligned. A caller-provided `out` must not overlap Q, K, V, or any
 metadata retained by the plan. The launch conservatively rejects overlapping
 storage spans. The API returns O only; rowwise LSE and other softmax state
 remain internal to the kernel.
+
+## Skip softmax
+
+`skip_softmax_threshold` selects the skip-softmax specialization of the same
+kernel. `None` compiles the dense kernel. Any provided value, including zero,
+compiles the skip-enabled kernel, whose decision runs once per 128-key K/V
+tile for each 32-row query group of a softmax warp:
+
+```text
+skip the tile for the group  <=>  for every row of the group,
+    exp(sm_scale * (tile_max - running_max)) < skip_softmax_threshold
+```
+
+The threshold is expressed in the ordinary softmax domain; the kernel
+converts it to the log2 domain once per work tile. `tile_max` is the row's
+largest masked score in the tile and `running_max` is the row's current
+softmax maximum, so a row that has not met a valid key yet never votes to
+skip, and a zero threshold never skips. Only the rows inside the request
+vote; the TMA padding rows of a partial query tile abstain. A skipped tile
+contributes zero probability mass: the warp publishes an all-zero P tile
+without exponentiation, keeps its running maximum and denominator, and votes
+in shared memory. When all four softmax warps of a 128-row query tile skip,
+the MMA task also skips that tile's PV MMA. K and V tiles are still loaded, so
+the saving is in softmax and tensor-core work rather than in memory traffic.
+Skipping is an approximation chosen by the caller: larger thresholds skip
+more tiles and deviate further from dense attention.
+
+A Python scalar applies the same threshold to every request and is fixed for
+the plan. If such a plan is captured in a CUDA graph, the value is baked into
+the graph and cannot change between replays. A contiguous CUDA `float32[B]`
+tensor gives request `b` its own threshold and is retained as a live input:
+the caller owns its allocation and lifetime, keeps its address stable, and
+may update its values in place between runs or graph replays. The kernel only
+reads the tensor. Element values must be finite and non-negative; their
+contents are not validated to avoid host synchronization. The one-shot APIs
+accept the same forms.
 
 ## Tensor and metadata layouts
 
@@ -153,7 +190,11 @@ Q + contiguous or paged K/V
 
 The TS graph assigns load, MMA, softmax, correction, epilogue, page-offset,
 and scheduling work to cooperating tasks. Resources own the corresponding
-SMEM/TMEM buffers and pipeline state.
+SMEM/TMEM buffers and pipeline state. Skip-softmax specializations add one
+shared-memory vote word per softmax warp, S/P stage, and Q/KV instance: the
+softmax warp writes its vote before publishing P, and the MMA task reads the
+four words of an instance after the P-ready wait to decide whether to issue
+the PV MMA.
 
 Paged D256 uses topology-derived page-ID staging. For a dense static domain
 that is divisible by the complete staged window and whose exact SMEM footprint
@@ -243,6 +284,8 @@ non-overlapping `out`.
 - Positive windows are restricted to even-ratio GQA because the kernel pairs
   query heads that share a K/V head.
 - Attention sinks, custom masks, and mixed Q/K/V dtypes are not exposed.
+- Skip softmax does not reduce K/V load traffic and exposes no skip
+  statistics; validate its accuracy impact for each threshold.
 - Re-plan after changing paged K/V metadata values. Live packed offsets may be
   updated only within their plan-time Q/K capacities, packed extents, and
   per-request causal contract.
@@ -252,7 +295,8 @@ non-overlapping `out`.
 The public suite covers fixed, ragged, and paged layouts; MHA/GQA; both head
 dimensions; `torch.float16`, `torch.bfloat16`, and `torch.float8_e4m3fn`
 inputs; dense, causal, and left-window masks; nonidentity pages; scheduler
-safety; CUDA graphs; and reference accuracy. Explicit input-to-output dtype
+safety; CUDA graphs; skip softmax against a tile-level emulation of its
+decisions; and reference accuracy. Explicit input-to-output dtype
 conversion coverage spans all nine pairings of FP16, BF16, and FP8 input and
 output state.
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -47,7 +47,7 @@ Feature Support Matrix:
   | `S_q` / `S_kv`   | Query-paired causal requires `S_q <= S_kv`; arbitrary positive tails are supported             |
   | GQA              | Must satisfy `h_q % h_kv == 0`; causal GQA can use head-paired scheduling                    |
   | Sliding window   | `mask_type="causal", window_left=N`; left window only                                        |
-  | Skip softmax     | Optional per-request threshold; skipped K/V tiles bypass exp2, P conversion, and PV MMA     |
+  | Skip softmax     | Optional per-request threshold; skipped K/V tiles omit exp2, P conversion, and PV MMA       |
   | Scheduler modes  | Query-paired: static CTAs, persistent, CLC; head-paired: persistent, CLC                      |
 
 ASCII Flow Chart:
@@ -2407,7 +2407,7 @@ class FmhaTs:
         extent fits one 128-token tile (default: False).
     enable_skip_softmax : bool, optional
         Compile the skip-softmax specialization. Each softmax warp skips the
-        exponentiation, P conversion, and row-sum work of a K/V tile whose
+        exp2, P conversion, and row-sum reduction of a K/V tile whose
         scaled score gap to the running maximum is below the per-request
         threshold, and the MMA task skips the PV MMA once every softmax warp of
         the instance voted to skip. The launch then requires the

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -695,7 +695,7 @@ def build_context_task_manager(
     it. ``output_scale`` multiplies the final O store; FP8 output can fold the
     V dequant scale and output quant scale into it. ``skip_softmax_threshold``
     is the ``float32[B]`` per-request skip-softmax threshold consumed only by
-    ``cfg.skip_softmax`` specializations; the softmax resource converts it to
+    ``cfg.enable_skip_softmax`` specializations; the softmax resource converts it to
     the log2 domain once per work tile. ``seq_len_q`` is the fixed-layout Q
     length those specializations use to let padding rows abstain from the
     skip vote; packed layouts derive it from ``cum_seqlen_q``.
@@ -1083,7 +1083,7 @@ def build_context_task_manager(
     # stage of each instance. The MMA task reads the four words of an instance
     # after the matching P-ready wait.
     skip_softmax_vote_alloc: SmemAllocation | None = None
-    if cfg.skip_softmax:
+    if cfg.enable_skip_softmax:
         skip_softmax_vote_alloc = SmemAllocation(
             "smem_skip_softmax_vote",
             dtype=cutlass.Int32,
@@ -1699,7 +1699,7 @@ def _infer_single_instance_kv_stages(
     control_bytes = (2 * cutlass.Int32.width + cutlass.Int64.width) // 8
     if is_clc_dynamic:
         control_bytes += cutlass.Int128.width // 8
-    if cfg.skip_softmax:
+    if cfg.enable_skip_softmax:
         control_bytes += cfg.skip_softmax_vote_words * cutlass.Int32.width // 8
     fixed_barrier_stages = sum(
         _context_pipeline_stage_counts(
@@ -2405,7 +2405,7 @@ class FmhaTs:
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V
         extent fits one 128-token tile (default: False).
-    skip_softmax : bool, optional
+    enable_skip_softmax : bool, optional
         Compile the skip-softmax specialization. Each softmax warp skips the
         exponentiation, P conversion, and row-sum work of a K/V tile whose
         scaled score gap to the running maximum is below the per-request
@@ -2435,7 +2435,7 @@ class FmhaTs:
         num_tokens_per_page: int = 32,
         max_num_pages_per_seq_kv: int = 1,
         causal_single_kv_tile: bool = False,
-        skip_softmax: bool = False,
+        enable_skip_softmax: bool = False,
         exhaustive_deadlock_race_check: bool = True,
     ) -> None:
         """Initialize mode-specific tiling, dtype, and schedule configuration."""
@@ -2492,7 +2492,7 @@ class FmhaTs:
         if d > 128:
             cfg.num_qkv_instances = 1
         cfg.use_paged_kv = use_paged_kv
-        cfg.skip_softmax = skip_softmax
+        cfg.enable_skip_softmax = enable_skip_softmax
         single_instance_persistent = (
             is_persistent and cfg.single_qkv_instance and not head_paired
         )
@@ -2665,7 +2665,9 @@ class FmhaTs:
                 or variable_window_cta_starts is None
             ):
                 raise ValueError("VariableWindow requires start and end tensors")
-        if cutlass.const_expr(cfg.skip_softmax and skip_softmax_threshold is None):
+        if cutlass.const_expr(
+            cfg.enable_skip_softmax and skip_softmax_threshold is None
+        ):
             raise ValueError(
                 "skip-softmax context requires the per-request threshold tensor"
             )

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -47,6 +47,7 @@ Feature Support Matrix:
   | `S_q` / `S_kv`   | Query-paired causal requires `S_q <= S_kv`; arbitrary positive tails are supported             |
   | GQA              | Must satisfy `h_q % h_kv == 0`; causal GQA can use head-paired scheduling                    |
   | Sliding window   | `mask_type="causal", window_left=N`; left window only                                        |
+  | Skip softmax     | Optional per-request threshold; skipped K/V tiles bypass exp2, P conversion, and PV MMA     |
   | Scheduler modes  | Query-paired: static CTAs, persistent, CLC; head-paired: persistent, CLC                      |
 
 ASCII Flow Chart:
@@ -660,6 +661,8 @@ def build_context_task_manager(
     variable_window_q_stride: int | Int32 = 0,
     scale_softmax_log2: cute.Tensor | None = None,
     output_scale: cute.Tensor | None = None,
+    skip_softmax_threshold: cute.Tensor | None = None,
+    seq_len_q: int | Int32 | None = None,
     g_page_idx_kv: cute.Pointer | None = None,
     g_seq_lens_kv: cute.Pointer | None = None,
     max_seq_len_kv: int | Int32 | None = None,
@@ -690,7 +693,12 @@ def build_context_task_manager(
     is the base-2 softmax multiplier, normally
     ``softmax_scale * log2(e)``; FP8 callers can fold Q/K dequant scales into
     it. ``output_scale`` multiplies the final O store; FP8 output can fold the
-    V dequant scale and output quant scale into it.
+    V dequant scale and output quant scale into it. ``skip_softmax_threshold``
+    is the ``float32[B]`` per-request skip-softmax threshold consumed only by
+    ``cfg.skip_softmax`` specializations; the softmax resource converts it to
+    the log2 domain once per work tile. ``seq_len_q`` is the fixed-layout Q
+    length those specializations use to let padding rows abstain from the
+    skip vote; packed layouts derive it from ``cum_seqlen_q``.
 
     SMEM buffers are declared via ``SmemAllocation`` and bound from
     ``ResourceContext`` by auxiliary resource init work. The ``SmemAllocator``
@@ -1071,6 +1079,18 @@ def build_context_task_manager(
         else:
             work_queue = WorkQueue(**work_queue_kwargs)
 
+    # Skip softmax publishes one Int32 vote per softmax warp for every S/P
+    # stage of each instance. The MMA task reads the four words of an instance
+    # after the matching P-ready wait.
+    skip_softmax_vote_alloc: SmemAllocation | None = None
+    if cfg.skip_softmax:
+        skip_softmax_vote_alloc = SmemAllocation(
+            "smem_skip_softmax_vote",
+            dtype=cutlass.Int32,
+            count=cfg.skip_softmax_vote_words,
+            alignment=16,
+        )
+
     tmem_sp0 = TmemSPResource(
         pipeline_config=tmem_sp0_pipeline_cfg,
         cfg=cfg,
@@ -1085,6 +1105,9 @@ def build_context_task_manager(
         variable_window_cta_starts=variable_window_cta_starts,
         variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
+        skip_softmax_threshold=skip_softmax_threshold,
+        skip_softmax_vote_alloc=skip_softmax_vote_alloc,
+        seq_len_q=seq_len_q,
         name="tmem_sp0",
     )
     tmem_p0: TmemPResource | None = None
@@ -1147,6 +1170,9 @@ def build_context_task_manager(
             variable_window_cta_starts=variable_window_cta_starts,
             variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
+            skip_softmax_threshold=skip_softmax_threshold,
+            skip_softmax_vote_alloc=skip_softmax_vote_alloc,
+            seq_len_q=seq_len_q,
             name="tmem_sp1",
         )
         tmem_vec1 = TmemStatsResource(
@@ -1190,6 +1216,7 @@ def build_context_task_manager(
         tmem_o1_offset=cfg.tmem_o1_offset,
         tmem_vec0_resource=tmem_vec0,
         tmem_vec1_resource=tmem_vec1,
+        skip_softmax_vote_alloc=skip_softmax_vote_alloc,
         name="tmem_o",
         **tmem_o_kwargs,
     )
@@ -1478,6 +1505,8 @@ def build_context_task_manager(
     dealloc_mbar_alloc = smem_allocator.add(
         SmemAllocation("tmem_dealloc_mbar", dtype=cutlass.Int64, alignment=8)
     )
+    if skip_softmax_vote_alloc is not None:
+        smem_allocator.add(skip_softmax_vote_alloc)
     clc_response_alloc: SmemAllocation | None = None
     if is_clc_dynamic and clc_response_ptr is None:
         # Keep the CLC response inside the unified TS allocation. The kernel
@@ -1670,6 +1699,8 @@ def _infer_single_instance_kv_stages(
     control_bytes = (2 * cutlass.Int32.width + cutlass.Int64.width) // 8
     if is_clc_dynamic:
         control_bytes += cutlass.Int128.width // 8
+    if cfg.skip_softmax:
+        control_bytes += cfg.skip_softmax_vote_words * cutlass.Int32.width // 8
     fixed_barrier_stages = sum(
         _context_pipeline_stage_counts(
             cfg,
@@ -2215,6 +2246,8 @@ def build_fmha_task_manager(
     variable_window_q_stride: int | Int32 = 0,
     scale_softmax_log2: cute.Tensor | None = None,
     output_scale: cute.Tensor | None = None,
+    skip_softmax_threshold: cute.Tensor | None = None,
+    seq_len_q: int | Int32 | None = None,
     q_offset: int | Int32 = 0,
     g_page_idx_kv: cute.Pointer | None = None,
     g_seq_lens_kv: cute.Pointer | None = None,
@@ -2305,6 +2338,8 @@ def build_fmha_task_manager(
         variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
         output_scale=output_scale,
+        skip_softmax_threshold=skip_softmax_threshold,
+        seq_len_q=seq_len_q,
         g_page_idx_kv=g_page_idx_kv,
         g_seq_lens_kv=g_seq_lens_kv,
         max_seq_len_kv=max_seq_len_kv,
@@ -2370,6 +2405,13 @@ class FmhaTs:
         Use the fixed causal one-K/V-tile task domains. The context runner
         enables this only for query-paired, fixed-length inputs whose K/V
         extent fits one 128-token tile (default: False).
+    skip_softmax : bool, optional
+        Compile the skip-softmax specialization. Each softmax warp skips the
+        exponentiation, P conversion, and row-sum work of a K/V tile whose
+        scaled score gap to the running maximum is below the per-request
+        threshold, and the MMA task skips the PV MMA once every softmax warp of
+        the instance voted to skip. The launch then requires the
+        ``skip_softmax_threshold`` tensor (default: False).
     """
 
     def __init__(
@@ -2393,6 +2435,7 @@ class FmhaTs:
         num_tokens_per_page: int = 32,
         max_num_pages_per_seq_kv: int = 1,
         causal_single_kv_tile: bool = False,
+        skip_softmax: bool = False,
         exhaustive_deadlock_race_check: bool = True,
     ) -> None:
         """Initialize mode-specific tiling, dtype, and schedule configuration."""
@@ -2449,6 +2492,7 @@ class FmhaTs:
         if d > 128:
             cfg.num_qkv_instances = 1
         cfg.use_paged_kv = use_paged_kv
+        cfg.skip_softmax = skip_softmax
         single_instance_persistent = (
             is_persistent and cfg.single_qkv_instance and not head_paired
         )
@@ -2601,6 +2645,7 @@ class FmhaTs:
         variable_window_token_starts: cute.Tensor | None = None,
         variable_window_token_ends: cute.Tensor | None = None,
         variable_window_cta_starts: cute.Tensor | None = None,
+        skip_softmax_threshold: cute.Tensor | None = None,
     ) -> None:
         """Set up TMA descriptors, compute grid, and launch the kernel.
 
@@ -2608,7 +2653,9 @@ class FmhaTs:
         device tensors. Example host values are
         ``[math.log2(math.e) / math.sqrt(d)]`` for the softmax scale and
         ``[1.0]`` for FP16 output. FP8 callers may fold Q/K/V and output
-        quantization scales into these runtime tensors.
+        quantization scales into these runtime tensors. Skip-softmax
+        specializations also require ``skip_softmax_threshold``, a
+        ``float32[B]`` device tensor of e-based per-request thresholds.
         """
         cfg = self.cfg
         if cutlass.const_expr(cfg.has_variable_window):
@@ -2618,6 +2665,10 @@ class FmhaTs:
                 or variable_window_cta_starts is None
             ):
                 raise ValueError("VariableWindow requires start and end tensors")
+        if cutlass.const_expr(cfg.skip_softmax and skip_softmax_threshold is None):
+            raise ValueError(
+                "skip-softmax context requires the per-request threshold tensor"
+            )
 
         # Create TMA descriptors. Both query-paired and head-paired modes use
         # the same logical Q/K/V/O tensor-map boxes after FmhaConfig lowers the
@@ -2866,6 +2917,7 @@ class FmhaTs:
             variable_window_token_ends,
             variable_window_cta_starts,
             Int32(s_q),
+            skip_softmax_threshold,
             self.is_persistent,
             self.is_clc_dynamic,
         ).launch(
@@ -2905,6 +2957,7 @@ class FmhaTs:
         variable_window_token_ends: cute.Tensor | None,
         variable_window_cta_starts: cute.Tensor | None,
         variable_window_q_stride: Int32,
+        skip_softmax_threshold: cute.Tensor | None,
         is_persistent: cutlass.Constexpr[bool] = True,
         is_clc_dynamic: cutlass.Constexpr[bool] = False,
     ) -> None:
@@ -2967,6 +3020,10 @@ class FmhaTs:
             variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
             output_scale=output_scale,
+            skip_softmax_threshold=skip_softmax_threshold,
+            # Fixed storage gives every request s_q rows, the same value that
+            # strides the variable-window row tables.
+            seq_len_q=variable_window_q_stride,
             q_offset=q_offset,
             is_persistent=is_persistent,
             is_clc_dynamic=is_clc_dynamic,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -171,6 +171,7 @@ from .fmha_resources import (
     SmemOResource,
     SmemPageOffsetsKvResource,
     SmemQResource,
+    SmemSkipVoteResource,
     TmemOResource,
     TmemPResource,
     TmemSPResource,
@@ -695,10 +696,11 @@ def build_context_task_manager(
     it. ``output_scale`` multiplies the final O store; FP8 output can fold the
     V dequant scale and output quant scale into it. ``skip_softmax_threshold``
     is the ``float32[B]`` per-request skip-softmax threshold consumed only by
-    ``cfg.enable_skip_softmax`` specializations; the softmax resource converts it to
-    the log2 domain once per work tile. ``seq_len_q`` is the fixed-layout Q
-    length those specializations use to let padding rows abstain from the
-    skip vote; packed layouts derive it from ``cum_seqlen_q``.
+    ``cfg.enable_skip_softmax`` specializations; the skip-vote resource of each
+    Q/KV instance converts it to the log2 domain once per work tile.
+    ``seq_len_q`` is the fixed-layout Q length those specializations use to let
+    padding rows abstain from the skip vote; packed layouts derive it from
+    ``cum_seqlen_q``.
 
     SMEM buffers are declared via ``SmemAllocation`` and bound from
     ``ResourceContext`` by auxiliary resource init work. The ``SmemAllocator``
@@ -1079,17 +1081,30 @@ def build_context_task_manager(
         else:
             work_queue = WorkQueue(**work_queue_kwargs)
 
-    # Skip softmax packs the votes of the four softmax warps of every S/P stage
-    # of each instance into one Int32 word, one byte per warp. The MMA task
-    # reads the word after the matching P-ready wait.
-    skip_softmax_vote_alloc: SmemAllocation | None = None
+    # Skip softmax gives every Q/KV instance a vote resource that owns the
+    # per-request threshold and one SMEM vote word per softmax warp and S/P stage.
+    skip_vote0: SmemSkipVoteResource | None = None
+    skip_vote1: SmemSkipVoteResource | None = None
     if cfg.enable_skip_softmax:
-        skip_softmax_vote_alloc = SmemAllocation(
-            "smem_skip_softmax_vote",
-            dtype=cutlass.Int32,
-            count=cfg.skip_softmax_vote_words,
-            alignment=4,
+        skip_vote0 = SmemSkipVoteResource(
+            cfg=cfg,
+            inst_idx=0,
+            skip_softmax_threshold=skip_softmax_threshold,
+            scale_softmax_log2=scale_softmax_log2,
+            cum_seqlen_q=cum_seqlen_q,
+            seq_len_q=seq_len_q,
+            name="smem_skip_vote_0",
         )
+        if not cfg.single_qkv_instance:
+            skip_vote1 = SmemSkipVoteResource(
+                cfg=cfg,
+                inst_idx=1,
+                skip_softmax_threshold=skip_softmax_threshold,
+                scale_softmax_log2=scale_softmax_log2,
+                cum_seqlen_q=cum_seqlen_q,
+                seq_len_q=seq_len_q,
+                name="smem_skip_vote_1",
+            )
 
     tmem_sp0 = TmemSPResource(
         pipeline_config=tmem_sp0_pipeline_cfg,
@@ -1105,9 +1120,7 @@ def build_context_task_manager(
         variable_window_cta_starts=variable_window_cta_starts,
         variable_window_q_stride=variable_window_q_stride,
         scale_softmax_log2=scale_softmax_log2,
-        skip_softmax_threshold=skip_softmax_threshold,
-        skip_softmax_vote_alloc=skip_softmax_vote_alloc,
-        seq_len_q=seq_len_q,
+        skip_vote_resource=skip_vote0,
         name="tmem_sp0",
     )
     tmem_p0: TmemPResource | None = None
@@ -1170,9 +1183,7 @@ def build_context_task_manager(
             variable_window_cta_starts=variable_window_cta_starts,
             variable_window_q_stride=variable_window_q_stride,
             scale_softmax_log2=scale_softmax_log2,
-            skip_softmax_threshold=skip_softmax_threshold,
-            skip_softmax_vote_alloc=skip_softmax_vote_alloc,
-            seq_len_q=seq_len_q,
+            skip_vote_resource=skip_vote1,
             name="tmem_sp1",
         )
         tmem_vec1 = TmemStatsResource(
@@ -1216,7 +1227,8 @@ def build_context_task_manager(
         tmem_o1_offset=cfg.tmem_o1_offset,
         tmem_vec0_resource=tmem_vec0,
         tmem_vec1_resource=tmem_vec1,
-        skip_softmax_vote_alloc=skip_softmax_vote_alloc,
+        skip_vote0_resource=skip_vote0,
+        skip_vote1_resource=skip_vote1,
         name="tmem_o",
         **tmem_o_kwargs,
     )
@@ -1277,6 +1289,7 @@ def build_context_task_manager(
         tmem_p0,
         s0s1_seq,
         work_queue,
+        skip_vote=skip_vote0,
         **softmax0_domain_kwargs,
     )
     softmax1_task: Task | None = None
@@ -1290,6 +1303,7 @@ def build_context_task_manager(
             None,
             s0s1_seq,
             work_queue,
+            skip_vote=skip_vote1,
             **softmax1_domain_kwargs,
         )
     correction_task = create_correction_task(
@@ -1411,6 +1425,10 @@ def build_context_task_manager(
         resource_dependency_graph[tmem_stats_done_0] = [tmem_vec0]
     if tmem_p0 is not None:
         resource_dependency_graph[tmem_p0] = scheduler_deps(tmem_sp0)
+    if skip_vote0 is not None:
+        resource_dependency_graph[skip_vote0] = scheduler_deps(tmem_sp0)
+    if skip_vote1 is not None:
+        resource_dependency_graph[skip_vote1] = scheduler_deps(tmem_sp1)
     if not single_qkv_instance:
         resource_dependency_graph.update(
             {
@@ -1461,6 +1479,8 @@ def build_context_task_manager(
         add_smem_resource(tmem_p0)
     add_smem_resource(tmem_vec0)
     add_smem_resource(tmem_o)
+    add_smem_resource(skip_vote0)
+    add_smem_resource(skip_vote1)
     if not cfg.stats_via_smem:
         add_smem_resource(tmem_stats_done_0)
     if tmem_sp1 is not None:
@@ -1505,8 +1525,6 @@ def build_context_task_manager(
     dealloc_mbar_alloc = smem_allocator.add(
         SmemAllocation("tmem_dealloc_mbar", dtype=cutlass.Int64, alignment=8)
     )
-    if skip_softmax_vote_alloc is not None:
-        smem_allocator.add(skip_softmax_vote_alloc)
     clc_response_alloc: SmemAllocation | None = None
     if is_clc_dynamic and clc_response_ptr is None:
         # Keep the CLC response inside the unified TS allocation. The kernel
@@ -1700,7 +1718,11 @@ def _infer_single_instance_kv_stages(
     if is_clc_dynamic:
         control_bytes += cutlass.Int128.width // 8
     if cfg.enable_skip_softmax:
-        control_bytes += cfg.skip_softmax_vote_words * cutlass.Int32.width // 8
+        # One Int32 vote per softmax warp and S/P stage of every Q/KV instance.
+        num_vote_words = (
+            cfg.num_qkv_instances * cfg.mma_softmax_stage * len(cfg.softmax0_warp_ids)
+        )
+        control_bytes += num_vote_words * cutlass.Int32.width // 8
     fixed_barrier_stages = sum(
         _context_pipeline_stage_counts(
             cfg,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_kernel.py
@@ -1079,16 +1079,16 @@ def build_context_task_manager(
         else:
             work_queue = WorkQueue(**work_queue_kwargs)
 
-    # Skip softmax publishes one Int32 vote per softmax warp for every S/P
-    # stage of each instance. The MMA task reads the four words of an instance
-    # after the matching P-ready wait.
+    # Skip softmax packs the votes of the four softmax warps of every S/P stage
+    # of each instance into one Int32 word, one byte per warp. The MMA task
+    # reads the word after the matching P-ready wait.
     skip_softmax_vote_alloc: SmemAllocation | None = None
     if cfg.enable_skip_softmax:
         skip_softmax_vote_alloc = SmemAllocation(
             "smem_skip_softmax_vote",
             dtype=cutlass.Int32,
             count=cfg.skip_softmax_vote_words,
-            alignment=16,
+            alignment=4,
         )
 
     tmem_sp0 = TmemSPResource(

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -394,15 +394,11 @@ class FmhaConfig:
     def skip_softmax_vote_words(self) -> int:
         """Return the SMEM Int32 skip-softmax vote words.
 
-        Every Q/KV instance keeps one word per softmax warp for each S/P
-        pipeline stage, so a vote slot is never rewritten before the MMA task
-        has consumed the matching P tile.
+        Every Q/KV instance keeps one word per S/P pipeline stage whose four
+        bytes hold the votes of the stage's four softmax warps, so a vote is
+        never rewritten before the MMA task has consumed the matching P tile.
         """
-        return (
-            self.num_qkv_instances
-            * self.mma_softmax_stage
-            * len(self.softmax0_warp_ids)
-        )
+        return self.num_qkv_instances * self.mma_softmax_stage
 
     @property
     def uses_early_tile_sum(self) -> bool:
@@ -687,22 +683,6 @@ def _resolve_work_tile_coords(
     if cutlass.const_expr(cfg.uses_causal_reversed_head_batch_seq_tile_order):
         seq_coord = cfg.num_seq_tiles - seq_coord - Int32(1)
     return seq_coord, head_coord, batch_coord
-
-
-@cute.jit
-def _skip_softmax_vote_view(
-    cfg: Constexpr[FmhaConfig],
-    vote_alloc: Constexpr[SmemAllocation],
-    stage_info: StageInfo,
-) -> cutlass.Array:
-    """Return the unified-SMEM Int32 view of the skip-softmax vote words."""
-    smem_base = stage_info.context.smem_base
-    return cutlass.Array(
-        smem_base.data_ptr() + vote_alloc.offset,
-        dtype=Int32,
-        shape=(cfg.skip_softmax_vote_words,),
-        addrspace=3,
-    )
 
 
 @dataclass(frozen=True)
@@ -1986,7 +1966,9 @@ class TmemSPResource(MemoryResource):
     skip_softmax_vote_alloc: Constexpr[Optional[SmemAllocation]] = field(
         init=False, default=None
     )
-    _smem_skip_softmax_vote: cutlass.Array = field(init=False, default=None)
+    # Byte view of the vote words: each softmax warp owns one byte of the word
+    # of its S/P stage.
+    _smem_skip_softmax_vote_bytes: cutlass.Array = field(init=False, default=None)
     # Fixed-layout Q length of every request; packed layouts derive it from
     # the cumulative offsets instead.
     seq_len_q: int | Int32 | None = field(init=False, default=None)
@@ -2057,7 +2039,7 @@ class TmemSPResource(MemoryResource):
         self.skip_softmax_threshold = skip_softmax_threshold
         self.skip_softmax_vote_alloc = skip_softmax_vote_alloc
         self.seq_len_q = seq_len_q
-        self._smem_skip_softmax_vote = _placeholder_smem_array(Int32)
+        self._smem_skip_softmax_vote_bytes = _placeholder_smem_array(cutlass.Int8)
         self.scale_softmax_log2_cached = Float32(0.0)
         self.log2_skip_softmax_threshold_cached = Float32(-Float32.inf)
         self.skip_softmax_row_valid_cached = Boolean(True)
@@ -2360,8 +2342,12 @@ class TmemSPResource(MemoryResource):
         self.tmem_s_addr_cached = Int32(0)
         self.tmem_p_addr_cached = Int32(0)
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            self._smem_skip_softmax_vote = _skip_softmax_vote_view(
-                self.cfg, self.skip_softmax_vote_alloc, stage_info
+            self._smem_skip_softmax_vote_bytes = cutlass.Array(
+                stage_info.context.smem_base.data_ptr()
+                + self.skip_softmax_vote_alloc.offset,
+                dtype=cutlass.Int8,
+                shape=(self.cfg.skip_softmax_vote_words * 4,),
+                addrspace=3,
             )
 
     @cute.jit
@@ -2662,15 +2648,12 @@ class TmemSPResource(MemoryResource):
         return old_row_max, row_max_safe
 
     @cute.jit
-    def _skip_softmax_vote_slot(self, stage_info: StageInfo) -> Int32:
-        """Return the first vote word of this instance's current S/P stage."""
-        num_softmax_warps = 4
+    def _skip_softmax_vote_word(self, stage_info: StageInfo) -> Int32:
+        """Return the vote word of this instance's current S/P stage."""
         stage_idx = Int32(0)
         if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
             stage_idx = Int32(stage_info.stage_idx)
-        return (Int32(self.q_half * self.cfg.mma_softmax_stage) + stage_idx) * Int32(
-            num_softmax_warps
-        )
+        return Int32(self.q_half * self.cfg.mma_softmax_stage) + stage_idx
 
     @cute.jit
     def _skip_softmax_row_max(
@@ -2697,15 +2680,18 @@ class TmemSPResource(MemoryResource):
         warp_skips = cute.arch.vote_all_sync(lane_skips)
         num_softmax_warps = 4
         warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
-        vote_idx = self._skip_softmax_vote_slot(stage_info) + warp_id_in_sg
-        vote = Int32(0)
+        vote_byte = (
+            self._skip_softmax_vote_word(stage_info) * Int32(num_softmax_warps)
+            + warp_id_in_sg
+        )
+        vote = cutlass.Int8(0)
         if warp_skips:
-            vote = Int32(1)
-        # Each warp owns one vote word, so no reset or atomic is needed. The
-        # P-ready pipeline arrive orders this store before the MMA warp reads
-        # the four words of the instance.
+            vote = cutlass.Int8(1)
+        # Each warp owns one byte of the vote word, so no reset or atomic is
+        # needed. The P-ready pipeline arrive orders this store before the MMA
+        # warp reads the word.
         if prims.elect_sync():
-            self._smem_skip_softmax_vote[vote_idx] = vote
+            self._smem_skip_softmax_vote_bytes[vote_byte] = vote
         _tmem_sp_skips[id(self)] = warp_skips
         row_max_next = row_max
         if not warp_skips:
@@ -4255,7 +4241,9 @@ class TmemOResource(MemoryResource):
     skip_softmax_vote_alloc: Constexpr[Optional[SmemAllocation]] = field(
         init=False, default=None
     )
-    _smem_skip_softmax_vote: cutlass.Array = field(init=False, default=None)
+    # Word view of the votes: one Int32 per Q/KV instance and S/P stage whose
+    # bytes hold the votes of the four softmax warps.
+    _smem_skip_softmax_vote_words: cutlass.Array = field(init=False, default=None)
     # References to TmemStats resources for reading cached correction stats.
     # consumer_work reads stats from these instead of from TMEM, because
     # the stats TMEM region overlaps with S0/S1 and can be overwritten by
@@ -4285,7 +4273,7 @@ class TmemOResource(MemoryResource):
         self.tmem_vec0_resource = tmem_vec0_resource
         self.tmem_vec1_resource = tmem_vec1_resource
         self.skip_softmax_vote_alloc = skip_softmax_vote_alloc
-        self._smem_skip_softmax_vote = _placeholder_smem_array(Int32)
+        self._smem_skip_softmax_vote_words = _placeholder_smem_array(Int32)
         self._alloc_o0 = TmemAllocation("tmem_o0", 128)
         self._alloc_o1 = TmemAllocation("tmem_o1", 128)
         self.tmem_addr_cached = Int32(0)
@@ -4324,8 +4312,12 @@ class TmemOResource(MemoryResource):
         self.p_stage_idx_cached = Int32(0)
         self.skips_pv_cached = Boolean(False)
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            self._smem_skip_softmax_vote = _skip_softmax_vote_view(
-                self.cfg, self.skip_softmax_vote_alloc, stage_info
+            self._smem_skip_softmax_vote_words = cutlass.Array(
+                stage_info.context.smem_base.data_ptr()
+                + self.skip_softmax_vote_alloc.offset,
+                dtype=Int32,
+                shape=(self.cfg.skip_softmax_vote_words,),
+                addrspace=3,
             )
 
     @producer_work(work_attrs=WorkAttr.AUXILIARY)
@@ -4384,23 +4376,19 @@ class TmemOResource(MemoryResource):
     def _skip_softmax_votes_skip(self, inst_idx: cutlass.Constexpr[int]) -> Boolean:
         """Return whether every softmax warp of the instance skipped this tile.
 
-        The four vote words were published before the P-ready arrive that the
-        MMA schedule waited on, so a plain SMEM read observes them.
+        The four vote bytes of the S/P stage were published before the P-ready
+        arrive that the MMA schedule waited on, so a plain SMEM read of the
+        word observes them.
         """
-        num_softmax_warps = 4
         stage_idx = Int32(0)
         if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
             stage_idx = self.p_stage_idx_cached
-        vote_idx = (Int32(inst_idx * self.cfg.mma_softmax_stage) + stage_idx) * Int32(
-            num_softmax_warps
+        vote_word = Int32(inst_idx * self.cfg.mma_softmax_stage) + stage_idx
+        votes = cute.arch.make_warp_uniform(
+            self._smem_skip_softmax_vote_words[vote_word]
         )
-        votes = self._smem_skip_softmax_vote.load(
-            vote_idx, vector_size=num_softmax_warps, alignment=16
-        )
-        all_votes = cute.arch.make_warp_uniform(
-            Int32(votes[0]) & Int32(votes[1]) & Int32(votes[2]) & Int32(votes[3])
-        )
-        return all_votes == Int32(1)
+        # Every byte reads 1 only when all four softmax warps voted to skip.
+        return votes == Int32(0x01010101)
 
     @producer_work
     @cute.jit

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -314,7 +314,7 @@ class FmhaConfig:
     # Skip softmax: each softmax warp compares its K/V tile row maxima with the
     # running maxima. When every row of the warp bounds its tile contribution
     # below the request threshold, the warp keeps its running statistics,
-    # publishes a zero P tile without exponentiation, and votes in SMEM so the
+    # publishes a zero P tile without exp2, and votes in SMEM so the
     # MMA task can also skip the PV MMA once all four softmax warps of the
     # instance voted to skip.
     enable_skip_softmax: bool = False
@@ -2507,7 +2507,7 @@ class TmemSPResource(MemoryResource):
         Rows past the request's Q length are TMA padding: zero-filled for
         fixed storage and NaN-filled for 16-bit packed storage. Their scores
         carry no information, so they abstain from the warp vote instead of
-        blocking the valid rows of a partial query tile.
+        blocking the valid rows of a partial Q tile.
         """
         seq_coord, _, batch_coord = _resolve_work_tile_coords(
             self.cfg, stage_info.work_tile.tile_idx
@@ -2648,7 +2648,7 @@ class TmemSPResource(MemoryResource):
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # The skip specialization carries the exact running maximum, which
             # stays -inf until a row meets its first valid key; the P store,
-            # row-sum, and statistics work substitute zero where needed.
+            # row-sum reduction, and stats store substitute zero where needed.
             return old_row_max, self._skip_softmax_row_max(
                 stage_info, row_max, tile_row_max
             )
@@ -2683,7 +2683,7 @@ class TmemSPResource(MemoryResource):
 
         A lane wants to skip when ``exp2`` of its scaled tile-versus-running
         maximum gap is below the request threshold, the same bound trtllm-gen
-        applies before its softmax and PV work. Comparing in the log2 domain
+        applies before its softmax and PV MMA. Comparing in the log2 domain
         keeps a ``-inf`` running maximum (no valid key yet) and a zero
         threshold from ever admitting a skip, and a fully masked tile skips
         only once the row already has a finite maximum. Every valid row of
@@ -2723,7 +2723,7 @@ class TmemSPResource(MemoryResource):
         tmem_p_addr = self.tmem_p_addr_cached + stage_col_offset
         s_data = _tmem_sp_sdata.pop(id(self))
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            # Exponentiate against zero while the exact running maximum is
+            # Apply exp2 against a zero maximum while the exact running maximum is
             # still -inf so masked scores become exact zeros instead of NaN.
             row_max_safe = row_max
             if row_max == -Float32.inf:
@@ -2748,7 +2748,7 @@ class TmemSPResource(MemoryResource):
 
     @cute.jit
     def _store_zero_p(self, tmem_p_addr: TmemAddr) -> None:
-        """Publish an all-zero probability tile for a skipped K/V tile.
+        """Publish an all-zero P tile for a skipped K/V tile.
 
         The PV MMA still consumes this P tile when another softmax warp of the
         same instance did not skip, so the skipped rows must contribute zero.
@@ -2777,7 +2777,7 @@ class TmemSPResource(MemoryResource):
         scale_softmax_log2: SoftmaxScalar,
         s_data: SoftmaxChunks,
     ) -> SoftmaxRowSumContribution:
-        """Exponentiate one loaded S tile into P and store it to TMEM."""
+        """Apply exp2 to one loaded S tile, producing P, and store it to TMEM."""
         tmem_shape = "32x32b"
         tmem_x = self.cfg.tmem_x_load_s
         num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -317,7 +317,7 @@ class FmhaConfig:
     # publishes a zero P tile without exponentiation, and votes in SMEM so the
     # MMA task can also skip the PV MMA once all four softmax warps of the
     # instance voted to skip.
-    skip_softmax: bool = False
+    enable_skip_softmax: bool = False
 
     # Variable sequence length mode stores Q/K/V/O as flattened
     # [sum_seqlen, head, dim] tensors and uses cum_seqlen_* for per-batch
@@ -2359,7 +2359,7 @@ class TmemSPResource(MemoryResource):
         # Initialize to establish DSL type; real values are set per work tile.
         self.tmem_s_addr_cached = Int32(0)
         self.tmem_p_addr_cached = Int32(0)
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             self._smem_skip_softmax_vote = _skip_softmax_vote_view(
                 self.cfg, self.skip_softmax_vote_alloc, stage_info
             )
@@ -2412,7 +2412,7 @@ class TmemSPResource(MemoryResource):
         scale_softmax_log2 = Float32(0.0)
         if cutlass.const_expr(self.scale_softmax_log2 is not None):
             scale_softmax_log2 = Float32(self.scale_softmax_log2[0])
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             self.scale_softmax_log2_cached = scale_softmax_log2
         return scale_softmax_log2
 
@@ -2645,7 +2645,7 @@ class TmemSPResource(MemoryResource):
             row_vector = cutlass.Vector.from_elements(row_values, self.cfg.qk_acc_dtype)
             tile_row_max = row_vector.reduce("max")
         _tmem_sp_sdata[id(self)] = s_data
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # The skip specialization carries the exact running maximum, which
             # stays -inf until a row meets its first valid key; the P store,
             # row-sum, and statistics work substitute zero where needed.
@@ -2722,7 +2722,7 @@ class TmemSPResource(MemoryResource):
         """Apply exp2 softmax P, fold the PV P scale, and store P to TMEM."""
         tmem_p_addr = self.tmem_p_addr_cached + stage_col_offset
         s_data = _tmem_sp_sdata.pop(id(self))
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # Exponentiate against zero while the exact running maximum is
             # still -inf so masked scores become exact zeros instead of NaN.
             row_max_safe = row_max
@@ -3624,7 +3624,7 @@ class TmemSPResource(MemoryResource):
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
         """Tail stage for softmax group 0: identity row_max, no S load."""
         row_max_safe = row_max
-        if cutlass.const_expr(not self.cfg.skip_softmax):
+        if cutlass.const_expr(not self.cfg.enable_skip_softmax):
             if row_max == -Float32.inf:
                 row_max_safe = Float32(0.0)
         _ = stage_info
@@ -3655,7 +3655,7 @@ class TmemSPResource(MemoryResource):
     ) -> SoftmaxScalar:
         """Accumulate row_sum from vector P fragments or their scalar sum."""
         _ = stage_info
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # A skipped tile publishes zero probabilities and keeps the running
             # maximum, so the accumulated denominator is unchanged.
             warp_skips = _tmem_sp_skips.pop(id(self))
@@ -3687,7 +3687,7 @@ class TmemSPResource(MemoryResource):
     ) -> Float32:
         """Return the base-2 exponent rescaling the previous row sum."""
         acc_scale_log2 = scale_softmax_log2 * (old_row_max - row_max)
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # Both maxima are -inf until the row meets a valid key. The row
             # sum is still zero there, so any finite exponent keeps it zero.
             if row_max == -Float32.inf:
@@ -4120,7 +4120,7 @@ class TmemStatsResource(MemoryResource):
           scale = exp2(scale_log2 * (old_max - new_max))
         and to forward row_sum to SmemO for the final normalization.
         """
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # The skip specialization carries exact -inf maxima for rows
             # without a valid key. Their O rows are still zero, so publish
             # zeros to keep the correction scale finite.
@@ -4323,7 +4323,7 @@ class TmemOResource(MemoryResource):
         self.tmem_p_base_cached = Int32(0)
         self.p_stage_idx_cached = Int32(0)
         self.skips_pv_cached = Boolean(False)
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             self._smem_skip_softmax_vote = _skip_softmax_vote_view(
                 self.cfg, self.skip_softmax_vote_alloc, stage_info
             )
@@ -4377,7 +4377,7 @@ class TmemOResource(MemoryResource):
         _ = stage_info
         self.tmem_p_base_cached = tmem_p_base
         self.p_stage_idx_cached = p_stage_idx
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             self.skips_pv_cached = self._skip_softmax_votes_skip(inst_idx=0)
 
     @cute.jit
@@ -4452,7 +4452,7 @@ class TmemOResource(MemoryResource):
         # Skip softmax: every softmax warp of this instance published a zero P
         # tile, so the PV MMA would add nothing to O.
         skips_pv = False
-        if cutlass.const_expr(self.cfg.skip_softmax):
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
             if cutlass.const_expr(
                 self.cfg.single_qkv_instance and self.cfg.has_tmem_p_pipeline
             ):

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -105,10 +105,6 @@ SoftmaxRowSumContribution: TypeAlias = SoftmaxChunks | SoftmaxScalar
 # Stored at module level (not on self) to avoid adding a non-dynamic-expression
 # field to the dataclass, which breaks the framework's scf.if handling.
 _tmem_sp_sdata: dict[int, list] = {}
-# Trace-time storage for the warp-uniform skip-softmax predicate produced by
-# the row-max work and consumed by the P store and row-sum work of the same
-# K/V tile.
-_tmem_sp_skips: dict[int, Any] = {}
 
 
 @cute.jit
@@ -389,16 +385,6 @@ class FmhaConfig:
     def single_qkv_instance(self) -> bool:
         """Return whether one work tile carries a single Q/KV/O instance."""
         return self.num_qkv_instances == 1
-
-    @property
-    def skip_softmax_vote_words(self) -> int:
-        """Return the SMEM Int32 skip-softmax vote words.
-
-        Every Q/KV instance keeps one word per S/P pipeline stage whose four
-        bytes hold the votes of the stage's four softmax warps, so a vote is
-        never rewritten before the MMA task has consumed the matching P tile.
-        """
-        return self.num_qkv_instances * self.mma_softmax_stage
 
     @property
     def uses_early_tile_sum(self) -> bool:
@@ -1931,6 +1917,171 @@ class SmemKVResource(MemoryResource):
 
 
 # ---------------------------------------------------------------------------
+# SmemSkipVoteResource -- skip-softmax state and vote word of one Q/KV instance
+# ---------------------------------------------------------------------------
+
+
+@dataclass(kw_only=True)
+class SmemSkipVoteResource(MemoryResource):
+    """Skip-softmax state and vote word of one Q/KV instance (no pipeline).
+
+    Owns the per-request skip threshold, the base-2 softmax scale, the
+    request Q-length inputs that let TMA padding rows abstain, and one SMEM
+    Int32 vote word per softmax warp and S/P stage of the instance. The
+    softmax schedule caches the per-work-tile state through ``cache_state``;
+    ``TmemSPResource`` decides the warp-uniform skip in its row-max work and
+    publishes each warp's word with ``publish``; ``TmemOResource`` reads the
+    words with ``all_skipped`` through a resource reference, like the cached
+    correction stats, to decide whether to issue the PV MMA. The words are
+    stored before the P-ready arrive of the S/P stage and read after the
+    matching P-ready wait, so the P-ready handoff (``TmemSPResource`` in the
+    paired schedule, ``TmemPResource`` in the staged schedule) orders the
+    votes and this resource needs no pipeline of its own.
+    """
+
+    cfg: Constexpr[FmhaConfig] = field(init=False, default=None)
+    # Q/KV instance whose softmax warps vote here (the q_half of its TmemSP).
+    inst_idx: Constexpr[int] = 0
+    # Per-request e-based skip-softmax thresholds, indexed by batch coordinate.
+    skip_softmax_threshold: cute.Tensor | None = field(init=False, default=None)
+    scale_softmax_log2: cute.Tensor | None = field(init=False, default=None)
+    cum_seqlen_q: cute.Tensor | None = field(init=False, default=None)
+    # Fixed-layout Q length of every request; packed layouts derive it from
+    # the cumulative offsets instead.
+    seq_len_q: int | Int32 | None = field(init=False, default=None)
+    _alloc: Constexpr[Optional[SmemAllocation]] = field(init=False, default=None)
+    # Per-work-tile state cached before the K/V loop: this request's log2 skip
+    # threshold, the base-2 softmax scale, and whether this lane's row lies
+    # inside the request.
+    log2_threshold_cached: Float32 | None = field(init=False, default=None)
+    scale_softmax_log2_cached: Float32 | None = field(init=False, default=None)
+    row_valid_cached: Boolean | None = field(init=False, default=None)
+
+    def __init__(
+        self,
+        cfg: FmhaConfig,
+        inst_idx: int,
+        skip_softmax_threshold: cute.Tensor | None,
+        scale_softmax_log2: cute.Tensor | None = None,
+        cum_seqlen_q: cute.Tensor | None = None,
+        seq_len_q: int | Int32 | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Bind the skip inputs and reserve the vote words of every S/P stage."""
+        super().__init__(**kwargs)
+        self.cfg = cfg
+        self.inst_idx = inst_idx
+        self.skip_softmax_threshold = skip_softmax_threshold
+        self.scale_softmax_log2 = scale_softmax_log2
+        self.cum_seqlen_q = cum_seqlen_q
+        self.seq_len_q = seq_len_q
+        self._alloc = SmemAllocation(
+            f"smem_skip_vote_{inst_idx}",
+            dtype=Int32,
+            count=cfg.mma_softmax_stage * len(cfg.softmax0_warp_ids),
+            alignment=16,
+        )
+        self.log2_threshold_cached = Float32(-Float32.inf)
+        self.scale_softmax_log2_cached = Float32(0.0)
+        self.row_valid_cached = Boolean(True)
+
+    def get_smem_requirements(self) -> list[SmemAllocation]:
+        """Return the vote words, one per softmax warp and S/P stage."""
+        return [self._alloc]
+
+    @cute.jit
+    def _vote_words(self, stage_info: StageInfo) -> cutlass.Array:
+        """Return the Int32 view of the vote words, S/P stage major."""
+        context = stage_info.context
+        assert context is not None and context.smem_base is not None
+        assert self._alloc is not None
+        return cutlass.Array(
+            context.smem_base.data_ptr() + self._alloc.offset,
+            dtype=Int32,
+            shape=(self.cfg.mma_softmax_stage * len(self.cfg.softmax0_warp_ids),),
+            addrspace=3,
+        )
+
+    @producer_work(work_attrs=WorkAttr.AUXILIARY)
+    @cute.jit
+    def cache_state(self, stage_info: StageInfo) -> None:
+        """Cache the log2 skip threshold, softmax scale, and row validity.
+
+        The public threshold bounds ``exp(sm_scale * (tile_max - running_max))``
+        in the ordinary softmax domain. The K/V loop compares base-2 scaled
+        score gaps, so the request value is converted once here; a zero
+        threshold becomes ``-inf`` and never admits a skip. The base-2 scale is
+        the same runtime value the softmax works receive as a task-local token.
+
+        Rows past the request's Q length are TMA padding: zero-filled for
+        fixed storage and NaN-filled for 16-bit packed storage. Their scores
+        carry no information, so they abstain from the warp vote instead of
+        blocking the valid rows of a partial Q tile.
+        """
+        seq_coord, _, batch_coord = _resolve_work_tile_coords(
+            self.cfg, stage_info.work_tile.tile_idx
+        )
+        threshold = Float32(self.skip_softmax_threshold[batch_coord])
+        self.log2_threshold_cached = cute.math.log2(threshold, fastmath=True)
+        if cutlass.const_expr(self.scale_softmax_log2 is not None):
+            self.scale_softmax_log2_cached = Float32(self.scale_softmax_log2[0])
+        num_softmax_warps = len(self.cfg.softmax0_warp_ids)
+        warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
+        row_in_tile = warp_id_in_sg * cute.arch.WARP_SIZE + cute.arch.lane_idx()
+        local_q = (
+            seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
+            + self.inst_idx * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
+            + row_in_tile
+        )
+        if cutlass.const_expr(self.cfg.has_varlen):
+            if cutlass.const_expr(self.cfg.has_uniform_varlen):
+                seqlen_q = Int32(self.cfg.uniform_seq_len_q)
+            else:
+                cuseqlen_q = Int32(self.cum_seqlen_q[batch_coord])
+                seqlen_q = Int32(self.cum_seqlen_q[batch_coord + Int32(1)]) - cuseqlen_q
+        else:
+            seqlen_q = Int32(self.seq_len_q)
+        self.row_valid_cached = local_q < seqlen_q
+
+    @cute.jit
+    def publish(
+        self, stage_info: StageInfo, stage_idx: Int32, warp_skips: Boolean
+    ) -> None:
+        """Store this softmax warp's vote word for the S/P stage.
+
+        Each warp owns one word of the stage, so no reset or atomic is needed.
+        The P-ready arrive that follows in the softmax schedule orders the
+        store before the MMA warp reads the words.
+        """
+        num_softmax_warps = len(self.cfg.softmax0_warp_ids)
+        warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
+        vote_word = stage_idx * Int32(num_softmax_warps) + warp_id_in_sg
+        vote = Int32(0)
+        if warp_skips:
+            vote = Int32(1)
+        if prims.elect_sync():
+            self._vote_words(stage_info)[vote_word] = vote
+
+    @cute.jit
+    def all_skipped(self, stage_info: StageInfo, stage_idx: Int32) -> Boolean:
+        """Return whether every softmax warp of the instance skipped the stage.
+
+        The vote words were published before the P-ready arrive that the MMA
+        schedule waited on, so one plain vector SMEM read observes them all.
+        """
+        num_softmax_warps = len(self.cfg.softmax0_warp_ids)
+        votes = self._vote_words(stage_info).load(
+            stage_idx * Int32(num_softmax_warps),
+            vector_size=num_softmax_warps,
+            alignment=16,
+        )
+        all_votes = Int32(votes[0])
+        for warp_idx in cutlass.range_constexpr(1, num_softmax_warps):
+            all_votes = all_votes & Int32(votes[warp_idx])
+        return cute.arch.make_warp_uniform(all_votes) == Int32(1)
+
+
+# ---------------------------------------------------------------------------
 # TmemSPResource -- TMEM S/P ping-pong buffer with UmmaAsync pipeline
 # ---------------------------------------------------------------------------
 
@@ -1961,23 +2112,12 @@ class TmemSPResource(MemoryResource):
     variable_window_cta_starts: cute.Tensor | None = field(init=False, default=None)
     variable_window_q_stride: int | Int32 = field(init=False, default=0)
     scale_softmax_log2: cute.Tensor | None = field(init=False, default=None)
-    # Per-request e-based skip-softmax thresholds, indexed by batch coordinate.
-    skip_softmax_threshold: cute.Tensor | None = field(init=False, default=None)
-    skip_softmax_vote_alloc: Constexpr[Optional[SmemAllocation]] = field(
-        init=False, default=None
-    )
-    # Byte view of the vote words: each softmax warp owns one byte of the word
-    # of its S/P stage.
-    _smem_skip_softmax_vote_bytes: cutlass.Array = field(init=False, default=None)
-    # Fixed-layout Q length of every request; packed layouts derive it from
-    # the cumulative offsets instead.
-    seq_len_q: int | Int32 | None = field(init=False, default=None)
-    # Softmax-warp copies of the base-2 softmax scale, this request's log2
-    # skip threshold, and whether this lane's row lies inside the request,
-    # cached before the K/V loop for the skip decision.
-    scale_softmax_log2_cached: Float32 | None = field(init=False, default=None)
-    log2_skip_softmax_threshold_cached: Float32 | None = field(init=False, default=None)
-    skip_softmax_row_valid_cached: Boolean | None = field(init=False, default=None)
+    # Skip-softmax votes of this instance; the row-max work decides the
+    # warp-uniform skip and publishes it there.
+    skip_vote_resource: SmemSkipVoteResource | None = field(init=False, default=None)
+    # Warp-uniform skip of the current K/V tile, produced by the row-max work
+    # and consumed by the P store and row-sum reduction of the same tile.
+    warp_skips_cached: Boolean | None = field(init=False, default=None)
     tmem_addr_cached: TmemAddr | None = field(init=False, default=None)
     # Precomputed TMEM pointers/addresses (set by auxiliary work). Avoids
     # per-iteration inttoptr + address math.
@@ -2016,9 +2156,7 @@ class TmemSPResource(MemoryResource):
         variable_window_cta_starts: cute.Tensor | None = None,
         variable_window_q_stride: int | Int32 = 0,
         scale_softmax_log2: cute.Tensor | None = None,
-        skip_softmax_threshold: cute.Tensor | None = None,
-        skip_softmax_vote_alloc: SmemAllocation | None = None,
-        seq_len_q: int | Int32 | None = None,
+        skip_vote_resource: SmemSkipVoteResource | None = None,
         **kwargs: Any,
     ) -> None:
         """Bind S/P TMEM offsets, Q peer index, and optional varlen metadata."""
@@ -2036,13 +2174,8 @@ class TmemSPResource(MemoryResource):
         self.variable_window_cta_starts = variable_window_cta_starts
         self.variable_window_q_stride = variable_window_q_stride
         self.scale_softmax_log2 = scale_softmax_log2
-        self.skip_softmax_threshold = skip_softmax_threshold
-        self.skip_softmax_vote_alloc = skip_softmax_vote_alloc
-        self.seq_len_q = seq_len_q
-        self._smem_skip_softmax_vote_bytes = _placeholder_smem_array(cutlass.Int8)
-        self.scale_softmax_log2_cached = Float32(0.0)
-        self.log2_skip_softmax_threshold_cached = Float32(-Float32.inf)
-        self.skip_softmax_row_valid_cached = Boolean(True)
+        self.skip_vote_resource = skip_vote_resource
+        self.warp_skips_cached = Boolean(False)
         self._alloc = TmemAllocation(
             f"tmem_sp_q{q_half}",
             cfg.qk_mma_tiler[1] * cfg.mma_softmax_stage,
@@ -2341,14 +2474,7 @@ class TmemSPResource(MemoryResource):
         # Initialize to establish DSL type; real values are set per work tile.
         self.tmem_s_addr_cached = Int32(0)
         self.tmem_p_addr_cached = Int32(0)
-        if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            self._smem_skip_softmax_vote_bytes = cutlass.Array(
-                stage_info.context.smem_base.data_ptr()
-                + self.skip_softmax_vote_alloc.offset,
-                dtype=cutlass.Int8,
-                shape=(self.cfg.skip_softmax_vote_words * 4,),
-                addrspace=3,
-            )
+        _ = stage_info
 
     @cute.jit
     def _default_p_chunk(self) -> SoftmaxRowSumContribution:
@@ -2394,13 +2520,10 @@ class TmemSPResource(MemoryResource):
     def load_scale_softmax_log2(self, stage_info: StageInfo) -> Float32:
         """Load the runtime softmax scale once before the K/V loop."""
         _ = stage_info
-        # Zero is a safe fallback for validation-only resource construction.
-        scale_softmax_log2 = Float32(0.0)
-        if cutlass.const_expr(self.scale_softmax_log2 is not None):
-            scale_softmax_log2 = Float32(self.scale_softmax_log2[0])
-        if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            self.scale_softmax_log2_cached = scale_softmax_log2
-        return scale_softmax_log2
+        if cutlass.const_expr(self.scale_softmax_log2 is None):
+            # Safe fallback for validation-only resource construction.
+            return Float32(0.0)
+        return self.scale_softmax_log2[0]
 
     @cute.jit
     def _init_work_tile_state(self, stage_info: StageInfo) -> None:
@@ -2480,46 +2603,6 @@ class TmemSPResource(MemoryResource):
         cuseqlen_k = Int32(self.cum_seqlen_k[batch_coord])
         return Int32(self.cum_seqlen_k[batch_coord + Int32(1)]) - cuseqlen_k
 
-    @consumer_work(work_attrs=WorkAttr.AUXILIARY)
-    @cute.jit
-    def cache_skip_softmax_state(self, stage_info: StageInfo) -> None:
-        """Cache the request's log2 skip threshold and this lane's row validity.
-
-        The public threshold bounds ``exp(sm_scale * (tile_max - running_max))``
-        in the ordinary softmax domain. The K/V loop compares base-2 scaled
-        score gaps, so the request value is converted once here; a zero
-        threshold becomes ``-inf`` and never admits a skip.
-
-        Rows past the request's Q length are TMA padding: zero-filled for
-        fixed storage and NaN-filled for 16-bit packed storage. Their scores
-        carry no information, so they abstain from the warp vote instead of
-        blocking the valid rows of a partial Q tile.
-        """
-        seq_coord, _, batch_coord = _resolve_work_tile_coords(
-            self.cfg, stage_info.work_tile.tile_idx
-        )
-        threshold = Float32(self.skip_softmax_threshold[batch_coord])
-        self.log2_skip_softmax_threshold_cached = cute.math.log2(
-            threshold, fastmath=True
-        )
-        num_softmax_warps = 4
-        warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
-        row_in_tile = warp_id_in_sg * cute.arch.WARP_SIZE + cute.arch.lane_idx()
-        local_q = (
-            seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
-            + self.q_half * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
-            + row_in_tile
-        )
-        if cutlass.const_expr(self.cfg.has_varlen):
-            if cutlass.const_expr(self.cfg.has_uniform_varlen):
-                seqlen_q = Int32(self.cfg.uniform_seq_len_q)
-            else:
-                cuseqlen_q = Int32(self.cum_seqlen_q[batch_coord])
-                seqlen_q = Int32(self.cum_seqlen_q[batch_coord + Int32(1)]) - cuseqlen_q
-        else:
-            seqlen_q = Int32(self.seq_len_q)
-        self.skip_softmax_row_valid_cached = local_q < seqlen_q
-
     @consumer_work(
         work_attrs=WorkAttr.AUXILIARY,
         returns=(variable_window_start, variable_window_end),
@@ -2591,23 +2674,20 @@ class TmemSPResource(MemoryResource):
         tmem_x = self.cfg.tmem_x_load_s
         num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
         old_row_max = row_max
-        uses_fp8_cadence = (
+        # The skip specialization reduces the tile alone so its maximum stays
+        # separate from the running maximum for the skip decision; the dense
+        # kernel folds the running maximum into the same reduction.
+        seed = row_max
+        if cutlass.const_expr(self.cfg.enable_skip_softmax):
+            seed = Float32(-Float32.inf)
+        if cutlass.const_expr(
             self.cfg.uses_d128_fp8_softmax_cadence
             or self.cfg.uses_d256_fp8_softmax_cadence
-        )
-        if cutlass.const_expr(uses_fp8_cadence):
-            # Four independent chains over the tile only; the running maximum
-            # joins after the tile reduction so the tile maximum stays
-            # available for the skip-softmax decision. Scores are read only
-            # inside the unrolled loop: the staged frontend resolves fragments
-            # that a mask branch rewrote through their variable references
-            # there, whereas a bare read right after that branch sees the
-            # stale in-branch value.
-            neg_inf = Float32(-Float32.inf)
-            max_0 = neg_inf
-            max_1 = neg_inf
-            max_2 = neg_inf
-            max_3 = neg_inf
+        ):
+            max_0 = seed
+            max_1 = seed
+            max_2 = seed
+            max_3 = seed
             for chunk_idx in cutlass.range_constexpr(num_chunks):
                 for elem_idx in cutlass.range_constexpr(0, tmem_x, 4):
                     max_0 = cute.math.max(max_0, s_data[chunk_idx][elem_idx], ftz=True)
@@ -2622,7 +2702,7 @@ class TmemSPResource(MemoryResource):
                     )
             max_0 = cute.math.max(max_0, max_2, ftz=True)
             max_1 = cute.math.max(max_1, max_3, ftz=True)
-            tile_row_max = cute.math.max(max_0, max_1, ftz=True)
+            row_max = cute.math.max(max_0, max_1, ftz=True)
         else:
             row_values: tuple[Any, ...] = ()
             for chunk_idx in cutlass.range_constexpr(num_chunks):
@@ -2630,30 +2710,20 @@ class TmemSPResource(MemoryResource):
                     row_values += (s_data[chunk_idx][elem_idx],)
             row_vector = cutlass.Vector.from_elements(row_values, self.cfg.qk_acc_dtype)
             tile_row_max = row_vector.reduce("max")
+            row_max = cute.math.max(seed, tile_row_max)
         _tmem_sp_sdata[id(self)] = s_data
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            # The skip specialization carries the exact running maximum, which
-            # stays -inf until a row meets its first valid key; the P store,
-            # row-sum reduction, and stats store substitute zero where needed.
+            # Seeded with -inf, row_max holds the tile maximum here. The skip
+            # specialization carries the exact running maximum, which stays
+            # -inf until a row meets its first valid key; the P store, row-sum
+            # reduction, and stats store substitute zero where needed.
             return old_row_max, self._skip_softmax_row_max(
-                stage_info, row_max, tile_row_max
+                stage_info, old_row_max, row_max
             )
-        if cutlass.const_expr(uses_fp8_cadence):
-            row_max = cute.math.max(row_max, tile_row_max, ftz=True)
-        else:
-            row_max = cute.math.max(row_max, tile_row_max)
         row_max_safe = row_max
         if row_max == -Float32.inf:
             row_max_safe = Float32(0.0)
         return old_row_max, row_max_safe
-
-    @cute.jit
-    def _skip_softmax_vote_word(self, stage_info: StageInfo) -> Int32:
-        """Return the vote word of this instance's current S/P stage."""
-        stage_idx = Int32(0)
-        if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
-            stage_idx = Int32(stage_info.stage_idx)
-        return Int32(self.q_half * self.cfg.mma_softmax_stage) + stage_idx
 
     @cute.jit
     def _skip_softmax_row_max(
@@ -2673,26 +2743,17 @@ class TmemSPResource(MemoryResource):
         the warp must agree because it owns 32 rows of the P tile consumed by
         one PV MMA; padding rows abstain.
         """
-        gap_log2 = (tile_row_max - row_max) * self.scale_softmax_log2_cached
-        lane_skips = gap_log2 < self.log2_skip_softmax_threshold_cached
-        if not self.skip_softmax_row_valid_cached:
+        skip_vote = self.skip_vote_resource
+        gap_log2 = (tile_row_max - row_max) * skip_vote.scale_softmax_log2_cached
+        lane_skips = gap_log2 < skip_vote.log2_threshold_cached
+        if not skip_vote.row_valid_cached:
             lane_skips = Boolean(True)
         warp_skips = cute.arch.vote_all_sync(lane_skips)
-        num_softmax_warps = 4
-        warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
-        vote_byte = (
-            self._skip_softmax_vote_word(stage_info) * Int32(num_softmax_warps)
-            + warp_id_in_sg
-        )
-        vote = cutlass.Int8(0)
-        if warp_skips:
-            vote = cutlass.Int8(1)
-        # Each warp owns one byte of the vote word, so no reset or atomic is
-        # needed. The P-ready pipeline arrive orders this store before the MMA
-        # warp reads the word.
-        if prims.elect_sync():
-            self._smem_skip_softmax_vote_bytes[vote_byte] = vote
-        _tmem_sp_skips[id(self)] = warp_skips
+        stage_idx = Int32(0)
+        if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
+            stage_idx = Int32(stage_info.stage_idx)
+        skip_vote.publish(stage_info, stage_idx, warp_skips)
+        self.warp_skips_cached = warp_skips
         row_max_next = row_max
         if not warp_skips:
             row_max_next = cute.math.max(row_max, tile_row_max)
@@ -2714,7 +2775,7 @@ class TmemSPResource(MemoryResource):
             row_max_safe = row_max
             if row_max == -Float32.inf:
                 row_max_safe = Float32(0.0)
-            warp_skips = _tmem_sp_skips[id(self)]
+            warp_skips = self.warp_skips_cached
             p_chunk = self._default_p_chunk()
             if warp_skips:
                 self._store_zero_p(tmem_p_addr)
@@ -3644,7 +3705,7 @@ class TmemSPResource(MemoryResource):
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
             # A skipped tile publishes zero probabilities and keeps the running
             # maximum, so the accumulated denominator is unchanged.
-            warp_skips = _tmem_sp_skips.pop(id(self))
+            warp_skips = self.warp_skips_cached
             row_sum_next = row_sum
             if not warp_skips:
                 row_sum_next = self._reduce_row_sum(
@@ -4238,12 +4299,10 @@ class TmemOResource(MemoryResource):
     # Skip-softmax vote of the staged P tile, read once per tile so both
     # head-dimension PV stages share one SMEM read.
     skips_pv_cached: Boolean | None = field(init=False, default=None)
-    skip_softmax_vote_alloc: Constexpr[Optional[SmemAllocation]] = field(
-        init=False, default=None
-    )
-    # Word view of the votes: one Int32 per Q/KV instance and S/P stage whose
-    # bytes hold the votes of the four softmax warps.
-    _smem_skip_softmax_vote_words: cutlass.Array = field(init=False, default=None)
+    # References to the skip-softmax vote resources of each Q/KV instance; the
+    # PV producer reads their words to skip all-zero P tiles.
+    skip_vote0_resource: SmemSkipVoteResource | None = field(init=False, default=None)
+    skip_vote1_resource: SmemSkipVoteResource | None = field(init=False, default=None)
     # References to TmemStats resources for reading cached correction stats.
     # consumer_work reads stats from these instead of from TMEM, because
     # the stats TMEM region overlaps with S0/S1 and can be overwritten by
@@ -4262,18 +4321,19 @@ class TmemOResource(MemoryResource):
         tmem_o1_offset: int,
         tmem_vec0_resource: TmemStatsResource | None = None,
         tmem_vec1_resource: TmemStatsResource | None = None,
-        skip_softmax_vote_alloc: SmemAllocation | None = None,
+        skip_vote0_resource: SmemSkipVoteResource | None = None,
+        skip_vote1_resource: SmemSkipVoteResource | None = None,
         **kwargs: Any,
     ) -> None:
-        """Bind O TMEM offsets and correction-stat resources."""
+        """Bind O TMEM offsets, correction-stat resources, and skip votes."""
         super().__init__(pipeline_config=pipeline_config, **kwargs)
         self.cfg = cfg
         self.tmem_o0_offset = tmem_o0_offset
         self.tmem_o1_offset = tmem_o1_offset
         self.tmem_vec0_resource = tmem_vec0_resource
         self.tmem_vec1_resource = tmem_vec1_resource
-        self.skip_softmax_vote_alloc = skip_softmax_vote_alloc
-        self._smem_skip_softmax_vote_words = _placeholder_smem_array(Int32)
+        self.skip_vote0_resource = skip_vote0_resource
+        self.skip_vote1_resource = skip_vote1_resource
         self._alloc_o0 = TmemAllocation("tmem_o0", 128)
         self._alloc_o1 = TmemAllocation("tmem_o1", 128)
         self.tmem_addr_cached = Int32(0)
@@ -4311,14 +4371,7 @@ class TmemOResource(MemoryResource):
         self.tmem_p_base_cached = Int32(0)
         self.p_stage_idx_cached = Int32(0)
         self.skips_pv_cached = Boolean(False)
-        if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            self._smem_skip_softmax_vote_words = cutlass.Array(
-                stage_info.context.smem_base.data_ptr()
-                + self.skip_softmax_vote_alloc.offset,
-                dtype=Int32,
-                shape=(self.cfg.skip_softmax_vote_words,),
-                addrspace=3,
-            )
+        _ = stage_info
 
     @producer_work(work_attrs=WorkAttr.AUXILIARY)
     @cute.jit
@@ -4366,29 +4419,12 @@ class TmemOResource(MemoryResource):
         The staged schedule calls this after the P-ready wait, so the skip
         vote of that P tile is read here once for both head-dimension stages.
         """
-        _ = stage_info
         self.tmem_p_base_cached = tmem_p_base
         self.p_stage_idx_cached = p_stage_idx
         if cutlass.const_expr(self.cfg.enable_skip_softmax):
-            self.skips_pv_cached = self._skip_softmax_votes_skip(inst_idx=0)
-
-    @cute.jit
-    def _skip_softmax_votes_skip(self, inst_idx: cutlass.Constexpr[int]) -> Boolean:
-        """Return whether every softmax warp of the instance skipped this tile.
-
-        The four vote bytes of the S/P stage were published before the P-ready
-        arrive that the MMA schedule waited on, so a plain SMEM read of the
-        word observes them.
-        """
-        stage_idx = Int32(0)
-        if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
-            stage_idx = self.p_stage_idx_cached
-        vote_word = Int32(inst_idx * self.cfg.mma_softmax_stage) + stage_idx
-        votes = cute.arch.make_warp_uniform(
-            self._smem_skip_softmax_vote_words[vote_word]
-        )
-        # Every byte reads 1 only when all four softmax warps voted to skip.
-        return votes == Int32(0x01010101)
+            self.skips_pv_cached = self.skip_vote0_resource.all_skipped(
+                stage_info, p_stage_idx
+            )
 
     @producer_work
     @cute.jit
@@ -4446,8 +4482,12 @@ class TmemOResource(MemoryResource):
             ):
                 skips_pv = self.skips_pv_cached
             else:
-                vote_inst_idx = 0 if (self.cfg.single_qkv_instance or writes_o0) else 1
-                skips_pv = self._skip_softmax_votes_skip(inst_idx=vote_inst_idx)
+                skip_vote = (
+                    self.skip_vote0_resource
+                    if (self.cfg.single_qkv_instance or writes_o0)
+                    else self.skip_vote1_resource
+                )
+                skips_pv = skip_vote.all_skipped(stage_info, Int32(0))
 
         if not skip_o0_invalid and not skips_pv:
             tmem_ptr_raw = self.tmem_ptr_raw_cached

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_resources.py
@@ -105,6 +105,10 @@ SoftmaxRowSumContribution: TypeAlias = SoftmaxChunks | SoftmaxScalar
 # Stored at module level (not on self) to avoid adding a non-dynamic-expression
 # field to the dataclass, which breaks the framework's scf.if handling.
 _tmem_sp_sdata: dict[int, list] = {}
+# Trace-time storage for the warp-uniform skip-softmax predicate produced by
+# the row-max work and consumed by the P store and row-sum work of the same
+# K/V tile.
+_tmem_sp_skips: dict[int, Any] = {}
 
 
 @cute.jit
@@ -307,6 +311,13 @@ class FmhaConfig:
     num_seq_tiles: int | Int32 = 0
     # Skip correction optimization: when True, skip rescale if old_max == new_max
     enable_skip_correction: bool = True
+    # Skip softmax: each softmax warp compares its K/V tile row maxima with the
+    # running maxima. When every row of the warp bounds its tile contribution
+    # below the request threshold, the warp keeps its running statistics,
+    # publishes a zero P tile without exponentiation, and votes in SMEM so the
+    # MMA task can also skip the PV MMA once all four softmax warps of the
+    # instance voted to skip.
+    skip_softmax: bool = False
 
     # Variable sequence length mode stores Q/K/V/O as flattened
     # [sum_seqlen, head, dim] tensors and uses cum_seqlen_* for per-batch
@@ -378,6 +389,20 @@ class FmhaConfig:
     def single_qkv_instance(self) -> bool:
         """Return whether one work tile carries a single Q/KV/O instance."""
         return self.num_qkv_instances == 1
+
+    @property
+    def skip_softmax_vote_words(self) -> int:
+        """Return the SMEM Int32 skip-softmax vote words.
+
+        Every Q/KV instance keeps one word per softmax warp for each S/P
+        pipeline stage, so a vote slot is never rewritten before the MMA task
+        has consumed the matching P tile.
+        """
+        return (
+            self.num_qkv_instances
+            * self.mma_softmax_stage
+            * len(self.softmax0_warp_ids)
+        )
 
     @property
     def uses_early_tile_sum(self) -> bool:
@@ -662,6 +687,22 @@ def _resolve_work_tile_coords(
     if cutlass.const_expr(cfg.uses_causal_reversed_head_batch_seq_tile_order):
         seq_coord = cfg.num_seq_tiles - seq_coord - Int32(1)
     return seq_coord, head_coord, batch_coord
+
+
+@cute.jit
+def _skip_softmax_vote_view(
+    cfg: Constexpr[FmhaConfig],
+    vote_alloc: Constexpr[SmemAllocation],
+    stage_info: StageInfo,
+) -> cutlass.Array:
+    """Return the unified-SMEM Int32 view of the skip-softmax vote words."""
+    smem_base = stage_info.context.smem_base
+    return cutlass.Array(
+        smem_base.data_ptr() + vote_alloc.offset,
+        dtype=Int32,
+        shape=(cfg.skip_softmax_vote_words,),
+        addrspace=3,
+    )
 
 
 @dataclass(frozen=True)
@@ -1940,6 +1981,21 @@ class TmemSPResource(MemoryResource):
     variable_window_cta_starts: cute.Tensor | None = field(init=False, default=None)
     variable_window_q_stride: int | Int32 = field(init=False, default=0)
     scale_softmax_log2: cute.Tensor | None = field(init=False, default=None)
+    # Per-request e-based skip-softmax thresholds, indexed by batch coordinate.
+    skip_softmax_threshold: cute.Tensor | None = field(init=False, default=None)
+    skip_softmax_vote_alloc: Constexpr[Optional[SmemAllocation]] = field(
+        init=False, default=None
+    )
+    _smem_skip_softmax_vote: cutlass.Array = field(init=False, default=None)
+    # Fixed-layout Q length of every request; packed layouts derive it from
+    # the cumulative offsets instead.
+    seq_len_q: int | Int32 | None = field(init=False, default=None)
+    # Softmax-warp copies of the base-2 softmax scale, this request's log2
+    # skip threshold, and whether this lane's row lies inside the request,
+    # cached before the K/V loop for the skip decision.
+    scale_softmax_log2_cached: Float32 | None = field(init=False, default=None)
+    log2_skip_softmax_threshold_cached: Float32 | None = field(init=False, default=None)
+    skip_softmax_row_valid_cached: Boolean | None = field(init=False, default=None)
     tmem_addr_cached: TmemAddr | None = field(init=False, default=None)
     # Precomputed TMEM pointers/addresses (set by auxiliary work). Avoids
     # per-iteration inttoptr + address math.
@@ -1978,6 +2034,9 @@ class TmemSPResource(MemoryResource):
         variable_window_cta_starts: cute.Tensor | None = None,
         variable_window_q_stride: int | Int32 = 0,
         scale_softmax_log2: cute.Tensor | None = None,
+        skip_softmax_threshold: cute.Tensor | None = None,
+        skip_softmax_vote_alloc: SmemAllocation | None = None,
+        seq_len_q: int | Int32 | None = None,
         **kwargs: Any,
     ) -> None:
         """Bind S/P TMEM offsets, Q peer index, and optional varlen metadata."""
@@ -1995,6 +2054,13 @@ class TmemSPResource(MemoryResource):
         self.variable_window_cta_starts = variable_window_cta_starts
         self.variable_window_q_stride = variable_window_q_stride
         self.scale_softmax_log2 = scale_softmax_log2
+        self.skip_softmax_threshold = skip_softmax_threshold
+        self.skip_softmax_vote_alloc = skip_softmax_vote_alloc
+        self.seq_len_q = seq_len_q
+        self._smem_skip_softmax_vote = _placeholder_smem_array(Int32)
+        self.scale_softmax_log2_cached = Float32(0.0)
+        self.log2_skip_softmax_threshold_cached = Float32(-Float32.inf)
+        self.skip_softmax_row_valid_cached = Boolean(True)
         self._alloc = TmemAllocation(
             f"tmem_sp_q{q_half}",
             cfg.qk_mma_tiler[1] * cfg.mma_softmax_stage,
@@ -2293,7 +2359,10 @@ class TmemSPResource(MemoryResource):
         # Initialize to establish DSL type; real values are set per work tile.
         self.tmem_s_addr_cached = Int32(0)
         self.tmem_p_addr_cached = Int32(0)
-        _ = stage_info
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            self._smem_skip_softmax_vote = _skip_softmax_vote_view(
+                self.cfg, self.skip_softmax_vote_alloc, stage_info
+            )
 
     @cute.jit
     def _default_p_chunk(self) -> SoftmaxRowSumContribution:
@@ -2339,10 +2408,13 @@ class TmemSPResource(MemoryResource):
     def load_scale_softmax_log2(self, stage_info: StageInfo) -> Float32:
         """Load the runtime softmax scale once before the K/V loop."""
         _ = stage_info
-        if cutlass.const_expr(self.scale_softmax_log2 is None):
-            # Safe fallback for validation-only resource construction.
-            return Float32(0.0)
-        return self.scale_softmax_log2[0]
+        # Zero is a safe fallback for validation-only resource construction.
+        scale_softmax_log2 = Float32(0.0)
+        if cutlass.const_expr(self.scale_softmax_log2 is not None):
+            scale_softmax_log2 = Float32(self.scale_softmax_log2[0])
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            self.scale_softmax_log2_cached = scale_softmax_log2
+        return scale_softmax_log2
 
     @cute.jit
     def _init_work_tile_state(self, stage_info: StageInfo) -> None:
@@ -2422,6 +2494,46 @@ class TmemSPResource(MemoryResource):
         cuseqlen_k = Int32(self.cum_seqlen_k[batch_coord])
         return Int32(self.cum_seqlen_k[batch_coord + Int32(1)]) - cuseqlen_k
 
+    @consumer_work(work_attrs=WorkAttr.AUXILIARY)
+    @cute.jit
+    def cache_skip_softmax_state(self, stage_info: StageInfo) -> None:
+        """Cache the request's log2 skip threshold and this lane's row validity.
+
+        The public threshold bounds ``exp(sm_scale * (tile_max - running_max))``
+        in the ordinary softmax domain. The K/V loop compares base-2 scaled
+        score gaps, so the request value is converted once here; a zero
+        threshold becomes ``-inf`` and never admits a skip.
+
+        Rows past the request's Q length are TMA padding: zero-filled for
+        fixed storage and NaN-filled for 16-bit packed storage. Their scores
+        carry no information, so they abstain from the warp vote instead of
+        blocking the valid rows of a partial query tile.
+        """
+        seq_coord, _, batch_coord = _resolve_work_tile_coords(
+            self.cfg, stage_info.work_tile.tile_idx
+        )
+        threshold = Float32(self.skip_softmax_threshold[batch_coord])
+        self.log2_skip_softmax_threshold_cached = cute.math.log2(
+            threshold, fastmath=True
+        )
+        num_softmax_warps = 4
+        warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
+        row_in_tile = warp_id_in_sg * cute.arch.WARP_SIZE + cute.arch.lane_idx()
+        local_q = (
+            seq_coord * self.cfg.q_tile_m * self.cfg.work_tile_q_seq_tiles
+            + self.q_half * self.cfg.peer_q_seq_tile_stride * self.cfg.q_tile_m
+            + row_in_tile
+        )
+        if cutlass.const_expr(self.cfg.has_varlen):
+            if cutlass.const_expr(self.cfg.has_uniform_varlen):
+                seqlen_q = Int32(self.cfg.uniform_seq_len_q)
+            else:
+                cuseqlen_q = Int32(self.cum_seqlen_q[batch_coord])
+                seqlen_q = Int32(self.cum_seqlen_q[batch_coord + Int32(1)]) - cuseqlen_q
+        else:
+            seqlen_q = Int32(self.seq_len_q)
+        self.skip_softmax_row_valid_cached = local_q < seqlen_q
+
     @consumer_work(
         work_attrs=WorkAttr.AUXILIARY,
         returns=(variable_window_start, variable_window_end),
@@ -2485,6 +2597,7 @@ class TmemSPResource(MemoryResource):
     @cute.jit
     def _reduce_row_max(
         self,
+        stage_info: StageInfo,
         s_data: SoftmaxChunks,
         row_max: SoftmaxScalar,
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
@@ -2492,14 +2605,23 @@ class TmemSPResource(MemoryResource):
         tmem_x = self.cfg.tmem_x_load_s
         num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
         old_row_max = row_max
-        if cutlass.const_expr(
+        uses_fp8_cadence = (
             self.cfg.uses_d128_fp8_softmax_cadence
             or self.cfg.uses_d256_fp8_softmax_cadence
-        ):
-            max_0 = row_max
-            max_1 = row_max
-            max_2 = row_max
-            max_3 = row_max
+        )
+        if cutlass.const_expr(uses_fp8_cadence):
+            # Four independent chains over the tile only; the running maximum
+            # joins after the tile reduction so the tile maximum stays
+            # available for the skip-softmax decision. Scores are read only
+            # inside the unrolled loop: the staged frontend resolves fragments
+            # that a mask branch rewrote through their variable references
+            # there, whereas a bare read right after that branch sees the
+            # stale in-branch value.
+            neg_inf = Float32(-Float32.inf)
+            max_0 = neg_inf
+            max_1 = neg_inf
+            max_2 = neg_inf
+            max_3 = neg_inf
             for chunk_idx in cutlass.range_constexpr(num_chunks):
                 for elem_idx in cutlass.range_constexpr(0, tmem_x, 4):
                     max_0 = cute.math.max(max_0, s_data[chunk_idx][elem_idx], ftz=True)
@@ -2514,7 +2636,7 @@ class TmemSPResource(MemoryResource):
                     )
             max_0 = cute.math.max(max_0, max_2, ftz=True)
             max_1 = cute.math.max(max_1, max_3, ftz=True)
-            row_max = cute.math.max(max_0, max_1, ftz=True)
+            tile_row_max = cute.math.max(max_0, max_1, ftz=True)
         else:
             row_values: tuple[Any, ...] = ()
             for chunk_idx in cutlass.range_constexpr(num_chunks):
@@ -2522,12 +2644,73 @@ class TmemSPResource(MemoryResource):
                     row_values += (s_data[chunk_idx][elem_idx],)
             row_vector = cutlass.Vector.from_elements(row_values, self.cfg.qk_acc_dtype)
             tile_row_max = row_vector.reduce("max")
-            row_max = cute.math.max(row_max, tile_row_max)
         _tmem_sp_sdata[id(self)] = s_data
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            # The skip specialization carries the exact running maximum, which
+            # stays -inf until a row meets its first valid key; the P store,
+            # row-sum, and statistics work substitute zero where needed.
+            return old_row_max, self._skip_softmax_row_max(
+                stage_info, row_max, tile_row_max
+            )
+        if cutlass.const_expr(uses_fp8_cadence):
+            row_max = cute.math.max(row_max, tile_row_max, ftz=True)
+        else:
+            row_max = cute.math.max(row_max, tile_row_max)
         row_max_safe = row_max
         if row_max == -Float32.inf:
             row_max_safe = Float32(0.0)
         return old_row_max, row_max_safe
+
+    @cute.jit
+    def _skip_softmax_vote_slot(self, stage_info: StageInfo) -> Int32:
+        """Return the first vote word of this instance's current S/P stage."""
+        num_softmax_warps = 4
+        stage_idx = Int32(0)
+        if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
+            stage_idx = Int32(stage_info.stage_idx)
+        return (Int32(self.q_half * self.cfg.mma_softmax_stage) + stage_idx) * Int32(
+            num_softmax_warps
+        )
+
+    @cute.jit
+    def _skip_softmax_row_max(
+        self,
+        stage_info: StageInfo,
+        row_max: SoftmaxScalar,
+        tile_row_max: SoftmaxScalar,
+    ) -> SoftmaxScalar:
+        """Decide the warp-uniform skip, publish the vote, and update the max.
+
+        A lane wants to skip when ``exp2`` of its scaled tile-versus-running
+        maximum gap is below the request threshold, the same bound trtllm-gen
+        applies before its softmax and PV work. Comparing in the log2 domain
+        keeps a ``-inf`` running maximum (no valid key yet) and a zero
+        threshold from ever admitting a skip, and a fully masked tile skips
+        only once the row already has a finite maximum. Every valid row of
+        the warp must agree because it owns 32 rows of the P tile consumed by
+        one PV MMA; padding rows abstain.
+        """
+        gap_log2 = (tile_row_max - row_max) * self.scale_softmax_log2_cached
+        lane_skips = gap_log2 < self.log2_skip_softmax_threshold_cached
+        if not self.skip_softmax_row_valid_cached:
+            lane_skips = Boolean(True)
+        warp_skips = cute.arch.vote_all_sync(lane_skips)
+        num_softmax_warps = 4
+        warp_id_in_sg = cute.arch.warp_idx() % num_softmax_warps
+        vote_idx = self._skip_softmax_vote_slot(stage_info) + warp_id_in_sg
+        vote = Int32(0)
+        if warp_skips:
+            vote = Int32(1)
+        # Each warp owns one vote word, so no reset or atomic is needed. The
+        # P-ready pipeline arrive orders this store before the MMA warp reads
+        # the four words of the instance.
+        if prims.elect_sync():
+            self._smem_skip_softmax_vote[vote_idx] = vote
+        _tmem_sp_skips[id(self)] = warp_skips
+        row_max_next = row_max
+        if not warp_skips:
+            row_max_next = cute.math.max(row_max, tile_row_max)
+        return row_max_next
 
     @cute.jit
     def _exp2_p_store(
@@ -2538,6 +2721,63 @@ class TmemSPResource(MemoryResource):
     ) -> SoftmaxRowSumContribution:
         """Apply exp2 softmax P, fold the PV P scale, and store P to TMEM."""
         tmem_p_addr = self.tmem_p_addr_cached + stage_col_offset
+        s_data = _tmem_sp_sdata.pop(id(self))
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            # Exponentiate against zero while the exact running maximum is
+            # still -inf so masked scores become exact zeros instead of NaN.
+            row_max_safe = row_max
+            if row_max == -Float32.inf:
+                row_max_safe = Float32(0.0)
+            warp_skips = _tmem_sp_skips[id(self)]
+            p_chunk = self._default_p_chunk()
+            if warp_skips:
+                self._store_zero_p(tmem_p_addr)
+            else:
+                tile_p_chunk = self._exp2_p_store_tile(
+                    tmem_p_addr, row_max_safe, scale_softmax_log2, s_data
+                )
+                if cutlass.const_expr(self.enable_early_tile_sum):
+                    p_chunk = tile_p_chunk
+                else:
+                    # Refill the retained fragment list in place so every
+                    # vector is yielded out of this branch.
+                    for chunk_idx in cutlass.range_constexpr(len(tile_p_chunk)):
+                        p_chunk[chunk_idx] = tile_p_chunk[chunk_idx]
+            return p_chunk
+        return self._exp2_p_store_tile(tmem_p_addr, row_max, scale_softmax_log2, s_data)
+
+    @cute.jit
+    def _store_zero_p(self, tmem_p_addr: TmemAddr) -> None:
+        """Publish an all-zero probability tile for a skipped K/V tile.
+
+        The PV MMA still consumes this P tile when another softmax warp of the
+        same instance did not skip, so the skipped rows must contribute zero.
+        """
+        tmem_x = self.cfg.tmem_x_load_s
+        num_p_words = self.cfg.qk_mma_tiler[1] * self.cfg.v_dtype.width // Int32.width
+        zeros = cutlass.vector.full([tmem_x], Int32(0), dtype=Int32)
+        for word_idx in cutlass.range_constexpr(0, num_p_words, tmem_x):
+            prims.tcgen05_st(
+                "32x32b",
+                prims.make_tmem_ptr(tmem_p_addr + word_idx, cutlass.Int8),
+                zeros,
+            )
+        if cutlass.const_expr(
+            self.enable_early_tile_sum or self.cfg.has_tmem_p_pipeline
+        ):
+            cute.arch.fence_view_async_tmem_store()
+        else:
+            prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+
+    @cute.jit
+    def _exp2_p_store_tile(
+        self,
+        tmem_p_addr: TmemAddr,
+        row_max: SoftmaxScalar,
+        scale_softmax_log2: SoftmaxScalar,
+        s_data: SoftmaxChunks,
+    ) -> SoftmaxRowSumContribution:
+        """Exponentiate one loaded S tile into P and store it to TMEM."""
         tmem_shape = "32x32b"
         tmem_x = self.cfg.tmem_x_load_s
         num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
@@ -2548,12 +2788,14 @@ class TmemSPResource(MemoryResource):
                 tmem_p_addr,
                 row_max,
                 scale,
+                s_data,
             )
         if cutlass.const_expr(self.cfg.uses_d128_fp8_softmax_cadence):
             return self._exp2_p_store_d128_fp8_cadence(
                 tmem_p_addr,
                 row_max,
                 scale,
+                s_data,
             )
         p_data_f32 = cutlass.Array(self.cfg.qk_acc_dtype, tmem_x, alignment=16)
         p_data_packed = cutlass.Array(
@@ -2563,7 +2805,6 @@ class TmemSPResource(MemoryResource):
         )
         p_scale_log2 = Float32(self.cfg.pv_p_scale_log2)
         minus_row_max_scale = (Float32(0.0) - row_max) * scale + p_scale_log2
-        s_data = _tmem_sp_sdata.pop(id(self))
         if cutlass.const_expr(self.enable_early_tile_sum):
             # Keep four independent scalar dependency chains while expressing
             # them as two packed float2 values.  The explicit packed primitive
@@ -2674,6 +2915,7 @@ class TmemSPResource(MemoryResource):
         tmem_p_addr: TmemAddr,
         row_max: SoftmaxScalar,
         scale: SoftmaxScalar,
+        s_data: SoftmaxChunks,
     ) -> Float32:
         """Use TRT's D128 FP8 softmax arithmetic cadence.
 
@@ -2689,7 +2931,6 @@ class TmemSPResource(MemoryResource):
         words_per_chunk = 2 * store_group_words
         p_scale_log2 = Float32(self.cfg.pv_p_scale_log2)
         minus_row_max_scale = (Float32(0.0) - row_max) * scale + p_scale_log2
-        s_data = _tmem_sp_sdata.pop(id(self))
         local_sum_chains = cutlass.Array(
             Float32,
             4,
@@ -2838,6 +3079,7 @@ class TmemSPResource(MemoryResource):
         tmem_p_addr: TmemAddr,
         row_max: SoftmaxScalar,
         scale: SoftmaxScalar,
+        s_data: SoftmaxChunks,
     ) -> Float32:
         """Interleave D256 FP8 EXP2, conversion, and tile-sum retirement.
 
@@ -2850,7 +3092,6 @@ class TmemSPResource(MemoryResource):
         num_values = self.cfg.qk_mma_tiler[1]
         p_scale_log2 = Float32(self.cfg.pv_p_scale_log2)
         minus_row_max_scale = (Float32(0.0) - row_max) * scale + p_scale_log2
-        s_data = _tmem_sp_sdata.pop(id(self))
 
         fma_values: tuple[Any, ...] = ()
         for flat_idx in cutlass.range_constexpr(0, 8, 2):
@@ -2971,7 +3212,7 @@ class TmemSPResource(MemoryResource):
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
         """Main K-loop stage: load S from TMEM and compute unmasked row_max."""
         s_data = self._load_s_chunks(stage_info)
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
@@ -3004,7 +3245,7 @@ class TmemSPResource(MemoryResource):
                 s_data[chunk_idx] = cutlass.vector.where(
                     mask, s_data[chunk_idx], neg_inf
                 )
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
@@ -3043,7 +3284,7 @@ class TmemSPResource(MemoryResource):
                 s_data[chunk_idx] = cutlass.vector.where(
                     mask, s_data[chunk_idx], neg_inf
                 )
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
@@ -3096,7 +3337,7 @@ class TmemSPResource(MemoryResource):
             s_data[chunk_idx] = cutlass.Vector.from_elements(
                 tuple(masked_scores), self.cfg.qk_acc_dtype
             )
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
@@ -3169,7 +3410,7 @@ class TmemSPResource(MemoryResource):
                 mask = mask & right_mask
             s_data[chunk_idx] = cutlass.vector.where(mask, s_data[chunk_idx], neg_inf)
 
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=(old_row_max, row_max))
     @cute.jit
@@ -3185,7 +3426,7 @@ class TmemSPResource(MemoryResource):
         s_data = self._apply_causal_mask_for_kv_tile(
             stage_info, s_data, kv_tile_idx=stage_info.loop_offset, q_offset=q_offset
         )
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=p_chunk)
     @cute.jit
@@ -3283,7 +3524,7 @@ class TmemSPResource(MemoryResource):
                 s_data[chunk_idx] = cutlass.vector.where(
                     mask, s_data[chunk_idx], neg_inf
                 )
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @cute.jit
     def _apply_causal_mask_for_kv_tile(
@@ -3357,7 +3598,7 @@ class TmemSPResource(MemoryResource):
         s_data = self._load_s_chunks(stage_info)
         if cutlass.const_expr(self.cfg.is_causal):
             s_data = self._apply_causal_mask(stage_info, s_data, q_offset)
-        return self._reduce_row_max(s_data, row_max)
+        return self._reduce_row_max(stage_info, s_data, row_max)
 
     @consumer_work(returns=p_chunk)
     @cute.jit
@@ -3383,8 +3624,9 @@ class TmemSPResource(MemoryResource):
     ) -> tuple[SoftmaxScalar, SoftmaxScalar]:
         """Tail stage for softmax group 0: identity row_max, no S load."""
         row_max_safe = row_max
-        if row_max == -Float32.inf:
-            row_max_safe = Float32(0.0)
+        if cutlass.const_expr(not self.cfg.skip_softmax):
+            if row_max == -Float32.inf:
+                row_max_safe = Float32(0.0)
         _ = stage_info
         return row_max, row_max_safe
 
@@ -3413,9 +3655,63 @@ class TmemSPResource(MemoryResource):
     ) -> SoftmaxScalar:
         """Accumulate row_sum from vector P fragments or their scalar sum."""
         _ = stage_info
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            # A skipped tile publishes zero probabilities and keeps the running
+            # maximum, so the accumulated denominator is unchanged.
+            warp_skips = _tmem_sp_skips.pop(id(self))
+            row_sum_next = row_sum
+            if not warp_skips:
+                row_sum_next = self._reduce_row_sum(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    row_sum=row_sum,
+                    p_chunk=p_chunk,
+                    scale_softmax_log2=scale_softmax_log2,
+                )
+            return row_sum_next
+        return self._reduce_row_sum(
+            old_row_max=old_row_max,
+            row_max=row_max,
+            row_sum=row_sum,
+            p_chunk=p_chunk,
+            scale_softmax_log2=scale_softmax_log2,
+        )
+
+    @cute.jit
+    def _row_sum_acc_scale_log2(
+        self,
+        *,
+        old_row_max: SoftmaxScalar,
+        row_max: SoftmaxScalar,
+        scale_softmax_log2: SoftmaxScalar,
+    ) -> Float32:
+        """Return the base-2 exponent rescaling the previous row sum."""
+        acc_scale_log2 = scale_softmax_log2 * (old_row_max - row_max)
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            # Both maxima are -inf until the row meets a valid key. The row
+            # sum is still zero there, so any finite exponent keeps it zero.
+            if row_max == -Float32.inf:
+                acc_scale_log2 = Float32(0.0)
+        return acc_scale_log2
+
+    @cute.jit
+    def _reduce_row_sum(
+        self,
+        *,
+        old_row_max: SoftmaxScalar,
+        row_max: SoftmaxScalar,
+        row_sum: SoftmaxScalar,
+        p_chunk: SoftmaxRowSumContribution,
+        scale_softmax_log2: SoftmaxScalar,
+    ) -> SoftmaxScalar:
+        """Rescale the previous row sum and add this tile's contribution."""
         if cutlass.const_expr(self.enable_early_tile_sum):
             acc_scale = cute.math.exp2(
-                scale_softmax_log2 * (old_row_max - row_max),
+                self._row_sum_acc_scale_log2(
+                    old_row_max=old_row_max,
+                    row_max=row_max,
+                    scale_softmax_log2=scale_softmax_log2,
+                ),
                 fastmath=True,
             )
             return row_sum * acc_scale + p_chunk
@@ -3452,8 +3748,11 @@ class TmemSPResource(MemoryResource):
         """Accumulate row_sum from P chunks saved by consumer_work."""
         tmem_x = self.cfg.tmem_x_load_s
         num_chunks = self.cfg.qk_mma_tiler[1] // tmem_x
-        scale = scale_softmax_log2
-        acc_scale_ = scale * (old_row_max - row_max)
+        acc_scale_ = self._row_sum_acc_scale_log2(
+            old_row_max=old_row_max,
+            row_max=row_max,
+            scale_softmax_log2=scale_softmax_log2,
+        )
         acc_scale = cute.math.exp2(acc_scale_, fastmath=True) * 0.5
         scaled_sum = row_sum * acc_scale
         if cutlass.const_expr(self.cfg.stage_kv_by_head_dim):
@@ -3533,6 +3832,7 @@ class TmemPResource(MemoryResource):
     cfg: Constexpr[FmhaConfig] = field(init=False, default=None)
     tmem_p_offset: Constexpr[int] = field(init=False, default=None)
     tmem_p_base: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
+    p_stage_idx: Constexpr[TaskLocalVariable] = TaskLocalVariable.uninitialized()
 
     def __init__(
         self,
@@ -3550,6 +3850,11 @@ class TmemPResource(MemoryResource):
             default=Int32(tmem_p_offset),
             docs="Selected staged P TMEM column base for PV MMA.",
         )
+        self.p_stage_idx = TaskLocalVariable(
+            dtype=Int32,
+            default=Int32(0),
+            docs="Staged P pipeline stage selected for PV MMA.",
+        )
 
     def get_tmem_requirements(self) -> list[TmemAllocation]:
         """Return no allocation because P aliases the TmemSP allocation."""
@@ -3561,14 +3866,16 @@ class TmemPResource(MemoryResource):
         _ = context
         return Int32(self.tmem_p_offset)
 
-    @consumer_work(returns=("tmem_p_base",))
+    @consumer_work(returns=("tmem_p_base", "p_stage_idx"))
     @cute.jit
-    def p_base(self, stage_info: StageInfo) -> Int32:
-        """Return the staged P column base for the MMA PV producer."""
+    def p_base(self, stage_info: StageInfo) -> tuple[Int32, Int32]:
+        """Return the staged P column base and stage for the MMA PV producer."""
         tmem_p_base = Int32(self.tmem_p_offset)
+        p_stage_idx = Int32(0)
         if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
-            tmem_p_base = tmem_p_base + stage_info.stage_idx * self.cfg.qk_mma_tiler[1]
-        return tmem_p_base
+            p_stage_idx = Int32(stage_info.stage_idx)
+            tmem_p_base = tmem_p_base + p_stage_idx * self.cfg.qk_mma_tiler[1]
+        return tmem_p_base, p_stage_idx
 
 
 # ---------------------------------------------------------------------------
@@ -3813,6 +4120,13 @@ class TmemStatsResource(MemoryResource):
           scale = exp2(scale_log2 * (old_max - new_max))
         and to forward row_sum to SmemO for the final normalization.
         """
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            # The skip specialization carries exact -inf maxima for rows
+            # without a valid key. Their O rows are still zero, so publish
+            # zeros to keep the correction scale finite.
+            if row_max == -Float32.inf:
+                old_row_max = Float32(0.0)
+                row_max = Float32(0.0)
         if cutlass.const_expr(self.cfg.stats_via_smem):
             stat0 = old_row_max
             if cutlass.const_expr(final_stats):
@@ -3932,8 +4246,16 @@ class TmemOResource(MemoryResource):
     # Precomputed per-warp TMEM O address base: (row_id << 16) | tmem_base_col.
     # consumer_work adds tmem_o_offset to get the final O0/O1 address.
     tmem_o_addr_base_cached: TmemAddr | None = field(init=False, default=None)
-    # P-stage base supplied by TmemPResource for split S/P scheduling.
+    # P-stage base and stage supplied by TmemPResource for split S/P scheduling.
     tmem_p_base_cached: TmemAddr | None = field(init=False, default=None)
+    p_stage_idx_cached: Int32 | None = field(init=False, default=None)
+    # Skip-softmax vote of the staged P tile, read once per tile so both
+    # head-dimension PV stages share one SMEM read.
+    skips_pv_cached: Boolean | None = field(init=False, default=None)
+    skip_softmax_vote_alloc: Constexpr[Optional[SmemAllocation]] = field(
+        init=False, default=None
+    )
+    _smem_skip_softmax_vote: cutlass.Array = field(init=False, default=None)
     # References to TmemStats resources for reading cached correction stats.
     # consumer_work reads stats from these instead of from TMEM, because
     # the stats TMEM region overlaps with S0/S1 and can be overwritten by
@@ -3952,6 +4274,7 @@ class TmemOResource(MemoryResource):
         tmem_o1_offset: int,
         tmem_vec0_resource: TmemStatsResource | None = None,
         tmem_vec1_resource: TmemStatsResource | None = None,
+        skip_softmax_vote_alloc: SmemAllocation | None = None,
         **kwargs: Any,
     ) -> None:
         """Bind O TMEM offsets and correction-stat resources."""
@@ -3961,6 +4284,8 @@ class TmemOResource(MemoryResource):
         self.tmem_o1_offset = tmem_o1_offset
         self.tmem_vec0_resource = tmem_vec0_resource
         self.tmem_vec1_resource = tmem_vec1_resource
+        self.skip_softmax_vote_alloc = skip_softmax_vote_alloc
+        self._smem_skip_softmax_vote = _placeholder_smem_array(Int32)
         self._alloc_o0 = TmemAllocation("tmem_o0", 128)
         self._alloc_o1 = TmemAllocation("tmem_o1", 128)
         self.tmem_addr_cached = Int32(0)
@@ -3996,7 +4321,12 @@ class TmemOResource(MemoryResource):
         )
         self.tmem_o_addr_base_cached = Int32(0)
         self.tmem_p_base_cached = Int32(0)
-        _ = stage_info
+        self.p_stage_idx_cached = Int32(0)
+        self.skips_pv_cached = Boolean(False)
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            self._smem_skip_softmax_vote = _skip_softmax_vote_view(
+                self.cfg, self.skip_softmax_vote_alloc, stage_info
+            )
 
     @producer_work(work_attrs=WorkAttr.AUXILIARY)
     @cute.jit
@@ -4032,10 +4362,45 @@ class TmemOResource(MemoryResource):
 
     @producer_work(work_attrs=WorkAttr.AUXILIARY)
     @cute.jit
-    def set_p_base(self, stage_info: StageInfo, *, tmem_p_base: Int32) -> None:
-        """Cache the P TMEM column base selected by TmemPResource."""
+    def set_p_base(
+        self,
+        stage_info: StageInfo,
+        *,
+        tmem_p_base: Int32,
+        p_stage_idx: Int32,
+    ) -> None:
+        """Cache the P TMEM column base and stage selected by TmemPResource.
+
+        The staged schedule calls this after the P-ready wait, so the skip
+        vote of that P tile is read here once for both head-dimension stages.
+        """
         _ = stage_info
         self.tmem_p_base_cached = tmem_p_base
+        self.p_stage_idx_cached = p_stage_idx
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            self.skips_pv_cached = self._skip_softmax_votes_skip(inst_idx=0)
+
+    @cute.jit
+    def _skip_softmax_votes_skip(self, inst_idx: cutlass.Constexpr[int]) -> Boolean:
+        """Return whether every softmax warp of the instance skipped this tile.
+
+        The four vote words were published before the P-ready arrive that the
+        MMA schedule waited on, so a plain SMEM read observes them.
+        """
+        num_softmax_warps = 4
+        stage_idx = Int32(0)
+        if cutlass.const_expr(self.cfg.mma_softmax_stage > 1):
+            stage_idx = self.p_stage_idx_cached
+        vote_idx = (Int32(inst_idx * self.cfg.mma_softmax_stage) + stage_idx) * Int32(
+            num_softmax_warps
+        )
+        votes = self._smem_skip_softmax_vote.load(
+            vote_idx, vector_size=num_softmax_warps, alignment=16
+        )
+        all_votes = cute.arch.make_warp_uniform(
+            Int32(votes[0]) & Int32(votes[1]) & Int32(votes[2]) & Int32(votes[3])
+        )
+        return all_votes == Int32(1)
 
     @producer_work
     @cute.jit
@@ -4084,7 +4449,19 @@ class TmemOResource(MemoryResource):
             if not is_tail:
                 skip_o0_invalid = stage_info.loop_offset == (stage_info.loop_end - 1)
 
-        if not skip_o0_invalid:
+        # Skip softmax: every softmax warp of this instance published a zero P
+        # tile, so the PV MMA would add nothing to O.
+        skips_pv = False
+        if cutlass.const_expr(self.cfg.skip_softmax):
+            if cutlass.const_expr(
+                self.cfg.single_qkv_instance and self.cfg.has_tmem_p_pipeline
+            ):
+                skips_pv = self.skips_pv_cached
+            else:
+                vote_inst_idx = 0 if (self.cfg.single_qkv_instance or writes_o0) else 1
+                skips_pv = self._skip_softmax_votes_skip(inst_idx=vote_inst_idx)
+
+        if not skip_o0_invalid and not skips_pv:
             tmem_ptr_raw = self.tmem_ptr_raw_cached
 
             if cutlass.const_expr(self.cfg.v_dtype.width == 8):

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -747,8 +747,8 @@ def create_mma_task(
 
                     to.acquire()
                     tp0.wait()
-                    tmem_p_base = tp0.p_base()
-                    to.set_p_base(tmem_p_base=tmem_p_base)
+                    tmem_p_base, p_stage_idx = tp0.p_base()
+                    to.set_p_base(tmem_p_base=tmem_p_base, p_stage_idx=p_stage_idx)
 
                     skv.wait()
                     desc_v_base = skv.v_desc()
@@ -773,8 +773,8 @@ def create_mma_task(
                 sq.release()
                 to.acquire()
                 tp0.wait()
-                tmem_p_base = tp0.p_base()
-                to.set_p_base(tmem_p_base=tmem_p_base)
+                tmem_p_base, p_stage_idx = tp0.p_base()
+                to.set_p_base(tmem_p_base=tmem_p_base, p_stage_idx=p_stage_idx)
                 for head_dim_stage_idx in range(num_head_dim_stages_v):
                     skv.wait()
                     desc_v_base = skv.v_desc()
@@ -1093,6 +1093,8 @@ def create_softmax_task(
                         sp.init_softmax_work_tile_state()
                     )
                     vec.init_store_work_tile_state()
+                    if tmem_sp.cfg.skip_softmax:
+                        sp.cache_skip_softmax_state()
                     if tmem_sp.uses_varlen_q_offset_cache:
                         q_offset = sp.cache_q_offset()
                     if tmem_sp.uses_packed_dense_k_mask:
@@ -1573,6 +1575,8 @@ def create_softmax_task(
             # Recompute per-tile SP/Vec TMEM state.
             old_row_max, row_max, row_sum, q_offset = sp.init_softmax_work_tile_state()
             vec.init_store_work_tile_state()
+            if tmem_sp.cfg.skip_softmax:
+                sp.cache_skip_softmax_state()
             if tmem_sp.uses_varlen_q_offset_cache:
                 q_offset = sp.cache_q_offset()
             if tmem_sp.uses_packed_dense_k_mask:

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -24,7 +24,7 @@ schedule before the repeated K/V tile loop, LOOP is the repeated K/V tile body,
 and TAIL is the one-time cleanup and drain after LOOP exits.
 """
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any
@@ -51,6 +51,7 @@ from .fmha_resources import (
     SmemOResource,
     SmemPageOffsetsKvResource,
     SmemQResource,
+    SmemSkipVoteResource,
     TmemOResource,
     TmemPResource,
     TmemSPResource,
@@ -118,6 +119,28 @@ def _schedule_with_work_queue(
     if work_queue is None:
         return schedule(*resources)
     return schedule(*resources, work_queue)
+
+
+def _present_resources(*resources: MemoryResource | None) -> list[MemoryResource]:
+    """Return the optional resources that exist, in declaration order."""
+    return [resource for resource in resources if resource is not None]
+
+
+def _optional_schedule_resources(
+    proxies: Sequence[object], *resources: MemoryResource | None
+) -> tuple[object | None, ...]:
+    """Bind the trailing optional arguments of a captured schedule.
+
+    ``@schedule`` passes resource proxies positionally, so optional resources
+    are appended to the argument list only when present and land in the
+    schedule's trailing ``*optional`` parameter in declaration order.
+    ``resources`` names the optional resources in that order; a ``None`` entry
+    was not passed and binds to ``None``.
+    """
+    proxy_iter = iter(proxies)
+    return tuple(
+        next(proxy_iter) if resource is not None else None for resource in resources
+    )
 
 
 def _packed_context_skip_predicate(
@@ -1056,6 +1079,7 @@ def create_softmax_task(
     s0s1_seq: S0S1SequenceResource | None,
     work_queue: WorkQueue | None,
     task_class: type[Task] = Task,
+    skip_vote: SmemSkipVoteResource | None = None,
     **task_kwargs: Any,
 ) -> Task:
     """Create a four-warp Softmax task.
@@ -1065,6 +1089,8 @@ def create_softmax_task(
 
     Args:
         task_class: Task subclass used to instantiate the softmax schedule.
+        skip_vote: Skip-softmax vote resource of this instance, published by
+            ``TmemSPResource`` through the softmax warps of this task.
     """
     loop_start, loop_end, loop_step = _captured_loop_bounds(task_class, task_kwargs)
     skip_work_tile_if = _packed_context_skip_predicate(work_queue)
@@ -1077,14 +1103,17 @@ def create_softmax_task(
         if tmem_p is not None and tmem_sp.cfg.has_tmem_p_pipeline:
             src = _src_resources(tmem_sp, work_queue=work_queue)
             dst = [tmem_vec, tmem_p]
+            if skip_vote is not None:
+                dst.append(skip_vote)
 
             @schedule
             def softmax_schedule(
                 sp: TmemSPResource,
                 vec: TmemStatsResource,
                 tp: TmemPResource,
-                wq: WorkQueue | None = None,
+                *optional: MemoryResource,
             ) -> None:
+                skip, wq = _optional_schedule_resources(optional, skip_vote, work_queue)
                 p_chunk = sp.init_softmax_state()
                 scale_softmax_log2 = sp.load_scale_softmax_log2()
                 vec.init_store_state()
@@ -1094,7 +1123,7 @@ def create_softmax_task(
                     )
                     vec.init_store_work_tile_state()
                     if tmem_sp.cfg.enable_skip_softmax:
-                        sp.cache_skip_softmax_state()
+                        skip.cache_state()
                     if tmem_sp.uses_varlen_q_offset_cache:
                         q_offset = sp.cache_q_offset()
                     if tmem_sp.uses_packed_dense_k_mask:
@@ -1338,7 +1367,12 @@ def create_softmax_task(
                         vec.commit()
 
             captured_schedule = _schedule_with_work_queue(
-                softmax_schedule, tmem_sp, tmem_vec, tmem_p, work_queue=work_queue
+                softmax_schedule,
+                tmem_sp,
+                tmem_vec,
+                tmem_p,
+                *_present_resources(skip_vote),
+                work_queue=work_queue,
             )
             return task_class(
                 src_resources=src,
@@ -1355,13 +1389,16 @@ def create_softmax_task(
         # SP stage and releases that same resource for MMA to consume directly.
         src = _src_resources(tmem_sp, work_queue=work_queue)
         dst = [tmem_vec]
+        if skip_vote is not None:
+            dst.append(skip_vote)
 
         @schedule
         def softmax_schedule(
             sp: TmemSPResource,
             vec: TmemStatsResource,
-            wq: WorkQueue | None = None,
+            *optional: MemoryResource,
         ) -> None:
+            skip, wq = _optional_schedule_resources(optional, skip_vote, work_queue)
             old_row_max, row_max, row_sum, p_chunk, q_offset = (
                 sp.create_function_variables()
             )
@@ -1377,6 +1414,8 @@ def create_softmax_task(
                         )
                     )
                     vec.create_work_tile_variables()
+                if tmem_sp.cfg.enable_skip_softmax:
+                    skip.cache_state()
                 if tmem_sp.uses_varlen_q_offset_cache:
                     q_offset = sp.cache_q_offset()
                 if tmem_sp.uses_packed_dense_k_mask:
@@ -1532,7 +1571,11 @@ def create_softmax_task(
                     vec.commit()
 
         captured_schedule = _schedule_with_work_queue(
-            softmax_schedule, tmem_sp, tmem_vec, work_queue=work_queue
+            softmax_schedule,
+            tmem_sp,
+            tmem_vec,
+            *_present_resources(skip_vote),
+            work_queue=work_queue,
         )
         return task_class(
             src_resources=src,
@@ -1554,15 +1597,18 @@ def create_softmax_task(
     dst = [tmem_vec]
     if s0s1_seq is not None and index == 0:
         dst.append(s0s1_seq)
+    if skip_vote is not None:
+        dst.append(skip_vote)
 
     @schedule
     def softmax_schedule(
         sp: TmemSPResource,
         vec: TmemStatsResource,
         seq: S0S1SequenceResource,
-        wq: WorkQueue | None = None,
+        *optional: MemoryResource,
     ) -> None:
         """Captured schedule for one softmax warp group."""
+        skip, wq = _optional_schedule_resources(optional, skip_vote, work_queue)
         if tmem_sp.enable_early_tile_sum:
             # The contribution is produced and consumed inside each iteration;
             # do not carry even the scalar tile sum through the persistent loop.
@@ -1576,7 +1622,7 @@ def create_softmax_task(
             old_row_max, row_max, row_sum, q_offset = sp.init_softmax_work_tile_state()
             vec.init_store_work_tile_state()
             if tmem_sp.cfg.enable_skip_softmax:
-                sp.cache_skip_softmax_state()
+                skip.cache_state()
             if tmem_sp.uses_varlen_q_offset_cache:
                 q_offset = sp.cache_q_offset()
             if tmem_sp.uses_packed_dense_k_mask:
@@ -1825,7 +1871,12 @@ def create_softmax_task(
                 vec.commit()
 
     captured_schedule = _schedule_with_work_queue(
-        softmax_schedule, tmem_sp, tmem_vec, s0s1_seq, work_queue=work_queue
+        softmax_schedule,
+        tmem_sp,
+        tmem_vec,
+        s0s1_seq,
+        *_present_resources(skip_vote),
+        work_queue=work_queue,
     )
     return task_class(
         src_resources=src,

--- a/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_context/fmha_tasks.py
@@ -1093,7 +1093,7 @@ def create_softmax_task(
                         sp.init_softmax_work_tile_state()
                     )
                     vec.init_store_work_tile_state()
-                    if tmem_sp.cfg.skip_softmax:
+                    if tmem_sp.cfg.enable_skip_softmax:
                         sp.cache_skip_softmax_state()
                     if tmem_sp.uses_varlen_q_offset_cache:
                         q_offset = sp.cache_q_offset()
@@ -1575,7 +1575,7 @@ def create_softmax_task(
             # Recompute per-tile SP/Vec TMEM state.
             old_row_max, row_max, row_sum, q_offset = sp.init_softmax_work_tile_state()
             vec.init_store_work_tile_state()
-            if tmem_sp.cfg.skip_softmax:
+            if tmem_sp.cfg.enable_skip_softmax:
                 sp.cache_skip_softmax_state()
             if tmem_sp.uses_varlen_q_offset_cache:
                 q_offset = sp.cache_q_offset()

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -525,6 +525,7 @@ def test_attention_ts_context_alias_guard_covers_fixed_plan_storage(
         "variable_window_token_starts",
         "variable_window_token_ends",
         "variable_window_cta_starts",
+        "skip_softmax_threshold",
     )
 
     for aliased_name in (*argument_names, *retained_names):
@@ -574,6 +575,7 @@ def test_attention_ts_context_alias_guard_covers_paged_plan_storage(
         "dense_page_idx_kv",
         "scale_softmax_log2",
         "output_scale",
+        "skip_softmax_threshold",
     )
 
     for aliased_name in (*argument_names, *retained_names):
@@ -3126,3 +3128,629 @@ def test_attention_ts_context_supplied_out_stream_and_cuda_graph():
     graph.replay()
     torch.cuda.synchronize()
     _assert_context_correct(graph_out, second)
+
+
+# ---------------------------------------------------------------------------
+# Skip softmax
+# ---------------------------------------------------------------------------
+
+_SKIP_SOFTMAX_KV_TILE = 128
+_SKIP_SOFTMAX_ROW_GROUP = 32
+
+
+@torch.no_grad()
+def _skip_softmax_reference(
+    case: _ContextCase,
+    thresholds: Sequence[float],
+) -> torch.Tensor:
+    """Emulate the kernel's warp-level skip-softmax algorithm in FP32.
+
+    The kernel decides per 128-key K/V tile and per 32-row query group whether
+    ``exp(sm_scale * (tile_max - running_max)) < threshold`` holds for every
+    valid row of the group; TMA padding rows past the request abstain. A
+    skipped tile adds no probability mass and leaves the running maximum
+    unchanged. Fully masked rows have a ``-inf`` tile maximum, so a row
+    without any valid key yet compares ``NaN`` and never votes to skip. This
+    oracle replays that decision sequence with the same comparison semantics
+    and normalizes like the kernel.
+    """
+
+    outputs = []
+    for batch_idx, (q_length, k_length) in enumerate(
+        zip(case.q_lengths, case.k_lengths, strict=True)
+    ):
+        threshold = float(thresholds[batch_idx])
+        q = _request_slice(case.q, case.q_lengths, batch_idx, packed=case.packed)
+        k = _request_slice(case.k, case.k_lengths, batch_idx, packed=case.packed)
+        v = _request_slice(case.v, case.k_lengths, batch_idx, packed=case.packed)
+        q = q.float()
+        k = k.float()
+        v = v.float()
+        head_ratio = q.shape[1] // k.shape[1]
+        k = k.repeat_interleave(head_ratio, dim=1)
+        v = v.repeat_interleave(head_ratio, dim=1)
+        device = q.device
+        num_heads, head_dim = q.shape[1], q.shape[2]
+
+        num_k_tiles = -(-k_length // _SKIP_SOFTMAX_KV_TILE)
+        padded_k = num_k_tiles * _SKIP_SOFTMAX_KV_TILE
+        k_pad = torch.zeros((padded_k, num_heads, head_dim), device=device)
+        k_pad[:k_length] = k
+        v_pad = torch.zeros_like(k_pad)
+        v_pad[:k_length] = v
+
+        rows = torch.arange(q_length, device=device)
+        keys = torch.arange(padded_k, device=device)
+        if case.mask_type == "dense":
+            visible = (keys[None, :] < k_length).expand(q_length, padded_k)
+        elif case.mask_type == "causal":
+            right = k_length - q_length + rows
+            visible = keys[None, :] <= right[:, None]
+            if case.window_left >= 0:
+                visible &= keys[None, :] >= (right - case.window_left)[:, None]
+        else:
+            raise ValueError("skip-softmax oracle supports dense and causal masks")
+
+        scores = torch.einsum("qhd,khd->hqk", q, k_pad) * case.sm_scale
+        scores = scores.masked_fill(~visible[None], float("-inf"))
+        out = torch.zeros((q_length, num_heads, head_dim), device=device)
+        for row_begin in range(0, q_length, _SKIP_SOFTMAX_ROW_GROUP):
+            row_end = min(row_begin + _SKIP_SOFTMAX_ROW_GROUP, q_length)
+            group_scores = scores[:, row_begin:row_end]
+            group_visible = visible[row_begin:row_end]
+            group_rows = row_end - row_begin
+            running_max = torch.full(
+                (num_heads, group_rows), float("-inf"), device=device
+            )
+            row_sum = torch.zeros_like(running_max)
+            acc = torch.zeros((num_heads, group_rows, head_dim), device=device)
+            for tile_idx in range(num_k_tiles):
+                k_begin = tile_idx * _SKIP_SOFTMAX_KV_TILE
+                k_end = k_begin + _SKIP_SOFTMAX_KV_TILE
+                if not bool(group_visible[:, k_begin:k_end].any()):
+                    # Whether skipped or computed, a fully masked tile
+                    # contributes nothing and keeps every running statistic.
+                    continue
+                tile_scores = group_scores[:, :, k_begin:k_end]
+                tile_max = tile_scores.amax(dim=-1)
+                # exp(-inf) = 0 skips a masked row once it has a finite
+                # maximum; exp(NaN) and exp(inf) never compare below.
+                lane_skips = torch.exp(tile_max - running_max) < threshold
+                warp_skips = lane_skips.all(dim=-1)
+                new_max = torch.where(
+                    warp_skips[:, None],
+                    running_max,
+                    torch.maximum(running_max, tile_max),
+                )
+                no_valid_key = new_max == float("-inf")
+                safe_max = torch.where(no_valid_key, torch.zeros_like(new_max), new_max)
+                probabilities = torch.exp(tile_scores - safe_max[..., None])
+                correction = torch.where(
+                    no_valid_key,
+                    torch.ones_like(new_max),
+                    torch.exp(running_max - new_max),
+                )
+                keep = ~warp_skips[:, None]
+                row_sum = torch.where(
+                    keep, row_sum * correction + probabilities.sum(dim=-1), row_sum
+                )
+                tile_out = torch.einsum(
+                    "hqk,khd->hqd", probabilities, v_pad[k_begin:k_end]
+                )
+                acc = torch.where(
+                    keep[..., None], acc * correction[..., None] + tile_out, acc
+                )
+                running_max = new_max
+            out[row_begin:row_end] = (acc / row_sum[..., None]).permute(1, 0, 2)
+        outputs.append(out * case.output_scale)
+    return torch.cat(outputs) if case.packed else torch.stack(outputs)
+
+
+def _run_skip_softmax(
+    case: _ContextCase,
+    threshold,
+    *,
+    use_wrapper: bool,
+) -> torch.Tensor:
+    if use_wrapper:
+        wrapper = BatchPrefillTSWrapper()
+        wrapper.plan(
+            case.q,
+            case.k,
+            case.v,
+            qo_indptr=case.qo_indptr,
+            kv_indptr=case.kv_indptr,
+            mask_type=case.mask_type,
+            window_left=case.window_left,
+            sm_scale=case.sm_scale,
+            output_scale=case.output_scale,
+            out_dtype=case.output_dtype,
+            skip_softmax_threshold=threshold,
+        )
+        assert dict(wrapper._policy)["skip_softmax"] is (threshold is not None)
+        return wrapper.run(case.q, case.k, case.v)
+    return batch_prefill(
+        case.q,
+        case.k,
+        case.v,
+        qo_indptr=case.qo_indptr,
+        kv_indptr=case.kv_indptr,
+        mask_type=case.mask_type,
+        window_left=case.window_left,
+        sm_scale=case.sm_scale,
+        output_scale=case.output_scale,
+        out_dtype=case.output_dtype,
+        skip_softmax_threshold=threshold,
+    )
+
+
+def _run_skip_softmax_paged(
+    case: _PagedContextCase,
+    threshold,
+) -> torch.Tensor:
+    wrapper = BatchPrefillPagedTSWrapper()
+    wrapper.plan(
+        case.reference.q,
+        case.k_cache,
+        case.v_cache,
+        case.qo_indptr,
+        case.paged_kv_indptr,
+        case.paged_kv_indices,
+        case.paged_kv_last_page_len,
+        page_size=case.page_size,
+        mask_type=case.reference.mask_type,
+        window_left=case.reference.window_left,
+        sm_scale=case.reference.sm_scale,
+        output_scale=case.reference.output_scale,
+        out_dtype=case.reference.output_dtype,
+        skip_softmax_threshold=threshold,
+    )
+    assert dict(wrapper._policy)["skip_softmax"] is (threshold is not None)
+    return wrapper.run(case.reference.q, case.k_cache, case.v_cache)
+
+
+def test_attention_ts_context_skip_softmax_oracle_tracks_tile_decisions():
+    """Cold tiles are skipped per 32-row group and hot tiles reset the maximum."""
+
+    case = _make_context_case(
+        q_lengths=(64,),
+        k_lengths=(384,),
+        num_qo_heads=1,
+        num_kv_heads=1,
+        qkv_dtype=torch.float32,
+        packed=False,
+        mask_type="dense",
+        output_scale=1.0,
+        device="cpu",
+    )
+    case.q.zero_()
+    case.k.zero_()
+    case.v.zero_()
+    # Scores equal the first K component: tile 0 is warm, tile 1 is cold, and
+    # tile 2 is hot. Rows 32-63 negate the query, so their hot and cold tiles
+    # trade places.
+    case.q[0, :32, 0, 0] = 1.0
+    case.q[0, 32:, 0, 0] = -1.0
+    case.k[0, 0:128, 0, 0] = 10.0
+    case.k[0, 128:256, 0, 0] = 5.0
+    case.k[0, 256:384, 0, 0] = 30.0
+    case.v[0, 0:128, 0, 1] = 1.0
+    case.v[0, 128:256, 0, 2] = 1.0
+    case.v[0, 256:384, 0, 3] = 1.0
+
+    skipped = _skip_softmax_reference(case, thresholds=(1.5,))
+    dense = _context_reference(case)
+    assert not torch.allclose(skipped, dense)
+
+    def visible_reference(row_begin: int, row_end: int, tiles: tuple[int, ...]):
+        keys = torch.cat([torch.arange(t * 128, (t + 1) * 128) for t in tiles])
+        sub = replace(
+            case,
+            q=case.q[:, row_begin:row_end],
+            k=case.k[:, keys],
+            v=case.v[:, keys],
+            q_lengths=(row_end - row_begin,),
+            k_lengths=(len(keys),),
+        )
+        return _context_reference(sub)
+
+    # Rows 0-31 skip the cold middle tile; rows 32-63 skip the (negated) last.
+    torch.testing.assert_close(skipped[0, :32], visible_reference(0, 32, (0, 2))[0])
+    torch.testing.assert_close(skipped[0, 32:], visible_reference(32, 64, (0, 1))[0])
+    # A zero threshold never skips and a padded, uniform threshold matches
+    # the dense oracle.
+    torch.testing.assert_close(_skip_softmax_reference(case, thresholds=(0.0,)), dense)
+
+
+_SKIP_SOFTMAX_CASES = (
+    pytest.param(
+        torch.bfloat16,
+        False,
+        (300,),
+        (300,),
+        8,
+        2,
+        "causal",
+        -1,
+        128,
+        True,
+        id="fixed-bf16-causal-d128-wrapper",
+    ),
+    pytest.param(
+        torch.float16,
+        True,
+        (200, 45),
+        (300, 400),
+        4,
+        4,
+        "dense",
+        -1,
+        128,
+        False,
+        id="packed-fp16-dense-mixed-d128-one-shot",
+    ),
+    pytest.param(
+        torch.bfloat16,
+        True,
+        (129, 257),
+        (257, 384),
+        8,
+        2,
+        "causal",
+        -1,
+        128,
+        False,
+        id="packed-bf16-causal-offset-d128-one-shot",
+    ),
+    pytest.param(
+        _FP8,
+        False,
+        (257,),
+        (385,),
+        8,
+        2,
+        "causal",
+        -1,
+        128,
+        True,
+        id="fixed-fp8-causal-offset-d128-wrapper",
+    ),
+    pytest.param(
+        torch.bfloat16,
+        False,
+        (200,),
+        (400,),
+        8,
+        2,
+        "causal",
+        200,
+        128,
+        True,
+        id="fixed-bf16-window-head-paired-d128-wrapper",
+    ),
+    pytest.param(
+        torch.bfloat16,
+        False,
+        (129,),
+        (385,),
+        8,
+        2,
+        "dense",
+        -1,
+        256,
+        True,
+        id="fixed-bf16-dense-d256-wrapper",
+    ),
+    pytest.param(
+        _FP8,
+        False,
+        (257,),
+        (257,),
+        8,
+        2,
+        "causal",
+        -1,
+        256,
+        True,
+        id="fixed-fp8-causal-d256-wrapper",
+    ),
+)
+
+
+def _make_skip_softmax_case(
+    qkv_dtype,
+    packed,
+    q_lengths,
+    k_lengths,
+    num_qo_heads,
+    num_kv_heads,
+    mask_type,
+    window_left,
+    head_dim,
+) -> _ContextCase:
+    case = _make_context_case(
+        q_lengths=q_lengths,
+        k_lengths=k_lengths,
+        num_qo_heads=num_qo_heads,
+        num_kv_heads=num_kv_heads,
+        qkv_dtype=qkv_dtype,
+        packed=packed,
+        mask_type=mask_type,
+        head_dim=head_dim,
+        window_left=window_left,
+        output_dtype=torch.bfloat16 if qkv_dtype == _FP8 else qkv_dtype,
+        device="cuda",
+        seed=2026090401 + head_dim + int(packed) + sum(k_lengths),
+    )
+    return case
+
+
+@pytest.mark.parametrize(
+    (
+        "qkv_dtype",
+        "packed",
+        "q_lengths",
+        "k_lengths",
+        "num_qo_heads",
+        "num_kv_heads",
+        "mask_type",
+        "window_left",
+        "head_dim",
+        "use_wrapper",
+    ),
+    _SKIP_SOFTMAX_CASES,
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_skip_softmax_zero_threshold_matches_dense(
+    qkv_dtype,
+    packed,
+    q_lengths,
+    k_lengths,
+    num_qo_heads,
+    num_kv_heads,
+    mask_type,
+    window_left,
+    head_dim,
+    use_wrapper,
+):
+    """A zero threshold selects the skip kernel but never skips a tile."""
+
+    case = _make_skip_softmax_case(
+        qkv_dtype,
+        packed,
+        q_lengths,
+        k_lengths,
+        num_qo_heads,
+        num_kv_heads,
+        mask_type,
+        window_left,
+        head_dim,
+    )
+    dense = _run_skip_softmax(case, None, use_wrapper=use_wrapper)
+    zero = _run_skip_softmax(case, 0.0, use_wrapper=use_wrapper)
+    _assert_context_correct(dense, case)
+    _assert_context_correct(zero, case)
+    assert torch.equal(zero, dense)
+
+
+@pytest.mark.parametrize(
+    (
+        "qkv_dtype",
+        "packed",
+        "q_lengths",
+        "k_lengths",
+        "num_qo_heads",
+        "num_kv_heads",
+        "mask_type",
+        "window_left",
+        "head_dim",
+        "use_wrapper",
+    ),
+    _SKIP_SOFTMAX_CASES,
+)
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_skip_softmax_matches_emulated_reference(
+    qkv_dtype,
+    packed,
+    q_lengths,
+    k_lengths,
+    num_qo_heads,
+    num_kv_heads,
+    mask_type,
+    window_left,
+    head_dim,
+    use_wrapper,
+):
+    """Skipped outputs follow the tile-level oracle and differ from dense."""
+
+    case = _make_skip_softmax_case(
+        qkv_dtype,
+        packed,
+        q_lengths,
+        k_lengths,
+        num_qo_heads,
+        num_kv_heads,
+        mask_type,
+        window_left,
+        head_dim,
+    )
+    # Random N(0, 0.2) inputs keep every tile-versus-running maximum gap far
+    # inside exp(gap) in [0.7, 1.4], so a threshold of 2 skips every K/V tile
+    # after a group's first one with a wide decision margin.
+    threshold = 2.0
+    actual = _run_skip_softmax(case, threshold, use_wrapper=use_wrapper)
+    expected = _skip_softmax_reference(case, thresholds=(threshold,) * len(q_lengths))
+    _assert_context_correct(actual, case, expected=expected)
+    dense = _context_reference(case)
+    skipped_distance = torch.linalg.vector_norm(actual.float() - expected)
+    dense_distance = torch.linalg.vector_norm(actual.float() - dense)
+    assert float(dense_distance) > 4.0 * float(skipped_distance)
+
+
+@pytest.mark.parametrize("head_dim", (128, 256), ids=("d128", "d256"))
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_skip_softmax_paged_matches_emulated_reference(
+    head_dim: int,
+):
+    case = _make_paged_context_case(
+        q_lengths=(129, 257),
+        k_lengths=(257, 385),
+        num_qo_heads=8,
+        num_kv_heads=2,
+        head_dim=head_dim,
+        qkv_dtype=torch.bfloat16,
+        mask_type="causal",
+        seed=2026090402 + head_dim,
+    )
+    dense = _run_skip_softmax_paged(case, None)
+    zero = _run_skip_softmax_paged(case, 0.0)
+    _assert_context_correct(dense, case.reference)
+    assert torch.equal(zero, dense)
+    threshold = 2.0
+    actual = _run_skip_softmax_paged(case, threshold)
+    expected = _skip_softmax_reference(
+        case.reference, thresholds=(threshold, threshold)
+    )
+    _assert_context_correct(actual, case.reference, expected=expected)
+    assert not torch.equal(actual, dense)
+
+
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_skip_softmax_per_request_tensor_thresholds():
+    """Element ``b`` of a threshold tensor applies to request ``b`` only."""
+
+    case = _make_context_case(
+        q_lengths=(257, 300),
+        k_lengths=(385, 300),
+        num_qo_heads=8,
+        num_kv_heads=2,
+        qkv_dtype=torch.bfloat16,
+        packed=True,
+        mask_type="causal",
+        device="cuda",
+        seed=2026090403,
+    )
+    thresholds = torch.tensor((0.0, 2.0), dtype=torch.float32, device="cuda")
+    actual = _run_skip_softmax(case, thresholds, use_wrapper=False)
+    expected = _skip_softmax_reference(case, thresholds=thresholds.tolist())
+    _assert_context_correct(actual, case, expected=expected)
+    dense = _run_skip_softmax(case, None, use_wrapper=False)
+    assert case.qo_indptr is not None
+    split = int(case.qo_indptr[1])
+    assert torch.equal(actual[:split], dense[:split])
+    assert not torch.equal(actual[split:], dense[split:])
+
+
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_skip_softmax_tensor_updates_apply_on_graph_replay():
+    """A live threshold tensor is reread by each replay; a scalar is frozen."""
+
+    case = _make_context_case(
+        q_lengths=(300,),
+        k_lengths=(300,),
+        num_qo_heads=8,
+        num_kv_heads=2,
+        qkv_dtype=torch.bfloat16,
+        packed=False,
+        mask_type="causal",
+        device="cuda",
+        seed=2026090404,
+    )
+    dense = _run_skip_softmax(case, None, use_wrapper=True)
+    skipped = _skip_softmax_reference(case, thresholds=(2.0,))
+
+    thresholds = torch.zeros(1, dtype=torch.float32, device="cuda")
+    wrapper = BatchPrefillTSWrapper()
+    wrapper.plan(
+        case.q,
+        case.k,
+        case.v,
+        mask_type=case.mask_type,
+        sm_scale=case.sm_scale,
+        output_scale=case.output_scale,
+        out_dtype=case.output_dtype,
+        skip_softmax_threshold=thresholds,
+    )
+    assert wrapper._skip_softmax_threshold is thresholds
+    graph_out = torch.full_like(case.q, float("nan"), dtype=case.output_dtype)
+    graph = _capture_context_graph(wrapper, case.q, case.k, case.v, graph_out)
+    graph_out.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(graph_out, dense)
+
+    thresholds.fill_(2.0)
+    graph_out.fill_(float("nan"))
+    graph.replay()
+    torch.cuda.synchronize()
+    _assert_context_correct(graph_out, case, expected=skipped)
+    assert not torch.equal(graph_out, dense)
+
+    scalar_wrapper = BatchPrefillTSWrapper()
+    scalar_wrapper.plan(
+        case.q,
+        case.k,
+        case.v,
+        mask_type=case.mask_type,
+        sm_scale=case.sm_scale,
+        output_scale=case.output_scale,
+        out_dtype=case.output_dtype,
+        skip_softmax_threshold=0.0,
+    )
+    scalar_out = torch.full_like(graph_out, float("nan"))
+    scalar_graph = _capture_context_graph(
+        scalar_wrapper, case.q, case.k, case.v, scalar_out
+    )
+    scalar_out.fill_(float("nan"))
+    scalar_graph.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(scalar_out, dense)
+
+
+@pytest.mark.arch_blackwell
+@_REQUIRES_CONTEXT_GPU
+def test_attention_ts_context_skip_softmax_rejects_invalid_thresholds():
+    case = _make_context_case(
+        q_lengths=(64, 64),
+        k_lengths=(64, 64),
+        num_qo_heads=4,
+        num_kv_heads=4,
+        qkv_dtype=torch.bfloat16,
+        packed=True,
+        mask_type="dense",
+        device="cuda",
+        seed=2026090405,
+    )
+
+    def plan_with(threshold):
+        wrapper = BatchPrefillTSWrapper()
+        wrapper.plan(
+            case.q,
+            case.k,
+            case.v,
+            qo_indptr=case.qo_indptr,
+            kv_indptr=case.kv_indptr,
+            mask_type=case.mask_type,
+            sm_scale=case.sm_scale,
+            skip_softmax_threshold=threshold,
+        )
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        plan_with(-1.0)
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        plan_with(float("inf"))
+    with pytest.raises(TypeError, match="skip_softmax_threshold must be None"):
+        plan_with(True)
+    with pytest.raises(TypeError, match="dtype torch.float32"):
+        plan_with(torch.zeros(2, dtype=torch.float16, device="cuda"))
+    with pytest.raises(ValueError, match=r"shape \[2\]"):
+        plan_with(torch.zeros(3, dtype=torch.float32, device="cuda"))
+    with pytest.raises(ValueError, match="must be a CUDA tensor"):
+        plan_with(torch.zeros(2, dtype=torch.float32))
+    with pytest.raises(ValueError, match="compact"):
+        plan_with(torch.zeros(4, dtype=torch.float32, device="cuda")[::2])

--- a/tests/attention/test_attention_ts_context.py
+++ b/tests/attention/test_attention_ts_context.py
@@ -3135,7 +3135,7 @@ def test_attention_ts_context_supplied_out_stream_and_cuda_graph():
 # ---------------------------------------------------------------------------
 
 _SKIP_SOFTMAX_KV_TILE = 128
-_SKIP_SOFTMAX_ROW_GROUP = 32
+_SKIP_SOFTMAX_WARP_ROWS = 32
 
 
 @torch.no_grad()
@@ -3145,9 +3145,9 @@ def _skip_softmax_reference(
 ) -> torch.Tensor:
     """Emulate the kernel's warp-level skip-softmax algorithm in FP32.
 
-    The kernel decides per 128-key K/V tile and per 32-row query group whether
-    ``exp(sm_scale * (tile_max - running_max)) < threshold`` holds for every
-    valid row of the group; TMA padding rows past the request abstain. A
+    The kernel decides per 128-key K/V tile and per softmax warp (32 Q rows)
+    whether ``exp(sm_scale * (tile_max - running_max)) < threshold`` holds for
+    every valid row of the warp; TMA padding rows past the request abstain. A
     skipped tile adds no probability mass and leaves the running maximum
     unchanged. Fully masked rows have a ``-inf`` tile maximum, so a row
     without any valid key yet compares ``NaN`` and never votes to skip. This
@@ -3194,24 +3194,24 @@ def _skip_softmax_reference(
         scores = torch.einsum("qhd,khd->hqk", q, k_pad) * case.sm_scale
         scores = scores.masked_fill(~visible[None], float("-inf"))
         out = torch.zeros((q_length, num_heads, head_dim), device=device)
-        for row_begin in range(0, q_length, _SKIP_SOFTMAX_ROW_GROUP):
-            row_end = min(row_begin + _SKIP_SOFTMAX_ROW_GROUP, q_length)
-            group_scores = scores[:, row_begin:row_end]
-            group_visible = visible[row_begin:row_end]
-            group_rows = row_end - row_begin
+        for row_begin in range(0, q_length, _SKIP_SOFTMAX_WARP_ROWS):
+            row_end = min(row_begin + _SKIP_SOFTMAX_WARP_ROWS, q_length)
+            warp_scores = scores[:, row_begin:row_end]
+            warp_visible = visible[row_begin:row_end]
+            warp_rows = row_end - row_begin
             running_max = torch.full(
-                (num_heads, group_rows), float("-inf"), device=device
+                (num_heads, warp_rows), float("-inf"), device=device
             )
             row_sum = torch.zeros_like(running_max)
-            acc = torch.zeros((num_heads, group_rows, head_dim), device=device)
+            acc = torch.zeros((num_heads, warp_rows, head_dim), device=device)
             for tile_idx in range(num_k_tiles):
                 k_begin = tile_idx * _SKIP_SOFTMAX_KV_TILE
                 k_end = k_begin + _SKIP_SOFTMAX_KV_TILE
-                if not bool(group_visible[:, k_begin:k_end].any()):
+                if not bool(warp_visible[:, k_begin:k_end].any()):
                     # Whether skipped or computed, a fully masked tile
                     # contributes nothing and keeps every running statistic.
                     continue
-                tile_scores = group_scores[:, :, k_begin:k_end]
+                tile_scores = warp_scores[:, :, k_begin:k_end]
                 tile_max = tile_scores.amax(dim=-1)
                 # exp(-inf) = 0 skips a masked row once it has a finite
                 # maximum; exp(NaN) and exp(inf) never compare below.
@@ -3310,7 +3310,7 @@ def _run_skip_softmax_paged(
 
 
 def test_attention_ts_context_skip_softmax_oracle_tracks_tile_decisions():
-    """Cold tiles are skipped per 32-row group and hot tiles reset the maximum."""
+    """Cold tiles are skipped per softmax warp and hot tiles reset the maximum."""
 
     case = _make_context_case(
         q_lengths=(64,),
@@ -3578,7 +3578,7 @@ def test_attention_ts_context_skip_softmax_matches_emulated_reference(
     )
     # Random N(0, 0.2) inputs keep every tile-versus-running maximum gap far
     # inside exp(gap) in [0.7, 1.4], so a threshold of 2 skips every K/V tile
-    # after a group's first one with a wide decision margin.
+    # after a softmax warp's first one with a wide decision margin.
     threshold = 2.0
     actual = _run_skip_softmax(case, threshold, use_wrapper=use_wrapper)
     expected = _skip_softmax_reference(case, thresholds=(threshold,) * len(q_lengths))


### PR DESCRIPTION
## 📌 Description

Add skip softmax to the PrimTS context (prefill) kernels, the successor of the trtllm-gen FMHA
context kernels, following the API agreed in
https://github.com/flashinfer-ai/flashinfer/pull/4859#issuecomment-5530078378 and
https://github.com/flashinfer-ai/flashinfer/pull/4859#issuecomment-5536049203.

**API.** `BatchPrefillTSWrapper.plan`, `BatchPrefillPagedTSWrapper.plan`, `batch_prefill`, and
`batch_prefill_with_paged_kv_cache` accept `skip_softmax_threshold: Optional[float | torch.Tensor]`.
The threshold is the final e-based value: a 128-key K/V tile is skipped for a 32-row query group
when every valid row satisfies `exp(sm_scale * (tile_max - running_max)) < threshold`. `None`
selects the dense kernel; any provided value, including zero, selects the skip-enabled
specialization. A float applies to every request and is fixed for the plan (and for any CUDA
graph that captures it). A contiguous CUDA `float32[B]` tensor gives request `b` its own
threshold and is retained as a live input whose values may be updated in place between runs or
graph replays. There is no sequence-length normalization and no `threshold_scale_factor`
convention; the shared `BatchPrefillWith*KVCacheWrapper` APIs are unchanged.

**Kernel** (mirrors trtllm-gen `TmemS.h` / `TmemP.h` / `TmemO.h`; like the trtllm-gen context
kernels, V tiles are still loaded):
- Softmax warps compute the tile row maximum separately from the running maximum, decide the
  warp-uniform skip with `vote.all` in the log2 domain, keep their running statistics, publish an
  all-zero P tile instead of exponentiating, and skip the row-sum reduction.
- Each warp writes one SMEM vote word per `(instance, S/P stage)`; the MMA task reads the four
  words of an instance after the P-ready wait and skips the PV MMA when all agree. No reset or
  atomics are needed, and slot reuse is ordered by the existing S/P pipeline.
- TMA padding rows past a request abstain from the vote (they are zero- or NaN-filled), so a
  partial query tile can still skip.
- The skip specialization carries the exact running maximum (`-inf` until the first valid key)
  and substitutes zero only where the dense kernel already did; the correction task's existing
  `old_max == new_max` ballot then skips the rescale for skipped tiles. Dense codegen is unchanged
  apart from a bit-identical reordering of the FP8 row-max chains.

Both PrimTS READMEs document the contract and the CUDA Graph semantics of the scalar and tensor
forms. `benchmarks/bench_prims_ts_skip_softmax.py` times the dense kernel against the skip-enabled
specialization at several thresholds.

## 🔍 Related Issues

Follow-up to #4357 (PrimTS kernels) and the API discussion in #4859. Decode is intentionally
left for a follow-up.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/attention/test_attention_ts_context.py` gains a tile-level oracle that replays the kernel's
skip decisions and tests for: a zero threshold being bitwise equal to the dense kernel; a skipping
threshold matching the oracle across fixed, packed, and paged layouts, D128/D256, BF16/FP16/FP8,
and dense, causal, and left-window masks; per-request tensor thresholds; live tensor updates
observed by CUDA graph replays while a scalar stays frozen; and argument validation. The existing
context and mask suites pass unchanged. Validated on B300 (SM103a).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

- The skip decision lives in `TmemSPResource._skip_softmax_row_max` and the PV skip in
  `TmemOResource.pv_mma` / `_skip_softmax_votes_skip` (`fmha_resources.py`); the vote SMEM words
  are allocated in `build_context_task_manager` (`fmha_kernel.py`).
- Two CuTe DSL frontend constraints shaped the code: fragment lists must be refilled in place
  rather than re-bound inside a dynamic branch, and score fragments are read only inside the
  unrolled loops after a masking branch rewrote them.
