### PR TITLE
perf(prims-ts): Optimize&refine PrimsTS block sparse attention

### DIFF
--- a/flashinfer/attention/prims_ts/_block_sparse/compiler.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/compiler.py
@@ -55,6 +55,7 @@ def _compile_block_sparse(key: _BlockSparseCompileKey) -> Callable[..., object]:
         "use_proxy_routes": key.use_proxy_routes,
         "use_causal_mask": key.mask_type == "causal",
         "apply_token_mask": key.use_kv_valid_bits,
+        "store_score_words": config.uses_prepared_score_keep_words,
     }
     if key.page_size is not None:
         if key.sparse_format != "bsr" or key.use_proxy_routes:

--- a/flashinfer/attention/prims_ts/_block_sparse/config.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/config.py
@@ -92,6 +92,9 @@ class _BlockSparseLaunchSpec:
 
     policy: tuple[tuple[str, object], ...]
     compile_key: _BlockSparseCompileKey
+    # Whether prepared routes carry K32 score-validity words; the decode
+    # config owns this rule and the plan sizes its route storage from it.
+    prepares_score_words: bool
 
 
 _CAPACITY_UNSET = object()
@@ -359,11 +362,13 @@ def _validate_block_sparse_static_profile(
         kv_block_size=kv_block_size,
     )
     if page_size is not None:
+        # Validate the paged route geometry with a capacity-free layout; the
+        # score-word slots do not take part in the page/atom checks.
         _BlockSparseRouteLayout.create(
             kv_route_size=kv_route_size,
             kv_block_size=kv_block_size,
             page_size=page_size,
-            has_token_bits=use_kv_valid_bits,
+            has_token_bits=False,
             route_metadata_capacity=0,
             num_rows=1,
         )
@@ -516,7 +521,7 @@ def _resolve_block_sparse_launch_spec(
         page_size=page_size,
     )
     try:
-        _make_block_sparse_config(compile_key)
+        config = _make_block_sparse_config(compile_key)
     except ValueError:
         if not compile_key.use_persistent_scheduler:
             raise
@@ -530,7 +535,7 @@ def _resolve_block_sparse_launch_spec(
                 use_persistent_scheduler=False,
             ),
         )
