### PR TITLE
fix(fa2): cover the full KV span of non-causal sliding-window tiles under split-KV

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -2873,7 +2873,23 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
     // skip out-of-window kv tile by add non-zero kv_start_idx offset
     const uint32_t kv_start_idx = sub_if_greater_or_zero(
         kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size, qo_len + window_left);
-    const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+    uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+    if constexpr (MASK_MODE == MaskMode::kNone || MASK_MODE == MaskMode::kCustom) {
+      // The scheduler (PrefillSplitQOKVIndptr) and num_kv_chunks below size a
+      // request's split-KV chunks for a span of window_left + CTA_TILE_Q keys,
+      // which bounds a causal tile but not a non-causal one: without the
+      // causal cut a tile attends every key in [kv_start_idx, kv_len), up to
+      // qo_len + window_left keys. Spread that span evenly over the chunks
+      // the scheduler allocated so the trailing keys are not dropped (#4972).
+      // window_left=-1 (window_left == kv_len, kv_start_idx == 0) keeps the
+      // original chunk boundaries.
+      if (partition_kv) {
+        // Must match num_kv_chunks below.
+        const uint32_t num_kv_chunks =
+            ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
+        max_chunk_size = max(max_chunk_size, ceil_div(kv_len - kv_start_idx, num_kv_chunks));
+      }
+    }
     const uint32_t chunk_start =
         partition_kv ? min(kv_tile_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
     const uint32_t chunk_end =
@@ -3658,7 +3674,23 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
 
     const uint32_t kv_start_idx = sub_if_greater_or_zero(
         kv_len + (qo_tile_idx * CTA_TILE_Q) / group_size, qo_len + window_left);
-    const uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+    uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
+    if constexpr (MASK_MODE == MaskMode::kNone || MASK_MODE == MaskMode::kCustom) {
+      // The scheduler (PrefillSplitQOKVIndptr) and num_kv_chunks below size a
+      // request's split-KV chunks for a span of window_left + CTA_TILE_Q keys,
+      // which bounds a causal tile but not a non-causal one: without the
+      // causal cut a tile attends every key in [kv_start_idx, kv_len), up to
+      // qo_len + window_left keys. Spread that span evenly over the chunks
+      // the scheduler allocated so the trailing keys are not dropped (#4972).
+      // window_left=-1 (window_left == kv_len, kv_start_idx == 0) keeps the
+      // original chunk boundaries.
+      if (partition_kv) {
+        // Must match num_kv_chunks below.
+        const uint32_t num_kv_chunks =
+            ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
+        max_chunk_size = max(max_chunk_size, ceil_div(kv_len - kv_start_idx, num_kv_chunks));
+      }
+    }
     const uint32_t chunk_start =
         partition_kv ? min(kv_tile_idx * max_chunk_size + kv_start_idx, kv_len) : kv_start_idx;
     const uint32_t chunk_end =

--- a/tests/attention/test_batch_prefill_kernels.py
+++ b/tests/attention/test_batch_prefill_kernels.py
@@ -24,7 +24,11 @@ from tests.test_helpers.jit_utils import gen_prefill_attention_modules
 import flashinfer
 from tests.test_helpers.test_helpers import assert_close_chunked, ref_single_prefill
 from tests.test_helpers.utils_fp4 import create_nvfp4_kv, nvfp4_to_float
-from flashinfer.utils import get_compute_capability, has_flashinfer_jit_cache
+from flashinfer.utils import (
+    get_compute_capability,
+    has_flashinfer_jit_cache,
+    is_sm90a_supported,
+)
 
 
 def head_dim_512_supported() -> bool:
@@ -2468,3 +2472,120 @@ def test_paged_prefill_split_kv_empty_chunk(dtype):
     assert not o.isnan().any() and not lse.isnan().any()
     torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)
     torch.testing.assert_close(lse, lse_ref, rtol=1e-2, atol=1e-2)
