### PR TITLE
fix(kda): compile direct serving modules as C++20

### DIFF
--- a/flashinfer/jit/flash_kda.py
+++ b/flashinfer/jit/flash_kda.py
@@ -751,6 +751,7 @@ def gen_flash_kda_generated_module(variant_id: str) -> JitSpec:
             *embedded_flags,
             *(
                 [
+                    "-std=c++20",
                     "-DFLASHKDA_GENERATED_DIRECT_SOURCE_ABI=1",
                     "-UPy_LIMITED_API",
                 ]

--- a/tests/jit/test_flash_kda_training_jit.py
+++ b/tests/jit/test_flash_kda_training_jit.py
@@ -18,12 +18,15 @@ def _kernel_symbols(source: str) -> set[str]:
     return set(re.findall(r"kernel_flashkda_[A-Za-z0-9_]+", source))
 
 
-def test_flash_kda_generated_direct_serving_uses_cxx20(monkeypatch):
+@pytest.mark.parametrize("target", ["sm100a", "sm103a"])
+def test_flash_kda_generated_direct_serving_uses_cxx20(monkeypatch, target):
     monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
     variant_id = next(
         variant_id
         for variant_id, module in flash_kda.get_flash_kda_generated_registry().items()
-        if module.abi_family == "direct_m128" and module.abi_variant == "serving"
+        if module.target == target
+        and module.abi_family == "direct_m128"
+        and module.abi_variant == "serving"
     )
 
     flash_kda.gen_flash_kda_generated_module.cache_clear()

--- a/tests/jit/test_flash_kda_training_jit.py
+++ b/tests/jit/test_flash_kda_training_jit.py
@@ -11,11 +11,26 @@ import re
 
 import pytest
 
-from flashinfer.jit import flash_kda, flash_kda_training
+from flashinfer.jit import core, flash_kda, flash_kda_training
 
 
 def _kernel_symbols(source: str) -> set[str]:
     return set(re.findall(r"kernel_flashkda_[A-Za-z0-9_]+", source))
+
+
+def test_flash_kda_generated_direct_serving_uses_cxx20(monkeypatch):
+    monkeypatch.setattr(core, "check_cuda_arch", lambda: None)
+    variant_id = next(
+        variant_id
+        for variant_id, module in flash_kda.get_flash_kda_generated_registry().items()
+        if module.abi_family == "direct_m128" and module.abi_variant == "serving"
+    )
+
+    flash_kda.gen_flash_kda_generated_module.cache_clear()
+    spec = flash_kda.gen_flash_kda_generated_module(variant_id)
+
+    assert "-std=c++20" in spec.extra_cuda_cflags
+    assert "-std=c++17" not in spec.extra_cuda_cflags
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## 📌 Description

Generated FlashKDA direct-M128 serving modules include ATen headers. PyTorch 2.14 requires C++20, while the shared JIT helper defaults to C++17. This adds an explicit standard only to direct serving specs, so unrelated modules retain C++17.

## 🔍 Related Issues

Fixes #4995.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit`.
- [x] I have installed the hooks.
- [x] I have run `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

The focused regression passes locally. The full CUDA 13 and PyTorch 2.14 JIT-cache build requires project CI.

## 🔬 Experimental Track

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported; the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature test, in every matrix cell.
```

## Reviewer Notes

Please verify the generated direct-NVRTC modules against PyTorch 2.14 in the scheduled JIT-cache environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated FlashKDA direct-serving modules to compile with the C++20 standard, improving compatibility with supported builds.

* **Tests**
  * Expanded validation of generated direct-serving modules to cover both `sm100a` and `sm103a` targets.
  * Verified that each target selects and validates its matching generated variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->