-        _make_block_sparse_config(compile_key)
+        config = _make_block_sparse_config(compile_key)
 
     policy_entries: list[tuple[str, object]] = [
         ("tile_size_q", q_tile_size),
@@ -556,6 +561,7 @@ def _resolve_block_sparse_launch_spec(
     return _BlockSparseLaunchSpec(
         policy=tuple(policy_entries),
         compile_key=compile_key,
+        prepares_score_words=config.uses_prepared_score_keep_words,
     )
 
 

--- a/flashinfer/attention/prims_ts/_block_sparse/config.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/config.py
@@ -195,9 +195,13 @@ def _select_block_sparse_scheduler(
     mask_type: Literal["dense", "causal"],
     use_kv_valid_bits: bool,
     max_row_route_capacity: int,
-    use_proxy_routes: bool,
 ) -> tuple[int, bool]:
-    """Select the Q tile and scheduler without depending on KV storage."""
+    """Select the Q tile and scheduler without depending on KV storage.
+
+    Proxy routes add one summary route per row on top of the exact routes and
+    see the same per-tile fixed cost the persistent scheduler amortizes, so
+    the selection does not depend on the route kind.
+    """
 
     heads_q_per_kv = num_qo_heads // num_kv_heads
     q_tile_size = _select_block_sparse_q_tile_size(
@@ -205,10 +209,6 @@ def _select_block_sparse_scheduler(
         heads_q_per_kv=heads_q_per_kv,
         kv_block_size=kv_block_size,
     )
-    # Proxy routes add one summary route per row on top of the exact routes,
-    # so they see the same per-tile fixed cost the persistent scheduler
-    # amortizes; both route kinds share one scheduler selection.
-    _ = use_proxy_routes
     if not _should_consider_clc(
         q_tile_size=q_tile_size,
         kv_block_size=kv_block_size,
@@ -472,9 +472,9 @@ def _resolve_block_sparse_launch_spec(
 
     ``max_row_route_capacity`` is a conservative prepared-route bound. Live
     index values and physical-tail morphology never specialize this cache
-    entry. Proxy routes use the direct grid; exact routes retain the common
-    automatic scheduler. An unsupported persistent profile falls back to its
-    valid static counterpart.
+    entry. Proxy and exact routes share one scheduler selection. An
+    unsupported persistent profile falls back to its valid static
+    counterpart.
     """
 
     q_tile_size, use_persistent_scheduler = _select_block_sparse_scheduler(
@@ -489,7 +489,6 @@ def _resolve_block_sparse_launch_spec(
         mask_type=mask_type,
         use_kv_valid_bits=use_kv_valid_bits,
         max_row_route_capacity=max_row_route_capacity,
-        use_proxy_routes=use_proxy_routes,
     )
     compile_key = _BlockSparseCompileKey(
         device_index=device_index,

--- a/flashinfer/attention/prims_ts/_block_sparse/config.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/config.py
@@ -205,11 +205,10 @@ def _select_block_sparse_scheduler(
         heads_q_per_kv=heads_q_per_kv,
         kv_block_size=kv_block_size,
     )
-    # Reusable planning sees route capacity, not the live exact-route work.
-    # Keep proxy execution on the direct grid as a conservative workload-level
-    # default until runtime work can participate in scheduling.
-    if use_proxy_routes:
-        return q_tile_size, False
+    # Proxy routes add one summary route per row on top of the exact routes,
+    # so they see the same per-tile fixed cost the persistent scheduler
+    # amortizes; both route kinds share one scheduler selection.
+    _ = use_proxy_routes
     if not _should_consider_clc(
         q_tile_size=q_tile_size,
         kv_block_size=kv_block_size,

--- a/flashinfer/attention/prims_ts/_block_sparse/plan.py
+++ b/flashinfer/attention/prims_ts/_block_sparse/plan.py
@@ -207,14 +207,6 @@ def _build_block_sparse_plan_state(
             static.kv_block_size,
         )
         max_row_route_capacity += ceil_div(num_summaries, static.kv_route_size)
-    route_layout = _BlockSparseRouteLayout.create(
-        kv_route_size=static.kv_route_size,
-        kv_block_size=static.kv_block_size,
-        page_size=static.page_size,
-        has_token_bits=static.use_kv_valid_bits or use_proxy_routes,
-        route_metadata_capacity=num_rows * max_row_route_capacity,
-        num_rows=num_rows,
-    )
     with torch.cuda.device(device_index), torch.cuda.stream(plan_stream):
         spec = _resolve_block_sparse_launch_spec(
             device_index=device_index,
@@ -238,6 +230,14 @@ def _build_block_sparse_plan_state(
         policy = (
             *spec.policy,
             ("max_blocks_per_row", static.max_blocks_per_row),
+        )
+        route_layout = _BlockSparseRouteLayout.create(
+            kv_route_size=static.kv_route_size,
+            kv_block_size=static.kv_block_size,
+            page_size=static.page_size,
+            has_token_bits=spec.prepares_score_words,
+            route_metadata_capacity=num_rows * max_row_route_capacity,
+            num_rows=num_rows,
         )
         compiled = _get_compiled_block_sparse(spec.compile_key)
         dummy_kv_valid_bits = (

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/block_sparse_prepare.py
@@ -604,12 +604,15 @@ class _PrepareRoutesBase:
         use_proxy_routes: bool,
         use_causal_mask: bool = False,
         apply_token_mask: bool = False,
+        store_score_words: bool = False,
         page_size: int | None = None,
     ) -> None:
         if not isinstance(use_proxy_routes, bool):
             raise TypeError("use_proxy_routes must be a bool")
         if not isinstance(apply_token_mask, bool):
             raise TypeError("apply_token_mask must be a bool")
+        if not isinstance(store_score_words, bool):
+            raise TypeError("store_score_words must be a bool")
         if not isinstance(use_causal_mask, bool):
             raise TypeError("use_causal_mask must be a bool")
         if use_proxy_routes and page_size is not None:
@@ -617,7 +620,9 @@ class _PrepareRoutesBase:
 
         num_q_blocks = (seq_len_q + q_block_size - 1) // q_block_size
         num_rows = batch_size * num_kv_heads * num_q_blocks
-        stores_score_words = use_proxy_routes or apply_token_mask
+        # Structural score words (sequence tail, invalid atoms) can be stored
+        # without a caller token mask; proxy routes and token masks require them.
+        stores_score_words = use_proxy_routes or apply_token_mask or store_score_words
         layout = _BlockSparseRouteLayout.create(
             kv_route_size=kv_route_size,
             kv_block_size=kv_block_size,
@@ -893,6 +898,7 @@ class _PrepareBitmaskRoutes(_PrepareRoutesBase):
         use_proxy_routes: bool,
         use_causal_mask: bool = False,
         apply_token_mask: bool = False,
+        store_score_words: bool = False,
     ) -> None:
         super().__init__(
             batch_size=batch_size,
@@ -905,6 +911,7 @@ class _PrepareBitmaskRoutes(_PrepareRoutesBase):
             use_proxy_routes=use_proxy_routes,
             use_causal_mask=use_causal_mask,
             apply_token_mask=apply_token_mask,
+            store_score_words=store_score_words,
         )
 
     @cute.jit

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -102,6 +102,16 @@ _GROUPED_KEEPS_STATIC_ONLY_PROFILES = {
     (Float16, Float16, Float16, 256, 128, 1, 1),
 }
 
+# Per-thread register budgets for the Q64/KV256 warp groups once the launch
+# bound enables ``setmaxnreg``. The MMA, load, and scheduler warps keep 56, so
+# the two softmax groups and the correction group share the remainder:
+# 8 * softmax + 4 * correction = 65536 / 32 - 4 * 56. An even split measured
+# fastest on B200 for both the static grid and the persistent scheduler; the
+# correction group needs the extra room for its persistent bookkeeping and
+# the KV256 tail merge, while the rolled softmax fragment loop needs less.
+KV_TILE_256_SOFTMAX_TASK_REGISTERS = 152
+KV_TILE_256_CORRECTION_TASK_REGISTERS = 152
+
 _KV_TILE_256_PHYSICAL_DEFAULTS: Mapping[str, ConfigValue] = {
     "tmem_s_cols": 128,
     "tmem_stats_cols": 32,
@@ -648,13 +658,13 @@ class FmhaDecodeConfig:
     def softmax_task_num_registers(self) -> int | None:
         if not self.uses_task_register_reallocation:
             return None
-        return 176 if self.tile_size_kv == 256 else 184
+        return KV_TILE_256_SOFTMAX_TASK_REGISTERS if self.tile_size_kv == 256 else 184
 
     @property
     def correction_task_num_registers(self) -> int | None:
         if not self.uses_task_register_reallocation:
             return None
-        return 104 if self.tile_size_kv == 256 else 88
+        return KV_TILE_256_CORRECTION_TASK_REGISTERS if self.tile_size_kv == 256 else 88
 
     @property
     def mma_load_task_num_registers(self) -> int | None:
@@ -1632,32 +1642,6 @@ class FmhaDecodeConfig:
             getattr(self, field) == expected
             for field, expected in _KV_TILE_256_TASK_TOPOLOGY_DEFAULTS.items()
         )
-
-    @property
-    def uses_rotating_kv256_exchange(self) -> bool:
-        """Whether this profile selects KV-ring scratch for correction.
-
-        Persistent direct output can overlap the next work tile's first two
-        K loads with correction by placing its exchange in the third, drained
-        KV stage. Split-KV and attention sinks retain the fixed exchange because
-        their tail storage and lifetime differ from direct output.
-        """
-        selects_persistent_kv256 = (
-            self.streams_tmem_p_fragments
-            and self.tile_size_q == 64
-            and self.tile_size_kv == 256
-            and self.use_persistent_scheduler
-        )
-        if not selects_persistent_kv256:
-            return False
-
-        has_rotating_kv_ring = (
-            self.num_head_dim_stages_kv == 1
-            and self.kv_stages == KV_TILE_256_SHARED_FIFO_STAGES
-            and self.load_num_warps == 1
-        )
-        has_direct_output_lifetime = not (self.use_split_kv or self.use_attention_sinks)
-        return has_rotating_kv_ring and has_direct_output_lifetime
 
     @property
     def keeps_separates_tmem_s_and_stats(self) -> bool:

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1081,14 +1081,12 @@ class FmhaDecodeConfig:
         """Return the maximum score fragment kept live in registers.
 
         Streamed profiles own 128 score values per lane but process them as
-        four native 32-register LDTM atoms: Q64/KV256 and the 16-bit
-        Q128/KV128 two-instance TMEM-P profiles share that geometry. Other
-        profiles retain their complete score fragment, so this property is
-        intentionally distinct from ``num_s_regs_per_thread`` (the total
-        logical ownership). FP8 Q128 keeps the complete row because its P
-        publication packs four values per column in one x16/x32 store.
+        four native 32-register LDTM atoms. Other profiles retain their
+        complete score fragment, so this property is intentionally distinct
+        from ``num_s_regs_per_thread`` (the total logical ownership). The
+        selection of streamed profiles lives in ``streams_tmem_p_fragments``.
         """
-        if self.uses_two_inst_tmem_p and not self.use_fp8_qkv:
+        if self.streams_tmem_p_fragments:
             return 32
         return self.num_s_regs_per_thread
 
@@ -1642,10 +1640,11 @@ class FmhaDecodeConfig:
     def uses_two_inst_tmem_p(self) -> bool:
         """Whether a two-instance Keeps profile uses the TMEM-P overlay.
 
-        FP8 Q128/KV128 publishes a complete packed-P row per pipeline token.
-        Q64/KV256 and 16-bit Q128/KV128 use the same S-to-P aliasing contract
-        but stream four independently ready K32 fragments. Q64/KV128 keeps the
-        base kernel's faster SMEM-P cadence.
+        FP8 Q128/KV128 and dense 16-bit Q128/KV128 publish a complete
+        packed-P row per pipeline token. Q64/KV256 and block-sparse 16-bit
+        Q128/KV128 use the same S-to-P aliasing contract but stream four
+        independently ready K32 fragments (see ``streams_tmem_p_fragments``).
+        Q64/KV128 keeps the base kernel's faster SMEM-P cadence.
         """
         # Two-instance Keeps keeps stats outside S, so both static and persistent
         # work tiles can overlay P on the consumed S instance. The split K/V
@@ -1670,9 +1669,23 @@ class FmhaDecodeConfig:
         Streamed profiles produce their K32 fragments from one rolled runtime
         loop: the max pass writes masked scores back to TMEM, so the P pass
         reloads each fragment without mask logic and the exponentiation body
-        exists once in the instruction stream.
+        exists once in the instruction stream. Each published fragment lets
+        the MMA warp start its PV k-slice before the row is complete, at the
+        cost of one barrier round per fragment.
+
+        Streaming is limited to the 16-bit two-instance profiles whose route
+        loop waits on the K/V loads, where the earlier PV start hides load
+        latency: Q64/KV256 and block-sparse Q128/KV128. Dense Q128/KV128
+        keeps the complete row because its route loop is not load-bound, so
+        the per-fragment barriers are not compensated. FP8 Q128 keeps the
+        complete row because its P publication packs four values per column
+        into one store.
         """
-        return self.uses_two_inst_tmem_p and self.num_softmax_score_fragments > 1
+        return (
+            self.uses_two_inst_tmem_p
+            and not self.use_fp8_qkv
+            and (self.tile_size_kv == 256 or self.use_block_sparse)
+        )
 
     @property
     def defers_softmax_anchor_updates(self) -> bool:

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1080,12 +1080,21 @@ class FmhaDecodeConfig:
     def softmax_score_fragment_regs(self) -> int:
         """Return the maximum score fragment kept live in registers.
 
-        KV256 owns 128 score values per lane but streams them as four native
-        32-register LDTM atoms. Other profiles retain their complete score
-        fragment, so this property is intentionally distinct from
-        ``num_s_regs_per_thread`` (the total logical ownership).
+        Streamed profiles own 128 score values per lane but process them as
+        four native 32-register LDTM atoms: Q64/KV256 and the 16-bit
+        Q128/KV128 two-instance TMEM-P profiles share that geometry. Other
+        profiles retain their complete score fragment, so this property is
+        intentionally distinct from ``num_s_regs_per_thread`` (the total
+        logical ownership). FP8 Q128 keeps the complete row because its P
+        publication packs four values per column in one x16/x32 store.
         """
         if self.tile_size_kv == 256:
+            return 32
+        if (
+            self.tile_size_q == 128
+            and self.uses_two_inst_tmem_p
+            and not self.use_fp8_qkv
+        ):
             return 32
         return self.num_s_regs_per_thread
 
@@ -1474,10 +1483,10 @@ class FmhaDecodeConfig:
     @property
     def uses_ordered_softmax_barrier(self) -> bool:
         """Whether this profile selects the ordered P0/P1 softmax barrier."""
-        if self.tile_size_kv == 256:
-            # KV256 uses independent four-stage P-fragment pipelines. Ordering
-            # the two softmax groups would serialize fragment production and
-            # defeat the intended P/PV overlap.
+        if self.streams_tmem_p_fragments:
+            # Streamed profiles use independent per-fragment P pipelines.
+            # Ordering the two softmax groups would serialize fragment
+            # production and defeat the intended P/PV overlap.
             return False
         if self.ordered_softmax_barrier_mode == 2:
             return True

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1088,13 +1088,7 @@ class FmhaDecodeConfig:
         logical ownership). FP8 Q128 keeps the complete row because its P
         publication packs four values per column in one x16/x32 store.
         """
-        if self.tile_size_kv == 256:
-            return 32
-        if (
-            self.tile_size_q == 128
-            and self.uses_two_inst_tmem_p
-            and not self.use_fp8_qkv
-        ):
+        if self.uses_two_inst_tmem_p and not self.use_fp8_qkv:
             return 32
         return self.num_s_regs_per_thread
 
@@ -1102,6 +1096,30 @@ class FmhaDecodeConfig:
     def num_softmax_score_fragments(self) -> int:
         """Return score fragments used to cover one logical KV tile."""
         return self.num_s_regs_per_thread // self.softmax_score_fragment_regs
+
+    @property
+    def block_sparse_kv_atom_size(self) -> int:
+        """Return the K token span of one block-sparse route origin."""
+        assert self.use_block_sparse
+        return _block_sparse_kv_atom_size(self.kv_block_size)
+
+    @property
+    def softmax_fragments_per_route_atom(self) -> int:
+        """Return the streamed score fragments that share one route origin.
+
+        Route origins are staged per K64 atom, so a 128-token KV block spans
+        two origins; the fragment-to-origin mapping follows the atom.
+        """
+        return self.block_sparse_kv_atom_size // self.softmax_score_fragment_regs
+
+    @property
+    def uses_ws_2x2_datapath(self) -> bool:
+        """Whether QK and PV issue the WS 2x2 instruction over two lane halves.
+
+        KV256 exposes two spatial KV128 partials per logical Q row; every other
+        Keeps profile issues the plain CTA-local instruction.
+        """
+        return self.tile_size_kv == 256
 
     @property
     def num_packed_p_regs(self) -> int:
@@ -1309,6 +1327,13 @@ class FmhaDecodeConfig:
             raise ValueError(
                 "block-sparse tile_size_kv=256 requires the Q64 16-bit Keeps "
                 "profile with coarse KV blocks and one load task"
+            )
+        if self.use_keeps_mma_ab and not self.streams_tmem_p_fragments:
+            # The block-sparse Keeps softmax and P passes exist only in their
+            # streamed K32-fragment form.
+            raise ValueError(
+                "block-sparse KeepsMmaAb requires a streamed TMEM-P profile "
+                "(Q64/KV256 or 16-bit Q128/KV128)"
             )
         if self.tile_size_q != selected_q_tile:
             raise ValueError(
@@ -1602,10 +1627,10 @@ class FmhaDecodeConfig:
     def uses_two_inst_tmem_p(self) -> bool:
         """Whether a two-instance Keeps profile uses the TMEM-P overlay.
 
-        Q128/KV128 and sparse Q64/KV128 publish a complete packed-P row per
-        pipeline token. Q64/KV256 uses the same S-to-P aliasing contract but
-        streams four independently ready K32 fragments. Dense Q64/KV128 keeps
-        the base kernel's faster SMEM-P cadence.
+        FP8 Q128/KV128 publishes a complete packed-P row per pipeline token.
+        Q64/KV256 and 16-bit Q128/KV128 use the same S-to-P aliasing contract
+        but stream four independently ready K32 fragments. Q64/KV128 keeps the
+        base kernel's faster SMEM-P cadence.
         """
         # Two-instance Keeps keeps stats outside S, so both static and persistent
         # work tiles can overlay P on the consumed S instance. The split K/V
@@ -1616,11 +1641,6 @@ class FmhaDecodeConfig:
             and (
                 (self.tile_size_q == 128 and self.tile_size_kv == 128)
                 or (self.tile_size_q == 64 and self.tile_size_kv == 256)
-                or (
-                    self.use_block_sparse
-                    and self.tile_size_q == 64
-                    and self.tile_size_kv == 128
-                )
             )
             and self.head_dim_per_stage_kv == 0
             and self.num_insts_kv == 2
@@ -1643,13 +1663,16 @@ class FmhaDecodeConfig:
     def defers_softmax_anchor_updates(self) -> bool:
         """Whether small row-max increases keep the previous exponent anchor.
 
-        Streamed KV256 tiles and block-sparse Keeps routes change the exact
-        row maximum often without changing it enough to justify rescaling the
-        live O tile; keeping the prior anchor within
-        ``SOFTMAX_RESCALE_THRESHOLD_LOG2`` makes the correction scale exactly
-        one and bounds 16-bit P by 2**8.
+        Keeps correction skips the in-place O rescale whenever the anchor is
+        unchanged, so keeping the prior anchor within
+        ``SOFTMAX_RESCALE_THRESHOLD_LOG2`` trades a bounded 16-bit P range
+        (2**8) for fewer TMEM rescales. The profiles listed here are the ones
+        where that trade was measured to pay: KV256 tiles and block-sparse
+        routes, whose row maximum moves often but rarely by much.
         """
-        return self.tile_size_kv == 256 or self.use_block_sparse
+        return self.use_keeps_mma_ab and (
+            self.tile_size_kv == 256 or self.use_block_sparse
+        )
 
     @property
     def matches_kv256_task_topology(self) -> bool:

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1621,19 +1621,26 @@ class FmhaDecodeConfig:
 
     @property
     def streams_tmem_p_fragments(self) -> bool:
-        """Whether P is published as independently ready TMEM fragments."""
+        """Whether P is published as independently ready TMEM fragments.
+
+        Streamed profiles produce their K32 fragments from one rolled runtime
+        loop: the max pass writes masked scores back to TMEM, so the P pass
+        reloads each fragment without mask logic and the exponentiation body
+        exists once in the instruction stream.
+        """
         return self.uses_two_inst_tmem_p and self.num_softmax_score_fragments > 1
 
     @property
-    def loops_softmax_p_fragments(self) -> bool:
-        """Whether streamed P fragments come from one rolled runtime loop.
+    def defers_softmax_anchor_updates(self) -> bool:
+        """Whether small row-max increases keep the previous exponent anchor.
 
-        KV256 masks scores in place during the max pass, so the P pass can
-        reload fragments without per-fragment mask logic and keep a single
-        copy of the exponentiation body in the instruction stream. The FP8
-        operand path still materializes P through its dedicated helpers.
+        Streamed KV256 tiles and block-sparse Keeps routes change the exact
+        row maximum often without changing it enough to justify rescaling the
+        live O tile; keeping the prior anchor within
+        ``SOFTMAX_RESCALE_THRESHOLD_LOG2`` makes the correction scale exactly
+        one and bounds 16-bit P by 2**8.
         """
-        return self.streams_tmem_p_fragments and not self.use_fp8_qkv
+        return self.tile_size_kv == 256 or self.use_block_sparse
 
     @property
     def matches_kv256_task_topology(self) -> bool:
@@ -2221,17 +2228,6 @@ def _validate_kv256_static_config(cfg: FmhaDecodeConfig) -> None:
             f"q_stages={cfg.q_stages}, kv_stages={cfg.kv_stages} require "
             f"{pipeline_smem_bytes} bytes, limit is "
             f"{pipeline_smem_budget_bytes} bytes"
-        )
-    if (
-        cfg.use_persistent_scheduler
-        and not cfg.use_split_kv
-        and not cfg.use_attention_sinks
-        and cfg.kv_stages != KV_TILE_256_SHARED_FIFO_STAGES
-    ):
-        raise ValueError(
-            "persistent KV256 requires kv_stages="
-            f"{KV_TILE_256_SHARED_FIFO_STAGES} for the rotating shared-KV "
-            f"exchange, got {cfg.kv_stages}"
         )
     if not cfg.supports_grouped_keeps:
         raise ValueError(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1386,9 +1386,24 @@ class FmhaDecodeConfig:
 
     @property
     def uses_prepared_score_keep_words(self) -> bool:
-        """Whether prepared routes carry BMM1 score-column validity words."""
+        """Whether prepared routes carry BMM1 score-column validity words.
 
-        return self.use_kv_valid_bits or self.use_block_sparse_proxy_routes
+        Dense block-sparse Keeps plans prepare them even without a caller
+        token mask: the streamed max pass trusts the words directly, which is
+        cheaper than deriving each fragment's visible range in the softmax
+        warps. The plan sizes its route storage and the prepare kernels store
+        the words from this same property, via the resolved launch spec.
+        """
+
+        return (
+            self.use_kv_valid_bits
+            or self.use_block_sparse_proxy_routes
+            or (
+                self.use_block_sparse
+                and self.use_keeps_mma_ab
+                and self.mask_type == DENSE
+            )
+        )
 
     @property
     def trusts_prepared_score_words(self) -> bool:

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_config.py
@@ -1615,6 +1615,17 @@ class FmhaDecodeConfig:
         return self.uses_two_inst_tmem_p and self.num_softmax_score_fragments > 1
 
     @property
+    def loops_softmax_p_fragments(self) -> bool:
+        """Whether streamed P fragments come from one rolled runtime loop.
+
+        KV256 masks scores in place during the max pass, so the P pass can
+        reload fragments without per-fragment mask logic and keep a single
+        copy of the exponentiation body in the instruction stream. The FP8
+        operand path still materializes P through its dedicated helpers.
+        """
+        return self.streams_tmem_p_fragments and not self.use_fp8_qkv
+
+    @property
     def matches_kv256_task_topology(self) -> bool:
         """Whether task roles match KV256's validated 16-warp layout."""
         return all(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_constants.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_constants.py
@@ -45,8 +45,12 @@ KV_TILE_256_K_SLOT_FOR_SEMANTIC_ATOM = (0, 2, 1, 3)
 # Keep the old maximum as the exponent reference while a new maximum is at
 # most eight log2 units larger. This avoids an output-correction round without
 # letting an intermediate probability exceed 2**8; the softmax identity is
-# unchanged apart from normal finite-precision rounding.
-KV_TILE_256_RESCALE_THRESHOLD_LOG2 = 8.0
+# unchanged apart from normal finite-precision rounding. As in the
+# FlashInfer/TRT-LLM policy, this assumes normal model logits rather than
+# adversarial values outside the qualified probability bound. Streamed KV256
+# and block-sparse Keeps profiles apply it; see
+# ``FmhaDecodeConfig.defers_softmax_anchor_updates``.
+SOFTMAX_RESCALE_THRESHOLD_LOG2 = 8.0
 
 # A launch bound makes ptxas honor warpgroup ``setmaxnreg`` allocations, but
 # the resulting register hand-off has a fixed cost. Paired B200 measurements

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
@@ -1768,13 +1768,15 @@ def _build_decode_gen_schedule(
         p0_alloc = smem_p0.get_tmem_requirements()[0]
         p1_alloc = smem_p1.get_tmem_requirements()[0]
         o_alloc = tmem_o.get_tmem_requirements()[0]
-        if cfg.tile_size_kv == 256:
-            # KV256 keeps O in the low 256 columns and overlays packed P on
-            # each S region from its first column. Softmax streams K32
-            # fragments in order, so every 16-column P store only overwrites
-            # scores that have already been consumed. Starting P after the
-            # nominal stats columns would instead clobber the next unread S
-            # fragment; KV256 keeps its softmax stats in SMEM.
+        if cfg.streams_tmem_p_fragments:
+            # Streamed profiles keep O in the low 256 columns and overlay
+            # packed P on each S region from its first column. Softmax streams
+            # K32 fragments in order, so every 16-column P store only
+            # overwrites scores that have already been consumed. Starting P
+            # after the nominal stats columns would instead clobber the next
+            # unread S fragment; streamed profiles keep their softmax stats in
+            # SMEM.
+            assert cfg.keeps_stats_via_smem
             o_alloc.offset = 0
             s0_alloc.offset = 2 * cfg.tmem_o_stage_cols
             s1_alloc.offset = s0_alloc.offset + cfg.tmem_s_cols

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
@@ -95,7 +95,6 @@ from .fmha_decode_resources.helpers_kv_tile_idx import _runtime_active_splits_kv
 from .fmha_decode_tasks import (
     PackedDecodeWorkQueue,
     ScheduleTokenThrottleResource,
-    SmemKvReuseCreditResource,
     _prefetch_prepared_sparse_row,
     create_block_sparse_load_tasks_per_inst,
     create_correction_task,
@@ -747,7 +746,6 @@ def _build_decode_gen_schedule(
     # ------------------------------------------------------------------
     work_queue = None
     schedule_token_throttle = None
-    smem_kv_reuse_credit = None
     # CLC remains the single persistent policy for every supported topology.
     # The stock static WorkQueue advances and decodes coordinates separately
     # in every task, which regresses multi-wave decode workloads. CLC computes
@@ -805,17 +803,6 @@ def _build_decode_gen_schedule(
             ),
             name="schedule_token_throttle",
         )
-        if cfg.uses_rotating_kv256_exchange:
-            smem_kv_reuse_credit = SmemKvReuseCreditResource(
-                cfg=cfg,
-                pipeline_config=PipelineConfig.create_async_async_pipeline_cfg(
-                    num_stages=1,
-                    producer_group=load_grp,
-                    consumer_group=correction_grp,
-                    cta_layout_vmnk=cta_layout,
-                ),
-                name="smem_kv_reuse_credit",
-            )
     smem_q = SmemQResource(
         pipeline_config=smem_q_cfg,
         cfg=cfg,
@@ -1313,7 +1300,6 @@ def _build_decode_gen_schedule(
                 smem_kv,
                 work_queue,
                 schedule_token_throttle,
-                smem_kv_reuse_credit,
                 cfg,
                 domain=load_domain,
                 domain_bias=0,
@@ -1457,7 +1443,6 @@ def _build_decode_gen_schedule(
             tmem_corr0,
             tmem_corr1,
             work_queue,
-            smem_kv_reuse_credit,
             cfg,
             domain=corr_domain,
             tmem_stats_done0=tmem_stats_done0,
@@ -1633,10 +1618,6 @@ def _build_decode_gen_schedule(
         )
     if schedule_token_throttle is not None:
         resource_dependency_graph[schedule_token_throttle] = [work_queue]
-    if smem_kv_reuse_credit is not None:
-        # A self-edge models the one-slot ownership token: Load produces it
-        # for the current tile and Correction consumes it before the next Load.
-        resource_dependency_graph[smem_kv_reuse_credit] = [smem_kv_reuse_credit]
     dma_consumer_release_labels: dict[
         tuple[MemoryResource, MemoryResource], set[str]
     ] = {}
@@ -1688,8 +1669,6 @@ def _build_decode_gen_schedule(
         smem_allocator.add_resource(work_queue)
     if schedule_token_throttle is not None:
         smem_allocator.add_resource(schedule_token_throttle)
-    if smem_kv_reuse_credit is not None:
-        smem_allocator.add_resource(smem_kv_reuse_credit)
     smem_allocator.add_resource(smem_q)
     if smem_page_offsets is not None:
         smem_allocator.add_resource(smem_page_offsets)
@@ -1727,18 +1706,6 @@ def _build_decode_gen_schedule(
     smem_allocator.add_resource(tmem_corr0)
     if not use_one_inst_qkv:
         smem_allocator.add_resource(tmem_corr1)
-    if cfg.tile_size_kv == 256:
-        # KV256 direct-output correction rotates one compact 35,840-byte
-        # payload through the shared 192-KiB K/V ring. Split-KV retains the
-        # fixed full exchange. Neither path increases the CTA SMEM footprint.
-        correction_exchange_requirements = tmem_corr1.get_smem_requirements()
-        if correction_exchange_requirements:
-            smem_allocator.add_alias_group(
-                [
-                    smem_kv.get_smem_requirements(),
-                    correction_exchange_requirements,
-                ]
-            )
     smem_allocator.add_tmem_ptr(
         SmemAllocation("fmha_tmem_ptr_i32", dtype=cutlass.Int32, alignment=4)
     )
@@ -1862,10 +1829,6 @@ def _build_decode_gen_schedule(
     eager_init_resources = (
         [tmem_corr0] if use_one_inst_qkv else [tmem_corr0, tmem_corr1]
     )
-    if smem_kv_reuse_credit is not None:
-        # Initialize the persistent ring cursor under the same CTA-wide fence
-        # and barrier used by other manually managed SMEM control state.
-        eager_init_resources.append(smem_kv_reuse_credit)
     if cfg.streams_tmem_p_fragments:
         # KV256's TMEM P operands use one-way per-fragment ready barriers.
         # Initialize them beside correction's manually managed SMEM state.

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
@@ -1832,7 +1832,7 @@ def _build_decode_gen_schedule(
         [tmem_corr0] if use_one_inst_qkv else [tmem_corr0, tmem_corr1]
     )
     if cfg.streams_tmem_p_fragments:
-        # KV256's TMEM P operands use one-way per-fragment ready barriers.
+        # Streamed TMEM P operands use one-way per-fragment ready barriers.
         # Initialize them beside correction's manually managed SMEM state.
         eager_init_resources.extend([smem_p0, smem_p1])
 
@@ -1855,10 +1855,10 @@ def _has_unmodeled_tmem_p_alias_protocol(cfg: FmhaDecodeConfig) -> bool:
     """Whether exhaustive TS checking would report a known false P/S race.
 
     The staged D256 path selects one of two physical P/S stages at runtime.
-    Static KV256 instead orders streamed P fragments with private mbarriers and
+    Static streamed profiles instead order P fragments with private mbarriers and
     reuses the matching TmemO-full barrier as the next-QK overwrite credit.
     Those intra-work protocols are below TaskManager's resource transitions,
-    so its allocation-level checker cannot prove them. Persistent KV256 has
+    so its allocation-level checker cannot prove them. Persistent streaming has
     enough task-level ordering for the checker and remains covered.
     """
     return cfg.uses_staged_one_inst_tmem_p or (

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_kernel.py
@@ -96,6 +96,7 @@ from .fmha_decode_tasks import (
     PackedDecodeWorkQueue,
     ScheduleTokenThrottleResource,
     SmemKvReuseCreditResource,
+    _prefetch_prepared_sparse_row,
     create_block_sparse_load_tasks_per_inst,
     create_correction_task,
     create_correction_task_one_inst_qkv,
@@ -343,6 +344,8 @@ def _build_decode_gen_schedule(
     sparse_row_route_offsets: cute.Pointer | None = None,
     sparse_row_route_counts: cute.Pointer | None = None,
     sparse_route_metadata: cute.Pointer | None = None,
+    sparse_row_route_begin: Int32 | None = None,
+    sparse_route_count: Int32 | None = None,
 ) -> tuple[
     list[Task],
     dict[MemoryResource, list[MemoryResource]],
@@ -1238,6 +1241,8 @@ def _build_decode_gen_schedule(
         "seq_len_q": seq_len_q,
         "sparse_row_route_offsets": sparse_row_route_offsets,
         "sparse_row_route_counts": sparse_row_route_counts,
+        "sparse_row_route_begin": sparse_row_route_begin,
+        "sparse_route_count": sparse_route_count,
         "num_heads_kv": num_heads_kv,
     }
     if use_one_inst_qkv:
@@ -2095,6 +2100,27 @@ def _run_decode_gen_active(
     if cutlass.const_expr(cfg.max_seq_len_q > 1):
         q_output_rows = g_h_r * Int32(cfg.max_seq_len_q)
 
+    # Static block-sparse tiles read their prepared row header here, before
+    # TMEM allocation and barrier setup, so that global-memory round trip is
+    # hidden instead of stalling every task at its first schedule step.
+    sparse_row_route_begin = None
+    sparse_route_count = None
+    if cutlass.const_expr(
+        cfg.use_block_sparse
+        and not cfg.use_persistent_scheduler
+        and g_sparse_row_route_offsets is not None
+        and g_sparse_row_route_counts is not None
+    ):
+        sparse_row_route_begin, sparse_route_count = _prefetch_prepared_sparse_row(
+            cfg,
+            g_sparse_row_route_offsets,
+            g_sparse_row_route_counts,
+            q_group_idx,
+            h_k_idx,
+            b_idx,
+            g_h_k,
+        )
+
     (
         task_list,
         dep_graph,
@@ -2145,6 +2171,8 @@ def _run_decode_gen_active(
         sparse_row_route_offsets=g_sparse_row_route_offsets,
         sparse_row_route_counts=g_sparse_row_route_counts,
         sparse_route_metadata=g_sparse_route_metadata,
+        sparse_row_route_begin=sparse_row_route_begin,
+        sparse_route_count=sparse_route_count,
     )
 
     smem_allocator.allocate()

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/helpers_softmax.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/helpers_softmax.py
@@ -72,6 +72,70 @@ def _pack_float4_to_fp8_e4m3_inline(
 
 
 @cute.jit
+def _combine_int_frac_ex2(
+    x_rounded: Float32, frac_ex2: Float32, *, loc=None, ip=None
+) -> Float32:
+    """Scale ``frac_ex2`` by ``2**floor(x)`` through the FP32 exponent bits.
+
+    ``x_rounded`` still carries the magic rounding constant, so its low
+    mantissa bits hold ``floor(x)``; shifting them into the exponent field and
+    adding the bits of the polynomial result multiplies by the integer power.
+    """
+    return cute.arch.inline_ptx(
+        "{\n"
+        "  .reg .b32 xi;\n"
+        "  .reg .b32 fi;\n"
+        "  .reg .b32 xe;\n"
+        "  .reg .b32 oi;\n"
+        "  mov.b32 xi, {$r0};\n"
+        "  mov.b32 fi, {$r1};\n"
+        "  shl.b32 xe, xi, 23;\n"
+        "  add.s32 oi, xe, fi;\n"
+        "  mov.b32 {$w0}, oi;\n"
+        "}",
+        write_only_types=[Float32],
+        read_only_args=[x_rounded, frac_ex2],
+        loc=loc,
+        ip=ip,
+    )
+
+
+@cute.jit
+def _ex2_emulation_packed_f32x2(x: Float32, y: Float32) -> tuple[Float32, Float32]:
+    """Evaluate ``2**x`` and ``2**y`` on the FMA pipe instead of MUFU.
+
+    Inputs are non-positive scaled scores minus the row maximum. The integer
+    part is split off with a magic-constant rounding add, the fraction in
+    [0, 1) goes through a degree-3 minimax polynomial, and the two parts are
+    recombined through the exponent bits. The relative error stays below the
+    BF16 rounding of the P operand, matching the emulation used by the dense
+    Blackwell FMHA kernels.
+    """
+    fp32_round_int = float(2**23 + 2**22)
+    xy_clamped = (cute.arch.fmax(x, -127.0), cute.arch.fmax(y, -127.0))
+    xy_rounded = cute.arch.add_packed_f32x2(
+        xy_clamped, (fp32_round_int, fp32_round_int), rnd="rm"
+    )
+    xy_rounded_back = cute.arch.sub_packed_f32x2(
+        xy_rounded, (fp32_round_int, fp32_round_int)
+    )
+    xy_frac = cute.arch.sub_packed_f32x2(xy_clamped, xy_rounded_back)
+    coeff = (
+        1.0,
+        0.695146143436431884765625,
+        0.227564394474029541015625,
+        0.077119089663028717041015625,
+    )
+    out = (coeff[3], coeff[3])
+    for degree in cutlass.range_constexpr(2, -1, -1):
+        out = cute.arch.fma_packed_f32x2(out, xy_frac, (coeff[degree], coeff[degree]))
+    return (
+        _combine_int_frac_ex2(xy_rounded[0], out[0]),
+        _combine_int_frac_ex2(xy_rounded[1], out[1]),
+    )
+
+
+@cute.jit
 def _compute_fp8_p_regs_and_local_sums(
     scale_softmax_log2: Float32,
     new_max_0: Float32,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_block_sparse_metadata.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_block_sparse_metadata.py
@@ -249,6 +249,18 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
             Int32(-1),
             "Metadata-relative record offset, or -1 for a dummy route.",
         ),
+        (
+            "prefetched_record_word_slot",
+            Int32,
+            Int32(0),
+            "Lane-owned record word loaded one resolution ahead.",
+        ),
+        (
+            "prefetched_record_offset_slot",
+            Int32,
+            Int32(-1),
+            "Record offset of the prefetched route, or -1 for a dummy route.",
+        ),
     )
     cfg: Constexpr[FmhaDecodeConfig] = None
     inst_id: Constexpr[int] = 0
@@ -268,6 +280,12 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         TaskLocalVariable.uninitialized()
     )
     route_record_word_offset_slot: Constexpr[TaskLocalVariable] = (
+        TaskLocalVariable.uninitialized()
+    )
+    prefetched_record_word_slot: Constexpr[TaskLocalVariable] = (
+        TaskLocalVariable.uninitialized()
+    )
+    prefetched_record_offset_slot: Constexpr[TaskLocalVariable] = (
         TaskLocalVariable.uninitialized()
     )
 
@@ -360,6 +378,78 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
             )
         return physical_page_id
 
+    @cute.jit
+    def _route_record_word_offset(
+        self, stage_info: StageInfo, route_idx: Int32
+    ) -> Int32:
+        """Return the record offset of one route index, or -1 past the row."""
+
+        task_cache = _decode_gen_task_cache(stage_info)
+        row_route_begin = _sparse_task_cache_route_begin(task_cache)
+        route_count = _sparse_task_cache_route_count(task_cache)
+        route_record_word_offset = Int32(-1)
+        if route_idx < route_count:
+            route_record_word_offset = (row_route_begin + route_idx) * Int32(
+                self.route_layout.route_metadata_stride_words
+            )
+        return cute.arch.make_warp_uniform(route_record_word_offset)
+
+    @consumer_work(
+        returns=(
+            prefetched_record_word_slot,
+            prefetched_record_offset_slot,
+        )
+    )
+    @cute.jit
+    def prefetch_route(
+        self, stage_info: StageInfo, *, target: Constexpr[str]
+    ) -> tuple[Int32, Int32]:
+        """Issue the record load for a route that ``resolve_route`` uses later.
+
+        ``target`` selects the route relative to the calling section:
+        ``"head"`` is this instance's HEAD route, ``"first_loop"`` the route of
+        LOOP iteration 0 (called from HEAD), ``"current_loop"`` the route of
+        the calling LOOP iteration (no pipelining), and ``"next_loop"`` the
+        route of the following LOOP iteration. Only the lane-distributed load is issued
+        here; the warp broadcasts happen in ``resolve_route`` so the global
+        memory latency overlaps the TMA issue of the current route instead of
+        stalling the load warp. Layouts without one-warp transport keep their
+        loads in ``resolve_route`` and get placeholder values here.
+        """
+
+        assert self.route_metadata is not None
+        num_insts = Int32(self.cfg.num_insts_kv)
+        if cutlass.const_expr(target == "head"):
+            route_idx = Int32(self.inst_id)
+        elif cutlass.const_expr(target == "first_loop"):
+            route_idx = num_insts + Int32(self.inst_id)
+        elif cutlass.const_expr(target == "current_loop"):
+            route_idx = (stage_info.loop_offset + Int32(1)) * num_insts + Int32(
+                self.inst_id
+            )
+        else:
+            route_idx = (stage_info.loop_offset + Int32(2)) * num_insts + Int32(
+                self.inst_id
+            )
+        route_record_word_offset = self._route_record_word_offset(stage_info, route_idx)
+        record_word = Int32(0)
+        if cutlass.const_expr(self.route_layout.uses_one_warp_transport):
+            assert self.route_layout.token_words_word_offset is not None
+            meaningful_words = (
+                self.route_layout.token_words_word_offset
+                + self.route_layout.token_words_per_route
+            )
+            lane_idx = cute.arch.thread_idx()[0] & Int32(0x1F)
+            if lane_idx < Int32(self.route_layout.logical_origins_per_route):
+                record_word = Int32(-1)
+            if route_record_word_offset >= Int32(0) and lane_idx < Int32(
+                meaningful_words
+            ):
+                record_word = Int32(
+                    self.route_metadata[route_record_word_offset + lane_idx]
+                )
+        return record_word, route_record_word_offset
+
     @consumer_work(
         returns=(
             resolved_record_word_slot,
@@ -370,14 +460,23 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
     )
     @cute.jit
     def resolve_route(
-        self, stage_info: StageInfo, *, section: Constexpr[FmhaStage]
+        self,
+        stage_info: StageInfo,
+        *,
+        section: Constexpr[FmhaStage],
+        prefetched_record_word_slot: Int32,
+        prefetched_record_offset_slot: Int32,
     ) -> tuple[Int32, Int32, Int32, Int32]:
-        """Load this resource instance's real or dummy prepared KV route."""
+        """Resolve this instance's real or dummy prepared KV route.
+
+        One-warp-transport layouts consume the words that ``prefetch_route``
+        loaded earlier; other layouts load their record here. The routed
+        inputs carry the task-local slot names so that every ``prefetch_route``
+        call, including the one at the end of the previous LOOP iteration,
+        updates the value read here.
+        """
 
         assert self.route_metadata is not None
-        task_cache = _decode_gen_task_cache(stage_info)
-        row_route_begin = _sparse_task_cache_route_begin(task_cache)
-        route_count = _sparse_task_cache_route_count(task_cache)
         # HEAD publishes one route per instruction. LOOP starts after those
         # two publications, hence the one-based loop offset below. Keeping the
         # constexpr branch local lets the task scheduler specialize each work
@@ -389,12 +488,12 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
                 self.cfg.num_insts_kv
             ) + Int32(self.inst_id)
         lane_idx = cute.arch.thread_idx()[0] & Int32(0x1F)
-        route_record_word_offset = Int32(-1)
-        if route_idx < route_count:
-            route_record_word_offset = (row_route_begin + route_idx) * Int32(
-                self.route_layout.route_metadata_stride_words
+        if cutlass.const_expr(self.route_layout.uses_one_warp_transport):
+            route_record_word_offset = prefetched_record_offset_slot
+        else:
+            route_record_word_offset = self._route_record_word_offset(
+                stage_info, route_idx
             )
-        route_record_word_offset = cute.arch.make_warp_uniform(route_record_word_offset)
 
         num_logical_origins = self.route_layout.logical_origins_per_route
         uses_two_fragment_route = num_logical_origins == 2
@@ -407,18 +506,7 @@ class SmemBlockSparseKvMetadataResource(DecodeGenResourceBase):
         route_record_is_valid = route_record_word_offset >= Int32(0)
 
         if cutlass.const_expr(self.route_layout.uses_one_warp_transport):
-            assert self.route_layout.token_words_word_offset is not None
-            meaningful_words = (
-                self.route_layout.token_words_word_offset
-                + self.route_layout.token_words_per_route
-            )
-            resolved_record_word = Int32(0)
-            if lane_idx < Int32(num_logical_origins):
-                resolved_record_word = Int32(-1)
-            if route_record_is_valid and lane_idx < Int32(meaningful_words):
-                resolved_record_word = Int32(
-                    self.route_metadata[route_record_word_offset + lane_idx]
-                )
+            resolved_record_word = prefetched_record_word_slot
             atom_valid_mask = _warp_broadcast_i32(
                 resolved_record_word,
                 self.route_layout.atom_valid_mask_word_offset,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_block_sparse_metadata.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_block_sparse_metadata.py
@@ -57,7 +57,6 @@ from .helpers_common import (
     DecodeGenResourceBase,
     ResourceVars,
     _decode_gen_task_cache,
-    _keeps_col_base,
     _sparse_task_cache_route_begin,
     _sparse_task_cache_route_count,
     _warp_broadcast_i32,
@@ -66,7 +65,9 @@ from .helpers_common import (
 
 # Keeps staging uses the low four bits for structural KV64 validity. Bit 4
 # carries the conservative prepared summary that token masking can be skipped;
-# structural, tail, and causal masking remain independent.
+# structural, tail, and causal masking remain independent. The streamed Keeps
+# max pass derives its keep words from the token words directly, so the bit is
+# currently staged for the consumer but not read.
 _SOFTMAX_TOKEN_MASK_IS_FULL_FLAG = 1 << 4
 # Keeps reserves bit 5 for the prepared route kind. The low four structural
 # validity bits and bit 4 keep their existing meaning.
@@ -1200,28 +1201,6 @@ class SmemBlockSparseSoftmaxMetadataResource(DecodeGenResourceBase):
                 )
                 token_word3 = Uint32(
                     self._smem_words[stage_base + token_base + word1_idx + Int32(1)]
-                )
-            elif cutlass.const_expr(self.cfg.tile_size_q == 64):
-                lane_idx = cute.arch.thread_idx()[0] & Int32(0x1F)
-                local_word_base = _keeps_col_base(
-                    self.cfg,
-                    lane_idx,
-                    self.cfg.num_s_regs_per_thread,
-                ) >> Int32(5)
-                token_word0 = Uint32(
-                    self._smem_words[
-                        stage_base
-                        + Int32(self.staging_layout.token_words_word_offset)
-                        + local_word_base
-                    ]
-                )
-                token_word1 = Uint32(
-                    self._smem_words[
-                        stage_base
-                        + Int32(self.staging_layout.token_words_word_offset)
-                        + local_word_base
-                        + Int32(1)
-                    ]
                 )
             else:
                 token_word0 = Uint32(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -86,19 +86,18 @@ from .helpers_softmax import (
 from .smem_block_sparse_metadata import _SOFTMAX_ROUTE_IS_PROXY_FLAG
 from .tmem_s import TmemSResource
 
-# Number of the 16 score pairs per streamed KV256 fragment whose exponentials
-# run as FMA polynomials instead of MUFU. The MUFU issue rate bounds the
-# fragment otherwise, while the FMA pipe is nearly idle in the softmax warps.
-# Larger shares grow the fragment body and the softmax warps become
-# instruction-fetch bound again, so one quarter is the measured optimum.
+# Tunable: number of score pairs per streamed fragment whose exponentials run
+# as FMA polynomials instead of MUFU. The MUFU issue rate bounds the fragment
+# otherwise, while the FMA pipe is nearly idle in the softmax warps. Larger
+# shares grow the fragment body and the softmax warps become instruction-fetch
+# bound again, so one quarter of the 16 pairs is the measured optimum.
 KV_TILE_256_EX2_EMULATED_PAIRS = 4
-_KV_TILE_256_PAIRS_PER_FRAGMENT = 16
 
 
-def _pair_uses_ex2_emulation(pair_idx: int) -> bool:
-    """Spread the emulated pairs evenly across a fragment's 16 pairs."""
+def _pair_uses_ex2_emulation(pair_idx: int, pairs_per_fragment: int) -> bool:
+    """Spread the emulated pairs evenly across a fragment's score pairs."""
     count = KV_TILE_256_EX2_EMULATED_PAIRS
-    pairs = _KV_TILE_256_PAIRS_PER_FRAGMENT
+    pairs = pairs_per_fragment
     return ((pair_idx + 1) * count) // pairs != (pair_idx * count) // pairs
 
 
@@ -341,189 +340,6 @@ class SmemPResource(DecodeGenResourceBase):
                 local_sum += Float32(tail_delta) * tail_p
         return local_sum
 
-    @cute.jit
-    def _compute_p_fragment_impl(
-        self,
-        stage_info: StageInfo,
-        *,
-        fragment_idx: Constexpr[int],
-        new_max_arr: cutlass.Array,
-        s_arr: cutlass.Array,
-        route_is_proxy: Int32,
-        route_origin0: Int32,
-        route_origin1: Int32,
-    ) -> None:
-        """Convert one KV256 K32 score fragment into its selected P storage."""
-        cfg = self.cfg
-        assert cfg.streams_tmem_p_fragments
-        assert not cfg.use_fp8_qkv
-        assert cfg.softmax_score_fragment_regs == 32
-
-        new_max = new_max_arr[0]
-        safe_new_max = new_max
-        if safe_new_max == _neg_max_f32():
-            safe_new_max = Float32(0.0)
-        minus_max_scale = Float32(-self.scale_softmax_log2 * safe_new_max)
-
-        # Eight independent chains keep the denominator update off one long
-        # dependency chain. Reuse s_arr for probabilities so only one K32 score
-        # fragment remains live while P is packed.
-        sum_chains = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
-        for chain_idx in cutlass.range_constexpr(8):
-            sum_chains[chain_idx] = Float32(0.0)
-        for pair_idx in cutlass.range_constexpr(16):
-            value_idx = pair_idx * 2
-            p0, p1 = cute.arch.fma_packed_f32x2(
-                (Float32(s_arr[value_idx]), Float32(s_arr[value_idx + 1])),
-                (self.scale_softmax_log2, self.scale_softmax_log2),
-                (minus_max_scale, minus_max_scale),
-            )
-            # This body is instantiated once per fragment and instance, so the
-            # FMA-pipe exponential is left to the rolled fragment loop: here its
-            # extra instructions would be replicated and the softmax warps
-            # become instruction-fetch bound.
-            p0 = Float32(cute.math.exp2(p0, fastmath=True))
-            p1 = Float32(cute.math.exp2(p1, fastmath=True))
-            s_arr[value_idx] = p0
-            s_arr[value_idx + 1] = p1
-            chain_idx = (pair_idx & 3) * 2
-            sum_chains[chain_idx], sum_chains[chain_idx + 1] = (
-                cute.arch.add_packed_f32x2(
-                    (sum_chains[chain_idx], sum_chains[chain_idx + 1]),
-                    (p0, p1),
-                )
-            )
-
-        # Collapse the eight reduction chains before packing P and publishing
-        # its barrier. This keeps only one sum scalar live across STTM instead
-        # of overlapping the full reduction state with packed P and addresses.
-        sum01 = cute.arch.add_packed_f32x2(
-            (sum_chains[0], sum_chains[1]),
-            (sum_chains[2], sum_chains[3]),
-        )
-        sum23 = cute.arch.add_packed_f32x2(
-            (sum_chains[4], sum_chains[5]),
-            (sum_chains[6], sum_chains[7]),
-        )
-        total_pair = cute.arch.add_packed_f32x2(sum01, sum23)
-        local_sum = Float32(total_pair[0] + total_pair[1])
-
-        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
-            if route_is_proxy != Int32(0):
-                # KC stores one mean K vector per semantic KV block while VC
-                # stores its V sum. Keep P itself unweighted for PV, and
-                # account for represented token mass only in the denominator.
-                num_summaries, tail_len = _block_sparse_proxy_summary_geometry(
-                    cfg.static_seq_len_kv,
-                    cfg.kv_block_size,
-                )
-                local_sum *= Float32(cfg.kv_block_size)
-                final_summary_idx = num_summaries - 1
-                tail_delta = tail_len - cfg.kv_block_size
-                if cutlass.const_expr(tail_delta != 0):
-                    fragment_origin = Int32(route_origin0)
-                    if cutlass.const_expr(fragment_idx >= 2):
-                        fragment_origin = Int32(route_origin1)
-                    fragment_origin += Int32((fragment_idx % 2) * 32)
-                    final_summary_offset = Int32(final_summary_idx) - fragment_origin
-                    if final_summary_offset >= Int32(
-                        0
-                    ) and final_summary_offset < Int32(32):
-                        # Proxy fragment origins are K32-aligned in summary
-                        # coordinates, so the tail's in-fragment lane is a
-                        # compile-time constant even though route ownership is
-                        # decided at runtime.  Keeping this index fixed avoids
-                        # materializing the whole FP32 probability array in
-                        # local memory.
-                        tail_lane = final_summary_idx % 32
-                        local_sum += Float32(tail_delta) * Float32(s_arr[tail_lane])
-
-        packed_p = (
-            s_arr.data_ptr().load(count=32, alignment=4).to(cfg.q_dtype).bitcast(Int32)
-        )
-        fragment_cols = cfg.softmax_score_fragment_regs // 2
-        p_tmem_addr = (
-            self._tmem_base_addr
-            + Int32(self._tmem_alloc.offset)
-            + Int32(fragment_idx * fragment_cols)
-        )
-        _keeps_tcgen05_st(
-            cfg,
-            prims.make_tmem_ptr(p_tmem_addr, Int32),
-            packed_p,
-            offset=cfg.tmem_p_cols_per_inst,
-        )
-        # This lowers to the warp-collective tcgen05.wait::st. The explicit
-        # proxy fence then makes every lane's completed STTM visible through
-        # the lane-0 mbarrier publication consumed by the MMA warp.
-        cute.arch.fence_view_async_tmem_store()
-        prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
-
-        if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-            # Streamed KV256 aliases P with the score tile that produced it.
-            # Each softmax warp publishes its rows after the TMEM store drains.
-            tidx, _, _ = cute.arch.thread_idx()
-            if (tidx & Int32(31)) == Int32(0):
-                prims.mbarrier_arrive(
-                    self._fragment_ready.data_ptr() + Int32(fragment_idx)
-                )
-
-        if cutlass.const_expr(fragment_idx != 0):
-            local_sum += self.tmem_s_ref.load_p_local_sum(0)
-        self.tmem_s_ref.store_p_local_sum(0, local_sum)
-
-    # Task Scheduling treats every non-constexpr work argument as required.
-    # Keep the established exact-only ABI separate from the proxy route
-    # transport while sharing the generated P implementation.
-    @producer_work
-    @cute.jit
-    def compute_p_fragment(
-        self,
-        stage_info: StageInfo,
-        *,
-        fragment_idx: Constexpr[int],
-        new_max_arr: cutlass.Array,
-        s_arr: cutlass.Array,
-    ) -> None:
-        """Convert one ordinary KV256 K32 score fragment into its TMEM P slice."""
-        self._compute_p_fragment_impl(
-            stage_info,
-            fragment_idx=fragment_idx,
-            new_max_arr=new_max_arr,
-            s_arr=s_arr,
-            route_is_proxy=Int32(0),
-            route_origin0=Int32(0),
-            route_origin1=Int32(0),
-        )
-
-    @producer_work
-    @cute.jit
-    def compute_proxy_route_p_fragment(
-        self,
-        stage_info: StageInfo,
-        *,
-        fragment_idx: Constexpr[int],
-        new_max_arr: cutlass.Array,
-        s_arr: cutlass.Array,
-        route_flags: Int32,
-        route_origin0: Int32,
-        route_origin1: Int32,
-    ) -> None:
-        """Convert one proxy-capable fragment with conditional proxy weighting."""
-        assert self.cfg.use_block_sparse_proxy_routes
-        route_is_proxy = Int32(
-            (route_flags & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Int32(0)
-        )
-        self._compute_p_fragment_impl(
-            stage_info,
-            fragment_idx=fragment_idx,
-            new_max_arr=new_max_arr,
-            s_arr=s_arr,
-            route_is_proxy=route_is_proxy,
-            route_origin0=route_origin0,
-            route_origin1=route_origin1,
-        )
-
     @producer_work
     @cute.jit
     def compute_p_fragments(
@@ -577,19 +393,21 @@ class SmemPResource(DecodeGenResourceBase):
     ) -> None:
         """Reload, exponentiate, and publish all K32 fragments in a rolled loop.
 
-        The unrolled per-fragment path replicates the exponentiation body for
-        every fragment and both softmax instances, which makes the softmax warps
-        instruction-fetch bound. Here the fragment index is a runtime loop
-        variable, so the body exists once and only the TMEM column offset, the
-        fragment barrier, and the proxy tail bookkeeping depend on it. The max
-        pass has already written masked scores back to TMEM, so the reload
-        needs no mask logic of its own.
+        The fragment index is a runtime loop variable, so the exponentiation
+        body exists once in the instruction stream and only the TMEM column
+        offset, the fragment barrier, and the proxy tail bookkeeping depend on
+        it. Unrolling the fragments would replicate that body for every
+        fragment and both softmax instances and leave the softmax warps
+        instruction-fetch bound. The max pass has already written masked
+        scores back to TMEM, so the reload needs no mask logic of its own.
         """
         _ = stage_info
         cfg = self.cfg
-        assert cfg.loops_softmax_p_fragments
-        assert cfg.softmax_score_fragment_regs == 32
+        assert cfg.streams_tmem_p_fragments
         assert self._tmem_alloc.offset == self.tmem_s_ref._alloc.offset
+        # One FP32 score per column, two packed 16-bit probabilities per column.
+        fragment_regs = cfg.softmax_score_fragment_regs
+        fragment_cols = fragment_regs // 2
 
         new_max = new_max_arr[0]
         safe_new_max = new_max
@@ -597,7 +415,6 @@ class SmemPResource(DecodeGenResourceBase):
             safe_new_max = Float32(0.0)
         minus_max_scale = Float32(-self.scale_softmax_log2 * safe_new_max)
         tmem_base = self._tmem_base_addr + Int32(self._tmem_alloc.offset)
-        fragment_cols = cfg.softmax_score_fragment_regs // 2
         tidx, _, _ = cute.arch.thread_idx()
         publishes_fragment = (tidx & Int32(31)) == Int32(0)
 
@@ -606,13 +423,17 @@ class SmemPResource(DecodeGenResourceBase):
             fragment = Int32(fragment_idx)
             loaded = _keeps_tcgen05_ld(
                 cfg,
-                prims.make_tmem_ptr(tmem_base + fragment * Int32(32), Float32),
-                num=32,
+                prims.make_tmem_ptr(
+                    tmem_base + fragment * Int32(fragment_regs), Float32
+                ),
+                num=fragment_regs,
                 offset=cfg.tile_size_kv // 2,
             )
             prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
-            s_arr = cutlass.Array(Float32, 32, space=cutlass.AddressSpace.rmem)
-            for score_idx in cutlass.range_constexpr(32):
+            s_arr = cutlass.Array(
+                Float32, fragment_regs, space=cutlass.AddressSpace.rmem
+            )
+            for score_idx in cutlass.range_constexpr(fragment_regs):
                 s_arr[score_idx] = loaded[score_idx]
 
             local_sum = self._exponentiate_fragment_pairs(s_arr, minus_max_scale)
@@ -628,7 +449,7 @@ class SmemPResource(DecodeGenResourceBase):
 
             packed_p = (
                 s_arr.data_ptr()
-                .load(count=32, alignment=4)
+                .load(count=fragment_regs, alignment=4)
                 .to(cfg.q_dtype)
                 .bitcast(Int32)
             )
@@ -649,11 +470,22 @@ class SmemPResource(DecodeGenResourceBase):
     def _runtime_fragment_origin(
         self, fragment: Int32, route_origin0: Int32, route_origin1: Int32
     ) -> Int32:
-        """Return the K32 origin of a fragment selected at runtime."""
+        """Return the token origin of a fragment selected at runtime.
+
+        Each lane's fragments cover two KV blocks in order: the first block's
+        fragments start at ``route_origin0``, the second block's at
+        ``route_origin1``, and consecutive fragments within a block advance by
+        one fragment width.
+        """
+        cfg = self.cfg
+        fragment_regs = cfg.softmax_score_fragment_regs
+        fragments_per_block = cfg.kv_block_size // fragment_regs
         fragment_origin = Int32(route_origin0)
-        if fragment >= Int32(2):
+        if fragment >= Int32(fragments_per_block):
             fragment_origin = Int32(route_origin1)
-        return fragment_origin + (fragment & Int32(1)) * Int32(32)
+        return fragment_origin + (fragment % Int32(fragments_per_block)) * Int32(
+            fragment_regs
+        )
 
     @cute.jit
     def _exponentiate_fragment_pairs(
@@ -665,17 +497,20 @@ class SmemPResource(DecodeGenResourceBase):
         the denominator update off one long dependency chain, and a configurable
         subset of pairs runs its exponentials on the FMA pipe.
         """
+        pairs_per_fragment = self.cfg.softmax_score_fragment_regs // 2
         sum_chains = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
         for chain_idx in cutlass.range_constexpr(8):
             sum_chains[chain_idx] = Float32(0.0)
-        for pair_idx in cutlass.range_constexpr(16):
+        for pair_idx in cutlass.range_constexpr(pairs_per_fragment):
             value_idx = pair_idx * 2
             p0, p1 = cute.arch.fma_packed_f32x2(
                 (Float32(s_arr[value_idx]), Float32(s_arr[value_idx + 1])),
                 (self.scale_softmax_log2, self.scale_softmax_log2),
                 (minus_max_scale, minus_max_scale),
             )
-            if cutlass.const_expr(_pair_uses_ex2_emulation(pair_idx)):
+            if cutlass.const_expr(
+                _pair_uses_ex2_emulation(pair_idx, pairs_per_fragment)
+            ):
                 p0, p1 = _ex2_emulation_packed_f32x2(p0, p1)
             else:
                 p0 = Float32(cute.math.exp2(p0, fastmath=True))
@@ -716,6 +551,7 @@ class SmemPResource(DecodeGenResourceBase):
         shorter tail block.
         """
         cfg = self.cfg
+        fragment_regs = cfg.softmax_score_fragment_regs
         num_summaries, tail_len = _block_sparse_proxy_summary_geometry(
             cfg.static_seq_len_kv,
             cfg.kv_block_size,
@@ -725,11 +561,13 @@ class SmemPResource(DecodeGenResourceBase):
         if cutlass.const_expr(tail_delta != 0):
             final_summary_idx = num_summaries - 1
             final_summary_offset = Int32(final_summary_idx) - fragment_origin
-            if final_summary_offset >= Int32(0) and final_summary_offset < Int32(32):
-                # Proxy fragment origins are K32-aligned in summary coordinates,
-                # so the tail's in-fragment lane is a compile-time constant even
-                # though route ownership is decided at runtime.
-                tail_lane = final_summary_idx % 32
+            if final_summary_offset >= Int32(0) and final_summary_offset < Int32(
+                fragment_regs
+            ):
+                # Proxy fragment origins are fragment-aligned in summary
+                # coordinates, so the tail's in-fragment lane is a compile-time
+                # constant even though route ownership is decided at runtime.
+                tail_lane = final_summary_idx % fragment_regs
                 local_sum += Float32(tail_delta) * Float32(s_arr[tail_lane])
         return local_sum
 
@@ -752,7 +590,7 @@ class SmemPResource(DecodeGenResourceBase):
         BMM2.
         """
         cfg = self.cfg
-        # KV256 uses compute_p_fragment so only one K32 score fragment is live.
+        # KV256 streams K32 fragments through the rolled fragment loop instead.
         assert not cfg.streams_tmem_p_fragments
         task_cache = _decode_gen_task_cache(stage_info)
         warp_grp_thread_idx = task_cache[_TASK_CACHE_WARP_GRP_THREAD_IDX]
@@ -1690,25 +1528,3 @@ class SmemPResource(DecodeGenResourceBase):
             self._tmem_alloc.offset + fragment_idx * fragment_cols
         )
         return p_tmem_addr
-
-    @consumer_work(work_attrs=WorkAttr.AUXILIARY)
-    @cute.jit
-    def wait_until_reusable_before_qk(self, stage_info: StageInfo) -> None:
-        """Wait until the previous same-instance PV has stopped reading P.
-
-        KV256 aliases each streamed P instance with its next S accumulator.
-        The existing two-stage O pipeline commits stage ``inst_id`` only when
-        the matching PV completes, so its full barrier is also the P-reuse
-        credit. The S producer phase supplies the generation: the first QK
-        waits on the initially complete opposite parity, and every later QK
-        waits for the preceding PV without another commit or barrier.
-        """
-        _ = stage_info
-        cfg = self.cfg
-        assert cfg.streams_tmem_p_fragments
-        assert cfg.o_stages == cfg.num_insts_kv == 2
-        barrier = self.tmem_o_ref.pipeline.sync_object_full.get_barrier(
-            Int32(self.inst_id)
-        )
-        _wait_for_mbarrier_phase(barrier, self.tmem_s_ref.producer_state.phase)
-        prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC)

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -42,10 +42,7 @@ from cutlass.experimental.task_scheduling.resources import (
 )
 
 from ..fmha_decode_config import FmhaDecodeConfig
-from ...._block_sparse.common import (
-    _block_sparse_kv_atom_size,
-    _block_sparse_proxy_summary_geometry,
-)
+from ...._block_sparse.common import _block_sparse_proxy_summary_geometry
 from ...placeholder_helpers import _placeholder_smem_array
 from .helpers_common import (
     Constexpr,
@@ -110,7 +107,7 @@ class SmemPResource(DecodeGenResourceBase):
 
     Softmax producers convert S to P, store it in the profile's TMEM or SMEM
     layout, and publish local sums back to TmemS. Most profiles use the generic
-    full/empty P pipeline. KV256 instead publishes four independently ready
+    full/empty P pipeline. Streamed profiles instead publish four independently ready
     K32 TMEM fragments; BMM2 consumes those fragments in order, while the
     matching TmemO full barrier prevents the next QK from overwriting aliased P.
     """
@@ -174,7 +171,7 @@ class SmemPResource(DecodeGenResourceBase):
         )
 
     def get_smem_requirements(self) -> list[SmemAllocation]:
-        """Allocate P storage or the KV256 fragment-ready barriers."""
+        """Allocate P storage or the streamed fragment-ready barriers."""
         if self.cfg.streams_tmem_p_fragments:
             if self._fragment_ready_alloc is None:
                 self._fragment_ready_alloc = SmemAllocation(
@@ -195,7 +192,7 @@ class SmemPResource(DecodeGenResourceBase):
 
     @cute.jit
     def _bind_fragment_ready(self, context: ResourceContext | None = None) -> None:
-        """Bind the one-way KV256 P-ready barriers from the SMEM context."""
+        """Bind the one-way streamed P-ready barriers from the SMEM context."""
         if cutlass.const_expr(
             self.cfg.streams_tmem_p_fragments
             and context is not None
@@ -213,7 +210,7 @@ class SmemPResource(DecodeGenResourceBase):
     def create_function_variables(
         self, context: ResourceContext | None = None
     ) -> ResourceVars:
-        """Bind and initialize KV256's per-fragment ready barriers."""
+        """Bind and initialize the streamed per-fragment ready barriers."""
         self._bind_fragment_ready(context)
         if cutlass.const_expr(self.cfg.streams_tmem_p_fragments):
             tidx, _, _ = cute.arch.thread_idx()
@@ -351,7 +348,7 @@ class SmemPResource(DecodeGenResourceBase):
         *,
         new_max_arr: cutlass.Array,
     ) -> None:
-        """Stream every ordinary KV256 K32 fragment from one rolled loop."""
+        """Stream every ordinary K32 fragment from one rolled loop."""
         self._compute_p_fragments_impl(
             stage_info,
             new_max_arr=new_max_arr,
@@ -482,9 +479,7 @@ class SmemPResource(DecodeGenResourceBase):
         """
         cfg = self.cfg
         fragment_regs = cfg.softmax_score_fragment_regs
-        fragments_per_origin = (
-            _block_sparse_kv_atom_size(cfg.kv_block_size) // fragment_regs
-        )
+        fragments_per_origin = cfg.softmax_fragments_per_route_atom
         fragment_origin = Int32(route_origin0)
         if fragment >= Int32(fragments_per_origin):
             fragment_origin = Int32(route_origin1)
@@ -583,20 +578,19 @@ class SmemPResource(DecodeGenResourceBase):
         *,
         new_max_arr: cutlass.Array,
         s_arr: cutlass.Array,
-        route_is_proxy: Int32,
-        route_origin0: Int32,
-        route_origin1: Int32,
     ) -> None:
-        """Materialize one non-KV256 row-major Keeps probability tile.
+        """Materialize one complete-row Keeps probability tile.
 
         TQ128 gives each warp-group thread a complete 128-column row. TQ64
         gives paired lanes the low/high 64-column halves of one row. Each lane
         writes disjoint packed blocks into the TMEM or SMEM layout consumed by
-        BMM2.
+        BMM2. Streamed profiles, including every block-sparse Keeps profile,
+        produce P through the rolled fragment loop instead.
         """
         cfg = self.cfg
-        # KV256 streams K32 fragments through the rolled fragment loop instead.
-        assert not cfg.streams_tmem_p_fragments
+        # Every block-sparse Keeps profile streams P; only dense complete rows
+        # reach this path.
+        assert not cfg.streams_tmem_p_fragments and not cfg.use_block_sparse
         task_cache = _decode_gen_task_cache(stage_info)
         warp_grp_thread_idx = task_cache[_TASK_CACHE_WARP_GRP_THREAD_IDX]
         lane_idx = task_cache[_TASK_CACHE_LANE_IDX]
@@ -625,8 +619,6 @@ class SmemPResource(DecodeGenResourceBase):
         # without keeping a second 16-value P array live beside the S row.
         local_sum_pair_01 = (Float32(0.0), Float32(0.0))
         local_sum_pair_23 = (Float32(0.0), Float32(0.0))
-        proxy_tail_p = Float32(0.0)
-
         # Each vector block is exactly 16 bytes after conversion. Compute and
         # pack adjacent pairs directly into their final register payload.
         packed_p_regs = cfg.num_packed_p_regs if cfg.uses_two_inst_tmem_p else 4
@@ -686,29 +678,6 @@ class SmemPResource(DecodeGenResourceBase):
                         cute.math.exp2(scaled_pair[0], fastmath=True),
                         cute.math.exp2(scaled_pair[1], fastmath=True),
                     )
-                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
-                        num_summaries, _ = _block_sparse_proxy_summary_geometry(
-                            cfg.static_seq_len_kv,
-                            cfg.kv_block_size,
-                        )
-                        final_summary_idx = num_summaries - 1
-                        for pair_element in cutlass.range_constexpr(2):
-                            reg_idx = s_base + val_base + pair_element
-                            summary_origin = route_origin0
-                            summary_offset = Int32(reg_idx)
-                            if cutlass.const_expr(
-                                cfg.tile_size_q == 128 and reg_idx >= 64
-                            ):
-                                summary_origin = route_origin1
-                                summary_offset = Int32(reg_idx - 64)
-                            elif cutlass.const_expr(cfg.tile_size_q == 64):
-                                if col_base >= Int32(64):
-                                    summary_origin = route_origin1
-                            logical_summary = summary_origin + summary_offset
-                            if summary_origin >= Int32(0) and logical_summary == Int32(
-                                final_summary_idx
-                            ):
-                                proxy_tail_p = Float32(p_pair[pair_element])
                     if cutlass.const_expr(packed_idx % 2 == 0):
                         local_sum_pair_01 = fadd2(local_sum_pair_01, p_pair)
                     else:
@@ -748,28 +717,17 @@ class SmemPResource(DecodeGenResourceBase):
                     packed_p.data_ptr().load(count=4, alignment=4), alignment=16
                 )
         if cutlass.const_expr(cfg.uses_two_inst_tmem_p):
-            # FP8 publishes a complete row with one x16/x32 STTM. FP16/BF16
-            # uses x16 slices to limit Softmax register pressure. This is the
-            # complete-row Q128/KV128 path; KV256 publishes K32 fragments.
-            assert cfg.num_packed_p_regs in (16, 32, 64)
-            regs_per_store = cfg.num_packed_p_regs if cfg.use_fp8_qkv else 16
-            assert cfg.num_packed_p_regs % regs_per_store == 0
-            for store_idx in cutlass.range_constexpr(
-                cfg.num_packed_p_regs // regs_per_store
-            ):
-                packed_offset = store_idx * regs_per_store
-                _keeps_tcgen05_st(
-                    cfg,
-                    prims.make_tmem_ptr(
-                        p_tmem_stage_base + Int32(packed_offset), Int32
-                    ),
-                    (packed_p.data_ptr() + packed_offset).load(
-                        count=regs_per_store, alignment=4
-                    ),
-                    # Separate the paired Softmax destinations by one packed
-                    # row (the half-row split for x16/x32 TMEM layouts).
-                    offset=cfg.num_packed_p_regs,
-                )
+            # FP8 Q128/KV128 publishes the complete packed row with one x32
+            # STTM; 16-bit two-instance profiles stream K32 fragments instead.
+            assert cfg.use_fp8_qkv and cfg.num_packed_p_regs == 32
+            _keeps_tcgen05_st(
+                cfg,
+                prims.make_tmem_ptr(p_tmem_stage_base, Int32),
+                packed_p.data_ptr().load(count=cfg.num_packed_p_regs, alignment=4),
+                # Separate the paired Softmax destinations by one packed row
+                # (the half-row split for x16/x32 TMEM layouts).
+                offset=cfg.num_packed_p_regs,
+            )
             if cutlass.const_expr(cfg.ordered_softmax_early_release):
                 # Hand the baton over as soon as this group's TMEM store has
                 # issued: the partner's exp2/pack/TMEM store touch only its own
@@ -783,11 +741,6 @@ class SmemPResource(DecodeGenResourceBase):
                 )
         local_sum_pair0 = fadd2(local_sum_pair_01, local_sum_pair_23)
         local_sum = local_sum_pair0[0] + local_sum_pair0[1]
-        local_sum = self._apply_proxy_route_denominator_mass(
-            local_sum,
-            proxy_tail_p,
-            route_is_proxy,
-        )
         self.tmem_s_ref.store_p_local_sum(0, local_sum)
 
         # Publish the selected memory view before the task-level P pipeline
@@ -826,9 +779,6 @@ class SmemPResource(DecodeGenResourceBase):
                 stage_info,
                 new_max_arr=new_max_arr,
                 s_arr=s_arr,
-                route_is_proxy=route_is_proxy,
-                route_origin0=route_origin0,
-                route_origin1=route_origin1,
             )
             return
         # ProdWork: transform the softmax S registers into the P operand layout
@@ -1484,7 +1434,7 @@ class SmemPResource(DecodeGenResourceBase):
             # stats-free columns of the corresponding S stage.
             p_stage_cols = cfg.tmem_s_cols
             if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-                # KV256's four pipeline stages are K32 fragments of one P
+                # A streamed profile's four pipeline stages are K32 fragments of one P
                 # operand, not four independent full S/P stages.
                 p_stage_cols = cfg.softmax_score_fragment_regs // 2
             p_tmem_addr = self._tmem_base_addr + Int32(
@@ -1518,7 +1468,7 @@ class SmemPResource(DecodeGenResourceBase):
         *,
         fragment_idx: Constexpr[int],
     ) -> Int32:
-        """Wait for and return the next KV256 P-fragment TMEM address."""
+        """Wait for and return the next streamed P-fragment TMEM address."""
         cfg = self.cfg
         _ = stage_info
         assert cfg.streams_tmem_p_fragments

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -42,7 +42,10 @@ from cutlass.experimental.task_scheduling.resources import (
 )
 
 from ..fmha_decode_config import FmhaDecodeConfig
-from ...._block_sparse.common import _block_sparse_proxy_summary_geometry
+from ...._block_sparse.common import (
+    _block_sparse_kv_atom_size,
+    _block_sparse_proxy_summary_geometry,
+)
 from ...placeholder_helpers import _placeholder_smem_array
 from .helpers_common import (
     Constexpr,
@@ -472,18 +475,20 @@ class SmemPResource(DecodeGenResourceBase):
     ) -> Int32:
         """Return the token origin of a fragment selected at runtime.
 
-        Each lane's fragments cover two KV blocks in order: the first block's
-        fragments start at ``route_origin0``, the second block's at
-        ``route_origin1``, and consecutive fragments within a block advance by
+        Each lane's fragments cover two K64 route atoms in order: the first
+        atom's fragments start at ``route_origin0``, the second atom's at
+        ``route_origin1``, and consecutive fragments within an atom advance by
         one fragment width.
         """
         cfg = self.cfg
         fragment_regs = cfg.softmax_score_fragment_regs
-        fragments_per_block = cfg.kv_block_size // fragment_regs
+        fragments_per_origin = (
+            _block_sparse_kv_atom_size(cfg.kv_block_size) // fragment_regs
+        )
         fragment_origin = Int32(route_origin0)
-        if fragment >= Int32(fragments_per_block):
+        if fragment >= Int32(fragments_per_origin):
             fragment_origin = Int32(route_origin1)
-        return fragment_origin + (fragment % Int32(fragments_per_block)) * Int32(
+        return fragment_origin + (fragment % Int32(fragments_per_origin)) * Int32(
             fragment_regs
         )
 

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -59,6 +59,7 @@ from .helpers_common import (
     _is_last_loop_iteration,
     _keeps_col_base,
     _keeps_row_idx,
+    _keeps_tcgen05_ld,
     _keeps_tcgen05_st,
     _named_barrier_arrive,
     _neg_max_f32,
@@ -78,11 +79,27 @@ from .helpers_softmax import (
     _compute_fp8_p_regs_and_local_sums,
     _compute_fp8_p_regs_and_local_sums_dense,
     _compute_p_values_and_local_sums_dense,
+    _ex2_emulation_packed_f32x2,
     _pack_float4_to_fp8_e4m3,
     _pack_float4_to_fp8_e4m3_inline,
 )
 from .smem_block_sparse_metadata import _SOFTMAX_ROUTE_IS_PROXY_FLAG
 from .tmem_s import TmemSResource
+
+# Number of the 16 score pairs per streamed KV256 fragment whose exponentials
+# run as FMA polynomials instead of MUFU. The MUFU issue rate bounds the
+# fragment otherwise, while the FMA pipe is nearly idle in the softmax warps.
+# Larger shares grow the fragment body and the softmax warps become
+# instruction-fetch bound again, so one quarter is the measured optimum.
+KV_TILE_256_EX2_EMULATED_PAIRS = 4
+_KV_TILE_256_PAIRS_PER_FRAGMENT = 16
+
+
+def _pair_uses_ex2_emulation(pair_idx: int) -> bool:
+    """Spread the emulated pairs evenly across a fragment's 16 pairs."""
+    count = KV_TILE_256_EX2_EMULATED_PAIRS
+    pairs = _KV_TILE_256_PAIRS_PER_FRAGMENT
+    return ((pair_idx + 1) * count) // pairs != (pair_idx * count) // pairs
 
 
 @dataclass(kw_only=True)
@@ -361,6 +378,10 @@ class SmemPResource(DecodeGenResourceBase):
                 (self.scale_softmax_log2, self.scale_softmax_log2),
                 (minus_max_scale, minus_max_scale),
             )
+            # This body is instantiated once per fragment and instance, so the
+            # FMA-pipe exponential is left to the rolled fragment loop: here its
+            # extra instructions would be replicated and the softmax warps
+            # become instruction-fetch bound.
             p0 = Float32(cute.math.exp2(p0, fastmath=True))
             p1 = Float32(cute.math.exp2(p1, fastmath=True))
             s_arr[value_idx] = p0
@@ -502,6 +523,215 @@ class SmemPResource(DecodeGenResourceBase):
             route_origin0=route_origin0,
             route_origin1=route_origin1,
         )
+
+    @producer_work
+    @cute.jit
+    def compute_p_fragments(
+        self,
+        stage_info: StageInfo,
+        *,
+        new_max_arr: cutlass.Array,
+    ) -> None:
+        """Stream every ordinary KV256 K32 fragment from one rolled loop."""
+        self._compute_p_fragments_impl(
+            stage_info,
+            new_max_arr=new_max_arr,
+            route_is_proxy=Int32(0),
+            route_origin0=Int32(0),
+            route_origin1=Int32(0),
+        )
+
+    @producer_work
+    @cute.jit
+    def compute_proxy_route_p_fragments(
+        self,
+        stage_info: StageInfo,
+        *,
+        new_max_arr: cutlass.Array,
+        route_flags: Int32,
+        route_origin0: Int32,
+        route_origin1: Int32,
+    ) -> None:
+        """Stream every proxy-capable KV256 K32 fragment from one rolled loop."""
+        assert self.cfg.use_block_sparse_proxy_routes
+        route_is_proxy = Int32(
+            (route_flags & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Int32(0)
+        )
+        self._compute_p_fragments_impl(
+            stage_info,
+            new_max_arr=new_max_arr,
+            route_is_proxy=route_is_proxy,
+            route_origin0=route_origin0,
+            route_origin1=route_origin1,
+        )
+
+    @cute.jit
+    def _compute_p_fragments_impl(
+        self,
+        stage_info: StageInfo,
+        *,
+        new_max_arr: cutlass.Array,
+        route_is_proxy: Int32,
+        route_origin0: Int32,
+        route_origin1: Int32,
+    ) -> None:
+        """Reload, exponentiate, and publish all K32 fragments in a rolled loop.
+
+        The unrolled per-fragment path replicates the exponentiation body for
+        every fragment and both softmax instances, which makes the softmax warps
+        instruction-fetch bound. Here the fragment index is a runtime loop
+        variable, so the body exists once and only the TMEM column offset, the
+        fragment barrier, and the proxy tail bookkeeping depend on it. The max
+        pass has already written masked scores back to TMEM, so the reload
+        needs no mask logic of its own.
+        """
+        _ = stage_info
+        cfg = self.cfg
+        assert cfg.loops_softmax_p_fragments
+        assert cfg.softmax_score_fragment_regs == 32
+        assert self._tmem_alloc.offset == self.tmem_s_ref._alloc.offset
+
+        new_max = new_max_arr[0]
+        safe_new_max = new_max
+        if safe_new_max == _neg_max_f32():
+            safe_new_max = Float32(0.0)
+        minus_max_scale = Float32(-self.scale_softmax_log2 * safe_new_max)
+        tmem_base = self._tmem_base_addr + Int32(self._tmem_alloc.offset)
+        fragment_cols = cfg.softmax_score_fragment_regs // 2
+        tidx, _, _ = cute.arch.thread_idx()
+        publishes_fragment = (tidx & Int32(31)) == Int32(0)
+
+        total_sum = Float32(0.0)
+        for fragment_idx in cutlass.range(cfg.num_softmax_score_fragments, unroll=1):
+            fragment = Int32(fragment_idx)
+            loaded = _keeps_tcgen05_ld(
+                cfg,
+                prims.make_tmem_ptr(tmem_base + fragment * Int32(32), Float32),
+                num=32,
+                offset=cfg.tile_size_kv // 2,
+            )
+            prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
+            s_arr = cutlass.Array(Float32, 32, space=cutlass.AddressSpace.rmem)
+            for score_idx in cutlass.range_constexpr(32):
+                s_arr[score_idx] = loaded[score_idx]
+
+            local_sum = self._exponentiate_fragment_pairs(s_arr, minus_max_scale)
+            if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                if route_is_proxy != Int32(0):
+                    local_sum = self._proxy_fragment_sum(
+                        local_sum,
+                        s_arr,
+                        fragment_origin=self._runtime_fragment_origin(
+                            fragment, route_origin0, route_origin1
+                        ),
+                    )
+
+            packed_p = (
+                s_arr.data_ptr()
+                .load(count=32, alignment=4)
+                .to(cfg.q_dtype)
+                .bitcast(Int32)
+            )
+            _keeps_tcgen05_st(
+                cfg,
+                prims.make_tmem_ptr(tmem_base + fragment * Int32(fragment_cols), Int32),
+                packed_p,
+                offset=cfg.tmem_p_cols_per_inst,
+            )
+            cute.arch.fence_view_async_tmem_store()
+            prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
+            if publishes_fragment:
+                prims.mbarrier_arrive(self._fragment_ready.data_ptr() + fragment)
+            total_sum += local_sum
+        self.tmem_s_ref.store_p_local_sum(0, total_sum)
+
+    @cute.jit
+    def _runtime_fragment_origin(
+        self, fragment: Int32, route_origin0: Int32, route_origin1: Int32
+    ) -> Int32:
+        """Return the K32 origin of a fragment selected at runtime."""
+        fragment_origin = Int32(route_origin0)
+        if fragment >= Int32(2):
+            fragment_origin = Int32(route_origin1)
+        return fragment_origin + (fragment & Int32(1)) * Int32(32)
+
+    @cute.jit
+    def _exponentiate_fragment_pairs(
+        self, s_arr: cutlass.Array, minus_max_scale: Float32
+    ) -> Float32:
+        """Turn one fragment of scaled scores into probabilities in place.
+
+        Returns the fragment's probability sum. Eight independent chains keep
+        the denominator update off one long dependency chain, and a configurable
+        subset of pairs runs its exponentials on the FMA pipe.
+        """
+        sum_chains = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
+        for chain_idx in cutlass.range_constexpr(8):
+            sum_chains[chain_idx] = Float32(0.0)
+        for pair_idx in cutlass.range_constexpr(16):
+            value_idx = pair_idx * 2
+            p0, p1 = cute.arch.fma_packed_f32x2(
+                (Float32(s_arr[value_idx]), Float32(s_arr[value_idx + 1])),
+                (self.scale_softmax_log2, self.scale_softmax_log2),
+                (minus_max_scale, minus_max_scale),
+            )
+            if cutlass.const_expr(_pair_uses_ex2_emulation(pair_idx)):
+                p0, p1 = _ex2_emulation_packed_f32x2(p0, p1)
+            else:
+                p0 = Float32(cute.math.exp2(p0, fastmath=True))
+                p1 = Float32(cute.math.exp2(p1, fastmath=True))
+            s_arr[value_idx] = p0
+            s_arr[value_idx + 1] = p1
+            chain_idx = (pair_idx & 3) * 2
+            sum_chains[chain_idx], sum_chains[chain_idx + 1] = (
+                cute.arch.add_packed_f32x2(
+                    (sum_chains[chain_idx], sum_chains[chain_idx + 1]),
+                    (p0, p1),
+                )
+            )
+        sum01 = cute.arch.add_packed_f32x2(
+            (sum_chains[0], sum_chains[1]),
+            (sum_chains[2], sum_chains[3]),
+        )
+        sum23 = cute.arch.add_packed_f32x2(
+            (sum_chains[4], sum_chains[5]),
+            (sum_chains[6], sum_chains[7]),
+        )
+        total_pair = cute.arch.add_packed_f32x2(sum01, sum23)
+        return Float32(total_pair[0] + total_pair[1])
+
+    @cute.jit
+    def _proxy_fragment_sum(
+        self,
+        local_sum: Float32,
+        s_arr: cutlass.Array,
+        *,
+        fragment_origin: Int32,
+    ) -> Float32:
+        """Weight a proxy fragment's sum by the token mass each summary stands for.
+
+        KC stores one mean K vector per semantic KV block while VC stores its V
+        sum. P itself stays unweighted for PV; only the denominator accounts
+        for the represented token count, with the final summary covering the
+        shorter tail block.
+        """
+        cfg = self.cfg
+        num_summaries, tail_len = _block_sparse_proxy_summary_geometry(
+            cfg.static_seq_len_kv,
+            cfg.kv_block_size,
+        )
+        local_sum *= Float32(cfg.kv_block_size)
+        tail_delta = tail_len - cfg.kv_block_size
+        if cutlass.const_expr(tail_delta != 0):
+            final_summary_idx = num_summaries - 1
+            final_summary_offset = Int32(final_summary_idx) - fragment_origin
+            if final_summary_offset >= Int32(0) and final_summary_offset < Int32(32):
+                # Proxy fragment origins are K32-aligned in summary coordinates,
+                # so the tail's in-fragment lane is a compile-time constant even
+                # though route ownership is decided at runtime.
+                tail_lane = final_summary_idx % 32
+                local_sum += Float32(tail_delta) * Float32(s_arr[tail_lane])
+        return local_sum
 
     @cute.jit
     def _compute_keeps_p(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/smem_p.py
@@ -717,17 +717,28 @@ class SmemPResource(DecodeGenResourceBase):
                     packed_p.data_ptr().load(count=4, alignment=4), alignment=16
                 )
         if cutlass.const_expr(cfg.uses_two_inst_tmem_p):
-            # FP8 Q128/KV128 publishes the complete packed row with one x32
-            # STTM; 16-bit two-instance profiles stream K32 fragments instead.
-            assert cfg.use_fp8_qkv and cfg.num_packed_p_regs == 32
-            _keeps_tcgen05_st(
-                cfg,
-                prims.make_tmem_ptr(p_tmem_stage_base, Int32),
-                packed_p.data_ptr().load(count=cfg.num_packed_p_regs, alignment=4),
-                # Separate the paired Softmax destinations by one packed row
-                # (the half-row split for x16/x32 TMEM layouts).
-                offset=cfg.num_packed_p_regs,
-            )
+            # FP8 publishes the complete row with one x32 STTM. Dense 16-bit
+            # Q128/KV128 uses x16 slices to limit Softmax register pressure.
+            # Block-sparse two-instance profiles stream K32 fragments instead.
+            assert cfg.num_packed_p_regs in (32, 64)
+            regs_per_store = cfg.num_packed_p_regs if cfg.use_fp8_qkv else 16
+            assert cfg.num_packed_p_regs % regs_per_store == 0
+            for store_idx in cutlass.range_constexpr(
+                cfg.num_packed_p_regs // regs_per_store
+            ):
+                packed_offset = store_idx * regs_per_store
+                _keeps_tcgen05_st(
+                    cfg,
+                    prims.make_tmem_ptr(
+                        p_tmem_stage_base + Int32(packed_offset), Int32
+                    ),
+                    (packed_p.data_ptr() + packed_offset).load(
+                        count=regs_per_store, alignment=4
+                    ),
+                    # Separate the paired Softmax destinations by one packed
+                    # row (the half-row split for x16/x32 TMEM layouts).
+                    offset=cfg.num_packed_p_regs,
+                )
             if cutlass.const_expr(cfg.ordered_softmax_early_release):
                 # Hand the baton over as soon as this group's TMEM store has
                 # issued: the partner's exp2/pack/TMEM store touch only its own

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
@@ -2478,10 +2478,12 @@ class TmemCorrResource(DecodeGenResourceBase):
                     packed = scaled_vector.to(cutlass.BFloat16).bitcast(Int32)
                 else:
                     packed = scaled_vector.to(cutlass.Float16).bitcast(Int32)
+                # Split-KV partials are 16-bit, so the column offset follows
+                # the partial element width
                 partial_o_dst = cutlass.inttoptr(
                     self.partial_o_ptr.toint()
                     + partial_row_base
-                    + Int64(output_col * cfg.o_dtype_bytes),
+                    + Int64(output_col * 2),
                     mem_space=1,
                     dtype=Int32,
                 )

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
@@ -91,7 +91,9 @@ from .tmem_softmax_stats import TmemSoftmaxLocalResource
 
 _KV_TILE_256_CORRECTION_THREADS = 128
 _KV_TILE_256_LOGICAL_OUTPUT_ROWS = 64
-_KV_TILE_256_EXCHANGE_ROW_STRIDE = 132
+# One D32 fragment per logical output row, padded by four floats so adjacent
+# rows fall on different bank groups.
+_KV_TILE_256_EXCHANGE_FRAGMENT_STRIDE = 36
 _KV_TILE_256_STATS_PER_THREAD = 4
 
 
@@ -157,10 +159,10 @@ class TmemCorrResource(DecodeGenResourceBase):
         )
 
     def _kv_tile_256_exchange_entries(self) -> int:
-        """Return 128 lane-local stats plus 64 logical output rows."""
+        """Return 128 lane-local stats plus one D32 fragment per output row."""
         return (
             _KV_TILE_256_CORRECTION_THREADS * _KV_TILE_256_STATS_PER_THREAD
-            + _KV_TILE_256_LOGICAL_OUTPUT_ROWS * _KV_TILE_256_EXCHANGE_ROW_STRIDE
+            + _KV_TILE_256_LOGICAL_OUTPUT_ROWS * _KV_TILE_256_EXCHANGE_FRAGMENT_STRIDE
         )
 
     def _init_placeholder_state(self) -> None:
@@ -306,22 +308,14 @@ class TmemCorrResource(DecodeGenResourceBase):
                 )
         if self.cfg.tile_size_kv == 256 and self._kv_tile_256_exchange_alloc is None:
             # Tail correction exchanges all lane-local stats, then pipelines
-            # D32 fragments through 64 logical output rows. Upper lanes publish
-            # one spatial half while lower lanes retain the matching fragment
-            # in registers. The dependency graph places this scratch after the
-            # shared KV ring so it can reuse the dead storage.
-            payload_bytes = self._kv_tile_256_exchange_entries() * 4
-            exchange_bytes = payload_bytes
-            if self.cfg.uses_rotating_kv256_exchange:
-                assert payload_bytes <= self.cfg.smem_kv_tile_bytes
-                # Runtime selects one compact payload inside this explicit
-                # full-ring alias envelope. The envelope keeps every dynamic
-                # pointer within a declared allocation while the actual live
-                # exchange remains only 35,840 B in one 64-KiB stage.
-                exchange_bytes = self.cfg.smem_kv_tile_bytes * self.cfg.kv_stages
+            # D32 fragments through 64 logical output rows one fragment at a
+            # time. Upper lanes publish one spatial half while lower lanes
+            # retain the matching fragment in registers. The buffer is
+            # dedicated, so the shared KV ring keeps streaming the next tile's
+            # routes while the tail runs.
             self._kv_tile_256_exchange_alloc = SmemAllocation(
                 name=f"{self.name}_kvTile256Exchange",
-                size_bytes=exchange_bytes,
+                size_bytes=self._kv_tile_256_exchange_entries() * 4,
                 alignment=16,
             )
         allocs = []
@@ -2356,24 +2350,6 @@ class TmemCorrResource(DecodeGenResourceBase):
             )
 
     @cute.jit
-    def _kv_tile_256_exchange_for_stage(
-        self,
-        stage_info: StageInfo,
-        scratch_stage: Int32 | None,
-    ) -> cutlass.Array:
-        """Return the fixed exchange or its dynamically selected KV stage."""
-        if cutlass.const_expr(scratch_stage is None):
-            return self._kv_tile_256_exchange
-        return cutlass.Array(
-            stage_info.context.smem_base.data_ptr()
-            + self._kv_tile_256_exchange_alloc.offset
-            + scratch_stage * Int32(self.cfg.smem_kv_tile_bytes),
-            dtype=Float32,
-            shape=(self._kv_tile_256_exchange_entries(),),
-            addrspace=3,
-        )
-
-    @cute.jit
     def _kv_tile_256_temporal_fragment(
         self,
         *,
@@ -2449,7 +2425,7 @@ class TmemCorrResource(DecodeGenResourceBase):
         output_lane = exchange_idx < Int32(_KV_TILE_256_LOGICAL_OUTPUT_ROWS)
         exchange_row_idx = exchange_idx & Int32(_KV_TILE_256_LOGICAL_OUTPUT_ROWS - 1)
         output_exchange_row_base = output_exchange_base + exchange_row_idx * Int32(
-            _KV_TILE_256_EXCHANGE_ROW_STRIDE
+            _KV_TILE_256_EXCHANGE_FRAGMENT_STRIDE
         )
         logical_output_row_idx = q_row_offset + exchange_row_idx
         valid_output_row = cutlass.Boolean(False)
@@ -2503,10 +2479,17 @@ class TmemCorrResource(DecodeGenResourceBase):
                 weight00=weight00,
                 weight10=weight10,
             )
+            if cutlass.const_expr(fragment != 0):
+                # The single fragment buffer is reused: lower lanes must have
+                # consumed the previous peer fragment before it is overwritten.
+                prims.barrier_cta_sync(
+                    self.store_barrier_id,
+                    thread_count=cfg.correction_barrier_threads,
+                )
             if exchange_idx >= Int32(_KV_TILE_256_LOGICAL_OUTPUT_ROWS):
-                (
-                    exchange.data_ptr() + output_exchange_row_base + Int32(fragment_col)
-                ).store(own_vals, alignment=16)
+                (exchange.data_ptr() + output_exchange_row_base).store(
+                    own_vals, alignment=16
+                )
 
             # Lower lanes keep ``own_vals`` live across the barrier. Once every
             # lane arrives, upper lanes may prepare the next fragment while
@@ -2517,9 +2500,9 @@ class TmemCorrResource(DecodeGenResourceBase):
             )
 
             if output_lane:
-                peer_vals = (
-                    exchange.data_ptr() + output_exchange_row_base + Int32(fragment_col)
-                ).load(count=32, alignment=16)
+                peer_vals = (exchange.data_ptr() + output_exchange_row_base).load(
+                    count=32, alignment=16
+                )
                 if cutlass.const_expr(not cfg.use_split_kv):
                     # Direct output: merge and store 16 columns per instruction so
                     # each lane writes one full 32-byte sector. Adjacent lanes own
@@ -2627,7 +2610,6 @@ class TmemCorrResource(DecodeGenResourceBase):
         self,
         stage_info: StageInfo,
         *,
-        scratch_stage: Int32 | None,
         tail_o_stage_idx_0: Int32,
         tail_o_stage_idx_1: Int32,
         inst0_new_max_arr: cutlass.Array,
@@ -2642,15 +2624,13 @@ class TmemCorrResource(DecodeGenResourceBase):
 
         The standard decode schedule still owns the two temporal instances.
         KV256 adds one physical spatial split per instance. Correction exchanges
-        their stats, stages one spatial half in SMEM after the shared KV ring is
-        dead, then publishes the ordinary logical Q64xD128 output.
+        their stats, stages one spatial half through its dedicated SMEM
+        exchange one D32 fragment at a time, then publishes the ordinary
+        logical Q64xD128 output.
         """
         cfg = self.cfg
         assert cfg.headdim == 128
-        exchange = self._kv_tile_256_exchange_for_stage(
-            stage_info,
-            scratch_stage,
-        )
+        exchange = self._kv_tile_256_exchange
 
         exchange_idx = warp_grp_thread_idx
         peer_idx = exchange_idx ^ Int32(_KV_TILE_256_LOGICAL_OUTPUT_ROWS)
@@ -4460,7 +4440,6 @@ class TmemCorrResource(DecodeGenResourceBase):
         self,
         stage_info: StageInfo,
         *,
-        scratch_stage: Int32 | None,
         o_stage_idx: Int32,
         tail_o_stage_idx_0: Int32,
         tail_o_stage_idx_1: Int32,
@@ -4506,7 +4485,6 @@ class TmemCorrResource(DecodeGenResourceBase):
                 if cutlass.const_expr(cfg.tile_size_kv == 256):
                     self._kv_tile_256_tail_epilogue(
                         stage_info,
-                        scratch_stage=scratch_stage,
                         tail_o_stage_idx_0=tail_o_stage_idx_0,
                         tail_o_stage_idx_1=tail_o_stage_idx_1,
                         inst0_new_max_arr=inst0_new_max_arr,
@@ -4582,9 +4560,6 @@ class TmemCorrResource(DecodeGenResourceBase):
         )
         return
 
-    # Task Scheduling routes every non-constexpr work argument as a required
-    # data-flow token. Keep separate fixed/rotating entry points so only the
-    # latter consumes ``scratch_stage``; both still share the implementation.
     @producer_work
     @cute.jit
     def correction_tail_epilogue(
@@ -4601,42 +4576,9 @@ class TmemCorrResource(DecodeGenResourceBase):
         inst1_new_max_arr: cutlass.Array,
         inst1_sum_arr: cutlass.Array,
     ) -> None:
-        """Run the ordinary fixed-exchange tail epilogue."""
+        """Normalize the final O stages and publish the output tile."""
         self._correction_tail_epilogue_impl(
             stage_info,
-            scratch_stage=None,
-            o_stage_idx=o_stage_idx,
-            tail_o_stage_idx_0=tail_o_stage_idx_0,
-            tail_o_stage_idx_1=tail_o_stage_idx_1,
-            old_max_arr=old_max_arr,
-            new_max_arr=new_max_arr,
-            inst0_new_max_arr=inst0_new_max_arr,
-            inst0_sum_arr=inst0_sum_arr,
-            inst1_new_max_arr=inst1_new_max_arr,
-            inst1_sum_arr=inst1_sum_arr,
-        )
-
-    @producer_work
-    @cute.jit
-    def correction_tail_epilogue_rotating_exchange(
-        self,
-        stage_info: StageInfo,
-        *,
-        scratch_stage: Int32,
-        o_stage_idx: Int32,
-        tail_o_stage_idx_0: Int32,
-        tail_o_stage_idx_1: Int32,
-        old_max_arr: cutlass.Array,
-        new_max_arr: cutlass.Array,
-        inst0_new_max_arr: cutlass.Array,
-        inst0_sum_arr: cutlass.Array,
-        inst1_new_max_arr: cutlass.Array,
-        inst1_sum_arr: cutlass.Array,
-    ) -> None:
-        """Run persistent direct output in the stage named by its credit."""
-        self._correction_tail_epilogue_impl(
-            stage_info,
-            scratch_stage=scratch_stage,
             o_stage_idx=o_stage_idx,
             tail_o_stage_idx_0=tail_o_stage_idx_0,
             tail_o_stage_idx_1=tail_o_stage_idx_1,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
@@ -895,113 +895,117 @@ class TmemCorrResource(DecodeGenResourceBase):
         return merged_vals
 
     @cute.jit
-    def _store_final_o_vec16(
+    def _store_final_o_columns(
         self,
         final_o_dst,
         output_vals: cutlass.Array,
         norm_scale: Float32,
-        o_is_32b_aligned: cutlass.Boolean,
+        *,
+        count: Constexpr[int],
+        sector_aligned: cutlass.Boolean,
     ) -> None:
-        """Pack 16 contiguous output columns and store them as one 32-byte sector.
+        """Scale, pack, and store ``count`` contiguous final output columns.
 
-        The 256-bit store needs a 32-byte-aligned destination; misaligned output
-        buffers fall back to two 16-byte stores of the same packed registers.
-        FP8 output keeps the 8-element packing path.
+        FP8 output packs four values per register and writes eight columns per
+        8-byte store. 16-bit output packs pairs; sixteen columns fill one
+        32-byte sector and go out as a single 256-bit store when the
+        destination is sector aligned, otherwise every eight columns use one
+        16-byte store. Callers choose ``count`` per path: the KV256 tail owns
+        whole rows per lane and pays for half-written sectors, while the
+        split-KV reducers write eight-column fragments.
         """
         cfg = self.cfg
+        assert count % 8 == 0
         if cutlass.const_expr(cfg.use_fp8_output):
-            self._store_final_o_vec8(final_o_dst, output_vals, norm_scale)
-            upper_vals = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
-            for elem in cutlass.range_constexpr(8):
-                upper_vals[elem] = output_vals[8 + elem]
-            self._store_final_o_vec8(
-                final_o_dst + Int32(8 * cfg.o_dtype_bytes // 4),
-                upper_vals,
-                norm_scale,
-            )
+            for chunk_idx in cutlass.range_constexpr(count // 8):
+                fp8_regs = self._pack_fp8_output_quads(
+                    output_vals, norm_scale, chunk_idx * 8
+                )
+                (final_o_dst + Int32(chunk_idx * 2)).store(
+                    fp8_regs.data_ptr().load(count=2, alignment=4),
+                    alignment=8,
+                )
         else:
-            final_regs = cutlass.Array(Int32, 8, space=cutlass.AddressSpace.rmem)
-            for reg_idx in cutlass.range_constexpr(8):
-                pair = fmul2(
-                    (norm_scale, norm_scale),
-                    (
-                        output_vals[reg_idx * 2],
-                        output_vals[reg_idx * 2 + 1],
-                    ),
-                )
-                if cutlass.const_expr(cfg.use_bf16_output):
-                    final_regs[reg_idx] = _pack_float2_to_bf16(pair[0], pair[1])
+            final_regs = self._pack_final_o_regs(output_vals, norm_scale, count)
+            if cutlass.const_expr(count == 16):
+                if sector_aligned:
+                    final_o_dst.store(
+                        final_regs.data_ptr().load(count=8, alignment=4),
+                        alignment=32,
+                    )
                 else:
-                    final_regs[reg_idx] = _pack_float2_to_fp16(pair[0], pair[1])
-            if o_is_32b_aligned:
-                final_o_dst.store(
-                    final_regs.data_ptr().load(count=8, alignment=4),
-                    alignment=32,
-                )
+                    self._store_16bit_output_chunks(final_o_dst, final_regs, count)
             else:
-                final_o_dst.store(
-                    final_regs.data_ptr().load(count=4, alignment=4),
-                    alignment=16,
-                )
-                (final_o_dst + Int32(4)).store(
-                    (final_regs.data_ptr() + Int32(4)).load(count=4, alignment=4),
-                    alignment=16,
-                )
+                self._store_16bit_output_chunks(final_o_dst, final_regs, count)
 
     @cute.jit
-    def _store_final_o_vec8(
+    def _store_16bit_output_chunks(
         self,
         final_o_dst,
-        output_vals: cutlass.Array,
-        norm_scale: Float32,
+        final_regs: cutlass.Array,
+        count: Constexpr[int],
     ) -> None:
-        """Pack one contiguous 8-element output fragment to the final O dtype."""
-        cfg = self.cfg
-        if cutlass.const_expr(cfg.use_fp8_output):
-            final_pairs = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
-            for pair_idx in cutlass.range_constexpr(4):
-                val_base = pair_idx * 2
-                pair = fmul2(
-                    (norm_scale, norm_scale),
-                    (output_vals[val_base], output_vals[val_base + 1]),
-                )
-                final_pairs[val_base] = pair[0]
-                final_pairs[val_base + 1] = pair[1]
-            final_fp8_regs = cutlass.Array(Int32, 2, space=cutlass.AddressSpace.rmem)
-            final_fp8_regs[0] = _pack_float4_to_fp8_e4m3(
-                final_pairs[0],
-                final_pairs[1],
-                final_pairs[2],
-                final_pairs[3],
-            )
-            final_fp8_regs[1] = _pack_float4_to_fp8_e4m3(
-                final_pairs[4],
-                final_pairs[5],
-                final_pairs[6],
-                final_pairs[7],
-            )
-            final_o_dst.store(
-                final_fp8_regs.data_ptr().load(count=2, alignment=4),
-                alignment=8,
-            )
-        else:
-            final_regs = cutlass.Array(Int32, 4, space=cutlass.AddressSpace.rmem)
-            for reg_idx in cutlass.range_constexpr(4):
-                pair = fmul2(
-                    (norm_scale, norm_scale),
-                    (
-                        output_vals[reg_idx * 2],
-                        output_vals[reg_idx * 2 + 1],
-                    ),
-                )
-                if cutlass.const_expr(cfg.use_bf16_output):
-                    final_regs[reg_idx] = _pack_float2_to_bf16(pair[0], pair[1])
-                else:
-                    final_regs[reg_idx] = _pack_float2_to_fp16(pair[0], pair[1])
-            final_o_dst.store(
-                final_regs.data_ptr().load(count=4, alignment=4),
+        """Store packed 16-bit output columns as 16-byte chunks of eight columns."""
+        for chunk_idx in cutlass.range_constexpr(count // 8):
+            (final_o_dst + Int32(chunk_idx * 4)).store(
+                (final_regs.data_ptr() + Int32(chunk_idx * 4)).load(
+                    count=4, alignment=4
+                ),
                 alignment=16,
             )
+
+    @cute.jit
+    def _pack_fp8_output_quads(
+        self,
+        output_vals: cutlass.Array,
+        norm_scale: Float32,
+        first_col: Constexpr[int],
+    ) -> cutlass.Array:
+        """Scale eight output columns from ``first_col`` into two FP8 registers."""
+        final_pairs = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
+        for pair_idx in cutlass.range_constexpr(4):
+            val_base = pair_idx * 2
+            pair = fmul2(
+                (norm_scale, norm_scale),
+                (
+                    output_vals[first_col + val_base],
+                    output_vals[first_col + val_base + 1],
+                ),
+            )
+            final_pairs[val_base] = pair[0]
+            final_pairs[val_base + 1] = pair[1]
+        fp8_regs = cutlass.Array(Int32, 2, space=cutlass.AddressSpace.rmem)
+        fp8_regs[0] = _pack_float4_to_fp8_e4m3(
+            final_pairs[0], final_pairs[1], final_pairs[2], final_pairs[3]
+        )
+        fp8_regs[1] = _pack_float4_to_fp8_e4m3(
+            final_pairs[4], final_pairs[5], final_pairs[6], final_pairs[7]
+        )
+        return fp8_regs
+
+    @cute.jit
+    def _pack_final_o_regs(
+        self,
+        output_vals: cutlass.Array,
+        norm_scale: Float32,
+        count: Constexpr[int],
+    ) -> cutlass.Array:
+        """Scale ``count`` output columns and pack them as 16-bit pairs."""
+        cfg = self.cfg
+        final_regs = cutlass.Array(Int32, count // 2, space=cutlass.AddressSpace.rmem)
+        for reg_idx in cutlass.range_constexpr(count // 2):
+            pair = fmul2(
+                (norm_scale, norm_scale),
+                (
+                    output_vals[reg_idx * 2],
+                    output_vals[reg_idx * 2 + 1],
+                ),
+            )
+            if cutlass.const_expr(cfg.use_bf16_output):
+                final_regs[reg_idx] = _pack_float2_to_bf16(pair[0], pair[1])
+            else:
+                final_regs[reg_idx] = _pack_float2_to_fp16(pair[0], pair[1])
+        return final_regs
 
     @cute.jit
     def _store_softmax_normalized_o_vec8(
@@ -1028,7 +1032,13 @@ class TmemCorrResource(DecodeGenResourceBase):
             mem_space=1,
             dtype=Int32,
         )
-        self._store_final_o_vec8(final_o_dst, output_vals, norm_scale)
+        self._store_final_o_columns(
+            final_o_dst,
+            output_vals,
+            norm_scale,
+            count=8,
+            sector_aligned=cutlass.Boolean(False),
+        )
 
     @cute.jit
     def _softmax_output_row_state(
@@ -2387,6 +2397,97 @@ class TmemCorrResource(DecodeGenResourceBase):
         return cutlass.Vector.from_elements(combined, Float32)
 
     @cute.jit
+    def _store_kv_tile_256_direct_fragment(
+        self,
+        own_vals: cutlass.Array,
+        peer_vals,
+        *,
+        fragment_col: Constexpr[int],
+        dst_row_base: Int64,
+        norm_scale: Float32,
+        valid_output_row: cutlass.Boolean,
+        o_is_32b_aligned: cutlass.Boolean,
+    ) -> None:
+        """Merge one D32 fragment with its peer half and write the final output.
+
+        Sixteen columns go out per store so each lane writes one full 32-byte
+        sector. Adjacent lanes own adjacent rows, so 16-byte stores would leave
+        every sector half-written twice.
+        """
+        cfg = self.cfg
+        for vector_pair in cutlass.range_constexpr(2):
+            pair_col = vector_pair * 16
+            merged_vals = self._merge_kv_tile_256_peer_fragment(
+                own_vals,
+                peer_vals,
+                pair_col,
+                16,
+            )
+            if valid_output_row:
+                output_col = fragment_col + pair_col
+                dst_offset = dst_row_base + Int32(output_col * cfg.o_dtype_bytes)
+                final_o_dst = cutlass.inttoptr(
+                    self.o_ptr.toint() + cutlass.Int64(dst_offset),
+                    mem_space=1,
+                    dtype=Int32,
+                )
+                self._store_final_o_columns(
+                    final_o_dst,
+                    merged_vals,
+                    norm_scale,
+                    count=16,
+                    sector_aligned=o_is_32b_aligned,
+                )
+
+    @cute.jit
+    def _store_kv_tile_256_partial_fragment(
+        self,
+        own_vals: cutlass.Array,
+        peer_vals,
+        *,
+        fragment_col: Constexpr[int],
+        partial_row_base: Int64,
+        partial_scale: Float32,
+        valid_output_row: cutlass.Boolean,
+    ) -> None:
+        """Merge one D32 fragment with its peer half and write the split-KV partial."""
+        cfg = self.cfg
+        partial_o_uses_bf16 = (
+            cfg.use_bf16_separate_partial_o
+            if cfg.use_separate_reduction_kernel
+            else cfg.use_bf16_output
+        )
+        for vector_idx in cutlass.range_constexpr(4):
+            vector_col = vector_idx * 8
+            output_vals = self._merge_kv_tile_256_peer_fragment(
+                own_vals,
+                peer_vals,
+                vector_col,
+                8,
+            )
+            if valid_output_row:
+                output_col = fragment_col + vector_col
+                scaled_values: tuple = ()
+                for elem in cutlass.range_constexpr(0, 8, 2):
+                    scaled_values += fmul2(
+                        (partial_scale, partial_scale),
+                        (output_vals[elem], output_vals[elem + 1]),
+                    )
+                scaled_vector = cutlass.Vector.from_elements(scaled_values, Float32)
+                if cutlass.const_expr(partial_o_uses_bf16):
+                    packed = scaled_vector.to(cutlass.BFloat16).bitcast(Int32)
+                else:
+                    packed = scaled_vector.to(cutlass.Float16).bitcast(Int32)
+                partial_o_dst = cutlass.inttoptr(
+                    self.partial_o_ptr.toint()
+                    + partial_row_base
+                    + Int64(output_col * cfg.o_dtype_bytes),
+                    mem_space=1,
+                    dtype=Int32,
+                )
+                partial_o_dst.store(packed, alignment=16)
+
+    @cute.jit
     def _kv_tile_256_merge_spatial_output(
         self,
         *,
@@ -2414,11 +2515,6 @@ class TmemCorrResource(DecodeGenResourceBase):
         serializing the complete D128 upper and lower halves.
         """
         cfg = self.cfg
-        partial_o_uses_bf16 = (
-            cfg.use_bf16_separate_partial_o
-            if cfg.use_separate_reduction_kernel
-            else cfg.use_bf16_output
-        )
         output_exchange_base = Int32(
             _KV_TILE_256_CORRECTION_THREADS * _KV_TILE_256_STATS_PER_THREAD
         )
@@ -2504,70 +2600,24 @@ class TmemCorrResource(DecodeGenResourceBase):
                     count=32, alignment=16
                 )
                 if cutlass.const_expr(not cfg.use_split_kv):
-                    # Direct output: merge and store 16 columns per instruction so
-                    # each lane writes one full 32-byte sector. Adjacent lanes own
-                    # adjacent rows, so 16-byte stores would leave every sector
-                    # half-written twice.
-                    for vector_pair in cutlass.range_constexpr(2):
-                        pair_col = vector_pair * 16
-                        merged_vals = self._merge_kv_tile_256_peer_fragment(
-                            own_vals,
-                            peer_vals,
-                            pair_col,
-                            16,
-                        )
-                        if valid_output_row:
-                            output_col = fragment_col + pair_col
-                            dst_offset = dst_row_base + Int32(
-                                output_col * cfg.o_dtype_bytes
-                            )
-                            final_o_dst = cutlass.inttoptr(
-                                self.o_ptr.toint() + cutlass.Int64(dst_offset),
-                                mem_space=1,
-                                dtype=Int32,
-                            )
-                            self._store_final_o_vec16(
-                                final_o_dst,
-                                merged_vals,
-                                norm_scale,
-                                o_is_32b_aligned,
-                            )
+                    self._store_kv_tile_256_direct_fragment(
+                        own_vals,
+                        peer_vals,
+                        fragment_col=fragment_col,
+                        dst_row_base=dst_row_base,
+                        norm_scale=norm_scale,
+                        valid_output_row=valid_output_row,
+                        o_is_32b_aligned=o_is_32b_aligned,
+                    )
                 else:
-                    for vector_idx in cutlass.range_constexpr(4):
-                        vector_col = vector_idx * 8
-                        output_vals = self._merge_kv_tile_256_peer_fragment(
-                            own_vals,
-                            peer_vals,
-                            vector_col,
-                            8,
-                        )
-                        if valid_output_row:
-                            output_col = fragment_col + vector_col
-                            scaled_values: tuple = ()
-                            for elem in cutlass.range_constexpr(0, 8, 2):
-                                scaled_values += fmul2(
-                                    (partial_scale, partial_scale),
-                                    (output_vals[elem], output_vals[elem + 1]),
-                                )
-                            scaled_vector = cutlass.Vector.from_elements(
-                                scaled_values, Float32
-                            )
-                            if cutlass.const_expr(partial_o_uses_bf16):
-                                packed = scaled_vector.to(cutlass.BFloat16).bitcast(
-                                    Int32
-                                )
-                            else:
-                                packed = scaled_vector.to(cutlass.Float16).bitcast(
-                                    Int32
-                                )
-                            partial_o_dst = cutlass.inttoptr(
-                                self.partial_o_ptr.toint()
-                                + partial_row_base
-                                + Int64(output_col * cfg.o_dtype_bytes),
-                                mem_space=1,
-                                dtype=Int32,
-                            )
-                            partial_o_dst.store(packed, alignment=16)
+                    self._store_kv_tile_256_partial_fragment(
+                        own_vals,
+                        peer_vals,
+                        fragment_col=fragment_col,
+                        partial_row_base=partial_row_base,
+                        partial_scale=partial_scale,
+                        valid_output_row=valid_output_row,
+                    )
 
         if cutlass.const_expr(cfg.use_split_kv):
             if valid_output_row:

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_corr.py
@@ -874,6 +874,87 @@ class TmemCorrResource(DecodeGenResourceBase):
         return output_vals, sum_val, new_max, new_max
 
     @cute.jit
+    def _merge_kv_tile_256_peer_fragment(
+        self,
+        own_vals: cutlass.Array,
+        peer_vals,
+        first_col: Constexpr[int],
+        count: Constexpr[int],
+    ) -> cutlass.Array:
+        """Add the peer spatial half to ``count`` own columns from ``first_col``."""
+        merged_vals = cutlass.Array(
+            Float32,
+            count,
+            space=cutlass.AddressSpace.rmem,
+        )
+        for elem in cutlass.range_constexpr(0, count, 2):
+            value_idx = first_col + elem
+            merged = fadd2(
+                (own_vals[value_idx], own_vals[value_idx + 1]),
+                (
+                    Float32(peer_vals[value_idx]),
+                    Float32(peer_vals[value_idx + 1]),
+                ),
+            )
+            merged_vals[elem] = merged[0]
+            merged_vals[elem + 1] = merged[1]
+        return merged_vals
+
+    @cute.jit
+    def _store_final_o_vec16(
+        self,
+        final_o_dst,
+        output_vals: cutlass.Array,
+        norm_scale: Float32,
+        o_is_32b_aligned: cutlass.Boolean,
+    ) -> None:
+        """Pack 16 contiguous output columns and store them as one 32-byte sector.
+
+        The 256-bit store needs a 32-byte-aligned destination; misaligned output
+        buffers fall back to two 16-byte stores of the same packed registers.
+        FP8 output keeps the 8-element packing path.
+        """
+        cfg = self.cfg
+        if cutlass.const_expr(cfg.use_fp8_output):
+            self._store_final_o_vec8(final_o_dst, output_vals, norm_scale)
+            upper_vals = cutlass.Array(Float32, 8, space=cutlass.AddressSpace.rmem)
+            for elem in cutlass.range_constexpr(8):
+                upper_vals[elem] = output_vals[8 + elem]
+            self._store_final_o_vec8(
+                final_o_dst + Int32(8 * cfg.o_dtype_bytes // 4),
+                upper_vals,
+                norm_scale,
+            )
+        else:
+            final_regs = cutlass.Array(Int32, 8, space=cutlass.AddressSpace.rmem)
+            for reg_idx in cutlass.range_constexpr(8):
+                pair = fmul2(
+                    (norm_scale, norm_scale),
+                    (
+                        output_vals[reg_idx * 2],
+                        output_vals[reg_idx * 2 + 1],
+                    ),
+                )
+                if cutlass.const_expr(cfg.use_bf16_output):
+                    final_regs[reg_idx] = _pack_float2_to_bf16(pair[0], pair[1])
+                else:
+                    final_regs[reg_idx] = _pack_float2_to_fp16(pair[0], pair[1])
+            if o_is_32b_aligned:
+                final_o_dst.store(
+                    final_regs.data_ptr().load(count=8, alignment=4),
+                    alignment=32,
+                )
+            else:
+                final_o_dst.store(
+                    final_regs.data_ptr().load(count=4, alignment=4),
+                    alignment=16,
+                )
+                (final_o_dst + Int32(4)).store(
+                    (final_regs.data_ptr() + Int32(4)).load(count=4, alignment=4),
+                    alignment=16,
+                )
+
+    @cute.jit
     def _store_final_o_vec8(
         self,
         final_o_dst,
@@ -2394,6 +2475,9 @@ class TmemCorrResource(DecodeGenResourceBase):
         else:
             dst_row_base = Int64(0)
             norm_scale = Float32(1.0)
+            # Row strides are multiples of 32 bytes for D128, so sector-wide
+            # stores are legal exactly when the output base pointer is.
+            o_is_32b_aligned = (self.o_ptr.toint() & Int64(31)) == Int64(0)
             if output_lane:
                 valid_output_row = _q_row_is_valid_for_seq(
                     cfg,
@@ -2436,27 +2520,46 @@ class TmemCorrResource(DecodeGenResourceBase):
                 peer_vals = (
                     exchange.data_ptr() + output_exchange_row_base + Int32(fragment_col)
                 ).load(count=32, alignment=16)
-                for vector_idx in cutlass.range_constexpr(4):
-                    vector_col = vector_idx * 8
-                    output_vals = cutlass.Array(
-                        Float32,
-                        8,
-                        space=cutlass.AddressSpace.rmem,
-                    )
-                    for elem in cutlass.range_constexpr(0, 8, 2):
-                        value_idx = vector_col + elem
-                        merged = fadd2(
-                            (own_vals[value_idx], own_vals[value_idx + 1]),
-                            (
-                                Float32(peer_vals[value_idx]),
-                                Float32(peer_vals[value_idx + 1]),
-                            ),
+                if cutlass.const_expr(not cfg.use_split_kv):
+                    # Direct output: merge and store 16 columns per instruction so
+                    # each lane writes one full 32-byte sector. Adjacent lanes own
+                    # adjacent rows, so 16-byte stores would leave every sector
+                    # half-written twice.
+                    for vector_pair in cutlass.range_constexpr(2):
+                        pair_col = vector_pair * 16
+                        merged_vals = self._merge_kv_tile_256_peer_fragment(
+                            own_vals,
+                            peer_vals,
+                            pair_col,
+                            16,
                         )
-                        output_vals[elem] = merged[0]
-                        output_vals[elem + 1] = merged[1]
-                    if valid_output_row:
-                        output_col = fragment_col + vector_col
-                        if cutlass.const_expr(cfg.use_split_kv):
+                        if valid_output_row:
+                            output_col = fragment_col + pair_col
+                            dst_offset = dst_row_base + Int32(
+                                output_col * cfg.o_dtype_bytes
+                            )
+                            final_o_dst = cutlass.inttoptr(
+                                self.o_ptr.toint() + cutlass.Int64(dst_offset),
+                                mem_space=1,
+                                dtype=Int32,
+                            )
+                            self._store_final_o_vec16(
+                                final_o_dst,
+                                merged_vals,
+                                norm_scale,
+                                o_is_32b_aligned,
+                            )
+                else:
+                    for vector_idx in cutlass.range_constexpr(4):
+                        vector_col = vector_idx * 8
+                        output_vals = self._merge_kv_tile_256_peer_fragment(
+                            own_vals,
+                            peer_vals,
+                            vector_col,
+                            8,
+                        )
+                        if valid_output_row:
+                            output_col = fragment_col + vector_col
                             scaled_values: tuple = ()
                             for elem in cutlass.range_constexpr(0, 8, 2):
                                 scaled_values += fmul2(
@@ -2482,20 +2585,6 @@ class TmemCorrResource(DecodeGenResourceBase):
                                 dtype=Int32,
                             )
                             partial_o_dst.store(packed, alignment=16)
-                        else:
-                            dst_offset = dst_row_base + Int32(
-                                output_col * cfg.o_dtype_bytes
-                            )
-                            final_o_dst = cutlass.inttoptr(
-                                self.o_ptr.toint() + cutlass.Int64(dst_offset),
-                                mem_space=1,
-                                dtype=Int32,
-                            )
-                            self._store_final_o_vec8(
-                                final_o_dst,
-                                output_vals,
-                                norm_scale,
-                            )
 
         if cutlass.const_expr(cfg.use_split_kv):
             if valid_output_row:

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_o.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_o.py
@@ -59,7 +59,7 @@ def _pv_mma_operand_contract_for_config(
         cfg.headdim if cfg.head_dim_per_stage_kv == 0 else cfg.head_dim_kv_stage
     )
     if cfg.use_keeps_mma_ab:
-        if cfg.tile_size_kv == 256:
+        if cfg.uses_ws_2x2_datapath:
             # The WS 2x2 PV instruction exposes two spatial D128 partials as
             # one physical KV256 operation. Correction merges those spatial
             # halves after the two temporal decode streams are complete.
@@ -196,7 +196,7 @@ class TmemOResource(DecodeGenResourceBase):
         p_tmem_addr: Int32,
         fragment_idx: Constexpr[int],
     ) -> None:
-        """Issue one K32 fragment of a KV256 loop PV tile."""
+        """Issue one K32 fragment of a streamed loop PV tile."""
         self._vp_mma_fragment(
             stage_info,
             v_desc=v_desc,
@@ -215,7 +215,7 @@ class TmemOResource(DecodeGenResourceBase):
         p_tmem_addr: Int32,
         fragment_idx: Constexpr[int],
     ) -> None:
-        """Issue one K32 fragment of the final KV256 PV tile."""
+        """Issue one K32 fragment of the final streamed PV tile."""
         self._vp_mma_fragment(
             stage_info,
             v_desc=v_desc,
@@ -243,7 +243,7 @@ class TmemOResource(DecodeGenResourceBase):
         the plain M=128 instruction and advances V by one K16 slice per step.
         """
         cfg = self.cfg
-        assert cfg.streams_tmem_p_fragments and not cfg.use_fp8_qkv
+        assert cfg.streams_tmem_p_fragments
         v_desc = _freeze_smem_descriptor(v_desc)
 
         task_cache = _decode_gen_task_cache(stage_info)
@@ -271,7 +271,7 @@ class TmemOResource(DecodeGenResourceBase):
                     p_tmem_addr + Int32(local_k_step * 8), Int32
                 )
                 scale_d = initial_scale_d or fragment_idx != 0 or local_k_step != 0
-                if cutlass.const_expr(cfg.tile_size_kv == 256):
+                if cutlass.const_expr(cfg.uses_ws_2x2_datapath):
                     # V holds four K64 atoms; jump between atoms every four
                     # K16 steps.
                     iter_v_desc = v_desc + Int32(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_o.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_o.py
@@ -234,14 +234,16 @@ class TmemOResource(DecodeGenResourceBase):
         fragment_idx: Constexpr[int],
         initial_scale_d,
     ) -> None:
-        """Issue the two WS MMA steps covered by one KV256 P fragment.
+        """Issue the two MMA K-steps covered by one streamed P fragment.
 
         ``p_tmem_addr`` is already the base of the fragment selected by
         ``wait_p_fragment``. Only the two local K-step offsets are added here;
-        ``fragment_idx`` must not be applied to the TMEM address again.
+        ``fragment_idx`` must not be applied to the TMEM address again. KV256
+        issues the WS 2x2 instruction over its two spatial halves; KV128 issues
+        the plain M=128 instruction and advances V by one K16 slice per step.
         """
         cfg = self.cfg
-        assert cfg.tile_size_kv == 256 and cfg.uses_two_inst_tmem_p
+        assert cfg.streams_tmem_p_fragments and not cfg.use_fp8_qkv
         v_desc = _freeze_smem_descriptor(v_desc)
 
         task_cache = _decode_gen_task_cache(stage_info)
@@ -268,17 +270,32 @@ class TmemOResource(DecodeGenResourceBase):
                 p_operand = prims.make_tmem_ptr(
                     p_tmem_addr + Int32(local_k_step * 8), Int32
                 )
-                iter_v_desc = v_desc + Int32(
-                    (k_step // 4) * cfg.headdim * 16 + (k_step % 4) * 128
-                )
-                tcgen05_mma_ws(
-                    _mma_kind_for_qkv(cfg),
-                    tmem_col,
-                    p_operand,
-                    iter_v_desc,
-                    idesc,
-                    initial_scale_d or fragment_idx != 0 or local_k_step != 0,
-                )
+                scale_d = initial_scale_d or fragment_idx != 0 or local_k_step != 0
+                if cutlass.const_expr(cfg.tile_size_kv == 256):
+                    # V holds four K64 atoms; jump between atoms every four
+                    # K16 steps.
+                    iter_v_desc = v_desc + Int32(
+                        (k_step // 4) * cfg.headdim * 16 + (k_step % 4) * 128
+                    )
+                    tcgen05_mma_ws(
+                        _mma_kind_for_qkv(cfg),
+                        tmem_col,
+                        p_operand,
+                        iter_v_desc,
+                        idesc,
+                        scale_d,
+                    )
+                else:
+                    iter_v_desc = v_desc + Int32(k_step * 128)
+                    prims.tcgen05_mma(
+                        _mma_kind_for_qkv(cfg),
+                        prims.CTAGroup.CTA_1,
+                        tmem_col,
+                        p_operand,
+                        iter_v_desc,
+                        idesc,
+                        scale_d,
+                    )
 
     @cute.jit
     def _vp_mma(

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
@@ -41,7 +41,6 @@ from cutlass.experimental.task_scheduling.resources import (
     producer_work,
 )
 
-from ...._block_sparse.common import _MAX_KV_ATOM_SIZE, _block_sparse_kv_atom_size
 from ...._block_sparse.prepared import _PREPARED_ROUTE_IS_FULL_FLAG
 from ..fmha_decode_config import CAUSAL, FmhaDecodeConfig
 from ..fmha_decode_constants import SOFTMAX_RESCALE_THRESHOLD_LOG2
@@ -84,7 +83,6 @@ from .helpers_common import (
 )
 from .smem_block_sparse_metadata import (
     _SOFTMAX_ROUTE_IS_PROXY_FLAG,
-    _SOFTMAX_TOKEN_MASK_IS_FULL_FLAG,
     _swaps_forwards_packed_route_full,
 )
 from .helpers_kv_tile_idx import (
@@ -140,38 +138,30 @@ def _swaps_uses_token_only_score_validity(cfg: FmhaDecodeConfig) -> bool:
 
 
 @cute.jit
-def _can_skip_sparse_keeps_structural_mask(
-    q_row_is_valid: Boolean,
-    origin0: Int32,
-    origin1: Int32,
-    valid0: Int32,
-    valid1: Int32,
-    seq_len_kv: Int32,
-    causal_end: Int32,
+def _dense_fragment_keep_word(
+    rows_are_active: Boolean,
+    visible_start: Int32,
+    visible_end: Int32,
     *,
-    apply_causal_mask: cutlass.Constexpr[bool],
-) -> Boolean:
-    """Return whether one Keeps row needs no Q/tail/causal predicate.
+    fragment_regs: cutlass.Constexpr[int],
+) -> Uint32:
+    """Return the keep word of one dense K32 fragment.
 
-    Token-bit masking is independent. Comparing against the last complete
-    KV64 origin avoids overflowing an origin near the Int32 upper bound.
+    ``visible_start`` and ``visible_end`` are the visible token range relative
+    to the fragment's first column. Columns outside ``[start, end)`` are
+    masked; an inactive tile or Q row masks the whole fragment.
     """
-
-    fragment_size = Int32(_MAX_KV_ATOM_SIZE)
-    last_complete_origin = seq_len_kv - fragment_size
-    can_skip = Boolean(
-        q_row_is_valid
-        and valid0 != Int32(0)
-        and valid1 != Int32(0)
-        and origin0 <= last_complete_origin
-        and origin1 <= last_complete_origin
-    )
-    if cutlass.const_expr(apply_causal_mask):
-        last_causal_origin = causal_end - fragment_size
-        can_skip = Boolean(
-            can_skip and origin0 <= last_causal_origin and origin1 <= last_causal_origin
-        )
-    return can_skip
+    keep_word = Uint32(0)
+    if rows_are_active:
+        first_kept = cute.math.max(visible_start, Int32(0))
+        end_kept = cute.math.min(visible_end, Int32(fragment_regs))
+        if first_kept < end_kept:
+            # Both shift amounts stay strictly below the register width:
+            # 1 <= end_kept <= fragment_regs and 0 <= first_kept < end_kept.
+            keep_word = (Uint32(0xFFFFFFFF) >> (Int32(fragment_regs) - end_kept)) & (
+                Uint32(0xFFFFFFFF) << first_kept
+            )
+    return keep_word
 
 
 @cute.jit
@@ -662,7 +652,7 @@ class TmemSResource(DecodeGenResourceBase):
                         a_desc, b_desc = q_desc, k_desc
                     else:
                         a_desc, b_desc = k_desc, q_desc
-                    if cutlass.const_expr(cfg.tile_size_kv == 256):
+                    if cutlass.const_expr(cfg.uses_ws_2x2_datapath):
                         tcgen05_mma_ws(
                             _mma_kind_for_qkv(cfg),
                             tmem_col,
@@ -837,6 +827,7 @@ class TmemSResource(DecodeGenResourceBase):
             is_valid_effective_tile,
             is_masked_final_wave,
             tile_is_unmasked,
+            tile_has_valid_scores,
         )
 
     @cute.jit
@@ -919,32 +910,6 @@ class TmemSResource(DecodeGenResourceBase):
         return new_max
 
     @cute.jit
-    def _mask_and_store_sparse_keeps_atom(
-        self,
-        s_vals: cutlass.Array,
-        loaded: cutlass.Vector,
-        token_word: Uint32,
-        *,
-        atom_col: Constexpr[int],
-        token_mask_is_required: cutlass.Boolean,
-    ) -> None:
-        """Store one 32-score atom, applying its token word when required."""
-
-        if token_mask_is_required:
-            for atom_reg_idx in cutlass.range_constexpr(32):
-                score_idx = atom_col + atom_reg_idx
-                s_vals[score_idx] = loaded[atom_reg_idx]
-                token_bit_is_valid = (
-                    (token_word >> Int32(atom_reg_idx)) & Uint32(1)
-                ) != Uint32(0)
-                if not token_bit_is_valid:
-                    s_vals[score_idx] = _neg_max_f32()
-        else:
-            for atom_reg_idx in cutlass.range_constexpr(32):
-                score_idx = atom_col + atom_reg_idx
-                s_vals[score_idx] = loaded[atom_reg_idx]
-
-    @cute.jit
     def _load_keeps_fragment_impl(
         self,
         stage_info: StageInfo,
@@ -958,9 +923,8 @@ class TmemSResource(DecodeGenResourceBase):
         is_masked_final_wave: cutlass.Boolean,
         *,
         apply_boundary_mask: Constexpr[bool],
-        fragment_idx: Constexpr[int] = 0,
     ) -> None:
-        """Load one Keeps score fragment with a compile-time mask policy.
+        """Load one complete-row Keeps score tile with a compile-time mask policy.
 
         The caller chooses the masked/unmasked path before TMEM load. Keeping the
         score fragment out of the branch condition avoids carrying 64/128 live
@@ -970,8 +934,7 @@ class TmemSResource(DecodeGenResourceBase):
         """
         cfg = self.cfg
         task_cache = _decode_gen_task_cache(stage_info)
-        num_s_regs = cfg.softmax_score_fragment_regs
-        fragment_reg_base = fragment_idx * num_s_regs
+        num_s_regs = cfg.num_s_regs_per_thread
         base_addr = (
             task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
             + Int32(self._alloc.offset)
@@ -981,9 +944,7 @@ class TmemSResource(DecodeGenResourceBase):
             atom_col = load_atom_idx * 32
             loaded = _keeps_tcgen05_ld(
                 cfg,
-                prims.make_tmem_ptr(
-                    base_addr + Int32(fragment_reg_base + atom_col), Float32
-                ),
+                prims.make_tmem_ptr(base_addr + Int32(atom_col), Float32),
                 num=32,
                 offset=cfg.tile_size_kv // 2,
             )
@@ -1027,7 +988,7 @@ class TmemSResource(DecodeGenResourceBase):
                     token_idx = tile_offset_k + _keeps_score_col(
                         cfg,
                         warp_grp_thread_idx,
-                        fragment_reg_base + reg_idx,
+                        reg_idx,
                         col_base,
                     )
                     if token_idx >= element_mask_end_idx:
@@ -1055,7 +1016,7 @@ class TmemSResource(DecodeGenResourceBase):
                     score_col = _keeps_score_col(
                         cfg,
                         warp_grp_thread_idx,
-                        fragment_reg_base + reg_idx,
+                        reg_idx,
                         col_base,
                     )
                     if cutlass.const_expr(cfg.use_sliding_window_causal):
@@ -1088,8 +1049,6 @@ class TmemSResource(DecodeGenResourceBase):
         is_valid_effective_tile: cutlass.Boolean,
         is_masked_final_wave: cutlass.Boolean,
         tile_is_unmasked: cutlass.Boolean,
-        *,
-        fragment_idx: Constexpr[int] = 0,
     ) -> None:
         """Select the masked or unmasked fragment loader before LDTM.
 
@@ -1110,7 +1069,6 @@ class TmemSResource(DecodeGenResourceBase):
                 is_valid_effective_tile,
                 is_masked_final_wave,
                 apply_boundary_mask=False,
-                fragment_idx=fragment_idx,
             )
         else:
             self._load_keeps_fragment_impl(
@@ -1124,286 +1082,7 @@ class TmemSResource(DecodeGenResourceBase):
                 is_valid_effective_tile,
                 is_masked_final_wave,
                 apply_boundary_mask=True,
-                fragment_idx=fragment_idx,
             )
-
-    @cute.jit
-    def _reduce_keeps_fragment_max(self, s_vals: cutlass.Array) -> Float32:
-        """Reduce the row maximum of a previously loaded Keeps fragment."""
-        cfg = self.cfg
-        num_s_regs = cfg.softmax_score_fragment_regs
-
-        max_chains = cutlass.Array(Float32, 4, space=cutlass.AddressSpace.rmem)
-        for chain_idx in cutlass.range_constexpr(4):
-            max_chains[chain_idx] = _neg_max_f32()
-        for reg_base in cutlass.range_constexpr(0, num_s_regs, 4):
-            for chain_idx in cutlass.range_constexpr(4):
-                max_chains[chain_idx] = cute.math.max(
-                    max_chains[chain_idx],
-                    s_vals[reg_base + chain_idx],
-                    ftz=True,
-                )
-        tile_max = cute.math.max(
-            cute.math.max(max_chains[0], max_chains[1], ftz=True),
-            cute.math.max(max_chains[2], max_chains[3], ftz=True),
-            ftz=True,
-        )
-        if cutlass.const_expr(cfg.tile_size_q == 64 and cfg.tile_size_kv != 256):
-            return cute.math.max(
-                tile_max,
-                Float32(
-                    prims.shfl_sync(
-                        thread_mask=0xFFFFFFFF,
-                        val=tile_max,
-                        offset=16,
-                        mask_and_clamp=0x1F,
-                        kind=prims.Shfl.BFLY,
-                    )
-                ),
-                ftz=True,
-            )
-        return tile_max
-
-    @cute.jit
-    def _decode_sparse_mask_metadata(
-        self,
-        routed_origin0: Int32,
-        routed_origin1: Int32,
-        routed_route_flags: Int32,
-        routed_token_word0: Uint32,
-        routed_token_word1: Uint32,
-        routed_token_word2: Uint32,
-        routed_token_word3: Uint32,
-    ) -> tuple[Int32, Int32, Int32, Int32, cutlass.Array, cutlass.Boolean]:
-        """Decode one prepared, register-routed mask payload."""
-
-        origin0 = Int32(routed_origin0)
-        origin1 = Int32(routed_origin1)
-        route_flags = Int32(routed_route_flags)
-        valid0 = route_flags & Int32(1)
-        valid1 = (route_flags >> Int32(1)) & Int32(1)
-        route_token_mask_is_full = cutlass.Boolean(False)
-        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
-            route_token_mask_is_full = cutlass.Boolean(
-                (route_flags & Int32(_SOFTMAX_TOKEN_MASK_IS_FULL_FLAG)) != Int32(0)
-            )
-
-        num_local_words = 4 if self.cfg.tile_size_q == 128 else 2
-        local_token_words = cutlass.Array(
-            Uint32,
-            num_local_words,
-            space=cutlass.AddressSpace.rmem,
-        )
-        for word_idx in cutlass.range_constexpr(num_local_words):
-            local_token_words[word_idx] = Uint32(0xFFFFFFFF)
-        if cutlass.const_expr(self.cfg.uses_prepared_score_keep_words):
-            if not route_token_mask_is_full:
-                if cutlass.const_expr(self.cfg.tile_size_q == 128):
-                    local_token_words[0] = Uint32(routed_token_word0)
-                    local_token_words[1] = Uint32(routed_token_word1)
-                    local_token_words[2] = Uint32(routed_token_word2)
-                    local_token_words[3] = Uint32(routed_token_word3)
-                else:
-                    local_word0 = Uint32(routed_token_word0)
-                    local_word1 = Uint32(routed_token_word1)
-                    local_token_words[0] = local_word0
-                    local_token_words[1] = local_word1
-        return (
-            origin0,
-            origin1,
-            valid0,
-            valid1,
-            local_token_words,
-            route_token_mask_is_full,
-        )
-
-    @cute.jit
-    def _compute_softmax_loop_sparse_keeps(
-        self,
-        stage_info: StageInfo,
-        *,
-        old_max_arr: cutlass.Array,
-        sum_arr: cutlass.Array,
-        new_max_arr: cutlass.Array,
-        s_arr: cutlass.Array,
-        routed_origin0: Int32,
-        routed_origin1: Int32,
-        routed_route_flags: Int32,
-        routed_token_word0: Uint32,
-        routed_token_word1: Uint32,
-        routed_token_word2: Uint32,
-        routed_token_word3: Uint32,
-    ) -> tuple[object, object, object, object]:
-        """Load Keeps scores and mask them in logical KV coordinates."""
-        cfg = self.cfg
-        num_s_regs = cfg.num_s_regs_per_thread
-        old_max = new_max_arr[0]
-        running_sum = sum_arr[0]
-        s_vals = cutlass.Array(Float32, num_s_regs, space=cutlass.AddressSpace.rmem)
-        task_cache = _decode_gen_task_cache(stage_info)
-        seq_len_kv = _load_runtime_seq_len_kv(
-            self.seqlens_kv,
-            self.max_seq_len_kv,
-            stage_info,
-            Int32(0),
-            Int32(0),
-        )
-        warp_grp_thread_idx = Int32(task_cache[_TASK_CACHE_WARP_GRP_THREAD_IDX])
-        lane_idx = Int32(task_cache[_TASK_CACHE_LANE_IDX])
-        tile_row_idx = _keeps_row_idx(cfg, warp_grp_thread_idx)
-        col_base = _keeps_col_base(cfg, lane_idx, num_s_regs)
-        (
-            origin0,
-            origin1,
-            valid0,
-            valid1,
-            local_token_words,
-            route_token_mask_is_full,
-        ) = self._decode_sparse_mask_metadata(
-            routed_origin0=routed_origin0,
-            routed_origin1=routed_origin1,
-            routed_route_flags=routed_route_flags,
-            routed_token_word0=routed_token_word0,
-            routed_token_word1=routed_token_word1,
-            routed_token_word2=routed_token_word2,
-            routed_token_word3=routed_token_word3,
-        )
-
-        base_addr = (
-            task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
-            + Int32(self._alloc.offset)
-            + self._softmax_loop_stage_slot_offset(stage_info)
-        )
-        num_load_atoms = num_s_regs // 32
-        if cutlass.const_expr(
-            cfg.tile_size_q == 64 and cfg.uses_prepared_score_keep_words
-        ):
-            token_mask_is_required = not route_token_mask_is_full
-
-            # Keep each Q64 atom's load, wait, and mask together. A/B testing
-            # showed that hoisting both loads extends live fragment ranges and
-            # regresses the Q64 code generated by ptxas.
-            for load_atom_idx in cutlass.range_constexpr(2):
-                atom_col = load_atom_idx * 32
-                loaded = _keeps_tcgen05_ld(
-                    cfg,
-                    prims.make_tmem_ptr(base_addr + Int32(atom_col), Float32),
-                    num=32,
-                    offset=cfg.tile_size_kv // 2,
-                )
-                prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
-                self._mask_and_store_sparse_keeps_atom(
-                    s_vals,
-                    loaded,
-                    local_token_words[load_atom_idx],
-                    atom_col=atom_col,
-                    token_mask_is_required=token_mask_is_required,
-                )
-        else:
-            for load_atom_idx in cutlass.range_constexpr(num_load_atoms):
-                atom_col = load_atom_idx * 32
-                loaded = _keeps_tcgen05_ld(
-                    cfg,
-                    prims.make_tmem_ptr(base_addr + Int32(atom_col), Float32),
-                    num=32,
-                    offset=cfg.tile_size_kv // 2,
-                )
-                prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
-                for atom_reg_idx in cutlass.range_constexpr(32):
-                    score_idx = atom_col + atom_reg_idx
-                    s_vals[score_idx] = loaded[atom_reg_idx]
-
-        logical_q_group_idx = _logical_q_group_idx(cfg, stage_info, self.q_group_idx)
-        q_token_idx, _ = _q_row_token_and_local_head(
-            cfg,
-            self.h_r,
-            logical_q_group_idx,
-            tile_row_idx,
-        )
-        q_row_is_valid = _q_row_is_valid_for_seq(
-            cfg,
-            self.h_r,
-            logical_q_group_idx,
-            tile_row_idx,
-            self.seq_len_q,
-        )
-        causal_end = seq_len_kv - self.seq_len_q + q_token_idx + Int32(1)
-        can_skip_structural_mask = _can_skip_sparse_keeps_structural_mask(
-            q_row_is_valid,
-            origin0,
-            origin1,
-            valid0,
-            valid1,
-            seq_len_kv,
-            causal_end,
-            apply_causal_mask=cfg.mask_type == CAUSAL,
-        )
-        if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
-            route_is_proxy = cutlass.Boolean(
-                (routed_route_flags & Int32(_SOFTMAX_ROUTE_IS_PROXY_FLAG)) != Int32(0)
-            )
-            if route_is_proxy and q_row_is_valid:
-                # Summary-row origins must not enter K/V-token tail predicates;
-                # prepared score words carry proxy validity.
-                can_skip_structural_mask = cutlass.Boolean(True)
-        # This guard covers only route/Q/tail/causal structure. Q64 token
-        # holes were applied while materializing its two LDTM atoms; Q128
-        # applies them in the post-pass below.
-        if not can_skip_structural_mask:
-            for reg_idx in cutlass.range_constexpr(num_s_regs):
-                fragment_offset = Int32(reg_idx)
-                logical_k = origin0 + fragment_offset
-                fragment_valid = valid0
-                if cutlass.const_expr(cfg.tile_size_q == 128 and reg_idx >= 64):
-                    fragment_offset = Int32(reg_idx - 64)
-                    logical_k = origin1 + fragment_offset
-                    fragment_valid = valid1
-                elif cutlass.const_expr(cfg.tile_size_q == 64):
-                    if col_base >= Int32(64):
-                        logical_k = origin1 + fragment_offset
-                        fragment_valid = valid1
-
-                score_is_valid = (
-                    q_row_is_valid
-                    and fragment_valid != Int32(0)
-                    and logical_k < seq_len_kv
-                )
-                if cutlass.const_expr(cfg.mask_type == CAUSAL):
-                    score_is_valid = score_is_valid and logical_k < causal_end
-                if not score_is_valid:
-                    s_vals[reg_idx] = _neg_max_f32()
-
-        # Q128 deliberately keeps all four LDTM atoms adjacent: unlike Q64,
-        # interleaving each load with mask control flow regresses its codegen.
-        # The post-pass follows structural masking; the producer's runtime
-        # route flag skips it only when all four current token words are full.
-        if cutlass.const_expr(
-            cfg.tile_size_q == 128 and cfg.uses_prepared_score_keep_words
-        ):
-            token_mask_is_required = not route_token_mask_is_full
-            if token_mask_is_required:
-                for word_idx in cutlass.range_constexpr(4):
-                    token_word = local_token_words[word_idx]
-                    for bit_idx in cutlass.range_constexpr(32):
-                        reg_idx = word_idx * 32 + bit_idx
-                        token_bit_is_valid = (
-                            (token_word >> Int32(bit_idx)) & Uint32(1)
-                        ) != Uint32(0)
-                        if not token_bit_is_valid:
-                            s_vals[reg_idx] = _neg_max_f32()
-
-        tile_max = self._reduce_keeps_row_max(s_vals)
-        self._publish_keeps_softmax_state(
-            s_vals,
-            tile_max,
-            old_max,
-            running_sum,
-            old_max_arr,
-            sum_arr,
-            new_max_arr,
-            s_arr,
-        )
-        return old_max_arr, sum_arr, new_max_arr, s_arr
 
     @cute.jit
     def _compute_softmax_loop_keeps(
@@ -1423,8 +1102,26 @@ class TmemSResource(DecodeGenResourceBase):
         reduction, whose 16x256b register mapping is unrelated to Keeps.
         """
         cfg = self.cfg
+        if cutlass.const_expr(cfg.streams_tmem_p_fragments):
+            # Streamed profiles share the fragment max pass with block-sparse
+            # routes; dense tiles describe their visible range as keep words.
+            return self._compute_softmax_loop_keeps_fragments(
+                stage_info,
+                old_max_arr=old_max_arr,
+                sum_arr=sum_arr,
+                new_max_arr=new_max_arr,
+                s_arr=s_arr,
+                use_sparse=False,
+                sparse_origin0=Int32(0),
+                sparse_origin1=Int32(0),
+                sparse_route_flags=Int32(0),
+                sparse_token_word0=Uint32(0xFFFFFFFF),
+                sparse_token_word1=Uint32(0xFFFFFFFF),
+                sparse_token_word2=Uint32(0xFFFFFFFF),
+                sparse_token_word3=Uint32(0xFFFFFFFF),
+            )
         task_cache = _decode_gen_task_cache(stage_info)
-        num_s_regs = cfg.softmax_score_fragment_regs
+        num_s_regs = cfg.num_s_regs_per_thread
         old_max = new_max_arr[0]
         running_sum = sum_arr[0]
         s_vals = cutlass.Array(Float32, num_s_regs, space=cutlass.AddressSpace.rmem)
@@ -1450,62 +1147,8 @@ class TmemSResource(DecodeGenResourceBase):
             is_valid_effective_tile,
             is_masked_final_wave,
             tile_is_unmasked,
+            tile_has_valid_scores,
         ) = self._resolve_keeps_tile_context(stage_info)
-
-        if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-            # Streamed profiles own four physical K32 fragments per lane.
-            # Reduce the max one fragment at a time so only one native LDTM
-            # atom is live; the P pass reloads the same fragments after the
-            # reference max is known.
-            tile_max = _neg_max_f32()
-            for fragment_idx in cutlass.range_constexpr(
-                cfg.num_softmax_score_fragments
-            ):
-                self._load_keeps_fragment(
-                    stage_info,
-                    s_vals,
-                    tile_offset_k,
-                    element_mask_end_idx,
-                    window_start_idx,
-                    seq_len_kv,
-                    logical_q_group_idx,
-                    is_valid_effective_tile,
-                    is_masked_final_wave,
-                    tile_is_unmasked,
-                    fragment_idx=fragment_idx,
-                )
-                if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-                    # The rolled P loop reloads scores without mask logic, so a
-                    # masked tile writes its masked fragment back in place.
-                    # The branch is warp-uniform: the loader above already
-                    # selected its mask policy on the same predicate.
-                    if not tile_is_unmasked:
-                        fragment_addr = (
-                            task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
-                            + Int32(self._alloc.offset)
-                            + self._softmax_loop_stage_slot_offset(stage_info)
-                            + Int32(fragment_idx * num_s_regs)
-                        )
-                        _keeps_tcgen05_st(
-                            cfg,
-                            prims.make_tmem_ptr(fragment_addr, Float32),
-                            s_vals.data_ptr().load(count=num_s_regs, alignment=4),
-                            offset=cfg.tile_size_kv // 2,
-                        )
-                fragment_max = self._reduce_keeps_fragment_max(s_vals)
-                tile_max = cute.math.max(tile_max, fragment_max, ftz=True)
-            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-                if not tile_is_unmasked:
-                    prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
-                    cute.arch.fence_view_async_tmem_store()
-
-            new_max = self._softmax_anchor(old_max, tile_max)
-            old_max_arr[0] = old_max
-            sum_arr[0] = running_sum
-            new_max_arr[0] = new_max
-            for reg_idx in cutlass.range_constexpr(num_s_regs):
-                s_arr[reg_idx] = s_vals[reg_idx]
-            return old_max_arr, sum_arr, new_max_arr, s_arr
 
         if cutlass.const_expr(use_preload_mask_split):
             # Select the complete unmasked/masked TMEM load+max path before any S
@@ -1524,7 +1167,7 @@ class TmemSResource(DecodeGenResourceBase):
                 is_masked_final_wave,
                 tile_is_unmasked,
             )
-            tile_max = self._reduce_keeps_fragment_max(s_vals)
+            tile_max = self._reduce_keeps_row_max(s_vals)
 
             self._publish_keeps_softmax_state(
                 s_vals,
@@ -1538,12 +1181,7 @@ class TmemSResource(DecodeGenResourceBase):
             )
             return old_max_arr, sum_arr, new_max_arr, s_arr
 
-        should_load_s = (
-            is_valid_effective_tile
-            and (tile_offset_k < seq_len_kv)
-            and not is_masked_final_wave
-        )
-        if should_load_s:
+        if tile_has_valid_scores:
             base_addr = (
                 task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
                 + Int32(self._alloc.offset)
@@ -2321,7 +1959,7 @@ class TmemSResource(DecodeGenResourceBase):
         return sum_arr
 
     @cute.jit
-    def _compute_softmax_loop_sparse_keeps_fragments(
+    def _compute_softmax_loop_keeps_fragments(
         self,
         stage_info: StageInfo,
         *,
@@ -2329,6 +1967,7 @@ class TmemSResource(DecodeGenResourceBase):
         sum_arr: cutlass.Array,
         new_max_arr: cutlass.Array,
         s_arr: cutlass.Array,
+        use_sparse: Constexpr[bool],
         sparse_origin0: Int32,
         sparse_origin1: Int32,
         sparse_route_flags: Int32,
@@ -2339,91 +1978,139 @@ class TmemSResource(DecodeGenResourceBase):
     ) -> tuple[object, object, object, object]:
         """Mask streamed K32 score fragments in place and reduce their max.
 
-        Each lane owns two K64 route atoms as ``num_softmax_score_fragments``
-        fragments: the first atom's fragments start at ``origin0`` and the
-        second atom's at ``origin1``. Masked fragments are written back to
-        TMEM so the P pass can reload them without any mask logic.
+        Every fragment gets one keep word. Block-sparse routes derive it from
+        their two K64 atom origins, validity flags and prepared token words;
+        dense tiles derive it from the tile's visible token range (sequence
+        end, uniform or per-row causal end, sliding-window start) and the Q
+        row's validity. Masked fragments are written back to TMEM so the P
+        pass can reload them without any mask logic.
         """
-
         cfg = self.cfg
         assert cfg.streams_tmem_p_fragments
         num_fragments = cfg.num_softmax_score_fragments
         fragment_regs = cfg.softmax_score_fragment_regs
-        fragments_per_origin = (
-            _block_sparse_kv_atom_size(cfg.kv_block_size) // fragment_regs
-        )
         # The seven-slot softmax metadata ABI carries exactly four token words.
         assert num_fragments == 4 and fragment_regs == 32
         task_cache = _decode_gen_task_cache(stage_info)
-        token_words = (
-            sparse_token_word0,
-            sparse_token_word1,
-            sparse_token_word2,
-            sparse_token_word3,
-        )
         keep_words = cutlass.Array(
             Uint32, num_fragments, space=cutlass.AddressSpace.rmem
         )
         warp_group_thread_idx = Int32(task_cache[_TASK_CACHE_WARP_GRP_THREAD_IDX])
         tile_row_idx = _keeps_row_idx(cfg, warp_group_thread_idx)
-        logical_q_group_idx = _logical_q_group_idx(cfg, stage_info, self.q_group_idx)
-        q_token_idx, _ = _q_row_token_and_local_head(
-            cfg,
-            self.h_r,
-            logical_q_group_idx,
-            tile_row_idx,
-        )
-        q_row_is_valid = _q_row_is_valid_for_seq(
-            cfg,
-            self.h_r,
-            logical_q_group_idx,
-            tile_row_idx,
-            self.seq_len_q,
-        )
-        seq_len_kv = _load_runtime_seq_len_kv(
-            self.seqlens_kv,
-            self.max_seq_len_kv,
-            stage_info,
-            Int32(0),
-            Int32(0),
-        )
-        causal_end = seq_len_kv - self.seq_len_q + q_token_idx + Int32(1)
-        origin0 = Int32(sparse_origin0)
-        origin1 = Int32(sparse_origin1)
-        valid0 = sparse_route_flags & Int32(1)
-        valid1 = (sparse_route_flags >> Int32(1)) & Int32(1)
-        for fragment_idx in cutlass.range_constexpr(num_fragments):
-            atom_offset = Int32((fragment_idx % fragments_per_origin) * fragment_regs)
-            fragment_origin = origin0 + atom_offset
-            fragment_valid = valid0
-            if cutlass.const_expr(fragment_idx >= fragments_per_origin):
-                fragment_origin = origin1 + atom_offset
-                fragment_valid = valid1
-            if cutlass.const_expr(cfg.trusts_prepared_score_words):
-                prepared_keep_word = Uint32(0)
-                if q_row_is_valid:
-                    prepared_keep_word = Uint32(token_words[fragment_idx])
-                keep_words[fragment_idx] = prepared_keep_word
-            else:
-                keep_words[fragment_idx] = _sparse_effective_keep_word(
-                    q_row_is_valid,
-                    fragment_origin,
-                    fragment_valid,
-                    Uint32(token_words[fragment_idx]),
-                    seq_len_kv,
-                    causal_end,
-                    apply_causal_mask=cfg.mask_type == CAUSAL,
-                    apply_token_mask=cfg.uses_prepared_score_keep_words,
-                )
-
-        warp_scores_are_unmasked = cutlass.Boolean(True)
-        for fragment_idx in cutlass.range_constexpr(num_fragments):
-            warp_scores_are_unmasked = cutlass.Boolean(
-                warp_scores_are_unmasked
-                and keep_words[fragment_idx] == Uint32(0xFFFFFFFF)
+        if cutlass.const_expr(use_sparse):
+            token_words = (
+                sparse_token_word0,
+                sparse_token_word1,
+                sparse_token_word2,
+                sparse_token_word3,
             )
-        # The load/store branch must be uniform for each participating warp.
-        warp_scores_are_unmasked = cute.arch.vote_all_sync(warp_scores_are_unmasked)
+            logical_q_group_idx = _logical_q_group_idx(
+                cfg, stage_info, self.q_group_idx
+            )
+            q_token_idx, _ = _q_row_token_and_local_head(
+                cfg,
+                self.h_r,
+                logical_q_group_idx,
+                tile_row_idx,
+            )
+            q_row_is_valid = _q_row_is_valid_for_seq(
+                cfg,
+                self.h_r,
+                logical_q_group_idx,
+                tile_row_idx,
+                self.seq_len_q,
+            )
+            seq_len_kv = _load_runtime_seq_len_kv(
+                self.seqlens_kv,
+                self.max_seq_len_kv,
+                stage_info,
+                Int32(0),
+                Int32(0),
+            )
+            causal_end = seq_len_kv - self.seq_len_q + q_token_idx + Int32(1)
+            origin0 = Int32(sparse_origin0)
+            origin1 = Int32(sparse_origin1)
+            valid0 = sparse_route_flags & Int32(1)
+            valid1 = (sparse_route_flags >> Int32(1)) & Int32(1)
+            fragments_per_origin = cfg.softmax_fragments_per_route_atom
+            for fragment_idx in cutlass.range_constexpr(num_fragments):
+                atom_offset = Int32(
+                    (fragment_idx % fragments_per_origin) * fragment_regs
+                )
+                fragment_origin = origin0 + atom_offset
+                fragment_valid = valid0
+                if cutlass.const_expr(fragment_idx >= fragments_per_origin):
+                    fragment_origin = origin1 + atom_offset
+                    fragment_valid = valid1
+                if cutlass.const_expr(cfg.trusts_prepared_score_words):
+                    prepared_keep_word = Uint32(0)
+                    if q_row_is_valid:
+                        prepared_keep_word = Uint32(token_words[fragment_idx])
+                    keep_words[fragment_idx] = prepared_keep_word
+                else:
+                    keep_words[fragment_idx] = _sparse_effective_keep_word(
+                        q_row_is_valid,
+                        fragment_origin,
+                        fragment_valid,
+                        Uint32(token_words[fragment_idx]),
+                        seq_len_kv,
+                        causal_end,
+                        apply_causal_mask=cfg.mask_type == CAUSAL,
+                        apply_token_mask=cfg.uses_prepared_score_keep_words,
+                    )
+
+        else:
+            (
+                seq_len_kv,
+                logical_q_group_idx,
+                element_mask_end_idx,
+                tile_offset_k,
+                window_start_idx,
+                _is_valid_effective_tile,
+                _is_masked_final_wave,
+                tile_is_unmasked,
+                rows_are_active,
+            ) = self._resolve_keeps_tile_context(stage_info)
+            if cutlass.const_expr(cfg.q_score_rows_need_mask):
+                rows_are_active = cutlass.Boolean(
+                    rows_are_active
+                    and _q_row_is_valid_for_seq(
+                        cfg,
+                        self.h_r,
+                        logical_q_group_idx,
+                        tile_row_idx,
+                        self.seq_len_q,
+                    )
+                )
+            visible_start = Int32(0)
+            visible_end = element_mask_end_idx
+            if cutlass.const_expr(cfg.uses_per_row_causal_mask):
+                q_token_idx, _ = _q_row_token_and_local_head(
+                    cfg,
+                    self.h_r,
+                    logical_q_group_idx,
+                    tile_row_idx,
+                )
+                visible_end = seq_len_kv - self.seq_len_q + q_token_idx + Int32(1)
+                visible_start = _sliding_window_start_idx(
+                    cfg, seq_len_kv, self.seq_len_q, q_token_idx
+                )
+            elif cutlass.const_expr(cfg.use_sliding_window_causal):
+                visible_start = window_start_idx
+            # A tile that is unmasked for the whole Q group has all-ones keep
+            # words on every active row, so only masked tiles build them.
+            warp_scores_are_unmasked = cute.arch.vote_all_sync(
+                cutlass.Boolean(tile_is_unmasked and rows_are_active)
+            )
+        if cutlass.const_expr(use_sparse):
+            warp_scores_are_unmasked = cutlass.Boolean(True)
+            for fragment_idx in cutlass.range_constexpr(num_fragments):
+                warp_scores_are_unmasked = cutlass.Boolean(
+                    warp_scores_are_unmasked
+                    and keep_words[fragment_idx] == Uint32(0xFFFFFFFF)
+                )
+            # The load/store branch must be uniform for each participating warp.
+            warp_scores_are_unmasked = cute.arch.vote_all_sync(warp_scores_are_unmasked)
 
         score_tmem_addr = (
             task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
@@ -2453,6 +2140,22 @@ class TmemSResource(DecodeGenResourceBase):
                         ftz=True,
                     )
         else:
+            if cutlass.const_expr(not use_sparse):
+                lane_idx = Int32(task_cache[_TASK_CACHE_LANE_IDX])
+                col_base = _keeps_col_base(cfg, lane_idx, num_fragments * fragment_regs)
+                for fragment_idx in cutlass.range_constexpr(num_fragments):
+                    fragment_token_base = tile_offset_k + _keeps_score_col(
+                        cfg,
+                        warp_group_thread_idx,
+                        fragment_idx * fragment_regs,
+                        col_base,
+                    )
+                    keep_words[fragment_idx] = _dense_fragment_keep_word(
+                        rows_are_active,
+                        visible_start - fragment_token_base,
+                        visible_end - fragment_token_base,
+                        fragment_regs=fragment_regs,
+                    )
             for fragment_idx in cutlass.range_constexpr(num_fragments):
                 fragment_addr = score_tmem_addr + Int32(fragment_idx * fragment_regs)
                 loaded = _keeps_tcgen05_ld(
@@ -2519,34 +2222,21 @@ class TmemSResource(DecodeGenResourceBase):
 
         assert self.cfg.use_block_sparse
         if cutlass.const_expr(self.cfg.use_keeps_mma_ab):
-            if cutlass.const_expr(self.cfg.streams_tmem_p_fragments):
-                return self._compute_softmax_loop_sparse_keeps_fragments(
-                    stage_info,
-                    old_max_arr=old_max_arr,
-                    sum_arr=sum_arr,
-                    new_max_arr=new_max_arr,
-                    s_arr=s_arr,
-                    sparse_origin0=sparse_origin0,
-                    sparse_origin1=sparse_origin1,
-                    sparse_route_flags=sparse_route_flags,
-                    sparse_token_word0=sparse_token_word0,
-                    sparse_token_word1=sparse_token_word1,
-                    sparse_token_word2=sparse_token_word2,
-                    sparse_token_word3=sparse_token_word3,
-                )
-            return self._compute_softmax_loop_sparse_keeps(
+            # Every block-sparse Keeps profile streams K32 fragments.
+            return self._compute_softmax_loop_keeps_fragments(
                 stage_info,
                 old_max_arr=old_max_arr,
                 sum_arr=sum_arr,
                 new_max_arr=new_max_arr,
                 s_arr=s_arr,
-                routed_origin0=sparse_origin0,
-                routed_origin1=sparse_origin1,
-                routed_route_flags=sparse_route_flags,
-                routed_token_word0=sparse_token_word0,
-                routed_token_word1=sparse_token_word1,
-                routed_token_word2=sparse_token_word2,
-                routed_token_word3=sparse_token_word3,
+                use_sparse=True,
+                sparse_origin0=sparse_origin0,
+                sparse_origin1=sparse_origin1,
+                sparse_route_flags=sparse_route_flags,
+                sparse_token_word0=sparse_token_word0,
+                sparse_token_word1=sparse_token_word1,
+                sparse_token_word2=sparse_token_word2,
+                sparse_token_word3=sparse_token_word3,
             )
         # SWAP reuses the Keeps seven-slot task ABI: all four origins remain
         # logical KV atom bases, but origin2 occupies the flags slot and

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
@@ -41,7 +41,7 @@ from cutlass.experimental.task_scheduling.resources import (
     producer_work,
 )
 
-from ...._block_sparse.common import _MAX_KV_ATOM_SIZE
+from ...._block_sparse.common import _MAX_KV_ATOM_SIZE, _block_sparse_kv_atom_size
 from ...._block_sparse.prepared import _PREPARED_ROUTE_IS_FULL_FLAG
 from ..fmha_decode_config import CAUSAL, FmhaDecodeConfig
 from ..fmha_decode_constants import SOFTMAX_RESCALE_THRESHOLD_LOG2
@@ -1452,11 +1452,11 @@ class TmemSResource(DecodeGenResourceBase):
             tile_is_unmasked,
         ) = self._resolve_keeps_tile_context(stage_info)
 
-        if cutlass.const_expr(cfg.tile_size_kv == 256):
-            # KV256 owns four physical K32 fragments per lane. Reduce the max
-            # one fragment at a time so only one native LDTM atom is live; the
-            # P pass reloads the same fragments after the reference max is
-            # known.
+        if cutlass.const_expr(cfg.streams_tmem_p_fragments):
+            # Streamed profiles own four physical K32 fragments per lane.
+            # Reduce the max one fragment at a time so only one native LDTM
+            # atom is live; the P pass reloads the same fragments after the
+            # reference max is known.
             tile_max = _neg_max_f32()
             for fragment_idx in cutlass.range_constexpr(
                 cfg.num_softmax_score_fragments
@@ -2321,7 +2321,7 @@ class TmemSResource(DecodeGenResourceBase):
         return sum_arr
 
     @cute.jit
-    def _compute_softmax_loop_sparse_keeps_kv256(
+    def _compute_softmax_loop_sparse_keeps_fragments(
         self,
         stage_info: StageInfo,
         *,
@@ -2337,10 +2337,23 @@ class TmemSResource(DecodeGenResourceBase):
         sparse_token_word2: Uint32,
         sparse_token_word3: Uint32,
     ) -> tuple[object, object, object, object]:
-        """Preserve the established KV256 online-softmax state update."""
+        """Mask streamed K32 score fragments in place and reduce their max.
+
+        Each lane owns two K64 route atoms as ``num_softmax_score_fragments``
+        fragments: the first atom's fragments start at ``origin0`` and the
+        second atom's at ``origin1``. Masked fragments are written back to
+        TMEM so the P pass can reload them without any mask logic.
+        """
 
         cfg = self.cfg
-        assert cfg.tile_size_kv == 256
+        assert cfg.streams_tmem_p_fragments
+        num_fragments = cfg.num_softmax_score_fragments
+        fragment_regs = cfg.softmax_score_fragment_regs
+        fragments_per_origin = (
+            _block_sparse_kv_atom_size(cfg.kv_block_size) // fragment_regs
+        )
+        # The seven-slot softmax metadata ABI carries exactly four token words.
+        assert num_fragments == 4 and fragment_regs == 32
         task_cache = _decode_gen_task_cache(stage_info)
         token_words = (
             sparse_token_word0,
@@ -2348,7 +2361,9 @@ class TmemSResource(DecodeGenResourceBase):
             sparse_token_word2,
             sparse_token_word3,
         )
-        keep_words = cutlass.Array(Uint32, 4, space=cutlass.AddressSpace.rmem)
+        keep_words = cutlass.Array(
+            Uint32, num_fragments, space=cutlass.AddressSpace.rmem
+        )
         warp_group_thread_idx = Int32(task_cache[_TASK_CACHE_WARP_GRP_THREAD_IDX])
         tile_row_idx = _keeps_row_idx(cfg, warp_group_thread_idx)
         logical_q_group_idx = _logical_q_group_idx(cfg, stage_info, self.q_group_idx)
@@ -2377,11 +2392,12 @@ class TmemSResource(DecodeGenResourceBase):
         origin1 = Int32(sparse_origin1)
         valid0 = sparse_route_flags & Int32(1)
         valid1 = (sparse_route_flags >> Int32(1)) & Int32(1)
-        for fragment_idx in cutlass.range_constexpr(4):
-            fragment_origin = origin0 + Int32((fragment_idx % 2) * 32)
+        for fragment_idx in cutlass.range_constexpr(num_fragments):
+            atom_offset = Int32((fragment_idx % fragments_per_origin) * fragment_regs)
+            fragment_origin = origin0 + atom_offset
             fragment_valid = valid0
-            if cutlass.const_expr(fragment_idx >= 2):
-                fragment_origin = origin1 + Int32((fragment_idx % 2) * 32)
+            if cutlass.const_expr(fragment_idx >= fragments_per_origin):
+                fragment_origin = origin1 + atom_offset
                 fragment_valid = valid1
             if cutlass.const_expr(cfg.trusts_prepared_score_words):
                 prepared_keep_word = Uint32(0)
@@ -2401,7 +2417,7 @@ class TmemSResource(DecodeGenResourceBase):
                 )
 
         warp_scores_are_unmasked = cutlass.Boolean(True)
-        for fragment_idx in cutlass.range_constexpr(4):
+        for fragment_idx in cutlass.range_constexpr(num_fragments):
             warp_scores_are_unmasked = cutlass.Boolean(
                 warp_scores_are_unmasked
                 and keep_words[fragment_idx] == Uint32(0xFFFFFFFF)
@@ -2419,17 +2435,17 @@ class TmemSResource(DecodeGenResourceBase):
             max_chains[chain_idx] = _neg_max_f32()
 
         if warp_scores_are_unmasked:
-            for fragment_idx in cutlass.range_constexpr(4):
+            for fragment_idx in cutlass.range_constexpr(num_fragments):
                 loaded = _keeps_tcgen05_ld(
                     cfg,
                     prims.make_tmem_ptr(
-                        score_tmem_addr + Int32(fragment_idx * 32), Float32
+                        score_tmem_addr + Int32(fragment_idx * fragment_regs), Float32
                     ),
-                    num=32,
+                    num=fragment_regs,
                     offset=cfg.tile_size_kv // 2,
                 )
                 prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
-                for score_idx in cutlass.range_constexpr(32):
+                for score_idx in cutlass.range_constexpr(fragment_regs):
                     chain_idx: Constexpr[int] = score_idx % 4
                     max_chains[chain_idx] = cute.math.max(
                         max_chains[chain_idx],
@@ -2437,19 +2453,19 @@ class TmemSResource(DecodeGenResourceBase):
                         ftz=True,
                     )
         else:
-            for fragment_idx in cutlass.range_constexpr(4):
-                fragment_addr = score_tmem_addr + Int32(fragment_idx * 32)
+            for fragment_idx in cutlass.range_constexpr(num_fragments):
+                fragment_addr = score_tmem_addr + Int32(fragment_idx * fragment_regs)
                 loaded = _keeps_tcgen05_ld(
                     cfg,
                     prims.make_tmem_ptr(fragment_addr, Float32),
-                    num=32,
+                    num=fragment_regs,
                     offset=cfg.tile_size_kv // 2,
                 )
                 prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
                 masked_scores = cutlass.Array(
-                    Float32, 32, space=cutlass.AddressSpace.rmem
+                    Float32, fragment_regs, space=cutlass.AddressSpace.rmem
                 )
-                for score_idx in cutlass.range_constexpr(32):
+                for score_idx in cutlass.range_constexpr(fragment_regs):
                     score = Float32(loaded[score_idx])
                     score_is_kept = (
                         (keep_words[fragment_idx] >> Int32(score_idx)) & Uint32(1)
@@ -2464,7 +2480,7 @@ class TmemSResource(DecodeGenResourceBase):
                 _keeps_tcgen05_st(
                     cfg,
                     prims.make_tmem_ptr(fragment_addr, Float32),
-                    masked_scores.data_ptr().load(count=32, alignment=4),
+                    masked_scores.data_ptr().load(count=fragment_regs, alignment=4),
                     offset=cfg.tile_size_kv // 2,
                 )
             prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
@@ -2503,8 +2519,8 @@ class TmemSResource(DecodeGenResourceBase):
 
         assert self.cfg.use_block_sparse
         if cutlass.const_expr(self.cfg.use_keeps_mma_ab):
-            if cutlass.const_expr(self.cfg.tile_size_kv == 256):
-                return self._compute_softmax_loop_sparse_keeps_kv256(
+            if cutlass.const_expr(self.cfg.streams_tmem_p_fragments):
+                return self._compute_softmax_loop_sparse_keeps_fragments(
                     stage_info,
                     old_max_arr=old_max_arr,
                     sum_arr=sum_arr,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
@@ -1472,8 +1472,30 @@ class TmemSResource(DecodeGenResourceBase):
                     tile_is_unmasked,
                     fragment_idx=fragment_idx,
                 )
+                if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+                    # The rolled P loop reloads scores without mask logic, so a
+                    # masked tile writes its masked fragment back in place.
+                    # The branch is warp-uniform: the loader above already
+                    # selected its mask policy on the same predicate.
+                    if not tile_is_unmasked:
+                        fragment_addr = (
+                            task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
+                            + Int32(self._alloc.offset)
+                            + self._softmax_loop_stage_slot_offset(stage_info)
+                            + Int32(fragment_idx * num_s_regs)
+                        )
+                        _keeps_tcgen05_st(
+                            cfg,
+                            prims.make_tmem_ptr(fragment_addr, Float32),
+                            s_vals.data_ptr().load(count=num_s_regs, alignment=4),
+                            offset=cfg.tile_size_kv // 2,
+                        )
                 fragment_max = self._reduce_keeps_fragment_max(s_vals)
                 tile_max = cute.math.max(tile_max, fragment_max, ftz=True)
+            if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+                if not tile_is_unmasked:
+                    prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
+                    cute.arch.fence_view_async_tmem_store()
 
             new_max = cute.math.max(old_max, tile_max, ftz=True)
             if old_max != _neg_max_f32():

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_resources/tmem_s.py
@@ -44,7 +44,7 @@ from cutlass.experimental.task_scheduling.resources import (
 from ...._block_sparse.common import _MAX_KV_ATOM_SIZE
 from ...._block_sparse.prepared import _PREPARED_ROUTE_IS_FULL_FLAG
 from ..fmha_decode_config import CAUSAL, FmhaDecodeConfig
-from ..fmha_decode_constants import KV_TILE_256_RESCALE_THRESHOLD_LOG2
+from ..fmha_decode_constants import SOFTMAX_RESCALE_THRESHOLD_LOG2
 from ...tcgen05_compat import tcgen05_mma_ws
 from ...placeholder_helpers import (
     _placeholder_local_array,
@@ -104,13 +104,6 @@ from .helpers_softmax import (
     _u32_to_float_for_atomic_max,
     _wspro_reduce_max4,
 )
-
-# A block-sparse route often changes the exact row maximum without changing it
-# enough to justify rescaling the live O tile. Keeping the prior anchor within
-# this bound makes the correction scale exactly one and bounds FP16/BF16 P by
-# 2**8. As in the FlashInfer/TRT-LLM policy, this assumes normal model logits
-# rather than adversarial values outside the qualified probability bound.
-_BLOCK_SPARSE_RESCALE_THRESHOLD_LOG2 = 8.0
 
 
 def _swaps_uses_origin0_k32_full_guard(cfg: FmhaDecodeConfig) -> bool:
@@ -898,23 +891,32 @@ class TmemSResource(DecodeGenResourceBase):
     ) -> None:
         """Publish a masked Keeps row and its updated softmax anchor."""
 
-        new_anchor = cute.math.max(old_max, tile_max, ftz=True)
-        if cutlass.const_expr(
-            self.cfg.use_block_sparse and _BLOCK_SPARSE_RESCALE_THRESHOLD_LOG2 > 0.0
-        ):
-            # Online softmax only requires a common finite reference for P,
-            # sum, and O; it does not require the exact row maximum. Defer a
-            # small anchor increase so correction can skip a TMEM O rescale.
-            rescale_log2 = (old_max - new_anchor) * self.scale_softmax_log2
-            if (old_max != _neg_max_f32()) and (
-                rescale_log2 >= Float32(-_BLOCK_SPARSE_RESCALE_THRESHOLD_LOG2)
-            ):
-                new_anchor = old_max
         old_max_arr[0] = old_max
         sum_arr[0] = running_sum
-        new_max_arr[0] = new_anchor
+        new_max_arr[0] = self._softmax_anchor(old_max, tile_max)
         for reg_idx in cutlass.range_constexpr(self.cfg.num_s_regs_per_thread):
             s_arr[reg_idx] = s_vals[reg_idx]
+
+    @cute.jit
+    def _softmax_anchor(self, old_max: Float32, tile_max: Float32) -> Float32:
+        """Return the exponent reference max for the tile's P pass.
+
+        Online softmax only requires a common finite reference for P, the
+        running sum, and O; it does not require the exact row maximum.
+        Profiles that defer anchor updates keep the previous reference while
+        the tile raises it by less than ``SOFTMAX_RESCALE_THRESHOLD_LOG2``
+        log2 units, so correction can skip the in-place TMEM O rescale. The
+        16-bit P path represents the bounded values above one, and the
+        numerator and denominator stay in the same scale frame. Larger jumps
+        still rebase to keep P comfortably in range.
+        """
+        new_max = cute.math.max(old_max, tile_max, ftz=True)
+        if cutlass.const_expr(self.cfg.defers_softmax_anchor_updates):
+            if old_max != _neg_max_f32():
+                max_delta_log2 = self.scale_softmax_log2 * (old_max - new_max)
+                if max_delta_log2 >= Float32(-SOFTMAX_RESCALE_THRESHOLD_LOG2):
+                    new_max = old_max
+        return new_max
 
     @cute.jit
     def _mask_and_store_sparse_keeps_atom(
@@ -1472,7 +1474,7 @@ class TmemSResource(DecodeGenResourceBase):
                     tile_is_unmasked,
                     fragment_idx=fragment_idx,
                 )
-                if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+                if cutlass.const_expr(cfg.streams_tmem_p_fragments):
                     # The rolled P loop reloads scores without mask logic, so a
                     # masked tile writes its masked fragment back in place.
                     # The branch is warp-uniform: the loader above already
@@ -1492,21 +1494,12 @@ class TmemSResource(DecodeGenResourceBase):
                         )
                 fragment_max = self._reduce_keeps_fragment_max(s_vals)
                 tile_max = cute.math.max(tile_max, fragment_max, ftz=True)
-            if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
                 if not tile_is_unmasked:
                     prims.tcgen05_wait(kind=prims.Tcgen05Wait.STORE)
                     cute.arch.fence_view_async_tmem_store()
 
-            new_max = cute.math.max(old_max, tile_max, ftz=True)
-            if old_max != _neg_max_f32():
-                # Keeping the previous reference max avoids an in-place O
-                # rescale when the new tile raises it only modestly. The
-                # 16-bit P path can represent the bounded values above one; the
-                # numerator and denominator remain in the same scale frame.
-                # Large jumps still rebase to keep P comfortably in range.
-                max_delta_log2 = self.scale_softmax_log2 * (old_max - new_max)
-                if max_delta_log2 >= Float32(-KV_TILE_256_RESCALE_THRESHOLD_LOG2):
-                    new_max = old_max
+            new_max = self._softmax_anchor(old_max, tile_max)
             old_max_arr[0] = old_max
             sum_arr[0] = running_sum
             new_max_arr[0] = new_max
@@ -1635,47 +1628,6 @@ class TmemSResource(DecodeGenResourceBase):
             s_arr,
         )
         return old_max_arr, sum_arr, new_max_arr, s_arr
-
-    @consumer_work(returns=s_arr, work_attrs=WorkAttr.AUXILIARY)
-    @cute.jit
-    def load_softmax_p_fragment(
-        self,
-        stage_info: StageInfo,
-        *,
-        fragment_idx: Constexpr[int],
-        s_arr: cutlass.Array,
-    ) -> cutlass.Array:
-        """Reload and mask one KV256 K32 fragment for P materialization."""
-        if cutlass.const_expr(self.cfg.use_block_sparse):
-            return self._load_block_sparse_softmax_p_fragment(
-                stage_info,
-                fragment_idx=fragment_idx,
-                s_arr=s_arr,
-            )
-        (
-            seq_len_kv,
-            logical_q_group_idx,
-            element_mask_end_idx,
-            tile_offset_k,
-            window_start_idx,
-            is_valid_effective_tile,
-            is_masked_final_wave,
-            tile_is_unmasked,
-        ) = self._resolve_keeps_tile_context(stage_info)
-        self._load_keeps_fragment(
-            stage_info,
-            s_arr,
-            tile_offset_k,
-            element_mask_end_idx,
-            window_start_idx,
-            seq_len_kv,
-            logical_q_group_idx,
-            is_valid_effective_tile,
-            is_masked_final_wave,
-            tile_is_unmasked,
-            fragment_idx=fragment_idx,
-        )
-        return s_arr
 
     @cute.jit
     def _compute_softmax_loop_swaps(
@@ -2524,43 +2476,10 @@ class TmemSResource(DecodeGenResourceBase):
             ftz=True,
         )
         old_max = new_max_arr[0]
-        new_max = cute.math.max(old_max, tile_max, ftz=True)
-        if old_max != _neg_max_f32():
-            max_delta_log2 = self.scale_softmax_log2 * (old_max - new_max)
-            if max_delta_log2 >= Float32(-KV_TILE_256_RESCALE_THRESHOLD_LOG2):
-                new_max = old_max
+        new_max = self._softmax_anchor(old_max, tile_max)
         old_max_arr[0] = old_max
         new_max_arr[0] = new_max
         return old_max_arr, sum_arr, new_max_arr, s_arr
-
-    @cute.jit
-    def _load_block_sparse_softmax_p_fragment(
-        self,
-        stage_info: StageInfo,
-        *,
-        fragment_idx: Constexpr[int],
-        s_arr: cutlass.Array,
-    ) -> cutlass.Array:
-        """Reload one full or already-predicated sparse KV256 fragment for P."""
-
-        assert self.cfg.tile_size_kv == 256
-        task_cache = _decode_gen_task_cache(stage_info)
-        score_tmem_addr = (
-            task_cache[_TASK_CACHE_TMEM_BASE_OFFSET]
-            + Int32(self._alloc.offset)
-            + self._softmax_loop_stage_slot_offset(stage_info)
-            + Int32(fragment_idx * 32)
-        )
-        loaded = _keeps_tcgen05_ld(
-            self.cfg,
-            prims.make_tmem_ptr(score_tmem_addr, Float32),
-            num=32,
-            offset=self.cfg.tile_size_kv // 2,
-        )
-        prims.tcgen05_wait(kind=prims.Tcgen05Wait.LOAD)
-        for score_idx in cutlass.range_constexpr(32):
-            s_arr[score_idx] = loaded[score_idx]
-        return s_arr
 
     @consumer_work(returns=("old_max_arr", "sum_arr", "new_max_arr", "s_arr"))
     @cute.jit

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -1022,29 +1022,63 @@ class DecodeGenTask(Task):
 def _resolve_and_store_sparse_route(
     sparse_kv_metadata: MemoryResource | None,
     section: FmhaStage,
-) -> tuple[Any, Any, Any, Any] | None:
-    """Resolve one prepared route and retain it for the matching K/V pair."""
+    prefetch: tuple[Any, Any] | None = None,
+    *,
+    pipeline: bool = True,
+) -> tuple[tuple[Any, Any, Any, Any] | None, tuple[Any, Any] | None]:
+    """Resolve one prepared route and retain it for the matching K/V pair.
+
+    Returns ``(route, prefetch)``. With ``pipeline`` the record load is issued
+    one resolution ahead: HEAD loads its own record immediately, and every
+    resolution issues the load for the next one (LOOP iteration 0 from HEAD,
+    iteration i + 1 from iteration i) before the caller's K TMA burst, so the
+    global-memory latency overlaps that issue instead of stalling the load
+    warp. Callers pass the returned ``prefetch`` back into the next resolution
+    of the same instance, the way ``_staged_kv_load`` threads its cached page
+    IDs. Without ``pipeline`` the record is loaded where it is resolved and no
+    state is returned; the split-ring load variants use this because the
+    pipelined form measured slower for them. Dense profiles pass ``None`` and
+    get ``(None, None)``.
+    """
 
     if sparse_kv_metadata is None:
-        return None
+        return None, None
+    if not pipeline:
+        prefetch = sparse_kv_metadata.prefetch_route(
+            target="head" if section == FmhaStage.Head else "current_loop"
+        )
+    elif section == FmhaStage.Head:
+        prefetch = sparse_kv_metadata.prefetch_route(target="head")
+    assert prefetch is not None
+    prefetched_record_word, prefetched_record_offset = prefetch
     (
         resolved_record_word,
         resolved_origin1,
         resolved_atom_validity,
         route_record_word_offset,
-    ) = sparse_kv_metadata.resolve_route(section=section)
+    ) = sparse_kv_metadata.resolve_route(
+        section=section,
+        prefetched_record_word_slot=prefetched_record_word,
+        prefetched_record_offset_slot=prefetched_record_offset,
+    )
     sparse_kv_metadata.store_route(
         resolved_record_word=resolved_record_word,
         resolved_origin1=resolved_origin1,
         resolved_atom_validity=resolved_atom_validity,
         route_record_word_offset=route_record_word_offset,
     )
-    return (
+    next_prefetch = None
+    if pipeline:
+        next_prefetch = sparse_kv_metadata.prefetch_route(
+            target="first_loop" if section == FmhaStage.Head else "next_loop"
+        )
+    route = (
         resolved_record_word,
         resolved_origin1,
         resolved_atom_validity,
         route_record_word_offset,
     )
+    return route, next_prefetch
 
 
 def _publish_sparse_softmax_route(
@@ -1150,14 +1184,19 @@ def create_load_task(
         # Dense profiles have no route metadata: the resolve and publish
         # helpers are no-ops for ``None`` resources, so one cadence serves
         # both dense and block-sparse loads.
-        route0 = _resolve_and_store_sparse_route(sparse_kv_metadata0, FmhaStage.Head)
+        route0, prefetch0 = _resolve_and_store_sparse_route(
+            sparse_kv_metadata0, FmhaStage.Head
+        )
         _kv_load("load_k0", FmhaStage.Head)
-        route1 = _resolve_and_store_sparse_route(sparse_kv_metadata1, FmhaStage.Head)
+        route1, prefetch1 = _resolve_and_store_sparse_route(
+            sparse_kv_metadata1, FmhaStage.Head
+        )
         _kv_load("load_k1", FmhaStage.Head)
         # Issue both K tiles before either metadata FIFO can backpressure
         # the load warp, matching the split-resource sparse cadence.
         _publish_sparse_softmax_route(sparse_softmax_metadata0, route0)
         _publish_sparse_softmax_route(sparse_softmax_metadata1, route1)
+        prefetch_by_label = {"load_k0": prefetch0, "load_k1": prefetch1}
 
         # LOOP: each iter prefetches the full ``num_insts_kv`` K/V pair set.
         # When P aliases the consumed S columns, MMA must consume each V/P pair
@@ -1180,7 +1219,9 @@ def create_load_task(
                 kv_metadata, softmax_metadata = route_metadata_by_label.get(
                     label, (None, None)
                 )
-                route = _resolve_and_store_sparse_route(kv_metadata, FmhaStage.Loop)
+                route, prefetch_by_label[label] = _resolve_and_store_sparse_route(
+                    kv_metadata, FmhaStage.Loop, prefetch_by_label.get(label)
+                )
                 _kv_load(label, FmhaStage.Loop)
                 if route is not None:
                     loop_routes.append((softmax_metadata, route))
@@ -1632,7 +1673,9 @@ def create_load_task_split_kv(
         ) in active_instances:
             if smem_k is None:
                 continue
-            route = _resolve_and_store_sparse_route(sparse_kv_metadata, FmhaStage.Head)
+            route, _ = _resolve_and_store_sparse_route(
+                sparse_kv_metadata, FmhaStage.Head, pipeline=False
+            )
             load_tile(smem_k, load_k, smem_page_offsets_k, FmhaStage.Head)
             head_routes.append((sparse_softmax_metadata, route))
         # In the combined task, preserve both K issues ahead of Softmax
@@ -1660,8 +1703,8 @@ def create_load_task_split_kv(
                     smem_page_offsets_v_local,
                     FmhaStage.Loop,
                 )
-                route = _resolve_and_store_sparse_route(
-                    sparse_kv_metadata, FmhaStage.Loop
+                route, _ = _resolve_and_store_sparse_route(
+                    sparse_kv_metadata, FmhaStage.Loop, pipeline=False
                 )
                 load_tile(smem_k, load_k, smem_page_offsets_k, FmhaStage.Loop)
                 loop_routes.append((sparse_softmax_metadata, route))

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -630,6 +630,47 @@ def _decode_work_tile_schedule_with_invariant_bridge(
 
 
 @cute.jit
+def _prepared_sparse_row_address(
+    cfg: cutlass.Constexpr[FmhaDecodeConfig],
+    q_group_idx: cutlass.Int32,
+    h_idx: cutlass.Int32,
+    b_idx: cutlass.Int32,
+    num_heads_kv: cutlass.Int32,
+) -> cutlass.Int32:
+    """Map a (q_group, head, batch) tile to its prepared row header index."""
+
+    q_token_base = _q_group_token_base(cfg, q_group_idx)
+    q_block = q_token_base // cutlass.Int32(cfg.q_block_size)
+    num_q_blocks = (cfg.max_seq_len_q + cfg.q_block_size - 1) // cfg.q_block_size
+    return (b_idx * num_heads_kv + h_idx) * cutlass.Int32(num_q_blocks) + q_block
+
+
+@cute.jit
+def _prefetch_prepared_sparse_row(
+    cfg: cutlass.Constexpr[FmhaDecodeConfig],
+    row_route_offsets: cute.Pointer,
+    row_route_counts: cute.Pointer,
+    q_group_idx: cutlass.Int32,
+    h_idx: cutlass.Int32,
+    b_idx: cutlass.Int32,
+    num_heads_kv: cutlass.Int32,
+) -> tuple[cutlass.Int32, cutlass.Int32]:
+    """Load one static tile's prepared row header before its tasks start.
+
+    Every thread loads the same two words, so each warp issues one request
+    and the global-memory latency overlaps the CTA prologue (TMEM allocation
+    and barrier setup) instead of stalling every task at its first step.
+    """
+
+    row_address = _prepared_sparse_row_address(
+        cfg, q_group_idx, h_idx, b_idx, num_heads_kv
+    )
+    row_route_begin = cutlass.Int32(row_route_offsets[row_address])
+    route_count = _assume_nonnegative_i32(cutlass.Int32(row_route_counts[row_address]))
+    return row_route_begin, route_count
+
+
+@cute.jit
 def _load_prepared_sparse_row_warp(
     row_route_offsets: cute.Pointer,
     row_route_counts: cute.Pointer,
@@ -662,6 +703,9 @@ class DecodeGenTask(Task):
         self.paged_kv_indptr = kwargs.pop("paged_kv_indptr", None)
         self.sparse_row_route_offsets = kwargs.pop("sparse_row_route_offsets", None)
         self.sparse_row_route_counts = kwargs.pop("sparse_row_route_counts", None)
+        # Static tiles may pass the already loaded row header instead.
+        self.sparse_row_route_begin = kwargs.pop("sparse_row_route_begin", None)
+        self.sparse_route_count = kwargs.pop("sparse_route_count", None)
         self.num_heads_kv = kwargs.pop("num_heads_kv", None)
         self.max_seq_len_kv = kwargs.pop("max_seq_len_kv", cutlass.Int32(0))
         self.seq_len_q = kwargs.pop("seq_len_q", None)
@@ -918,20 +962,20 @@ class DecodeGenTask(Task):
             q_group_idx = cutlass.Int32(tile_coord[0])
             h_idx = cutlass.Int32(tile_coord[1])
             b_idx = cutlass.Int32(tile_coord[2])
-            q_token_base = _q_group_token_base(self.cfg, q_group_idx)
-
-            q_block = q_token_base // self.cfg.q_block_size
-            num_q_blocks = (
-                self.cfg.max_seq_len_q + self.cfg.q_block_size - 1
-            ) // self.cfg.q_block_size
-            row_address = (b_idx * self.num_heads_kv + h_idx) * num_q_blocks + q_block
-
-            row_route_begin, route_count = _load_prepared_sparse_row_warp(
-                row_route_offsets,
-                row_route_counts,
-                cutlass.Int32(row_address),
-                self._lane_idx,
-            )
+            if self.sparse_row_route_begin is not None:
+                # The static kernel prologue already loaded this tile's header.
+                row_route_begin = self.sparse_row_route_begin
+                route_count = self.sparse_route_count
+            else:
+                row_address = _prepared_sparse_row_address(
+                    self.cfg, q_group_idx, h_idx, b_idx, self.num_heads_kv
+                )
+                row_route_begin, route_count = _load_prepared_sparse_row_warp(
+                    row_route_offsets,
+                    row_route_counts,
+                    row_address,
+                    self._lane_idx,
+                )
 
             # Sparse route-span accessors share two underlying cache words
             # with paged KV. Clear dense/paged-only coordinates on every
@@ -2728,6 +2772,12 @@ def create_mma_task(
                     cfg,
                 )
 
+        # Q is live for every BMM1 call, and the last BMM1 has been issued once
+        # the loop ends. Releasing here commits after those MMAs complete, so
+        # the next tile's Q load overlaps the final softmax and BMM2 waves
+        # instead of waiting for them.
+        smem_q.release()
+
         # TAIL: no future K tiles remain, so only the final two BMM2 waves run.
         _consume_staged_pv_mma(
             smem_kv,
@@ -2749,8 +2799,6 @@ def create_mma_task(
             FmhaStage.Tail,
             cfg,
         )
-        # Q is live for every BMM1 call and can be released only after the loop.
-        smem_q.release()
 
     def mma_schedule_prelude(
         smem_q: MemoryResource,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -349,6 +349,44 @@ def _consume_staged_qk_mma(
     tmem_s.commit()
 
 
+def _consume_streamed_pv_fragments(
+    smem_kv: MemoryResource,
+    tmem_p: MemoryResource,
+    tmem_o: MemoryResource,
+    v_desc_label: str,
+    vp_mma_label: str,
+    cfg: FmhaDecodeConfig,
+) -> None:
+    """Issue one PV wave as its K32 P fragments become ready.
+
+    P fragment 0 is the earliest dependency: wait for it and for the
+    correction credit before holding the V stage. Later fragments may become
+    ready while the previous PV fragment is already executing; every slot
+    stays live through the complete async UMMA wave so the producer cannot
+    overwrite an operand prematurely.
+    """
+    assert cfg.num_head_dim_stages_kv == 1
+    fragment_label = f"{vp_mma_label}_fragment"
+    p_tmem_addr = tmem_p.wait_p_fragment(fragment_idx=0)
+    tmem_o.acquire()
+    smem_kv.wait()
+    v_desc = getattr(smem_kv, v_desc_label)()
+    getattr(tmem_o, fragment_label)(
+        v_desc=v_desc,
+        p_tmem_addr=p_tmem_addr,
+        fragment_idx=0,
+    )
+    for fragment_idx in range(1, cfg.num_softmax_score_fragments):
+        p_tmem_addr = tmem_p.wait_p_fragment(fragment_idx=fragment_idx)
+        getattr(tmem_o, fragment_label)(
+            v_desc=v_desc,
+            p_tmem_addr=p_tmem_addr,
+            fragment_idx=fragment_idx,
+        )
+    smem_kv.release()
+    tmem_o.commit()
+
+
 def _consume_staged_pv_mma(
     smem_kv: MemoryResource,
     tmem_p: MemoryResource,
@@ -362,33 +400,9 @@ def _consume_staged_pv_mma(
     """Consume all V head-dim stages for one PV MMA wave."""
     _ = section
     if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-        assert cfg.num_head_dim_stages_kv == 1
-        fragment_label = f"{vp_mma_label}_fragment"
-
-        # P fragment 0 is the earliest dependency. Wait for it and for the
-        # correction credit before holding the shared V FIFO stage.
-        p_tmem_addr = tmem_p.wait_p_fragment(fragment_idx=0)
-        tmem_o.acquire()
-        smem_kv.wait()
-        v_desc = getattr(smem_kv, v_desc_label)()
-        getattr(tmem_o, fragment_label)(
-            v_desc=v_desc,
-            p_tmem_addr=p_tmem_addr,
-            fragment_idx=0,
+        _consume_streamed_pv_fragments(
+            smem_kv, tmem_p, tmem_o, v_desc_label, vp_mma_label, cfg
         )
-
-        # Later P fragments may become ready while the previous PV fragment is
-        # already executing. Keep every slot live through the complete async
-        # UMMA wave so the producer cannot overwrite an operand prematurely.
-        for fragment_idx in range(1, cfg.num_softmax_score_fragments):
-            p_tmem_addr = tmem_p.wait_p_fragment(fragment_idx=fragment_idx)
-            getattr(tmem_o, fragment_label)(
-                v_desc=v_desc,
-                p_tmem_addr=p_tmem_addr,
-                fragment_idx=fragment_idx,
-            )
-        smem_kv.release()
-        tmem_o.commit()
         return
 
     tmem_p.wait()
@@ -2081,6 +2095,11 @@ def create_mma_task_split_kv(
         ) -> None:
             """Issue one scheduled PV wave using the selected phase work."""
             _ = section
+            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
+                _consume_streamed_pv_fragments(
+                    smem_kv, tmem_p, tmem_o, "v_desc", vp_mma_label, cfg
+                )
+                return
             tmem_p.wait()
             p_desc_0, p_desc_1, p_tmem_addr_0, p_tmem_addr_1 = tmem_p.p_operands()
             tmem_o.acquire()

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -422,20 +422,15 @@ def _consume_staged_qk_mma(
     cfg: FmhaDecodeConfig,
 ) -> None:
     """Consume all K head-dim stages for one QK MMA wave."""
+    # Streamed KV256 aliases P with the S columns this QK overwrites. The
+    # preceding same-instance PV reads P as its TMEM A operand from the same
+    # issuing thread, and the tensor core interlocks that read against a later
+    # MMA's accumulator write, so no completion wait is needed before QK.
+    _ = aliased_p
     tmem_s.acquire()
     for head_dim_stage_idx in range(cfg.num_head_dim_stages_kv):
         smem_kv.wait()
         kv_desc = getattr(smem_kv, k_desc_label)()
-        if cutlass.const_expr(
-            cfg.streams_tmem_p_fragments
-            and head_dim_stage_idx == 0
-            and (section == FmhaStage.Loop or cfg.use_persistent_scheduler)
-        ):
-            # Wait as late as possible: K staging overlaps the previous PV,
-            # but QK cannot overwrite the matching S/P alias until PV is done.
-            # Static HEAD has no previous tile; persistent HEAD may follow the
-            # same CTA's tail from another logical work tile and must wait.
-            aliased_p.wait_until_reusable_before_qk()
         if cfg.uses_q_desc_ref:
             getattr(tmem_s, f"{qk_mma_label}_from_q_ref")(
                 kv_desc=kv_desc,
@@ -2933,7 +2928,19 @@ def create_softmax0_task(
                 sum_arr=sum_arr,
             )
             tmem_softmax_local0.commit()
-            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
+            if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+                # One rolled loop streams every K32 probability fragment; the
+                # fragment body exists once in the instruction stream.
+                if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                    smem_p0.compute_proxy_route_p_fragments(
+                        new_max_arr=new_max_arr,
+                        route_flags=sparse_route_flags,
+                        route_origin0=sparse_origin0,
+                        route_origin1=sparse_origin1,
+                    )
+                else:
+                    smem_p0.compute_p_fragments(new_max_arr=new_max_arr)
+            elif cutlass.const_expr(cfg.streams_tmem_p_fragments):
                 # Publish one K32 probability fragment at a time so PV can
                 # consume early fragments while later scores are processed.
                 for fragment_idx in range(cfg.num_softmax_score_fragments):
@@ -3177,7 +3184,17 @@ def create_softmax1_task(
                 sum_arr=sum_arr,
             )
             tmem_softmax_local1.commit()
-            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
+            if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+                if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
+                    smem_p1.compute_proxy_route_p_fragments(
+                        new_max_arr=new_max_arr,
+                        route_flags=sparse_route_flags,
+                        route_origin0=sparse_origin0,
+                        route_origin1=sparse_origin1,
+                    )
+                else:
+                    smem_p1.compute_p_fragments(new_max_arr=new_max_arr)
+            elif cutlass.const_expr(cfg.streams_tmem_p_fragments):
                 for fragment_idx in range(cfg.num_softmax_score_fragments):
                     s_arr = tmem_s1.load_softmax_p_fragment(
                         fragment_idx=fragment_idx,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -117,14 +117,18 @@ def _schedule_with_optional_resources(
     return traced
 
 
-def _block_sparse_route_loop_domain(
-    route_count: cutlass.Int32,
+def _loop_domain_after_head(
+    total_kv_tiles: cutlass.Int32,
     *,
     num_insts_kv: int,
 ) -> cutlass.Int32:
-    """Return LOOP iterations after HEAD reserves one candidate per instance."""
+    """Return LOOP iterations after HEAD reserves one KV tile per instance.
 
-    remaining = route_count - cutlass.Int32(num_insts_kv)
+    Dense tiles and block-sparse routes share this recurrence; only the tile
+    count's source differs.
+    """
+
+    remaining = total_kv_tiles - cutlass.Int32(num_insts_kv)
     remaining = cute.math.max(remaining, cutlass.Int32(0))
     insts = cutlass.Int32(num_insts_kv)
     return (remaining + insts - cutlass.Int32(1)) // insts
@@ -313,19 +317,19 @@ def _produce_staged_page_offsets(
 def _consume_staged_qk_mma(
     smem_kv: MemoryResource,
     tmem_s: MemoryResource,
-    aliased_p: MemoryResource,
     q_desc: Any,
     k_desc_label: str,
     qk_mma_label: str,
     section: FmhaStage,
     cfg: FmhaDecodeConfig,
 ) -> None:
-    """Consume all K head-dim stages for one QK MMA wave."""
-    # Streamed KV256 aliases P with the S columns this QK overwrites. The
-    # preceding same-instance PV reads P as its TMEM A operand from the same
-    # issuing thread, and the tensor core interlocks that read against a later
-    # MMA's accumulator write, so no completion wait is needed before QK.
-    _ = aliased_p
+    """Consume all K head-dim stages for one QK MMA wave.
+
+    Streamed KV256 aliases P with the S columns this QK overwrites. The
+    preceding same-instance PV reads P as its TMEM A operand from the same
+    issuing thread, and the tensor core interlocks that read against a later
+    MMA's accumulator write, so no completion wait is needed before QK.
+    """
     tmem_s.acquire()
     for head_dim_stage_idx in range(cfg.num_head_dim_stages_kv):
         smem_kv.wait()
@@ -889,7 +893,7 @@ class DecodeGenTask(Task):
             self._kv_valid_tile_end = route_count
             self._kv_window_start = cutlass.Int32(0)
 
-            loop_domain = _block_sparse_route_loop_domain(
+            loop_domain = _loop_domain_after_head(
                 route_count,
                 num_insts_kv=self.cfg.num_insts_kv,
             )
@@ -927,14 +931,10 @@ class DecodeGenTask(Task):
             self._kv_window_start = cutlass.Int32(0)
             self._kv_valid_tile_end = total_kv_tiles
             self._kv_raw_tile_base = cutlass.Int32(0)
-            remaining_kv_tiles = cute.math.max(
-                total_kv_tiles - cutlass.Int32(self.cfg.num_insts_kv),
-                cutlass.Int32(0),
+            loop_domain = _loop_domain_after_head(
+                total_kv_tiles,
+                num_insts_kv=self.cfg.num_insts_kv,
             )
-            num_insts_kv = cutlass.Int32(self.cfg.num_insts_kv)
-            loop_domain = (
-                remaining_kv_tiles + num_insts_kv - cutlass.Int32(1)
-            ) // num_insts_kv
             return loop_domain + cutlass.Int32(self.domain_bias)
 
         # Decode the logical Q tile with the configured physical split fanout,
@@ -1136,22 +1136,17 @@ def create_load_task(
                 smem_page_offsets.wait()
             else:
                 _page_offsets_consume(smem_page_offsets)
-        if sparse_kv_metadata0 is None:
-            for label in ("load_k0", "load_k1"):
-                _kv_load(label, FmhaStage.Head)
-        else:
-            route0 = _resolve_and_store_sparse_route(
-                sparse_kv_metadata0, FmhaStage.Head
-            )
-            _kv_load("load_k0", FmhaStage.Head)
-            route1 = _resolve_and_store_sparse_route(
-                sparse_kv_metadata1, FmhaStage.Head
-            )
-            _kv_load("load_k1", FmhaStage.Head)
-            # Issue both K tiles before either metadata FIFO can backpressure
-            # the load warp, matching the split-resource sparse cadence.
-            _publish_sparse_softmax_route(sparse_softmax_metadata0, route0)
-            _publish_sparse_softmax_route(sparse_softmax_metadata1, route1)
+        # Dense profiles have no route metadata: the resolve and publish
+        # helpers are no-ops for ``None`` resources, so one cadence serves
+        # both dense and block-sparse loads.
+        route0 = _resolve_and_store_sparse_route(sparse_kv_metadata0, FmhaStage.Head)
+        _kv_load("load_k0", FmhaStage.Head)
+        route1 = _resolve_and_store_sparse_route(sparse_kv_metadata1, FmhaStage.Head)
+        _kv_load("load_k1", FmhaStage.Head)
+        # Issue both K tiles before either metadata FIFO can backpressure
+        # the load warp, matching the split-resource sparse cadence.
+        _publish_sparse_softmax_route(sparse_softmax_metadata0, route0)
+        _publish_sparse_softmax_route(sparse_softmax_metadata1, route1)
 
         # LOOP: each iter prefetches the full ``num_insts_kv`` K/V pair set.
         # When P aliases the consumed S columns, MMA must consume each V/P pair
@@ -1163,32 +1158,27 @@ def create_load_task(
             else ("load_k0", "load_v0", "load_k1", "load_v1")
         )
         with domain_loop(0, domain, 1, unroll=1):
-            if sparse_kv_metadata0 is None:
-                for label in loop_labels:
-                    _kv_load(label, FmhaStage.Loop)
-            else:
-                # Follow the dense stage order exactly. Generic V-first
-                # profiles consume their retained route before the matching K
-                # label replaces it.
-                loop_routes = []
-                for label in loop_labels:
-                    route = None
-                    sparse_softmax_metadata = None
-                    if label == "load_k0":
-                        route = _resolve_and_store_sparse_route(
-                            sparse_kv_metadata0, FmhaStage.Loop
-                        )
-                        sparse_softmax_metadata = sparse_softmax_metadata0
-                    elif label == "load_k1":
-                        route = _resolve_and_store_sparse_route(
-                            sparse_kv_metadata1, FmhaStage.Loop
-                        )
-                        sparse_softmax_metadata = sparse_softmax_metadata1
-                    _kv_load(label, FmhaStage.Loop)
-                    if route is not None:
-                        loop_routes.append((sparse_softmax_metadata, route))
-                for sparse_softmax_metadata, route in loop_routes:
-                    _publish_sparse_softmax_route(sparse_softmax_metadata, route)
+            # Generic V-first profiles consume their retained route before the
+            # matching K label replaces it.
+            loop_routes = []
+            for label in loop_labels:
+                route = None
+                sparse_softmax_metadata = None
+                if label == "load_k0":
+                    route = _resolve_and_store_sparse_route(
+                        sparse_kv_metadata0, FmhaStage.Loop
+                    )
+                    sparse_softmax_metadata = sparse_softmax_metadata0
+                elif label == "load_k1":
+                    route = _resolve_and_store_sparse_route(
+                        sparse_kv_metadata1, FmhaStage.Loop
+                    )
+                    sparse_softmax_metadata = sparse_softmax_metadata1
+                _kv_load(label, FmhaStage.Loop)
+                if route is not None:
+                    loop_routes.append((sparse_softmax_metadata, route))
+            for sparse_softmax_metadata, route in loop_routes:
+                _publish_sparse_softmax_route(sparse_softmax_metadata, route)
 
         # TAIL: after no more future K tiles are needed, load the final two V
         # tiles consumed by the final BMM2 calls.
@@ -2567,7 +2557,6 @@ def create_mma_task(
         _consume_staged_qk_mma(
             smem_kv,
             tmem_s0,
-            smem_p0,
             q_desc,
             "k_desc_0",
             "qk_mma_head",
@@ -2577,7 +2566,6 @@ def create_mma_task(
         _consume_staged_qk_mma(
             smem_kv,
             tmem_s1,
-            smem_p1,
             q_desc,
             "k_desc_1",
             "qk_mma_head",
@@ -2604,7 +2592,6 @@ def create_mma_task(
             _consume_staged_qk_mma(
                 smem_kv,
                 tmem_s0,
-                smem_p0,
                 q_desc,
                 "k_desc_0",
                 "qk_mma_loop",
@@ -2636,7 +2623,6 @@ def create_mma_task(
             _consume_staged_qk_mma(
                 smem_kv,
                 tmem_s1,
-                smem_p1,
                 q_desc,
                 "k_desc_1",
                 "qk_mma_loop",
@@ -2859,7 +2845,7 @@ def create_softmax0_task(
                 sum_arr=sum_arr,
             )
             tmem_softmax_local0.commit()
-            if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
                 # One rolled loop streams every K32 probability fragment; the
                 # fragment body exists once in the instruction stream.
                 if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
@@ -2871,29 +2857,6 @@ def create_softmax0_task(
                     )
                 else:
                     smem_p0.compute_p_fragments(new_max_arr=new_max_arr)
-            elif cutlass.const_expr(cfg.streams_tmem_p_fragments):
-                # Publish one K32 probability fragment at a time so PV can
-                # consume early fragments while later scores are processed.
-                for fragment_idx in range(cfg.num_softmax_score_fragments):
-                    s_arr = tmem_s0.load_softmax_p_fragment(
-                        fragment_idx=fragment_idx,
-                        s_arr=s_arr,
-                    )
-                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
-                        smem_p0.compute_proxy_route_p_fragment(
-                            fragment_idx=fragment_idx,
-                            new_max_arr=new_max_arr,
-                            s_arr=s_arr,
-                            route_flags=sparse_route_flags,
-                            route_origin0=sparse_origin0,
-                            route_origin1=sparse_origin1,
-                        )
-                    else:
-                        smem_p0.compute_p_fragment(
-                            fragment_idx=fragment_idx,
-                            new_max_arr=new_max_arr,
-                            s_arr=s_arr,
-                        )
             else:
                 # Wait for a free P stage before entering the ordered window so
                 # BMM2 backpressure on this group's P pipeline cannot extend the
@@ -3115,7 +3078,7 @@ def create_softmax1_task(
                 sum_arr=sum_arr,
             )
             tmem_softmax_local1.commit()
-            if cutlass.const_expr(cfg.loops_softmax_p_fragments):
+            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
                 if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
                     smem_p1.compute_proxy_route_p_fragments(
                         new_max_arr=new_max_arr,
@@ -3125,27 +3088,6 @@ def create_softmax1_task(
                     )
                 else:
                     smem_p1.compute_p_fragments(new_max_arr=new_max_arr)
-            elif cutlass.const_expr(cfg.streams_tmem_p_fragments):
-                for fragment_idx in range(cfg.num_softmax_score_fragments):
-                    s_arr = tmem_s1.load_softmax_p_fragment(
-                        fragment_idx=fragment_idx,
-                        s_arr=s_arr,
-                    )
-                    if cutlass.const_expr(cfg.use_block_sparse_proxy_routes):
-                        smem_p1.compute_proxy_route_p_fragment(
-                            fragment_idx=fragment_idx,
-                            new_max_arr=new_max_arr,
-                            s_arr=s_arr,
-                            route_flags=sparse_route_flags,
-                            route_origin0=sparse_origin0,
-                            route_origin1=sparse_origin1,
-                        )
-                    else:
-                        smem_p1.compute_p_fragment(
-                            fragment_idx=fragment_idx,
-                            new_max_arr=new_max_arr,
-                            s_arr=s_arr,
-                        )
             else:
                 # Wait for a free P stage before entering the ordered window so
                 # BMM2 backpressure on this group's P pipeline cannot extend the

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -1002,13 +1002,10 @@ class DecodeGenTask(Task):
             self._kv_raw_tile_base = skipped_tiles + split_idx * total_kv_tiles
         else:
             self._kv_raw_tile_base = skipped_tiles
-        remaining_kv_tiles = cute.math.max(
-            total_kv_tiles - cutlass.Int32(self.cfg.num_insts_kv), cutlass.Int32(0)
+        loop_domain = _loop_domain_after_head(
+            total_kv_tiles,
+            num_insts_kv=self.cfg.num_insts_kv,
         )
-        num_insts_kv = cutlass.Int32(self.cfg.num_insts_kv)
-        loop_domain = (
-            remaining_kv_tiles + num_insts_kv - cutlass.Int32(1)
-        ) // num_insts_kv
         # All tasks share the MMA-loop domain; tail-only tasks add a bias.
         return loop_domain + cutlass.Int32(self.domain_bias)
 
@@ -1174,23 +1171,19 @@ def create_load_task(
         with domain_loop(0, domain, 1, unroll=1):
             # Generic V-first profiles consume their retained route before the
             # matching K label replaces it.
+            route_metadata_by_label = {
+                "load_k0": (sparse_kv_metadata0, sparse_softmax_metadata0),
+                "load_k1": (sparse_kv_metadata1, sparse_softmax_metadata1),
+            }
             loop_routes = []
             for label in loop_labels:
-                route = None
-                sparse_softmax_metadata = None
-                if label == "load_k0":
-                    route = _resolve_and_store_sparse_route(
-                        sparse_kv_metadata0, FmhaStage.Loop
-                    )
-                    sparse_softmax_metadata = sparse_softmax_metadata0
-                elif label == "load_k1":
-                    route = _resolve_and_store_sparse_route(
-                        sparse_kv_metadata1, FmhaStage.Loop
-                    )
-                    sparse_softmax_metadata = sparse_softmax_metadata1
+                kv_metadata, softmax_metadata = route_metadata_by_label.get(
+                    label, (None, None)
+                )
+                route = _resolve_and_store_sparse_route(kv_metadata, FmhaStage.Loop)
                 _kv_load(label, FmhaStage.Loop)
                 if route is not None:
-                    loop_routes.append((sparse_softmax_metadata, route))
+                    loop_routes.append((softmax_metadata, route))
             for sparse_softmax_metadata, route in loop_routes:
                 _publish_sparse_softmax_route(sparse_softmax_metadata, route)
 
@@ -2094,31 +2087,9 @@ def create_mma_task_split_kv(
             section: FmhaStage,
         ) -> None:
             """Issue one scheduled PV wave using the selected phase work."""
-            _ = section
-            if cutlass.const_expr(cfg.streams_tmem_p_fragments):
-                _consume_streamed_pv_fragments(
-                    smem_kv, tmem_p, tmem_o, "v_desc", vp_mma_label, cfg
-                )
-                return
-            tmem_p.wait()
-            p_desc_0, p_desc_1, p_tmem_addr_0, p_tmem_addr_1 = tmem_p.p_operands()
-            tmem_o.acquire()
-            for head_dim_stage_idx in range(cfg.num_head_dim_stages_kv):
-                smem_kv.wait()
-                v_desc = smem_kv.v_desc()
-                getattr(tmem_o, vp_mma_label)(
-                    v_desc_0=v_desc,
-                    v_desc_1=v_desc,
-                    p_desc_0=p_desc_0,
-                    p_desc_1=p_desc_1,
-                    p_tmem_addr_0=p_tmem_addr_0,
-                    p_tmem_addr_1=p_tmem_addr_1,
-                    inst_idx=inst_idx,
-                    head_dim_stage_idx=head_dim_stage_idx,
-                )
-                smem_kv.release()
-            tmem_o.commit()
-            tmem_p.release()
+            _consume_staged_pv_mma(
+                smem_kv, tmem_p, tmem_o, "v_desc", vp_mma_label, inst_idx, section, cfg
+            )
 
         qk_mma(
             smem_k0,

--- a/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
+++ b/flashinfer/attention/prims_ts/kernels/fmha_decode/fmha_decode_tasks.py
@@ -32,16 +32,13 @@ from typing import Any, Callable
 
 import cutlass
 import cutlass.cute as cute
-from cutlass import Int32
 from cutlass.experimental import primitives as prims
 from cutlass.experimental.task_scheduling.memory import (
     ResourceContext,
-    SmemAllocation,
 )
 from cutlass.experimental.task_scheduling.resources import (
     MemoryResource,
     StageInfo,
-    TaskLocalVariable,
     WorkQueue,
     consumer_work,
     producer_work,
@@ -61,10 +58,8 @@ from .fmha_decode_constants import (
     KV_INST1,
     KV_KIND_K,
     KV_KIND_V,
-    KV_TILE_256_SHARED_FIFO_STAGES,
 )
 from .fmha_decode_resources.helpers_common import (
-    ResourceVars,
     _assume_nonnegative_i32,
     _q_group_token_base,
     _q_seq_bounds,
@@ -150,102 +145,6 @@ class ScheduleTokenThrottleResource(MemoryResource):
     def consume_schedule_token(self, stage_info: StageInfo) -> None:
         """Wait until the load task no longer needs the current schedule token."""
         del stage_info
-
-
-@dataclass(kw_only=True)
-class SmemKvReuseCreditResource(MemoryResource):
-    """One-slot credit carrying the rotating KV256 exchange-stage index.
-
-    Load publishes which drained 64-KiB physical K/V stage Correction may use
-    as tail scratch. The one-stage pipeline couples that payload to the same
-    ownership epoch: the following Load may use the other two physical stages,
-    but cannot publish a new alias until Correction releases this credit after
-    all output work completes.
-    """
-
-    cfg: cutlass.Constexpr[FmhaDecodeConfig] = None
-    _alloc: cutlass.Constexpr[SmemAllocation | None] = None
-    scratch_stage_slot: cutlass.Constexpr[TaskLocalVariable] = (
-        TaskLocalVariable.uninitialized()
-    )
-
-    def __post_init__(self) -> None:
-        """Create the routed consumer slot for one physical K/V stage."""
-        assert KV_TILE_256_SHARED_FIFO_STAGES == 3, (
-            "KV256 reuse-credit rotation requires exactly three shared FIFO stages"
-        )
-        if not self.cfg.uses_rotating_kv256_exchange:
-            raise ValueError(
-                "rotating KV scratch requires persistent direct Q64/KV256 "
-                "with two KV instructions, one head-dimension stage, and "
-                "one load warp"
-            )
-        self.scratch_stage_slot = TaskLocalVariable(
-            dtype=Int32,
-            default=Int32(0),
-            docs="Physical shared-K/V stage reserved for KV256 tail exchange.",
-        )
-
-    def get_smem_requirements(self) -> list[SmemAllocation]:
-        """Allocate the one-word stage payload guarded by this pipeline."""
-        if self._alloc is None:
-            self._alloc = SmemAllocation(
-                name=f"{self.name}_scratchStage",
-                size_bytes=4,
-                alignment=4,
-            )
-        return [self._alloc]
-
-    @cute.jit
-    def _payload(self, stage_info: StageInfo) -> cutlass.Array:
-        """Return the natural next-stage cursor owned by this credit."""
-        return cutlass.Array(
-            stage_info.context.smem_base.data_ptr() + self._alloc.offset,
-            dtype=Int32,
-            shape=(1,),
-            addrspace=3,
-        )
-
-    @cute.jit
-    def create_function_variables(
-        self,
-        context: ResourceContext | None = None,
-    ) -> ResourceVars:
-        """Initialize the persistent ring cursor before TS tasks start."""
-        if cutlass.const_expr(context is not None and context.smem_base is not None):
-            payload = cutlass.Array(
-                context.smem_base.data_ptr() + self._alloc.offset,
-                dtype=Int32,
-                shape=(1,),
-                addrspace=3,
-            )
-            thread_idx, _, _ = cute.arch.thread_idx()
-            if thread_idx == Int32(0):
-                payload[0] = Int32(0)
-        return {}
-
-    @producer_work
-    @cute.jit
-    def publish_scratch_stage(self, stage_info: StageInfo) -> None:
-        """Advance the persistent ring cursor and publish the drained stage."""
-        num_stages = Int32(KV_TILE_256_SHARED_FIFO_STAGES)
-        if prims.elect_sync():
-            payload = self._payload(stage_info)
-            # Each work commits T = 4 * (loop_end + 1) K/V transactions.
-            # Since 4 == 1 (mod 3), the cursor advances by loop_end + 1.
-            # loop_end is the resolved per-work domain, so heterogeneous
-            # runtime sequence lengths do not inherit a captured host bound.
-            payload[0] = (
-                Int32(payload[0]) + stage_info.loop_end + Int32(1)
-            ) % num_stages
-
-    @consumer_work(returns=scratch_stage_slot)
-    @cute.jit
-    def read_scratch_stage(self, stage_info: StageInfo) -> Int32:
-        """Read the alias only after the matching credit wait completes."""
-        num_stages = Int32(KV_TILE_256_SHARED_FIFO_STAGES)
-        next_stage = Int32(self._payload(stage_info)[0])
-        return (next_stage + num_stages - Int32(1)) % num_stages
 
 
 @dataclass(kw_only=True)
@@ -1167,7 +1066,6 @@ def create_load_task(
     smem_kv: MemoryResource,
     work_queue: WorkQueue | None,
     schedule_token_throttle: MemoryResource | None,
-    smem_kv_reuse_credit: MemoryResource | None,
     cfg: FmhaDecodeConfig,
     *,
     domain: int | cutlass.Int32,
@@ -1189,7 +1087,6 @@ def create_load_task(
         smem_kv: MemoryResource,
         smem_page_offsets: MemoryResource | None,
         schedule_token_throttle: MemoryResource | None,
-        smem_kv_reuse_credit: MemoryResource | None,
         sparse_kv_metadata0: MemoryResource | None = None,
         sparse_kv_metadata1: MemoryResource | None = None,
         sparse_softmax_metadata0: MemoryResource | None = None,
@@ -1255,10 +1152,6 @@ def create_load_task(
             # the load warp, matching the split-resource sparse cadence.
             _publish_sparse_softmax_route(sparse_softmax_metadata0, route0)
             _publish_sparse_softmax_route(sparse_softmax_metadata1, route1)
-        if smem_kv_reuse_credit is not None:
-            # K0/K1 occupy the two stages disjoint from the previous work's
-            # scratch. Acquire only before issuing the third K/V transaction.
-            smem_kv_reuse_credit.acquire()
 
         # LOOP: each iter prefetches the full ``num_insts_kv`` K/V pair set.
         # When P aliases the consumed S columns, MMA must consume each V/P pair
@@ -1301,11 +1194,6 @@ def create_load_task(
         # tiles consumed by the final BMM2 calls.
         for label in ("load_v0", "load_v1"):
             _kv_load(label, FmhaStage.Tail)
-        if smem_kv_reuse_credit is not None:
-            # Publish the physical stage drained by this work together with
-            # the ownership token consumed by the correction tail.
-            smem_kv_reuse_credit.publish_scratch_stage()
-            smem_kv_reuse_credit.commit()
         if hold_page_window:
             _page_offsets_release(smem_page_offsets)
 
@@ -1320,7 +1208,6 @@ def create_load_task(
         sparse_softmax_metadata1: MemoryResource | None,
         work_queue: WorkQueue | None,
         schedule_token_throttle: MemoryResource | None,
-        smem_kv_reuse_credit: MemoryResource | None,
     ) -> None:
         """Schedule shared-KV loads with only the resources in this profile."""
 
@@ -1332,7 +1219,6 @@ def create_load_task(
                 smem_kv,
                 smem_page_offsets,
                 schedule_token_throttle,
-                smem_kv_reuse_credit,
                 sparse_kv_metadata0,
                 sparse_kv_metadata1,
                 sparse_softmax_metadata0,
@@ -1366,7 +1252,6 @@ def create_load_task(
         sparse_softmax_metadata1,
         work_queue,
         schedule_token_throttle,
-        smem_kv_reuse_credit,
     )
     src = []
     for sparse_kv_metadata in (sparse_kv_metadata0, sparse_kv_metadata1):
@@ -1382,8 +1267,6 @@ def create_load_task(
             dst.append(sparse_resource)
     if schedule_token_throttle is not None:
         dst.append(schedule_token_throttle)
-    if smem_kv_reuse_credit is not None:
-        dst.append(smem_kv_reuse_credit)
     return task_class(
         src_resources=src,
         dst_resources=dst,
@@ -3397,7 +3280,6 @@ def create_correction_task(
     tmem_corr0: MemoryResource,
     tmem_corr1: MemoryResource,
     work_queue: WorkQueue | None,
-    smem_kv_reuse_credit: MemoryResource | None,
     cfg: FmhaDecodeConfig,
     *,
     domain: int | cutlass.Int32,
@@ -3408,9 +3290,6 @@ def create_correction_task(
 ) -> Task:
     """Create the two-instance correction and output task."""
 
-    if smem_kv_reuse_credit is not None and work_queue is None:
-        raise ValueError("KV reuse credit requires a work queue")
-
     def correction_schedule_body(
         tmem_softmax_local0: MemoryResource,
         tmem_softmax_local1: MemoryResource,
@@ -3419,7 +3298,6 @@ def create_correction_task(
         tmem_corr1: MemoryResource,
         tmem_stats_done0: MemoryResource | None,
         tmem_stats_done1: MemoryResource | None,
-        smem_kv_reuse_credit: MemoryResource | None,
     ) -> None:
         """Schedule two-instance O correction and final output normalization."""
 
@@ -3613,37 +3491,17 @@ def create_correction_task(
             tail_o_stage_idx_1=tail_1,
             inst_idx=KV_INST1,
         )
-        if smem_kv_reuse_credit is None:
-            tmem_corr1.correction_tail_epilogue(
-                o_stage_idx=o_stage_idx,
-                tail_o_stage_idx_0=tail_0,
-                tail_o_stage_idx_1=tail_1,
-                old_max_arr=old_max_arr,
-                new_max_arr=new_max_arr,
-                inst0_new_max_arr=inst0_new_max_arr,
-                inst0_sum_arr=inst0_sum_arr,
-                inst1_new_max_arr=inst1_new_max_arr,
-                inst1_sum_arr=inst1_sum_arr,
-            )
-        else:
-            # The stage selector and ownership token share one pipeline epoch.
-            # Wait before the first aliased access and release immediately
-            # after correction stops touching the selected KV-ring stage.
-            smem_kv_reuse_credit.wait()
-            scratch_stage = smem_kv_reuse_credit.read_scratch_stage()
-            tmem_corr1.correction_tail_epilogue_rotating_exchange(
-                scratch_stage=scratch_stage,
-                o_stage_idx=o_stage_idx,
-                tail_o_stage_idx_0=tail_0,
-                tail_o_stage_idx_1=tail_1,
-                old_max_arr=old_max_arr,
-                new_max_arr=new_max_arr,
-                inst0_new_max_arr=inst0_new_max_arr,
-                inst0_sum_arr=inst0_sum_arr,
-                inst1_new_max_arr=inst1_new_max_arr,
-                inst1_sum_arr=inst1_sum_arr,
-            )
-            smem_kv_reuse_credit.release()
+        tmem_corr1.correction_tail_epilogue(
+            o_stage_idx=o_stage_idx,
+            tail_o_stage_idx_0=tail_0,
+            tail_o_stage_idx_1=tail_1,
+            old_max_arr=old_max_arr,
+            new_max_arr=new_max_arr,
+            inst0_new_max_arr=inst0_new_max_arr,
+            inst0_sum_arr=inst0_sum_arr,
+            inst1_new_max_arr=inst1_new_max_arr,
+            inst1_sum_arr=inst1_sum_arr,
+        )
         # Inst1 final reduction consumes both O0 and O1, so defer O0 release
         # until after inst1 has finished reading it.
         tmem_o.release()
@@ -3657,7 +3515,6 @@ def create_correction_task(
         tmem_corr1: MemoryResource,
         tmem_stats_done0: MemoryResource | None,
         tmem_stats_done1: MemoryResource | None,
-        smem_kv_reuse_credit: MemoryResource | None,
         work_queue: WorkQueue | None,
     ) -> None:
         """Wrap correction with optional stats lifetime gates."""
@@ -3672,7 +3529,6 @@ def create_correction_task(
                 tmem_corr1,
                 tmem_stats_done0,
                 tmem_stats_done1,
-                smem_kv_reuse_credit,
             ),
         )
 
@@ -3684,7 +3540,6 @@ def create_correction_task(
         tmem_corr0: MemoryResource,
         tmem_corr1: MemoryResource,
         work_queue: WorkQueue | None = None,
-        smem_kv_reuse_credit: MemoryResource | None = None,
     ) -> None:
         """Capture the Swaps correction schedule."""
         run_correction_schedule(
@@ -3695,7 +3550,6 @@ def create_correction_task(
             tmem_corr1,
             None,
             None,
-            smem_kv_reuse_credit,
             work_queue,
         )
 
@@ -3709,7 +3563,6 @@ def create_correction_task(
         tmem_stats_done0: MemoryResource,
         tmem_stats_done1: MemoryResource,
         work_queue: WorkQueue | None = None,
-        smem_kv_reuse_credit: MemoryResource | None = None,
     ) -> None:
         """Capture Keeps correction with explicit stats lifetime gates."""
         run_correction_schedule(
@@ -3720,7 +3573,6 @@ def create_correction_task(
             tmem_corr1,
             tmem_stats_done0,
             tmem_stats_done1,
-            smem_kv_reuse_credit,
             work_queue,
         )
 
@@ -3733,15 +3585,6 @@ def create_correction_task(
                 tmem_corr0,
                 tmem_corr1,
             )
-        elif smem_kv_reuse_credit is None:
-            captured_schedule = correction_schedule(
-                tmem_softmax_local0,
-                tmem_softmax_local1,
-                tmem_o,
-                tmem_corr0,
-                tmem_corr1,
-                work_queue,
-            )
         else:
             captured_schedule = correction_schedule(
                 tmem_softmax_local0,
@@ -3750,7 +3593,6 @@ def create_correction_task(
                 tmem_corr0,
                 tmem_corr1,
                 work_queue,
-                smem_kv_reuse_credit,
             )
         src = [tmem_softmax_local0, tmem_softmax_local1, tmem_o]
     else:
@@ -3764,17 +3606,6 @@ def create_correction_task(
                 tmem_stats_done0,
                 tmem_stats_done1,
             )
-        elif smem_kv_reuse_credit is None:
-            captured_schedule = correction_keeps_schedule(
-                tmem_softmax_local0,
-                tmem_softmax_local1,
-                tmem_o,
-                tmem_corr0,
-                tmem_corr1,
-                tmem_stats_done0,
-                tmem_stats_done1,
-                work_queue,
-            )
         else:
             captured_schedule = correction_keeps_schedule(
                 tmem_softmax_local0,
@@ -3785,7 +3616,6 @@ def create_correction_task(
                 tmem_stats_done0,
                 tmem_stats_done1,
                 work_queue,
-                smem_kv_reuse_credit,
             )
         src = [
             tmem_softmax_local0,
@@ -3796,8 +3626,6 @@ def create_correction_task(
         ]
     if work_queue is not None:
         src.append(work_queue)
-    if smem_kv_reuse_credit is not None:
-        src.append(smem_kv_reuse_credit)
     return task_class(
         src_resources=src,
         dst_resources=[tmem_corr0, tmem_corr1],

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -3292,7 +3292,7 @@ def test_gqa_launch_spec_uses_q_token_cta_geometry(
 
 
 @pytest.mark.parametrize("use_proxy_routes", (False, True))
-def test_proxy_routes_select_static_while_exact_routes_preserve_auto(
+def test_proxy_routes_share_exact_route_scheduler_selection(
     monkeypatch: pytest.MonkeyPatch,
     use_proxy_routes: bool,
 ) -> None:
@@ -3340,11 +3340,12 @@ def test_proxy_routes_select_static_while_exact_routes_preserve_auto(
         block_sparse_config._resolve_block_sparse_launch_spec.cache_clear()
 
     policy = dict(spec.policy)
-    expected_persistent = not use_proxy_routes
-    assert len(selector_calls) == int(expected_persistent)
-    assert spec.compile_key.use_persistent_scheduler is expected_persistent
-    assert policy["scheduler"] == ("persistent" if expected_persistent else "static")
-    assert policy["use_persistent_scheduler"] is expected_persistent
+    # Proxy and exact routes consult the same launch-mode selector, so the
+    # persistent answer it returns applies to both.
+    assert len(selector_calls) == 1
+    assert spec.compile_key.use_persistent_scheduler is True
+    assert policy["scheduler"] == "persistent"
+    assert policy["use_persistent_scheduler"] is True
     assert "scheduler_policy" not in policy
 
 

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -2526,7 +2526,19 @@ def test_public_api_rejects_invalid_usage(monkeypatch: pytest.MonkeyPatch) -> No
     with pytest.raises(ValueError, match="proxy routes require mask_type='dense'"):
         cfg.validate_block_sparse_profile(heads_q_per_kv=1)
 
+    # Exact routes accept causal masking; Q64 Keeps plans use KV256 routes.
     exact_causal_cfg = FmhaDecodeConfig(
+        use_block_sparse=True,
+        groups_tokens_heads_q=True,
+        q_block_size=64,
+        kv_block_size=64,
+        tile_size_q=64,
+        tile_size_kv=256,
+        use_keeps_mma_ab=True,
+        mask_type=CAUSAL,
+    )
+    exact_causal_cfg.validate_block_sparse_profile(heads_q_per_kv=1)
+    q64_kv128_keeps_cfg = FmhaDecodeConfig(
         use_block_sparse=True,
         groups_tokens_heads_q=True,
         q_block_size=64,
@@ -2534,9 +2546,9 @@ def test_public_api_rejects_invalid_usage(monkeypatch: pytest.MonkeyPatch) -> No
         tile_size_q=64,
         tile_size_kv=128,
         use_keeps_mma_ab=True,
-        mask_type=CAUSAL,
     )
-    exact_causal_cfg.validate_block_sparse_profile(heads_q_per_kv=1)
+    with pytest.raises(ValueError, match="requires a streamed TMEM-P profile"):
+        q64_kv128_keeps_cfg.validate_block_sparse_profile(heads_q_per_kv=1)
 
 
 def _validate_cpu_routing(
@@ -4091,7 +4103,7 @@ def test_public_block_sparse_correctness(
 @pytest.mark.parametrize(
     "case",
     _PROXY_ROUTE_CASES,
-    ids=("bk8-swaps", "bk64-keeps", "bk64-keeps-kv128", "bk128-keeps"),
+    ids=lambda case: case.name,
 )
 @torch.no_grad()
 def test_public_proxy_bsr_and_bitmask_match_reference_for_tail(

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -564,6 +564,24 @@ _PROXY_ROUTE_CASES = (
         expected_q_tile=128,
         expected_kv_tile=128,
     ),
+    # A 128-token KV block spans two K64 route atoms; the fragment-to-origin
+    # mapping must follow the atom, not the block.
+    _Case(
+        "proxy_bk128_keeps",
+        1,
+        1,
+        64,
+        269,
+        64,
+        128,
+        torch.bfloat16,
+        "dense",
+        "none",
+        "static",
+        pattern="proxy_tail",
+        expected_q_tile=64,
+        expected_kv_tile=256,
+    ),
 )
 
 
@@ -4073,7 +4091,7 @@ def test_public_block_sparse_correctness(
 @pytest.mark.parametrize(
     "case",
     _PROXY_ROUTE_CASES,
-    ids=("bk8-swaps", "bk64-keeps", "bk64-keeps-kv128"),
+    ids=("bk8-swaps", "bk64-keeps", "bk64-keeps-kv128", "bk128-keeps"),
 )
 @torch.no_grad()
 def test_public_proxy_bsr_and_bitmask_match_reference_for_tail(

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -585,6 +585,11 @@ _PROXY_ROUTE_CASES = (
 )
 
 
+def _stub_block_sparse_config(_key):
+    """Stand in for the decode config where only the launch policy matters."""
+    return SimpleNamespace(uses_prepared_score_keep_words=False)
+
+
 def _make_patterns(case: _Case) -> _Patterns:
     num_q_rows = math.ceil(case.seq_len_q / case.q_block_size)
     num_kv_blocks = math.ceil(case.seq_len_kv / case.kv_block_size)
@@ -2463,6 +2468,43 @@ def test_prepared_block_sparse_layout_allows_empty_route_metadata() -> None:
     assert layout.workspace_size_words == layout.route_metadata_base_word_offset
 
 
+def test_dense_keeps_plans_prepare_structural_score_words() -> None:
+    """Dense Keeps plans carry trusted score words; causal and Swaps do not."""
+    from flashinfer.attention.prims_ts.kernels.fmha_decode.fmha_decode_config import (
+        CAUSAL,
+        DENSE,
+        FmhaDecodeConfig,
+    )
+
+    def keeps_cfg(mask_type):
+        return FmhaDecodeConfig(
+            use_block_sparse=True,
+            groups_tokens_heads_q=True,
+            q_block_size=128,
+            kv_block_size=64,
+            tile_size_q=128,
+            tile_size_kv=128,
+            use_keeps_mma_ab=True,
+            mask_type=mask_type,
+        )
+
+    dense = keeps_cfg(DENSE)
+    assert dense.uses_prepared_score_keep_words
+    assert dense.trusts_prepared_score_words
+    assert not keeps_cfg(CAUSAL).uses_prepared_score_keep_words
+    swaps = FmhaDecodeConfig(
+        use_block_sparse=True,
+        groups_tokens_heads_q=True,
+        q_block_size=32,
+        kv_block_size=32,
+        tile_size_q=32,
+        tile_size_kv=128,
+        use_keeps_mma_ab=False,
+        mask_type=DENSE,
+    )
+    assert not swaps.uses_prepared_score_keep_words
+
+
 def test_public_api_rejects_invalid_usage(monkeypatch: pytest.MonkeyPatch) -> None:
     metadata = torch.empty((1, 1, 2), dtype=torch.int32)
     indices = torch.empty((0,), dtype=torch.int32)
@@ -3218,7 +3260,7 @@ def test_block_sparse_clc_requires_about_two_sm_waves(
     monkeypatch.setattr(
         config_module,
         "_make_block_sparse_config",
-        lambda _key: None,
+        _stub_block_sparse_config,
     )
     monkeypatch.setattr(torch.cuda, "device", lambda _index: nullcontext())
 
@@ -3281,7 +3323,7 @@ def test_gqa_launch_spec_uses_q_token_cta_geometry(
     monkeypatch.setattr(
         config_module,
         "_make_block_sparse_config",
-        lambda _key: None,
+        _stub_block_sparse_config,
     )
     monkeypatch.setattr(torch.cuda, "device", lambda _index: nullcontext())
 
@@ -3342,7 +3384,7 @@ def test_proxy_routes_share_exact_route_scheduler_selection(
     monkeypatch.setattr(
         block_sparse_config,
         "_make_block_sparse_config",
-        lambda _key: None,
+        _stub_block_sparse_config,
     )
     monkeypatch.setattr(torch.cuda, "device", lambda _index: nullcontext())
 
@@ -3403,7 +3445,7 @@ def test_clc_capacity_gates_control_launch_resolution(
     monkeypatch.setattr(
         config_module,
         "_make_block_sparse_config",
-        lambda _key: None,
+        _stub_block_sparse_config,
     )
     monkeypatch.setattr(torch.cuda, "device", lambda _index: nullcontext())
 
@@ -3449,10 +3491,11 @@ def test_static_fallback_reselects_sparse_load_policy(
     )
     config_calls: list[object] = []
 
-    def validate_config(key: object) -> None:
+    def validate_config(key: object) -> SimpleNamespace:
         config_calls.append(key)
         if key.use_persistent_scheduler:
             raise ValueError("reject persistent profile")
+        return _stub_block_sparse_config(key)
 
     monkeypatch.setattr(
         fmha_decode_config,
@@ -3975,7 +4018,8 @@ def test_plan_owns_uniform_route_storage_for_skewed_rows() -> None:
     route_layout = _BlockSparseRouteLayout.create(
         kv_route_size=policy["tile_size_kv"],
         kv_block_size=256,
-        has_token_bits=False,
+        # Dense Keeps plans store structural score words with every route.
+        has_token_bits=True,
         route_metadata_capacity=12,
         num_rows=6,
     )

--- a/tests/attention/test_attention_ts_block_sparse.py
+++ b/tests/attention/test_attention_ts_block_sparse.py
@@ -637,9 +637,14 @@ def _make_patterns(case: _Case) -> _Patterns:
                     rows.append((*range(1, 9), *range(22, 30)))
                     continue
                 if case.pattern == "proxy_tail":
-                    rows.append(
-                        (0, 32) if row_idx % 2 == 1 and num_kv_blocks > 32 else (1, 3)
-                    )
+                    if row_idx % 2 == 1 and num_kv_blocks > 32:
+                        rows.append((0, 32))
+                    elif num_kv_blocks > 3:
+                        rows.append((1, 3))
+                    else:
+                        # Three-block rows (128-token KV blocks over 269
+                        # tokens) keep the ragged final block in the set.
+                        rows.append((1, num_kv_blocks - 1))
                     continue
                 selected = {0, num_kv_blocks - 1}
                 if num_kv_blocks > 2:

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -2177,6 +2177,30 @@ def test_attention_ts_decode_kv256_uses_fragment_ready_p_policy() -> None:
     _assert_decode_smem_within_capacity(cfg, smem_allocator)
 
 
+@pytest.mark.parametrize("persistent", (False, True))
+def test_attention_ts_decode_streamed_p_fragments_follow_kv_tile(
+    persistent: bool,
+) -> None:
+    """Only KV256 splits its scores into streamed K32 P fragments.
+
+    Streamed profiles share one rolled fragment loop whose geometry follows
+    the fragment register count, so the profile property and the fragment
+    count are pinned together. Single-fragment profiles keep the complete
+    score row and never stream.
+    """
+
+    kv256 = _make_contiguous_kv256_config(persistent=persistent)
+    assert kv256.streams_tmem_p_fragments
+    assert kv256.softmax_score_fragment_regs == 32
+    assert kv256.num_softmax_score_fragments == 4
+    assert kv256.kv_block_size % kv256.softmax_score_fragment_regs == 0
+
+    kv128 = _make_contiguous_keeps_config(dtype=BFloat16, tile_size_q=128)
+    assert kv128.tile_size_kv != 256
+    assert kv128.num_softmax_score_fragments == 1
+    assert not kv128.streams_tmem_p_fragments
+
+
 def test_attention_ts_decode_kv256_static_skips_unmodeled_fragment_alias_check() -> (
     None
 ):
@@ -2263,12 +2287,7 @@ def test_attention_ts_decode_kv256_rejects_incompatible_profile_overrides(
     ("persistent", "use_attention_sinks", "expected_error"),
     (
         pytest.param(False, False, None, id="static"),
-        pytest.param(
-            True,
-            False,
-            "persistent KV256 requires kv_stages=3",
-            id="persistent-direct",
-        ),
+        pytest.param(True, False, None, id="persistent-direct"),
         pytest.param(True, True, None, id="persistent-sinks"),
     ),
 )
@@ -2277,7 +2296,11 @@ def test_attention_ts_decode_kv256_explicit_pipeline_depth_contract(
     use_attention_sinks: bool,
     expected_error: str | None,
 ) -> None:
-    """Keep KV2 where work boundaries make its fixed exchange safe."""
+    """Two K/V stages are legal for every KV256 scheduler.
+
+    The tail exchange owns its own SMEM, so no scheduler needs a spare ring
+    stage for it; the pipeline depth is a pure throughput tunable.
+    """
 
     config_args = {
         "kv_stages": 2,

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -1659,7 +1659,7 @@ def test_attention_ts_decode_planned_kv_domain_detects_unpaired_tail(
         (128, 128, False, 32, (None, None, None)),
         (128, 128, True, 1, (184, 88, 56)),
         (64, 256, True, 31, (None, None, None)),
-        (64, 256, True, 32, (176, 104, 56)),
+        (64, 256, True, 32, (152, 152, 56)),
     ),
 )
 def test_attention_ts_decode_register_reallocation_follows_task_graph(
@@ -2298,7 +2298,6 @@ def test_attention_ts_decode_kv256_explicit_pipeline_depth_contract(
     assert cfg.kv_stages == 2
     assert cfg.use_persistent_scheduler is persistent
     assert cfg.use_attention_sinks is use_attention_sinks
-    assert not cfg.uses_rotating_kv256_exchange
 
     if not persistent:
         resources, smem_allocator, _tmem_allocator = _build_decode_resources(cfg)
@@ -2306,24 +2305,17 @@ def test_attention_ts_decode_kv256_explicit_pipeline_depth_contract(
         _assert_decode_smem_within_capacity(cfg, smem_allocator)
 
 
-def test_attention_ts_decode_kv256_rotates_compact_direct_exchange() -> None:
-    """Direct persistent KV256 carries its drained-stage alias in one credit."""
+@pytest.mark.parametrize("persistent", (False, True))
+def test_attention_ts_decode_kv256_uses_dedicated_fragment_exchange(
+    persistent: bool,
+) -> None:
+    """Direct KV256 correction owns a compact exchange outside the K/V ring."""
 
     from flashinfer.attention.prims_ts.kernels.fmha_decode.fmha_decode_resources.tmem_corr import (
         TmemCorrResource,
     )
-    from flashinfer.attention.prims_ts.kernels.fmha_decode.fmha_decode_tasks import (
-        SmemKvReuseCreditResource,
-    )
 
-    cfg = _make_contiguous_kv256_config(persistent=True)
-    assert cfg.uses_rotating_kv256_exchange
-    reuse_credit = SmemKvReuseCreditResource(
-        cfg=cfg,
-        pipeline_config=None,
-        name="smem_kv_reuse_credit",
-    )
-    credit_alloc = reuse_credit.get_smem_requirements()[0]
+    cfg = _make_contiguous_kv256_config(persistent=persistent)
     tmem_corr1 = TmemCorrResource(
         cfg=cfg,
         inst_id=1,
@@ -2332,57 +2324,15 @@ def test_attention_ts_decode_kv256_rotates_compact_direct_exchange() -> None:
     )
     exchange_alloc = tmem_corr1.get_smem_requirements()[-1]
 
-    # Direct output exchanges 128 float4 stats plus 64 rows of 132 floats.
-    # The live 35,840-byte view dynamically selects one stage inside a
-    # full-ring allocation envelope that aliases, but does not enlarge, KV.
-    assert tmem_corr1._kv_tile_256_exchange_entries() * 4 == 35_840
-    assert exchange_alloc.size_bytes == 3 * 65_536
-    assert credit_alloc.size_bytes == 4
+    # The tail exchanges 128 float4 stats plus one padded D32 fragment per
+    # logical output row, so the buffer no longer has to alias the K/V ring
+    # and the load warp can stream the next tile while correction finishes.
+    assert tmem_corr1._kv_tile_256_exchange_entries() * 4 == 11_264
+    assert exchange_alloc.size_bytes == 11_264
 
-
-def test_attention_ts_decode_kv256_reuse_credit_requires_three_stage_ring(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The reuse-credit cursor arithmetic is specialized to three stages."""
-
-    from flashinfer.attention.prims_ts.kernels.fmha_decode import fmha_decode_tasks
-
-    cfg = _make_contiguous_kv256_config(persistent=True)
-    assert cfg.uses_rotating_kv256_exchange
-    monkeypatch.setattr(fmha_decode_tasks, "KV_TILE_256_SHARED_FIFO_STAGES", 4)
-
-    with pytest.raises(AssertionError, match="exactly three shared FIFO stages"):
-        fmha_decode_tasks.SmemKvReuseCreditResource(
-            cfg=cfg,
-            pipeline_config=None,
-            name="smem_kv_reuse_credit",
-        )
-
-
-def test_attention_ts_decode_rejects_reuse_credit_before_schedule_capture(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A rotating reuse credit is invalid without a persistent work queue."""
-
-    from flashinfer.attention.prims_ts.kernels.fmha_decode import fmha_decode_tasks
-
-    def unexpected_schedule_capture(_fn):
-        pytest.fail("invalid reuse-credit topology reached schedule capture")
-
-    monkeypatch.setattr(fmha_decode_tasks, "schedule", unexpected_schedule_capture)
-
-    with pytest.raises(ValueError, match="reuse credit requires a work queue"):
-        fmha_decode_tasks.create_correction_task(
-            object(),
-            object(),
-            object(),
-            object(),
-            object(),
-            None,
-            object(),
-            object(),
-            domain=0,
-        )
+    if not persistent:
+        _resources, smem_allocator, _tmem_allocator = _build_decode_resources(cfg)
+        _assert_decode_smem_within_capacity(cfg, smem_allocator)
 
 
 @pytest.mark.parametrize(
@@ -2423,49 +2373,8 @@ def test_attention_ts_decode_kv256_split_uses_compact_exchange(
     )
     exchange_alloc = tmem_corr1.get_smem_requirements()[-1]
 
-    assert tmem_corr1._kv_tile_256_exchange_entries() * 4 == 35_840
-    assert exchange_alloc.size_bytes == 35_840
-
-
-def test_attention_ts_decode_rotating_exchange_is_a_storage_agnostic_capability() -> (
-    None
-):
-    """Select rotation by physical topology, not contiguous versus paged K/V."""
-
-    contiguous = _make_contiguous_kv256_config(persistent=True)
-    paged = make_decode_config(
-        headdim=128,
-        args={
-            "use_keeps_mma_ab": True,
-            "tile_size_q": 64,
-            "tile_size_kv": 256,
-            "groups_tokens_heads_q": True,
-            "use_persistent_scheduler": True,
-        },
-        seq_len_q=64,
-        seq_len_kv=4096,
-        batch_size=1,
-        num_heads_q=32,
-        num_heads_kv=32,
-        qkv_dtype=BFloat16,
-        o_dtype=BFloat16,
-        qkv_layout="pagedKv",
-        num_tokens_per_page=64,
-        split_kv_mode="disabled",
-        splits_kv=1,
-        mask_type="dense",
-        auto_tuner=False,
-    )
-
-    assert contiguous.uses_rotating_kv256_exchange
-    assert paged.uses_rotating_kv256_exchange
-    assert not replace(
-        contiguous, use_persistent_scheduler=False
-    ).uses_rotating_kv256_exchange
-    assert not replace(contiguous, use_split_kv=True).uses_rotating_kv256_exchange
-    assert not replace(
-        contiguous, use_attention_sinks=True
-    ).uses_rotating_kv256_exchange
+    assert tmem_corr1._kv_tile_256_exchange_entries() * 4 == 11_264
+    assert exchange_alloc.size_bytes == 11_264
 
 
 def test_attention_ts_decode_kv256_register_launch_bound_is_amortized() -> None:
@@ -2512,7 +2421,7 @@ def test_attention_ts_decode_kv256_register_budget_matches_launch_bound() -> Non
         long_cfg.softmax_task_num_registers,
         long_cfg.correction_task_num_registers,
         long_cfg.mma_load_task_num_registers,
-    ) == (176, 104, 56)
+    ) == (152, 152, 56)
     assert cfg.tmem_s_cols == 128
     assert cfg.mma_tile_n_bmm1 == 256
 
@@ -3060,8 +2969,8 @@ def test_attention_ts_decode_auto_config_selects_kv256(monkeypatch, dtype):
     assert cfg.groups_tokens_heads_q is True
     assert cfg.q_tokens_per_cta == 2
     register_cfg = replace(cfg, total_kv_tiles=32)
-    assert register_cfg.softmax_task_num_registers == 176
-    assert register_cfg.correction_task_num_registers == 104
+    assert register_cfg.softmax_task_num_registers == 152
+    assert register_cfg.correction_task_num_registers == 152
     assert cfg == explicit_reference
 
 

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -2119,9 +2119,18 @@ def test_attention_ts_decode_q128_tmem_p_aliases_consumed_s_region(
             assert stats._alloc is None
         else:
             assert stats._alloc is not None
-    if cfg.keeps_stats_via_smem:
+    if cfg.streams_tmem_p_fragments:
+        # Streamed P fragments overlay S from its first column so every
+        # 16-column P store lands on consumed scores; O leads the layout.
+        assert cfg.keeps_stats_via_smem
+        assert output.offset == 0
+        assert s0.offset == output.offset + output.num_columns
+        assert p0.offset == s0.offset
+        assert p1.offset == s1.offset
+    elif cfg.keeps_stats_via_smem:
         assert p0.offset == s0.offset + cfg.tmem_stats_cols
         assert p1.offset == s1.offset + cfg.tmem_stats_cols
+        assert output.offset >= s1.offset + s1.num_columns
     else:
         stats0 = resources["tmemSoftmaxLocal0"]._alloc
         stats1 = resources["tmemSoftmaxLocal1"]._alloc
@@ -2137,7 +2146,6 @@ def test_attention_ts_decode_q128_tmem_p_aliases_consumed_s_region(
     assert p0.offset + p0.num_columns <= s0.offset + s0.num_columns
     assert s1.offset <= p1.offset
     assert p1.offset + p1.num_columns <= s1.offset + s1.num_columns
-    assert output.offset >= s1.offset + s1.num_columns
     assert resources["smemP0"]._alloc is None
     assert resources["smemP1"]._alloc is None
     assert {"smemK0", "smemK1", "smemV0", "smemV1"} <= resources.keys()
@@ -2181,12 +2189,12 @@ def test_attention_ts_decode_kv256_uses_fragment_ready_p_policy() -> None:
 def test_attention_ts_decode_streamed_p_fragments_follow_kv_tile(
     persistent: bool,
 ) -> None:
-    """Only KV256 splits its scores into streamed K32 P fragments.
+    """KV256 and 16-bit Q128/KV128 split their scores into streamed fragments.
 
     Streamed profiles share one rolled fragment loop whose geometry follows
     the fragment register count, so the profile property and the fragment
-    count are pinned together. Single-fragment profiles keep the complete
-    score row and never stream.
+    count are pinned together. They also run their two softmax groups
+    unordered. FP8 Q128 publishes a complete packed row and never streams.
     """
 
     kv256 = _make_contiguous_kv256_config(persistent=persistent)
@@ -2194,11 +2202,19 @@ def test_attention_ts_decode_streamed_p_fragments_follow_kv_tile(
     assert kv256.softmax_score_fragment_regs == 32
     assert kv256.num_softmax_score_fragments == 4
     assert kv256.kv_block_size % kv256.softmax_score_fragment_regs == 0
+    assert not kv256.uses_ordered_softmax_barrier
 
-    kv128 = _make_contiguous_keeps_config(dtype=BFloat16, tile_size_q=128)
-    assert kv128.tile_size_kv != 256
-    assert kv128.num_softmax_score_fragments == 1
-    assert not kv128.streams_tmem_p_fragments
+    q128 = _make_contiguous_keeps_config(dtype=BFloat16, tile_size_q=128)
+    assert q128.tile_size_kv == 128 and q128.uses_two_inst_tmem_p
+    assert q128.streams_tmem_p_fragments
+    assert q128.softmax_score_fragment_regs == 32
+    assert q128.num_softmax_score_fragments == 4
+    assert not q128.uses_ordered_softmax_barrier
+
+    q128_fp8 = _make_contiguous_keeps_config(dtype=Float8E4M3FN, tile_size_q=128)
+    assert q128_fp8.uses_two_inst_tmem_p
+    assert q128_fp8.num_softmax_score_fragments == 1
+    assert not q128_fp8.streams_tmem_p_fragments
 
 
 def test_attention_ts_decode_kv256_static_skips_unmodeled_fragment_alias_check() -> (

--- a/tests/attention/test_attention_ts_decode.py
+++ b/tests/attention/test_attention_ts_decode.py
@@ -2189,12 +2189,14 @@ def test_attention_ts_decode_kv256_uses_fragment_ready_p_policy() -> None:
 def test_attention_ts_decode_streamed_p_fragments_follow_kv_tile(
     persistent: bool,
 ) -> None:
-    """KV256 and 16-bit Q128/KV128 split their scores into streamed fragments.
+    """KV256 splits its scores into streamed fragments; dense Q128 does not.
 
     Streamed profiles share one rolled fragment loop whose geometry follows
     the fragment register count, so the profile property and the fragment
     count are pinned together. They also run their two softmax groups
-    unordered. FP8 Q128 publishes a complete packed row and never streams.
+    unordered. Dense 16-bit Q128/KV128 keeps the complete P row because its
+    route loop is not load-bound; only block-sparse Q128 streams. FP8 Q128
+    publishes a complete packed row and never streams.
     """
 
     kv256 = _make_contiguous_kv256_config(persistent=persistent)
@@ -2206,10 +2208,8 @@ def test_attention_ts_decode_streamed_p_fragments_follow_kv_tile(
 
     q128 = _make_contiguous_keeps_config(dtype=BFloat16, tile_size_q=128)
     assert q128.tile_size_kv == 128 and q128.uses_two_inst_tmem_p
-    assert q128.streams_tmem_p_fragments
-    assert q128.softmax_score_fragment_regs == 32
-    assert q128.num_softmax_score_fragments == 4
-    assert not q128.uses_ordered_softmax_barrier
+    assert not q128.streams_tmem_p_fragments
+    assert q128.num_softmax_score_fragments == 1
 
     q128_fp8 = _make_contiguous_keeps_config(dtype=Float8E4M3FN, tile_size_q=128)
     assert q128_fp8.uses_two_inst_tmem_p


### PR DESCRIPTION
## Summary

Performance work on the PrimTS block-sparse decode attention kernel (`flashinfer/attention/prims_ts`) that follows #4872. The changes target the exact block-sparse path first (Q64/KV256 and Q128/KV128 Keeps profiles) and also carry over to the proxy-compensated routes and to the dense KV256 decode profile that shares the same kernel. Eleven commits; each performance commit was measured with paired ABBA runs on B200 against the commit before it.

### What changed

1. **Stream the KV256 P fragments from one rolled loop** (`5d8d79a2`). The per-fragment P path was fully unrolled and made the kernel instruction-cache bound. One rolled loop over the four K32 fragments, with the FMA exp2 emulation limited to 4 of 16 pairs, shrinks the code and keeps MUFU and FMA balanced. Also drops the redundant same-instance PV completion wait before QK (tcgen05 orders the A-operand read before the accumulator write). Dense KV256 shares the masked write-back path.
2. **Proxy routes use the shared scheduler selection** (`f5b4a6f1`). Proxy plans no longer force the static grid, so the CLC persistent scheduler is selected for large shapes as it is for exact plans.
3. **Trim the KV256 per-tile fixed costs** (`b1c737f7`). Full-sector output stores in the epilogue, static-grid row-header prefetch in the CTA prologue, and releasing the Q stage before the tail PV MMAs.
4. **Rebalance KV256 registers and free the K/V ring from the tail** (`02f83c00`). Softmax/correction register split 152/152 and a dedicated 11 KB SMEM exchange for the tail merge instead of a rotating credit on the K/V ring.
5. **Consolidate the KV256 fragment and tail paths and the shared dense/sparse load cadence** (`58107d1b`). Codegen-neutral (SASS byte-identical); removes an unreachable unrolled path and several duplicated helpers.
6. **Stream Q128/KV128 P as K32 fragments** (`c7b42e41`). The 16-bit two-instance Q128 profile now uses the same fragment streaming as KV256 (TMEM layout O-first with P aliased at S column 0, per-fragment barriers, PV k-slices per fragment). Includes a fix for fragment-to-origin mapping with 128-token KV blocks and a proxy test for that layout.
7. **One streamed Keeps max pass for dense and block-sparse tiles** (`37f351cc`). Deletes the unreachable sparse Q64/KV128 complete-row arm and unifies the dense and sparse fragment max pass; dense tiles derive one 32-bit keep word per fragment instead of per-element boundary compares.
8. **Prepare structural score words for dense Keeps plans** (`c2557b69`). Exact plans with a dense mask type now prepare the per-fragment keep words too, so the streamed max pass can trust them.
9. **Prefetch block-sparse route records one iteration ahead** (`aea0b1e8`). PerfSim warp timelines showed the load warp saturated per route by TMA issue plus a fully exposed global load of the next route record. The shared-KV load cadence now issues that load one resolution ahead, threading the prefetch state like the cached page IDs; the split-ring load variants keep the immediate load.
10. **Keep dense Q128/KV128 on the complete-row P path** (`ee119fe4`). Streaming the Q128 P row only pays off where the route loop waits on the K/V loads; the dense GQA-128 decode profile measured slower with it. `streams_tmem_p_fragments` is now the single policy (16-bit two-instance profiles with a KV256 tile or a block-sparse plan), and the 16-bit x16-slice publication of the complete-row path is restored. Dense Q128 is back at main's timing with identical output.
11. **Review fixes** (`679bf00f`, `f2f7cf52`). The KV256 split-KV partial store advances its column offset by the two-byte partial width instead of the final output width. No reachable configuration changes today since KV256 admits only 16-bit output, and the FP16/BF16 split-KV SASS is unchanged. The `proxy_bk128_keeps` test case now selects only in-range KV blocks and keeps the ragged tail block in its set.

### Correctness

- `tests/attention/test_attention_ts_block_sparse.py`: 228 passed (one pre-existing failure, `test_runtime_routes_cuda_graph_replays_routes_and_token_mask`, deselected; it fails on main as well).
- `tests/attention/test_attention_ts_decode.py`: 212 passed (rebased on main with #4915).
- New tests: the config truth table for streamed profiles, the alias layout of the streamed TMEM P, the kv_block 128 proxy tail case, the structural score-word preparation for dense Keeps plans, and the rejection of an unstreamed Keeps profile.

### Performance

Paired ABBA on one B200 (5 runs per leg, 3 legs, min of graph-replay time per call), block-sparse decode attention, S=10800, H=40, D=128, bf16, block 64, exact mask density 0.175 ("hot" pattern), automatic scheduler selection. Baseline is upstream `main` at 1989b509.

| Profile (auto scheduler) | main 1989b509 | this PR | paired B/A (95% CI) |
|---|---|---|---|
| Q64/KV256 exact (block-sparse, SOL shape) | 664.5 us | 521.8 us | 0.786 [0.785, 0.787] (-21.4%) |
| Q64/KV256 proxy-compensated | 705.0 us | 594.3 us | 0.842 [0.839, 0.844] (-15.8%) |
| Q128/KV128 exact (q_block 128) | 468.9 us | 426.3 us | 0.909 [0.909, 0.910] (-9.1%) |
| Q128/KV128 proxy-compensated | 861.2 us | 592.0 us | 0.688 [0.685, 0.691] (-31.2%) |

Dense decode (same kernel, `prims_ts_batch_decode_with_kv_cache`, sq=1024, kv=10800, page 128, bf16; four interleaved main/branch runs, min per call):

| Dense profile | main 1989b509 | this PR | change |
|---|---|---|---|
| Q64/KV256 Keeps, H=40 (grouped) | 323.7-324.9 us | 240.6-240.9 us | -25.7% |
| Q128/KV128 Keeps, GQA ratio 128 (H=128, 1 KV head, ungrouped) | 599.9-602.9 us | 600.6-603.0 us | neutral (kept on the complete-row P path, see item 10) |

The block-sparse SASS is byte-identical across the two codegen-neutral refactor commits and across the dense-Q128 gating commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded streamed attention support across KV256 and Q128/KV128 configurations.
  * Added score-validity handling for dense block-sparse Keeps plans.
  * Added route metadata prefetching for sparse attention.
  * Enabled shared scheduling behavior for proxy and exact routes.
  * Added support for two-stage KV256 scheduling.

* **Bug Fixes**
  * Improved validation for block-sparse Keeps and proxy-route configurations.
  * Improved softmax and output handling across streamed attention paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->