### PR TITLE
test: cover RMSNorm caller-owned output contracts

### DIFF
--- a/tests/utils/test_norm.py
+++ b/tests/utils/test_norm.py
@@ -136,6 +136,58 @@ def test_norm(batch_size, hidden_size, dtype, specify_out, enable_pdl, contiguou
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
+@pytest.mark.parametrize("shape", [(5, 111), (5, 1024), (3, 5, 64), (3, 5, 256)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padded", [False, True])
+@pytest.mark.parametrize("pattern", ["zero", "tiny", "sparse", "alternating", "large"])
+def test_rmsnorm_output_contract(shape, dtype, padded, pattern):
+    """Exercise finite edge inputs and caller-owned output storage on the public API."""
+    hidden = shape[-1]
+    storage_shape = (*shape[:-1], hidden + 16) if padded else shape
+    input_storage = torch.full(storage_shape, -23, dtype=dtype, device="cuda")
+    output_storage = torch.full_like(input_storage, -23)
+    x = input_storage[..., 8:-8] if padded else input_storage
+    out = output_storage[..., 8:-8] if padded else output_storage
+    columns = torch.arange(hidden, device="cuda")
+    signs = (columns % 2 * 2 - 1).to(dtype)
+    if pattern == "zero":
+        x.zero_()
+    elif pattern == "tiny":
+        x.copy_(signs * 2**-14)
+    elif pattern == "sparse":
+        x.zero_()
+        x[..., hidden // 2] = 2
+    elif pattern == "alternating":
+        x.copy_(signs)
+    else:
+        # Finite in the input dtype and FP32 reduction, but not an FP16 square.
+        magnitude = 2**14 if dtype == torch.float16 else 2**30
+        x.copy_(signs * magnitude)
+    weight = ((columns % 9 - 4).float() / 4).to(dtype)
+    input_before = input_storage.clone()
+    weight_before = weight.clone()
+    expected = llama_rms_norm(x, weight)
+    assert torch.isfinite(expected).all()
+    tolerance = 1e-3 if dtype == torch.float16 else 1e-2
+
+    previous = None
+    for poison in (float("nan"), 17.0):
+        out.fill_(poison)
+        returned = flashinfer.norm.rmsnorm(x, weight, out=out, enable_pdl=False)
+        torch.cuda.synchronize()
+        assert returned is out
+        assert torch.isfinite(out).all()
+        torch.testing.assert_close(out, expected, rtol=tolerance, atol=tolerance)
+        torch.testing.assert_close(input_storage, input_before, rtol=0, atol=0)
+        torch.testing.assert_close(weight, weight_before, rtol=0, atol=0)
+        if padded:
+            assert (output_storage[..., :8] == -23).all()
+            assert (output_storage[..., -8:] == -23).all()
+        if previous is not None:
+            torch.testing.assert_close(out, previous, rtol=0, atol=0)
+        previous = out.clone()
+
+
 @pytest.mark.parametrize("batch_size", [1, 19, 99, 989])
 @pytest.mark.parametrize("hidden_size", [111, 500, 1024, 3072, 3584, 4096, 8192, 16384])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Add 80 parameterized RMSNorm output-buffer contract cases to the existing `tests/utils/test_norm.py` CI entry point.

The tests cover FP16/BF16, 2D/3D shapes, dense/padded row storage, and zero/tiny/sparse/alternating/large finite inputs. They check caller-supplied output identity, complete overwrite of NaN and finite poison, input/weight preservation, output-padding guards, finite outputs and agreement with the existing FP32 reference after synchronization.

This is test-only correctness coverage. No production kernel, dispatch, dependency or tolerance is changed, and no existing kernel defect or performance improvement is claimed.

## Related Issues

<!-- Link any related issues here -->

Related to #3605. @YangXu1990uiuc [confirmed the bounded RMSNorm slice was available](https://github.com/flashinfer-ai/flashinfer/issues/3605#issuecomment-5564614029) and [recorded the Norm/RoPE stream direction](https://github.com/flashinfer-ai/flashinfer/issues/3605#issuecomment-5564708820). This PR is only the first, 80-case RMSNorm output-contract slice; it does not close the whole quality RFC or add RoPE/quantized-norm coverage. GPU evidence is in the [updated collaboration comment](https://github.com/flashinfer-ai/flashinfer/issues/3605#issuecomment-5561845889).

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

Full-repository hooks passed, including mypy, Ruff, clang-format and the experimental-scope self-test. The hook-installation checkbox is left unchecked because only the manual full run is verified here. `git diff --check` also passed.

## Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

The new 80-case selection passed on an NVIDIA L20 (SM 8.9) through **each actual dispatch path**, CuTe and forced CUDA: 80 passed, zero failures/errors/skips per run. These are 80 distinct cases exercised twice, not 160 different contracts. The entire library test suite was not run, so the broad all-tests checkbox remains unchecked.

```sh
FLASHINFER_USE_CUDA_NORM=0 python -m pytest tests/utils/test_norm.py -k test_rmsnorm_output_contract -q
FLASHINFER_USE_CUDA_NORM=1 python -m pytest tests/utils/test_norm.py -k test_rmsnorm_output_contract -q
```

Base: `6c14bbd5ff34210404d5d4b5f6ff3b4b2527f59f`; tested patch: `92da53c4c4b9a2a5d261650b401dd891904ba0b5`.
Environment: Torch 2.13.0+cu130, CUDA 13.0, CUTLASS DSL 4.6.2, TVM FFI 0.1.11, pytest 9.1.1. Before both runs, all 6,991 source/header manifest entries were checked and the actual backend selection was asserted. Results and boundaries are summarized in the linked issue comment.

## Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
# tests/experimental/test_my_backend.py
# tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

Please focus on the public output/storage contract and whether the finite edge-input patterns add useful coverage to the existing norm suite. Validation covers one GPU architecture; no PDL or performance conclusion is intended.

AI-assisted test implementation, disclosed in the commit. Upstream maintainer review/CI remains pending.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated fused normalization test coverage to automatically skip cases when the device lacks sufficient shared memory.
  - Improved test compatibility for devices with lower per-block memory limits, including configurations using wide hidden dimensions.
  - Continued validating normalization behavior across varied shapes, data types, padding layouts, edge-value inputs, buffer handling, immutability, and output aliasing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->