+
+
+def _ref_sliding_window_prefill(q, k, v, window_left, causal):
+    """fp32 reference with the visibility predicate of variants.cuh.
+
+    Query row qo_idx sits at position qo_idx + kv_len - qo_len; it sees key
+    kv_idx iff kv_idx >= q_pos - window_left (window_left >= 0) and, when
+    causal, kv_idx <= q_pos.
+    """
+    qo_len, num_qo_heads, head_dim = q.shape
+    kv_len, num_kv_heads, _ = k.shape
+    group_size = num_qo_heads // num_kv_heads
+    k32 = k.float().repeat_interleave(group_size, dim=1)
+    v32 = v.float().repeat_interleave(group_size, dim=1)
+    scores = torch.einsum("qhd,khd->hqk", q.float(), k32) * head_dim**-0.5
+    q_pos = torch.arange(qo_len, device=q.device)[:, None] + (kv_len - qo_len)
+    k_pos = torch.arange(kv_len, device=q.device)[None, :]
+    visible = torch.ones(qo_len, kv_len, dtype=torch.bool, device=q.device)
+    if window_left >= 0:
+        visible &= k_pos >= q_pos - window_left
+    if causal:
+        visible &= k_pos <= q_pos
+    scores = scores.masked_fill(~visible[None], float("-inf"))
+    return torch.einsum("hqk,khd->qhd", torch.softmax(scores, dim=-1), v32)
+
+
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("window_left", [-1, 1, 64, 333])
+@pytest.mark.parametrize("qo_len,kv_len", [(300, 4096), (1024, 1024), (1, 512)])
+@pytest.mark.parametrize("group_size", [1, 4])
+@pytest.mark.parametrize("kv_kind", ["paged", "ragged"])
+@pytest.mark.parametrize("split_kv", ["auto", "fixed"])
+def test_batch_prefill_sliding_window(
+    backend, causal, window_left, qo_len, kv_len, group_size, kv_kind, split_kv
+):
+    # Regression test for #4972: with causal=False and a finite window_left
+    # the FA2 split-KV path sized each query tile's KV chunks for
+    # window_left + CTA_TILE_Q keys, although a non-causal tile attends every
+    # key up to kv_len, so the leading query tiles never saw the last keys.
+    # split_kv="fixed" forces 128-token chunks so the split-KV path is taken
+    # on any GPU; "auto" leaves the decision to the scheduler.
+    if backend == "fa3" and not is_sm90a_supported(torch.device("cuda:0")):
+        pytest.skip("fa3 requires SM90")
+    if backend == "fa3" and split_kv == "fixed":
+        pytest.skip("fixed_split_size is an FA2 scheduler option")
+    num_kv_heads, head_dim, page_size = 2, 128, 16
+    num_qo_heads = num_kv_heads * group_size
+    dtype = torch.float16
+    torch.manual_seed(0)
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=dtype, device="cuda:0")
+    k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device="cuda:0")
+    v = torch.randn_like(k)
+    workspace = torch.empty(256 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor([0, qo_len], dtype=torch.int32, device="cuda:0")
+
+    if kv_kind == "paged":
+        num_pages = (kv_len + page_size - 1) // page_size
+        padded = num_pages * page_size
+        k_pages = torch.zeros(
+            padded, num_kv_heads, head_dim, dtype=dtype, device="cuda:0"
+        )
+        v_pages = torch.zeros_like(k_pages)
+        k_pages[:kv_len] = k
+        v_pages[:kv_len] = v
+        kv_data = torch.stack(
+            [
+                k_pages.view(num_pages, page_size, num_kv_heads, head_dim),
+                v_pages.view(num_pages, page_size, num_kv_heads, head_dim),
+            ],
+            dim=1,
+        )
+        plan_kwargs = (
+            {"fixed_split_size": 128 // page_size} if split_kv == "fixed" else {}
+        )
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            workspace, "NHD", backend=backend
+        )
+        wrapper.plan(
+            qo_indptr,
+            torch.tensor([0, num_pages], dtype=torch.int32, device="cuda:0"),
+            torch.arange(num_pages, dtype=torch.int32, device="cuda:0"),
+            torch.tensor(
+                [(kv_len - 1) % page_size + 1], dtype=torch.int32, device="cuda:0"
+            ),
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            page_size,
+            causal=causal,
+            window_left=window_left,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            **plan_kwargs,
+        )
+        o = wrapper.run(q, kv_data)
+    else:
+        plan_kwargs = {"fixed_split_size": 128} if split_kv == "fixed" else {}
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace, "NHD", backend=backend
+        )
+        wrapper.plan(
+            qo_indptr,
+            torch.tensor([0, kv_len], dtype=torch.int32, device="cuda:0"),
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            causal=causal,
+            window_left=window_left,
+            q_data_type=dtype,
+            kv_data_type=dtype,
+            **plan_kwargs,
+        )
+        o = wrapper.run(q, k, v)
+
+    o_ref = _ref_sliding_window_prefill(q, k, v, window_left, causal)
+    torch.testing.assert_close(o.float(), o_ref, rtol=1e-3, atol=5e-3)


