### PR TITLE
perf(attention): Refresh DSL_FMHA cubins

### DIFF
--- a/flashinfer/artifacts.py
+++ b/flashinfer/artifacts.py
@@ -147,7 +147,7 @@ class ArtifactPath:
     CUDNN_SDPA: str = "a72d85b019dc125b9f711300cb989430f762f5a6/fmha/cudnn/"
     # For DEEPGEMM, we also need to update KernelMap.KERNEL_MAP_HASH in flashinfer/deep_gemm.py
     DEEPGEMM: str = "7ec7ac40b9fd48172651b77ff2ebe20d79decc39/deep-gemm/"
-    DSL_FMHA: str = "5b34f84266cbc2135066ce96885b664992535670/fmha/cute-dsl/"
+    DSL_FMHA: str = "6efb974aae4c012d9fb317c2ef360210b3f352e4/fmha/cute-dsl/"
     DSL_FMHA_ARCHS: tuple[str, ...] = (
         "sm_100a",
         "sm_103a",
@@ -177,16 +177,16 @@ class CheckSumHash:
     # NOT hashes of individual kernel .so files.
     DSL_FMHA_CHECKSUMS: dict[str, dict[str, str]] = {
         "x86_64": {
-            "sm_100a": "832c303bb9b386af590d3efc294681859829b91991975fd2e188a5d7dc30c461",
-            "sm_103a": "57322c10ddbbe9072c7ded41e2856fdf9d4276fbd79ac4bc825af0cd78844da6",
-            "sm_107a": "8480678539adf622f8395e875923471bce683be7158694556bd6c536eadeaa45",
-            "sm_110a": "4f6f0f3a868f0e9171c8ab217e6d2a87fde46b02a9417d8f55f1a779c53fa9fb",
+            "sm_100a": "7bb9eb497d295a6471ce85d0913e3b4955fd9a7d918ddd9b92882cba41af5365",
+            "sm_103a": "3c0dc183a6f73fe3f0705a4b6d6fe8de667cf1dd1908bfe27422327faa16e27b",
+            "sm_107a": "70be29547f3d9b2e7e22981865de20f35eef61fa3b6493443680b058e7523dd4",
+            "sm_110a": "817e55486f3c35fe1841dccafc9b7fe34e50aff99edc4a15da952ace123d9edd",
         },
         "aarch64": {
-            "sm_100a": "064cfcac21886c3e16b5007ca769f1b93111db7a63864db1e026a53e61fe20fe",
-            "sm_103a": "1631a884738d706f5bc39bf4032bcd54b25ba0a0d734c26f388dce4ae32093c9",
-            "sm_107a": "0348ef0b74dffa67c0c9662d3f567b26dccf46c356009f315860f31a9550e207",
-            "sm_110a": "8f16f510d159797432bda92d55d0d82d65d3e19080f9af1b751dec4146cdcbe6",
+            "sm_100a": "f1395b80f2c8917fd1f52dca0bf0a37efc6f74fc594c245284076c72bf7e8130",
+            "sm_103a": "c4a44f8be82d9544f18eb7e139712d9fe3b09b30d890b5d09e3cbc5a203a1544",
+            "sm_107a": "fe30ea44d746c630c0347ed357ce317de29968da3e1d848a1d6a6864cbd25b7e",
+            "sm_110a": "634636627af7a98f8e1ff8c8332baac91a2e2f4f3dddbf647b6da9d60a8085ca",
         },
     }
     map_checksums: dict[str, str] = {

--- a/flashinfer/attention/cute_dsl/fmha.py
+++ b/flashinfer/attention/cute_dsl/fmha.py
@@ -542,6 +542,11 @@ def cute_dsl_fmha_ragged_prefill(
             None,  # skip_softmax_count
             None,  # total_softmax_count
             enable_pdl,
+            None,
+            None,
+            None,
+            None,
+            None,
         )
     else:
         # CuTe native ABI: convert to cute tensors and pass with explicit stream.
@@ -624,4 +629,9 @@ def cute_dsl_fmha_ragged_prefill(
             None,  # total_softmax_count
             stream,
             enable_pdl,
+            None,
+            None,
+            None,
+            None,
+            None,
         )

--- a/flashinfer/cute_dsl/attention/fmha/compile.py
+++ b/flashinfer/cute_dsl/attention/fmha/compile.py
@@ -117,6 +117,11 @@ def compile_cute_dsl_fmha_kernel(
         mask_type=_mask_type(has_window_left or has_window_right),
         enable_ex2_emulation=enable_ex2_emulation,
         enable_skip_correction=True,
+        # Rescale threshold compresses the dynamic range when quantizing P and interferes
+        # skip-softmax criteria. Limit rescale threshold to a small epsilon (0.0 disables
+        # skip-correction) when skip-softmax is enabled, or P becomes the main source of
+        # quantization error (P, in v_dtype, being narrower than qk_dtype).
+        rescale_threshold=2**-8 if enable_skip_softmax or pv.width < qk.width else 8.0,
         use_tma_store=False,  # varlen -> STG
     )
 
@@ -200,6 +205,11 @@ def compile_cute_dsl_fmha_kernel(
         None,
         stream_fake,
         use_pdl,
+        None,
+        None,
+        None,
+        None,
+        None,
         options="--enable-tvm-ffi --opt-level 2",
     )
 
@@ -212,7 +222,7 @@ def compile_cute_dsl_fmha_kernel(
 @functools.cache
 def compile_cute_dsl_fmha_blockscaled_kernel(
     qk_mode: str,
-    pv_dtype: torch.dtype,
+    v_dtype: torch.dtype,
     out_dtype: torch.dtype,
     num_qo_heads: int,
     num_kv_heads: int,
@@ -232,7 +242,7 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         has_window_right = is_causal
     enable_ex2_emulation = _ex2_emulation_enabled(device)
     qk, sf_dt, sf_vec = _BLOCKSCALED_MODES[qk_mode]
-    pv = _CUTLASS_DTYPE[pv_dtype]
+    pv = _CUTLASS_DTYPE[v_dtype]
     out = _CUTLASS_DTYPE[out_dtype]
     d = dv = head_dim
 
@@ -246,6 +256,10 @@ def compile_cute_dsl_fmha_blockscaled_kernel(
         enable_ex2_emulation=enable_ex2_emulation,
         enable_skip_correction=True,
         qk_sf_vec_size=sf_vec,
+        # Rescale threshold compresses the dynamic range when quantizing P and interferes
+        # skip-softmax criteria. Limit rescale threshold to a small epsilon (0.0 disables
+        # skip-correction) when either is enabled.
+        rescale_threshold=2**-8 if enable_skip_softmax or pv.width <= 8 else 8.0,
         use_tma_store=True,  # non-varlen
     )
 

--- a/flashinfer/cute_dsl/attention/fmha/fmha.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha.py
@@ -117,6 +117,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         mask_type: fmha_utils.MaskEnum,
         enable_ex2_emulation: bool,
         enable_skip_correction: bool,
+        rescale_threshold: float = 8.0,
         use_tma_store: bool = True,
     ):
         """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
@@ -190,6 +191,7 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.is_persistent = is_persistent
         self.mask_type = mask_type
         self.enable_skip_correction = enable_skip_correction
+        self.rescale_threshold = rescale_threshold if enable_skip_correction else 0.0
         self.enable_ex2_emulation = enable_ex2_emulation
         self.use_tma_store = use_tma_store
 
@@ -334,7 +336,6 @@ class BlackwellFusedMultiHeadAttentionForward:
         self.epi_stage = 2
 
         # Tunable parameters
-        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
         # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
         # more of E4M3's [0, 448] range, improving quantization precision.
         # Derived from rescale_threshold to guarantee P*2^offset <= 448.
@@ -370,6 +371,11 @@ class BlackwellFusedMultiHeadAttentionForward:
         total_softmax_count: Optional[cute.Tensor],
         stream: cuda.CUstream,
         use_pdl: bool,
+        reserved_0=None,
+        reserved_1=None,
+        reserved_2=None,
+        reserved_3=None,
+        reserved_4=None,
     ):
         """Execute the Fused Multi-Head Attention operation on the provided tensors.
 

--- a/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
+++ b/flashinfer/cute_dsl/attention/fmha/fmha_blockscaled.py
@@ -213,6 +213,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         enable_ex2_emulation: bool,
         enable_skip_correction: bool,
         qk_sf_vec_size: int,
+        rescale_threshold: float = 8.0,
         use_tma_store: bool = True,
     ):
         """Initializes the configuration for a Blackwell Fused Multi-Head Attention (FMHA) kernel.
@@ -290,6 +291,7 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         self.is_persistent = is_persistent
         self.mask_type = mask_type
         self.enable_skip_correction = enable_skip_correction
+        self.rescale_threshold = rescale_threshold if enable_skip_correction else 0.0
         self.enable_ex2_emulation = enable_ex2_emulation
         self.qk_sf_vec_size = qk_sf_vec_size
         self.qk_mma_inst_bits_k = 256
@@ -449,7 +451,6 @@ class BlackwellFusedMultiHeadBlockScaledAttentionForward:
         self.epi_stage = 2
 
         # Tunable parameters
-        self.rescale_threshold = 8.0 if self.enable_skip_correction else 0.0
         # FP8 P pre-scale: offset added to exp2 exponent so that P*2^offset fills
         # more of E4M3's [0, 448] range, improving quantization precision.
         # Derived from rescale_threshold to guarantee P*2^offset <= 448.

--- a/tests/attention/test_cute_dsl_fmha_backend.py
+++ b/tests/attention/test_cute_dsl_fmha_backend.py
@@ -11,12 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Frontend tests for the `cute-dsl` backend routed to the trtllm JIT FMHA kernel.
+"""Frontend tests for APIs backed by the shared CuTe DSL FMHA runner.
 
 Covers entry points:
-* `trtllm_ragged_attention_deepseek(backend="cute-dsl")` — the shared low-level API.
-* `BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")` — delegates to the former
-  for standard attention, falls back to prefill.py for ALiBi / soft-cap.
+* `trtllm_ragged_attention_deepseek(backend="cute-dsl")` — the TRT-LLM API entry.
+* `BatchPrefillWithRaggedKVCacheWrapper(backend="cute-dsl")` — independently calls
+  the runner for standard attention and uses modular prefill for ALiBi / soft-cap.
 """
 
 import math
@@ -208,7 +208,7 @@ def test_cute_dsl_jit_case(monkeypatch):
 
 
 def test_batch_prefill_cute_dsl_alibi():
-    """ALiBi is unsupported by the trtllm kernel; must use prefill.py instead."""
+    """ALiBi is unsupported by the FMHA runner; use modular prefill instead."""
     torch.manual_seed(0)
     b, s, H, D = 2, 256, 8, 128
     qo = _indptr([s] * b)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

+ Refresh DSL_FMHA cubins
+ Minimal change to source code to keep backward compatibility (unlike cubin builder, FlashInfer needs to ensure JIT source compatibility with multiple `nvidia-cutlass-dsl` versions).

### Performance on B300

Base shape: B=2, H=16, D=128 data:
- Internal compiler scheduling decision might have caused regression in some shapes, but overall there is a consistent latency improvement over the Blackwell Ultra horizon:

| S | Causal | QK/V | `main` median (ms) | Refresh median (ms) | Refresh latency delta | Refresh speedup |
|---:|:------:|:------|-------------------:|--------------------:|----------------------:|----------------:|
| 2048 | True | BF16/BF16 | 0.064800 | 0.060704 | -6.32% | 1.0675x |
| 2048 | True | BF16/FP8 | 0.059040 | 0.055952 | -5.23% | 1.0552x |
| 2048 | True | FP8/FP8 | 0.053393 | 0.049728 | -6.86% | 1.0737x |
| 2048 | False | BF16/BF16 | 0.070321 | 0.065408 | -6.99% | 1.0751x |
| 2048 | False | BF16/FP8 | 0.061056 | 0.058912 | -3.51% | 1.0364x |
| 2048 | False | FP8/FP8 | 0.049504 | 0.049729 | +0.45% | 0.9955x |
| 16384 | True | BF16/BF16 | 1.386919 | 1.383943 | -0.21% | 1.0022x |
| 16384 | True | BF16/FP8 | 1.114918 | 1.170806 | +5.01% | 0.9523x |
| 16384 | True | FP8/FP8 | 1.050949 | 1.038149 | -1.22% | 1.0123x |
| 16384 | False | BF16/BF16 | 2.621342 | 2.425229 | -7.48% | 1.0809x |
| 16384 | False | BF16/FP8 | 2.146891 | 2.001659 | -6.76% | 1.0726x |
| 16384 | False | FP8/FP8 | 1.764121 | 1.729594 | -1.96% | 1.0200x |

## 🔍 Related Issues

<!-- Link any related issues here -->

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the CuTe DSL fused multi-head attention backend for compatibility with the latest kernel interface.
  - Improved softmax-scaling behavior for skip-softmax and low-precision attention modes.
  - Added configurable rescaling thresholds for standard and block-scaled attention paths.
  - Refreshed backend artifacts and checksums across supported GPU and CPU architectures.
- **Documentation**
  - Clarified CuTe DSL attention backend coverage, including ALiBi and modular prefill behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->