### PR TITLE
fix(activation): pick a vector width that divides hidden_size in act_and_mul (fixes d=3420)

### DIFF
--- a/flashinfer/activation.py
+++ b/flashinfer/activation.py
@@ -63,6 +63,14 @@ def get_act_and_mul_module(act_func_name: str):
     return SimpleNamespace(**{fname: _act_and_mul})
 
 
+def _check_act_and_mul_input(input: torch.Tensor) -> None:
+    # The kernel picks a vector width that divides hidden_size, so any even
+    # last dimension (2 * hidden_size) is supported; it no longer has to be a
+    # multiple of 16 bytes.
+    if input.shape[-1] % 2 != 0:
+        raise ValueError("The last dimension must be even (2 * hidden_size).")
+
+
 def _check_shape(input: torch.Tensor, output: torch.Tensor) -> None:
     assert input.ndim == output.ndim, f"{input.ndim} != {output.ndim}"
     assert input.shape[:-1] == output.shape[:-1], (
@@ -100,8 +108,7 @@ def silu_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
-        raise ValueError("The pointers must be multiple of 16 bytes.")
+    _check_act_and_mul_input(input)
     if out is not None:
         _check_shape(input, out)
     else:
@@ -145,8 +152,7 @@ def gelu_tanh_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
-        raise ValueError("The pointers must be multiple of 16 bytes.")
+    _check_act_and_mul_input(input)
     if out is not None:
         _check_shape(input, out)
     else:
@@ -186,8 +192,7 @@ def gelu_and_mul(
     """
     if enable_pdl is None:
         enable_pdl = device_support_pdl(input.device)
-    if input.shape[-1] * input.dtype.itemsize % 16 != 0:
-        raise ValueError("The pointers must be multiple of 16 bytes.")
+    _check_act_and_mul_input(input)
     if out is not None:
         _check_shape(input, out)
     else:

--- a/flashinfer/jit/activation.py
+++ b/flashinfer/jit/activation.py
@@ -25,6 +25,7 @@ from .utils import write_if_different
 activation_templ = r"""
 #include <flashinfer/activation.cuh>
 #include <cuda_runtime.h>
+#include <type_traits>
 #include "tvm_ffi_utils.h"
 
 {% set func_name = act_func_name ~ '_and_mul' %}
@@ -41,20 +42,8 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
   cudaSetDevice(out.device().device_id);
   const cudaStream_t stream = get_stream(out.device());
   DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16(input.dtype(), c_type, [&] {
-    uint32_t vec_size = 16 / sizeof(c_type);
     cudaLaunchConfig_t config;
     config.gridDim = num_tokens;
-    // Cap the block size instead of scaling it with d: at large d (e.g. 8192)
-    // the old `min(d / vec_size, 1024U)` sizing drove blockDim to 1024, which
-    // raises per-block register pressure enough to limit how many blocks can
-    // be resident per SM at once. The kernel body below already loops over
-    // d / vec_size in strides of blockDim.x, so capping the block size lets
-    // more blocks co-reside per SM instead of growing a single block; this
-    // improves achieved occupancy and DRAM throughput on sm_100a without
-    // changing kernel semantics (measured ~15-20% lower latency and ~10pp
-    // higher DRAM throughput at d=8192 on B200; the exact gain depends on the
-    // compiler's register allocation for this kernel).
-    config.blockDim = std::min(d / vec_size, 256U);
     config.dynamicSmemBytes = 0;
     config.stream = stream;
     cudaLaunchAttribute attrs[1];
@@ -63,10 +52,40 @@ void {{ func_name }}(TensorView out, TensorView input, bool enable_pdl) {
     config.numAttrs = 1;
     config.attrs = attrs;
 
-    auto kernel = flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}>;
+    auto launch = [&](auto vec_size_tag) {
+      constexpr uint32_t vec_size = decltype(vec_size_tag)::value;
+      // Cap the block size instead of scaling it with d: at large d (e.g. 8192)
+      // the old `min(d / vec_size, 1024U)` sizing drove blockDim to 1024, which
+      // raises per-block register pressure enough to limit how many blocks can
+      // be resident per SM at once. The kernel body already loops over
+      // d / vec_size in strides of blockDim.x, so capping the block size lets
+      // more blocks co-reside per SM instead of growing a single block; this
+      // improves achieved occupancy and DRAM throughput on sm_100a without
+      // changing kernel semantics (measured ~15-20% lower latency and ~10pp
+      // higher DRAM throughput at d=8192 on B200; the exact gain depends on the
+      // compiler's register allocation for this kernel).
+      config.blockDim = std::min(d / vec_size, 256U);
+      auto kernel =
+          flashinfer::activation::act_and_mul_kernel<c_type, {{ act_func_name }}, vec_size>;
+      cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
+                         static_cast<c_type*>(input.data_ptr()), d);
+    };
 
-    cudaLaunchKernelEx(&config, kernel, static_cast<c_type*>(out.data_ptr()),
-                       static_cast<c_type*>(input.data_ptr()), d);
+    // Use the widest vector that divides d. The y half of a row starts d
+    // elements in and the output row token_idx * d elements in, so a vector
+    // width that does not divide d puts those accesses off their natural
+    // alignment (d = 3420 in fp16: byte offset 6840, only 8-byte aligned)
+    // and the 16-byte loads fault. Power-of-two dims keep the full width.
+    constexpr uint32_t max_vec_size = 16 / sizeof(c_type);
+    if (d % max_vec_size == 0) {
+      launch(std::integral_constant<uint32_t, max_vec_size>{});
+    } else if (d % 4 == 0) {
+      launch(std::integral_constant<uint32_t, 4>{});
+    } else if (d % 2 == 0) {
+      launch(std::integral_constant<uint32_t, 2>{});
+    } else {
+      launch(std::integral_constant<uint32_t, 1>{});
+    }
 
     cudaError_t err = cudaGetLastError();
     TVM_FFI_ICHECK(err == cudaSuccess) << "Failed to launch kernel: " << cudaGetErrorString(err);

--- a/include/flashinfer/activation.cuh
+++ b/include/flashinfer/activation.cuh
@@ -25,11 +25,15 @@ namespace flashinfer {
 
 namespace activation {
 
-template <typename T, float (*Activation)(const float&)>
+// vec_size must divide d: every vectorized access below (the x half at
+// offset, the y half at offset + d, and the output row at token_idx * d) is
+// then aligned to vec_size * sizeof(T) bytes. The launcher picks the largest
+// power of two that satisfies this, so d = 3420 (Qwen2.5-VL) runs with
+// vec_size = 4 instead of faulting on a 16-byte load at an 8-byte address.
+template <typename T, float (*Activation)(const float&), uint32_t vec_size>
 __global__ __launch_bounds__(256) void act_and_mul_kernel(T* __restrict__ out,
                                                           const T* __restrict__ input,
                                                           const int d) {
-  constexpr uint32_t vec_size = 16 / sizeof(T);
   const int64_t token_idx = blockIdx.x;
   const int64_t thread_idx = threadIdx.x;
   const int64_t stride = blockDim.x;
@@ -49,15 +53,6 @@ __global__ __launch_bounds__(256) void act_and_mul_kernel(T* __restrict__ out,
       out_vec[i] = Activation(x_vec[i]) * y_vec[i];
     }
     out_vec.cast_store(out + token_idx * d + idx * vec_size);
-  }
-
-  const int64_t remaining_offset = d - d % (stride * vec_size);
-  // process the remaining elements
-#pragma unroll 1
-  for (int64_t idx = thread_idx; idx < d % (stride * vec_size); idx += stride) {
-    float x = input[offset + remaining_offset + idx],
-          y = input[offset + remaining_offset + d + idx];
-    out[token_idx * d + remaining_offset + idx] = Activation(x) * y;
   }
 
 #if (__CUDACC_VER_MAJOR__ >= 12 && defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))

--- a/tests/utils/test_activation.py
+++ b/tests/utils/test_activation.py
@@ -37,7 +37,9 @@ def warmup_jit():
     yield
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize(
+    "dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384]
+)
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -51,7 +53,9 @@ def test_fused_silu_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize(
+    "dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384]
+)
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])
@@ -65,7 +69,9 @@ def test_fused_gelu_tanh_mul(dim, batch_size, seq_len, enable_pdl):
     torch.testing.assert_close(y_ref, y, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.parametrize("dim", [128, 256, 512, 2048, 4096, 11008, 16384])
+@pytest.mark.parametrize(
+    "dim", [128, 256, 512, 855, 1710, 2048, 3420, 4096, 11008, 16384]
+)
 @pytest.mark.parametrize("batch_size", [1, 2, 4, 8, 16])
 @pytest.mark.parametrize("seq_len", [1, 2, 4, 8, 16, 32, 64, 128, 512])
 @pytest.mark.parametrize("enable_pdl", [True, False])


### PR DESCRIPTION
## 📌 Description

`act_and_mul_kernel` hardcodes `vec_size = 16 / sizeof(T)` (8 for fp16/bf16) and reads the second half of each row at element offset `d` and writes the output row at `token_idx * d`. When `d` is not a multiple of 8 those addresses are not 16-byte aligned and the vectorized loads fault. Qwen2.5-VL's vision MLP has `intermediate_size = 3420`: the y half starts at byte 6840, which is only 8-byte aligned, and `silu_and_mul` dies with `cudaErrorMisalignedAddress` in both fp16 and bf16.

The Python guard did not catch it because it checks the full row: `input.shape[-1] * itemsize % 16`, i.e. `4d % 16`, which passes for any `d % 4 == 0`. So `d = 1234` was rejected cleanly while `d = 3420` reached the kernel and crashed.

This PR:

- makes `vec_size` a template parameter of `act_and_mul_kernel`, and has the launcher pick the largest power of two that divides `d` (8, 4, 2 or 1). With `vec_size | d` every access (x half, y half at `+d`, output row at `token_idx * d`) is aligned to `vec_size * sizeof(T)`. Power-of-two and multiple-of-8 dims keep the full width, so common models are untouched.
- relaxes the guard in `silu_and_mul`, `gelu_and_mul` and `gelu_tanh_and_mul` to "last dimension must be even".
- removes the kernel's tail loop. With `vec_size | d` the grid-stride main loop already covers every element, so the tail can only re-process elements. Since #4733 capped `blockDim` at 256, its bound `d % (blockDim * vec_size)` no longer equals `d % vec_size`, so on main it re-computes up to 2047 already-written elements per row with scalar accesses (768 for `d = 11008`). Output was correct, the work was wasted.

Same design as #2613 (approved by @yzh119 in February, never rebased and now conflicting), redone on current main.

## 🔍 Related Issues

Fixes #2526. Supersedes #2613.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`tests/utils/test_activation.py` gains `855` (odd, `vec_size = 1`), `1710` (`vec_size = 2`) and `3420` (`vec_size = 4`) in all three dim lists.

On an RTX 3050 Laptop (sm_86, CUDA 13.3, torch 2.14.0+cu130):

```
pytest tests/utils/test_activation.py -k "855 or 1710 or 3420 or 11008"
540 passed, 540 skipped (enable_pdl=True needs sm_90), 1620 deselected
```

Before the patch, `silu_and_mul` on `(4, 2*3420)` raises `CUDA error: misaligned address` in fp16 and bf16; after it matches the torch reference.

Throughput (fp16, 4096 tokens, median of 5x200 iterations, kernel is memory-bound at ~179 GB/s on this GPU):

| d | before (us) | after (us) |
| --- | ---: | ---: |
| 3416 | 482.2 | 468.8 |
| 4096 | 561.0 | 560.3 |
| 8192 | 1118.9 | 1119.8 |
| 11008 | 1517.1 | 1504.0 |
| 12288 | 1680.2 | 1679.4 |
| 16384 | 2240.4 | 2239.9 |

The small gains at 3416 and 11008 are the removed duplicate tail; the rest is noise.

## Reviewer Notes

- Only fp16/bf16 go through `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16`, so the maximum `vec_size` is 8 and the dispatch has four cases.
- Base pointers are still assumed 16-byte aligned, as before. Offset views (e.g. `x[:, 1:]`) are out of scope here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Activation-and-mul operations now support any input shape with an even final dimension, including dimensions that were previously rejected.
  - Improved handling of varying activation dimensions enables broader compatibility across supported inputs.

- **Tests**
  - Expanded coverage for fused SiLU, GELU-tanh, and GELU activation-and-mul operations with additional nonstandard dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->