### PR TITLE
feat(kda): support graph-safe CuTe DSL prefix checkpoints

### DIFF
--- a/docs/api/kda_prefill.rst
+++ b/docs/api/kda_prefill.rst
@@ -153,16 +153,16 @@ performs both launch plans before enqueueing either kernel so the dependent
 launches do not expose a Python/FFI inter-kernel gap. CUDA Graph capture still
 records the same two kernels and preserves the workspace contract below.
 
-For eager packed CuTe DSL engine calls, omitting ``seq_order`` builds and
-caches a stable decreasing-length order on the host. CuTe DSL decomp retains
-the original sequence order because its CTA grid fits in one wave.
-``flashinfer.RecurrentKDAPrefillWrapper`` provides the explicit planned path
-needed for packed engine CUDA Graph capture: ``plan`` builds the order and the
-decomp ``cu_chunks`` prefix, then ``run`` consumes fixed-address buffers. The
-decomp prep kernel binary-searches this compact prefix instead of carrying a
-dense chunk-to-sequence tensor. The number of sequences, total tokens, and
-total BT=16 chunks are fixed by the first plan so the metadata and launch
-geometry remain valid across CUDA Graph replays.
+For packed CuTe DSL engine calls, omitting ``seq_order`` generates a stable
+decreasing-length order on the device. CuTe DSL decomp retains the original
+sequence order in the eager path because its CTA grid fits in one wave.
+``flashinfer.RecurrentKDAPrefillWrapper`` provides fixed-address metadata for
+CUDA Graph capture: ``plan`` only copies packed offsets into its device buffer,
+while a captured GPU prepass generates the order and decomp ``cu_chunks``
+prefix before the recurrent kernels run. The decomp prep kernel binary-searches
+this compact prefix instead of carrying a dense chunk-to-sequence tensor. Its
+workspace and launch use a graph-static chunk capacity derived from tensor
+shapes, while the GPU prefix supplies the actual chunk count on each replay.
 
 State and graph semantics
 -------------------------

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -79,6 +79,7 @@ def recurrent_kda(
     state_checkpoints: Optional[torch.Tensor] = None,
     checkpoint_cu_starts: Optional[torch.Tensor] = None,
     checkpoint_every_n_tokens: int = 0,
+    checkpoint_state_indices: Optional[torch.Tensor] = None,
     *,
     disable_state_update: bool = False,
     correction_cache: Optional[torch.Tensor] = None,
@@ -242,19 +243,25 @@ def recurrent_kda(
             eager-only B200/GB200 route because its bins depend on host-visible
             sequence lengths.
         state_checkpoints (Optional[torch.Tensor]):
-            Caller-owned checkpoint output ``[C, H, 128, 128]`` for frozen
-            prefill. CuTe DSL accepts BF16 or FP32 and requires it to match
-            ``initial_state`` when present; Cake accepts BF16. Row zero for
-            each sequence is its initial state; later rows are the states
-            before token blocks beginning at ``N, 2N, ...``. ``C`` must be at
-            least ``checkpoint_cu_starts[N_seq]``; this capacity contract is
-            not host-validated. Required when
-            ``checkpoint_every_n_tokens > 0``.
+            Checkpoint output or pool ``[C, H, 128, 128]`` for prefill. CuTe DSL
+            accepts BF16 or FP32 and requires it to match ``initial_state`` when
+            present; Cake accepts BF16. Without ``checkpoint_state_indices``,
+            row zero for each sequence is its initial state and later rows are
+            states before token blocks beginning at ``N, 2N, ...``. CuTe DSL
+            allocates this packed output during eager execution when omitted;
+            CUDA graph capture requires a caller-owned tensor.
         checkpoint_cu_starts (Optional[torch.Tensor]):
             Contiguous CUDA int64 cumulative checkpoint counts ``[N_seq+1]``.
-            The first value must be zero, and each consecutive difference must
-            equal ``ceil(seq_len / checkpoint_every_n_tokens)`` for that
-            sequence.
+            The first value must be zero. Without ``checkpoint_state_indices``,
+            each difference is ``ceil(seq_len / N)``. With indices, each
+            difference is ``floor(seq_len / N)`` and counts completed periodic
+            boundaries, including an aligned final boundary and excluding the
+            initial state.
+        checkpoint_state_indices (Optional[torch.Tensor]):
+            CuTe DSL-only contiguous CUDA int32 destination rows. Entry ``i``
+            selects the row of the ``state_checkpoints`` pool written for packed
+            completed-boundary entry ``i``. The kernel writes the pool directly;
+            no temporary checkpoint tensor or scatter is used.
         checkpoint_every_n_tokens (int):
             Checkpoint interval. Zero disables checkpoints; a positive value
             must be divisible by 32, except that the SM100-family exact-N16
@@ -288,11 +295,13 @@ def recurrent_kda(
         raise ValueError(
             f"backend must be 'auto', 'cute-dsl', or 'cake', got {backend!r}"
         )
+    if checkpoint_state_indices is not None and backend == "cake":
+        raise ValueError("checkpoint_state_indices is supported only by CuTe DSL")
 
     # SM120 is an architecture-specific CuTe DSL implementation. Try it before
     # the SM100-family CuTe DSL path, whose eligibility check rejects SM120.
     sm120_rejection: Optional[str] = None
-    if backend in ("auto", "cute-dsl"):
+    if backend in ("auto", "cute-dsl") and checkpoint_state_indices is None:
         sm120_prefill_kwargs = dict(
             q=q,
             k=k,
@@ -386,6 +395,7 @@ def recurrent_kda(
             or prefill_workspace is not None
             or state_checkpoints is not None
             or checkpoint_cu_starts is not None
+            or checkpoint_state_indices is not None
             or checkpoint_every_n_tokens != 0
         ):
             raise ValueError(
@@ -495,6 +505,7 @@ def recurrent_kda(
             beta_is_logit=beta_is_logit,
             state_checkpoints=state_checkpoints,
             checkpoint_cu_starts=checkpoint_cu_starts,
+            checkpoint_state_indices=checkpoint_state_indices,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
         )
         if backend == "cute-dsl" and not cute_dsl_eligible:
@@ -534,6 +545,7 @@ def recurrent_kda(
                 state_indices=ssm_state_indices,
                 state_checkpoints=state_checkpoints,
                 checkpoint_cu_starts=checkpoint_cu_starts,
+                checkpoint_state_indices=checkpoint_state_indices,
                 checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             )
 
@@ -548,6 +560,7 @@ def recurrent_kda(
             )
         )
         and backend != "cute-dsl"
+        and checkpoint_state_indices is None
         and _kda_prefill._flash_kda_prefill_is_eligible(
             q=q,
             k=k,
@@ -619,6 +632,7 @@ def recurrent_kda(
         checkpoint_every_n_tokens != 0
         or state_checkpoints is not None
         or checkpoint_cu_starts is not None
+        or checkpoint_state_indices is not None
     ):
         raise ValueError(
             "state checkpoints are supported only by eligible frozen "
@@ -829,6 +843,7 @@ class RecurrentKDAPrefillWrapper:
         state_checkpoints: Optional[torch.Tensor] = None,
         checkpoint_cu_starts: Optional[torch.Tensor] = None,
         checkpoint_every_n_tokens: int = 0,
+        checkpoint_state_indices: Optional[torch.Tensor] = None,
         ssm_state_indices: Optional[torch.Tensor] = None,
     ) -> (
         tuple[torch.Tensor, Optional[torch.Tensor]]
@@ -871,6 +886,7 @@ class RecurrentKDAPrefillWrapper:
             prefill_workspace=self._workspace,
             state_checkpoints=state_checkpoints,
             checkpoint_cu_starts=checkpoint_cu_starts,
+            checkpoint_state_indices=checkpoint_state_indices,
             checkpoint_every_n_tokens=checkpoint_every_n_tokens,
             backend="cute-dsl",
         )

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -169,14 +169,13 @@ def recurrent_kda(
             int64 outside graph capture; graph capture requires caller-provided
             int64 offsets. For frozen prefill, values must start at zero, be
             non-decreasing, and end at the total token count. This value
-            contract is not normally host-validated. Eager calls without an
-            explicit workspace or ``seq_order`` read these values once per
-            unchanged offsets tensor to schedule longer sequences first on
-            Cake. Eager packed CuTe DSL engine calls also cache a
-            longest-sequence-first order; CuTe DSL decomp calls retain the
-            original order because their CTA grid fits in one wave. Eligible
-            148-SM B200 and 152-SM GB200 Cake calls additionally cache
-            persistent worker task bins.
+            contract is not normally host-validated. Cake may read these values
+            to prepare and cache host scheduling metadata. CuTe DSL generates
+            packed sequence ordering on the device and can generate decomposed
+            chunk metadata there when using
+            :class:`RecurrentKDAPrefillWrapper`. Eligible 148-SM B200 and
+            152-SM GB200 Cake calls additionally cache persistent worker task
+            bins.
         ssm_state_indices (Optional[torch.Tensor]):
             State cache indices. Shape ``[N]`` int32 for standard decode, or
             ``[N, 1+S]`` int32 for spec decode (``num_spec_tokens`` must also
@@ -221,16 +220,14 @@ def recurrent_kda(
             cache ``[num_slots, HV, T_max, 2*K]``.
         seq_order (Optional[torch.Tensor]):
             Optional packed-prefill sequence order, as a contiguous CUDA int32
-            permutation of shape ``[N]``. For eager CuTe DSL packed engine
-            calls, omitting it builds and caches a longest-sequence-first order;
-            CuTe DSL decomp keeps the original order because its CTA grid fits
-            in one wave. CUDA Graph capture of a packed CuTe DSL engine call
-            requires an explicit plan prepared with
-            :class:`RecurrentKDAPrefillWrapper`. Cake constructs and caches its
-            own eager host metadata. On Cake, supplying an order disables
-            persistent host task-bin planning but does not force direct M128;
-            the selected non-persistent route may still be BT16 prepare/chain,
-            M64, small-BH, or direct according to the input shape.
+            permutation of shape ``[N]``. CuTe DSL packed engine calls generate
+            a stable longest-sequence-first order on the device when this is
+            omitted; CuTe DSL decomp keeps the original order unless the graph
+            wrapper requests device-generated metadata. Cake constructs and
+            caches its own eager host metadata. On Cake, supplying an order
+            disables persistent host task-bin planning but does not force direct
+            M128; the selected non-persistent route may still be BT16
+            prepare/chain, M64, small-BH, or direct according to the input shape.
             Fixed-layout prefill and decode calls must leave it as ``None``.
         prefill_workspace (Optional[RecurrentKDAPrefillWorkspace]):
             Caller-owned workspace for SM100-family and SM120 prefill backends.
@@ -686,16 +683,15 @@ class RecurrentKDAPrefillWrapper:
     supports neither, so a CC 12.0 caller should use
     :func:`flashinfer.kda.recurrent_kda` directly.
 
-    ``plan`` runs outside CUDA Graph capture.  It reads ``cu_seqlens`` on the
-    host, builds a stable descending-length sequence order and cumulative chunk
-    prefix, and copies them into fixed-address device buffers.  ``run`` consumes
-    those buffers through :func:`recurrent_kda` as an explicit host plan.
+    ``plan`` runs outside CUDA Graph capture and copies ``cu_seqlens`` into a
+    fixed-address device buffer without reading its values on the host. ``run``
+    generates the stable descending-length sequence order and cumulative chunk
+    prefix on the GPU before the recurrent kernels consume them.
 
-    The number of sequences, total token count, and total BT=16 chunk count are
-    fixed by the first ``plan`` call so device buffer addresses, workspace
-    capacity, and captured launch geometry remain valid across CUDA Graph
-    replays.  Call ``plan`` again before replay to update individual lengths,
-    order, and chunk metadata in place when those totals remain unchanged.
+    The number of sequences and packed token tensor extent are fixed after the
+    first warmup run so device buffer addresses, workspace capacity, and launch
+    geometry remain valid across CUDA Graph replays. Call ``plan`` again before
+    replay to update individual lengths in place.
 
     This wrapper is specific to the CuTe DSL backend and intentionally uses
     its non-persistent schedule. One wrapper instance is a single-writer
@@ -718,7 +714,7 @@ class RecurrentKDAPrefillWrapper:
         self._cu_chunks_buf: Optional[torch.Tensor] = None
         self._num_sequences: Optional[int] = None
         self._total_tokens: Optional[int] = None
-        self._total_chunks: Optional[int] = None
+        self._planned = False
         self._lock = threading.Lock()
 
     def plan(
@@ -730,11 +726,9 @@ class RecurrentKDAPrefillWrapper:
         """Plan a packed prefill sequence order outside CUDA Graph capture.
 
         ``cu_seqlens`` may reside on CPU or on this wrapper's CUDA device and
-        may use int32 or int64 storage.  Device input is copied to the host for
-        validation and sorting.  The resulting metadata is then copied into
-        stable int64/int32 CUDA buffers owned by the wrapper. Repeated offsets
-        represent zero-length sequences and are retained in the sequence plan
-        with zero chunks.
+        may use int32 or int64 storage. Its values are copied into a stable
+        int64 CUDA buffer; GPU metadata generation during ``run`` handles
+        repeated offsets for zero-length sequences.
         """
 
         if torch.cuda.is_current_stream_capturing():
@@ -758,25 +752,7 @@ class RecurrentKDAPrefillWrapper:
                 f"cu_seqlens must be on {self.device} or CPU, got {cu_seqlens.device}"
             )
 
-        offsets = tuple(int(value) for value in cu_seqlens.to("cpu").tolist())
-        if offsets[0] != 0 or any(
-            right < left for left, right in zip(offsets, offsets[1:], strict=False)
-        ):
-            raise ValueError("cu_seqlens must start at zero and be non-decreasing")
-        num_sequences = len(offsets) - 1
-        sequence_order = sorted(
-            range(num_sequences),
-            key=lambda index: offsets[index + 1] - offsets[index],
-            reverse=True,
-        )
-        chunk_counts = [
-            (offsets[index + 1] - offsets[index] + 15) // 16
-            for index in range(num_sequences)
-        ]
-        cu_chunks = [0]
-        for count in chunk_counts:
-            cu_chunks.append(cu_chunks[-1] + count)
-        total_chunks = cu_chunks[-1]
+        num_sequences = cu_seqlens.numel() - 1
 
         with self._lock:
             if self._num_sequences is None:
@@ -790,38 +766,18 @@ class RecurrentKDAPrefillWrapper:
                 self._cu_chunks_buf = torch.empty(
                     num_sequences + 1, dtype=torch.int32, device=self.device
                 )
-                self._total_chunks = total_chunks
             elif num_sequences != self._num_sequences:
                 raise ValueError(
                     "the number of sequences is fixed after the first plan call: "
                     f"expected {self._num_sequences}, got {num_sequences}"
                 )
-            elif offsets[-1] != self._total_tokens:
-                raise ValueError(
-                    "the total token count is fixed after the first plan call: "
-                    f"expected {self._total_tokens}, got {offsets[-1]}"
-                )
-            elif total_chunks != self._total_chunks:
-                raise ValueError(
-                    "the total BT=16 chunk count is fixed after the first plan "
-                    "call so CUDA Graph launch geometry remains stable: "
-                    f"expected {self._total_chunks}, got {total_chunks}"
-                )
             assert self._cu_seqlens_buf is not None
             assert self._seq_order_buf is not None
             assert self._cu_chunks_buf is not None
             self._cu_seqlens_buf.copy_(cu_seqlens, non_blocking=non_blocking)
-            self._seq_order_buf.copy_(
-                torch.tensor(sequence_order, dtype=torch.int32),
-                non_blocking=non_blocking,
-            )
-            self._cu_chunks_buf.copy_(
-                torch.tensor(cu_chunks, dtype=torch.int32),
-                non_blocking=non_blocking,
-            )
             self._workspace.__dict__["_cute_dsl_cu_chunks"] = self._cu_chunks_buf
-            self._workspace.__dict__["_cute_dsl_total_chunks"] = total_chunks
-            self._total_tokens = offsets[-1]
+            self._workspace.__dict__["_cute_dsl_generate_planned_metadata"] = True
+            self._planned = True
 
     def run(
         self,
@@ -852,13 +808,23 @@ class RecurrentKDAPrefillWrapper:
         """Run packed recurrent-KDA prefill using the most recent plan."""
 
         with self._lock:
-            if self._total_tokens is None:
+            if not self._planned:
                 raise RuntimeError("call plan before run")
-            if q.ndim != 4 or q.shape[0] * q.shape[1] != self._total_tokens:
+            token_count = q.shape[0] * q.shape[1] if q.ndim == 4 else None
+            if self._total_tokens is None:
+                if torch.cuda.is_current_stream_capturing():
+                    raise RuntimeError(
+                        "warm RecurrentKDAPrefillWrapper.run once before CUDA "
+                        "graph capture"
+                    )
+                if token_count is None:
+                    raise ValueError("q must be a rank-4 tensor")
+                self._total_tokens = token_count
+            elif token_count != self._total_tokens:
                 raise ValueError(
-                    "q token count must match the most recent plan: "
+                    "q token count is fixed after the first run: "
                     f"expected {self._total_tokens}, got "
-                    f"{q.shape[0] * q.shape[1] if q.ndim == 4 else 'invalid rank'}"
+                    f"{token_count if token_count is not None else 'invalid rank'}"
                 )
             cu_seqlens = self._cu_seqlens_buf
             seq_order = self._seq_order_buf

--- a/flashinfer/kda.py
+++ b/flashinfer/kda.py
@@ -141,9 +141,9 @@ def recurrent_kda(
         scale (Optional[float]):
             Scale factor for queries. If ``None``, defaults to ``1 / sqrt(K)``.
         initial_state (Optional[torch.Tensor]):
-            Initial state of shape ``[N, HV, V, K]``. Must normally be
-            bfloat16; the source-only generated indexed prefill domain requires
-            float32. If ``None``, zero-initialized. Updated in-place. For
+            Initial state of shape ``[N, HV, V, K]``. Eligible prefill
+            backends accept bfloat16 or float32; other modes may be stricter.
+            If ``None``, zero-initialized. Updated in-place. For
             batched spec decode without ``cu_seqlens``, ``N`` is the packed
             checkpoint-slot count ``B * (1 + num_spec_tokens)`` when
             ``ssm_state_indices`` is omitted. For eligible frozen prefill with
@@ -242,12 +242,14 @@ def recurrent_kda(
             eager-only B200/GB200 route because its bins depend on host-visible
             sequence lengths.
         state_checkpoints (Optional[torch.Tensor]):
-            Caller-owned BF16 checkpoint output ``[C, H, 128, 128]`` for
-            frozen prefill. Row zero for each sequence is its initial state;
-            later rows are the states before token blocks beginning at
-            ``N, 2N, ...``. ``C`` must be at least
-            ``checkpoint_cu_starts[N_seq]``; this capacity contract is not
-            host-validated. Required when ``checkpoint_every_n_tokens > 0``.
+            Caller-owned checkpoint output ``[C, H, 128, 128]`` for frozen
+            prefill. CuTe DSL accepts BF16 or FP32 and requires it to match
+            ``initial_state`` when present; Cake accepts BF16. Row zero for
+            each sequence is its initial state; later rows are the states
+            before token blocks beginning at ``N, 2N, ...``. ``C`` must be at
+            least ``checkpoint_cu_starts[N_seq]``; this capacity contract is
+            not host-validated. Required when
+            ``checkpoint_every_n_tokens > 0``.
         checkpoint_cu_starts (Optional[torch.Tensor]):
             Contiguous CUDA int64 cumulative checkpoint counts ``[N_seq+1]``.
             The first value must be zero, and each consecutive difference must

--- a/flashinfer/kda_kernels/kda_chunked_bt16.py
+++ b/flashinfer/kda_kernels/kda_chunked_bt16.py
@@ -71,10 +71,10 @@ Optimization notes (each expanded at its definition site):
 
 State checkpoints (opt-in): `compile(has_state_ckpt=True)` returns a callable
 taking `state_ckpt`, `checkpoint_cu_starts`, and `ckpt_interval` (a positive
-multiple of BT).  Each sequence stores its initial state first, followed by
-states at `ckpt_interval` boundaries strictly before the end of the sequence;
-the final state remains a separate output.  This matches the public KDA/Cake
-checkpoint contract.
+multiple of BT).  Without `checkpoint_state_indices`, each sequence stores its
+initial state first, followed by states at interior interval boundaries.  With
+indices, completed boundaries (including an aligned final boundary, excluding
+the initial state) are written directly to the selected rows of `state_ckpt`.
 
 Reproducing the results::
 
@@ -4616,6 +4616,7 @@ def kernel(
     SCALE: cutlass.Float32,
     state_ckpt: cute.Tensor | None,
     cu_ckpts: cute.Tensor | None,
+    checkpoint_state_indices: cute.Tensor | None,
     checkpoint_stride_chunks: cutlass.Int32,
     SAFE_GATE: cutlass.Constexpr,
     GATE_SCALE_LOG2: cutlass.Constexpr,
@@ -5679,22 +5680,38 @@ def kernel(
             ckpt_stride = checkpoint_stride_chunks
             ckpt_next = ckpt_stride
             ckpt_slot = cutlass.Int32(cu_ckpts[bidx])
-        tcgen05_store_initial_state_tmem(
-            tmem_raw_addr,
-            initial_state,
-            state_ckpt,
-            ckpt_slot,
-            state_slot,
-            bidy,
-            cutlass.Int32(0),
-            warp_idx,
-            lane,
-            HALF=False,
-        )
+        if cutlass.const_expr(checkpoint_state_indices is not None):
+            tcgen05_store_initial_state_tmem(
+                tmem_raw_addr,
+                initial_state,
+                None,
+                cutlass.Int32(0),
+                state_slot,
+                bidy,
+                cutlass.Int32(0),
+                warp_idx,
+                lane,
+                HALF=False,
+            )
+        else:
+            tcgen05_store_initial_state_tmem(
+                tmem_raw_addr,
+                initial_state,
+                state_ckpt,
+                ckpt_slot,
+                state_slot,
+                bidy,
+                cutlass.Int32(0),
+                warp_idx,
+                lane,
+                HALF=False,
+            )
         prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC)
         state_input_ready_arrive(initial_state_ready_mbar)
         shared_acc_event_id = cutlass.Int32(0)
-        if cutlass.const_expr(state_ckpt is not None):
+        if cutlass.const_expr(
+            state_ckpt is not None and checkpoint_state_indices is None
+        ):
             # cu_ckpts supplies the per-sequence base slot offsets.  A
             # loop-carried counter replaces a per-chunk div/mod.
             ckpt_slot += cutlass.Int32(1)
@@ -5781,16 +5798,26 @@ def kernel(
             if cutlass.const_expr(state_ckpt is not None):
                 # Peeled chunk 0's checkpoint (fires only for stride 1, i.e. a
                 # checkpoint every BT tokens).
-                if (ckpt_next == cutlass.Int32(1)) & (cutlass.Int32(1) < num_chunks):
+                checkpoint_due = ckpt_next == cutlass.Int32(1)
+                if cutlass.const_expr(checkpoint_state_indices is not None):
+                    checkpoint_due = checkpoint_due & (cutlass.Int32(BT) <= seqlen)
+                else:
+                    checkpoint_due = checkpoint_due & (cutlass.Int32(1) < num_chunks)
+                if checkpoint_due:
                     tcgen05_wait_acc_buffer_ready(k_restore_consumed_mbar.subview(0), 0)
-                    if (ckpt_slot >= cutlass.Int32(0)) & (
-                        ckpt_slot < cutlass.Int32(state_ckpt.shape[0])
+                    checkpoint_output_slot = ckpt_slot
+                    if cutlass.const_expr(checkpoint_state_indices is not None):
+                        checkpoint_output_slot = cutlass.Int32(
+                            checkpoint_state_indices[ckpt_slot]
+                        )
+                    if (checkpoint_output_slot >= cutlass.Int32(0)) & (
+                        checkpoint_output_slot < cutlass.Int32(state_ckpt.shape[0])
                     ):
                         tcgen05_store_final_state_tmem(
                             tmem_raw_addr,
                             KDA_TMEM_FINAL_STATE_ACC_COL_OFFSET,
                             state_ckpt,
-                            ckpt_slot,
+                            checkpoint_output_slot,
                             bidy,
                             cutlass.Int32(0),
                             warp_idx,
@@ -5928,21 +5955,33 @@ def kernel(
                 # post-loop final store waits (the chunk's state-update MMA has
                 # committed), then reuse the final-state store routine with the
                 # flat checkpoint slot standing in for the sequence index.
-                if (chunk + cutlass.Int32(1) == ckpt_next) & (
-                    chunk + cutlass.Int32(1) < num_chunks
-                ):
+                checkpoint_due = chunk + cutlass.Int32(1) == ckpt_next
+                if cutlass.const_expr(checkpoint_state_indices is not None):
+                    checkpoint_due = checkpoint_due & (
+                        (chunk + cutlass.Int32(1)) * cutlass.Int32(BT) <= seqlen
+                    )
+                else:
+                    checkpoint_due = checkpoint_due & (
+                        chunk + cutlass.Int32(1) < num_chunks
+                    )
+                if checkpoint_due:
                     tcgen05_wait_acc_buffer_ready(
                         k_restore_consumed_mbar.subview(chunk % DECAY_STAGE_COUNT),
                         (chunk // DECAY_STAGE_COUNT) % 2,
                     )
-                    if (ckpt_slot >= cutlass.Int32(0)) & (
-                        ckpt_slot < cutlass.Int32(state_ckpt.shape[0])
+                    checkpoint_output_slot = ckpt_slot
+                    if cutlass.const_expr(checkpoint_state_indices is not None):
+                        checkpoint_output_slot = cutlass.Int32(
+                            checkpoint_state_indices[ckpt_slot]
+                        )
+                    if (checkpoint_output_slot >= cutlass.Int32(0)) & (
+                        checkpoint_output_slot < cutlass.Int32(state_ckpt.shape[0])
                     ):
                         tcgen05_store_final_state_tmem(
                             tmem_raw_addr,
                             KDA_TMEM_FINAL_STATE_ACC_COL_OFFSET,
                             state_ckpt,
-                            ckpt_slot,
+                            checkpoint_output_slot,
                             bidy,
                             cutlass.Int32(0),
                             warp_idx,
@@ -6023,6 +6062,7 @@ def host(
     SCALE: cutlass.Float32,
     state_ckpt: cute.Tensor | None,
     cu_ckpts: cute.Tensor | None,
+    checkpoint_state_indices: cute.Tensor | None,
     checkpoint_stride_chunks: cutlass.Int32,
     SAFE_GATE: cutlass.Constexpr,
     GATE_SCALE_LOG2: cutlass.Constexpr,
@@ -6146,6 +6186,7 @@ def host(
         SCALE,
         state_ckpt,
         cu_ckpts,
+        checkpoint_state_indices,
         checkpoint_stride_chunks,
         SAFE_GATE,
         GATE_SCALE_LOG2,
@@ -8586,6 +8627,7 @@ def kernel_chain_dv2(
     SCALE: cutlass.Float32,
     state_ckpt: cute.Tensor | None,
     cu_ckpts: cute.Tensor | None,
+    checkpoint_state_indices: cute.Tensor | None,
     checkpoint_stride_chunks: cutlass.Int32,
 ) -> None:
     """kernel 2, DV-split: each CTA owns half the hidden dimension.
@@ -9006,19 +9048,35 @@ def kernel_chain_dv2(
             ckpt_stride = checkpoint_stride_chunks
             ckpt_next = ckpt_stride
             ckpt_slot = cutlass.Int32(cu_ckpts[bidx])
-        tcgen05_store_initial_state_tmem(
-            tmem_raw_addr,
-            initial_state,
-            state_ckpt,
-            ckpt_slot,
-            state_slot,
-            bidy,
-            dv_half,
-            warp_idx,
-            lane,
-            HALF=True,
-        )
-        if cutlass.const_expr(state_ckpt is not None):
+        if cutlass.const_expr(checkpoint_state_indices is not None):
+            tcgen05_store_initial_state_tmem(
+                tmem_raw_addr,
+                initial_state,
+                None,
+                cutlass.Int32(0),
+                state_slot,
+                bidy,
+                dv_half,
+                warp_idx,
+                lane,
+                HALF=True,
+            )
+        else:
+            tcgen05_store_initial_state_tmem(
+                tmem_raw_addr,
+                initial_state,
+                state_ckpt,
+                ckpt_slot,
+                state_slot,
+                bidy,
+                dv_half,
+                warp_idx,
+                lane,
+                HALF=True,
+            )
+        if cutlass.const_expr(
+            state_ckpt is not None and checkpoint_state_indices is None
+        ):
             ckpt_slot += cutlass.Int32(1)
         if num_chunks > 0:
             diag_raw_stage = diag_raw_smem.subview(0)
@@ -9066,19 +9124,29 @@ def kernel_chain_dv2(
             update_ready_arrive(update_ready_mbar)
             if cutlass.const_expr(state_ckpt is not None):
                 # Peeled chunk 0's checkpoint (stride 1 only).
-                if (ckpt_next == cutlass.Int32(1)) & (cutlass.Int32(1) < num_chunks):
+                checkpoint_due = ckpt_next == cutlass.Int32(1)
+                if cutlass.const_expr(checkpoint_state_indices is not None):
+                    checkpoint_due = checkpoint_due & (cutlass.Int32(BT) <= seqlen)
+                else:
+                    checkpoint_due = checkpoint_due & (cutlass.Int32(1) < num_chunks)
+                if checkpoint_due:
                     tcgen05_wait_acc_buffer_ready(
                         k_restore_consumed_l_mbar.subview(0), 0
                     )
                     tcgen05_wait_acc_buffer_ready(k_restore_consumed_mbar.subview(0), 0)
-                    if (ckpt_slot >= cutlass.Int32(0)) & (
-                        ckpt_slot < cutlass.Int32(state_ckpt.shape[0])
+                    checkpoint_output_slot = ckpt_slot
+                    if cutlass.const_expr(checkpoint_state_indices is not None):
+                        checkpoint_output_slot = cutlass.Int32(
+                            checkpoint_state_indices[ckpt_slot]
+                        )
+                    if (checkpoint_output_slot >= cutlass.Int32(0)) & (
+                        checkpoint_output_slot < cutlass.Int32(state_ckpt.shape[0])
                     ):
                         tcgen05_store_final_state_tmem(
                             tmem_raw_addr,
                             KDA_TMEM_STATE_COL_OFFSET,
                             state_ckpt,
-                            ckpt_slot,
+                            checkpoint_output_slot,
                             bidy,
                             dv_half,
                             warp_idx,
@@ -9138,9 +9206,16 @@ def kernel_chain_dv2(
                 # Same contract as the engine-side checkpoint; both M=64 TMEM
                 # halves wait their own k_restore parity slot (the same wait
                 # the post-loop final store performs) before draining.
-                if (chunk + cutlass.Int32(1) == ckpt_next) & (
-                    chunk + cutlass.Int32(1) < num_chunks
-                ):
+                checkpoint_due = chunk + cutlass.Int32(1) == ckpt_next
+                if cutlass.const_expr(checkpoint_state_indices is not None):
+                    checkpoint_due = checkpoint_due & (
+                        (chunk + cutlass.Int32(1)) * cutlass.Int32(BT) <= seqlen
+                    )
+                else:
+                    checkpoint_due = checkpoint_due & (
+                        chunk + cutlass.Int32(1) < num_chunks
+                    )
+                if checkpoint_due:
                     tcgen05_wait_acc_buffer_ready(
                         k_restore_consumed_l_mbar.subview(chunk % 2),
                         (chunk // 2) % 2,
@@ -9149,14 +9224,19 @@ def kernel_chain_dv2(
                         k_restore_consumed_mbar.subview(chunk % 2),
                         (chunk // 2) % 2,
                     )
-                    if (ckpt_slot >= cutlass.Int32(0)) & (
-                        ckpt_slot < cutlass.Int32(state_ckpt.shape[0])
+                    checkpoint_output_slot = ckpt_slot
+                    if cutlass.const_expr(checkpoint_state_indices is not None):
+                        checkpoint_output_slot = cutlass.Int32(
+                            checkpoint_state_indices[ckpt_slot]
+                        )
+                    if (checkpoint_output_slot >= cutlass.Int32(0)) & (
+                        checkpoint_output_slot < cutlass.Int32(state_ckpt.shape[0])
                     ):
                         tcgen05_store_final_state_tmem(
                             tmem_raw_addr,
                             KDA_TMEM_STATE_COL_OFFSET,
                             state_ckpt,
-                            ckpt_slot,
+                            checkpoint_output_slot,
                             bidy,
                             dv_half,
                             warp_idx,
@@ -9290,6 +9370,7 @@ def host_chain_dv2(
     SCALE: cutlass.Float32,
     state_ckpt: cute.Tensor | None,
     cu_ckpts: cute.Tensor | None,
+    checkpoint_state_indices: cute.Tensor | None,
     checkpoint_stride_chunks: cutlass.Int32,
     THREADS: cutlass.Constexpr,
 ) -> None:
@@ -9396,6 +9477,7 @@ def host_chain_dv2(
         SCALE,
         state_ckpt,
         cu_ckpts,
+        checkpoint_state_indices,
         checkpoint_stride_chunks,
     ).launch(
         grid=(num_sequences, launch_heads * 2, 1),
@@ -9451,6 +9533,7 @@ def host_unified(
     scale: cutlass.Float32,
     state_ckpt: cute.Tensor | None,
     cu_ckpts: cute.Tensor | None,
+    checkpoint_state_indices: cute.Tensor | None,
     SAFE_GATE: cutlass.Constexpr,
     GATE_SCALE_LOG2: cutlass.Constexpr,
     THREADS: cutlass.Constexpr,
@@ -9528,6 +9611,7 @@ def host_unified(
             scale,
             state_ckpt,
             cu_ckpts,
+            checkpoint_state_indices,
             checkpoint_stride_chunks,
             THREADS,
         )
@@ -9551,6 +9635,7 @@ def host_unified(
             scale,
             state_ckpt,
             cu_ckpts,
+            checkpoint_state_indices,
             checkpoint_stride_chunks,
             SAFE_GATE,
             GATE_SCALE_LOG2,
@@ -9566,6 +9651,7 @@ def _unified_fakes(
     has_state_out: bool,
     has_state_ckpt: bool,
     has_state_indices: bool,
+    has_checkpoint_state_indices: bool,
     gate_dtype: type = cutlass.BFloat16,
 ) -> tuple:
     """Union fake-tensor set for the single `host_unified` compile.
@@ -9638,9 +9724,20 @@ def _unified_fakes(
             state_dtype, (sk, sh, DV, DK), stride_order=(3, 2, 1, 0), assumed_align=16
         )
         fcuk = F(cutlass.Int64, (scuk,), stride_order=(0,), assumed_align=8)
+        fcheckpoint_state_indices = (
+            F(
+                cutlass.Int32,
+                (cute.sym_int64(divisibility=1),),
+                stride_order=(0,),
+                assumed_align=4,
+            )
+            if has_checkpoint_state_indices
+            else None
+        )
     else:
         fckpt = None
         fcuk = None
+        fcheckpoint_state_indices = None
     return (
         (
             fq,
@@ -9665,6 +9762,7 @@ def _unified_fakes(
         ),
         fckpt,
         fcuk,
+        fcheckpoint_state_indices,
     )
 
 
@@ -9757,6 +9855,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
         spec["has_state_out"],
         spec["has_state_ckpt"],
         spec["has_state_indices"],
+        spec.get("has_checkpoint_state_indices", False),
     )
 
     def call(
@@ -9781,7 +9880,10 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
         planned_cu_chunks=None,
         planned_total_chunks=None,
         state_indices=None,
+        checkpoint_state_indices=None,
     ):
+        if checkpoint_state_indices is not None and state_ckpt is None:
+            raise ValueError("checkpoint_state_indices requires state_ckpt")
         # The state specialization is DERIVED from which state tensors the call
         # actually passes (initial/final/checkpoint present or None); if it
         # differs from this build, transparently delegate to the matching one
@@ -9791,6 +9893,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
             final_state is not None,
             state_ckpt is not None,
             state_indices is not None,
+            checkpoint_state_indices is not None,
         )
         if want != built_states:
             sibling = compile(
@@ -9803,6 +9906,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
                 has_state_out=want[1],
                 has_state_ckpt=want[2],
                 has_state_indices=want[3],
+                has_checkpoint_state_indices=want[4],
                 mode=spec["mode"],
             )
             return sibling(
@@ -9823,6 +9927,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
                 state_indices=state_indices,
                 state_ckpt=state_ckpt,
                 checkpoint_cu_starts=checkpoint_cu_starts,
+                checkpoint_state_indices=checkpoint_state_indices,
                 ckpt_interval=ckpt_interval,
                 seq_order=seq_order,
                 planned_cu_chunks=planned_cu_chunks,
@@ -9867,6 +9972,17 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
             raise ValueError(
                 "state_indices requires initial_state and must be a contiguous "
                 "CUDA int32 tensor with one entry per sequence"
+            )
+        if checkpoint_state_indices is not None and (
+            state_ckpt is None
+            or checkpoint_state_indices.device != device
+            or checkpoint_state_indices.dtype != torch.int32
+            or checkpoint_state_indices.ndim != 1
+            or not checkpoint_state_indices.is_contiguous()
+        ):
+            raise ValueError(
+                "checkpoint_state_indices requires state_ckpt and must be a "
+                "contiguous CUDA int32 tensor"
             )
         key = (n_seq, str(device), heads, compile_mode)
         kind = decisions.get(key)
@@ -9931,7 +10047,10 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
                 offsets, total = [0], 0
                 for i in range(n_seq):
                     seq_len = cu_list[i + 1] - cu_list[i]
-                    total += (seq_len + ckpt_interval - 1) // ckpt_interval
+                    if checkpoint_state_indices is None:
+                        total += (seq_len + ckpt_interval - 1) // ckpt_interval
+                    else:
+                        total += seq_len // ckpt_interval
                     offsets.append(total)
                 cu_ckpts_arg = torch.tensor(offsets, dtype=torch.int64, device=device)
             else:
@@ -9997,6 +10116,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
                 scale,
                 state_ckpt,
                 cu_ckpts_arg,
+                checkpoint_state_indices,
             )
             return
 
@@ -10067,6 +10187,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
             scale,
             state_ckpt,
             cu_ckpts_arg,
+            checkpoint_state_indices,
         )
 
     def _ws_size(cu_seqlens, heads, mode=None, *, batch=None, seqlen=None):
@@ -10102,6 +10223,7 @@ def compile(  # noqa: A001
     has_state_out: bool = True,
     has_state_ckpt: bool = False,
     has_state_indices: bool = False,
+    has_checkpoint_state_indices: bool = False,
     mode=None,
 ) -> CompiledKDA:
     """Compile KDA; the returned callable is the single host entry.
@@ -10125,6 +10247,8 @@ def compile(  # noqa: A001
         raise ValueError(f"Unsupported dtype: {dtype}")
     if state_dtype not in (cutlass.BFloat16, cutlass.Float32):
         raise ValueError(f"Unsupported state dtype: {state_dtype}")
+    if has_checkpoint_state_indices and not has_state_ckpt:
+        raise ValueError("checkpoint state indices require checkpoint state output")
     validate_gate_dtype(gate_dtype)
     if mode == "auto":
         mode = None
@@ -10132,13 +10256,14 @@ def compile(  # noqa: A001
         raise ValueError(f"Unknown mode: {mode}")
     gate_scale_log2 = gate_lower_bound * LOG2_E
 
-    fakes, fckpt, fcuk = _unified_fakes(
+    fakes, fckpt, fcuk, fcheckpoint_state_indices = _unified_fakes(
         dtype,
         state_dtype,
         has_state_in,
         has_state_out,
         has_state_ckpt,
         has_state_indices,
+        has_checkpoint_state_indices,
         gate_dtype,
     )
     unified = cute.compile(
@@ -10153,6 +10278,7 @@ def compile(  # noqa: A001
         DEFAULT_SCALE,
         fckpt,
         fcuk,
+        fcheckpoint_state_indices,
         safe_gate,
         gate_scale_log2,
         THREADS_PER_CTA,
@@ -10172,6 +10298,7 @@ def compile(  # noqa: A001
             has_state_out=has_state_out,
             has_state_ckpt=has_state_ckpt,
             has_state_indices=has_state_indices,
+            has_checkpoint_state_indices=has_checkpoint_state_indices,
             mode=mode,
         ),
     )
@@ -10187,6 +10314,7 @@ def compile(  # noqa: A001
             has_state_out,
             has_state_ckpt,
             has_state_indices,
+            has_checkpoint_state_indices,
             gate_dtype,
         )
     return fn
@@ -10200,6 +10328,7 @@ def _eager_module_load(
     has_state_out: bool,
     has_state_ckpt: bool = False,
     has_state_indices: bool = False,
+    has_checkpoint_state_indices: bool = False,
     gate_dtype: type = cutlass.BFloat16,
 ) -> None:
     """One launch to make the device module resident so no real call lazy-loads.
@@ -10266,6 +10395,11 @@ def _eager_module_load(
                 else None
             ),
             ckpt_interval=(BT if has_state_ckpt else 0),
+            checkpoint_state_indices=(
+                torch.arange(64, dtype=torch.int32, device="cuda")
+                if has_checkpoint_state_indices
+                else None
+            ),
         )
         torch.cuda.synchronize()
     except Exception:  # noqa: BLE001 — best-effort module preload; never fatal

--- a/flashinfer/kda_kernels/kda_chunked_bt16.py
+++ b/flashinfer/kda_kernels/kda_chunked_bt16.py
@@ -4592,6 +4592,56 @@ def tcgen05_store_final_state_tmem(
                 )
 
 
+PACKED_METADATA_THREADS: int = 256
+
+
+@cute.kernel
+def packed_metadata_kernel(
+    cu_seqlens: cute.Tensor,
+    seq_order: cute.Tensor,
+    cu_chunks: cute.Tensor,
+    generate_seq_order: cutlass.Int32,
+    generate_cu_chunks: cutlass.Int32,
+) -> None:
+    """Build packed scheduling metadata from device-resident prefix offsets."""
+
+    tidx, _, _ = cute.arch.thread_idx()
+    n_seq = cutlass.Int32(seq_order.shape[0])
+    if generate_seq_order != cutlass.Int32(0):
+        for index in cutlass.range(tidx, n_seq, PACKED_METADATA_THREADS):
+            seq_order[index] = cutlass.Int32(index)
+        cute.arch.sync_threads()
+
+        # Stable descending-length order.  The issue workload has at most 64
+        # sequences; odd-even transposition keeps the implementation compact
+        # and supports a runtime sequence count without temporary storage.
+        for phase in cutlass.range(n_seq):
+            parity = phase & cutlass.Int32(1)
+            pair_count = (n_seq - parity) // cutlass.Int32(2)
+            for pair in cutlass.range(tidx, pair_count, PACKED_METADATA_THREADS):
+                left = parity + pair * cutlass.Int32(2)
+                right = left + cutlass.Int32(1)
+                left_seq = cutlass.Int32(seq_order[left])
+                right_seq = cutlass.Int32(seq_order[right])
+                left_len = cu_seqlens[left_seq + 1] - cu_seqlens[left_seq]
+                right_len = cu_seqlens[right_seq + 1] - cu_seqlens[right_seq]
+                swap = (right_len > left_len) | (
+                    (right_len == left_len) & (right_seq < left_seq)
+                )
+                if swap:
+                    seq_order[left] = right_seq
+                    seq_order[right] = left_seq
+            cute.arch.sync_threads()
+
+    if (generate_cu_chunks != cutlass.Int32(0)) & (tidx == cutlass.Int32(0)):
+        cu_chunks[0] = cutlass.Int32(0)
+        total_chunks = cutlass.Int32(0)
+        for index in cutlass.range(n_seq):
+            seq_len = cutlass.Int32(cu_seqlens[index + 1] - cu_seqlens[index])
+            total_chunks += (seq_len + cutlass.Int32(BT - 1)) // cutlass.Int32(BT)
+            cu_chunks[index + 1] = total_chunks
+
+
 @cute.kernel
 def kernel(
     tma_desc_q: cutlass.GridConstant[cuda.TensorMap],
@@ -6853,26 +6903,6 @@ def host_prep(
 
 
 _PLAN_CACHE: dict = {}
-_LPT_SEQUENCE_ORDER_CACHE: dict = {}
-
-
-def _lpt_sequence_order(cu_seqlens: torch.Tensor) -> torch.Tensor:
-    """Cached longest-processing-time-first order for packed engine calls."""
-
-    cu_list = _cu_seqlens_contents(cu_seqlens)
-    key = (cu_list, str(cu_seqlens.device))
-    order = _LPT_SEQUENCE_ORDER_CACHE.get(key)
-    if order is None:
-        lengths = [
-            cu_list[index + 1] - cu_list[index] for index in range(len(cu_list) - 1)
-        ]
-        order = torch.tensor(
-            sorted(range(len(lengths)), key=lengths.__getitem__, reverse=True),
-            dtype=torch.int32,
-            device=cu_seqlens.device,
-        )
-        _LPT_SEQUENCE_ORDER_CACHE[key] = order
-    return order
 
 
 def _plan(cu_seqlens: torch.Tensor) -> dict:
@@ -7715,7 +7745,9 @@ def kernel_prep(
     warp_idx = cute.arch.make_warp_uniform(cute.arch.warp_idx())
     lane = tidx % THREADS_PER_WARP
 
-    total_chunks = cutlass.Int32(ws_qk.shape[2])
+    # The workspace extent is a graph-static capacity.  The device-generated
+    # prefix carries the actual count for the current replay.
+    total_chunks = cutlass.Int32(cu_chunks[cu_chunks.shape[0] - 1])
     gchunk_stride = cutlass.Int32(1)
     chunk_lo = bidx * chunks_per_cta
     my_chunks = total_chunks - chunk_lo
@@ -9514,8 +9546,10 @@ def host_unified(
     beta: cute.Tensor,
     cu_seqlens: cute.Tensor,
     seq_order: cute.Tensor,
+    generate_seq_order: cutlass.Int32,
     state_indices: cute.Tensor | None,
     cu_chunks: cute.Tensor,
+    generate_cu_chunks: cutlass.Int32,
     ws_kd: cute.Tensor,
     ws_qd: cute.Tensor,
     ws_w: cute.Tensor,
@@ -9544,6 +9578,21 @@ def host_unified(
     heads = q.shape[2]
     h32 = cutlass.Int32(heads)
     z = cutlass.Int32(0)
+    if (generate_seq_order != z) | (generate_cu_chunks != z):
+        # A separate launch supplies the grid-wide publication boundary needed
+        # before either the persistent engine or decomposed kernels consume the
+        # generated metadata.  The launch is captured as part of a CUDA Graph.
+        packed_metadata_kernel(
+            cu_seqlens,
+            seq_order,
+            cu_chunks,
+            generate_seq_order,
+            generate_cu_chunks,
+        ).launch(
+            grid=(1, 1, 1),
+            block=(PACKED_METADATA_THREADS, 1, 1),
+            stream=stream_a,
+        )
     # Route selection.  MODE is a COMPILE-TIME constexpr:
     #   MODE is None    -> RUNTIME routing (both routes emitted, one .o handles
     #                      all shapes) — the default build.
@@ -9749,8 +9798,10 @@ def _unified_fakes(
             fbeta,
             fcu,
             forder,
+            0,  # generate_seq_order
             fstate_indices,
             fcuc,
+            0,  # generate_cu_chunks
             fkd,
             fqd,
             fw,
@@ -9798,6 +9849,27 @@ _UNIFORM_CU_CACHE: dict = {}
 
 
 _IDENTITY_SEQUENCE_ORDER_CACHE: dict = {}
+_DEVICE_SEQUENCE_ORDER_CACHE: dict = {}
+
+
+def _stream_pointer(stream) -> int:
+    value = getattr(stream, "value", stream)
+    return int(value or 0)
+
+
+def _device_sequence_order_buffer(num_sequences: int, device, stream) -> torch.Tensor:
+    """Reusable per-stream output for device-side packed sequence sorting."""
+
+    key = (str(device), _stream_pointer(stream), int(num_sequences))
+    order = _DEVICE_SEQUENCE_ORDER_CACHE.get(key)
+    if order is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError(
+                "KDA device sequence order must be warmed before CUDA graph capture"
+            )
+        order = torch.empty(num_sequences, dtype=torch.int32, device=device)
+        _DEVICE_SEQUENCE_ORDER_CACHE[key] = order
+    return order
 
 
 def _identity_sequence_order(num_sequences: int, device) -> torch.Tensor:
@@ -9833,9 +9905,10 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
 
     Runtime ABI: (q, k, v, raw_gate, a_log, dt_bias, beta, cu_seqlens,
     initial_state, out, final_state, workspace, stream_a, scale, ..., seq_order)
-    — for packed engine calls, ``seq_order=None`` builds and caches an eager LPT
-    order; fixed and decomp calls retain the original sequence order. An explicit
-    packed CUDA int32 permutation overrides either default. The remaining
+    — packed engine calls with ``seq_order=None`` generate an LPT order on the
+    device; fixed and decomp calls retain the original sequence order unless a
+    wrapper requests device-generated metadata. An explicit packed CUDA int32
+    permutation overrides the implicit engine order. The remaining
     positional ABI is
     the reference host ABI (stream_a == the reference `stream`, scale in the same
     position) plus the `workspace` operand.  Decomp always runs prep-first on
@@ -9879,6 +9952,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
         seq_order=None,
         planned_cu_chunks=None,
         planned_total_chunks=None,
+        generate_planned_metadata=False,
         state_indices=None,
         checkpoint_state_indices=None,
     ):
@@ -9932,6 +10006,7 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
                 seq_order=seq_order,
                 planned_cu_chunks=planned_cu_chunks,
                 planned_total_chunks=planned_total_chunks,
+                generate_planned_metadata=generate_planned_metadata,
             )
         # One stream.  There used to be an optional `stream_b` that opted into a
         # co-resident k1/k2 overlap; it was removed because the flag-ring it
@@ -9989,15 +10064,11 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
         if kind is None:
             kind = _route_for_workspace(n_seq, heads, device, compile_mode or "auto")
             decisions[key] = kind
+        generate_seq_order = bool(generate_planned_metadata)
         if seq_order is None:
             if packed_layout and kind == "engine":
-                if torch.cuda.is_current_stream_capturing():
-                    raise RuntimeError(
-                        "packed CuTe DSL engine CUDA Graph capture requires "
-                        "an explicit sequence plan; use "
-                        "RecurrentKDAPrefillWrapper.plan() before capture"
-                    )
-                seq_order = _lpt_sequence_order(cu_seqlens)
+                generate_seq_order = True
+                seq_order = _device_sequence_order_buffer(n_seq, device, stream_a)
             else:
                 seq_order = _identity_sequence_order(n_seq, device)
         elif (
@@ -10017,6 +10088,11 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
         if (planned_cu_chunks is None) != (planned_total_chunks is None):
             raise ValueError(
                 "planned_cu_chunks and planned_total_chunks must be provided together"
+            )
+        if generate_planned_metadata and not has_planned_chunks:
+            raise ValueError(
+                "device-generated chunk metadata requires planned_cu_chunks and "
+                "planned_total_chunks capacity"
             )
         cu_list = None
         if (kind == "decomp" and not has_planned_chunks) or (
@@ -10097,8 +10173,10 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
                 beta,
                 cu_seqlens,
                 seq_order,
+                int(generate_seq_order),
                 state_indices,
                 cuc,
+                0,  # engine does not consume a chunk prefix
                 kd,
                 qd,
                 wt,
@@ -10168,8 +10246,10 @@ def _make_call(unified: Callable, spec: dict) -> CompiledKDA:
             beta,
             cu_seqlens,
             seq_order,
+            int(generate_seq_order),
             state_indices,
             plan["cu_chunks"],
+            int(generate_planned_metadata),
             ws["kd"],
             ws["qd"],
             ws["w"],

--- a/flashinfer/kda_prefill_cute.py
+++ b/flashinfer/kda_prefill_cute.py
@@ -87,6 +87,7 @@ def _is_cute_dsl_kda_prefill_eligible(
     state_checkpoints: Optional[torch.Tensor],
     checkpoint_cu_starts: Optional[torch.Tensor],
     checkpoint_every_n_tokens: int,
+    checkpoint_state_indices: Optional[torch.Tensor] = None,
 ) -> bool:
     """Return whether the ported BT=16 kernel can serve this call.
 
@@ -249,14 +250,7 @@ def _is_cute_dsl_kda_prefill_eligible(
         return False
     if checkpoint_every_n_tokens:
         if (
-            not isinstance(state_checkpoints, torch.Tensor)
-            or state_checkpoints.device != q.device
-            or state_checkpoints.dtype not in (torch.bfloat16, torch.float32)
-            or state_checkpoints.ndim != 4
-            or tuple(state_checkpoints.shape[1:]) != (num_heads, _HEAD_DIM, _HEAD_DIM)
-            or state_checkpoints.shape[0] > torch.iinfo(torch.int32).max
-            or not state_checkpoints.is_contiguous()
-            or not isinstance(checkpoint_cu_starts, torch.Tensor)
+            not isinstance(checkpoint_cu_starts, torch.Tensor)
             or checkpoint_cu_starts.device != q.device
             or checkpoint_cu_starts.dtype != torch.int64
             or checkpoint_cu_starts.ndim != 1
@@ -264,9 +258,37 @@ def _is_cute_dsl_kda_prefill_eligible(
             or not checkpoint_cu_starts.is_contiguous()
         ):
             return False
-        if initial_state is not None and state_checkpoints.dtype != initial_state.dtype:
+        if state_checkpoints is not None and (
+            not isinstance(state_checkpoints, torch.Tensor)
+            or state_checkpoints.device != q.device
+            or state_checkpoints.dtype not in (torch.bfloat16, torch.float32)
+            or state_checkpoints.ndim != 4
+            or tuple(state_checkpoints.shape[1:]) != (num_heads, _HEAD_DIM, _HEAD_DIM)
+            or state_checkpoints.shape[0] > torch.iinfo(torch.int32).max
+            or not state_checkpoints.is_contiguous()
+        ):
             return False
-    elif state_checkpoints is not None or checkpoint_cu_starts is not None:
+        if checkpoint_state_indices is not None and (
+            state_checkpoints is None
+            or not isinstance(checkpoint_state_indices, torch.Tensor)
+            or checkpoint_state_indices.device != q.device
+            or checkpoint_state_indices.dtype != torch.int32
+            or checkpoint_state_indices.ndim != 1
+            or not checkpoint_state_indices.is_contiguous()
+            or checkpoint_state_indices.numel() > torch.iinfo(torch.int32).max
+        ):
+            return False
+        if (
+            initial_state is not None
+            and state_checkpoints is not None
+            and state_checkpoints.dtype != initial_state.dtype
+        ):
+            return False
+    elif (
+        state_checkpoints is not None
+        or checkpoint_cu_starts is not None
+        or checkpoint_state_indices is not None
+    ):
         return False
     # Probed last so that calls rejected above reach Cake exactly as before.
     return _is_cute_dsl_kda_runtime_available()
@@ -280,6 +302,7 @@ def _get_compiled_cute_dsl_kda(
     has_state_out: bool,
     has_state_ckpt: bool,
     has_state_indices: bool,
+    has_checkpoint_state_indices: bool,
 ):
     # Keep the large CuTe DSL module lazy so normal Cake and decode imports do
     # not initialize its compilation stack.
@@ -301,6 +324,7 @@ def _get_compiled_cute_dsl_kda(
         has_state_out=has_state_out,
         has_state_ckpt=has_state_ckpt,
         has_state_indices=has_state_indices,
+        has_checkpoint_state_indices=has_checkpoint_state_indices,
         mode=None,
     )
 
@@ -326,6 +350,7 @@ def _run_cute_dsl_kda_prefill(
     checkpoint_cu_starts: Optional[torch.Tensor],
     checkpoint_every_n_tokens: int,
     state_indices: Optional[torch.Tensor] = None,
+    checkpoint_state_indices: Optional[torch.Tensor] = None,
 ) -> (
     tuple[torch.Tensor, Optional[torch.Tensor]]
     | tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor]
@@ -376,6 +401,22 @@ def _run_cute_dsl_kda_prefill(
             state_checkpoints.dtype if state_checkpoints is not None else torch.bfloat16
         )
     )
+    if checkpoint_every_n_tokens and state_checkpoints is None:
+        if capturing:
+            raise RuntimeError(
+                "CUDA graph capture requires preallocated state_checkpoints for "
+                "backend='cute-dsl'"
+            )
+        assert checkpoint_cu_starts is not None
+        checkpoint_count = int(checkpoint_cu_starts[-1].item())
+        state_checkpoints = torch.empty(
+            checkpoint_count,
+            q.shape[2],
+            _HEAD_DIM,
+            _HEAD_DIM,
+            dtype=state_dtype,
+            device=q.device,
+        )
     if seq_order is None and cu_seqlens is None:
         seq_order = _identity_seq_order(
             device=q.device,
@@ -415,6 +456,7 @@ def _run_cute_dsl_kda_prefill(
         has_state_out=final_state is not None,
         has_state_ckpt=state_checkpoints is not None,
         has_state_indices=state_indices is not None,
+        has_checkpoint_state_indices=checkpoint_state_indices is not None,
     )
     planned_cu_chunks = (
         getattr(prefill_workspace, "_cute_dsl_cu_chunks", None)
@@ -463,6 +505,7 @@ def _run_cute_dsl_kda_prefill(
             checkpoint_kwargs = {
                 "state_ckpt": state_checkpoints,
                 "checkpoint_cu_starts": checkpoint_cu_starts,
+                "checkpoint_state_indices": checkpoint_state_indices,
                 "ckpt_interval": checkpoint_every_n_tokens,
             }
         compiled(

--- a/flashinfer/kda_prefill_cute.py
+++ b/flashinfer/kda_prefill_cute.py
@@ -33,6 +33,14 @@ from .utils import get_compute_capability
 
 _SUPPORTED_COMPUTE_CAPABILITIES = {(10, 0), (10, 3)}
 _HEAD_DIM = 128
+_CHUNK_SIZE = 16
+
+
+def _max_packed_chunks(total_tokens: int, num_sequences: int) -> int:
+    """Graph-static capacity for sum(ceil(sequence_length / 16))."""
+
+    nonempty_sequences = min(total_tokens, num_sequences)
+    return nonempty_sequences + (total_tokens - nonempty_sequences) // _CHUNK_SIZE
 
 
 def _is_cute_dsl_kda_runtime_available() -> bool:
@@ -463,11 +471,24 @@ def _run_cute_dsl_kda_prefill(
         if prefill_workspace is not None
         else None
     )
+    generate_planned_metadata = bool(
+        getattr(prefill_workspace, "_cute_dsl_generate_planned_metadata", False)
+        if prefill_workspace is not None
+        else False
+    )
     planned_total_chunks = (
         getattr(prefill_workspace, "_cute_dsl_total_chunks", None)
         if prefill_workspace is not None
         else None
     )
+    if generate_planned_metadata:
+        if planned_cu_chunks is None:
+            raise RuntimeError("missing CuTe DSL device chunk-prefix buffer")
+        total_tokens = q.shape[0] * q.shape[1]
+        # Maximum sum(ceil(seq_len / 16)) for non-negative integer lengths
+        # summing to total_tokens. This graph-static capacity avoids reading the
+        # actual per-replay prefix offsets on the host.
+        planned_total_chunks = _max_packed_chunks(total_tokens, num_sequences)
     if (planned_cu_chunks is None) != (planned_total_chunks is None):
         raise RuntimeError("incomplete CuTe DSL chunk plan on prefill workspace")
     if planned_cu_chunks is not None:
@@ -527,6 +548,7 @@ def _run_cute_dsl_kda_prefill(
             seq_order=seq_order,
             planned_cu_chunks=planned_cu_chunks,
             planned_total_chunks=planned_total_chunks,
+            generate_planned_metadata=generate_planned_metadata,
             **checkpoint_kwargs,
         )
 

--- a/flashinfer/kda_prefill_cute.py
+++ b/flashinfer/kda_prefill_cute.py
@@ -219,7 +219,7 @@ def _is_cute_dsl_kda_prefill_eligible(
         if (
             not isinstance(initial_state, torch.Tensor)
             or initial_state.device != q.device
-            or initial_state.dtype != torch.bfloat16
+            or initial_state.dtype not in (torch.bfloat16, torch.float32)
             or initial_state.ndim != 4
             or initial_state.shape[0] <= 0
             or tuple(initial_state.shape[1:]) != (num_heads, _HEAD_DIM, _HEAD_DIM)
@@ -251,7 +251,7 @@ def _is_cute_dsl_kda_prefill_eligible(
         if (
             not isinstance(state_checkpoints, torch.Tensor)
             or state_checkpoints.device != q.device
-            or state_checkpoints.dtype != torch.bfloat16
+            or state_checkpoints.dtype not in (torch.bfloat16, torch.float32)
             or state_checkpoints.ndim != 4
             or tuple(state_checkpoints.shape[1:]) != (num_heads, _HEAD_DIM, _HEAD_DIM)
             or state_checkpoints.shape[0] > torch.iinfo(torch.int32).max
@@ -264,6 +264,8 @@ def _is_cute_dsl_kda_prefill_eligible(
             or not checkpoint_cu_starts.is_contiguous()
         ):
             return False
+        if initial_state is not None and state_checkpoints.dtype != initial_state.dtype:
+            return False
     elif state_checkpoints is not None or checkpoint_cu_starts is not None:
         return False
     # Probed last so that calls rejected above reach Cake exactly as before.
@@ -273,6 +275,7 @@ def _is_cute_dsl_kda_prefill_eligible(
 def _get_compiled_cute_dsl_kda(
     *,
     lower_bound: float,
+    state_dtype: torch.dtype,
     has_state_in: bool,
     has_state_out: bool,
     has_state_ckpt: bool,
@@ -284,9 +287,13 @@ def _get_compiled_cute_dsl_kda(
 
     from .kda_kernels.kda_chunked_bt16 import compile
 
+    cutlass_state_dtype = {
+        torch.bfloat16: cutlass.BFloat16,
+        torch.float32: cutlass.Float32,
+    }[state_dtype]
     return compile(
         dtype=cutlass.BFloat16,
-        state_dtype=cutlass.BFloat16,
+        state_dtype=cutlass_state_dtype,
         gate_dtype=cutlass.BFloat16,
         safe_gate=True,
         gate_lower_bound=lower_bound,
@@ -362,6 +369,13 @@ def _run_cute_dsl_kda_prefill(
         raise ValueError(f"scale must be finite, got {scale_value}")
 
     num_sequences = q.shape[0] if cu_seqlens is None else cu_seqlens.numel() - 1
+    state_dtype = (
+        initial_state.dtype
+        if initial_state is not None
+        else (
+            state_checkpoints.dtype if state_checkpoints is not None else torch.bfloat16
+        )
+    )
     if seq_order is None and cu_seqlens is None:
         seq_order = _identity_seq_order(
             device=q.device,
@@ -380,7 +394,7 @@ def _run_cute_dsl_kda_prefill(
             q.shape[2],
             _HEAD_DIM,
             _HEAD_DIM,
-            dtype=torch.bfloat16,
+            dtype=state_dtype,
             device=q.device,
         )
     else:
@@ -396,6 +410,7 @@ def _run_cute_dsl_kda_prefill(
 
     compiled = _get_compiled_cute_dsl_kda(
         lower_bound=float(lower_bound),
+        state_dtype=state_dtype,
         has_state_in=initial_state is not None,
         has_state_out=final_state is not None,
         has_state_ckpt=state_checkpoints is not None,

--- a/flashinfer/kda_prefill_cute.py
+++ b/flashinfer/kda_prefill_cute.py
@@ -126,7 +126,7 @@ def _is_cute_dsl_kda_prefill_eligible(
     batch_size, token_count, num_heads, head_dim = q.shape
     if batch_size <= 0 or token_count <= 1 or num_heads <= 0 or head_dim != _HEAD_DIM:
         return False
-    for tensor in (k, v, g):
+    for tensor in (k, v):
         if (
             not isinstance(tensor, torch.Tensor)
             or tensor.device != q.device
@@ -136,11 +136,25 @@ def _is_cute_dsl_kda_prefill_eligible(
         ):
             return False
     if (
+        not isinstance(g, torch.Tensor)
+        or g.device != q.device
+        or g.dtype != torch.bfloat16
+        or g.ndim != 4
+        or g.shape[0] != batch_size
+        or g.shape[1] < token_count
+        or tuple(g.shape[2:]) != (num_heads, head_dim)
+        or not g[:, :token_count].is_contiguous()
+    ):
+        return False
+    if (
         not isinstance(beta, torch.Tensor)
         or beta.device != q.device
         or beta.dtype != torch.bfloat16
-        or beta.shape != (batch_size, token_count, num_heads)
-        or not beta.is_contiguous()
+        or beta.ndim != 3
+        or beta.shape[0] != batch_size
+        or beta.shape[1] < token_count
+        or beta.shape[2] != num_heads
+        or not beta[:, :token_count].is_contiguous()
         or beta.data_ptr() % 16 != 0
     ):
         return False
@@ -336,6 +350,12 @@ def _run_cute_dsl_kda_prefill(
         beta=beta,
         initial_state=initial_state,
     )
+
+    # SGLang may retain page-aligned padding in its gate and beta buffers.
+    # Narrow to Q's logical token extent with views before building TensorMaps.
+    token_count = q.shape[1]
+    g = g[:, :token_count]
+    beta = beta[:, :token_count]
 
     scale_value = _HEAD_DIM**-0.5 if scale is None else float(scale)
     if not math.isfinite(scale_value):

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -70,6 +70,16 @@ def test_public_api_uses_phase_neutral_facade_and_prefill_workspace():
     assert flashinfer.RecurrentKDAPrefillWrapper is RecurrentKDAPrefillWrapper
 
 
+@pytest.mark.parametrize(
+    ("total_tokens", "num_sequences", "expected"),
+    [(256, 4, 19), (17, 2, 2), (8, 16, 8), (0, 4, 0)],
+)
+def test_cute_dsl_max_packed_chunks(total_tokens, num_sequences, expected):
+    assert (
+        kda_prefill_cute_api._max_packed_chunks(total_tokens, num_sequences) == expected
+    )
+
+
 def test_cake_kda_prefill_jit_surface_includes_checkpoint_aligned_bt64():
     assert cake_kda_jit_api.CAKE_KDA_VARIANTS == (
         "m128_unbounded_softplus",
@@ -229,40 +239,33 @@ def test_cake_kda_affine_workspace_buffer_is_grow_only(monkeypatch):
         )
 
 
-def test_prefill_wrapper_plan_builds_stable_device_metadata(cuda_device):
+def test_prefill_wrapper_plan_builds_stable_device_metadata(cuda_device, monkeypatch):
     wrapper = RecurrentKDAPrefillWrapper(cuda_device)
-    wrapper.plan(torch.tensor([0, 0, 7, 7, 12], device=cuda_device))
+    offsets = torch.tensor([0, 0, 7, 7, 12], device=cuda_device)
+    original_to = torch.Tensor.to
+
+    def reject_device_to_host(self, *args, **kwargs):
+        if args and torch.device(args[0]).type == "cpu" and self.is_cuda:
+            pytest.fail("wrapper plan must not read CUDA offsets on the host")
+        return original_to(self, *args, **kwargs)
+
+    monkeypatch.setattr(torch.Tensor, "to", reject_device_to_host)
+    wrapper.plan(offsets)
 
     cu_seqlens_ptr = wrapper._cu_seqlens_buf.data_ptr()
     seq_order_ptr = wrapper._seq_order_buf.data_ptr()
     cu_chunks_ptr = wrapper._cu_chunks_buf.data_ptr()
     assert wrapper._cu_seqlens_buf.dtype == torch.int64
     assert wrapper._cu_seqlens_buf.tolist() == [0, 0, 7, 7, 12]
-    assert wrapper._seq_order_buf.tolist() == [1, 3, 0, 2]
-    assert wrapper._cu_chunks_buf.tolist() == [0, 0, 1, 1, 2]
-    assert wrapper._workspace._cute_dsl_total_chunks == 2
+    assert wrapper._workspace._cute_dsl_generate_planned_metadata is True
 
     wrapper.plan(torch.tensor([0, 0, 2, 2, 12], device=cuda_device))
     assert wrapper._cu_seqlens_buf.data_ptr() == cu_seqlens_ptr
     assert wrapper._seq_order_buf.data_ptr() == seq_order_ptr
     assert wrapper._cu_chunks_buf.data_ptr() == cu_chunks_ptr
-    assert wrapper._seq_order_buf.tolist() == [3, 1, 0, 2]
-
-    with pytest.raises(ValueError, match="total token count is fixed"):
-        wrapper.plan(torch.tensor([0, 0, 2, 2, 13], device=cuda_device))
 
     with pytest.raises(ValueError, match="number of sequences is fixed"):
         wrapper.plan(torch.tensor([0, 2, 12], device=cuda_device))
-
-    chunk_wrapper = RecurrentKDAPrefillWrapper(cuda_device)
-    chunk_wrapper.plan(torch.tensor([0, 16, 16, 32], device=cuda_device))
-    with pytest.raises(ValueError, match="chunk count is fixed"):
-        chunk_wrapper.plan(torch.tensor([0, 1, 17, 32], device=cuda_device))
-
-    with pytest.raises(ValueError, match="non-decreasing"):
-        RecurrentKDAPrefillWrapper(cuda_device).plan(
-            torch.tensor([0, 2, 1, 12], device=cuda_device)
-        )
 
 
 def test_prefill_wrapper_run_forwards_planned_buffers(cuda_device, monkeypatch):
@@ -287,7 +290,7 @@ def test_prefill_wrapper_run_forwards_planned_buffers(cuda_device, monkeypatch):
     assert calls[0]["prefill_workspace"] is wrapper._workspace
     assert calls[0]["backend"] == "cute-dsl"
     assert wrapper._workspace._cute_dsl_cu_chunks is wrapper._cu_chunks_buf
-    assert wrapper._workspace._cute_dsl_total_chunks == 2
+    assert wrapper._workspace._cute_dsl_generate_planned_metadata is True
 
 
 def _cpu_route_tensors(token_count=2):
@@ -611,6 +614,7 @@ def test_cute_dsl_prefill_adapter_preserves_indexed_in_place_state_semantics(
         "state_indices": state_indices,
         "planned_cu_chunks": None,
         "planned_total_chunks": None,
+        "generate_planned_metadata": False,
     }
 
 
@@ -864,26 +868,28 @@ def test_cute_dsl_prefill_adapter_forwards_packed_sequence_order(
         "seq_order",
         "planned_cu_chunks",
         "planned_total_chunks",
+        "generate_planned_metadata",
     }
     assert kwargs["seq_order"] is seq_order
     assert kwargs["state_indices"] is None
     assert kwargs["planned_cu_chunks"] is None
     assert kwargs["planned_total_chunks"] is None
+    assert kwargs["generate_planned_metadata"] is False
 
 
-def test_cute_dsl_lpt_sequence_order_is_content_cached(monkeypatch):
+def test_cute_dsl_device_sequence_order_buffer_is_stream_cached(monkeypatch):
     kernel_module = importlib.import_module("flashinfer.kda_kernels.kda_chunked_bt16")
-    monkeypatch.setattr(kernel_module, "_CU_CONTENTS_MEMO", {})
-    monkeypatch.setattr(kernel_module, "_LPT_SEQUENCE_ORDER_CACHE", {})
-    cu_seqlens = torch.tensor(
-        [0, 1300, 1847, 3895, 4858, 5129, 8192], dtype=torch.int64
+    monkeypatch.setattr(kernel_module, "_DEVICE_SEQUENCE_ORDER_CACHE", {})
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+
+    first = kernel_module._device_sequence_order_buffer(6, torch.device("cpu"), 7)
+    second = kernel_module._device_sequence_order_buffer(6, torch.device("cpu"), 7)
+    other_stream = kernel_module._device_sequence_order_buffer(
+        6, torch.device("cpu"), 8
     )
 
-    first = kernel_module._lpt_sequence_order(cu_seqlens)
-    second = kernel_module._lpt_sequence_order(cu_seqlens.clone())
-
-    assert first.tolist() == [5, 2, 0, 3, 1, 4]
     assert second.data_ptr() == first.data_ptr()
+    assert other_stream.data_ptr() != first.data_ptr()
 
 
 def test_cute_dsl_unplanned_packed_engine_rejects_graph_capture(monkeypatch):
@@ -913,7 +919,7 @@ def test_cute_dsl_unplanned_packed_engine_rejects_graph_capture(monkeypatch):
     inputs = _cpu_route_tensors()
     cu_seqlens = torch.tensor([0, 1, 2], dtype=torch.int64)
 
-    with pytest.raises(RuntimeError, match=r"Wrapper\.plan\(\)"):
+    with pytest.raises(RuntimeError, match="device sequence order must be warmed"):
         compiled(
             inputs["q"],
             inputs["k"],
@@ -6671,6 +6677,9 @@ def test_cute_dsl_planned_zero_length_cuda_graph_capture_and_replay(
         inputs["initial_state"].copy_(initial_state_seed)
         output.zero_()
     capture_stream.synchronize()
+    assert wrapper._seq_order_buf.tolist() == [3, 1, 0, 2]
+    if num_heads == 12:
+        assert wrapper._cu_chunks_buf.tolist() == [0, 0, 2, 2, 5]
 
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph, stream=capture_stream):
@@ -6691,6 +6700,41 @@ def test_cute_dsl_planned_zero_length_cuda_graph_capture_and_replay(
     )
     torch.testing.assert_close(
         captured_state.float(), expected_state.float(), atol=1e-2, rtol=1e-2
+    )
+
+    # Reuse the captured graph with different device-resident offsets.  The
+    # graph's metadata prepass must refresh both scheduling buffers without a
+    # data-dependent host read or a changed launch geometry.
+    replay_seq_lens = [8, 0, 25, 17]
+    replay_offsets = torch.tensor(
+        [0, 8, 8, 33, 50], dtype=torch.int64, device=flash_kda_device
+    )
+    replay_inputs = {**inputs, "cu_seqlens": replay_offsets}
+    expected_replay_output, expected_replay_state = reference(
+        {**replay_inputs, "initial_state": initial_state_seed.clone()}
+    )
+    with torch.cuda.stream(capture_stream):
+        wrapper.plan(replay_offsets)
+        inputs["initial_state"].copy_(initial_state_seed)
+        output.fill_(float("nan"))
+        graph.replay()
+    capture_stream.synchronize()
+
+    assert wrapper._seq_order_buf.tolist() == [2, 3, 0, 1]
+    if num_heads == 12:
+        assert wrapper._cu_chunks_buf.tolist() == [0, 1, 1, 3, 5]
+    assert sum(replay_seq_lens) == output.shape[1]
+    torch.testing.assert_close(
+        captured_output.float(),
+        expected_replay_output.float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        captured_state.float(),
+        expected_replay_state.float(),
+        atol=1e-2,
+        rtol=1e-2,
     )
 
 

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -569,6 +569,67 @@ def test_cute_dsl_prefill_adapter_preserves_indexed_in_place_state_semantics(
     }
 
 
+def test_cute_dsl_prefill_adapter_narrows_padded_gate_and_beta_without_copy(
+    monkeypatch,
+):
+    calls = []
+
+    class Compiled:
+        def workspace_size(self, cu_seqlens, heads, **kwargs):
+            return 0
+
+        def __call__(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_get_compiled_cute_dsl_kda",
+        lambda **kwargs: Compiled(),
+    )
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_identity_seq_order",
+        lambda **kwargs: torch.tensor([0], dtype=torch.int32),
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", lambda device=None: SimpleNamespace(cuda_stream=7)
+    )
+
+    inputs = _cpu_route_tensors(token_count=2)
+    padded_g = torch.empty((1, 4, 1, 128), dtype=torch.bfloat16)
+    padded_beta = torch.empty((1, 4, 1), dtype=torch.bfloat16)
+    output = torch.empty_like(inputs["q"])
+    kda_prefill_cute_api._run_cute_dsl_kda_prefill(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=padded_g,
+        beta=padded_beta,
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        scale=None,
+        initial_state=None,
+        output_final_state=False,
+        lower_bound=-5.0,
+        cu_seqlens=None,
+        seq_order=None,
+        output=output,
+        prefill_workspace=None,
+        state_checkpoints=None,
+        checkpoint_cu_starts=None,
+        checkpoint_every_n_tokens=0,
+    )
+
+    args, _ = calls[0]
+    kernel_g = args[3]
+    kernel_beta = args[6]
+    assert kernel_g.shape == inputs["q"].shape
+    assert kernel_beta.shape == inputs["beta"].shape
+    assert kernel_g.data_ptr() == padded_g.data_ptr()
+    assert kernel_beta.data_ptr() == padded_beta.data_ptr()
+
+
 @pytest.mark.parametrize("explicit_order", [False, True])
 def test_cute_dsl_prefill_adapter_forwards_packed_sequence_order(
     monkeypatch, explicit_order
@@ -777,6 +838,91 @@ def _make_inputs(
             torch.tensor(offsets, dtype=torch.int64, device="cuda") if packed else None
         ),
     }
+
+
+@pytest.mark.parametrize(
+    ("valid_tokens", "physical_gate_tokens"),
+    [(26, 28), (68, 80), (502, 512), (1495, 1536)],
+)
+def test_cute_dsl_prefill_accepts_padded_gate_and_beta_token_extents(
+    flash_kda_device,
+    monkeypatch,
+    valid_tokens,
+    physical_gate_tokens,
+):
+    inputs = _make_inputs(
+        seq_lens=[valid_tokens],
+        num_heads=1,
+        packed=True,
+        seed=4896 + valid_tokens,
+    )
+    padded_g = torch.empty(
+        (1, physical_gate_tokens, 1, 128),
+        dtype=inputs["g"].dtype,
+        device=flash_kda_device,
+    )
+    padded_beta = torch.empty(
+        (1, physical_gate_tokens, 1),
+        dtype=inputs["beta"].dtype,
+        device=flash_kda_device,
+    )
+    padded_g[:, :valid_tokens].copy_(inputs["g"])
+    padded_beta[:, :valid_tokens].copy_(inputs["beta"])
+    inputs["g"] = padded_g
+    inputs["beta"] = padded_beta
+
+    sentinel = (object(), object())
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_is_cute_dsl_kda_runtime_available",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_run_cute_dsl_kda_prefill",
+        lambda **kwargs: sentinel,
+    )
+
+    assert (
+        recurrent_kda(**_strict_prefill_kwargs(inputs), backend="cute-dsl") is sentinel
+    )
+
+
+def test_cute_dsl_padded_gate_and_beta_match_compact_inputs(flash_kda_device):
+    inputs = _make_inputs(
+        seq_lens=[26, 42],
+        num_heads=12,
+        packed=True,
+        initial_state=True,
+        seed=4896,
+    )
+    compact_state = inputs["initial_state"].clone()
+    compact_output, compact_final_state = recurrent_kda(
+        **_strict_prefill_kwargs(inputs),
+        output_final_state=True,
+        backend="cute-dsl",
+    )
+
+    padded_inputs = {
+        **inputs,
+        "initial_state": compact_state,
+        "g": torch.empty(
+            (1, 80, 12, 128), dtype=inputs["g"].dtype, device=flash_kda_device
+        ),
+        "beta": torch.empty(
+            (1, 80, 12), dtype=inputs["beta"].dtype, device=flash_kda_device
+        ),
+    }
+    padded_inputs["g"][:, :68].copy_(inputs["g"])
+    padded_inputs["beta"][:, :68].copy_(inputs["beta"])
+    padded_output, padded_final_state = recurrent_kda(
+        **_strict_prefill_kwargs(padded_inputs),
+        output_final_state=True,
+        backend="cute-dsl",
+    )
+
+    torch.testing.assert_close(padded_output, compact_output, atol=0, rtol=0)
+    torch.testing.assert_close(padded_final_state, compact_final_state, atol=0, rtol=0)
 
 
 @pytest.mark.parametrize(

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -454,6 +454,49 @@ def test_public_prefill_auto_routes_supported_checkpoints_to_cute_dsl(monkeypatc
     assert calls[0]["checkpoint_every_n_tokens"] == 32
 
 
+def test_public_prefill_forwards_checkpoint_state_indices_only_to_cute_dsl(
+    monkeypatch,
+):
+    calls = []
+    sentinel = (object(), object(), object())
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_is_cute_dsl_kda_prefill_eligible",
+        lambda **kwargs: True,
+    )
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_run_cute_dsl_kda_prefill",
+        lambda **kwargs: calls.append(kwargs) or sentinel,
+    )
+
+    checkpoints = torch.empty((4, 1, 128, 128), dtype=torch.bfloat16)
+    starts = torch.tensor([0, 2], dtype=torch.int64)
+    indices = torch.tensor([3, 1], dtype=torch.int32)
+    assert (
+        recurrent_kda(
+            **_cpu_route_tensors(token_count=64),
+            state_checkpoints=checkpoints,
+            checkpoint_cu_starts=starts,
+            checkpoint_state_indices=indices,
+            checkpoint_every_n_tokens=32,
+            backend="cute-dsl",
+        )
+        is sentinel
+    )
+    assert calls[0]["checkpoint_state_indices"] is indices
+
+    with pytest.raises(ValueError, match="checkpoint_state_indices.*CuTe DSL"):
+        recurrent_kda(
+            **_cpu_route_tensors(token_count=64),
+            state_checkpoints=checkpoints,
+            checkpoint_cu_starts=starts,
+            checkpoint_state_indices=indices,
+            checkpoint_every_n_tokens=32,
+            backend="cake",
+        )
+
+
 def test_public_prefill_cake_backend_is_strict(monkeypatch):
     monkeypatch.setattr(
         kda_prefill_api,
@@ -555,6 +598,7 @@ def test_cute_dsl_prefill_adapter_preserves_indexed_in_place_state_semantics(
             "has_state_out": True,
             "has_state_ckpt": False,
             "has_state_indices": True,
+            "has_checkpoint_state_indices": False,
         }
     ]
     args, kwargs = calls[0]
@@ -628,6 +672,75 @@ def test_cute_dsl_prefill_adapter_compiles_fp32_state_and_checkpoints(monkeypatc
     assert args[8] is state
     assert args[10] is state
     assert kwargs["state_ckpt"] is checkpoints
+
+
+def test_cute_dsl_prefill_adapter_indexes_checkpoint_pool_and_auto_allocates(
+    monkeypatch,
+):
+    calls = []
+
+    class Compiled:
+        def workspace_size(self, cu_seqlens, heads, **kwargs):
+            return 0
+
+        def __call__(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_get_compiled_cute_dsl_kda",
+        lambda **kwargs: Compiled(),
+    )
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_identity_seq_order",
+        lambda **kwargs: torch.tensor([0], dtype=torch.int32),
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", lambda device=None: SimpleNamespace(cuda_stream=7)
+    )
+
+    inputs = _cpu_route_tensors(token_count=64)
+    adapter_inputs = {
+        key: inputs[key]
+        for key in ("q", "k", "v", "g", "beta", "A_log", "dt_bias", "lower_bound")
+    }
+    starts = torch.tensor([0, 2], dtype=torch.int64)
+    indices = torch.tensor([3, 1], dtype=torch.int32)
+    pool = torch.empty((4, 1, 128, 128), dtype=torch.bfloat16)
+    result = kda_prefill_cute_api._run_cute_dsl_kda_prefill(
+        **adapter_inputs,
+        scale=None,
+        initial_state=None,
+        output_final_state=False,
+        cu_seqlens=None,
+        seq_order=None,
+        output=torch.empty_like(inputs["q"]),
+        prefill_workspace=None,
+        state_checkpoints=pool,
+        checkpoint_cu_starts=starts,
+        checkpoint_every_n_tokens=32,
+        checkpoint_state_indices=indices,
+    )
+    assert result[2] is pool
+    assert calls[-1][1]["checkpoint_state_indices"] is indices
+
+    result = kda_prefill_cute_api._run_cute_dsl_kda_prefill(
+        **adapter_inputs,
+        scale=None,
+        initial_state=None,
+        output_final_state=False,
+        cu_seqlens=None,
+        seq_order=None,
+        output=torch.empty_like(inputs["q"]),
+        prefill_workspace=None,
+        state_checkpoints=None,
+        checkpoint_cu_starts=starts,
+        checkpoint_every_n_tokens=32,
+    )
+    assert result[2].shape == (2, 1, 128, 128)
+    assert calls[-1][1]["state_ckpt"] is result[2]
 
 
 def test_cute_dsl_prefill_adapter_narrows_padded_gate_and_beta_without_copy(
@@ -1053,6 +1166,172 @@ def test_cute_dsl_fp32_indexed_state_checkpoints_match_prefix_runs(
         torch.stack(expected_checkpoints),
         atol=0,
         rtol=0,
+    )
+
+
+def test_cute_dsl_checkpoint_state_indices_write_pool_and_aligned_final_boundary(
+    flash_kda_device,
+):
+    seq_lens = [130, 128]
+    inputs = _make_inputs(
+        seq_lens=seq_lens,
+        num_heads=12,
+        packed=True,
+        initial_state=True,
+        state_dtype=torch.float32,
+        seed=4896,
+    )
+    initial_states = inputs["initial_state"].clone()
+    expected = []
+    sequence_start = 0
+    for sequence, seq_len in enumerate(seq_lens):
+        for boundary in (64, 128):
+            assert boundary <= seq_len
+            token_slice = slice(sequence_start, sequence_start + boundary)
+            prefix_inputs = {
+                **inputs,
+                "q": inputs["q"][:, token_slice].contiguous(),
+                "k": inputs["k"][:, token_slice].contiguous(),
+                "v": inputs["v"][:, token_slice].contiguous(),
+                "g": inputs["g"][:, token_slice].contiguous(),
+                "beta": inputs["beta"][:, token_slice].contiguous(),
+                "initial_state": initial_states[sequence : sequence + 1].clone(),
+                "cu_seqlens": torch.tensor(
+                    [0, boundary], dtype=torch.int64, device=flash_kda_device
+                ),
+            }
+            _, prefix_state = recurrent_kda(
+                **_strict_prefill_kwargs(prefix_inputs),
+                output_final_state=True,
+                backend="cute-dsl",
+            )
+            expected.append(prefix_state[0].clone())
+        sequence_start += seq_len
+
+    state_pool = torch.zeros(
+        (4, 12, 128, 128), dtype=torch.float32, device=flash_kda_device
+    )
+    state_indices = torch.tensor([3, 0], dtype=torch.int32, device=flash_kda_device)
+    state_pool[state_indices.long()] = initial_states
+    checkpoint_pool = torch.full(
+        (7, 12, 128, 128),
+        torch.nan,
+        dtype=torch.float32,
+        device=flash_kda_device,
+    )
+    checkpoint_indices = torch.tensor(
+        [5, 1, 4, 2], dtype=torch.int32, device=flash_kda_device
+    )
+    checkpoint_starts = torch.tensor(
+        [0, 2, 4], dtype=torch.int64, device=flash_kda_device
+    )
+    _, _, returned_pool = recurrent_kda(
+        **_strict_prefill_kwargs({**inputs, "initial_state": state_pool}),
+        output_final_state=True,
+        ssm_state_indices=state_indices,
+        state_checkpoints=checkpoint_pool,
+        checkpoint_cu_starts=checkpoint_starts,
+        checkpoint_state_indices=checkpoint_indices,
+        checkpoint_every_n_tokens=64,
+        backend="cute-dsl",
+    )
+
+    assert returned_pool is checkpoint_pool
+    torch.testing.assert_close(
+        checkpoint_pool[checkpoint_indices.long()],
+        torch.stack(expected),
+        atol=0,
+        rtol=0,
+    )
+    assert torch.isnan(checkpoint_pool[[0, 3, 6]]).all()
+
+    packed_starts = torch.tensor([0, 3, 5], dtype=torch.int64, device=flash_kda_device)
+    _, _, allocated_checkpoints = recurrent_kda(
+        **_strict_prefill_kwargs({**inputs, "initial_state": initial_states.clone()}),
+        state_checkpoints=None,
+        checkpoint_cu_starts=packed_starts,
+        checkpoint_every_n_tokens=64,
+        backend="cute-dsl",
+    )
+    assert allocated_checkpoints.shape == (5, 12, 128, 128)
+    torch.testing.assert_close(
+        allocated_checkpoints,
+        torch.stack(
+            [
+                initial_states[0],
+                expected[0],
+                expected[1],
+                initial_states[1],
+                expected[2],
+            ]
+        ),
+        atol=0,
+        rtol=0,
+    )
+
+
+def test_cute_dsl_checkpoint_state_indices_engine_route_matches_packed_states(
+    flash_kda_device,
+):
+    num_sequences = 7
+    inputs = _make_inputs(
+        seq_lens=[128] * num_sequences,
+        num_heads=12,
+        packed=True,
+        initial_state=True,
+        state_dtype=torch.float32,
+        seed=4897,
+    )
+    initial_states = inputs["initial_state"].clone()
+    checkpoint_starts = torch.arange(
+        0,
+        2 * num_sequences + 1,
+        2,
+        dtype=torch.int64,
+        device=flash_kda_device,
+    )
+    legacy_checkpoints = torch.empty(
+        (2 * num_sequences, 12, 128, 128),
+        dtype=torch.float32,
+        device=flash_kda_device,
+    )
+    _, legacy_final_states, _ = recurrent_kda(
+        **_strict_prefill_kwargs({**inputs, "initial_state": initial_states.clone()}),
+        output_final_state=True,
+        state_checkpoints=legacy_checkpoints,
+        checkpoint_cu_starts=checkpoint_starts,
+        checkpoint_every_n_tokens=64,
+        backend="cute-dsl",
+    )
+    expected = torch.stack(
+        [
+            state
+            for sequence in range(num_sequences)
+            for state in (
+                legacy_checkpoints[2 * sequence + 1],
+                legacy_final_states[sequence],
+            )
+        ]
+    )
+
+    checkpoint_indices = torch.tensor(
+        [13, 0, 12, 1, 11, 2, 10, 3, 9, 4, 8, 5, 7, 6],
+        dtype=torch.int32,
+        device=flash_kda_device,
+    )
+    checkpoint_pool = torch.full_like(legacy_checkpoints, torch.nan)
+    _, _, returned_pool = recurrent_kda(
+        **_strict_prefill_kwargs({**inputs, "initial_state": initial_states.clone()}),
+        state_checkpoints=checkpoint_pool,
+        checkpoint_cu_starts=checkpoint_starts,
+        checkpoint_state_indices=checkpoint_indices,
+        checkpoint_every_n_tokens=64,
+        backend="cute-dsl",
+    )
+
+    assert returned_pool is checkpoint_pool
+    torch.testing.assert_close(
+        checkpoint_pool[checkpoint_indices.long()], expected, atol=0, rtol=0
     )
 
 

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -6738,6 +6738,193 @@ def test_cute_dsl_planned_zero_length_cuda_graph_capture_and_replay(
     )
 
 
+def test_cute_dsl_cuda_graph_replay_updates_offsets_and_indexed_checkpoints(
+    flash_kda_device,
+):
+    inputs = _make_inputs(
+        seq_lens=[64, 131],
+        num_heads=12,
+        packed=True,
+        initial_state=True,
+        seed=4898,
+    )
+    initial_states = inputs["initial_state"].clone()
+
+    def eager_control(offsets, state_indices, checkpoint_starts, checkpoint_indices):
+        state_pool = torch.zeros(
+            (4, 12, 128, 128),
+            dtype=initial_states.dtype,
+            device=flash_kda_device,
+        )
+        state_pool[state_indices.long()] = initial_states
+        checkpoint_pool = torch.full(
+            (6, 12, 128, 128),
+            torch.nan,
+            dtype=initial_states.dtype,
+            device=flash_kda_device,
+        )
+        output, returned_state, returned_checkpoints = recurrent_kda(
+            **_strict_prefill_kwargs(
+                {
+                    **inputs,
+                    "cu_seqlens": offsets,
+                    "initial_state": state_pool,
+                }
+            ),
+            output=torch.empty_like(inputs["q"]),
+            output_final_state=True,
+            ssm_state_indices=state_indices,
+            state_checkpoints=checkpoint_pool,
+            checkpoint_cu_starts=checkpoint_starts,
+            checkpoint_state_indices=checkpoint_indices,
+            checkpoint_every_n_tokens=64,
+            backend="cute-dsl",
+        )
+        assert returned_state is state_pool
+        assert returned_checkpoints is checkpoint_pool
+        return (
+            output.clone(),
+            state_pool[state_indices.long()].clone(),
+            checkpoint_pool[checkpoint_indices.long()].clone(),
+        )
+
+    offsets = inputs["cu_seqlens"]
+    state_indices = torch.tensor([0, 2], dtype=torch.int32, device=flash_kda_device)
+    checkpoint_starts = torch.tensor(
+        [0, 1, 3], dtype=torch.int64, device=flash_kda_device
+    )
+    checkpoint_indices = torch.tensor(
+        [5, 1, 4], dtype=torch.int32, device=flash_kda_device
+    )
+    expected = eager_control(
+        offsets, state_indices, checkpoint_starts, checkpoint_indices
+    )
+
+    state_pool = torch.zeros(
+        (4, 12, 128, 128),
+        dtype=initial_states.dtype,
+        device=flash_kda_device,
+    )
+    checkpoint_pool = torch.full(
+        (6, 12, 128, 128),
+        torch.nan,
+        dtype=initial_states.dtype,
+        device=flash_kda_device,
+    )
+    output = torch.empty_like(inputs["q"])
+    wrapper = RecurrentKDAPrefillWrapper(flash_kda_device)
+    wrapper.plan(offsets)
+    run_kwargs = {
+        **_strict_prefill_kwargs({**inputs, "initial_state": state_pool}),
+        "output": output,
+        "output_final_state": True,
+        "ssm_state_indices": state_indices,
+        "state_checkpoints": checkpoint_pool,
+        "checkpoint_cu_starts": checkpoint_starts,
+        "checkpoint_state_indices": checkpoint_indices,
+        "checkpoint_every_n_tokens": 64,
+    }
+    run_kwargs.pop("cu_seqlens")
+
+    capture_stream = torch.cuda.Stream(device=flash_kda_device)
+    capture_stream.wait_stream(torch.cuda.current_stream(flash_kda_device))
+    with torch.cuda.stream(capture_stream):
+        state_pool[state_indices.long()] = initial_states
+        wrapper.run(**run_kwargs)
+        state_pool.zero_()
+        state_pool[state_indices.long()] = initial_states
+        checkpoint_pool.fill_(float("nan"))
+        output.fill_(float("nan"))
+    capture_stream.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=capture_stream):
+        captured_output, captured_state, captured_checkpoints = wrapper.run(
+            **run_kwargs
+        )
+
+    with torch.cuda.stream(capture_stream):
+        state_pool.zero_()
+        state_pool[state_indices.long()] = initial_states
+        checkpoint_pool.fill_(float("nan"))
+        output.fill_(float("nan"))
+        graph.replay()
+    capture_stream.synchronize()
+
+    assert captured_output is output
+    assert captured_state is state_pool
+    assert captured_checkpoints is checkpoint_pool
+    torch.testing.assert_close(
+        output.float(), expected[0].float(), atol=1e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        state_pool[state_indices.long()].float(),
+        expected[1].float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        checkpoint_pool[checkpoint_indices.long()].float(),
+        expected[2].float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    assert torch.count_nonzero(state_pool[[1, 3]]) == 0
+    assert torch.isnan(checkpoint_pool[[0, 2, 3]]).all()
+
+    # Keep all captured addresses fixed while changing the sequence split,
+    # initial-state slots, checkpoint prefix, and checkpoint destinations.
+    replay_offsets = torch.tensor(
+        [0, 129, 195], dtype=torch.int64, device=flash_kda_device
+    )
+    replay_state_indices = torch.tensor(
+        [3, 1], dtype=torch.int32, device=flash_kda_device
+    )
+    replay_checkpoint_starts = torch.tensor(
+        [0, 2, 3], dtype=torch.int64, device=flash_kda_device
+    )
+    replay_checkpoint_indices = torch.tensor(
+        [0, 3, 2], dtype=torch.int32, device=flash_kda_device
+    )
+    expected_replay = eager_control(
+        replay_offsets,
+        replay_state_indices,
+        replay_checkpoint_starts,
+        replay_checkpoint_indices,
+    )
+    with torch.cuda.stream(capture_stream):
+        wrapper.plan(replay_offsets)
+        state_indices.copy_(replay_state_indices)
+        checkpoint_starts.copy_(replay_checkpoint_starts)
+        checkpoint_indices.copy_(replay_checkpoint_indices)
+        state_pool.zero_()
+        state_pool[replay_state_indices.long()] = initial_states
+        checkpoint_pool.fill_(float("nan"))
+        output.fill_(float("nan"))
+        graph.replay()
+    capture_stream.synchronize()
+
+    assert wrapper._seq_order_buf.tolist() == [0, 1]
+    assert wrapper._cu_chunks_buf.tolist() == [0, 9, 14]
+    torch.testing.assert_close(
+        output.float(), expected_replay[0].float(), atol=1e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        state_pool[replay_state_indices.long()].float(),
+        expected_replay[1].float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    torch.testing.assert_close(
+        checkpoint_pool[replay_checkpoint_indices.long()].float(),
+        expected_replay[2].float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    assert torch.count_nonzero(state_pool[[0, 2]]) == 0
+    assert torch.isnan(checkpoint_pool[[1, 4, 5]]).all()
+
+
 @pytest.mark.parametrize("num_heads", [6, 12])
 def test_frozen_prefill_non_aligned_heads_graph_refreshes_beta(
     flash_kda_device, num_heads

--- a/tests/kda/test_recurrent_kda_prefill.py
+++ b/tests/kda/test_recurrent_kda_prefill.py
@@ -550,6 +550,7 @@ def test_cute_dsl_prefill_adapter_preserves_indexed_in_place_state_semantics(
     assert compile_args == [
         {
             "lower_bound": -5.0,
+            "state_dtype": torch.bfloat16,
             "has_state_in": True,
             "has_state_out": True,
             "has_state_ckpt": False,
@@ -567,6 +568,66 @@ def test_cute_dsl_prefill_adapter_preserves_indexed_in_place_state_semantics(
         "planned_cu_chunks": None,
         "planned_total_chunks": None,
     }
+
+
+def test_cute_dsl_prefill_adapter_compiles_fp32_state_and_checkpoints(monkeypatch):
+    calls = []
+    compile_args = []
+
+    class Compiled:
+        def workspace_size(self, cu_seqlens, heads, **kwargs):
+            return 0
+
+        def __call__(self, *args, **kwargs):
+            calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_get_compiled_cute_dsl_kda",
+        lambda **kwargs: compile_args.append(kwargs) or Compiled(),
+    )
+    monkeypatch.setattr(
+        kda_prefill_cute_api,
+        "_identity_seq_order",
+        lambda **kwargs: torch.tensor([0], dtype=torch.int32),
+    )
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        torch.cuda, "current_stream", lambda device=None: SimpleNamespace(cuda_stream=7)
+    )
+
+    inputs = _cpu_route_tensors(token_count=65)
+    state = torch.empty((1, 1, 128, 128), dtype=torch.float32)
+    checkpoints = torch.empty((2, 1, 128, 128), dtype=torch.float32)
+    checkpoint_starts = torch.tensor([0, 2], dtype=torch.int64)
+    result = kda_prefill_cute_api._run_cute_dsl_kda_prefill(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        A_log=inputs["A_log"],
+        dt_bias=inputs["dt_bias"],
+        scale=None,
+        initial_state=state,
+        output_final_state=True,
+        lower_bound=-5.0,
+        cu_seqlens=None,
+        seq_order=None,
+        output=torch.empty_like(inputs["q"]),
+        prefill_workspace=None,
+        state_checkpoints=checkpoints,
+        checkpoint_cu_starts=checkpoint_starts,
+        checkpoint_every_n_tokens=64,
+    )
+
+    assert compile_args[0]["state_dtype"] == torch.float32
+    assert result[1] is state
+    assert result[2] is checkpoints
+    args, kwargs = calls[0]
+    assert args[8] is state
+    assert args[10] is state
+    assert kwargs["state_ckpt"] is checkpoints
 
 
 def test_cute_dsl_prefill_adapter_narrows_padded_gate_and_beta_without_copy(
@@ -923,6 +984,100 @@ def test_cute_dsl_padded_gate_and_beta_match_compact_inputs(flash_kda_device):
 
     torch.testing.assert_close(padded_output, compact_output, atol=0, rtol=0)
     torch.testing.assert_close(padded_final_state, compact_final_state, atol=0, rtol=0)
+
+
+def test_cute_dsl_fp32_indexed_state_checkpoints_match_prefix_runs(
+    flash_kda_device,
+):
+    inputs = _make_inputs(
+        seq_lens=[130],
+        num_heads=12,
+        packed=True,
+        initial_state=True,
+        state_dtype=torch.float32,
+        seed=4964,
+    )
+    initial_state = inputs["initial_state"].clone()
+
+    control_output, control_final_state = recurrent_kda(
+        **_strict_prefill_kwargs({**inputs, "initial_state": initial_state.clone()}),
+        output_final_state=True,
+        backend="cute-dsl",
+    )
+    expected_checkpoints = [initial_state[0]]
+    for boundary in (64, 128):
+        prefix_inputs = {
+            **inputs,
+            "q": inputs["q"][:, :boundary],
+            "k": inputs["k"][:, :boundary],
+            "v": inputs["v"][:, :boundary],
+            "g": inputs["g"][:, :boundary],
+            "beta": inputs["beta"][:, :boundary],
+            "initial_state": initial_state.clone(),
+            "cu_seqlens": torch.tensor(
+                [0, boundary], dtype=torch.int64, device=flash_kda_device
+            ),
+        }
+        _, prefix_final_state = recurrent_kda(
+            **_strict_prefill_kwargs(prefix_inputs),
+            output_final_state=True,
+            backend="cute-dsl",
+        )
+        expected_checkpoints.append(prefix_final_state[0])
+
+    state_pool = torch.zeros(
+        (3, 12, 128, 128), dtype=torch.float32, device=flash_kda_device
+    )
+    state_pool[1].copy_(initial_state[0])
+    state_indices = torch.tensor([1], dtype=torch.int32, device=flash_kda_device)
+    checkpoints = torch.empty(
+        (3, 12, 128, 128), dtype=torch.float32, device=flash_kda_device
+    )
+    checkpoint_starts = torch.tensor([0, 3], dtype=torch.int64, device=flash_kda_device)
+    output, final_state, actual_checkpoints = recurrent_kda(
+        **_strict_prefill_kwargs({**inputs, "initial_state": state_pool}),
+        output_final_state=True,
+        ssm_state_indices=state_indices,
+        state_checkpoints=checkpoints,
+        checkpoint_cu_starts=checkpoint_starts,
+        checkpoint_every_n_tokens=64,
+        backend="cute-dsl",
+    )
+
+    assert final_state is state_pool
+    assert actual_checkpoints is checkpoints
+    torch.testing.assert_close(output, control_output, atol=0, rtol=0)
+    torch.testing.assert_close(state_pool[1], control_final_state[0], atol=0, rtol=0)
+    torch.testing.assert_close(
+        checkpoints,
+        torch.stack(expected_checkpoints),
+        atol=0,
+        rtol=0,
+    )
+
+
+def test_cute_dsl_rejects_mixed_state_and_checkpoint_dtypes(flash_kda_device):
+    inputs = _make_inputs(
+        seq_lens=[65],
+        num_heads=1,
+        packed=True,
+        initial_state=True,
+        state_dtype=torch.float32,
+        seed=4965,
+    )
+    checkpoints = torch.empty(
+        (2, 1, 128, 128), dtype=torch.bfloat16, device=flash_kda_device
+    )
+    checkpoint_starts = torch.tensor([0, 2], dtype=torch.int64, device=flash_kda_device)
+
+    with pytest.raises(ValueError, match="backend='cute-dsl' does not support"):
+        recurrent_kda(
+            **_strict_prefill_kwargs(inputs),
+            state_checkpoints=checkpoints,
+            checkpoint_cu_starts=checkpoint_starts,
+            checkpoint_every_n_tokens=64,
+            backend="cute-dsl",
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR improves the CuTe DSL KDA prefill path for prefix caching:

  - Supports padded gate and beta buffers.
  - Supports BF16/FP32 checkpoint states.
  - Writes checkpoints directly into indexed state pools.
  - Preserves floor-aligned checkpoint semantics, including the 130-token → 128-token case.
  - Generates packed sequence order and chunk metadata on the GPU.
  - Supports CUDA Graph replay with changing sequence offsets, state indices, and checkpoint destinations.

  The Cake backend is unchanged.

## 🔍 Related Issues

#4896 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting checkpoint output rows with `checkpoint_state_indices`.
  - Added support for `float32` initial states and state checkpoints in packed KDA prefill.
  - Improved CUDA Graph compatibility by generating packed scheduling metadata during GPU execution.
  - Added support for changing sequence lengths across planning calls while preserving a fixed token count after the first run.

- **Bug Fixes**
  - Improved handling of padded gate and beta buffers.
  - Preserved sequence order in applicable eager execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->