### PR TITLE
feat(moe): extend cuTile fused MoE to datacenter Blackwell (SM100/SM103)

### DIFF
--- a/flashinfer/fused_moe/api.py
+++ b/flashinfer/fused_moe/api.py
@@ -404,8 +404,8 @@ _CUTLASS_BF16_ARCHS = (89, 90, 100, 103, 107, 110, 120, 121)
 # W4A16 uses Hopper-specific mixed-input weight and scale layouts.
 _CUTLASS_W4A16_ARCHS = (90,)
 
-_CUTILE_BF16_ARCHS = (89, 90, 120, 121)
-_CUTILE_NVFP4_ARCHS = (120, 121)
+_CUTILE_BF16_ARCHS = (89, 90, 100, 103, 120, 121)
+_CUTILE_NVFP4_ARCHS = (100, 103, 120, 121)
 _CUTILE_SUPPORTED_ACTIVATIONS = (
     ActivationType.Swiglu,
     ActivationType.SwigluStep,

--- a/flashinfer/fused_moe/runners.py
+++ b/flashinfer/fused_moe/runners.py
@@ -2645,6 +2645,10 @@ class CutlassHummingRunner(_CutlassRunnerBase):
 _CUTILE_BF16_DEFAULT_GEMM_CONFIGS = {
     89: (128, 32, 4),
     90: (128, 64, 1),
+    # Datacenter Blackwell: seed the autotune default from the SM90 datacenter
+    # profile; the full config set is still searched when autotuning is on.
+    100: (128, 64, 1),
+    103: (128, 64, 1),
     120: (128, 32, 4),
     121: (128, 32, 4),
 }
@@ -3093,7 +3097,9 @@ class CuTileBf16Runner(MoERunner):
     def _candidate_non_gated_block_sizes(self, num_assignments: int) -> tuple[int, ...]:
         num_experts = self.config.routing.num_experts
         rows_per_expert = (num_assignments + num_experts - 1) // num_experts
-        prefill_threshold = {89: 256, 90: 32, 120: 128, 121: 128}[self._device_arch]
+        prefill_threshold = {89: 256, 90: 32, 100: 32, 103: 32, 120: 128, 121: 128}[
+            self._device_arch
+        ]
         return (32,) if rows_per_expert < prefill_threshold else (64,)
 
     def _gated_block_size(self, num_assignments: int) -> int:

--- a/tests/moe/test_unified_moe_cutile.py
+++ b/tests/moe/test_unified_moe_cutile.py
@@ -234,7 +234,7 @@ def _cutile_device_is_supported() -> bool:
 
 cutile_bf16_required = pytest.mark.skipif(
     not _cutile_device_is_supported(),
-    reason="requires a working cuTile toolchain on SM89/SM90/SM120/SM121",
+    reason="requires a working cuTile toolchain on SM89/SM90/SM100/SM103/SM120/SM121",
 )
 
 
@@ -840,7 +840,7 @@ def _cutile_nvfp4_is_supported() -> bool:
 
 cutile_nvfp4_required = pytest.mark.skipif(
     not _cutile_nvfp4_is_supported(),
-    reason="requires a working cuTile toolchain on SM120/SM121",
+    reason="requires a working cuTile toolchain on SM100/SM103/SM120/SM121",
 )
 
 


### PR DESCRIPTION
## 📌 Description

Extend the cuTile fused MoE backend (added in #4646) to **datacenter Blackwell — SM100 (B200) and SM103 (B300)** — for both **BF16** and **NVFP4 W4A4**.

The cuTile MoE kernels (`flashinfer/fused_moe/cutile/moe.py`, `fp4.py`) are architecture-agnostic `cuda.tile` DSL — there is no SM branching or arch intrinsic in the kernels; `tileiras`+NVRTC lower them per target SM. Adding datacenter Blackwell is therefore a **runner/config-layer** change only, no kernel work:

- `flashinfer/fused_moe/api.py`: add `100, 103` to `_CUTILE_BF16_ARCHS` and `_CUTILE_NVFP4_ARCHS`.
- `flashinfer/fused_moe/runners.py`: add SM100/103 entries to the two arch-keyed BF16 tables (`_CUTILE_BF16_DEFAULT_GEMM_CONFIGS` default-tile map, and the `prefill_threshold` in `_candidate_non_gated_block_sizes`). Seeds mirror the SM90 datacenter profile and are refined by autotuning (the full config set is still searched when autotune is on). NVFP4 has no arch-keyed table, so it needs only the tuple widen.
- `tests/moe/test_unified_moe_cutile.py`: widen the human-readable skip-guard reason strings. No new parametrization is needed — the guards gate on `Config.supported(cc)`, so the existing BF16/NVFP4 test matrix auto-activates on the new arches.

The runtime `is_cuda_tile_available()` gate (`flashinfer/cutile/cutile_common.py`) already probes `tileiras`/NVRTC per device, so an env whose toolchain lacks SM100/103 still fails closed.

> **Draft — pending on-hardware validation.** Code is complete and passes static checks (py_compile, `ruff check`/`format`, scope audit). Numeric parity vs `compute_reference_moe` and a cuTile-vs-CUTLASS autotune sweep on real B200 (sm100) / B300 (sm103) are still to be run; the SM100/103 tile-config seeds will be confirmed/refined from that sweep, and before/after perf numbers with named GPUs will be added here per CONTRIBUTING.

## 🔍 Related Issues

Follow-up to #4646 (cuTile fused MoE backend).

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed. (Existing `tests/moe/test_unified_moe_cutile.py` matrix auto-covers SM100/103 via the supported-arch skip guards.)
- [ ] All tests are passing (`unittest`, etc.). *Pending on-hardware B200/B300 run — see Description.*

## Reviewer Notes

Kept the change strictly additive so it cannot affect the already-shipped SM89/90/120/121 paths. The one thing worth a close look is the NVFP4 W4A4 path on datacenter Blackwell: it has no arch-keyed config table (its heuristics are shape-driven), so correctness should carry over, but the FP4 MMA path on SM100/103 will get an explicit numeric-parity run before this leaves Draft. Perf headroom on `_CUTILE_W4A4_GEMM_CONFIGS` re-tuning for datacenter is noted as a follow-up.
