### PR TITLE
fix(ci): preserve estimate file compression during refresh

### DIFF
--- a/scripts/test_sharding/observations.py
+++ b/scripts/test_sharding/observations.py
@@ -82,6 +82,18 @@ def adjust_first_case_warmup(
     return adjusted, dict(warmup)
 
 
+def _write_estimate_file(path: Path, content: str) -> None:
+    if path.suffix != ".gz":
+        atomic_write_text(path, content)
+        return
+    buffer = io.BytesIO()
+    with gzip.GzipFile(
+        filename="", mode="wb", fileobj=buffer, compresslevel=9, mtime=0
+    ) as compressed:
+        compressed.write(content.encode("utf-8"))
+    atomic_write_bytes(path, buffer.getvalue())
+
+
 def _write_duration_file(path: Path, rows: Iterable[DurationEstimate]) -> None:
     stream = io.StringIO(newline="")
     writer = csv.writer(stream, lineterminator="\n")
@@ -97,12 +109,7 @@ def _write_duration_file(path: Path, rows: Iterable[DurationEstimate]) -> None:
                 row.sample_count,
             ]
         )
-    buffer = io.BytesIO()
-    with gzip.GzipFile(
-        filename="", mode="wb", fileobj=buffer, compresslevel=9, mtime=0
-    ) as compressed:
-        compressed.write(stream.getvalue().encode("utf-8"))
-    atomic_write_bytes(path, buffer.getvalue())
+    _write_estimate_file(path, stream.getvalue())
 
 
 def _write_overhead_file(path: Path, rows: Iterable[OverheadEstimate]) -> None:
@@ -129,7 +136,7 @@ def _write_overhead_file(path: Path, rows: Iterable[OverheadEstimate]) -> None:
                 row.sample_count,
             ]
         )
-    atomic_write_text(path, stream.getvalue())
+    _write_estimate_file(path, stream.getvalue())
 
 
 def _write_summary(path: Path, rows: Iterable[DurationEstimate]) -> None:

--- a/tests/test_sharding/test_estimate_refresh.py
+++ b/tests/test_sharding/test_estimate_refresh.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import pytest
 
 from scripts.rebuild_test_duration_estimates import _prune_scope
+from scripts.test_sharding.estimates import EstimateBook
 from scripts.test_sharding.models import CollectedNode, Plan, PlanningOptions
 from scripts.test_sharding.observations import (
     EstimateRefresh,
     ObservedCase,
+    ObservedOverhead,
     adjust_first_case_warmup,
     refresh_estimates,
 )
@@ -123,6 +125,41 @@ def test_refresh_is_byte_reproducible_and_decreases_gradually(tmp_path: Path) ->
         ),
     )
     assert second_file.read_bytes() == first_bytes
+
+
+@pytest.mark.parametrize(
+    ("duration_suffix", "overhead_suffix"),
+    [(".csv", ".csv"), (".csv.gz", ".csv.gz")],
+)
+def test_refresh_preserves_readable_estimate_formats(
+    tmp_path: Path, duration_suffix: str, overhead_suffix: str
+) -> None:
+    request = EstimateRefresh(
+        duration_file=tmp_path / f"duration{duration_suffix}",
+        overhead_file=tmp_path / f"overhead{overhead_suffix}",
+        summary_file=tmp_path / "summary.csv",
+    )
+    nodeid = "tests/test_sample.py::test_case[0]"
+    observations = [_observation(nodeid, 10)]
+    overheads = [
+        ObservedOverhead(
+            profile="profile",
+            source_file="tests/test_sample.py",
+            process_startup_seconds=2,
+            source_warmup_seconds=3,
+            run_id="run",
+            batch_id="batch",
+        )
+    ]
+
+    refresh_estimates(observations, overheads, request)
+    refresh_estimates(observations, overheads, request)
+    book = EstimateBook.from_files(request.duration_file, request.overhead_file)
+
+    assert book.lookup_runtime(nodeid, 99).seconds == 12
+    assert book.overhead_ms_runtime("tests/test_sample.py", 99) == 6000
+    assert book.durations[0].sample_count == 2
+    assert book.overheads[0].sample_count == 2
 
 
 def test_prune_scope_resolves_test_path_from_repository_root(


### PR DESCRIPTION
## Description

I've made both estimate writers follow the same `.gz` suffix rule as the reader. Previously, duration estimates were always compressed and overhead estimates never were. A second refresh could then fail with `UnicodeDecodeError` or `BadGzipFile`.

The regression refreshes plain and gzip files twice and checks that the saved estimates remain readable. Atomic replacement and deterministic gzip headers are unchanged.

## Related Issues

None linked.

## Pull Request Checklist

### Pre-commit Checks
- [x] I have installed `pre-commit`.
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run `pre-commit run --all-files`.

## Tests
- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

The five sharding tests passed, including the existing deterministic-gzip regression. Applicable pre-commit checks passed in the sparse checkout. GPU fixtures were excluded; the full GPU suite was not run. CI still needs maintainer authorization.

## Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
# tests/experimental/test_my_backend.py
# tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

I used AI for this patch; this has been manually reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Estimate refreshes now preserve both plain-text and gzip-compressed estimate files.
  - Repeated refreshes correctly retain readable runtime and overhead estimates while accumulating sample data.
- **Tests**
  - Added coverage for refreshing estimates across supported file formats and verifying estimate values and sample counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->