### PR TITLE
Nccl extensions dependency update

### DIFF
--- a/benchmarks/MoE_benchmarks.md
+++ b/benchmarks/MoE_benchmarks.md
@@ -27,7 +27,8 @@ DOCA / UCX-from-source / GDRCopy layers of the NIXL image are unnecessary for NC
 
 Build (`docker/install/build_flashinfer_ep_pytorch.sh` does the install): it pins the
 verified set over the base image's constraints — `nvidia-nccl-cu13==2.30.7` (via
-`PIP_CONSTRAINT=` to beat torch's 2.30.4 pin), `nccl4py[cu13]==0.3.1`, `cuda-core==1.0.1`,
+`PIP_CONSTRAINT=` to beat torch's 2.30.4 pin), `nccl-extensions[cu13]==0.1.0`,
+`nccl4py[cu13]==0.5.0`, `cuda-core==1.0.1`,
 `cuda-bindings==13.2.0` — then `BUILD_NCCL_EP=1 BUILD_NIXL_EP=0 pip install -e .`
 (the moe_ep deps are base dependencies now; no extra needed).
 
@@ -45,7 +46,7 @@ srun -N1 --container-image=nvcr.io/nvidia/pytorch:26.05-py3 \
 stack even single-node; **NCCL ≥ 2.30.7** (2.27/2.29 fail group-create at `nccl_ep.cc:1438`
 on B200) bound **first** on `LD_LIBRARY_PATH`; and **`NCCL_MNNVL_ENABLE=1` for multi-node**
 (single-node intra-tray NVLink works without it). The PyTorch image + the pinned wheels
-above satisfy these; `nccl.ep` is the `nccl4py` wheel (no in-tree NCCL build).
+above satisfy these; `nccl.ep` is the `nccl-extensions` wheel (no in-tree NCCL build).
 
 Smoke: `python -c "import nccl.ep; from flashinfer.moe_ep import available_backends; print(available_backends())"` → `['nccl_ep', ...]`.
 

--- a/build_backend.py
+++ b/build_backend.py
@@ -31,8 +31,9 @@ _data_dir = _root / "flashinfer" / "data"
 
 # moe_ep build infra. Both EP backends are ON BY DEFAULT since the moe_ep
 # runtime deps moved into the base dependencies (`pip install .` is enough):
-#   NCCL-EP  — provided by the `nccl4py>=0.3.1` wheel (a base dep now); NO
-#              in-tree build.
+#   NCCL-EP  — provided by the `nccl-extensions>=0.1.0` wheel (a base dep
+#              now); NO in-tree build. (nccl.ep used to ship in nccl4py;
+#              nccl4py 0.4.1 dropped it — see requirements.txt.)
 #   NIXL-EP  — built in-tree from 3rdparty/nixl (meson). Missing build deps
 #              (meson/ninja/nvcc/UCX/...) skip the backend with a warning
 #              instead of failing the install (best-effort).
@@ -491,8 +492,9 @@ def _build_nccl_ep() -> None:
             shutil.copy(sopath, dst / soname)
             print(f"[BUILD_NVEP] staged: {soname}")
 
-    # NOTE: nccl_ep (ctypes wrapper from contrib/nccl_ep/python) and nccl4py
-    # (Cython bindings + Communicator(ptr=...) bridge) are NOT pip-installed
+    # NOTE: nccl_ep (ctypes wrapper from contrib/nccl_ep/python) and the
+    # nccl Python bindings (Cython bindings + Communicator(ptr=...) bridge)
+    # are NOT pip-installed
     # from this build hook. When `uv pip install` runs the FlashInfer build,
     # sys.executable points to uv's isolated build env (which has no pip), so
     # `python -m pip install` from here fails. Install them as a separate
@@ -500,11 +502,12 @@ def _build_nccl_ep() -> None:
     #
     #   pip install -e 3rdparty/nccl/contrib/nccl_ep/python
     #   CUDA_HOME=/usr/local/cuda pip install -e 3rdparty/nccl/bindings/nccl4py[cu13]
+    #   CUDA_HOME=/usr/local/cuda pip install -e 3rdparty/nccl-extensions/python[cu13]
     #
     # docker/Dockerfile.flashinfer-nvep already chains these after the main
     # `BUILD_NVEP=1 uv pip install ...` step.
     print(
-        "[BUILD_NVEP] nccl_ep + nccl4py pip-installs deferred to post-build "
+        "[BUILD_NVEP] nccl_ep + nccl4py/nccl-extensions pip-installs deferred to post-build "
         "step (see docker/Dockerfile.flashinfer-nvep). Skipping in hook."
     )
 
@@ -922,12 +925,12 @@ def _build_nvep_if_enabled() -> None:
         )
 
     # NCCL-EP is not built from source — it is provided by the released
-    # `nccl4py` wheel (>=0.3.1, the `nccl.ep` API + bundled libnccl_ep.so),
-    # which is a base dependency now. So BUILD_NCCL_EP requires no in-tree
-    # build step; we only note it here.
+    # `nccl-extensions` wheel (>=0.1.0, the `nccl.ep` API + bundled
+    # libnccl_ep.so), which is a base dependency now. So BUILD_NCCL_EP
+    # requires no in-tree build step; we only note it here.
     if _BUILD_NCCL_EP:
         print(
-            "[BUILD_NVEP] NCCL-EP is provided by the nccl4py wheel (>=0.3.1), "
+            "[BUILD_NVEP] NCCL-EP is provided by the nccl-extensions wheel (>=0.1.0), "
             "a base dependency of flashinfer-python; no in-tree build."
         )
         # torch's cu13 wheels pin nvidia-nccl-cu13 exactly (< the B200 EP
@@ -995,7 +998,7 @@ def _build_nvep_if_enabled() -> None:
 
     built = [b for b, is_enabled in (("NIXL-EP", built_nixl),) if is_enabled]
     if _BUILD_NCCL_EP:
-        built.append("NCCL-EP (via nccl4py wheel)")
+        built.append("NCCL-EP (via nccl-extensions wheel)")
     print(f"[BUILD_NVEP] done — built: {', '.join(built) if built else 'nothing'}")
 
 

--- a/docker/Dockerfile.flashinfer-ep-pytorch
+++ b/docker/Dockerfile.flashinfer-ep-pytorch
@@ -38,11 +38,14 @@
 #
 # Build args:
 #   CUDA_IMAGE   — base image (default: the 26.05 PyTorch image).
-#   FI_NCCL_VERSION — nvidia-nccl-cu13 pin (default 2.30.7, matching nccl4py
-#                  0.3.1). FI_-prefixed because the base image's ENV
+#   FI_NCCL_VERSION — nvidia-nccl-cu13 pin (default 2.30.7, matching
+#                  nccl-extensions 0.1.0). FI_-prefixed because the base image's ENV
 #                  NCCL_VERSION (Debian version, e.g. 2.28.3-1) would override
 #                  a same-named ARG inside RUN and break the pip pin.
-#   NCCL4PY_SPEC — nccl4py pin (default nccl4py[cu13]==0.3.1).
+#   NCCL_EXT_SPEC — nccl-extensions pin (default nccl-extensions[cu13]==0.1.0);
+#                  ships nccl.ep since it moved out of nccl4py in 0.4.1.
+#   NCCL4PY_SPEC — nccl4py pin (default nccl4py[cu13]==0.5.0); ships
+#                  nccl.core.Communicator in the same `nccl` namespace.
 
 ARG CUDA_IMAGE=nvcr.io/nvidia/pytorch:26.05-py3
 FROM ${CUDA_IMAGE}