### PR DESCRIPTION
## 📌 Description

Fixes #4972.

### Symptom

`BatchPrefillWithPagedKVCacheWrapper` / `BatchPrefillWithRaggedKVCacheWrapper` with
`backend="fa2"`, `causal=False` and a finite `window_left` return wrong outputs for the
leading query rows of a request whenever the scheduler splits the request along KV.
With the issue's shape (`qo_len=300, kv_len=4096, window_left=333, 8/2 heads,
head_dim 128, page 16`) rows 0..127 are wrong; with `qo_len = kv_len = 1024,
window_left=333` rows 0..895 are wrong, ragged and paged alike. `causal=True` and
`window_left=-1` are unaffected.

### Root cause

The FA2 batch prefill kernels and the scheduler size a request's split-KV chunks from
an estimated per-tile KV span of `window_left + CTA_TILE_Q` keys:

* `include/flashinfer/attention/scheduler.cuh:628-652` (`PrefillSplitQOKVIndptr`):
  `effective_kv_len = min(ceil_div(window_left + cta_tile_q, page_size), kv_len)` and
  `num_chunks_kv = ceil_div(effective_kv_len, kv_chunk_size)`, which also lays out
  `o_indptr` / `merge_indptr`;
* `include/flashinfer/attention/prefill.cuh:3201` (ragged) and `:4107` (paged):
  `num_kv_chunks = ceil_div(min(kv_len, window_left + CTA_TILE_Q), kv_chunk_size)`.

Each CTA then maps its `kv_tile_idx` to `[kv_start_idx + kv_tile_idx * kv_chunk_size,
kv_start_idx + (kv_tile_idx + 1) * kv_chunk_size)` (`prefill.cuh:2874-2881`,
`:3659-3666`), with `kv_start_idx = max(0, kv_len + first_row - qo_len - window_left)`
the first key visible to the tile. So a tile's chunks cover at most
`window_left + CTA_TILE_Q` keys after `kv_start_idx`. That bounds a **causal** tile,
whose visible keys end at its diagonal, but not a **non-causal** one: with
`causal=False` every key in `[kv_start_idx, kv_len)` is visible, up to
`qo_len + window_left` keys for the first tile. Whenever
`kv_start_idx + num_kv_chunks * kv_chunk_size < kv_len` the trailing keys are simply
never loaded and the softmax is normalised over a truncated window. For the issue's
shape (`CTA_TILE_Q = 128`, `kv_chunk_size = 128`): 4 chunks cover 512 keys per tile,
tile `t` needs `633 - 32 t`, so the 4 tiles covering rows 0..127 are wrong and row 128
is the first correct row, on the reporter's GH200 as well as on the A40 used here.

### Why the mask predicate is innocent

`variants.cuh:89` implements `kv_idx + qo_len + window_left >= kv_len + qo_idx` for
causal and non-causal alike, and the `iter >= mask_iteration || iter < window_iteration`
gating only decides whether that predicate is evaluated for a KV tile that *is*
iterated. The wrong rows are not mis-masked keys; they are keys the CTA never
visited. That is why the error is independent of `group_size` (it reproduces at
`group_size=1`), disappears with `disable_split_kv=True` on every affected shape,
and appears on shapes the scheduler would not split as soon as `fixed_split_size`
forces a split. `variants.cuh` is untouched.

### The fix

`include/flashinfer/attention/prefill.cuh` only, mirrored in the ragged and paged
kernels. For the non-causal mask modes (`kNone`, `kCustom`) under `partition_kv`,
spread the tile's true span over the chunks the scheduler already allocated:

```cpp
uint32_t max_chunk_size = partition_kv ? kv_chunk_size : kv_len - kv_start_idx;
if constexpr (MASK_MODE == MaskMode::kNone || MASK_MODE == MaskMode::kCustom) {
  if (partition_kv) {
    const uint32_t num_kv_chunks =
        ceil_div(min(kv_len_safe, window_left + CTA_TILE_Q), kv_chunk_size);
    max_chunk_size = max(max_chunk_size, ceil_div(kv_len - kv_start_idx, num_kv_chunks));
  }
}
```

* Chunk count, `o_indptr` layout and the merge are unchanged, so no scheduler or
  binding change is needed.
* `window_left=-1` (`window_left == kv_len`, `kv_start_idx == 0`) already satisfies
  `kv_len <= num_kv_chunks * kv_chunk_size`, so its chunk boundaries are unchanged;
  `fixed_split_size` semantics are preserved on that path.
* The block is compiled out of the causal and multi-item-scoring kernels: their SASS
  is byte-identical to `main` (checked with `cuobjdump -sass` on SM86 for the fp16 and
  bf16 head_dim 128 paged and ragged kernels, `use_sliding_window` on and off).
* Empty trailing chunks (already possible before this change) keep going through the
  existing `d == 0 -> zero output, lse = -inf` path.

A scheduler-side alternative (`effective_kv_len = min(kv_len, qo_len + window_left)`
when `!causal`) would give the non-causal windowed case more CTAs, but the scheduler
does not receive `causal` today and threading it through `PrefillPlan` /
`csrc/batch_prefill.cu` / POD overlaps with #4873; that can be a follow-up.

## 🔍 Related Issues

* #4972 (fixed)
* #4873 adds `window_right` in the same functions; with `window_right = -1` its
  scheduler and kernel expressions reduce to today's code, so it does not address
  this bug. The two changes touch adjacent lines and merge mechanically.

## 🧪 Tests

`tests/attention/test_batch_prefill_kernels.py` had **no `window_left` coverage at
all**, which is how this survived. `test_batch_prefill_sliding_window` adds
backend {fa2, fa3} × causal {False, True} × window_left {-1, 1, 64, 333} ×
(qo_len, kv_len) {(300, 4096), (1024, 1024), (1, 512)} × group_size {1, 4} ×
{paged, ragged} × split-KV {auto, fixed 128-token chunks} against an fp32 reference
with the `variants.cuh` visibility predicate. The `fixed` split mode forces the
split-KV path regardless of the GPU's SM count, so the failing cases fail on any
device.

On an A40 (SM86; fa3 parametrizations skip):

| tree | result |
|---|---|
| `main` @ `6c14bbd5` | **48 failed**, 144 passed, 192 skipped — every failure is `causal=False`, `window_left ∈ {1, 64, 333}` on (300, 4096) and (1024, 1024) |
| this branch | 192 passed, 192 skipped |

Other suites on this branch (same A40):

| suite | result |
|---|---|
| `tests/attention/test_batch_prefill_kernels.py` (whole file) | 8980 passed, 1521 skipped, 5760 xfailed (pre-existing cuda-graph xfails), 0 failed |
| `tests/attention/test_batch_prefill.py` | 4 passed |
| `tests/attention/test_batch_invariant_fa2.py` | 2016 passed |
| `tests/attention/test_alibi.py` | 180 passed, 36 skipped |
| `tests/attention/test_hopper_fp8_sliding_window.py` | 18 skipped (SM90 only) |

Diagnostic sweep (`issue4972/sweep.py` on the evidence branch
[`200lz/flashinfer:fix/fa2-noncausal-sliding-window`](https://github.com/200lz/flashinfer/tree/fix/fa2-noncausal-sliding-window/issue4972); group_size {1,2,4,8} × qo_len {1,17,128,300,1024}
× window_left {1,64,333,4096} × kv_len {512,1024,4096}, paged and ragged, plus
`window_left=-1` controls and forced / disabled split-KV probes):

| | configs | wrong on `main` | wrong on this branch |
|---|---|---|---|
| causal=False | 636 | 158 | 0 |
| causal=True | 576 | 0 | 0 |

The coverage model above predicts the exact wrong-row set of every failing `main`
configuration.

## 📈 Performance

`issue4972/bench.py` (same evidence branch), A40 (SM86), fp16, head_dim 128, page 16, `wrapper.run` timed
with CUDA events, 3 interleaved rounds (main, branch, main, branch, …) of 3 runs × 50
iterations; the table shows the median of the 9 per-run medians.

| config (batch × qo_len / kv_len, heads) | causal | window_left | split-KV | main (ms) | branch (ms) | Δ |
|---|---|---|---|---|---|---|
| 4 × 4096 / 4096, 32/8 | yes | -1 | no | 5.7062 | 5.7063 | +0.0% |
| 4 × 4096 / 4096, 32/8 | no | -1 | no | 10.5496 | 10.5932 | +0.4% |
| 4 × 4096 / 4096, 32/8 | yes | 333 | no | 1.3179 | 1.3057 | -0.9% |
| 4 × 4096 / 4096, 32/8 | no | 333 | no | 6.4187 | 6.4589 | +0.6% |
| 8 × 1024 / 8192, 32/8 | yes | -1 | no | 10.2920 | 10.3004 | +0.1% |
| 8 × 1024 / 8192, 32/8 | no | -1 | no | 10.7024 | 10.7436 | +0.4% |
| 8 × 1024 / 8192, 32/8 | yes | 333 | no | 0.7164 | 0.7134 | -0.4% |
| 8 × 1024 / 8192, 32/8 | no | 333 | no | 1.3437 | 1.3499 | +0.5% |
| 1 × 300 / 4096, 8/2 | no | 333 | yes | 0.0762 | 0.0690 | -9.5% |
| 1 × 4096 / 4096, 32/8 | yes | -1 | no | 1.5938 | 1.6006 | +0.4% |
| 1 × 4096 / 4096, 32/8 | no | -1 | no | 2.7953 | 2.8012 | +0.2% |
| 1 × 4096 / 4096, 32/8 | yes | 333 | no | 0.3789 | 0.3738 | -1.4% |
| 1 × 4096 / 4096, 32/8 | no | 333 | no | 1.6845 | 1.7121 | +1.6% |
| 1 × 128 / 16384, 32/8 | yes | -1 | yes | 0.4239 | 0.4220 | -0.4% |
| 1 × 128 / 16384, 32/8 | no | -1 | yes | 0.4230 | 0.4280 | +1.2% |

The causal and `window_left=-1` rows move by -1.4% .. +1.2% with overlapping per-run
ranges (the causal kernels are SASS-identical to `main`, so their deltas are the
measurement noise floor). The `1 × 300 / 4096` row is the issue's shape (70 µs,
launch-overhead dominated); its output was wrong on `main`, so that comparison is
not like-for-like. The only path whose work changes is non-causal + finite window
under split-KV, which now loads the keys it previously skipped.

## ✅ Pre-commit Checks

- [x] `clang-format` (v19.1.1) and `ruff` (v0.12.8) run on the changed files.

## Verified on GPU vs. inferred

* Verified on an A40 (SM86, CUDA 12.8): the reproduction, the sweep, the RED/GREEN
  runs of the new test, the listed suites, the benchmark numbers and the SASS
  comparison.
* Not verified: any SM90 (fa3) behaviour and the fa3 half of the new test; the
  reporter's GH200 numbers are taken from the issue. The kernel change is
  architecture-independent, but no Hopper GPU was available.
