### PR TITLE
fix(attention): scope the NVFP4 split-KV gate on sm120/121 to the VO-split plan shape

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -1518,9 +1518,12 @@ _NVFP4_SPLIT_KV_BROKEN_ARCHS = ((12, 0), (12, 1))
 
 
 def _nvfp4_kv_requires_disabled_split_kv(
-    kv_data_type: torch.dtype, device: torch.device
+    kv_data_type: torch.dtype,
+    device: torch.device,
+    head_dim_qk: Optional[int] = None,
+    head_dim_vo: Optional[int] = None,
 ) -> bool:
-    """Whether split-KV must be disabled because the KV cache is NVFP4 on an affected arch.
+    """Whether split-KV must be disabled: NVFP4 KV, on an affected arch, on the VO-split plan.
 
     This gate is an *empirical workaround*: with split-KV (flash-decoding)
     enabled, NVFP4 paged KV was observed to produce corrupted outputs whenever
@@ -1545,10 +1548,39 @@ def _nvfp4_kv_requires_disabled_split_kv(
     boundaries, with the gate-on/gate-off difference staying at output-dtype
     rounding scale. FP8 and 16-bit KV caches were never gated and keep split-KV
     everywhere.
+
+    The gate is further scoped to the plan shape the corruption was actually
+    observed on: the asymmetric VO-split plan (``head_dim_qk != head_dim_vo``,
+    i.e. Gemma-4's 512-wide QK against a 256-wide VO slice) or a head wider
+    than 256. Symmetric plans at ``head_dim <= 256`` on SM120/121 were tested
+    clean with split-KV enabled from several directions (vllm-project/vllm
+    #46329): a kernel-level A/B ladder at head_dim 128 (qo 1..9, kv to 262k,
+    fixed and auto split, ragged batches), a dense-reference comparison and a
+    needle battery served from cached prefix at head_dim 256, paired
+    gate-on/gate-off end-to-end runs on both RTX 5090 (sm120) and GB10 (sm121)
+    with byte-identical greedy retrieval to 262k, and a week of production
+    traffic on a build that predates the gate with the planner confirmed to be
+    splitting for every prefix-cache-extend request. On those shapes the gate
+    only costs: speculative-decode verify batches (``qo_len`` 2..9) are planned
+    through this wrapper and, with split-KV off, stream the whole KV from one
+    CTA row, so decode falls off linearly with context (about 9x at 262k on a
+    5090). The VO-split shape has not been re-tested with split-KV on since the
+    original report and stays gated until it is.
+
+    ``head_dim_qk``/``head_dim_vo`` default to ``None`` for callers that only
+    know the dtype and device; that conservative path keeps the arch-level
+    gate unchanged.
     """
     if not _is_nvfp4_kv_dtype(kv_data_type):
         return False
-    return get_compute_capability(device) in _NVFP4_SPLIT_KV_BROKEN_ARCHS
+    if get_compute_capability(device) not in _NVFP4_SPLIT_KV_BROKEN_ARCHS:
+        return False
+    if head_dim_qk is None:
+        # Shape unknown: keep the arch-level gate.
+        return True
+    if head_dim_vo is None:
+        head_dim_vo = head_dim_qk
+    return head_dim_qk != head_dim_vo or head_dim_qk > 256
 
 
 def _build_block_tables_from_paged_kv_indices(
@@ -2730,11 +2762,13 @@ class BatchPrefillWithPagedKVCacheWrapper:
             if self._backend == "fa2":
                 args.append(fixed_split_size or -1)  # fixed_split_size
                 if not disable_split_kv and _nvfp4_kv_requires_disabled_split_kv(
-                    kv_data_type, self.device
+                    kv_data_type, self.device, head_dim_qk, head_dim_vo
                 ):
                     # Empirical workaround: split-KV corrupted NVFP4 KV reads
-                    # when qo_len << kv_len (decode / prefix-cache extend); see
-                    # _nvfp4_kv_requires_disabled_split_kv for details.
+                    # when qo_len << kv_len (decode / prefix-cache extend) on
+                    # the SM120/121 VO-split plan; see
+                    # _nvfp4_kv_requires_disabled_split_kv for details and the
+                    # shapes that are exempt.
                     disable_split_kv = True
                 args.append(disable_split_kv)  # disable_split_kv
                 args.append(0)  # num_colocated_ctas
@@ -4263,11 +4297,13 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             if self._backend == "fa2":
                 args.append(fixed_split_size or -1)  # fixed_split_size
                 if not disable_split_kv and _nvfp4_kv_requires_disabled_split_kv(
-                    kv_data_type, self.device
+                    kv_data_type, self.device, head_dim_qk, head_dim_vo
                 ):
                     # Empirical workaround: split-KV corrupted NVFP4 KV reads
-                    # when qo_len << kv_len (decode / prefix-cache extend); see
-                    # _nvfp4_kv_requires_disabled_split_kv for details.
+                    # when qo_len << kv_len (decode / prefix-cache extend) on
+                    # the SM120/121 VO-split plan; see
+                    # _nvfp4_kv_requires_disabled_split_kv for details and the
+                    # shapes that are exempt.
                     disable_split_kv = True
                 args.append(disable_split_kv)  # disable_split_kv
                 args.append(0)  # num_colocated_ctas

--- a/tests/attention/test_nvfp4_attention_sm120.py
+++ b/tests/attention/test_nvfp4_attention_sm120.py
@@ -853,3 +853,39 @@ def test_nvfp4_split_kv_gate_arch_scope(monkeypatch):
         torch.float8_e5m2,
     ):
         assert not prefill._nvfp4_kv_requires_disabled_split_kv(dtype, device)
+
+
+def test_nvfp4_split_kv_gate_shape_scope(monkeypatch):
+    """On SM120/121 the gate must fire only for the VO-split plan shape.
+
+    The corruption behind the gate was observed on Gemma-4's asymmetric plan
+    (head_dim_qk 512 / head_dim_vo 256). Symmetric plans at head_dim <= 256
+    were validated clean with split-KV enabled on both sm120 and sm121
+    (vllm-project/vllm#46329), and for them the gate only costs: spec-decode
+    verify batches (qo_len 2..9) run through the prefill wrapper and lose
+    flash-decoding parallelism. The compute capability is faked, so this runs
+    without a GPU.
+    """
+    from flashinfer import prefill
+
+    device = torch.device("cuda:0")
+    monkeypatch.setattr(prefill, "get_compute_capability", lambda _device: (12, 0))
+    gate = prefill._nvfp4_kv_requires_disabled_split_kv
+
+    # Symmetric heads up to 256 wide keep split-KV.
+    for head_dim in (64, 128, 256):
+        assert not gate(torch.uint8, device, head_dim, head_dim)
+        assert not gate(torch.uint8, device, head_dim)  # vo defaults to qk
+
+    # The asymmetric VO-split plan stays gated, as does any head wider than 256.
+    assert gate(torch.uint8, device, 512, 256)
+    assert gate(torch.uint8, device, 512, 512)
+    assert gate(torch.uint8, device, 256, 128)
+
+    # Callers that know only dtype and device keep the arch-level gate.
+    assert gate(torch.uint8, device)
+
+    # Shape never overrides the dtype or arch tests.
+    assert not gate(torch.bfloat16, device, 512, 256)
+    monkeypatch.setattr(prefill, "get_compute_capability", lambda _device: (9, 0))
+    assert not gate(torch.uint8, device, 512, 256)


### PR DESCRIPTION
## Summary

Scope the NVFP4 split-KV gate on sm120/sm121 to the plan shape it was introduced for, instead of disabling split-KV for every NVFP4 KV plan on those archs.

`_nvfp4_kv_requires_disabled_split_kv` (mine, #3684, later arch-scoped in #4747) forces `disable_split_kv=True` for any NVFP4 KV `BatchPrefillWithPagedKVCacheWrapper.plan()` on sm120/121. The corruption it works around was only ever observed on the asymmetric VO-split plan (`head_dim_qk=512`, `head_dim_vo=256`, Gemma-4 global layers). For symmetric plans it costs a lot: with split-KV off a decode / spec-decode-verify step streams the whole KV range from one CTA per (batch, head), so decode throughput falls roughly linearly with context.

This PR keeps the gate for `head_dim_qk != head_dim_vo` or `head_dim_qk > 256`, and for plans that do not pass head dims, and lets symmetric plans up to 256 keep split-KV. Both `plan()` call sites (paged and ragged) pass `head_dim_qk`/`head_dim_vo` through.

## Measurements

vLLM (jethac/vllm `nvfp4-fa2-consumer-blackwell`, FA2 NVFP4 KV path), `--kv-cache-dtype nvfp4`, MTP k=3, Qwen3.8-27B-MTP-NVFP4 (head_dim 256), decode tok/s at increasing context; "gate on" is stock 0.6.18, "narrowed" is the same wheel with this `prefill.py`:

| context | RTX 5090 gate on | RTX 5090 narrowed | GB10 gate on | GB10 narrowed |
|---|---|---|---|---|
| 1k | 153.6 | 135.1 | 21.9 | 24.1 |
| 8k | 105.5 | 158.4 | 22.1 | 23.7 |
| 32k | 46.8 | 145.2 | 17.3 | 23.6 |
| 64k | 26.6 | 138.7 | 12.3 | 25.3 |
| 128k | 14.2 | 117.2 | 9.3 | 18.7 |

Needle retrieval 10/10 on every run; MTP acceptance identical on both sides (mean accepted length 3.0-3.7 of 4). The 1k point on the 5090 is ~12% slower with split-KV on; I have not chased it.

Correctness of the newly un-gated shape: Gemma-3-1B with a calibrated 4-bit KV scheme (head 256, split-KV on) retrieves 15/16 needles, identical to bf16 KV on the same prompts. Independently, @TechPrototyper's kernel ladder (qo 1..9 x kv 2k-32k, `head_dim_qk=512` / `head_dim_vo=256`, both V chunks, split-KV forced on) is 72/72 clean at `max_rel` ~0.005 (vllm-project/vllm#46329, comment 5554547616), which suggests the remaining gated shape may also be safe; I have left it gated here since that is the shape the original report came from.

## Test

`tests/attention/test_nvfp4_attention_sm120.py::test_nvfp4_split_kv_gate_shape_scope` fakes the compute capability: symmetric 64/128/256 not gated; 512/256, 512/512, 256/128 gated; no shape -> gated; bf16 never gated; (9,0) never gated. Passes on CPU-only import of the module and on a 5090 against the real device (128/128 and 256/256 allowed, 512/256 and 512/512 disabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NVFP4 attention planning on supported GPU architectures by keeping split-KV enabled for symmetric head dimensions up to 256.
  * Continued disabling split-KV for asymmetric configurations, head dimensions wider than 256, or when shape details are unavailable.

* **Tests**
  * Added coverage for shape-specific split-KV behavior, including architecture and data type safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->