@@ -69,12 +72,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # keeps the base torch intact; nccl.ep also imports cuda.core / cuda.bindings,
 # installed explicitly at ep_bench's exact versions.
 ARG FI_NCCL_VERSION=2.30.7
-ARG NCCL4PY_SPEC=nccl4py[cu13]==0.3.1
+ARG NCCL4PY_SPEC=nccl4py[cu13]==0.5.0
+ARG NCCL_EXT_SPEC=nccl-extensions[cu13]==0.1.0
 ARG CUDA_CORE_VERSION=1.0.1
 ARG CUDA_BINDINGS_VERSION=13.2.0
 RUN PIP_CONSTRAINT= pip install --no-cache-dir --no-deps \
         "nvidia-nccl-cu13==${FI_NCCL_VERSION}" \
         "${NCCL4PY_SPEC}" \
+        "${NCCL_EXT_SPEC}" \
     && PIP_CONSTRAINT= pip install --no-cache-dir \
         "cuda-core==${CUDA_CORE_VERSION}" \
         "cuda-bindings==${CUDA_BINDINGS_VERSION}" \
@@ -87,7 +92,7 @@ print('nccl.ep OK; libnccl', v.value); assert v.value>=23007"
 # Build & install FlashInfer with the NCCL-EP backend only.
 # --no-build-isolation uses the base image's python/torch for the build hook
 # (so meson/torch are found); BUILD_NIXL_EP=0 opts out of the (default-on)
-# NIXL-EP submodule build. NCCL-EP needs no build step — the nccl4py wheel is
+# NIXL-EP submodule build. NCCL-EP needs no build step — the nccl-extensions wheel is
 # a base dependency (already pinned above; the >= constraint no-ops).
 ARG BUILD_NCCL_EP=1
 ARG BUILD_NIXL_EP=0

--- a/docker/Dockerfile.flashinfer-ep-pytorch
+++ b/docker/Dockerfile.flashinfer-ep-pytorch
@@ -96,8 +96,14 @@ print('nccl.ep OK; libnccl', v.value); assert v.value>=23007"
 # a base dependency (already pinned above; the >= constraint no-ops).
 # Ensure the 2.30.7 wheel's libnccl wins over the image's system
 # /usr/lib/<triple>/libnccl.so.2.30.4. nccl-extensions' libnccl_ep is built
-# against 2.30.7 and aborts on an older runtime; see the same pin in
-# docker/install/build_flashinfer_ep_pytorch.sh.
+# against 2.30.7 and aborts on an older runtime. Registered with ldconfig so it
+# applies to every process regardless of environment (an ENV alone is lost by
+# anything that scrubs it); ENV kept so interactive `docker run` inherits it
+# too. Mirrors docker/install/build_flashinfer_ep_pytorch.sh.
+RUN echo /usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib \
+      > /etc/ld.so.conf.d/000-flashinfer-nccl.conf \
+    && ldconfig \
+    && ldconfig -p | grep -E "libnccl\.so\.2"
 ENV LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib:${LD_LIBRARY_PATH}
 
 ARG BUILD_NCCL_EP=1

--- a/docker/Dockerfile.flashinfer-ep-pytorch
+++ b/docker/Dockerfile.flashinfer-ep-pytorch
@@ -94,6 +94,12 @@ print('nccl.ep OK; libnccl', v.value); assert v.value>=23007"
 # (so meson/torch are found); BUILD_NIXL_EP=0 opts out of the (default-on)
 # NIXL-EP submodule build. NCCL-EP needs no build step — the nccl-extensions wheel is
 # a base dependency (already pinned above; the >= constraint no-ops).
+# Ensure the 2.30.7 wheel's libnccl wins over the image's system
+# /usr/lib/<triple>/libnccl.so.2.30.4. nccl-extensions' libnccl_ep is built
+# against 2.30.7 and aborts on an older runtime; see the same pin in
+# docker/install/build_flashinfer_ep_pytorch.sh.
+ENV LD_LIBRARY_PATH=/usr/local/lib/python3.12/dist-packages/nvidia/nccl/lib:${LD_LIBRARY_PATH}
+
 ARG BUILD_NCCL_EP=1
 ARG BUILD_NIXL_EP=0
 ARG FLASHINFER_SRC=/workspace/flashinfer

--- a/docker/Dockerfile.flashinfer-nvep
+++ b/docker/Dockerfile.flashinfer-nvep
@@ -2,9 +2,10 @@
 #
 # Reference Dockerfile for building FlashInfer with the moe_ep transport
 # backends enabled (the default): NIXL-EP is compiled from the in-tree git
-# submodule; NCCL-EP is the released `nccl4py>=0.3.1` wheel (a base
+# submodule; NCCL-EP is the released `nccl-extensions>=0.1.0` wheel (a base
 # dependency), which ships the `nccl.ep` API + bundled libnccl_ep.so (no
-# in-tree NCCL build).
+# in-tree NCCL build). nccl.ep used to live in nccl4py; it moved out in
+# nccl4py 0.4.1 — nccl4py is still pulled in for `nccl.core.Communicator`.
 #
 # Usage:
 #   cd /path/to/flashinfer
@@ -160,7 +161,7 @@ RUN uv pip install --python ${VENV}/bin/python --no-deps \
 # loader in flashinfer/moe_ep/nixl_ep ctypes-preloads the base libs from the
 # same wheel. Set BUILD_NIXL_EP_HERMETIC=1 to opt back into the full
 # from-source build (for hosts without PyPI access or when investigating ABI
-# mismatches). NCCL-EP has no build step — it ships in the nccl4py wheel.
+# mismatches). NCCL-EP has no build step — it ships in the nccl-extensions wheel.
 ARG BUILD_NVEP=1
 ARG BUILD_NCCL_EP=
 ARG BUILD_NIXL_EP=
@@ -172,7 +173,7 @@ WORKDIR ${FLASHINFER_SRC}
 # the submodule .git pointers reference the host superproject's .git/modules/
 # tree which isn't copied, and `git apply` in _apply_patches works on a plain
 # directory without a git repo.
-# The base deps pull the released `nccl4py>=0.3.1` wheel (NCCL-EP: the
+# The base deps pull the released `nccl-extensions>=0.1.0` wheel (NCCL-EP: the
 # `nccl.ep` API + bundled libnccl_ep.so) — no in-tree NCCL build. The build
 # hook builds NIXL-EP from the submodule by default.
 RUN BUILD_NVEP=${BUILD_NVEP} \
@@ -192,6 +193,6 @@ b = available_backends(); \
 print('moe_ep backends:', b); \
 assert 'nccl_ep' in b, 'nccl_ep backend missing'; \
 assert 'nixl_ep' in b, 'nixl_ep backend missing'"
-RUN python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep + nccl4py OK')"
+RUN python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep (nccl-extensions) + nccl.core (nccl4py) OK')"
 
 CMD ["bash"]

--- a/docker/Dockerfile.vllm-flashinfer-ep
+++ b/docker/Dockerfile.vllm-flashinfer-ep
@@ -10,7 +10,8 @@
 #
 # It layers on top of docker/Dockerfile.flashinfer-ep-pytorch (which provides
 # the NGC PyTorch 26.05 base + CUDA 13.2 + torch + IB/HPC-X/GPUDirect stack +
