### PR TITLE
feat(moe): Support relu2 Accumulator (SM107)

### DIFF
--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -80,7 +80,7 @@ from .blackwell.blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
 
 
 @functools.cache
-def _sm107_swiglu_kernel_cls():
+def _sm107_act_kernel_cls():
     """Import the SM107 kernel lazily.
 
     It requires CuTe DSL >= 4.8 (``cutlass.utils.rubin_helpers``); importing at
@@ -93,11 +93,11 @@ def _sm107_swiglu_kernel_cls():
             "cutlass.utils.rubin_helpers; the installed CuTe DSL does not "
             "have it."
         )
-    from .rubin.blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion import (
-        Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel,
+    from .rubin.blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
+        Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel,
     )
 
-    return Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel
+    return Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel
 
 
 def create_gather_gemm_tensors(
@@ -347,7 +347,7 @@ def _get_compiled_gather_kernel(
                     "kernel yet: its wrapper has no a_per_token_scale_ptr "
                     "parameter."
                 )
-            gemm = _sm107_swiglu_kernel_cls()(
+            gemm = _sm107_act_kernel_cls()(
                 sf_vec_size=sf_vec_size,
                 mma_inst_shape=mma_inst_shape,
                 mma_tiler=mma_tiler,
@@ -661,7 +661,7 @@ def blockscaled_contiguous_gather_grouped_gemm_act_fusion(
     c_dtype_cutlass = get_cutlass_dtype(c_dtype)
 
     if is_rubin:
-        can_impl = _sm107_swiglu_kernel_cls().can_implement(
+        can_impl = _sm107_act_kernel_cls().can_implement(
             a_dtype=a_dtype_cutlass,
             b_dtype=b_dtype_cutlass,
             sf_dtype=sf_dtype_cutlass,

--- a/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -322,23 +322,29 @@ def _get_compiled_gather_kernel(
 
     if cache_key not in _gather_kernel_cache:
         if is_rubin:
-            # The Rubin (SM107) kernel currently only implements the gated
-            # (SwiGLU) activation path with the default SwiGLU constants.
-            if normalized_activation_type != ActivationType.Swiglu:
+            # SM107 currently supports standard SwiGLU and non-gated ReLU^2.
+            if normalized_activation_type not in (
+                ActivationType.Swiglu,
+                ActivationType.Relu2,
+            ):
                 raise NotImplementedError(
                     f"activation_type {normalized_activation_type!r} is not supported by "
                     "the Rubin (SM107) gather grouped GEMM kernel yet "
-                    "(SwiGLU only)."
+                    "(supported: SwiGLU and ReLU2)."
                 )
-            if (swiglu_alpha, swiglu_beta, swiglu_limit) != (
-                DEFAULT_SWIGLU_ALPHA,
-                DEFAULT_SWIGLU_BETA,
-                DEFAULT_SWIGLU_LIMIT,
+            if normalized_activation_type == ActivationType.Swiglu and (
+                (swiglu_alpha, swiglu_beta, swiglu_limit)
+                != (
+                    DEFAULT_SWIGLU_ALPHA,
+                    DEFAULT_SWIGLU_BETA,
+                    DEFAULT_SWIGLU_LIMIT,
+                )
+                or situ_beta is not None
+                or situ_linear_beta is not None
             ):
                 raise NotImplementedError(
-                    "Custom swiglu_alpha/swiglu_beta/swiglu_limit are not "
-                    "supported by the Rubin (SM107) gather grouped GEMM "
-                    "kernel yet."
+                    "Parameterized SwiGLU and SiTU are not supported by the "
+                    "Rubin (SM107) gather grouped GEMM kernel yet."
                 )
             if use_a_per_token_scale:
                 raise NotImplementedError(
@@ -356,6 +362,7 @@ def _get_compiled_gather_kernel(
                 topk=topk,
                 raster_along_m=raster_along_m,
                 enable_pdl=enable_pdl,
+                gated=gated,
             )
         else:
             # Create kernel instance

--- a/flashinfer/fused_moe/cute_dsl/rubin/__init__.py
+++ b/flashinfer/fused_moe/cute_dsl/rubin/__init__.py
@@ -20,8 +20,8 @@ This module contains CuteDSL kernels optimized for NVIDIA Rubin architecture.
 These kernels are adapted from TensorRT-LLM.
 """
 
-from .blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion import (
-    Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel,
+from .blockscaled_contiguous_gather_grouped_gemm_act_fusion import (
+    Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel,
 )
 from .blockscaled_contiguous_grouped_gemm_finalize_fusion import (
     Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel,

--- a/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -199,6 +199,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         enable_pdl: Optional[bool] = None,
         gated: bool = True,
     ):
+        """Configure an SM107 gather GEMM for gated SwiGLU or ReLU2."""
         # flashinfer dispatcher compatibility: the pre-sync kernel took
         # `enable_pdl`; TRT-LLM renamed it to `use_pdl`. Explicit enable_pdl
         # wins over the use_pdl default.
@@ -3984,6 +3985,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         c_stride_m: cutlass.Int64 = cutlass.Int64(0),
         c_sf_n_tile_offset: cutlass.Int64 = cutlass.Int64(0),
     ):
+        """Build runtime tensor views and launch the activation-fused kernel."""
         scale_k = k // scaling_vector_size
         interm_size = n // self.out_n_factor
         num_tiles = m // tile_size
@@ -4786,6 +4788,7 @@ def run(
             )
 
     def generate_tensors():
