### PR TITLE
Add granularity for mla decode

### DIFF
--- a/flashinfer/cute_dsl/attention/mla_dispatch.py
+++ b/flashinfer/cute_dsl/attention/mla_dispatch.py
@@ -54,6 +54,7 @@ DCP_KWARGS = (
     "cp_world",
     "cp_rank",
     "causal_seqlens_kv_global",
+    "cp_interleave_granularity",
 )
 
 
@@ -89,10 +90,20 @@ def _validate_dcp_kwargs(kwargs: dict) -> bool:
     cp_world = kwargs.get("cp_world", 1)
     cp_rank = kwargs.get("cp_rank", 0)
     causal_seqlens_kv_global = kwargs.get("causal_seqlens_kv_global")
+    cp_interleave_granularity = kwargs.get("cp_interleave_granularity", 1)
     if not isinstance(cp_world, int) or isinstance(cp_world, bool) or cp_world <= 0:
         raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
     if not isinstance(cp_rank, int) or isinstance(cp_rank, bool):
         raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
+    if (
+        not isinstance(cp_interleave_granularity, int)
+        or isinstance(cp_interleave_granularity, bool)
+        or cp_interleave_granularity <= 0
+    ):
+        raise ValueError(
+            "cp_interleave_granularity must be a positive integer, got "
+            f"{cp_interleave_granularity!r}"
+        )
     if enable_dcp and not 0 <= cp_rank < cp_world:
         raise ValueError(
             f"cp_rank must satisfy 0 <= cp_rank < cp_world, got "
@@ -106,6 +117,10 @@ def _validate_dcp_kwargs(kwargs: dict) -> bool:
             nondefault.append(f"cp_rank={cp_rank!r}")
         if causal_seqlens_kv_global is not None:
             nondefault.append("causal_seqlens_kv_global")
+        if cp_interleave_granularity != 1:
+            nondefault.append(
+                f"cp_interleave_granularity={cp_interleave_granularity!r}"
+            )
         if nondefault:
             raise ValueError(
                 "DCP arguments require enable_dcp=True; got " + ", ".join(nondefault)

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode.py
@@ -160,15 +160,27 @@ def _check_can_implement(
     is_var_split_kv: bool,
     enable_dcp: bool = False,
     cp_world: int = 1,
+    cp_interleave_granularity: int = 1,
 ) -> None:
     """Check if the kernel supports the given configuration (cached)."""
     if not isinstance(enable_dcp, bool):
         raise TypeError(f"enable_dcp must be a bool, got {type(enable_dcp).__name__}")
     if not isinstance(cp_world, int) or isinstance(cp_world, bool) or cp_world <= 0:
         raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
-    if not enable_dcp and cp_world != 1:
+    if (
+        not isinstance(cp_interleave_granularity, int)
+        or isinstance(cp_interleave_granularity, bool)
+        or cp_interleave_granularity <= 0
+    ):
         raise ValueError(
-            f"cp_world={cp_world} requires enable_dcp=True; disabled DCP uses cp_world=1"
+            "cp_interleave_granularity must be a positive integer, got "
+            f"{cp_interleave_granularity!r}"
+        )
+    if not enable_dcp and (cp_world != 1 or cp_interleave_granularity != 1):
+        raise ValueError(
+            "non-default DCP layout arguments require enable_dcp=True; got "
+            f"cp_world={cp_world}, "
+            f"cp_interleave_granularity={cp_interleave_granularity}"
         )
 
     mma_qk_tiler_mn = (128, 128)
@@ -227,6 +239,7 @@ def _get_compiled_mla_kernel(
     enable_pdl: bool = False,
     enable_dcp: bool = False,
     cp_world: int = 1,
+    cp_interleave_granularity: int = 1,
 ) -> Callable:
     """Compile and cache an MLA decode kernel.
 
@@ -274,6 +287,7 @@ def _get_compiled_mla_kernel(
         reducer_max_splits=reducer_max_splits,
         enable_dcp=enable_dcp,
         cp_world=cp_world,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
 
     # All dimensions as sym_int — this matches the original kernel's use of
@@ -472,6 +486,7 @@ def cute_dsl_mla_decode(
     cp_world: int = 1,
     cp_rank: int = 0,
     causal_seqlens_kv_global: Optional[torch.Tensor] = None,
+    cp_interleave_granularity: int = 1,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """CuTe DSL MLA decode kernel for Blackwell SM100.
 
@@ -549,18 +564,23 @@ def cute_dsl_mla_decode(
         at least the largest request query length; the compiled kernel is
         specialized to this capacity.
     enable_dcp : bool
-        Enable static cyclic decode context-parallel masking. DCP returns a
-        rank-local attention state and therefore requires ``return_lse=True``.
+        Enable static block-cyclic decode context-parallel masking. DCP returns
+        a rank-local attention state and therefore requires ``return_lse=True``.
         Compact variable-Q input is supported when ``cum_seq_lens_q`` and
         ``max_q_len`` are provided.
     cp_world : int
-        Compile-time context-parallel world size. The local cache owns global
-        token positions ``cp_world * local_k + cp_rank``.
+        Compile-time context-parallel world size.
     cp_rank : int
         Runtime-uniform context-parallel rank.
     causal_seqlens_kv_global : Optional[torch.Tensor]
         Contiguous CUDA int32 tensor ``[B]`` containing the global exclusive
         causal bound for the newest query token. Required when DCP is enabled.
+    cp_interleave_granularity : int
+        Compile-time number of consecutive global tokens assigned to a rank
+        before ownership advances to the next rank. A local key ``k`` maps to
+        ``((k // G) * cp_world + cp_rank) * G + (k % G)``, where
+        ``G=cp_interleave_granularity``. The default ``1`` preserves token-level
+        interleaving.
     Returns
     -------
     torch.Tensor or Tuple[torch.Tensor, torch.Tensor]
@@ -604,6 +624,15 @@ def cute_dsl_mla_decode(
         raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
     if not isinstance(cp_rank, int) or isinstance(cp_rank, bool):
         raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
+    if (
+        not isinstance(cp_interleave_granularity, int)
+        or isinstance(cp_interleave_granularity, bool)
+        or cp_interleave_granularity <= 0
+    ):
+        raise ValueError(
+            "cp_interleave_granularity must be a positive integer, got "
+            f"{cp_interleave_granularity!r}"
+        )
 
     if enable_dcp:
         if not 0 <= cp_rank < cp_world:
@@ -652,6 +681,8 @@ def cute_dsl_mla_decode(
             nondefault.append(f"cp_rank={cp_rank}")
         if causal_seqlens_kv_global is not None:
             nondefault.append("causal_seqlens_kv_global")
+        if cp_interleave_granularity != 1:
+            nondefault.append(f"cp_interleave_granularity={cp_interleave_granularity}")
         if nondefault:
             raise ValueError(
                 "DCP arguments require enable_dcp=True; got " + ", ".join(nondefault)
@@ -815,6 +846,7 @@ def cute_dsl_mla_decode(
         is_var_split_kv=is_var_split_kv,
         enable_dcp=enable_dcp,
         cp_world=cp_world,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
 
     enable_pdl = device_support_pdl(query.device) if enable_pdl is None else enable_pdl
@@ -841,6 +873,7 @@ def cute_dsl_mla_decode(
         enable_pdl=enable_pdl,
         enable_dcp=enable_dcp,
         cp_world=cp_world,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
 
     # Call the kernel

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp16.py
@@ -155,6 +155,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         reducer_max_splits: int = MAX_SPLITS,
         enable_dcp: bool = False,
         cp_world: int = 1,
+        cp_interleave_granularity: int = 1,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -199,9 +200,13 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :param enable_dcp: Whether to compile the decode-context-parallel
             global-coordinate causal mask.
         :type enable_dcp: bool
-        :param cp_world: Number of cyclic context-parallel shards. This is a
-            compile-time parameter when DCP is enabled.
+        :param cp_world: Number of block-cyclic context-parallel shards. This
+            is a compile-time parameter when DCP is enabled.
         :type cp_world: int
+        :param cp_interleave_granularity: Number of consecutive global tokens
+            assigned to one rank before ownership advances to the next rank.
+            This is a compile-time parameter when DCP is enabled.
+        :type cp_interleave_granularity: int
         """
 
         self.latent_dim = 512
@@ -235,12 +240,30 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         # Both flatten (query token, head) into the same physical M128 mode.
         if cp_world < 1:
             raise ValueError(f"cp_world must be positive, got {cp_world}")
+        if not isinstance(cp_interleave_granularity, int) or isinstance(
+            cp_interleave_granularity, bool
+        ):
+            raise TypeError(
+                "cp_interleave_granularity must be an integer, got "
+                f"{type(cp_interleave_granularity).__name__}"
+            )
+        if cp_interleave_granularity < 1:
+            raise ValueError(
+                "cp_interleave_granularity must be positive, got "
+                f"{cp_interleave_granularity}"
+            )
         if not enable_dcp and cp_world != 1:
             raise ValueError(
                 f"cp_world must be 1 when DCP is disabled, got cp_world={cp_world}"
             )
+        if not enable_dcp and cp_interleave_granularity != 1:
+            raise ValueError(
+                "cp_interleave_granularity must be 1 when DCP is disabled, got "
+                f"cp_interleave_granularity={cp_interleave_granularity}"
+            )
         self.enable_dcp = enable_dcp
         self.cp_world = cp_world
+        self.cp_interleave_granularity = cp_interleave_granularity
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
         (
@@ -1678,6 +1701,62 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             valid_rows = self.tail_q_rows
         return valid_rows
 
+    @cute.jit
+    def dcp_local_key_to_global(
+        self, local_key: cutlass.Int32, cp_rank: cutlass.Int32
+    ) -> cutlass.Int32:
+        """Map a compact rank-local key index to its global token index."""
+        if cutlass.const_expr(self.cp_interleave_granularity == 1):
+            # Preserve the original token-cyclic specialization exactly.
+            return self.cp_world * local_key + cp_rank
+
+        local_block = local_key // self.cp_interleave_granularity
+        return (
+            local_key
+            + ((self.cp_world - 1) * local_block + cp_rank)
+            * self.cp_interleave_granularity
+        )
+
+    @cute.jit
+    def dcp_global_bound_to_local_bound(
+        self, global_bound: cutlass.Int32, cp_rank: cutlass.Int32
+    ) -> cutlass.Int32:
+        """Count this rank's keys below an exclusive global token bound."""
+        if cutlass.const_expr(self.cp_interleave_granularity == 1):
+            # Preserve the original token-cyclic specialization exactly.
+            local_bound_numer = global_bound - cp_rank
+            return cute.ceil_div(
+                cutlass.max(local_bound_numer, cutlass.Int32(0)), self.cp_world
+            )
+
+        nonnegative_bound = cutlass.max(global_bound, cutlass.Int32(0))
+        global_cycle = self.cp_world * self.cp_interleave_granularity
+        full_cycles = nonnegative_bound // global_cycle
+        cycle_remainder = nonnegative_bound - full_cycles * global_cycle
+        rank_remainder = cutlass.max(
+            cycle_remainder - cp_rank * self.cp_interleave_granularity,
+            cutlass.Int32(0),
+        )
+        rank_remainder = cutlass.min(rank_remainder, self.cp_interleave_granularity)
+        return full_cycles * self.cp_interleave_granularity + rank_remainder
+
+    @cute.jit
+    def dcp_flat_query_row_to_local_bound(
+        self,
+        flat_q_row: cutlass.Int32,
+        physical_k: cutlass.Int32,
+        causal_global: cutlass.Int32,
+        q_len: cutlass.Int32,
+        cp_rank: cutlass.Int32,
+    ) -> cutlass.Int32:
+        """Return the visible local prefix for one flattened query row."""
+        query_token = flat_q_row // self.num_heads
+        query_global_bound = causal_global - (q_len - 1) + query_token
+        return cutlass.min(
+            physical_k,
+            self.dcp_global_bound_to_local_bound(query_global_bound, cp_rank),
+        )
+
     @cute.kernel
     def reduction_kernel(
         self,
@@ -2819,6 +2898,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         # static power of two, so the remaining division is a shift.
         tile_n = self.mma_qk_tiler[1]
         first_q_token = cutlass.Int32(0)
+        dcp_mask_local_bound = cutlass.Int32(0)
         if cutlass.const_expr(self.num_q_tiles > 1):
             first_q_token = (
                 common_params.blk_coord[1] * self.mma_qk_tiler[0]
@@ -2828,18 +2908,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             # dense-prefix boundary shared by both CTAs.  Keep the physical
             # local K bound separate so a partial final local tile is never
             # misclassified as dense.
-            earliest_bound_numer = (
-                common_params.causal_global
-                - common_params.cp_rank
-                - (common_params.q_len - 1)
-                + first_q_token
+            earliest_global_bound = (
+                common_params.causal_global - (common_params.q_len - 1) + first_q_token
             )
-            earliest_local_bound = cute.ceil_div(
-                cutlass.max(earliest_bound_numer, cutlass.Int32(0)),
-                self.cp_world,
+            earliest_local_bound = self.dcp_global_bound_to_local_bound(
+                earliest_global_bound, common_params.cp_rank
             )
             effective_local_bound = cutlass.min(common_params.K, earliest_local_bound)
             first_mask_tile_idx = effective_local_bound // tile_n
+            if cutlass.const_expr(self.seq_len_q == 1):
+                # Every flattened row represents the same query token. Reuse
+                # the tile-level prefix in the score mask instead of mapping
+                # every local key back to a global coordinate.
+                dcp_mask_local_bound = effective_local_bound
         else:
             first_mask_tile_idx = cutlass.max(
                 (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
@@ -2865,6 +2946,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 row_max,
                 row_sum,
                 correction_factor,
+                dcp_mask_local_bound,
                 False,
                 False,
             )
@@ -2891,6 +2973,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 row_max,
                 row_sum,
                 correction_factor,
+                dcp_mask_local_bound,
                 True,
                 False,
             )
@@ -2916,6 +2999,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             row_max,
             row_sum,
             correction_factor,
+            dcp_mask_local_bound,
             k_index >= first_mask_tile_idx,
             True,
         )
@@ -3046,6 +3130,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         row_max: cutlass.Float32,
         row_sum: cutlass.Float32,
         correction_factor: cutlass.Float32,
+        dcp_mask_local_bound: cutlass.Int32,
         apply_mask: bool,
         is_local_last_tile: cutlass.Boolean,
     ) -> tuple[
@@ -3076,6 +3161,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         :type row_sum: cutlass.Float32
         :param correction_factor: The correction factor
         :type correction_factor: cutlass.Float32
+        :param dcp_mask_local_bound: Visible rank-local prefix for the
+            single-query DCP specialization. Unused for non-DCP or Q > 1.
+        :type dcp_mask_local_bound: cutlass.Int32
         :param apply_mask: Whether the tile needs K-bound / causal masking (Python bool
             for the unmasked/masked bulk loops; runtime cutlass.Boolean for a
             work-split final tile at the exact per-query-tile mask boundary).
@@ -3122,41 +3210,53 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
         tTR_rAcc = cute.make_fragment_like(tTR_tS, self.acc_dtype)
 
         row_max_new = row_max
-        # Spec-decoding (MTP) causal mask.  A flattened row r corresponds to
-        # q_token=floor(r/H), whose last valid key is K-S_q+q_token.  Avoid the
-        # per-element integer division using the equivalent integer predicate:
+        # Spec-decoding (MTP) causal mask. A flattened row r corresponds to
+        # q_token=floor(r/H), whose last valid key is K-S_q+q_token. For the
+        # ordinary local layout, avoid per-element integer division with:
         #
         #   H * (key_pos - K + S_q) <= r
         #
-        # This arithmetic remains inside `if apply_mask`, so the compile-time
-        # dense path emits no row-mask work.  Masked positions use a large
+        # A DCP thread's 64 score elements all share one M row, so convert that
+        # row's global causal bound to one local prefix outside the score loop.
+        # Q1 reuses the prefix already computed for dense-tile classification.
+        # This work remains inside `if apply_mask`, so the compile-time dense
+        # path emits no row-mask work. Masked positions use a large
         # negative sentinel (not -inf) to avoid all-masked-row NaNs.
         cta_m_rows = self.mma_qk_tiler[0] // self.cluster_shape_mnk[0]
         arch = BaseDSL._get_dsl().get_arch_enum()
         if cutlass.const_expr(arch >= Arch.sm_100 and arch <= Arch.sm_100f):
             cute.copy(tmem_tiled_copy, tTR_tAcc, tTR_rAcc)
-            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                if apply_mask:
-                    flat_q_row = (
-                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
-                        + common_params.blk_coord[0] * cta_m_rows
-                        + tTR_tS[i][0]
-                    )
-                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    if cutlass.const_expr(self.enable_dcp):
-                        mask_threshold = self.num_heads * (
-                            self.cp_world * key_pos
-                            + common_params.cp_rank
-                            - common_params.causal_global
-                            + common_params.q_len
+            if apply_mask:
+                if cutlass.const_expr(self.enable_dcp):
+                    dcp_thread_local_bound = dcp_mask_local_bound
+                    if cutlass.const_expr(self.seq_len_q > 1):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[0][0]
                         )
+                        dcp_thread_local_bound = self.dcp_flat_query_row_to_local_bound(
+                            flat_q_row,
+                            common_params.K,
+                            common_params.causal_global,
+                            common_params.q_len,
+                            common_params.cp_rank,
+                        )
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         tTR_rAcc[i] = (
                             tTR_rAcc[i]
-                            if cute.elem_less(key_pos, common_params.K)
-                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            if cute.elem_less(key_pos, dcp_thread_local_bound)
                             else self.acc_dtype(-1.0e6)
                         )
-                    else:
+                else:
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[i][0]
+                        )
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         mask_threshold = self.num_heads * (
                             key_pos - common_params.K + common_params.q_len
                         )
@@ -3191,27 +3291,36 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
             )
             tTR_rAcc = cute.make_tensor(tTR_rAcc_red.iterator, tTR_rAcc.layout)
             if apply_mask:
-                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                    flat_q_row = (
-                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
-                        + common_params.blk_coord[0] * cta_m_rows
-                        + tTR_tS[i][0]
-                    )
-                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    if cutlass.const_expr(self.enable_dcp):
-                        mask_threshold = self.num_heads * (
-                            self.cp_world * key_pos
-                            + common_params.cp_rank
-                            - common_params.causal_global
-                            + common_params.q_len
+                if cutlass.const_expr(self.enable_dcp):
+                    dcp_thread_local_bound = dcp_mask_local_bound
+                    if cutlass.const_expr(self.seq_len_q > 1):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[0][0]
                         )
+                        dcp_thread_local_bound = self.dcp_flat_query_row_to_local_bound(
+                            flat_q_row,
+                            common_params.K,
+                            common_params.causal_global,
+                            common_params.q_len,
+                            common_params.cp_rank,
+                        )
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         tTR_rAcc[i] = (
                             tTR_rAcc[i]
-                            if cute.elem_less(key_pos, common_params.K)
-                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            if cute.elem_less(key_pos, dcp_thread_local_bound)
                             else self.acc_dtype(-1.0e6)
                         )
-                    else:
+                else:
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[i][0]
+                        )
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         mask_threshold = self.num_heads * (
                             key_pos - common_params.K + common_params.q_len
                         )
@@ -3674,11 +3783,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP16:
                 flat_q_row = (
                     common_params.blk_coord[1] * self.mma_qk_tiler[0] + tTR_cO[0][0]
                 )
+                first_global_key = self.dcp_local_key_to_global(
+                    common_params.split_start_key, common_params.cp_rank
+                )
                 first_key_threshold = self.num_heads * (
-                    self.cp_world * common_params.split_start_key
-                    + common_params.cp_rank
-                    - common_params.causal_global
-                    + common_params.q_len
+                    first_global_key - common_params.causal_global + common_params.q_len
                 )
                 row_has_key = cute.elem_less(
                     common_params.split_start_key, common_params.K

--- a/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
+++ b/flashinfer/cute_dsl/attention/monolithic/mla_decode_fp8.py
@@ -153,6 +153,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         reducer_max_splits: int = MAX_SPLITS,
         enable_dcp: bool = False,
         cp_world: int = 1,
+        cp_interleave_granularity: int = 1,
     ):
         """Initializes the configuration for a Blackwell Multi-Head Latent Attention (MLA) kernel.
 
@@ -194,11 +195,14 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             a smaller specialization must cap runtime split-KV accordingly.
         :type reducer_max_splits: int
         :param enable_dcp: Statically enable decode context-parallel causal
-            masking over a cyclic rank-local KV shard.
+            masking over a block-cyclic rank-local KV shard.
         :type enable_dcp: bool
-        :param cp_world: Compile-time DCP world size. Rank-local key ``k`` maps
-            to global key ``k * cp_world + cp_rank``.
+        :param cp_world: Compile-time DCP world size.
         :type cp_world: int
+        :param cp_interleave_granularity: Number of consecutive global tokens
+            assigned to one rank before ownership advances to the next rank.
+            This is a compile-time parameter when DCP is enabled.
+        :type cp_interleave_granularity: int
         """
 
         self.latent_dim = 512
@@ -231,12 +235,30 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # specializations load each request's actual length from its indptr.
         if cp_world < 1:
             raise ValueError(f"cp_world must be positive, got {cp_world}")
+        if not isinstance(cp_interleave_granularity, int) or isinstance(
+            cp_interleave_granularity, bool
+        ):
+            raise TypeError(
+                "cp_interleave_granularity must be an integer, got "
+                f"{type(cp_interleave_granularity).__name__}"
+            )
+        if cp_interleave_granularity < 1:
+            raise ValueError(
+                "cp_interleave_granularity must be positive, got "
+                f"{cp_interleave_granularity}"
+            )
         if not enable_dcp and cp_world != 1:
             raise ValueError(
                 "cp_world must be 1 when decode context parallelism is disabled"
             )
+        if not enable_dcp and cp_interleave_granularity != 1:
+            raise ValueError(
+                "cp_interleave_granularity must be 1 when decode context "
+                "parallelism is disabled"
+            )
         self.enable_dcp = enable_dcp
         self.cp_world = cp_world
+        self.cp_interleave_granularity = cp_interleave_granularity
         self.num_heads = num_heads
         self.seq_len_q = seq_len_q
         (
@@ -1165,7 +1187,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             newest query. Present only in the statically enabled DCP
             specialization.
         :type causal_seqlens_kv_global: cute.Tensor
-        :param cp_rank: Runtime rank of this cyclic KV shard
+        :param cp_rank: Runtime rank of this block-cyclic KV shard
         :type cp_rank: cutlass.Int32
         :param block_split_kvs: The per-block split_kv values tensor
         :type block_split_kvs: cute.Tensor
@@ -1929,6 +1951,62 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         if q_tile_idx == self.num_q_tiles - 1:
             valid_rows = self.tail_q_rows
         return valid_rows
+
+    @cute.jit
+    def dcp_local_key_to_global(
+        self, local_key: cutlass.Int32, cp_rank: cutlass.Int32
+    ) -> cutlass.Int32:
+        """Map a compact rank-local key index to its global token index."""
+        if cutlass.const_expr(self.cp_interleave_granularity == 1):
+            # Preserve the original token-cyclic specialization exactly.
+            return self.cp_world * local_key + cp_rank
+
+        local_block = local_key // self.cp_interleave_granularity
+        return (
+            local_key
+            + ((self.cp_world - 1) * local_block + cp_rank)
+            * self.cp_interleave_granularity
+        )
+
+    @cute.jit
+    def dcp_global_bound_to_local_bound(
+        self, global_bound: cutlass.Int32, cp_rank: cutlass.Int32
+    ) -> cutlass.Int32:
+        """Count this rank's keys below an exclusive global token bound."""
+        if cutlass.const_expr(self.cp_interleave_granularity == 1):
+            # Preserve the original token-cyclic specialization exactly.
+            local_bound_numer = global_bound - cp_rank
+            return cute.ceil_div(
+                cutlass.max(local_bound_numer, cutlass.Int32(0)), self.cp_world
+            )
+
+        nonnegative_bound = cutlass.max(global_bound, cutlass.Int32(0))
+        global_cycle = self.cp_world * self.cp_interleave_granularity
+        full_cycles = nonnegative_bound // global_cycle
+        cycle_remainder = nonnegative_bound - full_cycles * global_cycle
+        rank_remainder = cutlass.max(
+            cycle_remainder - cp_rank * self.cp_interleave_granularity,
+            cutlass.Int32(0),
+        )
+        rank_remainder = cutlass.min(rank_remainder, self.cp_interleave_granularity)
+        return full_cycles * self.cp_interleave_granularity + rank_remainder
+
+    @cute.jit
+    def dcp_flat_query_row_to_local_bound(
+        self,
+        flat_q_row: cutlass.Int32,
+        physical_k: cutlass.Int32,
+        causal_global: cutlass.Int32,
+        q_len: cutlass.Int32,
+        cp_rank: cutlass.Int32,
+    ) -> cutlass.Int32:
+        """Return the visible local prefix for one flattened query row."""
+        query_token = flat_q_row // self.num_heads
+        query_global_bound = causal_global - (q_len - 1) + query_token
+        return cutlass.min(
+            physical_k,
+            self.dcp_global_bound_to_local_bound(query_global_bound, cp_rank),
+        )
 
     @cute.kernel
     def reduction_kernel(
@@ -3015,6 +3093,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         # static power of two, so the remaining division is a shift.
         tile_n = self.mma_qk_tiler[1]
         first_q_token = cutlass.Int32(0)
+        dcp_mask_local_bound = cutlass.Int32(0)
         if cutlass.const_expr(self.num_q_tiles > 1):
             first_q_token = (
                 common_params.blk_coord[1] * self.mma_qk_tiler[0]
@@ -3024,18 +3103,19 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             # M128 tile has the smallest visible rank-local K bound.  Compute
             # that bound once per query tile, then cap it by the physical
             # rank-local K extent so a partial physical tail is still masked.
-            dcp_bound_numerator = cutlass.max(
-                common_params.causal_seq_len
-                - common_params.cp_rank
-                - (common_params.q_len - 1)
-                + first_q_token,
-                cutlass.Int32(0),
+            earliest_global_bound = (
+                common_params.causal_seq_len - (common_params.q_len - 1) + first_q_token
             )
-            earliest_local_bound = (
-                dcp_bound_numerator + self.cp_world - 1
-            ) // self.cp_world
+            earliest_local_bound = self.dcp_global_bound_to_local_bound(
+                earliest_global_bound, common_params.cp_rank
+            )
             effective_local_bound = cutlass.min(common_params.K, earliest_local_bound)
             first_mask_tile_idx = effective_local_bound // tile_n
+            if cutlass.const_expr(self.seq_len_q == 1):
+                # Every flattened row represents the same query token. Reuse
+                # the tile-level prefix in the score mask instead of mapping
+                # every local key back to a global coordinate.
+                dcp_mask_local_bound = effective_local_bound
         else:
             first_mask_tile_idx = cutlass.max(
                 (common_params.K - common_params.q_len + 1 + first_q_token) // tile_n,
@@ -3076,6 +3156,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 row_max,
                 row_sum,
                 correction_factor,
+                dcp_mask_local_bound,
                 is_second_compute_warp,
                 False,
                 is_local_last_tile,
@@ -3117,6 +3198,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
                 row_max,
                 row_sum,
                 correction_factor,
+                dcp_mask_local_bound,
                 is_second_compute_warp,
                 k_index >= first_mask_tile_idx,
                 True,
@@ -3450,6 +3532,7 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         row_max: cutlass.Float32,
         row_sum: cutlass.Float32,
         correction_factor: cutlass.Float32,
+        dcp_mask_local_bound: cutlass.Int32,
         is_second_compute_warp: bool,
         apply_mask: bool,
         is_local_last_tile: cutlass.Boolean,
@@ -3482,6 +3565,9 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         :type row_sum: cutlass.Float32
         :param correction_factor: The correction factor
         :type correction_factor: cutlass.Float32
+        :param dcp_mask_local_bound: Visible rank-local prefix for the
+            single-query DCP specialization. Unused for non-DCP or Q > 1.
+        :type dcp_mask_local_bound: cutlass.Int32
         :param apply_mask: Whether the tile needs K-bound / causal masking (Python bool
             for the unmasked/masked bulk loops; runtime cutlass.Boolean for a
             work-split final tile at the exact per-query-tile mask boundary).
@@ -3540,11 +3626,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         #   r = q_token * H + q_head,
         # the usual key < K - S_q + 1 + q_token predicate is equivalent to
         #   H * (key - K + S_q) <= r.
-        # With cyclic DCP, local key k maps to W*k+rank, producing
-        #   H * (W*k + rank - G + S_q) <= r.
-        # Both forms avoid integer division/modulo. The enclosing apply_mask
-        # branch remains compile-time false for dense bulk K tiles, so they do
-        # not execute any of this row-dependent arithmetic.
+        # A DCP thread's 64 score elements all share one M row, so convert that
+        # row's global causal bound to one local prefix outside the score loop.
+        # Q1 reuses the prefix already computed for dense-tile classification.
+        # The enclosing apply_mask branch remains compile-time false for dense
+        # bulk K tiles, so they execute none of this row-dependent arithmetic.
         # Masked positions are filled with a large negative sentinel (not -inf)
         # to avoid NaN propagation when an entire row becomes masked. The DCP
         # epilogue turns such an empty row into the neutral O=0, LSE=-inf pair.
@@ -3552,28 +3638,37 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
         arch = BaseDSL._get_dsl().get_arch_enum()
         if cutlass.const_expr(arch >= Arch.sm_100 and arch <= Arch.sm_100f):
             cute.copy(tmem_tiled_copy, tTR_tAcc, tTR_rAcc)
-            for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                if apply_mask:
-                    flat_q_row = (
-                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
-                        + common_params.blk_coord[0] * cta_m_rows
-                        + tTR_tS[i][0]
-                    )
-                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    if cutlass.const_expr(self.enable_dcp):
-                        mask_threshold = self.num_heads * (
-                            self.cp_world * key_pos
-                            + common_params.cp_rank
-                            - common_params.causal_seq_len
-                            + common_params.q_len
+            if apply_mask:
+                if cutlass.const_expr(self.enable_dcp):
+                    dcp_thread_local_bound = dcp_mask_local_bound
+                    if cutlass.const_expr(self.seq_len_q > 1):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[0][0]
                         )
+                        dcp_thread_local_bound = self.dcp_flat_query_row_to_local_bound(
+                            flat_q_row,
+                            common_params.K,
+                            common_params.causal_seq_len,
+                            common_params.q_len,
+                            common_params.cp_rank,
+                        )
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         tTR_rAcc[i] = (
                             tTR_rAcc[i]
-                            if cute.elem_less(key_pos, common_params.K)
-                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            if cute.elem_less(key_pos, dcp_thread_local_bound)
                             else self.acc_dtype(-1.0e6)
                         )
-                    else:
+                else:
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[i][0]
+                        )
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         mask_threshold = self.num_heads * (
                             key_pos - common_params.K + common_params.q_len
                         )
@@ -3612,27 +3707,36 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
             )
             tTR_rAcc = cute.make_tensor(tTR_rAcc_red.iterator, tTR_rAcc.layout)
             if apply_mask:
-                for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
-                    flat_q_row = (
-                        common_params.blk_coord[1] * self.mma_qk_tiler[0]
-                        + common_params.blk_coord[0] * cta_m_rows
-                        + tTR_tS[i][0]
-                    )
-                    key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
-                    if cutlass.const_expr(self.enable_dcp):
-                        mask_threshold = self.num_heads * (
-                            self.cp_world * key_pos
-                            + common_params.cp_rank
-                            - common_params.causal_seq_len
-                            + common_params.q_len
+                if cutlass.const_expr(self.enable_dcp):
+                    dcp_thread_local_bound = dcp_mask_local_bound
+                    if cutlass.const_expr(self.seq_len_q > 1):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[0][0]
                         )
+                        dcp_thread_local_bound = self.dcp_flat_query_row_to_local_bound(
+                            flat_q_row,
+                            common_params.K,
+                            common_params.causal_seq_len,
+                            common_params.q_len,
+                            common_params.cp_rank,
+                        )
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         tTR_rAcc[i] = (
                             tTR_rAcc[i]
-                            if cute.elem_less(key_pos, common_params.K)
-                            and not cute.elem_less(flat_q_row, mask_threshold)
+                            if cute.elem_less(key_pos, dcp_thread_local_bound)
                             else self.acc_dtype(-1.0e6)
                         )
-                    else:
+                else:
+                    for i in cutlass.range_constexpr(cute.size(tTR_rAcc)):
+                        flat_q_row = (
+                            common_params.blk_coord[1] * self.mma_qk_tiler[0]
+                            + common_params.blk_coord[0] * cta_m_rows
+                            + tTR_tS[i][0]
+                        )
+                        key_pos = tTR_tS[i][1] + self.mma_qk_tiler[1] * k_index
                         mask_threshold = self.num_heads * (
                             key_pos - common_params.K + common_params.q_len
                         )
@@ -4124,11 +4228,11 @@ class BlackwellMultiHeadLatentAttentionForwardFP8:
     ) -> cutlass.Boolean:
         """Whether this row has a visible key in the current local K split."""
         first_local_key = common_params.k_index * self.mma_qk_tiler[1]
+        first_global_key = self.dcp_local_key_to_global(
+            first_local_key, common_params.cp_rank
+        )
         mask_threshold = self.num_heads * (
-            self.cp_world * first_local_key
-            + common_params.cp_rank
-            - common_params.causal_seq_len
-            + common_params.q_len
+            first_global_key - common_params.causal_seq_len + common_params.q_len
         )
         return cute.elem_less(first_local_key, common_params.K) and not cute.elem_less(
             flat_q_row, mask_threshold

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -2320,6 +2320,7 @@ def _validate_mla_dcp_args(
     cp_world: int,
     cp_rank: int,
     causal_seqlens_kv_global: Optional[torch.Tensor],
+    cp_interleave_granularity: int,
 ) -> str:
     """Validate the public DCP contract and return the effective backend."""
     if not isinstance(enable_dcp, bool):
@@ -2328,6 +2329,15 @@ def _validate_mla_dcp_args(
         raise ValueError(f"cp_world must be a positive integer, got {cp_world!r}")
     if not isinstance(cp_rank, int) or isinstance(cp_rank, bool):
         raise TypeError(f"cp_rank must be an integer, got {type(cp_rank).__name__}")
+    if (
+        not isinstance(cp_interleave_granularity, int)
+        or isinstance(cp_interleave_granularity, bool)
+        or cp_interleave_granularity <= 0
+    ):
+        raise ValueError(
+            "cp_interleave_granularity must be a positive integer, got "
+            f"{cp_interleave_granularity!r}"
+        )
 
     if not enable_dcp:
         nondefault = []
@@ -2337,6 +2347,8 @@ def _validate_mla_dcp_args(
             nondefault.append(f"cp_rank={cp_rank}")
         if causal_seqlens_kv_global is not None:
             nondefault.append("causal_seqlens_kv_global")
+        if cp_interleave_granularity != 1:
+            nondefault.append(f"cp_interleave_granularity={cp_interleave_granularity}")
         if nondefault:
             raise ValueError(
                 "DCP arguments require enable_dcp=True; got " + ", ".join(nondefault)
@@ -2433,6 +2445,7 @@ def _cute_dsl_incompatibility_reason(
     max_q_len: Optional[int] = None,
     enable_dcp: bool = False,
     cp_world: int = 1,
+    cp_interleave_granularity: int = 1,
 ) -> Optional[str]:
     """Return None if cute-dsl can handle this call, else a human-readable reason.
 
@@ -2515,6 +2528,7 @@ def _cute_dsl_incompatibility_reason(
                 "cum_seq_lens_q": cum_seq_lens_q,
                 "max_q_len": max_q_len,
                 "enable_dcp": enable_dcp,
+                "cp_interleave_granularity": cp_interleave_granularity,
             },
         )
     except (TypeError, ValueError, ImportError) as e:
@@ -2543,7 +2557,11 @@ def _cute_dsl_incompatibility_reason(
             is_var_split_kv=False,
         )
         if resolved_impl == "monolithic":
-            check_kwargs.update(enable_dcp=enable_dcp, cp_world=cp_world)
+            check_kwargs.update(
+                enable_dcp=enable_dcp,
+                cp_world=cp_world,
+                cp_interleave_granularity=cp_interleave_granularity,
+            )
             check_monolithic_can_implement(**check_kwargs)
         else:
             check_modular_can_implement(**check_kwargs)
@@ -2562,6 +2580,7 @@ def _mla_decode_tuning_config(
     enable_dcp: bool = False,
     cp_world: int = 1,
     cp_rank: int = 0,
+    cp_interleave_granularity: int = 1,
 ) -> TuningConfig:
     """One TuningConfig and stable initializer set per key.
 
@@ -2578,8 +2597,9 @@ def _mla_decode_tuning_config(
     ``random_(0, num_pages)`` which wraps mod kv_cache size — safe for autotune
     profiling because MLA decode reads kv_cache and never writes it, so aliased
     page reads give correct timing measurements. ``seq_lens`` is filled with
-    ``profile_seq_len``; the synthetic DCP global bound preserves that exact
-    rank-local length.
+    ``profile_seq_len``; the synthetic DCP global bound maps the first excluded
+    local key back to global coordinates and therefore preserves that exact
+    rank-local length for any block-interleaving granularity.
     """
 
     def init_block_tables(shapes, dtype, device):
@@ -2599,7 +2619,11 @@ def _mla_decode_tuning_config(
 
     def init_causal_seqlens_kv_global(shapes, dtype, device):
         tensor = torch.empty(shapes, dtype=dtype, device=device)
-        tensor.fill_(profile_seq_len * cp_world + cp_rank)
+        local_block, block_offset = divmod(profile_seq_len, cp_interleave_granularity)
+        first_excluded_global = (
+            local_block * cp_world + cp_rank
+        ) * cp_interleave_granularity + block_offset
+        tensor.fill_(first_excluded_global)
         return tensor
 
     # At most one optional fifth batch-swept tensor: native qk_rope_head_dim=0
@@ -2652,6 +2676,7 @@ def _build_mla_decode_tuning_config(
     enable_dcp: bool = False,
     cp_world: int = 1,
     cp_rank: int = 0,
+    cp_interleave_granularity: int = 1,
 ) -> TuningConfig:
     """Reduce call args to the memoization key of ``_mla_decode_tuning_config``.
 
@@ -2690,6 +2715,7 @@ def _build_mla_decode_tuning_config(
         enable_dcp,
         cp_world,
         cp_rank,
+        cp_interleave_granularity,
     )
 
 
@@ -2926,6 +2952,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         enable_dcp: bool = False,
         cp_world: int = 1,
         cp_rank: int = 0,
+        cp_interleave_granularity: int = 1,
     ):
         from ..cute_dsl.attention import cute_dsl_mla_decode
 
@@ -2953,6 +2980,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
         self.enable_dcp = enable_dcp
         self.cp_world = cp_world
         self.cp_rank = cp_rank
+        self.cp_interleave_granularity = cp_interleave_granularity
         self._profile_lse: Optional[torch.Tensor] = None
         self._workspace_sizer, self._resolved_cute_dsl_impl = (
             _resolve_cute_dsl_workspace_sizer(cute_dsl_impl, sinks, enable_dcp)
@@ -3027,6 +3055,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
             self.cute_dsl_impl,
             getattr(self, "enable_dcp", False),
             getattr(self, "cp_world", 1),
+            getattr(self, "cp_interleave_granularity", 1),
         )
 
     def forward(
@@ -3084,6 +3113,7 @@ class CuteDslMlaDecodeRunner(TunableRunner):
             cp_world=self.cp_world,
             cp_rank=self.cp_rank,
             causal_seqlens_kv_global=causal_seqlens_kv_global,
+            cp_interleave_granularity=self.cp_interleave_granularity,
         )
 
 
@@ -3120,6 +3150,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
     cp_world: int = 1,
     cp_rank: int = 0,
     causal_seqlens_kv_global: Optional[torch.Tensor] = None,
+    cp_interleave_granularity: int = 1,
     use_fp16_softmax: Optional[bool] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode MLA with TRTLLM-GEN, CuteDSL, XQA, or SM120/SM121 sparse kernels.
@@ -3312,19 +3343,23 @@ def trtllm_batch_decode_with_kv_cache_mla(
         padding. Zero-length rows are unsupported; padded query rows should
         contain one valid dummy index and use length 1.
     enable_dcp : bool = False
-        Statically enable cyclic decode context parallelism in the monolithic
-        CuTeDSL MLA kernel. DCP returns a rank-local output/LSE state, so
-        ``return_lse=True`` is required and the caller must merge rank states.
-        Both fixed-Q input and compact variable-Q input described by
-        ``cum_seq_lens_q`` are supported.
+        Statically enable block-cyclic decode context parallelism in the
+        monolithic CuTeDSL MLA kernel. DCP returns a rank-local output/LSE
+        state, so ``return_lse=True`` is required and the caller must merge
+        rank states. Both fixed-Q input and compact variable-Q input described
+        by ``cum_seq_lens_q`` are supported.
     cp_world : int = 1
-        Compile-time context-parallel world size. Rank ``r`` stores global KV
-        positions whose token index modulo ``cp_world`` equals ``r``.
+        Compile-time context-parallel world size.
     cp_rank : int = 0
         Runtime-uniform context-parallel rank.
     causal_seqlens_kv_global : Optional[torch.Tensor] = None
         Contiguous CUDA int32 tensor ``[batch_size]`` containing the global
         exclusive causal bound for the newest query token. Required with DCP.
+    cp_interleave_granularity : int = 1
+        Compile-time number of consecutive global tokens assigned to one rank.
+        With granularity ``G``, local key ``k`` on rank ``r`` maps to
+        ``((k // G) * cp_world + r) * G + (k % G)``. Assignment is anchored at
+        global token zero. The default ``1`` preserves token-level interleaving.
 
     Note
     ----
@@ -3416,6 +3451,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
         cp_world=cp_world,
         cp_rank=cp_rank,
         causal_seqlens_kv_global=causal_seqlens_kv_global,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
 
     check_trtllm_gen_sm107_only_feature(
@@ -3850,6 +3886,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
         cute_dsl_impl=cute_dsl_impl,
         enable_dcp=enable_dcp,
         cp_world=cp_world,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
     if backend == "cute-dsl":
         if cute_dsl_reason is not None:
@@ -3938,6 +3975,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
                 enable_dcp=enable_dcp,
                 cp_world=cp_world,
                 cp_rank=cp_rank,
+                cp_interleave_granularity=cp_interleave_granularity,
             )
         )
 
@@ -3958,6 +3996,7 @@ def trtllm_batch_decode_with_kv_cache_mla(
         enable_dcp=enable_dcp,
         cp_world=cp_world,
         cp_rank=cp_rank,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
     inputs = [query, block_tables, seq_lens, out]
     if sparse_mla_top_k_lens is not None:

--- a/tests/attention/test_cute_dsl_mla_dcp.py
+++ b/tests/attention/test_cute_dsl_mla_dcp.py
@@ -43,16 +43,73 @@ def _ceil_div(numerator: int, denominator: int) -> int:
     return -(-numerator // denominator)
 
 
+def _global_position(
+    local_key: int,
+    cp_world: int,
+    cp_rank: int,
+    cp_interleave_granularity: int = 1,
+) -> int:
+    """Map one rank-local key coordinate to its block-cyclic global index."""
+    local_block, block_offset = divmod(local_key, cp_interleave_granularity)
+    return (local_block * cp_world + cp_rank) * cp_interleave_granularity + block_offset
+
+
+def _local_prefix_length(
+    global_bound: int,
+    cp_world: int,
+    cp_rank: int,
+    cp_interleave_granularity: int = 1,
+) -> int:
+    """Count rank-owned global positions strictly below ``global_bound``."""
+    if global_bound <= 0:
+        return 0
+    global_cycle = cp_world * cp_interleave_granularity
+    full_cycles, cycle_remainder = divmod(global_bound, global_cycle)
+    rank_remainder = min(
+        max(cycle_remainder - cp_rank * cp_interleave_granularity, 0),
+        cp_interleave_granularity,
+    )
+    return full_cycles * cp_interleave_granularity + rank_remainder
+
+
+def _rank_global_positions(
+    global_length: int,
+    cp_world: int,
+    cp_rank: int,
+    cp_interleave_granularity: int = 1,
+) -> list[int]:
+    """Return the ordered global positions physically stored by one rank."""
+    return [
+        _global_position(
+            local_key,
+            cp_world,
+            cp_rank,
+            cp_interleave_granularity,
+        )
+        for local_key in range(
+            _local_prefix_length(
+                global_length,
+                cp_world,
+                cp_rank,
+                cp_interleave_granularity,
+            )
+        )
+    ]
+
+
 def _local_causal_bound(
     global_bound_newest: int,
     q_len: int,
     q_idx: int,
     cp_world: int,
     cp_rank: int,
+    cp_interleave_granularity: int = 1,
 ) -> int:
-    return _ceil_div(
-        global_bound_newest - cp_rank - (q_len - 1) + q_idx,
+    return _local_prefix_length(
+        global_bound_newest - (q_len - 1) + q_idx,
         cp_world,
+        cp_rank,
+        cp_interleave_granularity,
     )
 
 
@@ -64,14 +121,29 @@ def _flat_dcp_score_is_valid(
     global_bound_newest: int,
     cp_world: int,
     cp_rank: int,
+    cp_interleave_granularity: int = 1,
 ) -> bool:
-    return flat_q_row >= num_heads * (
-        cp_world * local_key + cp_rank - global_bound_newest + q_len
+    global_key = _global_position(
+        local_key,
+        cp_world,
+        cp_rank,
+        cp_interleave_granularity,
     )
+    return flat_q_row >= num_heads * (global_key - global_bound_newest + q_len)
 
 
-def _local_length(global_length: int, cp_world: int, cp_rank: int) -> int:
-    return max(_ceil_div(global_length - cp_rank, cp_world), 0)
+def _local_length(
+    global_length: int,
+    cp_world: int,
+    cp_rank: int,
+    cp_interleave_granularity: int = 1,
+) -> int:
+    return _local_prefix_length(
+        global_length,
+        cp_world,
+        cp_rank,
+        cp_interleave_granularity,
+    )
 
 
 def _make_inputs(
@@ -131,12 +203,19 @@ def _pack_cyclic_rank_pages(
     global_lens: torch.Tensor,
     cp_world: int,
     cp_rank: int,
+    cp_interleave_granularity: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
-    """Pack ``g % cp_world == cp_rank`` tokens into a contiguous paged cache."""
+    """Pack one block-cyclic rank into a contiguous paged cache."""
     batch_size, _, d_qk = global_kv.shape
     global_lens_host = global_lens.tolist()
     local_lens_host = [
-        _local_length(global_len, cp_world, cp_rank) for global_len in global_lens_host
+        _local_length(
+            global_len,
+            cp_world,
+            cp_rank,
+            cp_interleave_granularity,
+        )
+        for global_len in global_lens_host
     ]
     pages_per_batch = [
         max(1, _ceil_div(local_len, _PAGE_SIZE)) for local_len in local_lens_host
@@ -175,7 +254,17 @@ def _pack_cyclic_rank_pages(
         )
         block_tables[batch_idx, :num_pages] = page_ids
         if local_len:
-            local_tokens = global_kv[batch_idx, cp_rank:global_len:cp_world]
+            global_positions = torch.tensor(
+                _rank_global_positions(
+                    global_len,
+                    cp_world,
+                    cp_rank,
+                    cp_interleave_granularity,
+                ),
+                dtype=torch.long,
+                device=global_kv.device,
+            )
+            local_tokens = global_kv[batch_idx].index_select(0, global_positions)
             local_cache[next_page : next_page + num_pages].view(-1, d_qk)[
                 :local_len
             ].copy_(local_tokens)
@@ -199,8 +288,9 @@ def _reference_attention(
     *,
     cp_world: int = 1,
     cp_rank: int = 0,
+    cp_interleave_granularity: int = 1,
 ) -> tuple[torch.Tensor, torch.Tensor]:
-    """Reference one cyclic rank; world=1 is the full-context reference."""
+    """Reference one block-cyclic rank; world=1 is the full-context reference."""
     batch_size, q_len, num_heads, _ = query.shape
     out = torch.zeros(
         batch_size,
@@ -219,12 +309,22 @@ def _reference_attention(
     softmax_scale = 1.0 / math.sqrt(_LATENT_DIM)
 
     for batch_idx, global_len in enumerate(global_lens.tolist()):
-        keys = global_kv[batch_idx, cp_rank:global_len:cp_world].float()
-        global_positions = range(cp_rank, global_len, cp_world)
+        global_positions = _rank_global_positions(
+            global_len,
+            cp_world,
+            cp_rank,
+            cp_interleave_granularity,
+        )
+        position_indices = torch.tensor(
+            global_positions,
+            dtype=torch.long,
+            device=global_kv.device,
+        )
+        keys = global_kv[batch_idx].index_select(0, position_indices).float()
         for q_idx in range(q_len):
             global_bound = global_len - (q_len - 1) + q_idx
             # Count directly in global coordinates so this reference remains
-            # independent of the ceiling-divided kernel formula without
+            # independent of the block-cyclic local-prefix formula without
             # synchronizing on a CUDA predicate.
             visible_count = bisect_left(global_positions, global_bound)
             if visible_count == 0:
@@ -310,6 +410,7 @@ def _prepare_rank_call(
     *,
     cp_world: int,
     cp_rank: int,
+    cp_interleave_granularity: int = 1,
     is_var_seq: bool = False,
     enable_pdl: bool = False,
 ) -> tuple[dict, int]:
@@ -319,7 +420,11 @@ def _prepare_rank_call(
     from flashinfer.cute_dsl.utils import get_num_sm
 
     kv_cache, block_tables, local_lens, max_local_len = _pack_cyclic_rank_pages(
-        global_kv, global_lens, cp_world, cp_rank
+        global_kv,
+        global_lens,
+        cp_world,
+        cp_rank,
+        cp_interleave_granularity,
     )
     batch_size, q_len, num_heads, _ = query.shape
     split_kv, workspace_size = _get_split_kv_and_workspace_size(
@@ -359,6 +464,7 @@ def _launch_rank(
     cp_world: int,
     cp_rank: int,
     enable_dcp: bool,
+    cp_interleave_granularity: int = 1,
     causal_lens: torch.Tensor | None = None,
     is_var_seq: bool = False,
     enable_pdl: bool = False,
@@ -373,6 +479,7 @@ def _launch_rank(
         global_lens,
         cp_world=cp_world,
         cp_rank=cp_rank,
+        cp_interleave_granularity=cp_interleave_granularity,
         is_var_seq=is_var_seq,
         enable_pdl=enable_pdl,
     )
@@ -382,6 +489,7 @@ def _launch_rank(
             "enable_dcp": True,
             "cp_world": cp_world,
             "cp_rank": cp_rank,
+            "cp_interleave_granularity": cp_interleave_granularity,
             "causal_seqlens_kv_global": (
                 global_lens if causal_lens is None else causal_lens
             ),
@@ -472,6 +580,7 @@ def _assert_dcp_rank_merge_matches_reference(
     *,
     cp_world: int,
     dtype: torch.dtype,
+    cp_interleave_granularity: int = 1,
     is_var_seq: bool = False,
 ) -> list[int]:
     """Check every rank-local state and their final natural-log merge."""
@@ -486,6 +595,7 @@ def _assert_dcp_rank_merge_matches_reference(
             cp_world=cp_world,
             cp_rank=cp_rank,
             enable_dcp=True,
+            cp_interleave_granularity=cp_interleave_granularity,
             is_var_seq=is_var_seq,
         )
         ref_rank_out, ref_rank_lse = _reference_attention(
@@ -494,6 +604,7 @@ def _assert_dcp_rank_merge_matches_reference(
             global_lens,
             cp_world=cp_world,
             cp_rank=cp_rank,
+            cp_interleave_granularity=cp_interleave_granularity,
         )
         _assert_close_to_reference(out, lse, ref_rank_out, ref_rank_lse, dtype)
         rank_outputs.append(out)
@@ -551,34 +662,156 @@ def _assert_variable_q_dcp_rank_merge_matches_reference(
     return split_kvs
 
 
-def test_dcp_flat_mask_matches_ceiling_divided_bound():
-    """The division-free flattened predicate must match global coordinates."""
+def test_dcp_block_cyclic_granularity_three_layout_and_prefix_bounds():
+    """Pin the requested W2/G3 ownership layout and its causal boundaries."""
+    assert _rank_global_positions(12, 2, 0, 3) == [0, 1, 2, 6, 7, 8]
+    assert _rank_global_positions(12, 2, 1, 3) == [3, 4, 5, 9, 10, 11]
+
+    # Every prefix is partitioned exactly once, including partial rank chunks.
+    for global_length in range(20):
+        rank_positions = [
+            _rank_global_positions(global_length, 2, cp_rank, 3) for cp_rank in range(2)
+        ]
+        assert sorted(rank_positions[0] + rank_positions[1]) == list(
+            range(global_length)
+        )
+        for cp_rank, positions in enumerate(rank_positions):
+            assert len(positions) == _local_length(global_length, 2, cp_rank, 3)
+
+    # At global bound 12 with Sq=4, rank zero owns the complete earlier chunk,
+    # while the newest four-token causal tail enters rank one's final chunk.
+    assert [_local_causal_bound(12, 4, q_idx, 2, 0, 3) for q_idx in range(4)] == [
+        6,
+        6,
+        6,
+        6,
+    ]
+    assert [_local_causal_bound(12, 4, q_idx, 2, 1, 3) for q_idx in range(4)] == [
+        3,
+        4,
+        5,
+        6,
+    ]
+
+    # Exercise partial page and K-tile boundaries on different ranks.
+    assert [
+        [_local_length(global_length, 2, cp_rank, 3) for cp_rank in range(2)]
+        for global_length in (126, 127, 128, 130, 131, 132)
+    ] == [
+        [63, 63],
+        [64, 63],
+        [65, 63],
+        [66, 64],
+        [66, 65],
+        [66, 66],
+    ]
+    assert [
+        [_local_length(global_length, 2, cp_rank, 3) for cp_rank in range(2)]
+        for global_length in (252, 253, 254, 256, 257, 258)
+    ] == [
+        [126, 126],
+        [127, 126],
+        [128, 126],
+        [129, 127],
+        [129, 128],
+        [129, 129],
+    ]
+
+
+@pytest.mark.parametrize("bad_granularity", [0, -1, True, 1.5])
+def test_dcp_dispatch_rejects_invalid_interleave_granularity(bad_granularity):
+    """Layout validation is host-only and must reject bools as integers."""
+    from flashinfer.cute_dsl.attention.mla_dispatch import _resolve_impl
+
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _resolve_impl(
+            requested="auto",
+            kwargs={
+                "enable_dcp": True,
+                "cp_world": 2,
+                "cp_rank": 0,
+                "cp_interleave_granularity": bad_granularity,
+            },
+        )
+
+
+def test_dcp_dispatch_requires_enable_for_nondefault_interleave_granularity():
+    from flashinfer.cute_dsl.attention.mla_dispatch import _resolve_impl
+
+    with pytest.raises(ValueError, match="DCP arguments require enable_dcp=True"):
+        _resolve_impl(
+            requested="auto",
+            kwargs={"cp_interleave_granularity": 3},
+        )
+    assert (
+        _resolve_impl(
+            requested="auto",
+            kwargs={
+                "enable_dcp": True,
+                "cp_world": 2,
+                "cp_rank": 0,
+                "cp_interleave_granularity": 3,
+            },
+        )
+        == "monolithic"
+    )
+
+
+def test_dcp_flat_mask_matches_block_cyclic_local_bound():
+    """The flattened predicate must match block-cyclic global coordinates."""
     for num_heads in (6, 12, 24, 48, 64, 96, 128):
         for q_len in (1, 2, 4, 8):
             for cp_world in (1, 2, 4):
-                for cp_rank in range(cp_world):
-                    for global_len in (q_len, q_len + 1, 127, 128, 129):
-                        local_len = _local_length(global_len, cp_world, cp_rank)
-                        for q_idx in range(q_len):
-                            for local_key in range(local_len):
-                                expected = (
-                                    local_key * cp_world + cp_rank
-                                    < global_len - (q_len - 1) + q_idx
-                                )
-                                for head in (0, num_heads - 1):
-                                    flat_q_row = q_idx * num_heads + head
-                                    assert (
-                                        _flat_dcp_score_is_valid(
-                                            flat_q_row,
-                                            num_heads,
+                for cp_interleave_granularity in (1, 3, 7):
+                    global_lengths = sorted(
+                        {
+                            q_len,
+                            q_len + 1,
+                            cp_interleave_granularity - 1,
+                            cp_interleave_granularity,
+                            cp_interleave_granularity + 1,
+                            cp_world * cp_interleave_granularity - 1,
+                            cp_world * cp_interleave_granularity,
+                            cp_world * cp_interleave_granularity + 1,
+                            127,
+                            128,
+                            129,
+                        }
+                    )
+                    for cp_rank in range(cp_world):
+                        for global_len in global_lengths:
+                            local_len = _local_length(
+                                global_len,
+                                cp_world,
+                                cp_rank,
+                                cp_interleave_granularity,
+                            )
+                            for q_idx in range(q_len):
+                                for local_key in range(local_len):
+                                    expected = (
+                                        _global_position(
                                             local_key,
-                                            q_len,
-                                            global_len,
                                             cp_world,
                                             cp_rank,
+                                            cp_interleave_granularity,
                                         )
-                                        == expected
+                                        < global_len - (q_len - 1) + q_idx
                                     )
+                                    for head in (0, num_heads - 1):
+                                        flat_q_row = q_idx * num_heads + head
+                                        assert (
+                                            _flat_dcp_score_is_valid(
+                                                flat_q_row,
+                                                num_heads,
+                                                local_key,
+                                                q_len,
+                                                global_len,
+                                                cp_world,
+                                                cp_rank,
+                                                cp_interleave_granularity,
+                                            )
+                                            == expected
+                                        )
 
 
 def test_dcp_per_query_tile_dense_boundary_is_conservative():
@@ -588,39 +821,51 @@ def test_dcp_per_query_tile_dense_boundary_is_conservative():
         for q_len in (2, 4, 8, 32):
             num_q_tiles = _ceil_div(q_len * num_heads, 128)
             for cp_world in (1, 2, 4):
-                for cp_rank in range(cp_world):
-                    global_len = max(q_len, 277)
-                    local_len = _local_length(global_len, cp_world, cp_rank)
-                    global_positions = range(cp_rank, global_len, cp_world)
-                    for q_tile_idx in range(num_q_tiles):
-                        first_flat_row = q_tile_idx * 128
-                        first_q = first_flat_row // num_heads
-                        earliest_bound = bisect_left(
-                            global_positions,
-                            global_len - (q_len - 1) + first_q,
+                for cp_interleave_granularity in (1, 3, 7):
+                    for cp_rank in range(cp_world):
+                        global_len = max(q_len, 277)
+                        local_len = _local_length(
+                            global_len,
+                            cp_world,
+                            cp_rank,
+                            cp_interleave_granularity,
                         )
-                        effective_bound = min(max(earliest_bound, 0), local_len)
-                        first_mask_k_tile = effective_bound // k_tile
-                        for k_tile_idx in range(first_mask_k_tile):
-                            local_begin = k_tile_idx * k_tile
-                            local_end = min(local_begin + k_tile, local_len)
-                            for flat_q_row in range(
-                                first_flat_row,
-                                min(
-                                    first_flat_row + 128,
-                                    q_len * num_heads,
-                                ),
-                            ):
-                                for local_key in range(local_begin, local_end):
-                                    assert _flat_dcp_score_is_valid(
-                                        flat_q_row,
-                                        num_heads,
-                                        local_key,
-                                        q_len,
-                                        global_len,
-                                        cp_world,
-                                        cp_rank,
-                                    )
+                        global_positions = _rank_global_positions(
+                            global_len,
+                            cp_world,
+                            cp_rank,
+                            cp_interleave_granularity,
+                        )
+                        for q_tile_idx in range(num_q_tiles):
+                            first_flat_row = q_tile_idx * 128
+                            first_q = first_flat_row // num_heads
+                            earliest_bound = bisect_left(
+                                global_positions,
+                                global_len - (q_len - 1) + first_q,
+                            )
+                            effective_bound = min(max(earliest_bound, 0), local_len)
+                            first_mask_k_tile = effective_bound // k_tile
+                            for k_tile_idx in range(first_mask_k_tile):
+                                local_begin = k_tile_idx * k_tile
+                                local_end = min(local_begin + k_tile, local_len)
+                                for flat_q_row in range(
+                                    first_flat_row,
+                                    min(
+                                        first_flat_row + 128,
+                                        q_len * num_heads,
+                                    ),
+                                ):
+                                    for local_key in range(local_begin, local_end):
+                                        assert _flat_dcp_score_is_valid(
+                                            flat_q_row,
+                                            num_heads,
+                                            local_key,
+                                            q_len,
+                                            global_len,
+                                            cp_world,
+                                            cp_rank,
+                                            cp_interleave_granularity,
+                                        )
 
 
 def test_cute_dsl_mla_dcp_rejects_incomplete_static_contract():
@@ -684,6 +929,14 @@ def test_cute_dsl_mla_dcp_rejects_incomplete_static_contract():
         )
     with pytest.raises(ValueError, match="require enable_dcp=True"):
         cute_dsl_mla_decode(**call_args, cp_world=2)
+    with pytest.raises(ValueError, match="require enable_dcp=True"):
+        cute_dsl_mla_decode(**call_args, cp_interleave_granularity=3)
+    for bad_granularity in (0, -1, True, 1.5):
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            cute_dsl_mla_decode(
+                **call_args,
+                cp_interleave_granularity=bad_granularity,
+            )
 
 
 def test_cute_dsl_mla_dcp_dispatch_is_strictly_monolithic():
@@ -696,7 +949,12 @@ def test_cute_dsl_mla_dcp_dispatch_is_strictly_monolithic():
     assert (
         _resolve_impl(
             requested="auto",
-            kwargs={"enable_dcp": True, "cp_world": 2, "cp_rank": 0},
+            kwargs={
+                "enable_dcp": True,
+                "cp_world": 2,
+                "cp_rank": 0,
+                "cp_interleave_granularity": 3,
+            },
         )
         == "monolithic"
     )
@@ -937,7 +1195,14 @@ def test_cute_dsl_mla_variable_q_dcp_public_api():
     _assert_close_to_reference(out, lse, ref_out, ref_lse, torch.bfloat16)
 
 
-def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():
+@pytest.mark.parametrize(
+    "cp_interleave_granularity",
+    [1, 3],
+    ids=["token-interleave", "block3-interleave"],
+)
+def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor(
+    cp_interleave_granularity,
+):
     """The public runner must batch-sweep DCP metadata and return caller B1."""
     _skip_if_unsupported()
     from flashinfer import autotune
@@ -950,7 +1215,7 @@ def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():
     query, global_kv, global_lens = _make_inputs(
         # Two local pages satisfy the common public dispatcher's aligned
         # block-table contract for page_size=64.
-        global_length=256,
+        global_length=252,
         q_len=4,
         num_heads=96,
         dtype=torch.bfloat16,
@@ -961,6 +1226,7 @@ def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():
         global_lens,
         cp_world=2,
         cp_rank=0,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
     assert split_kv == 1
 
@@ -984,11 +1250,12 @@ def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():
         "enable_dcp": True,
         "cp_world": 2,
         "cp_rank": 0,
+        "cp_interleave_granularity": cp_interleave_granularity,
     }
     with pytest.raises(TypeError, match="must be a torch.Tensor"):
         trtllm_batch_decode_with_kv_cache_mla(
             **public_args,
-            causal_seqlens_kv_global=[256],
+            causal_seqlens_kv_global=[252],
         )
 
     AutoTuner.get().clear_cache()
@@ -1013,6 +1280,7 @@ def test_cute_dsl_mla_dcp_public_api_autotune_profiles_causal_tensor():
         global_lens,
         cp_world=2,
         cp_rank=0,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
     _assert_close_to_reference(
         out,
@@ -1049,6 +1317,219 @@ def test_cute_dsl_mla_dcp_rank_mask_and_merge(dtype):
 
     # In particular, query zero on rank one has local bound 62, not 63.
     assert _local_causal_bound(128, 4, 0, cp_world=2, cp_rank=1) == 62
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float16, torch.float8_e4m3fn],
+    ids=["bf16", "fp16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_granularity3_rank_mask_and_merge(dtype):
+    """Cover both kernel families with the requested three-token rank chunks."""
+    _skip_if_unsupported()
+    torch.manual_seed(142)
+    query, global_kv, global_lens = _make_inputs(
+        # Divisible by W*G, so both ranks own exactly 66 physical keys while
+        # the Sq4 causal tail walks through rank one's final three-token chunk.
+        global_length=132,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+        cp_interleave_granularity=3,
+    )
+    assert split_kvs == [1, 1]
+
+
+def test_cute_dsl_mla_dcp_granularity3_dense_prefix_boundary():
+    """A block-cyclic boundary must not be promoted to a dense K tile."""
+    _skip_if_unsupported()
+    torch.manual_seed(146)
+    query, global_kv, physical_global_lens = _make_inputs(
+        global_length=258,
+        q_len=1,
+        num_heads=128,
+        dtype=torch.bfloat16,
+    )
+    # With zero scores, a stale dense path would average this excluded value
+    # into the output by 4 / 128, comfortably above the BF16 test tolerance.
+    query.zero_()
+    global_kv.zero_()
+    global_kv[0, 256, :_LATENT_DIM] = 4.0
+    causal_lens = torch.tensor([256], dtype=torch.int32, device=query.device)
+
+    # Rank one physically stores 129 keys, but only 127 precede the causal
+    # bound. Token-cyclic math would report 128 and incorrectly make the first
+    # K128 tile dense, bypassing the per-score block-cyclic mask for local k=127.
+    assert _local_length(258, 2, 1, 3) == 129
+    assert _local_prefix_length(256, 2, 1, 3) == 127
+    assert _ceil_div(256 - 1, 2) == 128
+    assert _global_position(127, 2, 1, 3) == 256
+
+    out, lse, _ = _launch_rank(
+        query,
+        global_kv,
+        physical_global_lens,
+        cp_world=2,
+        cp_rank=1,
+        enable_dcp=True,
+        cp_interleave_granularity=3,
+        causal_lens=causal_lens,
+    )
+    ref_out, ref_lse = _reference_attention(
+        query,
+        global_kv,
+        causal_lens,
+        cp_world=2,
+        cp_rank=1,
+        cp_interleave_granularity=3,
+    )
+    _assert_close_to_reference(
+        out,
+        lse,
+        ref_out,
+        ref_lse,
+        torch.bfloat16,
+    )
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_granularity64_page_block_rank_merge(dtype):
+    """Cover one-rank-per-page ownership used by inference deployments."""
+    _skip_if_unsupported()
+    torch.manual_seed(143)
+    query, global_kv, global_lens = _make_inputs(
+        # Two complete W2/G64 ownership cycles give each rank two full pages.
+        global_length=256,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+        cp_interleave_granularity=64,
+    )
+    assert split_kvs == [1, 1]
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_granularity64_partial_page_rank_merge(dtype):
+    """G64 must support a global length ending within one rank-owned page."""
+    rank_positions = [
+        _rank_global_positions(500, 2, cp_rank, 64) for cp_rank in range(2)
+    ]
+    assert rank_positions == [
+        [
+            *range(0, 64),
+            *range(128, 192),
+            *range(256, 320),
+            *range(384, 448),
+        ],
+        [
+            *range(64, 128),
+            *range(192, 256),
+            *range(320, 384),
+            *range(448, 500),
+        ],
+    ]
+    assert [len(positions) for positions in rank_positions] == [256, 244]
+    assert [_ceil_div(len(positions), _PAGE_SIZE) for positions in rank_positions] == [
+        4,
+        4,
+    ]
+    assert [4 * _PAGE_SIZE - len(positions) for positions in rank_positions] == [0, 12]
+    assert [
+        [_local_causal_bound(500, 4, q_idx, 2, cp_rank, 64) for q_idx in range(4)]
+        for cp_rank in range(2)
+    ] == [[256, 256, 256, 256], [241, 242, 243, 244]]
+
+    _skip_if_unsupported()
+    torch.manual_seed(145)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=500,
+        q_len=4,
+        num_heads=96,
+        dtype=dtype,
+    )
+    assert [_local_length(500, 2, cp_rank, 64) for cp_rank in range(2)] == [256, 244]
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=dtype,
+        cp_interleave_granularity=64,
+    )
+    assert split_kvs == [2, 2]
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.bfloat16, torch.float8_e4m3fn],
+    ids=["bf16", "fp8"],
+)
+def test_cute_dsl_mla_dcp_granularity64_padded_page_single_query(dtype):
+    """Q1 masks the unused suffix of a physically complete G64 page."""
+    _skip_if_unsupported()
+    torch.manual_seed(148)
+    query, global_kv, physical_global_lens = _make_inputs(
+        global_length=512,
+        q_len=1,
+        num_heads=96,
+        dtype=dtype,
+    )
+    query.zero_()
+    global_kv.zero_()
+    global_kv[0, 500:512, :_LATENT_DIM] = 4.0
+    causal_lens = torch.tensor([500], dtype=torch.int32, device=query.device)
+
+    # Rank one owns one complete physical page [448, 512), but only its first
+    # 52 entries precede the global bound. The final 12 values must not leak.
+    assert _local_length(512, 2, 1, 64) == 256
+    assert _local_prefix_length(500, 2, 1, 64) == 244
+    out, lse, _ = _launch_rank(
+        query,
+        global_kv,
+        physical_global_lens,
+        cp_world=2,
+        cp_rank=1,
+        enable_dcp=True,
+        cp_interleave_granularity=64,
+        causal_lens=causal_lens,
+    )
+    ref_out, ref_lse = _reference_attention(
+        query,
+        global_kv,
+        causal_lens,
+        cp_world=2,
+        cp_rank=1,
+        cp_interleave_granularity=64,
+    )
+    _assert_close_to_reference(
+        out,
+        lse,
+        ref_out,
+        ref_lse,
+        dtype,
+    )
 
 
 @pytest.mark.parametrize(
@@ -1304,6 +1785,75 @@ def test_cute_dsl_mla_dcp_split_kv_rank_merge(dtype):
         ref_empty_out,
         ref_empty_lse,
         dtype,
+    )
+
+
+def test_cute_dsl_mla_dcp_granularity3_split_kv_rank_merge():
+    """Three-token chunks must retain mergeable LSE through split reduction."""
+    _skip_if_unsupported()
+    torch.manual_seed(144)
+    query, global_kv, global_lens = _make_inputs(
+        global_length=4098,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    split_kvs = _assert_dcp_rank_merge_matches_reference(
+        query,
+        global_kv,
+        global_lens,
+        cp_world=2,
+        dtype=torch.bfloat16,
+        cp_interleave_granularity=3,
+    )
+    assert all(split_kv > 1 for split_kv in split_kvs)
+
+
+def test_cute_dsl_mla_dcp_granularity3_all_empty_split_reduction():
+    """Block-cyclic split validity must emit the neutral empty rank state."""
+    _skip_if_unsupported()
+    torch.manual_seed(147)
+    query, global_kv, physical_global_lens = _make_inputs(
+        global_length=4098,
+        q_len=4,
+        num_heads=96,
+        dtype=torch.bfloat16,
+    )
+    empty_causal_lens = torch.tensor([3], dtype=torch.int32, device=query.device)
+
+    # Rank one's first block-cyclic key is global token 3, so an exclusive
+    # bound of 3 makes every physical key causally invisible. Stale token-level
+    # mapping would place local key zero at global token 1 and mark it valid.
+    assert _global_position(0, 2, 1, 3) == 3
+    assert _local_prefix_length(3, 2, 1, 3) == 0
+    empty_out, empty_lse, split_kv = _launch_rank(
+        query,
+        global_kv,
+        physical_global_lens,
+        cp_world=2,
+        cp_rank=1,
+        enable_dcp=True,
+        cp_interleave_granularity=3,
+        causal_lens=empty_causal_lens,
+    )
+    assert split_kv > 1
+    assert torch.equal(empty_out, torch.zeros_like(empty_out))
+    assert torch.isneginf(empty_lse).all()
+
+    ref_empty_out, ref_empty_lse = _reference_attention(
+        query,
+        global_kv,
+        empty_causal_lens,
+        cp_world=2,
+        cp_rank=1,
+        cp_interleave_granularity=3,
+    )
+    _assert_close_to_reference(
+        empty_out,
+        empty_lse,
+        ref_empty_out,
+        ref_empty_lse,
+        torch.bfloat16,
     )
 
 

--- a/tests/autotuner/test_autotuner_core.py
+++ b/tests/autotuner/test_autotuner_core.py
@@ -2007,7 +2007,9 @@ def test_find_nearest_profile_cache_ignores_fresh_closure_initializer(monkeypatc
 
 
 def _call_build_mla_decode_tuning_config(
-    enable_dcp: bool = False, has_sparse_mla_top_k_lens: bool = False
+    enable_dcp: bool = False,
+    has_sparse_mla_top_k_lens: bool = False,
+    cp_interleave_granularity: int = 1,
 ):
     """Call _build_mla_decode_tuning_config with fresh (equivalent) tensors.
 
@@ -2029,6 +2031,7 @@ def _call_build_mla_decode_tuning_config(
         enable_dcp=enable_dcp,
         cp_world=4,
         cp_rank=1,
+        cp_interleave_granularity=cp_interleave_granularity,
     )
 
 
@@ -2036,20 +2039,23 @@ def _call_build_mla_decode_tuning_config(
     (
         "enable_dcp",
         "has_sparse_mla_top_k_lens",
+        "cp_interleave_granularity",
         "expected_input_idx",
         "expected_initializer_indices",
         "expected_fifth_value",
     ),
     [
-        (False, False, (0, 1, 2, 3), {1, 2}, None),
-        (True, False, (0, 1, 2, 3, 4), {1, 2, 4}, 4097),
-        (False, True, (0, 1, 2, 3, 4), {1, 2, 4}, 64),
+        (False, False, 1, (0, 1, 2, 3), {1, 2}, None),
+        (True, False, 1, (0, 1, 2, 3, 4), {1, 2, 4}, 4097),
+        (True, False, 3, (0, 1, 2, 3, 4), {1, 2, 4}, 4096),
+        (False, True, 1, (0, 1, 2, 3, 4), {1, 2, 4}, 64),
     ],
-    ids=("default", "dcp", "sparse-top-k"),
+    ids=("default", "dcp-token", "dcp-block3", "sparse-top-k"),
 )
 def test_mla_decode_tuning_config_is_memoized(
     enable_dcp,
     has_sparse_mla_top_k_lens,
+    cp_interleave_granularity,
     expected_input_idx,
     expected_initializer_indices,
     expected_fifth_value,
@@ -2063,10 +2069,14 @@ def test_mla_decode_tuning_config_is_memoized(
     _mla_decode_tuning_config.cache_clear()
     try:
         config_a = _call_build_mla_decode_tuning_config(
-            enable_dcp, has_sparse_mla_top_k_lens
+            enable_dcp,
+            has_sparse_mla_top_k_lens,
+            cp_interleave_granularity,
         )
         config_b = _call_build_mla_decode_tuning_config(
-            enable_dcp, has_sparse_mla_top_k_lens
+            enable_dcp,
+            has_sparse_mla_top_k_lens,
+            cp_interleave_granularity,
         )
 
         assert config_a is config_b, (
@@ -2083,6 +2093,28 @@ def test_mla_decode_tuning_config_is_memoized(
                 fifth_tensor,
                 torch.full((8,), expected_fifth_value, dtype=torch.int32),
             )
+    finally:
+        _mla_decode_tuning_config.cache_clear()
+
+
+def test_mla_decode_tuning_config_keys_dcp_interleave_granularity():
+    """Different block-cyclic layouts must not share captured DCP metadata."""
+    _mla_decode_tuning_config.cache_clear()
+    try:
+        token_config = _call_build_mla_decode_tuning_config(
+            enable_dcp=True, cp_interleave_granularity=1
+        )
+        block_config = _call_build_mla_decode_tuning_config(
+            enable_dcp=True, cp_interleave_granularity=3
+        )
+        assert token_config is not block_config
+
+        token_init = dict(token_config.tensor_initializers)[4]
+        block_init = dict(block_config.tensor_initializers)[4]
+        token_bound = token_init((1,), torch.int32, torch.device("cpu"))
+        block_bound = block_init((1,), torch.int32, torch.device("cpu"))
+        torch.testing.assert_close(token_bound, torch.tensor([4097], dtype=torch.int32))
+        torch.testing.assert_close(block_bound, torch.tensor([4096], dtype=torch.int32))
     finally:
         _mla_decode_tuning_config.cache_clear()
 


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable block-cyclic token interleaving for MLA decode with context parallelism.
  * Added `cp_interleave_granularity` to MLA decode APIs; the default preserves existing behavior.
  * Added support across FP8 and FP16 execution paths, including causal masking and split-KV scenarios.
  * Added validation ensuring the setting is a positive integer and is used with context parallelism enabled.

* **Tests**
  * Expanded coverage for block-cyclic layouts, edge cases, empty ranks, and tuning configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->