-# FlashInfer built with BUILD_NCCL_EP=1 + the pinned nccl4py/nccl 2.30.7 wheels).
+# FlashInfer built with BUILD_NCCL_EP=1 + the pinned nccl-extensions/nccl4py/nccl
+# 2.30.7 wheels).
 # Build that base first:
 #
 #   docker build -f docker/Dockerfile.flashinfer-ep-pytorch -t flashinfer-ep:pt2605 .

--- a/docker/install/build_flashinfer_ep_pytorch.sh
+++ b/docker/install/build_flashinfer_ep_pytorch.sh
@@ -74,12 +74,21 @@ PIP_CONSTRAINT="" pip install --no-cache-dir \
 # off nccl4py. Persist it too, so later `srun`/exec shells in a saved container
 # inherit it.
 NCCL_WHEEL_LIB="$(python -c "import nvidia.nccl, os; print(os.path.join(list(nvidia.nccl.__path__)[0], 'lib'))")"
+# ldconfig, not just LD_LIBRARY_PATH: an `export` here dies with this script
+# and never reaches whatever runs the tests, and /etc/profile.d is only read by
+# login shells. Registering the directory in the loader cache makes EVERY
+# process in the image resolve libnccl.so.2 to the wheel's copy with no env
+# plumbing at all. LD_LIBRARY_PATH is still exported for the rest of THIS
+# script, and profile.d is kept as a belt-and-braces for interactive shells.
+echo "${NCCL_WHEEL_LIB}" > /etc/ld.so.conf.d/000-flashinfer-nccl.conf
+ldconfig
 export LD_LIBRARY_PATH="${NCCL_WHEEL_LIB}:${LD_LIBRARY_PATH:-}"
 cat > /etc/profile.d/flashinfer-nccl.sh <<EOF
 export LD_LIBRARY_PATH=${NCCL_WHEEL_LIB}:\${LD_LIBRARY_PATH:-}
 EOF
 chmod +x /etc/profile.d/flashinfer-nccl.sh
-echo "== libnccl search path pinned to ${NCCL_WHEEL_LIB} =="
+echo "== libnccl pinned to ${NCCL_WHEEL_LIB} =="
+ldconfig -p | grep -E "libnccl\.so\.2" || true
 
 python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep (nccl-extensions) + nccl.core (nccl4py) import OK')"
 