+        """Create a fresh tensor set for one cold-L2 benchmark workspace."""
         (
             a_tensor,
             b_tensor,

--- a/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -111,17 +111,18 @@ class S2TCopyBundle(NamedTuple):
 
 """
 Rubin (SM107) persistent blockscaled contiguous grouped GEMM with token gather
-and fused SwiGLU activation (FC1 of MoE).
+and fused FC1 activation (SwiGLU or ReLU^2).
 
 Compute:
   acc = alpha * (SFA * A[token_ids]) * (SFB * B)         # GEMM
-  C   = up * silu(gate)                                   # SwiGLU on interleaved acc
+  C   = up * silu(gate)                                   # gated=True
+  C   = relu(acc)^2                                       # gated=False
   + optional NVFP4 quantization (generates SFC) when c_dtype == Float4E2M1FN.
 
-Shapes: A is M×K×1; B is N×K×L (L = num experts), interleaved [up, gate] at
-granularity=64; C is M×(N/2)×1 (N halved by SwiGLU). SFA/SFB layouts follow
-BlockScaledBasicChunk. token_id_mapping drives the row gather for A/SFA;
-token_id == -1 marks padding rows.
+Shapes: A is M×K×1; B is N×K×L (L = num experts). Gated B is interleaved
+[up, gate] at granularity=64 and C is M×(N/2)×1; non-gated C is M×N×1.
+SFA/SFB layouts follow BlockScaledBasicChunk. token_id_mapping drives the row
+gather for A/SFA; token_id == -1 marks padding rows.
 
 Within a tile, valid_m varies per group; padding rows are handled at load:
 TMA gather4 passes -1 to zero-fill; CpAsync predicates on `abs_row < mn_limit`.
@@ -137,7 +138,7 @@ to permuted_m; padded tiles are filtered by the scheduler.
 
 class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
     """Rubin (SM107) FC1: contiguous grouped blockscaled GEMM with token
-    gather on A/SFA and SwiGLU activation fusion in the epilogue.
+    gather on A/SFA and activation fusion in the epilogue.
 
     Builds on Sm107BlockScaledContiguousGroupedGemmKernel (persistent tile
     scheduling, warp specialization, B-reuse, tcgen05.mma block-scale, TMA
@@ -155,13 +156,14 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
             merged ab_pipeline (no relay warp needed).
         SFA is always loaded via CpAsync128.CG, then reorganized into SFA
         TMEM by transform warps via LDS + tcgen05.st (sfa_transform_pipeline).
-      - SwiGLU epilogue: C = up * silu(gate), where up/gate come from
+      - Gated epilogue: C = up * silu(gate), where up/gate come from
         interleaved accumulator at granularity=64 → output N is halved.
+      - Non-gated epilogue: C = relu(alpha * acc)^2 → output N is unchanged.
       - Optional NVFP4 quant: when c_dtype == Float4E2M1FN, the epilogue
         also generates SFC and quantizes the output.
 
     Extra warp roles (20 warps total; 4-19 are FC1-only):
-      - 0-3   epilogue (tcgen05.ld → SwiGLU → optional quant → TMA store)
+      - 0-3   epilogue (tcgen05.ld → activation → optional quant → TMA store)
       - 4-7   gather A         (CpAsync128.CG or TMA gather4)
       - 8     MMA
       - 9     TMA B / SFB
@@ -178,6 +180,8 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
     :param topk: Experts selected per token.
     :param raster_along_m: If True, raster tiles along M first.
     :param a_path: "cpasync" or "tma" — A load implementation.
+    :param gated: If True, run the gated SwiGLU path. If False, run the
+        non-gated ReLU^2 path.
     """
 
     def __init__(
@@ -193,6 +197,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         use_pdl: bool = True,
         ugpu_half_gemm: bool = False,
         enable_pdl: Optional[bool] = None,
+        gated: bool = True,
     ):
         # flashinfer dispatcher compatibility: the pre-sync kernel took
         # `enable_pdl`; TRT-LLM renamed it to `use_pdl`. Explicit enable_pdl
@@ -208,6 +213,8 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         self.acc_dtype = cutlass.Float32
         self.mma_inst_shape = mma_inst_shape
         self.mma_tiler = mma_tiler
+        self.gated = gated
+        self.out_n_factor = 2 if gated else 1
         self.cluster_shape_mn = cluster_shape_mn
         self.raster_along_m = raster_along_m
         # Honor the TRTLLM_ENABLE_PDL env flag (PDL on by default); a caller
@@ -401,7 +408,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
 
         self.mma_tiler_c = (
             self.mma_tiler[0],
-            self.mma_tiler[1] // 2,
+            self.mma_tiler[1] // self.out_n_factor,
             self.mma_tiler[2],
         )
 
@@ -460,10 +467,10 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
         self.is_a_mcast = self.num_mcast_ctas_a > 1
 
-        # Fixed epilogue tile (128, 64). SwiGLU halves N, so the default
+        # Fixed epilogue tile (128, 64). For gated activations, the default
         # SM107_TILES lookup (keyed on full cta_n) can pick epi_tile_n too
-        # small (wrong TMA store strides + insufficient SFC for cvt_fptrunc
-        # 32-bit alignment). (128, 64) works for all configs.
+        # small after N is halved (wrong TMA store strides + insufficient SFC
+        # for cvt_fptrunc 32-bit alignment). (128, 64) works for both paths.
         self.epi_tile = (128, 64)
         self.epi_tile_n = cute.size(self.epi_tile[1])
         self.epi_tile_cnt = (
@@ -713,17 +720,17 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         epilogue_op: cutlass.Constexpr = lambda x: x,
         c_sf_n_tile_offset: cutlass.Int64 = cutlass.Int64(0),
     ):
-        """Execute the contiguous grouped GEMM with gather operation and SwiGLU fusion.
+        """Execute the contiguous grouped GEMM with gather and activation fusion.
 
         This method performs FC1 layer computation:
         1. GEMM: acc = alpha * (SFA * A[token_ids]) * (SFB * B)
-        2. SwiGLU: C = up * silu(gate), where up/gate are extracted from interleaved acc (granularity=64)
+        2. Activation: gated SwiGLU or non-gated ReLU^2
         3. Optional Quant: When c_dtype is Float4E2M1FN, generates SFC and quantizes output
 
         Data loading:
         - A and SFA are loaded using CpAsync instructions with token-based gather
         - B and SFB are loaded using TMA instructions with multicast
-        - B weights are interleaved: [up_0:64, gate_64:128, up_128:192, gate_192:256, ...]
+        - Gated B weights are interleaved: [up_0:64, gate_64:128, up_128:192, gate_192:256, ...]
 
         Execution steps:
         1. Setup static attributes before smem/grid computation
@@ -737,13 +744,13 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
              shared memory when use_2cta_instrs is True
            - TMA warp: Load B and SFB with multicast
            - MMA warp: Perform matrix multiply-accumulate
-           - Epilogue warps: Apply SwiGLU activation, optional quantization, and store results
+           - Epilogue warps: Apply activation, optional quantization, and store results
 
         :param a: Input tensor A (MxKx1), will be gathered using token_id_mapping
         :type a: cute.Tensor
-        :param b: Input tensor B (NxKxL), L is the number of experts/groups, weights are interleaved for SwiGLU
+        :param b: Input tensor B (NxKxL), L is the number of experts/groups
         :type b: cute.Tensor
-        :param c: Output tensor C (Mx(N/2)x1), N is halved due to SwiGLU fusion
+        :param c: Output tensor C, with N/out_n_factor columns
         :type c: cute.Tensor
         :param sfa: Scale factor tensor A, will be gathered using token_id_mapping
         :type sfa: cute.Tensor
@@ -2960,23 +2967,20 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
                 #
                 acc_pipeline.consumer_wait(acc_consumer_state)
 
-                # SwiGLU epilogue. Acc has full N cols with interleaved
-                # [up, gate] at granularity=64; C has N/2 cols. Iterate M and
-                # N output subtiles → up * silu(gate).
+                # Activation epilogue. The gated path interprets accumulator
+                # columns as interleaved [up, gate] blocks at granularity=64
+                # and produces N/2 columns. The non-gated path applies ReLU^2
+                # directly and preserves all N columns.
                 #   tTR_tAcc: (T2R, T2R_M, T2R_N, EPI_M, EPI_N, STAGE), sliced on STAGE.
                 #   bSG_gC:   ((ATOM_V, REST_V), EPI_M, EPI_N, loopM, loopN, loopL).
-                interleave_granularity = 64
-                gate_offset = interleave_granularity // self.epi_tile_n
                 epi_m_cnt = cute.size(tTR_tAcc.shape, mode=[3])
                 acc_n_subtile_cnt = cute.size(tTR_tAcc.shape, mode=[4])
-                out_n_subtile_cnt = acc_n_subtile_cnt // 2  # N/2 output subtiles per M subtile
+                out_n_subtile_cnt = acc_n_subtile_cnt // self.out_n_factor
 
                 for epi_m_idx in cutlass.range(epi_m_cnt):
                     for out_n_idx in cutlass.range(out_n_subtile_cnt):
-                        # Map output N subtile → acc N subtile. Each
-                        # interleave block of 2*gate_offset subtiles is
-                        # [up*gate_offset, gate*gate_offset]. acc[0] in
-                        # overlap mode iterates in reverse (consume high-col
+                        # Map output N subtile → accumulator N subtile. acc[0]
+                        # in overlap mode iterates in reverse (consume high-col
                         # overlap region first).
                         if cutlass.const_expr(self.use_overlap_accum):
                             real_out_n_idx = (
@@ -2986,23 +2990,33 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
                             )
                         else:
                             real_out_n_idx = out_n_idx
-                        block_idx = real_out_n_idx // gate_offset
-                        within_block = real_out_n_idx % gate_offset
-                        up_n_subtile = block_idx * 2 * gate_offset + within_block
-                        gate_n_subtile = block_idx * 2 * gate_offset + gate_offset + within_block
                         #
                         # Load accumulator from tensor memory buffer to register
                         #
-                        tTR_tAcc_mn_up = tTR_tAcc[(None, None, None, epi_m_idx, up_n_subtile)]
-                        tTR_tAcc_mn_gate = tTR_tAcc[(None, None, None, epi_m_idx, gate_n_subtile)]
+                        if cutlass.const_expr(self.gated):
+                            # Each interleave block of 2*gate_offset subtiles is
+                            # [up*gate_offset, gate*gate_offset].
+                            interleave_granularity = 64
+                            gate_offset = interleave_granularity // self.epi_tile_n
+                            block_idx = real_out_n_idx // gate_offset
+                            within_block = real_out_n_idx % gate_offset
+                            up_n_subtile = block_idx * 2 * gate_offset + within_block
+                            gate_n_subtile = block_idx * 2 * gate_offset + gate_offset + within_block
+                            tTR_tAcc_mn_up = tTR_tAcc[(None, None, None, epi_m_idx, up_n_subtile)]
+                            tTR_tAcc_mn_gate = tTR_tAcc[(None, None, None, epi_m_idx, gate_n_subtile)]
 
-                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
-                        cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+                            cute.copy(tiled_copy_t2r, tTR_tAcc_mn_up, tTR_rAcc_up)
+                            cute.copy(tiled_copy_t2r, tTR_tAcc_mn_gate, tTR_rAcc_gate)
+                        else:
+                            tTR_tAcc_mn = tTR_tAcc[(None, None, None, epi_m_idx, real_out_n_idx)]
+                            # ReLU^2 has a single accumulator branch, so reuse
+                            # the up-branch register fragment as its input buffer.
+                            cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc_up)
 
-                        # Overlap mode: after iter 0 the up/gate tcgen05.ld has
-                        # covered cols 192..255 (reverse for acc[0], forward
-                        # for acc[1]). Fence + early-release so MMA can write
-                        # the next stage into the overlap region without racing.
+                        # Overlap mode: iteration 0 consumes the shared 64
+                        # columns (the high subtile of acc[0], or the low
+                        # subtile of acc[1]). Fence + early-release so MMA can
+                        # write the next stage into that region without racing.
                         if cutlass.const_expr(self.use_overlap_accum):
                             if out_n_idx == 0:
                                 cute.arch.fence_view_async_tmem_load()
@@ -3010,70 +3024,94 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
                                     acc_pipeline.consumer_release(acc_consumer_state)
                                 acc_consumer_state.advance()
 
-                        acc_vec_up = tTR_rAcc_up.load()
-                        acc_vec_gate = tTR_rAcc_gate.load()
+                        if cutlass.const_expr(self.gated):
+                            acc_vec_up = tTR_rAcc_up.load()
+                            acc_vec_gate = tTR_rAcc_gate.load()
 
-                        # SwiGLU: output = up * silu(gate),  silu(x) = x * sigmoid(x).
-                        tCompute = cute.make_rmem_tensor(acc_vec_gate.shape, self.acc_dtype)
-                        if cutlass.const_expr(self.vectorized_f32):
-                            # SwiGLU Packed Version: uses f32x2 packed operations for better performance
-                            # Computes: output = (alpha * up) * silu(alpha * gate)
-                            # where silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
-                            LOG2_E = cutlass.Float32(1.4426950408889634)
-                            for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc_up), 2):
-                                acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
-                                    (acc_vec_up[i], acc_vec_up[i + 1]),
+                            # SwiGLU: output = up * silu(gate),  silu(x) = x * sigmoid(x).
+                            tCompute = cute.make_rmem_tensor(acc_vec_gate.shape, self.acc_dtype)
+                            if cutlass.const_expr(self.vectorized_f32):
+                                # SwiGLU Packed Version: uses f32x2 packed operations for better performance
+                                # Computes: output = (alpha * up) * silu(alpha * gate)
+                                # where silu(x) = x * sigmoid(x) = x / (1 + exp(-x))
+                                LOG2_E = cutlass.Float32(1.4426950408889634)
+                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc_up), 2):
+                                    acc_vec_up_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_up[i], acc_vec_up[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    tCompute_log2e = cute.arch.mul_packed_f32x2(
+                                        (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                                        (-LOG2_E, -LOG2_E),
+                                    )
                                     (
-                                        cutlass.Float32(alpha_val),
-                                        cutlass.Float32(alpha_val),
-                                    ),
-                                )
-                                acc_vec_gate_alpha = cute.arch.mul_packed_f32x2(
-                                    (acc_vec_gate[i], acc_vec_gate[i + 1]),
+                                        tCompute[i],
+                                        tCompute[i + 1],
+                                    ) = cute.arch.add_packed_f32x2(
+                                        (
+                                            cute.math.exp2(tCompute_log2e[0], fastmath=True),
+                                            cute.math.exp2(tCompute_log2e[1], fastmath=True),
+                                        ),
+                                        (1.0, 1.0),
+                                    )
+                                    tCompute[i] = cute.arch.rcp_approx(tCompute[i])
+                                    tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
                                     (
-                                        cutlass.Float32(alpha_val),
-                                        cutlass.Float32(alpha_val),
-                                    ),
-                                )
-                                tCompute_log2e = cute.arch.mul_packed_f32x2(
-                                    (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
-                                    (-LOG2_E, -LOG2_E),
-                                )
-                                (
-                                    tCompute[i],
-                                    tCompute[i + 1],
-                                ) = cute.arch.add_packed_f32x2(
+                                        tCompute[i],
+                                        tCompute[i + 1],
+                                    ) = cute.arch.mul_packed_f32x2(
+                                        (tCompute[i], tCompute[i + 1]),
+                                        (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
+                                    )
                                     (
-                                        cute.math.exp2(tCompute_log2e[0], fastmath=True),
-                                        cute.math.exp2(tCompute_log2e[1], fastmath=True),
-                                    ),
-                                    (1.0, 1.0),
-                                )
-                                tCompute[i] = cute.arch.rcp_approx(tCompute[i])
-                                tCompute[i + 1] = cute.arch.rcp_approx(tCompute[i + 1])
-                                (
-                                    tCompute[i],
-                                    tCompute[i + 1],
-                                ) = cute.arch.mul_packed_f32x2(
-                                    (tCompute[i], tCompute[i + 1]),
-                                    (acc_vec_gate_alpha[0], acc_vec_gate_alpha[1]),
-                                )
-                                (
-                                    tCompute[i],
-                                    tCompute[i + 1],
-                                ) = cute.arch.mul_packed_f32x2(
-                                    (tCompute[i], tCompute[i + 1]),
-                                    (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
-                                )
+                                        tCompute[i],
+                                        tCompute[i + 1],
+                                    ) = cute.arch.mul_packed_f32x2(
+                                        (tCompute[i], tCompute[i + 1]),
+                                        (acc_vec_up_alpha[0], acc_vec_up_alpha[1]),
+                                    )
+                            else:
+                                # SwiGLU Unpacked Version: scalar operations
+                                # Computes: output = (alpha * up) * silu(alpha * gate)
+                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
+                                    acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(alpha_val)
+                                    acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
+                                    tCompute[i] = acc_vec_up_alpha * silu_f32(
+                                        acc_vec_gate_alpha, fastmath=True
+                                    )
                         else:
-                            # SwiGLU Unpacked Version: scalar operations
-                            # Computes: output = (alpha * up) * silu(alpha * gate)
-                            for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
-                                acc_vec_up_alpha = acc_vec_up[i] * cutlass.Float32(alpha_val)
-                                acc_vec_gate_alpha = acc_vec_gate[i] * cutlass.Float32(alpha_val)
-                                tCompute[i] = acc_vec_up_alpha * silu_f32(
-                                    acc_vec_gate_alpha, fastmath=True
-                                )
+                            acc_vec = tTR_rAcc_up.load()
+                            tCompute = cute.make_rmem_tensor(acc_vec.shape, self.acc_dtype)
+                            if cutlass.const_expr(self.vectorized_f32):
+                                for i in cutlass.range_constexpr(0, cute.size(tTR_rAcc_up), 2):
+                                    acc_alpha = cute.arch.mul_packed_f32x2(
+                                        (acc_vec[i], acc_vec[i + 1]),
+                                        (
+                                            cutlass.Float32(alpha_val),
+                                            cutlass.Float32(alpha_val),
+                                        ),
+                                    )
+                                    r0 = cute.arch.fmax(acc_alpha[0], cutlass.Float32(0.0))
+                                    r1 = cute.arch.fmax(acc_alpha[1], cutlass.Float32(0.0))
+                                    (
+                                        tCompute[i],
+                                        tCompute[i + 1],
+                                    ) = cute.arch.mul_packed_f32x2((r0, r1), (r0, r1))
+                            else:
+                                for i in cutlass.range_constexpr(cute.size(tTR_rAcc_up)):
+                                    v = acc_vec[i] * cutlass.Float32(alpha_val)
+                                    v = cute.arch.fmax(v, cutlass.Float32(0.0))
+                                    tCompute[i] = v * v
 
                         if cutlass.const_expr(self.generate_sfc):
                             # Float4E2M1FN quantization: per-vector absmax →
@@ -3324,7 +3362,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, STAGE)
         tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
 
-        # gC_mnl is already transformed: (M, N_half, loopM, loopN, loopL)
+        # gC_mnl is already transformed: (M, output_N, loopM, loopN, loopL)
         # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
         gC_mnl_epi = cute.flat_divide(gC_mnl, epi_tile)
 
@@ -3409,7 +3447,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
                 - bSG_gC: The partitioned global tensor C
         :rtype: Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]
         """
-        # gC_mnl is already transformed: (M, N_half, loopM, loopN, loopL)
+        # gC_mnl is already transformed: (M, output_N, loopM, loopN, loopL)
         # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, loopM, loopN, loopL)
         gC_epi = cute.flat_divide(gC_mnl, epi_tile)
         tma_atom_c = atom
@@ -3730,7 +3768,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         # Check valid mma_inst_shape
         if mma_inst_shape[0] not in [128, 256]:
             return False
-        # SwiGLU Fusion requires even epi_tile counts
+        # The gated path pairs 64-column up/gate epilogue subtiles.
         if mma_inst_shape[1] not in [128, 256]:
             return False
 
@@ -3947,7 +3985,7 @@ class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
         c_sf_n_tile_offset: cutlass.Int64 = cutlass.Int64(0),
     ):
         scale_k = k // scaling_vector_size
-        interm_size = n // 2
+        interm_size = n // self.out_n_factor
         num_tiles = m // tile_size
         a = cute.make_tensor(
             a_ptr, layout=cute.make_ordered_layout((orig_m, k, 1), order=(1, 0, 2))
@@ -4269,8 +4307,9 @@ def create_tensors(
     sf_vec_size,
     mma_tiler_m,
     permuted_m=None,
+    gated=True,
 ):
-    """Create tensors for grouped blockscaled GEMM with gather and SwiGLU fusion."""
+    """Create tensors for grouped blockscaled GEMM with gather and activation fusion."""
     torch.manual_seed(1111)
 
     alpha_torch_cpu = torch.randn((num_groups,), dtype=torch.float32)
@@ -4288,7 +4327,8 @@ def create_tensors(
 
     a_torch_cpu = cutlass_torch.matrix(1, max_m, k, a_major == "m", cutlass.Float32)
     b_torch_cpu = cutlass_torch.matrix(num_groups, n, k, b_major == "n", cutlass.Float32)
-    c_torch_cpu = cutlass_torch.matrix(1, tensor_m, n // 2, cd_major == "m", cutlass.Float32)
+    out_n_factor = 2 if gated else 1
+    c_torch_cpu = cutlass_torch.matrix(1, tensor_m, n // out_n_factor, cd_major == "m", cutlass.Float32)
 
     a_tensor, a_torch_gpu = cutlass_torch.cute_tensor_like(
         a_torch_cpu, a_dtype, is_dynamic_layout=True, assumed_align=16
@@ -4338,7 +4378,7 @@ def create_tensors(
     norm_const_torch_cpu = None
     norm_const_tensor = None
     norm_const_torch_gpu = None
-    n_out = n // 2
+    n_out = n // out_n_factor
     if c_dtype == cutlass.Float4E2M1FN:
         sfc_torch_cpu, sfc_tensor, sfc_torch_gpu = create_scale_factor_tensor(
             1, tensor_m, n_out, sf_vec_size, sf_dtype
@@ -4405,13 +4445,14 @@ def run(
     use_cupti: bool = False,
     a_path: str = "cpasync",
     use_pdl: bool = True,
+    gated: bool = True,
 ):
-    """Run the Rubin blockscaled contiguous gather grouped GEMM SwiGLU kernel."""
+    """Run the Rubin blockscaled contiguous gather grouped GEMM activation kernel."""
     mma_tiler_m = mma_tiler[0]
 
     print(
         "Running Rubin Persistent Contiguous Grouped BlockScaled GEMM with "
-        "Gather and SwiGLU Fusion:"
+        f"Gather and {'SwiGLU' if gated else 'ReLU^2'} Fusion:"
     )
     print(f"nkl: {nkl}")
     print(f"group_m_list: {group_m_list}")
@@ -4504,6 +4545,7 @@ def run(
         sf_vec_size,
         mma_tiler_m,
         permuted_m,
+        gated,
     )
 
     gemm = Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel(
@@ -4516,6 +4558,7 @@ def run(
         raster_along_m=raster_along_m,
         a_path=a_path,
         use_pdl=use_pdl,
+        gated=gated,
     )
     hardware_info = cutlass.utils.HardwareInfo()
     max_active_clusters = hardware_info.get_max_active_clusters(
@@ -4567,7 +4610,7 @@ def run(
     if not skip_ref_check:
         print("Verifying results...")
         interleave_granularity = 64
-        n_out = n // 2
+        n_out = n // (2 if gated else 1)
 
         gemm_result = torch.empty((1, valid_m, n), dtype=torch.float32)
         start = 0
@@ -4581,20 +4624,23 @@ def run(
             )
             start = end
 
-        assert n % (2 * interleave_granularity) == 0
-        ref = torch.empty((1, valid_m, n_out), dtype=torch.float32)
-        for n_block in range(0, n, 2 * interleave_granularity):
-            up_result = gemm_result[0, :, n_block : n_block + interleave_granularity]
-            gate_result = gemm_result[
-                0,
-                :,
-                n_block + interleave_granularity : n_block + 2 * interleave_granularity,
-            ]
-            silu_gate = gate_result * torch.sigmoid(gate_result)
-            output_block = up_result * silu_gate
-            out_start = n_block // 2
-            out_end = out_start + interleave_granularity
-            ref[0, :, out_start:out_end] = output_block
+        if gated:
+            assert n % (2 * interleave_granularity) == 0
+            ref = torch.empty((1, valid_m, n_out), dtype=torch.float32)
+            for n_block in range(0, n, 2 * interleave_granularity):
+                up_result = gemm_result[0, :, n_block : n_block + interleave_granularity]
+                gate_result = gemm_result[
+                    0,
+                    :,
+                    n_block + interleave_granularity : n_block + 2 * interleave_granularity,
+                ]
+                silu_gate = gate_result * torch.sigmoid(gate_result)
+                output_block = up_result * silu_gate
+                out_start = n_block // 2
+                out_end = out_start + interleave_granularity
+                ref[0, :, out_start:out_end] = output_block
+        else:
+            ref = torch.relu(gemm_result) ** 2
 
         ref = ref.permute((1, 2, 0))
 
@@ -4769,6 +4815,7 @@ def run(
             sf_vec_size,
             mma_tiler_m,
             permuted_m,
+            gated,
         )
         return cute.testing.JitArguments(
             a_tensor,
@@ -4907,9 +4954,9 @@ def parse_benchmark_arg(
 
 
 def main():
-    """Main entry point for running the Rubin blockscaled SwiGLU fusion kernel."""
+    """Main entry point for the Rubin blockscaled activation-fusion kernel."""
     parser = argparse.ArgumentParser(
-        description=("Rubin BlockScaled Contiguous Gather Grouped GEMM with SwiGLU Fusion.")
+        description=("Rubin BlockScaled Contiguous Gather Grouped GEMM with activation fusion.")
     )
 
     parser.add_argument("--nkl", type=parse_comma_separated_ints, default=(256, 512, 1))
@@ -4937,6 +4984,12 @@ def main():
     parser.add_argument("--use_cold_l2", action="store_true", default=False)
     parser.add_argument("--raster_along_m", action="store_true", default=False)
     parser.add_argument("--use_cupti", action="store_true", default=False)
+    parser.add_argument(
+        "--activation",
+        choices=["swiglu", "relu2"],
+        default="swiglu",
+        help="FC1 activation fused into the epilogue.",
+    )
     parser.add_argument(
         "--a_path",
         choices=["cpasync", "tma"],
@@ -5008,6 +5061,7 @@ def main():
         use_cupti=args.use_cupti,
         a_path=args.a_path,
         use_pdl=args.use_pdl,
+        gated=args.activation == "swiglu",
     )
     print(f"Execution time: {exec_time:.2f} us")
     print("PASS")

--- a/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
+++ b/flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py
@@ -135,7 +135,7 @@ to permuted_m; padded tiles are filtered by the scheduler.
 """
 
 
-class Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel:
+class Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel:
     """Rubin (SM107) FC1: contiguous grouped blockscaled GEMM with token
     gather on A/SFA and SwiGLU activation fusion in the epilogue.
 
@@ -4434,7 +4434,7 @@ def run(
     if not torch.cuda.is_available():
         raise RuntimeError("GPU is required to run this example!")
 
-    if not Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel.can_implement(
+    if not Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel.can_implement(
         a_dtype=a_dtype,
         b_dtype=b_dtype,
         sf_dtype=sf_dtype,
@@ -4506,7 +4506,7 @@ def run(
         permuted_m,
     )
 
-    gemm = Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel(
+    gemm = Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel(
         sf_vec_size,
         mma_inst_shape,
         mma_tiler,

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -733,6 +733,7 @@ class CuteDslFusedMoERunner(TunableRunner):
             final_scale_dtype = cutlass.Float16
 
         def _tactic_ok(tactic):
+            """Return whether both GEMM kernels support this tactic and workload."""
             tile_size, gemm1_tactic, gemm2_tactic = tactic
             permuted_m = get_max_num_permuted_tokens(
                 num_tokens, self.top_k, self.num_local_experts, tile_size

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -739,9 +739,27 @@ class CuteDslFusedMoERunner(TunableRunner):
             )
 
             if _is_rubin_tactic(tactic):
-                # The Rubin (SM107) kernels only implement the gated (SwiGLU)
-                # activation path; skip Rubin tactics for non-gated activations.
-                if not gated:
+                # SM107 currently supports standard SwiGLU and non-gated
+                # ReLU^2. Other gated formulas remain unsupported on SM107.
+                if self.activation_type not in (
+                    ActivationType.Swiglu,
+                    ActivationType.Relu2,
+                ):
+                    return False
+                if self.activation_type == ActivationType.Swiglu and (
+                    (
+                        self.swiglu_alpha,
+                        self.swiglu_beta,
+                        self.swiglu_limit,
+                    )
+                    != (
+                        DEFAULT_SWIGLU_ALPHA,
+                        DEFAULT_SWIGLU_BETA,
+                        DEFAULT_SWIGLU_LIMIT,
+                    )
+                    or self.situ_beta is not None
+                    or self.situ_linear_beta is not None
+                ):
                     return False
 
                 # The SM107 kernels need cutlass.utils.rubin_helpers, which only
@@ -778,7 +796,7 @@ class CuteDslFusedMoERunner(TunableRunner):
                     mma_tiler=gemm1_mma_tiler,
                     cluster_shape_mn=gemm1_cluster_shape_mn,
                     m=permuted_m,
-                    n=2 * intermediate_size,
+                    n=gemm1_n,
                     k=hidden_size,
                     l=num_local_experts,
                     a_major="k",

--- a/flashinfer/fused_moe/cute_dsl/tuner.py
+++ b/flashinfer/fused_moe/cute_dsl/tuner.py
@@ -78,7 +78,7 @@ def _seeded_activation(shapes, dtype, device):
 
 
 def get_blackwell_gemm1_valid_tactics(tile_size: int) -> List[Tuple]:
-    """Get valid Blackwell tactics for GEMM1 (Gather + SwiGLU Fusion).
+    """Get valid Blackwell tactics for GEMM1 (gather + activation fusion).
 
     Format: (mma_tiler_mn, cluster_shape_mn, raster_along_m)
     """
@@ -179,7 +179,7 @@ VALID_TILE_SIZES: Tuple[int, ...] = (128, 256)
 # Format: (mma_tiler, mma_inst_shape, cluster_shape_mn, raster_along_m)
 # where mma_tiler = (M, N, K) and mma_inst_shape = (M', N, K')
 def get_rubin_gemm1_valid_tactics(tile_size: int) -> List[Tuple]:
-    """Get valid Rubin tactics for GEMM1 (Gather + SwiGLU Fusion).
+    """Get valid Rubin tactics for GEMM1 (gather + activation fusion).
 
     Format: (mma_tiler, mma_inst_shape, cluster_shape_mn, raster_along_m)
     """
@@ -757,7 +757,7 @@ class CuteDslFusedMoERunner(TunableRunner):
                     return False
 
                 from .rubin import (
-                    Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel,
+                    Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel,
                     Sm107BlockScaledContiguousGroupedGemmFinalizeFusionKernel,
                 )
 
@@ -768,7 +768,7 @@ class CuteDslFusedMoERunner(TunableRunner):
                     gemm2_tactic
                 )
 
-                gemm1_ok = Sm107BlockScaledContiguousGatherGroupedGemmSwigluFusionKernel.can_implement(
+                gemm1_ok = Sm107BlockScaledContiguousGatherGroupedGemmActFusionKernel.can_implement(
                     a_dtype=a_dtype,
                     b_dtype=b_dtype,
                     sf_dtype=sf_dtype,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ exclude = [
   "flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src/",
   "flashinfer/moe_ep/kernel_src/sm120/swapab_cutedsl_megakernel/src/",
   "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py",
-  "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py",
+  "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py",
   "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_grouped_gemm_finalize_fusion.py",
   # DKG filtered top-k kernels, vendored verbatim from dynamic-kernel-generator
   # (see the provenance header in each file). Kept byte-faithful so upstream
@@ -163,7 +163,7 @@ extend-exclude = [
   "flashinfer/moe_ep/kernel_src/sm90/pull_style_cutedsl_megakernel/src",
   "flashinfer/moe_ep/kernel_src/sm120/swapab_cutedsl_megakernel/src",
   "flashinfer/gemm/kernels/dense_blockscaled_gemm_sm107.py",
-  "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_swiglu_fusion.py",
+  "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_gather_grouped_gemm_act_fusion.py",
   "flashinfer/fused_moe/cute_dsl/rubin/blockscaled_contiguous_grouped_gemm_finalize_fusion.py",
 ]
 force-exclude = true

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -64,12 +64,12 @@ def _skip_sm107_unimplemented_moe_features(request):
     """Skip parameterizations the SM107 (Rubin) CuTe DSL MoE kernels do not implement.
 
     ``fused_moe/cute_dsl/rubin/`` holds a narrower specialisation of the
-    Blackwell kernels rather than a port of them: the gather kernel hardcodes
-    SwiGLU and exposes no ``activation_type``, its wrapper has no
-    ``a_per_token_scale_ptr``, and the finalize kernel implements no unfused
-    path. The wrappers raise ``NotImplementedError`` for these cases, which is
-    correct behaviour -- but on Rubin it reports as a test failure on every CI
-    sweep, for features the kernels were never built to have.
+    Blackwell kernels rather than a full port: the gather kernel implements
+    standard SwiGLU and ReLU^2, but not other gated formulas; its wrapper has
+    no ``a_per_token_scale_ptr``; and the finalize kernel implements no
+    unfused path. The wrappers raise ``NotImplementedError`` for these cases,
+    which is correct behaviour -- but on Rubin it reports as a test failure on
+    every CI sweep, for features the kernels were never built to have.
 
     The decision is made from the parameterization alone, before the test body
     runs. It therefore cannot absorb a genuine regression: anything that fails
@@ -97,7 +97,7 @@ def _skip_sm107_unimplemented_moe_features(request):
         pytest.skip("SM107 finalize kernel implements only the fused path")
 
     if params.get("activation_type") == ActivationType.GegluTanh:
-        pytest.skip("SM107 gather grouped GEMM is SwiGLU-only")
+        pytest.skip("SM107 gather grouped GEMM does not implement GeGLU")
 
     # test_geglu_tanh_accuracy sets the activation in its body rather than via a
     # parameter, so it has to be matched by identity. Match the function exactly
@@ -105,7 +105,7 @@ def _skip_sm107_unimplemented_moe_features(request):
     # prefix but only exercises normalize_cute_dsl_moe_activation_type, touches no
     # kernel, and passes on SM107 -- a substring match silently dropped it.
     if request.node.function.__name__ == "test_geglu_tanh_accuracy":
-        pytest.skip("SM107 gather grouped GEMM is SwiGLU-only")
+        pytest.skip("SM107 gather grouped GEMM does not implement GeGLU")
 
     if (
         request.node.function.__name__
@@ -1671,12 +1671,6 @@ class TestCuteDslFusedMoeFunctional:
     ):
         from flashinfer import cute_dsl_fused_moe
 
-        if activation_type == ActivationType.Relu2 and is_sm107():
-            pytest.skip(
-                "Rubin (SM107) cute-dsl MoE kernels only implement the gated "
-                "(SwiGLU) activation path"
-            )
-
         _, gated = normalize_cute_dsl_moe_activation_type(activation_type)
         num_local_experts = num_experts
 
@@ -1829,8 +1823,7 @@ class TestCuteDslFusedMoeFunctional:
         if is_sm107():
             pytest.skip(
                 "Rubin (SM107) cute-dsl MoE kernels do not implement SiTU; the "
-                "gather kernel is SwiGLU-only and silently ignores situ_beta/"
-                "situ_linear_beta"
+                "dispatcher accepts only plain SwiGLU or ReLU2"
             )
         from flashinfer import cute_dsl_fused_moe
 
@@ -2331,11 +2324,8 @@ class TestCuteDslMoEWrapper:
         from flashinfer import autotune
         from flashinfer import CuteDslMoEWrapper
 
-        if activation_type == ActivationType.Relu2 and is_sm107():
-            pytest.skip(
-                "Rubin (SM107) cute-dsl MoE kernels only implement the gated "
-                "(SwiGLU) activation path"
-            )
+        if situ_beta is not None and is_sm107():
+            pytest.skip("SM107 gather grouped GEMM does not implement SiTU")
 
         _, gated = normalize_cute_dsl_moe_activation_type(activation_type)
         num_tokens, hidden_size, intermediate_size = 256, 256, 512

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1613,6 +1613,12 @@ class TestCuteDslFusedMoeFunctional:
     ):
         from flashinfer.autotuner import AutoTuner
 
+        if is_sm107():
+            pytest.skip(
+                "This test forces a Blackwell cluster-N=2 finalize tactic; "
+                "SM107 finalize tactics pin cluster-N to 1"
+            )
+
         if quant_mode == "w4a4":
             # hidden=256 leaves one padding CTA in the N=256, cluster_n=2
             # configuration. hidden=384 also gives the second CTA a partial tile.

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -1611,6 +1611,7 @@ class TestCuteDslFusedMoeFunctional:
         hidden_size: int,
         monkeypatch: pytest.MonkeyPatch,
     ):
+        """Exercise finalize tactics with cluster padding and partial N tiles."""
         from flashinfer.autotuner import AutoTuner
 
         if is_sm107():
@@ -1642,6 +1643,7 @@ class TestCuteDslFusedMoeFunctional:
         def choose_tail_config(
             _self, _custom_op, runners, _tuning_config, _inputs, **_kwargs
         ):
+            """Force the padding-sensitive tactic for this regression test."""
             return runners[0], tail_config
 
         monkeypatch.setattr(AutoTuner, "choose_one", choose_tail_config)

--- a/tests/moe/test_cute_dsl_fused_moe.py
+++ b/tests/moe/test_cute_dsl_fused_moe.py
@@ -2176,8 +2176,12 @@ class TestCuteDslMoEWrapper:
     )
     @pytest.mark.parametrize("num_tokens", [64, 128, 256])
     @pytest.mark.parametrize("num_experts", [256, 384])
+    @pytest.mark.parametrize(
+        "activation_type", [ActivationType.Swiglu, ActivationType.Relu2]
+    )
     def test_wrapper_cuda_graph(
         self,
+        activation_type: ActivationType,
         num_tokens: int,
         num_experts: int,
         quant_mode: str,
@@ -2185,7 +2189,7 @@ class TestCuteDslMoEWrapper:
         use_fused_finalize: bool,
     ):
         """Test wrapper API with CUDA graph capture and replay."""
-        if is_sm107():
+        if is_sm107() and activation_type == ActivationType.Swiglu:
             pytest.skip(
                 "Rubin (SM107) cute-dsl MoE kernels do not implement custom "
                 "SwiGLU constants (swiglu_alpha/beta/limit)"
@@ -2194,6 +2198,7 @@ class TestCuteDslMoEWrapper:
 
         hidden_size, intermediate_size = 256, 512
         top_k = 2
+        _, gated = normalize_cute_dsl_moe_activation_type(activation_type)
 
         tensors = create_moe_tensors(
             num_tokens=num_tokens,
@@ -2202,6 +2207,7 @@ class TestCuteDslMoEWrapper:
             num_experts=num_experts,
             num_local_experts=num_experts,
             top_k=top_k,
+            gated=gated,
             use_per_token_activation=use_per_token_activation,
         )
         api_inputs, reference_inputs = _prepare_moe_quant_mode_inputs(
@@ -2216,7 +2222,7 @@ class TestCuteDslMoEWrapper:
             intermediate_size=intermediate_size,
             use_cuda_graph=True,
             max_num_tokens=num_tokens,
-            activation_type=ActivationType.Swiglu,
+            activation_type=activation_type,
             swiglu_alpha=1.702,
             swiglu_beta=1.0,
             swiglu_limit=7.0,
@@ -2291,7 +2297,7 @@ class TestCuteDslMoEWrapper:
             top_k=top_k,
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
-            activation_type=ActivationType.Swiglu,
+            activation_type=activation_type,
             swiglu_alpha=1.702,
             swiglu_beta=1.0,
             swiglu_limit=7.0,
@@ -3060,6 +3066,9 @@ class TestAllValidTactics:
     pytestmark = _requires_dsl_arch
 
     @pytest.mark.parametrize(
+        "activation_type", [ActivationType.Swiglu, ActivationType.Relu2]
+    )
+    @pytest.mark.parametrize(
         "num_tokens,hidden_size,intermediate_size,num_experts,top_k",
         [
             (128, 256, 512, 256, 2),
@@ -3068,6 +3077,7 @@ class TestAllValidTactics:
     )
     def test_all_tactics_accuracy(
         self,
+        activation_type: ActivationType,
         num_tokens: int,
         hidden_size: int,
         intermediate_size: int,
@@ -3078,6 +3088,7 @@ class TestAllValidTactics:
         from flashinfer import CuteDslMoEWrapper
 
         num_local_experts = num_experts
+        _, gated = normalize_cute_dsl_moe_activation_type(activation_type)
 
         tensors = create_moe_tensors(
             num_tokens=num_tokens,
@@ -3086,6 +3097,7 @@ class TestAllValidTactics:
             num_experts=num_experts,
             num_local_experts=num_local_experts,
             top_k=top_k,
+            gated=gated,
         )
 
         ref_output = compute_reference_moe_fp4(
@@ -3102,6 +3114,7 @@ class TestAllValidTactics:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             fc2_input_scale=tensors["fc2_input_scale"],
+            activation_type=activation_type,
         )
 
         # Create wrapper without CUDA graph so we can freely try different tile_sizes
@@ -3111,6 +3124,7 @@ class TestAllValidTactics:
             hidden_size=hidden_size,
             intermediate_size=intermediate_size,
             use_cuda_graph=False,
+            activation_type=activation_type,
         )
 
         # Get the filtered list of valid tactics for this problem size


### PR DESCRIPTION
## 📌 Description

This PR adds non-gated ReLU2 support to the SM107 (Rubin) CuTe DSL fused-MoE FC1 gather/GEMM path.

This enables NVFP4 models such as NVIDIA Nemotron 3 Ultra to use vLLM's `flashinfer_cutedsl` MoE backend on SM107. vLLM already maps `RELU2_NO_MUL` to `ActivationType.Relu2`, but FlashInfer previously rejected that activation for the Rubin kernel.

Changes include:

- Generalize the SM107 FC1 kernel from SwiGLU-only fusion to activation fusion.
- Add a non-gated epilogue that computes `relu(alpha * accumulator)^2`.
- Preserve the full GEMM1 N dimension for ReLU2 while retaining the existing halved, interleaved output layout for gated SwiGLU.
- Support optional NVFP4 output quantization and scale-factor generation on the ReLU2 path.
- Allow `ActivationType.Relu2` through SM107 dispatch and autotuning, using the activation-dependent GEMM1 dimension rather than always assuming `2 * intermediate_size`.
- Continue rejecting unsupported SM107 configurations such as GeGLU, SiTU, parameterized SwiGLU, and per-token activation scaling.
- Rename the SM107 kernel module and class from `swiglu_fusion` to `act_fusion` to reflect the expanded activation support.
- Extend functional, wrapper, CUDA graph, autotuning, and all-valid-tactics regression coverage for ReLU2.
- Skip a test that explicitly forces a Blackwell-only cluster-N=2 finalize tactic; SM107 finalize tactics pin cluster-N to 1.

This changes no public function signature: it enables the existing ReLU2 activation option for the SM107 implementation.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation performed at commit `c58849a7d9065bb201eb8d29649c74fa4a64df93`:

- `git diff --check origin/main...HEAD` passes.
- A full-model integration smoke completed on four SM107 GPUs using:
  - `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-NVFP4`
  - NVFP4, TP1/DP4/EP4
  - vLLM `--moe-backend flashinfer_cutedsl`
  - one warmup request and one measured request with requested ISL 128 / OSL 16
- All four ranks completed the 25/25 ReLU2 autotuner profiles.
- Both requests returned HTTP 200.
- The measured request generated all 16 output tokens with zero request errors or cancellations.

This smoke validates model startup, SM107 CuTe DSL JIT compilation, ReLU2 autotuning, and end-to-end request completion. It is not intended as a performance benchmark.

Targeted unit coverage added or extended in `tests/moe/test_cute_dsl_fused_moe.py` includes:

- Functional ReLU2 numerical accuracy.
- Wrapper execution under autotuning.
- CUDA graph capture and replay.
- Numerical validation of every admitted SM107 tactic.
- Activation-dependent tensor shapes for gated and non-gated paths.

## Reviewer Notes

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rubin fused MoE execution now supports non-gated ReLU² activation alongside gated SwiGLU.
  * Activation fusion adapts output sizing, validation, tensor processing, and execution to the selected activation.
  * Kernel selection and execution checks now support the expanded activation options.

* **Compatibility**
  * Unsupported parameterized SwiGLU, SiTU, and other activation configurations remain unavailable on Rubin hardware.

* **Tests**
  * Added coverage for Rubin SwiGLU and ReLU² execution paths, including accuracy and autotuning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->