@@ -95,7 +104,23 @@ got = (code // 10000, (code // 100) % 100, code % 100)
 print("loaded libnccl version:", ".".join(map(str, got)))
 assert got >= (2, 30, 7), (
     f"loaded libnccl {got} < 2.30.7 required by nccl-extensions' libnccl_ep; "
-    "a system libnccl is shadowing the wheel (check LD_LIBRARY_PATH)"
+    "a system libnccl is shadowing the wheel (check ldconfig -p / LD_LIBRARY_PATH)"
+)
+PYEOF
+
+# Same check with LD_LIBRARY_PATH cleared: proves the ldconfig pin holds for
+# processes that do not inherit this script's environment (e.g. the test suite).
+env -u LD_LIBRARY_PATH python - <<'PYEOF'
+import ctypes
+lib = ctypes.CDLL("libnccl.so.2")
+out = ctypes.c_int()
+assert lib.ncclGetVersion(ctypes.byref(out)) == 0, "ncclGetVersion failed"
+code = out.value
+got = (code // 10000, (code // 100) % 100, code % 100)
+print("loaded libnccl version (clean env):", ".".join(map(str, got)))
+assert got >= (2, 30, 7), (
+    f"loaded libnccl {got} < 2.30.7 with LD_LIBRARY_PATH unset — the ldconfig "
+    "pin in /etc/ld.so.conf.d/000-flashinfer-nccl.conf did not take effect"
 )
 PYEOF
 

--- a/docker/install/build_flashinfer_ep_pytorch.sh
+++ b/docker/install/build_flashinfer_ep_pytorch.sh
@@ -14,7 +14,10 @@
 #   FI_NCCL_VERSION  nvidia-nccl-<cuXX> pin (default 2.30.7). FI_-prefixed
 #                 because NVIDIA base images export NCCL_VERSION as the Debian
 #                 package version (e.g. 2.28.3-1), which is not a valid pip pin.
-#   NCCL4PY_SPEC  nccl4py pin (default nccl4py[<cuXX>]==0.3.1)
+#   NCCL_EXT_SPEC nccl-extensions pin (default nccl-extensions[<cuXX>]==0.1.0).
+#                 nccl.ep lives here since it moved out of nccl4py (0.4.1).
+#   NCCL4PY_SPEC  nccl4py pin (default nccl4py[<cuXX>]==0.5.0); supplies
+#                 nccl.core.Communicator in the same `nccl` namespace.
 #   FI_EP_PREWARM 1 runs the ~25-min trtllm fused-MoE JIT prewarm (default 0).
 #                 Set to 1 when baking container-save images for torchrun jobs
 #                 (lazy JIT under torchrun outlives the NCCL watchdog); PR CI
@@ -34,7 +37,8 @@ fi
 
 FI_SRC="${FI_SRC:-/host/flashinfer}"
 NCCL_VERSION="${FI_NCCL_VERSION:-2.30.7}"
-NCCL4PY_SPEC="${NCCL4PY_SPEC:-nccl4py[${CU}]==0.3.1}"
+NCCL_EXT_SPEC="${NCCL_EXT_SPEC:-nccl-extensions[${CU}]==0.1.0}"
+NCCL4PY_SPEC="${NCCL4PY_SPEC:-nccl4py[${CU}]==0.5.0}"
 CUDA_CORE_VERSION="${CUDA_CORE_VERSION:-1.0.1}"
 CUDA_BINDINGS_VERSION="${CUDA_BINDINGS_VERSION:-13.2.0}"
 DEEPGEMM_SRC="${DEEPGEMM_SRC:-/tmp/DeepGEMM}"
@@ -47,17 +51,19 @@ nvcc --version | grep release || true
 
 echo "== pin NCCL-EP runtime wheels to ep_bench's verified set =="
 # PIP_CONSTRAINT= overrides the NVIDIA base image's constraint file (which pins
-# nvidia-nccl-<cuXX> to torch's 2.30.4) so we install the 2.30.7 that nccl4py 0.3.1's
-# libnccl_ep.so expects. --no-deps on the NCCL wheels keeps the base torch intact;
+# nvidia-nccl-<cuXX> to torch's 2.30.4) so we install the 2.30.7 that
+# nccl-extensions 0.1.0's libnccl_ep.so expects. --no-deps on the NCCL wheels
+# keeps the base torch intact;
 # nccl.ep additionally imports cuda.core / cuda.bindings, installed explicitly at
 # ep_bench's exact versions (cuda-core 1.0.1, cuda-bindings 13.2.0).
 PIP_CONSTRAINT="" pip install --no-cache-dir --no-deps \
     "nvidia-nccl-${CU}==${NCCL_VERSION}" \
-    "${NCCL4PY_SPEC}"
+    "${NCCL4PY_SPEC}" \
+    "${NCCL_EXT_SPEC}"
 PIP_CONSTRAINT="" pip install --no-cache-dir \
     "cuda-core==${CUDA_CORE_VERSION}" \
     "cuda-bindings==${CUDA_BINDINGS_VERSION}"
-python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep + nccl4py import OK')"
+python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep (nccl-extensions) + nccl.core (nccl4py) import OK')"
 
 echo "== install DeepGEMM + NVSHMEM / CUTLASS DSL deps =="
 PIP_CONSTRAINT="" python -m pip install --no-cache-dir \
@@ -77,8 +83,9 @@ PIP_CONSTRAINT="" python -m pip install --no-cache-dir \
 )
 
 echo "== build & install FlashInfer (NCCL-EP + Mega path) =="
-# The EP backends are ON by default now: NCCL-EP needs no build step (nccl4py
-# is a base dependency of flashinfer-python), so only NIXL-EP is opted out.
+# The EP backends are ON by default now: NCCL-EP needs no build step
+# (nccl-extensions is a base dependency of flashinfer-python), so only NIXL-EP
+# is opted out.
 # PIP_CONSTRAINT= so the build hook's --no-deps NCCL floor upgrade
 # (_ensure_nccl_floor, nvidia-nccl-cu13>=2.30.7) isn't blocked by the base
 # image's constraint file — a no-op here since 2.30.7 is already pinned above.

--- a/docker/install/build_flashinfer_ep_pytorch.sh
+++ b/docker/install/build_flashinfer_ep_pytorch.sh
@@ -63,7 +63,41 @@ PIP_CONSTRAINT="" pip install --no-cache-dir --no-deps \
 PIP_CONSTRAINT="" pip install --no-cache-dir \
     "cuda-core==${CUDA_CORE_VERSION}" \
     "cuda-bindings==${CUDA_BINDINGS_VERSION}"
+
+# Put the wheel's libnccl AHEAD of any system copy. Installing the 2.30.7 wheel
+# is not enough: NGC images ship /usr/lib/<triple>/libnccl.so.2.30.4, the linker
+# finds it first, and torch loads it before flashinfer is imported. Since
+# nccl-extensions 0.1.0, libnccl_ep is built against 2.30.7 and hard-refuses an
+# older runtime ("NCCL library is too old" -> ncclInvalidUsage, process abort),
+# so the older system copy silently breaks every NCCL-EP collective. nccl-ep
+# 0.1.0 tolerated 2.30.4, which is why this only began to matter with the move
+# off nccl4py. Persist it too, so later `srun`/exec shells in a saved container
+# inherit it.
+NCCL_WHEEL_LIB="$(python -c "import nvidia.nccl, os; print(os.path.join(list(nvidia.nccl.__path__)[0], 'lib'))")"
+export LD_LIBRARY_PATH="${NCCL_WHEEL_LIB}:${LD_LIBRARY_PATH:-}"
+cat > /etc/profile.d/flashinfer-nccl.sh <<EOF
+export LD_LIBRARY_PATH=${NCCL_WHEEL_LIB}:\${LD_LIBRARY_PATH:-}
+EOF
+chmod +x /etc/profile.d/flashinfer-nccl.sh
+echo "== libnccl search path pinned to ${NCCL_WHEEL_LIB} =="
+
 python -c "import nccl.ep; from nccl.core import Communicator; print('nccl.ep (nccl-extensions) + nccl.core (nccl4py) import OK')"
+
+# Assert the libnccl that actually LOADS meets libnccl_ep's build-time floor.
+# Cheap here, and far clearer than a mid-collective abort on a compute node.
+python - <<'PYEOF'
+import ctypes
+lib = ctypes.CDLL("libnccl.so.2")
+out = ctypes.c_int()
+assert lib.ncclGetVersion(ctypes.byref(out)) == 0, "ncclGetVersion failed"
+code = out.value
+got = (code // 10000, (code // 100) % 100, code % 100)
+print("loaded libnccl version:", ".".join(map(str, got)))
+assert got >= (2, 30, 7), (
+    f"loaded libnccl {got} < 2.30.7 required by nccl-extensions' libnccl_ep; "
+    "a system libnccl is shadowing the wheel (check LD_LIBRARY_PATH)"
+)
+PYEOF
 
 echo "== install DeepGEMM + NVSHMEM / CUTLASS DSL deps =="
 PIP_CONSTRAINT="" python -m pip install --no-cache-dir \

--- a/docs/design_docs/moe_ep_architecture.md
+++ b/docs/design_docs/moe_ep_architecture.md
@@ -50,7 +50,7 @@ backend packs them); the kernel backend computes on this rank's expert shard.
 
 | Backend | Config | Transport | Modes | Constraints |
 |---|---|---|---|---|
-| `nccl_ep` | `NcclEpConfig` | NCCL (nccl4py wheel) | LL `EXPERT_MAJOR` / `RANK_MAJOR`, HT `FLAT` | LL device kernel whitelists per-token row widths and caps top-k at 8 — see the runbook's "NCCL-EP low-latency device-kernel limits" |
+| `nccl_ep` | `NcclEpConfig` | NCCL (nccl-extensions wheel) | LL `EXPERT_MAJOR` / `RANK_MAJOR`, HT `FLAT` | LL device kernel whitelists per-token row widths and caps top-k at 8 — see the runbook's "NCCL-EP low-latency device-kernel limits" |
 | `nixl_ep` | `NvepConfig` | NIXL over UCX device API (GPU-initiated RDMA) | LL `EXPERT_MAJOR` only | needs `BUILD_NIXL_EP=1` (UCX v1.21+ device headers) and `BootstrapConfig.tcp_store`; `max_tokens_per_rank ≤ 1024`; hidden ∈ {2048, 2560, 3072, 4096, 5120, 6144, 7168, 8192}; handles top-k > 8 |
 
 #### Kernel backends (post-dispatch inner compute)
@@ -302,7 +302,7 @@ When `auto_bootstrap=False`: dist must be up at layer construction if `process_g
 
 Split comm backends ship native libs under `backends/split/comm/*/_libs/`. Probe with `have_nccl_ep()`, `have_nixl_ep()`, `available_backends()`. Missing libs raise `MoEEpNotBuiltError`.
 
-**Recommended build:** `docker/install/build_flashinfer_ep_pytorch.sh` builds the full NCCL-EP + Mega environment inside the NVIDIA PyTorch base image (`nvcr.io/nvidia/pytorch`): it pins the NCCL-EP runtime wheels (`nvidia-nccl-cu13`, `nccl4py`, `cuda-core`, `cuda-bindings`), installs the mega deps (DeepGEMM, NVSHMEM, CUTLASS DSL), then runs `BUILD_NIXL_EP=0 pip install --no-build-isolation -e .`. The EP backends are ON by default: NCCL-EP needs no build step (`nccl4py>=0.3.1` is a base dependency), and the NIXL-EP meson build runs best-effort unless opted out with `BUILD_NIXL_EP=0` (set `BUILD_NIXL_EP=1` to make missing build deps a hard error; `BUILD_NVEP=0` turns both backends off).
+**Recommended build:** `docker/install/build_flashinfer_ep_pytorch.sh` builds the full NCCL-EP + Mega environment inside the NVIDIA PyTorch base image (`nvcr.io/nvidia/pytorch`): it pins the NCCL-EP runtime wheels (`nvidia-nccl-cu13`, `nccl-extensions`, `nccl4py`, `cuda-core`, `cuda-bindings`), installs the mega deps (DeepGEMM, NVSHMEM, CUTLASS DSL), then runs `BUILD_NIXL_EP=0 pip install --no-build-isolation -e .`. The EP backends are ON by default: NCCL-EP needs no build step (`nccl-extensions>=0.1.0` is a base dependency; `nccl.ep` moved there out of `nccl4py` in nccl4py 0.4.1), and the NIXL-EP meson build runs best-effort unless opted out with `BUILD_NIXL_EP=0` (set `BUILD_NIXL_EP=1` to make missing build deps a hard error; `BUILD_NVEP=0` turns both backends off).
 
 ## Lifetimes
 

--- a/docs/design_docs/moe_ep_runbook.md
+++ b/docs/design_docs/moe_ep_runbook.md
@@ -37,7 +37,7 @@ srun --jobid="$SLURM_JOB_ID" \
   --pty bash -l
 
 # 3. (Re)build FlashInfer in editable mode (EP backends are on by default;
-#    NCCL-EP needs no build step — nccl4py is a base dependency)
+#    NCCL-EP needs no build step — nccl-extensions is a base dependency)
 BUILD_NIXL_EP=0 \
     pip install --no-cache-dir --no-build-isolation -e .
 ```
@@ -222,7 +222,7 @@ Notes:
 ### NCCL-EP low-latency device-kernel limits
 
 Two constraints of the `nccl.ep` LL device kernel (probed empirically on
-nccl4py 0.3.1; not enforced by `validate_fleet_params`, so they surface as
+nccl-extensions 0.1.0; not enforced by `validate_fleet_params`, so they surface as
 device-side aborts):
 
 - **Per-token row widths are whitelisted**: LL dispatch accepts bf16 rows of
@@ -670,12 +670,12 @@ first — it needs more than the backend being built:
 
 ```python
 from flashinfer.moe_ep import supports_fault_tolerance
-supports_fault_tolerance("nccl_ep")   # needs nccl4py with GroupConfig.enable_mask
+supports_fault_tolerance("nccl_ep")   # needs nccl-extensions with GroupConfig.enable_mask
                                       # AND a libnccl_ep exporting ncclEpMask*
 supports_fault_tolerance("nixl_ep")   # true whenever the backend is staged
 ```
 
-If `nccl_ep` returns False, upgrade the nccl4py wheel that ships
+If `nccl_ep` returns False, upgrade the nccl-extensions wheel that ships
 `libnccl_ep.so` and confirm it is the one actually loaded
 (`python -m nccl show_versions`). The probe never raises, and the Fleet
 constructor fails with the same diagnosis rather than waiting for a real fault.

--- a/flashinfer/moe_ep/__init__.py
+++ b/flashinfer/moe_ep/__init__.py
@@ -308,7 +308,7 @@ def supports_fault_tolerance(backend: str) -> bool:
 
     Rank masking needs more than the backend being present:
 
-    * ``nccl_ep`` also needs an nccl4py whose ``GroupConfig`` carries
+    * ``nccl_ep`` also needs an nccl-extensions whose ``GroupConfig`` carries
       ``enable_mask`` and a libnccl exporting the ``ncclEpMask*`` symbols.
       Both are feature-detected, never version-pinned.
     * ``nixl_ep``'s mask buffer is allocated unconditionally by

--- a/flashinfer/moe_ep/backends/split/comm/nccl_ep/__init__.py
+++ b/flashinfer/moe_ep/backends/split/comm/nccl_ep/__init__.py
@@ -1,11 +1,16 @@
 """NCCL-EP backend (nccl-ep-v0.1.0).
 
-As of ``nccl-ep-v0.1.0`` the backend is driven entirely by the **nccl4py**
-Python package's ``nccl.ep`` API — there is no longer an in-tree
-``libnccl_ep.so`` to dlopen or a flat ``nccl_ep`` ctypes module to import.
-The ``nccl`` package (the released ``nccl4py`` wheel, a base dependency of
-flashinfer-python) self-loads its native library; we just import ``nccl.ep``
-lazily in :mod:`.fleet` / :mod:`.handle`.
+As of ``nccl-ep-v0.1.0`` the backend is driven entirely by the ``nccl.ep``
+API — there is no longer an in-tree ``libnccl_ep.so`` to dlopen or a flat
+``nccl_ep`` ctypes module to import. ``nccl.ep`` self-loads its native
+library; we just import it lazily in :mod:`.fleet` / :mod:`.handle`.
+
+``nccl.ep`` ships in the **nccl-extensions** wheel (a base dependency of
+flashinfer-python), which installs into the same ``nccl`` namespace package
+as nccl4py. It used to ship in nccl4py itself; nccl4py 0.4.1 dropped
+``nccl/ep`` when the EP and M2N libraries moved out to
+https://github.com/NVIDIA/nccl-extensions. nccl4py is still required — and
+comes in transitively — for ``nccl.core.Communicator``.
 
 Availability is probed via :func:`flashinfer.moe_ep._probe_nccl_ep`, which checks
 that ``nccl.ep`` is importable.

--- a/flashinfer/moe_ep/backends/split/comm/nccl_ep/_mask_ffi.py
+++ b/flashinfer/moe_ep/backends/split/comm/nccl_ep/_mask_ffi.py
@@ -1,7 +1,7 @@
 """ctypes shim for NCCL-EP's fault-tolerance mask API.
 
-``nccl4py`` binds ``GroupConfig.enable_mask`` and ``timeout_ns`` (so masking
-can be switched on) but its ``Group`` class stops at ``create`` /
+``nccl-extensions`` binds ``GroupConfig.enable_mask`` and ``timeout_ns`` (so
+masking can be switched on) but its ``Group`` class stops at ``create`` /
 ``create_handle`` / ``destroy`` / ``.ptr`` — the five mask functions are not
 exposed to Python:
 
@@ -9,12 +9,12 @@ exposed to Python:
     ncclEpGetAsyncError / ncclEpErrorClear
 
 ``Group.ptr`` is the raw ``ncclEpGroup_t``, so we can call them directly until
-nccl4py catches up. Every method here tries a native ``Group`` method FIRST
+nccl-extensions catches up. Every method here tries a native ``Group`` method FIRST
 and only then falls back to ctypes, so the shim retires itself with no
 call-site churn the day those bindings land.
 
 Which library: the symbols live in **libnccl_ep.so**, not libnccl.so.2.
-nccl4py dlopens it with ``RTLD_GLOBAL`` and resolves through
+``nccl.ep`` dlopens it with ``RTLD_GLOBAL`` and resolves through
 ``dlsym(RTLD_DEFAULT, ...)``, so once ``nccl.ep`` has initialized, the symbols
 are in the process-global namespace and ``CDLL(None)`` binds *exactly* the
 library the caller's group came from. That matters: resolving a path
@@ -23,7 +23,7 @@ LD_LIBRARY_PATH disagree, and calling into it with a group created by the
 other one is undefined behaviour. Path resolution is only a fallback for
 probing before any group exists.
 
-TODO(moe_ep): drop the ctypes fallback once nccl4py binds ncclEpMask* on
+TODO(moe_ep): drop the ctypes fallback once nccl-extensions binds ncclEpMask* on
 ``nccl.ep.Group``; the native-first dispatch below already prefers it.
 """
 
@@ -65,17 +65,18 @@ _NCCL_RESULT_NAMES = {
 
 _UPGRADE_HINT = (
     "Fault tolerance needs an NCCL-EP build carrying the ncclEpMask* API "
-    "(nccl-ep >= v0.1.0 with active-mask support). Upgrade the nccl4py wheel "
-    "that ships libnccl_ep.so, and make sure it is the one actually loaded "
-    "(check `python -m nccl show_versions`)."
+    "(nccl-ep >= v0.1.0 with active-mask support). Upgrade the nccl-extensions "
+    "wheel that ships libnccl_ep.so, and make sure it is the one actually "
+    "loaded (check `python -c 'import nccl.ep; print(nccl.ep.get_lib_path(), "
+    "nccl.ep.get_lib_version())'`)."
 )
 
 
 def _resolve_libnccl_ep() -> ctypes.CDLL | None:
     """Return a handle exporting the mask symbols, or None.
 
-    Mirrors nccl4py's own resolution order so we bind the same library it
-    does. The global namespace is tried first because that is the one case
+    Mirrors nccl-extensions' own resolution order so we bind the same library
+    it does. The global namespace is tried first because that is the one case
     where the identity is *guaranteed* rather than merely likely.
     """
     # 1. Process-global namespace. If nccl.ep has initialized, its
@@ -87,14 +88,38 @@ def _resolve_libnccl_ep() -> ctypes.CDLL | None:
     except (OSError, AttributeError):
         pass
 
-    # 2. nccl4py package path (nccl/ep/lib/libnccl_ep.so), then the linker's
-    #    own search. libnccl_ep.so has NEEDED libnccl.so.2, so preload that
-    #    first exactly as the transport backend does.
+    # 2. Ask nccl.ep itself, then fall back to its package layout, then to
+    #    the linker's own search. ``get_lib_path()`` reports the library the
+    #    bindings actually loaded, which is the only answer guaranteed to
+    #    match the one a Group would come from; it raises rather than returns
+    #    None when libnccl.so.2 is missing, hence the broad except.
+    #
+    #    Layout note: since nccl-extensions 0.1.0 the bundled libraries are
+    #    split per CUDA major (nccl/ep/lib/cu{12,13}/libnccl_ep.so), whereas
+    #    nccl4py <= 0.3.x shipped a flat nccl/ep/lib/libnccl_ep.so. Probe the
+    #    CUDA-matched directory first, then the other, then the flat legacy
+    #    path. libnccl_ep.so has NEEDED libnccl.so.2, so preload that first
+    #    exactly as the transport backend does.
     candidates: list[str] = []
     try:
-        import nccl  # type: ignore[import-not-found]
+        import nccl.ep as _nccl_ep  # type: ignore[import-not-found]
 
-        candidates.append(str(Path(nccl.__path__[0]) / "ep" / "lib" / "libnccl_ep.so"))
+        with contextlib.suppress(Exception):
+            lib_path = _nccl_ep.get_lib_path()
+            if lib_path is not None:
+                candidates.append(str(lib_path))
+
+        ep_lib = Path(_nccl_ep.__path__[0]) / "lib"
+        majors = ["12", "13"]
+        with contextlib.suppress(Exception):
+            from nccl._extensions._runtime import (  # type: ignore[import-not-found]
+                cuda_major,
+            )
+
+            majors.remove(str(cuda_major()))
+            majors.insert(0, str(cuda_major()))
+        candidates += [str(ep_lib / f"cu{m}" / "libnccl_ep.so") for m in majors]
+        candidates.append(str(ep_lib / "libnccl_ep.so"))
     except Exception:
         pass
     conda = os.environ.get("CONDA_PREFIX")
@@ -176,7 +201,7 @@ class _MaskFfi:
 
     # ------------------------------------------------------- public wrappers
     #
-    # Each prefers a native nccl4py Group method when one exists, so this
+    # Each prefers a native nccl.ep Group method when one exists, so this
     # module becomes dead weight (not a blocker) once those land.
 
     def mask_query(self, group, dev_ptr: int, stream: int) -> None:

--- a/flashinfer/moe_ep/backends/split/comm/nccl_ep/fleet.py
+++ b/flashinfer/moe_ep/backends/split/comm/nccl_ep/fleet.py
@@ -58,7 +58,7 @@ NCCL_EP_AUTO = 0
 # (``nccl/ep/include/nccl_ep/common.hpp``: ``#define MAX_SUPPORTED_TOKENS_PER_RANK
 # 8192``). We mirror it here to *clamp* the HT dispatch budget (graceful) rather
 # than let a large caller value (e.g. vLLM ``max_num_batched_tokens``) hit the C++
-# assert. LL has no such cap. Kept in sync with the nccl4py wheel.
+# assert. LL has no such cap. Kept in sync with the nccl-extensions wheel.
 _HT_MAX_SUPPORTED_TOKENS_PER_RANK = 8192
 
 
@@ -100,8 +100,10 @@ def _import_nccl_ep():
     except ImportError as e:  # pragma: no cover
         raise MoEEpNotBuiltError(
             "nccl.ep (nccl-ep-v0.1.0) python package unavailable. It ships in "
-            "the nccl4py wheel, a base dependency of flashinfer-python — "
-            "install with `pip install 'nccl4py>=0.3.1'`."
+            "the nccl-extensions wheel, a base dependency of flashinfer-python "
+            "— install with `pip install 'nccl-extensions>=0.1.0'`. NOTE: "
+            "nccl.ep used to ship in nccl4py; it moved out in nccl4py 0.4.1, "
+            "so an environment pinned to nccl4py alone no longer provides it."
         ) from e
 
 
@@ -310,8 +312,8 @@ class NcclEpFleet(FaultToleranceMixin, Fleet):
         if names is not None and "enable_mask" not in names:
             raise MoEEpFaultToleranceUnsupportedError(
                 "nccl.ep.GroupConfig has no `enable_mask` field: the installed "
-                "nccl4py predates EP fault tolerance. Upgrade the nccl4py wheel, "
-                "or drop FleetAlgoKnobFaultTolerance."
+                "nccl-extensions predates EP fault tolerance. Upgrade the "
+                "nccl-extensions wheel, or drop FleetAlgoKnobFaultTolerance."
             )
         ffi = mask_ffi()
         if not ffi.available:

--- a/flashinfer/moe_ep/core/validation/common.py
+++ b/flashinfer/moe_ep/core/validation/common.py
@@ -174,8 +174,10 @@ def validate_arch_for_backend(backend: str) -> None:
     """Check the GPU arch and CUDA version are supported by `backend`."""
     import torch
 
-    # The EP runtime wheels (nccl4py, nvidia-nccl-cu13, nixl-cu13) are
-    # CUDA-13-only, so a torch built for CUDA 12 can't drive either backend —
+    # The EP runtime stack is CUDA-13-only here: nvidia-nccl-cu13 and
+    # nixl-cu13 ship CUDA-13 binaries only. (nccl-extensions itself bundles
+    # both cu12 and cu13 libnccl_ep.so, but the rest of the stack does not.)
+    # So a torch built for CUDA 12 can't drive either backend —
     # fail here with a clear message instead of a cryptic dlopen error later.
     # Parse defensively: custom/nightly torch builds can carry version
     # strings this check shouldn't crash on; skip it when unparseable.
@@ -186,8 +188,8 @@ def validate_arch_for_backend(backend: str) -> None:
         cuda_major = None
     if cuda_major is not None and cuda_major < 13:
         raise MoEEpConfigError(
-            f"{backend} requires CUDA 13: the EP runtime wheels (nccl4py, "
-            f"nvidia-nccl-cu13, nixl-cu13) ship CUDA-13 binaries only, but "
+            f"{backend} requires CUDA 13: the EP runtime wheels "
+            f"(nvidia-nccl-cu13, nixl-cu13) ship CUDA-13 binaries only, but "
             f"the installed torch was built for CUDA {cuda_ver}. Install a "
             "CUDA-13 torch build to use flashinfer.moe_ep."
         )

--- a/flashinfer/moe_ep/core/validation/common.py
+++ b/flashinfer/moe_ep/core/validation/common.py
@@ -140,21 +140,27 @@ def validate_split_forward_inputs(
 
 
 def _installed_nccl_version() -> "tuple[int, int, int] | None":
-    """Best-effort probe of the NCCL version the EP backend will load.
+    """Best-effort probe of the NCCL version the EP backend will actually load.
 
-    Prefers the nvidia-nccl-cu13 pip wheel's metadata (cuda-pathfinder loads
-    that wheel's libnccl first when present); falls back to ncclGetVersion on
-    the dynamic linker's default search path (covers NGC-style images with a
-    system NCCL and no pip wheel). Returns None when undeterminable — callers
-    must not block in that case.
+    Asks the *loaded* library first (``ncclGetVersion`` through the dynamic
+    linker), and only falls back to the nvidia-nccl-cu13 wheel's metadata when
+    no libnccl can be opened. Returns None when undeterminable — callers must
+    not block in that case.
+
+    Order matters, and this used to be the other way round. Installing the
+    wheel does NOT guarantee it is the copy that loads: NGC-style images ship a
+    system libnccl (e.g. /usr/lib/<triple>/libnccl.so.2.30.4) that the linker
+    finds first, and torch pulls it in before flashinfer is even imported, so
+    the later RTLD_GLOBAL preload in the nccl_ep backend cannot displace it.
+    Trusting the metadata there reports a version that is merely *installed*,
+    passes the Blackwell floor below, and then libnccl_ep — which since
+    nccl-extensions 0.1.0 is built against 2.30.7 and refuses anything older —
+    prints "NCCL library is too old" and aborts the process with
+    ncclInvalidUsage before any Python exception can be raised. Probing the
+    loaded library turns that into the actionable error below. Put the wheel's
+    lib dir ahead of the system one on LD_LIBRARY_PATH to fix the environment
+    (docker/install/build_flashinfer_ep_pytorch.sh does this).
     """
-    try:
-        from importlib.metadata import version
-
-        parts = version("nvidia-nccl-cu13").split(".")[:3]
-        return tuple(int(p) for p in parts)  # type: ignore[return-value]
-    except Exception:
-        pass
     try:
         import ctypes
 
@@ -165,6 +171,13 @@ def _installed_nccl_version() -> "tuple[int, int, int] | None":
             # (e.g. 2.30.7 -> 23007).
             code = out.value
             return (code // 10000, (code // 100) % 100, code % 100)
+    except Exception:
+        pass
+    try:
+        from importlib.metadata import version
+
+        parts = version("nvidia-nccl-cu13").split(".")[:3]
+        return tuple(int(p) for p in parts)  # type: ignore[return-value]
     except Exception:
         pass
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ license-files = ["LICENSE", "LICENSE*.txt"]
 cu12 = ["nvidia-cutlass-dsl>=4.7.0a0"]
 cu13 = ["nvidia-cutlass-dsl[cu13]>=4.7.0a0"]
 # DEPRECATED alias, kept so existing `pip install ".[nvep]"` commands keep
-# working. The moe_ep runtime deps (cuda-python, nccl4py) are now part of the
+# working. The moe_ep runtime deps (cuda-python, nccl-extensions) are now part of the
 # BASE dependencies (requirements.txt) and the NIXL-EP submodule build runs by
 # default (best-effort) on `pip install .` — see the moe_ep section at the top
 # of build_backend.py. libnccl comes from torch's own nvidia-nccl-cu13 pin;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,25 @@
 apache-tvm-ffi>=0.1.6,!=0.1.8,!=0.1.8.post0,<0.2
 click
-# cuda-python + nccl4py: runtime deps for the moe_ep EP transport backends
-# (default since the EP install became opt-out; CUDA-13 wheels only — see
-# build_backend.py). NCCL-EP is the released nccl4py wheel (`nccl.ep` API +
-# bundled libnccl_ep.so); no in-tree NCCL build.
+# cuda-python + nccl-extensions: runtime deps for the moe_ep EP transport
+# backends (default since the EP install became opt-out; CUDA-13 wheels only
+# — see build_backend.py). NCCL-EP is the released nccl-extensions wheel
+# (`nccl.ep` API + bundled libnccl_ep.so); no in-tree NCCL build.
+#
+# nccl.ep MOVED: it used to ship inside nccl4py, but the EP/M2N libraries were
+# split out to https://github.com/NVIDIA/nccl-extensions and nccl4py 0.4.1
+# dropped `nccl/ep` entirely. Depending on nccl4py alone therefore resolves to
+# a wheel with no nccl.ep at all. Both distributions install into the shared
+# `nccl` namespace package: nccl4py owns nccl/core + nccl/bindings (we still
+# need `nccl.core.Communicator`, and nccl-extensions pulls it in transitively),
+# nccl-extensions owns nccl/ep + nccl/m2n + nccl/_extensions. The explicit
+# nccl4py>=0.4.1 floor is a *conflict* guard, not a feature floor: nccl4py
+# 0.3.1 still shipped its own nccl/ep into that same namespace directory, so
+# co-installing it with nccl-extensions overwrites files and yields an
+# ambiguous nccl.ep.
+#
+# The nccl-extensions cu12/cu13 extras are deliberately NOT used here: they
+# pin nvidia-nccl-cuXX==2.30.7 exactly, which trips the torch-eviction problem
+# described below. Plain `nccl-extensions` pulls no nvidia-nccl wheel.
 #
 # nvidia-nccl-cu13 is deliberately NOT a base dep: torch's cu13 wheels pin it
 # EXACTLY (e.g. ==2.29.7), so any floor here (>=2.30.7 for B200 EP) makes the
@@ -25,7 +41,8 @@ click
 cuda-python>=12.0
 cuda-tile>=1.4.0
 einops
-nccl4py>=0.3.1
+nccl-extensions>=0.1.0
+nccl4py>=0.4.1
 ninja
 numpy
 nvidia-cudnn-frontend>=1.25.0

--- a/scripts/build_in_container.sh
+++ b/scripts/build_in_container.sh
@@ -114,7 +114,7 @@ uv pip install --python "${VENV}/bin/python" \
 
 # NIXL-EP runtime base library — supplied by this pip wheel; the NIXL-EP
 # plugin loads libnixl.so from it at first use. (NCCL-EP's base libnccl.so.2 +
-# libnccl_ep.so come from the nccl4py wheel installed below.)
+# libnccl_ep.so come from the nccl-extensions wheel installed below.)
 uv pip install --python "${VENV}/bin/python" --no-deps \
     "nixl-cu13>=1.0.1"
 
@@ -124,9 +124,12 @@ uv pip install --python "${VENV}/bin/python" --no-deps \
 # Why: torch 2.12's `cuda-toolkit[nvjitlink]` metapackage pin trips uv's
 # resolver during the editable `-e .` resolution (nvidia-nvjitlink METADATA
 # mismatch). Installing the leaf deps first + `--no-deps -e .` sidesteps that.
-# nccl4py>=0.3.1 = NCCL-EP (nccl.ep + bundled libnccl_ep.so); cuda-python and
-# nccl4py's cuda.core/cuda-bindings come along here. Use the project's CUDA
-# extra dependency floor for this runtime environment.
+# nccl-extensions>=0.1.0 = NCCL-EP (nccl.ep + bundled libnccl_ep.so). nccl.ep
+# moved out of nccl4py in 0.4.1, so nccl4py alone no longer provides it; we
+# still need nccl4py>=0.4.1 for nccl.core.Communicator (it comes in
+# transitively, pinned here only to exclude the 0.3.1 that also shipped
+# nccl/ep). cuda-python and cuda.core/cuda-bindings come along here. Use the
+# project's CUDA extra dependency floor for this runtime environment.
 CUDA_EXTRA_DEPENDENCY_OUTPUT="$(
     PYTHONPATH="${REPO_ROOT}" "${VENV}/bin/python" -c \
         'from build_utils import get_cuda_extra_dependency_requirements; print(*get_cuda_extra_dependency_requirements("13"), sep="\n")'
@@ -138,7 +141,8 @@ fi
 uv pip install --python "${VENV}/bin/python" \
     numpy einops ninja nvidia-ml-py click requests tabulate tqdm \
     "${CUDA_EXTRA_DEPENDENCIES[@]}" "nvidia-cudnn-frontend>=1.13.0" \
-    "cuda-tile>=1.4.0" "cuda-python>=13.0" "nccl4py>=0.3.1" \
+    "cuda-tile>=1.4.0" "cuda-python>=13.0" \
+    "nccl-extensions>=0.1.0" "nccl4py>=0.4.1" \
     "nvidia-nccl-cu13>=2.30.7"   # B200 NCCL-EP needs >=2.30.7; load this first on LD_LIBRARY_PATH
 
 # ---- 6. FlashInfer + both EP backends -------------------------------------
@@ -170,7 +174,7 @@ rm -rf "${REPO_ROOT}/build_nvep/nixl" "${REPO_ROOT}/build_nvep/nccl"
 echo "=== building flashinfer + NIXL-EP (this is the long step) ==="
 cd "${REPO_ROOT}"
 # Build flashinfer + compile NIXL-EP from the submodule. --no-deps because all
-# runtime deps (incl. nccl4py for NCCL-EP) were installed above; this avoids the
+# runtime deps (incl. nccl-extensions for NCCL-EP) were installed above; this avoids the
 # torch/cuda-toolkit nvjitlink resolution conflict under uv.
 BUILD_NIXL_EP=1 \
     uv pip install --python "${VENV}/bin/python" \

--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -705,6 +705,7 @@ def _runtime_version_line() -> str:
         ("cuda-tile", _package_version("cuda-tile")),
         ("cuDNN-frontend", _package_version("nvidia-cudnn-frontend")),
         ("triton", _package_version("triton")),
+        ("nccl-extensions", _package_version("nccl-extensions")),
         ("nccl4py", _package_version("nccl4py")),
     ]
     return " ".join(f"{name}={version}" for name, version in versions)

--- a/tests/moe_ep/nccl_ep/conftest.py
+++ b/tests/moe_ep/nccl_ep/conftest.py
@@ -3,7 +3,7 @@
 ``fake_nccl_ep`` injects a recording stand-in for the whole ``nccl`` package
 tree (``nccl.ep``, ``nccl.core``, ``nccl.ep.interop.torch``) into
 ``sys.modules`` so fleet/handle marshaling and the host-path caching layer can
-be exercised without a GPU, RDMA fabric, or the nccl4py wheel.
+be exercised without a GPU, RDMA fabric, or the nccl-extensions wheel.
 """
 
 from __future__ import annotations

--- a/tests/moe_ep/nccl_ep/test_handle_mock.py
+++ b/tests/moe_ep/nccl_ep/test_handle_mock.py
@@ -8,7 +8,7 @@ cross-handle recv-buffer reuse, cache invalidation on dtype change and
 
 Everything runs on CPU tensors against the fake ``nccl.ep`` from
 ``conftest.py`` — the fake handle records calls instead of communicating, so
-no GPU or nccl4py wheel is needed.
+no GPU or nccl-extensions wheel is needed.
 """
 
 from __future__ import annotations

--- a/tests/moe_ep/nccl_ep/test_mask_ffi.py
+++ b/tests/moe_ep/nccl_ep/test_mask_ffi.py
@@ -155,7 +155,7 @@ class TestErrorMapping:
         with pytest.raises(MoEEpFaultToleranceUnsupportedError) as ei:
             ffi.mask_clean(_FakeGroup(), 0x2)
         assert "ncclEpMaskClean" in str(ei.value)
-        assert "nccl4py" in str(ei.value)
+        assert "nccl-extensions" in str(ei.value)
 
     def test_result_names_cover_the_nccl_enum(self):
         assert _NCCL_RESULT_NAMES[0] == "ncclSuccess"

--- a/tests/moe_ep/smoke_nccl_ep.py
+++ b/tests/moe_ep/smoke_nccl_ep.py
@@ -10,7 +10,7 @@ softmax-normalized topk_weights, the output approximates the input within
 bf16 tolerance.
 
 Requires ``nccl.ep``, which is available by default: it ships in the
-``nccl4py`` wheel, a base dependency of flashinfer-python (a plain
+``nccl-extensions`` wheel, a base dependency of flashinfer-python (a plain
 ``pip install -e .`` is enough).
 """
 

--- a/tests/moe_ep/test_arch_and_build.py
+++ b/tests/moe_ep/test_arch_and_build.py
@@ -207,8 +207,42 @@ def test_nccl_floor_not_checked_on_hopper_or_for_nixl():
         validate_arch_for_backend("nixl_ep")
 
 
-def test_installed_nccl_version_prefers_wheel_metadata():
+def _fake_loaded_libnccl(code):
+    """A ctypes.CDLL stand-in whose ncclGetVersion reports ``code``."""
+    lib = mock.MagicMock()
+
+    def _get_version(ptr):
+        ptr._obj.value = code
+        return 0
+
+    lib.ncclGetVersion.side_effect = _get_version
+    return mock.patch("ctypes.CDLL", return_value=lib)
+
+
+def test_installed_nccl_version_prefers_the_loaded_library():
+    """The library that actually loads wins over the wheel's metadata.
+
+    Regression guard: NGC images ship a system libnccl that the linker finds
+    ahead of the nvidia-nccl-cu13 wheel, so metadata reports a version that is
+    merely installed. Trusting it let the Blackwell floor pass while
+    libnccl_ep (built against 2.30.7 since nccl-extensions 0.1.0) aborted the
+    process with "NCCL library is too old".
+    """
     from flashinfer.moe_ep.core.validation import common
 
-    with mock.patch("importlib.metadata.version", return_value="2.30.7"):
+    with (
+        _fake_loaded_libnccl(23004),  # 2.30.4 actually loaded
+        mock.patch("importlib.metadata.version", return_value="2.30.7"),
+    ):
+        assert common._installed_nccl_version() == (2, 30, 4)
+
+
+def test_installed_nccl_version_falls_back_to_metadata():
+    """No openable libnccl -> the wheel's metadata is the only signal left."""
+    from flashinfer.moe_ep.core.validation import common
+
+    with (
+        mock.patch("ctypes.CDLL", side_effect=OSError("no libnccl")),
+        mock.patch("importlib.metadata.version", return_value="2.30.7"),
+    ):
         assert common._installed_nccl_version() == (2, 30, 7)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the `nccl-extensions` package as the provider of NCCL-EP functionality.
  - Improved runtime library selection across CUDA environments and ensured the correct NCCL library version is loaded.
  - Added NCCL-EP package version reporting.

- **Bug Fixes**
  - NCCL version checks now prioritize the actively loaded library, with metadata fallback when unavailable.
  - Updated container builds and installation scripts to use compatible NCCL-EP packages and runtime libraries.

- **Documentation**
  - Updated setup guidance, dependency references, architecture notes, and troubleshooting messages to reflect the new package split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->