### PR TITLE
Support compact GLM NoPE FP8 rows and fix masked reads

### DIFF
--- a/csrc/sparse_mla_sm120.cu
+++ b/csrc/sparse_mla_sm120.cu
@@ -184,15 +184,15 @@ void SparseMlaSm120PagedAttention(
   const int d_qk = static_cast<int>(q.size(2));
   const int topk = check_dense_indices_2d_or_s_q_3d(indices, "indices", num_tokens);
   const ModelType mt = resolve_model_type(d_qk, model_type);
-  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bytes_per_token(mt), "kv_cache");
+  const int bpt = bytes_per_token(mt, kv_cache.ndim() >= 3 ? kv_cache.size(-1) : 0);
+  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bpt, "kv_cache");
   const int page_block_size = kv_layout.page_block_size;
   // Inline-scale models (DSV3_2 / GLM_NSA / GLM53_NOPE) are addressed by the
   // prefill kernels as a flat token array (prefill_kv_entry_base), so a
   // padded block stride would be silently misread; only footer-scale models
   // honor stride_kv_block. Padded strides remain a decode-path capability.
   if (mt == ModelType::DSV3_2 || mt == ModelType::GLM_NSA || mt == ModelType::GLM53_NOPE) {
-    TVM_FFI_ICHECK_EQ(kv_layout.stride_kv_block,
-                      static_cast<size_t>(page_block_size) * bytes_per_token(mt))
+    TVM_FFI_ICHECK_EQ(kv_layout.stride_kv_block, static_cast<size_t>(page_block_size) * bpt)
         << "prefill for inline-scale KV caches (DSv3.2/GLM) requires densely packed blocks "
            "(stride_kv_block == page_block_size * bytes_per_token); padded block strides are "
            "decode-only";

--- a/csrc/sparse_mla_sm120_decode_dsv3_2.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv3_2.cu
@@ -189,6 +189,9 @@ bool launch_sparse_mla_decode_dsv3_2(ModelType mt, int num_heads, int topk, int 
   // indexer window. The TP1 (64-head) and TP2 (32-head) shapes keep
   // dedicated instantiations; any other shard rides the runtime-H fallback.
   if (mt == ModelType::GLM53_NOPE) {
+    // The public scratch allocator uses eight rows for H=8. A dedicated
+    // instantiation preserves that ABI instead of the runtime-H padded stride.
+    DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 8)
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 32)
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 64)
     DSV3_2_DISPATCH_RT_MT(ModelType::GLM53_NOPE)

--- a/csrc/sparse_mla_sm120_jit_binding.cu
+++ b/csrc/sparse_mla_sm120_jit_binding.cu
@@ -263,7 +263,8 @@ void SparseMlaSm120DecodeDsv3_2(TensorView q, TensorView kv_cache, TensorView in
       << "decode-v32 expects DSV3_2/GLM_NSA d_qk=576 or GLM53_NOPE d_qk=512; got d_qk=" << d_qk
       << " model_type=" << model_type;
 
-  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bytes_per_token(mt), "kv_cache");
+  const int bpt = bytes_per_token(mt, kv_cache.ndim() >= 3 ? kv_cache.size(-1) : 0);
+  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bpt, "kv_cache");
 
   const int* topk_len_ptr =
       topk_length.has_value() ? static_cast<const int*>(topk_length.value().data_ptr()) : nullptr;

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -180,6 +180,11 @@ class SparseMLASm120DecodeConfig:
     compact_bytes_per_token : Optional[int]
         Optional smaller lossless row layout for explicitly shaped 3-D or
         4-D caches. GLM53_NOPE can omit its 128 unused RoPE padding bytes.
+    glm53_nope_contract_version : int
+        GLM53_NOPE integration contract. Version 1 guarantees zero-padded
+        masked candidate reads and an eight-head decode kernel compatible
+        with eight-head scratch buffers. Zero does not advertise this
+        contract. Compact row support is advertised separately.
     head_counts : Optional[frozenset[int]]
         Exact instantiated head counts when the kernel has no runtime-head
         fallback. ``None`` means every count in ``[1, max_num_heads]``.
@@ -203,6 +208,7 @@ class SparseMLASm120DecodeConfig:
     topk_is_runtime: bool = True
     extra_page_block_sizes: frozenset[int] = frozenset()
     compact_bytes_per_token: Optional[int] = None
+    glm53_nope_contract_version: int = 0
 
     def supported_num_heads(self) -> tuple[int, ...]:
         """Sorted instantiated head counts, including any runtime-H envelope."""
@@ -341,6 +347,7 @@ def supported_sparse_mla_sm120_configs(
             max_num_heads=_DECODE_MAX_HEADS,
             bytes_per_token=_BPT_DSV3_2,
             compact_bytes_per_token=528,
+            glm53_nope_contract_version=1,
         ),
         "dots3_swa": SparseMLASm120DecodeConfig(
             d_qk=1088,

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -176,7 +176,10 @@ class SparseMLASm120DecodeConfig:
         Packed cache format described by this entry (``"fp8"`` or
         ``"nvfp4"``).
     bytes_per_token : int
-        Logical packed-cache bytes per token.
+        Default packed-cache bytes per token, including for flat 2-D caches.
+    compact_bytes_per_token : Optional[int]
+        Optional smaller lossless row layout for explicitly shaped 3-D or
+        4-D caches. GLM53_NOPE can omit its 128 unused RoPE padding bytes.
     head_counts : Optional[frozenset[int]]
         Exact instantiated head counts when the kernel has no runtime-head
         fallback. ``None`` means every count in ``[1, max_num_heads]``.
@@ -199,6 +202,7 @@ class SparseMLASm120DecodeConfig:
     head_counts: Optional[frozenset[int]] = None
     topk_is_runtime: bool = True
     extra_page_block_sizes: frozenset[int] = frozenset()
+    compact_bytes_per_token: Optional[int] = None
 
     def supported_num_heads(self) -> tuple[int, ...]:
         """Sorted instantiated head counts, including any runtime-H envelope."""
@@ -336,6 +340,7 @@ def supported_sparse_mla_sm120_configs(
             min_topk=1,
             max_num_heads=_DECODE_MAX_HEADS,
             bytes_per_token=_BPT_DSV3_2,
+            compact_bytes_per_token=528,
         ),
         "dots3_swa": SparseMLASm120DecodeConfig(
             d_qk=1088,
@@ -519,6 +524,12 @@ def _packed_kv_page_block_size(
     name: str,
 ) -> int:
     bytes_per_token = _bytes_per_token_for_model_type(model_type)
+    if (
+        model_type == _MODEL_TYPE_GLM53_NOPE
+        and kv_cache.ndim >= 3
+        and kv_cache.shape[-1] == 528
+    ):
+        bytes_per_token = 528
     if kv_cache.ndim == 2:
         block_bytes = int(kv_cache.shape[1])
         if block_bytes % bytes_per_token != 0:

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -180,11 +180,6 @@ class SparseMLASm120DecodeConfig:
     compact_bytes_per_token : Optional[int]
         Optional smaller lossless row layout for explicitly shaped 3-D or
         4-D caches. GLM53_NOPE can omit its 128 unused RoPE padding bytes.
-    glm53_nope_contract_version : int
-        GLM53_NOPE integration contract. Version 1 guarantees zero-padded
-        masked candidate reads and an eight-head decode kernel compatible
-        with eight-head scratch buffers. Zero does not advertise this
-        contract. Compact row support is advertised separately.
     head_counts : Optional[frozenset[int]]
         Exact instantiated head counts when the kernel has no runtime-head
         fallback. ``None`` means every count in ``[1, max_num_heads]``.
@@ -208,7 +203,6 @@ class SparseMLASm120DecodeConfig:
     topk_is_runtime: bool = True
     extra_page_block_sizes: frozenset[int] = frozenset()
     compact_bytes_per_token: Optional[int] = None
-    glm53_nope_contract_version: int = 0
 
     def supported_num_heads(self) -> tuple[int, ...]:
         """Sorted instantiated head counts, including any runtime-H envelope."""
@@ -347,7 +341,6 @@ def supported_sparse_mla_sm120_configs(
             max_num_heads=_DECODE_MAX_HEADS,
             bytes_per_token=_BPT_DSV3_2,
             compact_bytes_per_token=528,
-            glm53_nope_contract_version=1,
         ),
         "dots3_swa": SparseMLASm120DecodeConfig(
             d_qk=1088,

--- a/include/flashinfer/attention/sparse_mla_sm120/common/glm53_padding.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/glm53_padding.cuh
@@ -1,0 +1,12 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+// Module-owned padding cannot be overwritten by cache allocation or graph
+// dummy writes. GLM NoPE gathers 512 FP8 bytes and four inline FP32 scales.
+// Both payload and scales are finite zero, so masked value MMA lanes cannot
+// produce 0 * NaN from an unrelated cache row.
+static __device__ __align__(16) const uint8_t glm53_padding_kv[528] = {};

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -84,7 +84,9 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, int idx,
   idx = (idx >= 0) ? idx : 0;
 
   const uint8_t* src;
-  if constexpr (KV::SCALE_IN_KV_SMEM) {
+  if constexpr (MT == ModelType::GLM53_NOPE) {
+    src = kv_ptr + (size_t)idx * (stride_kv_block / PAGE_BLOCK_SIZE);
+  } else if constexpr (KV::SCALE_IN_KV_SMEM) {
     src = kv_ptr + (size_t)idx * IO::IO_STRIDE;
   } else {
     constexpr int pbs = PAGE_BLOCK_SIZE;
@@ -113,7 +115,9 @@ __device__ __forceinline__ void io_bulk_prefetch_l2(int idx, const uint8_t* __re
   if (io_tid >= TILE_BI || idx < 0) return;
 
   const uint8_t* src;
-  if constexpr (KV::SCALE_IN_KV_SMEM) {
+  if constexpr (MT == ModelType::GLM53_NOPE) {
+    src = kv_ptr + (size_t)idx * (stride_kv_block / PAGE_BLOCK_SIZE);
+  } else if constexpr (KV::SCALE_IN_KV_SMEM) {
     src = kv_ptr + (size_t)idx * IO::IO_STRIDE;
   } else {
     constexpr int pbs = PAGE_BLOCK_SIZE;
@@ -123,10 +127,12 @@ __device__ __forceinline__ void io_bulk_prefetch_l2(int idx, const uint8_t* __re
                             (size_t)(idx % pbs) * KV::SCALE_BYTES_PER_TOKEN;
     prefetch_l2_line(footer);
   }
+  constexpr int PREFETCH_BYTES =
+      MT == ModelType::GLM53_NOPE ? KV::KV_SMEM_COPY_BYTES : IO::IO_STRIDE;
   if constexpr (USE_L2_HINT)
-    cp_async_bulk_prefetch_l2_hint(src, IO::IO_STRIDE, cache_policy);
+    cp_async_bulk_prefetch_l2_hint(src, PREFETCH_BYTES, cache_policy);
   else
-    cp_async_bulk_prefetch_l2(src, IO::IO_STRIDE);
+    cp_async_bulk_prefetch_l2(src, PREFETCH_BYTES);
 }
 
 // `idx` is the same per-thread staged value passed to io_bulk_gather_tile, so

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -31,6 +31,7 @@
 #include "../arch/barrier.cuh"
 #include "../arch/cp_async.cuh"
 #include "../model/kv_cache_traits.cuh"
+#include "glm53_padding.cuh"
 
 // KV cache IO: gather BI entries from global KV pool to smem.
 //
@@ -81,11 +82,12 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, int idx,
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, TILE_BI * COPY_BYTES);
   if (io_tid >= TILE_BI) return;
 
-  idx = (idx >= 0) ? idx : 0;
+  const bool valid = idx >= 0;
+  idx = valid ? idx : 0;
 
   const uint8_t* src;
   if constexpr (MT == ModelType::GLM53_NOPE) {
-    src = kv_ptr + (size_t)idx * (stride_kv_block / PAGE_BLOCK_SIZE);
+    src = valid ? kv_ptr + (size_t)idx * (stride_kv_block / PAGE_BLOCK_SIZE) : glm53_padding_kv;
   } else if constexpr (KV::SCALE_IN_KV_SMEM) {
     src = kv_ptr + (size_t)idx * IO::IO_STRIDE;
   } else {

--- a/include/flashinfer/attention/sparse_mla_sm120/common/smem_layout.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/smem_layout.cuh
@@ -255,7 +255,9 @@ struct SmemLayoutSwapAB {
   using KV = KVCacheTraits<MT>;
   using CT = ComputeTraitsSwapAB<MT>;
 
-  static constexpr int KV_STRIDE = KV::KV_GMEM_STRIDE;          // 656
+  // NoPE has no RoPE payload to stage, including with a padded global row.
+  static constexpr int KV_STRIDE =
+      MT == ModelType::GLM53_NOPE ? KV::KV_SMEM_COPY_BYTES : KV::KV_GMEM_STRIDE;
   static constexpr int P_TILE_BYTES = CT::HEADS_PER_WARP * BI;  // 512
 
   // nope + inline scales + rope, one linear tile per candidate.

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv3_2_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv3_2_kernel.cuh
@@ -11,6 +11,7 @@
 #include "arch/mma_sm120.cuh"
 #include "common/d2_load_b.cuh"
 #include "common/fp8_quant.cuh"
+#include "common/glm53_padding.cuh"
 #include "common/online_softmax.cuh"
 #include "common/scale_mma.cuh"
 #include "model/kv_cache_traits.cuh"
@@ -268,6 +269,9 @@ __global__ void __launch_bounds__(DSV3_2_BLOCK_THREADS) sparse_mla_decode_dsv3_2
       const int local_idx_g = idx - block_idx_g * pbs;
       const uint8_t* data_base = KV_cache + (size_t)block_idx_g * stride_kv_block +
                                  (size_t)local_idx_g * (size_t)stride_kv_row;
+      if constexpr (MT == ModelType::GLM53_NOPE) {
+        if (idx_raw < 0) data_base = glm53_padding_kv;
+      }
       // Bulk 1: NoPE + INLINE scales (528 B) → sm_kv_fp8 slot.
       cp_async_bulk_g2s(kv_fp8_dst + (size_t)entry_idx * KV_SMEM_STRIDE, data_base,
                         V2_BULK_NOPESC_BYTES, sm.mbar_full(buf));

--- a/include/flashinfer/attention/sparse_mla_sm120/model/model_type.h
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/model_type.h
@@ -45,7 +45,10 @@
 enum class ModelType { DSV3_2, DSV4, GLM_NSA, GLM53_NOPE, DOTS3_SWA };
 
 // Bytes per packed KV cache token row, per model type.
-constexpr int bytes_per_token(ModelType mt) {
+constexpr int bytes_per_token(ModelType mt, int row_width = 0) {
+  // Explicitly shaped NoPE caches may omit the unused 128-byte RoPE pad.
+  // A flat 2D cache retains the historical 656-byte interpretation.
+  if (mt == ModelType::GLM53_NOPE && row_width == 528) return 528;
   switch (mt) {
     case ModelType::DSV3_2:
     case ModelType::GLM_NSA:

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_common.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_common.cuh
@@ -197,7 +197,9 @@ __device__ __forceinline__ const uint8_t* prefill_kv_entry_base(
   // This matches io_bulk_gather_tile. Keying it on V_HAS_ROPE happened to agree
   // for the three DeepSeek-family models and disagrees for DOTS3_SWA, which is
   // footer-scaled with no rope in V.
-  if constexpr (!KV::SCALE_IN_KV_SMEM) {
+  if constexpr (MT == ModelType::GLM53_NOPE) {
+    return kv_global + (size_t)idx * (stride_kv_block / PAGE_BLOCK_SIZE);
+  } else if constexpr (!KV::SCALE_IN_KV_SMEM) {
     const int bi = idx / PAGE_BLOCK_SIZE;
     const int li = idx % PAGE_BLOCK_SIZE;
     return kv_global + (size_t)bi * stride_kv_block + (size_t)li * IO::IO_STRIDE;

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_mg_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_mg_kernel.cuh
@@ -575,6 +575,9 @@ __global__ void __launch_bounds__(PrefillTileCfg<MT>::BLOCK_THREADS, 1)
     // This thread's candidate index for tile t, staged a tile ahead of use so
     // the index LDG latency is hidden behind the previous tile's gather.
     auto load_idx = [&](int t) -> int {
+      if constexpr (MT == ModelType::GLM53_NOPE) {
+        if (t * Cfg::BI + io_tid >= topk_len) return -1;
+      }
       return (t < actual_ni && io_tid < Cfg::BI) ? __ldg(idx_base + t * Cfg::BI + io_tid) : -1;
     };
     // Scales first (plain stores, no mbar signal), then bulk gather
@@ -1260,6 +1263,9 @@ __device__ __forceinline__ void prefill_mg_impl(
     // split needs no branch on the tile-length mode.
     auto load_idx = [&](int t) -> int {
       if (t >= loop_bound || io_tid >= BI) return -1;
+      if constexpr (MT == ModelType::GLM53_NOPE) {
+        if (t * BI + io_tid >= topk_len) return -1;
+      }
       if constexpr (DUAL_CACHE) {
         const bool is_main = t < main_ni;
         const int32_t* p = is_main ? (idx_base + t * BI) : (idx_base_extra + (t - main_ni) * BI);

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_swapab_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_swapab_kernel.cuh
@@ -56,14 +56,16 @@ template <ModelType MT>
 __device__ __forceinline__ void io_bulk_gather_tile_swapab(uint8_t* dst, int idx,
                                                            const uint8_t* __restrict__ kv_ptr,
                                                            uint64_t* mbar, int io_tid,
-                                                           uint64_t cache_policy) {
+                                                           uint64_t cache_policy,
+                                                           size_t stride_kv_row) {
   constexpr int STRIDE = SmemLayoutSwapAB<MT>::KV_STRIDE;
   static_assert(BI <= IO_THREADS, "per-thread index staging assumes one candidate per IO thread");
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * STRIDE);
   if (io_tid >= BI) return;
 
-  const uint8_t* src = kv_ptr + (size_t)(idx >= 0 ? idx : 0) * STRIDE;
+  const size_t row_stride = MT == ModelType::GLM53_NOPE ? stride_kv_row : STRIDE;
+  const uint8_t* src = kv_ptr + (size_t)(idx >= 0 ? idx : 0) * row_stride;
   cp_async_bulk_g2s_l2hint(dst + io_tid * STRIDE, src, STRIDE, mbar, cache_policy);
 }
 
@@ -72,10 +74,12 @@ __device__ __forceinline__ void io_bulk_gather_tile_swapab(uint8_t* dst, int idx
 template <ModelType MT>
 __device__ __forceinline__ void io_bulk_prefetch_l2_swapab(int idx,
                                                            const uint8_t* __restrict__ kv_ptr,
-                                                           int io_tid, uint64_t cache_policy) {
+                                                           int io_tid, uint64_t cache_policy,
+                                                           size_t stride_kv_row) {
   constexpr int STRIDE = SmemLayoutSwapAB<MT>::KV_STRIDE;
   if (io_tid >= BI || idx < 0) return;
-  cp_async_bulk_prefetch_l2_hint(kv_ptr + (size_t)idx * STRIDE, STRIDE, cache_policy);
+  const size_t row_stride = MT == ModelType::GLM53_NOPE ? stride_kv_row : STRIDE;
+  cp_async_bulk_prefetch_l2_hint(kv_ptr + (size_t)idx * row_stride, STRIDE, cache_policy);
 }
 
 template <ModelType MT, int NUM_HEADS>
@@ -142,8 +146,8 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
       const int next = ld_idx(ti + 2);
       mbarrier_wait_parity(sm.mbar_wr + buf, wr_phase);
       io_bulk_gather_tile_swapab<MT>(sm.kv_bufs[buf], staged, KV_cache, sm.mbar_kv + buf, io_tid,
-                                     kv_l2_policy);
-      io_bulk_prefetch_l2_swapab<MT>(pf, KV_cache, io_tid, kv_l2_policy);
+                                     kv_l2_policy, cold.stride_kv_block / 64);
+      io_bulk_prefetch_l2_swapab<MT>(pf, KV_cache, io_tid, kv_l2_policy, cold.stride_kv_block / 64);
       staged = pf;
       pf = next;
       if (buf == 1) wr_phase ^= 1;

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_swapab_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_swapab_kernel.cuh
@@ -66,6 +66,9 @@ __device__ __forceinline__ void io_bulk_gather_tile_swapab(uint8_t* dst, int idx
 
   const size_t row_stride = MT == ModelType::GLM53_NOPE ? stride_kv_row : STRIDE;
   const uint8_t* src = kv_ptr + (size_t)(idx >= 0 ? idx : 0) * row_stride;
+  if constexpr (MT == ModelType::GLM53_NOPE) {
+    if (idx < 0) src = glm53_padding_kv;
+  }
   cp_async_bulk_g2s_l2hint(dst + io_tid * STRIDE, src, STRIDE, mbar, cache_policy);
 }
 
@@ -135,6 +138,9 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
     // `pf` (tile ti+1) warms L2 after the gather issue: this pipeline is one
     // tile deep, so the prefetch must not delay the gather the math waits on.
     auto ld_idx = [&](int t) -> int {
+      if constexpr (MT == ModelType::GLM53_NOPE) {
+        if (t * BI + io_tid >= topk_len) return -1;
+      }
       return (t < actual_ni && io_tid < BI) ? __ldg(idx_base + t * BI + io_tid) : -1;
     };
     int staged = ld_idx(0);

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -3665,3 +3665,100 @@ def test_glm53_compact_rows_match_padded_rows(layout, num_tokens, num_heads, imp
     run(padded, a, la)
     torch.testing.assert_close(b, a, rtol=0, atol=0)
     torch.testing.assert_close(lb, la, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("layout", [528, 656])
+@pytest.mark.parametrize(
+    "num_tokens,num_heads,impl",
+    [
+        (1, 8, None),
+        (4, 8, None),
+        (1, 32, None),
+        (1, 64, None),
+        (65, 8, "mg"),
+        (65, 32, "mg"),
+        (65, 64, "swapab"),
+        (65, 128, "swapab"),
+    ],
+)
+@pytest.mark.parametrize("pattern", ["partial", "holes", "bounded", "empty"])
+def test_glm53_masked_cache_rows_ignore_poisoned_slot_zero(
+    layout, num_tokens, num_heads, impl, pattern
+):
+    from flashinfer.mla import SparseMLASm120Wrapper
+
+    kv = torch.full((1, 64, 1, 512), 0.5, device="cuda", dtype=torch.bfloat16)
+    packed = quantize_kv_glm53_nope(kv)[..., :layout].contiguous()
+    q = torch.zeros((num_tokens, num_heads, 512), device="cuda", dtype=torch.bfloat16)
+    indices = torch.full((num_tokens, 2176), -1, device="cuda", dtype=torch.int32)
+    lengths = torch.ones(num_tokens, device="cuda", dtype=torch.int32)
+    if pattern == "empty":
+        lengths.zero_()
+    else:
+        indices[:, 0] = 1
+        if pattern == "holes":
+            indices[:, 2048:2051] = torch.tensor(
+                [2, 3, 4], device="cuda", dtype=torch.int32
+            )
+            lengths.fill_(2051)
+        elif pattern == "bounded":
+            # Even non-negative candidates beyond topk_length must be ignored.
+            indices[:, 1:] = 0
+    wrapper = SparseMLASm120Wrapper(
+        max_num_tokens=num_tokens,
+        max_num_heads=num_heads,
+        d_v=512,
+        kv_scale_format="arbitrary_fp32",
+        device="cuda",
+    )
+    clean, poisoned = torch.empty_like(q), torch.empty_like(q)
+    clean_lse = torch.empty((num_tokens, num_heads), device="cuda", dtype=torch.float32)
+    poisoned_lse = torch.empty_like(clean_lse)
+    wrapper.run(
+        q,
+        packed,
+        indices,
+        clean,
+        512**-0.5,
+        topk_length=lengths,
+        prefill_impl=impl,
+        out_lse=clean_lse,
+    )
+    expected = torch.full_like(clean, 0.0 if pattern == "empty" else 0.5)
+    torch.testing.assert_close(clean, expected, atol=1e-3, rtol=1e-3)
+    # E4M3 0x7f is NaN. Cache slot zero is never a valid candidate here.
+    packed.reshape(-1, layout)[0, :512] = 0x7F
+    wrapper.run(
+        q,
+        packed,
+        indices,
+        poisoned,
+        512**-0.5,
+        topk_length=lengths,
+        prefill_impl=impl,
+        out_lse=poisoned_lse,
+    )
+    assert torch.isfinite(poisoned).all()
+    torch.testing.assert_close(poisoned, clean, atol=0, rtol=0)
+    torch.testing.assert_close(poisoned_lse, clean_lse, atol=0, rtol=0)
+
+    if pattern == "holes":
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            wrapper.run(
+                q,
+                packed,
+                indices,
+                poisoned,
+                512**-0.5,
+                topk_length=lengths,
+                prefill_impl=impl,
+                out_lse=poisoned_lse,
+            )
+        # Preserve addresses while changing valid payloads between replays.
+        packed.copy_(quantize_kv_glm53_nope(kv * 0.5)[..., :layout])
+        packed.reshape(-1, layout)[0, :512] = 0x7F
+        graph.replay()
+        torch.testing.assert_close(
+            poisoned, torch.full_like(poisoned, 0.25), atol=1e-3, rtol=1e-3
+        )

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -3581,3 +3581,87 @@ def test_sparse_mla_sm120_envelope_consistency(
     else:
         with pytest.raises(RuntimeError, match="sparse-MLA"):
             call()
+
+
+@pytest.mark.parametrize("layout", ["3d", "nhd", "hnd"])
+@pytest.mark.parametrize(
+    "num_tokens,num_heads,impl",
+    [
+        (1, 32, None),
+        (6, 64, None),
+        (65, 32, None),
+        (65, 8, None),
+        (65, 64, "mg"),
+        (65, 64, "swapab"),
+    ],
+)
+def test_glm53_compact_rows_match_padded_rows(layout, num_tokens, num_heads, impl):
+    """Compaction preserves payload bits, attention, LSE and graph replay."""
+    torch.manual_seed(53)
+    device = torch.device("cuda")
+    pages, page_size, topk = 32, 64, 2176
+    kv = torch.randn(pages, page_size, 1, 512, device=device, dtype=torch.bfloat16) / 10
+    padded = quantize_kv_glm53_nope(kv)
+    compact = padded[..., :528].contiguous()
+    assert compact.numel() * 656 == padded.numel() * 528
+    # Poison the unused padded bytes. Neither layout may use them as values.
+    padded[..., 528:] = 255
+    q = (
+        torch.randn(num_tokens, num_heads, 512, device=device, dtype=torch.bfloat16)
+        / 10
+    )
+    indices = torch.randint(
+        pages * page_size, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, 0] = pages * page_size - 1
+    counts = torch.arange(num_tokens, device=device, dtype=torch.int32) % 3
+    lengths = torch.where(counts == 0, 1, torch.where(counts == 1, 70, topk)).to(
+        torch.int32
+    )
+    indices.masked_fill_(
+        torch.arange(topk, device=device)[None, :] >= lengths[:, None], -1
+    )
+    scratch = (
+        _make_decode_scratch(num_tokens, num_heads, topk, 512, device)
+        if num_tokens <= 64
+        else (None, None)
+    )
+
+    def reshape(cache):
+        if layout == "3d":
+            return cache.squeeze(2)
+        if layout == "hnd":
+            return cache.transpose(1, 2)
+        return cache
+
+    def run(cache, out, lse):
+        sparse_mla_sm120_paged_attention(
+            q,
+            reshape(cache),
+            indices,
+            out,
+            lse,
+            512**-0.5,
+            d_v=512,
+            kv_scale_format="arbitrary_fp32",
+            prefill_impl=impl,
+            topk_length=lengths,
+            mid_out=scratch[0],
+            mid_lse=scratch[1],
+        )
+
+    a, b = torch.empty_like(q), torch.empty_like(q)
+    la = torch.empty((num_tokens, num_heads), device=device, dtype=torch.float32)
+    lb = torch.empty_like(la)
+    run(padded, a, la)
+    run(compact, b, lb)
+    torch.testing.assert_close(b, a, rtol=0, atol=0)
+    torch.testing.assert_close(lb, la, rtol=0, atol=0)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run(compact, b, lb)
+    q.mul_(0.75)
+    graph.replay()
+    run(padded, a, la)
+    torch.testing.assert_close(b, a, rtol=0, atol=0)
+    torch.testing.assert_close(lb, la, rtol=0, atol=0)

--- a/tests/attention/test_sparse_mla_sm120_dispatch.py
+++ b/tests/attention/test_sparse_mla_sm120_dispatch.py
@@ -60,6 +60,7 @@ from flashinfer.mla._sparse_mla_sm120 import (
     _decode_scratch_views,
     _decode_dispatch_error_message,
     _resolve_model_type,
+    _packed_kv_page_block_size,
 )
 from flashinfer.mla._sparse_mla_sm120_plan import (
     _PREFILL_IMPL_SWAPAB,
@@ -73,6 +74,9 @@ def test_supported_configs_families() -> None:
     """The query API mirrors the decode dispatch envelopes exactly."""
     configs = supported_sparse_mla_sm120_configs()
     assert set(configs) == {"dsv4", "dsv3_2", "glm_nsa", "glm53_nope", "dots3_swa"}
+    assert configs["glm53_nope"].bytes_per_token == 656
+    assert configs["glm53_nope"].compact_bytes_per_token == 528
+    assert configs["glm_nsa"].compact_bytes_per_token is None
     assert all(
         isinstance(config, SparseMLASm120DecodeConfig) for config in configs.values()
     )
@@ -889,3 +893,22 @@ def test_sparse_mla_sm120_wrapper_public_export() -> None:
 
     assert SparseMLASm120Wrapper is _SparseMLAPagedAttentionRunner
     assert "SparseMLASm120Wrapper" in dir(flashinfer.mla)
+
+
+@pytest.mark.parametrize("shape", [(2, 64, 528), (2, 1, 64, 528), (2, 64, 1, 528)])
+def test_glm53_compact_page_shape(shape):
+    cache = torch.empty(shape, dtype=torch.uint8)
+    assert (
+        _packed_kv_page_block_size(cache, model_type=_MODEL_TYPE_GLM53_NOPE, name="kv")
+        == 64
+    )
+    with pytest.raises(ValueError):
+        _packed_kv_page_block_size(cache, model_type=_MODEL_TYPE_GLM_NSA, name="kv")
+
+
+def test_glm53_flat_cache_keeps_legacy_layout():
+    cache = torch.empty((2, 64 * 656), dtype=torch.uint8)
+    assert (
+        _packed_kv_page_block_size(cache, model_type=_MODEL_TYPE_GLM53_NOPE, name="kv")
+        == 64
+    )

--- a/tests/attention/test_sparse_mla_sm120_dispatch.py
+++ b/tests/attention/test_sparse_mla_sm120_dispatch.py
@@ -76,12 +76,6 @@ def test_supported_configs_families() -> None:
     assert set(configs) == {"dsv4", "dsv3_2", "glm_nsa", "glm53_nope", "dots3_swa"}
     assert configs["glm53_nope"].bytes_per_token == 656
     assert configs["glm53_nope"].compact_bytes_per_token == 528
-    assert configs["glm53_nope"].glm53_nope_contract_version == 1
-    assert all(
-        config.glm53_nope_contract_version == 0
-        for family, config in configs.items()
-        if family != "glm53_nope"
-    )
     assert configs["glm_nsa"].compact_bytes_per_token is None
     assert all(
         isinstance(config, SparseMLASm120DecodeConfig) for config in configs.values()

--- a/tests/attention/test_sparse_mla_sm120_dispatch.py
+++ b/tests/attention/test_sparse_mla_sm120_dispatch.py
@@ -76,6 +76,12 @@ def test_supported_configs_families() -> None:
     assert set(configs) == {"dsv4", "dsv3_2", "glm_nsa", "glm53_nope", "dots3_swa"}
     assert configs["glm53_nope"].bytes_per_token == 656
     assert configs["glm53_nope"].compact_bytes_per_token == 528
+    assert configs["glm53_nope"].glm53_nope_contract_version == 1
+    assert all(
+        config.glm53_nope_contract_version == 0
+        for family, config in configs.items()
+        if family != "glm53_nope"
+    )
     assert configs["glm_nsa"].compact_bytes_per_token is None
     assert all(
         isinstance(config, SparseMLASm120DecodeConfig) for config in configs.values()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

GLM NoPE cache rows contain 512 FP8 values and four FP32 scales. The 656-byte layout also reserves 128 bytes for RoPE values that GLM NoPE does not use. Support 528-byte rows and advertise that capability to callers without changing the stored values or scales.

Masked sparse candidates currently read mutable cache slot zero. If that slot contains NaNs, zero attention weights do not prevent `0 * NaN` from contaminating valid outputs. Make masked candidates read a dedicated zero row and apply explicit length bounds before prefill gathers. Add an eight-head decoder that matches the existing eight-row scratch layout.

Compact rows require kernels that understand this format and explicit three- or four-dimensional row geometry. The flat two-dimensional API continues to use the 656-byte layout, and existing 656-byte callers remain supported. This format applies to GLM NoPE; models that use the reserved RoPE values retain their existing layout.

## 🔍 Related Issues

This extends the native GLM NoPE backend merged in #4802. The companion [sgl-project/sglang#38430](https://github.com/sgl-project/sglang/pull/38430) selects compact rows only when this capability is advertised and requires the masked-read correction for padded sparse candidates.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

Configured pre-commit hooks, including clang-format and Ruff, pass on the changed files. The full-repository hook run is not claimed.

## 🧪 Tests

Author CPU validation at `a47c44ec32`: 35 dispatch tests passed with CUDA hidden. This update removes the model-specific contract-version field; the CUDA/C++ sources and GPU tests are unchanged from `3b3ef40730`.

Earlier author validation at `3b3ef40730` on main `9c10d2e8f2` on one RTX PRO 6000 Blackwell Max-Q (SM120): 605 tests passed. Targets: `tests/attention/test_sparse_mla_sm120_dispatch.py`, `tests/attention/test_sparse_mla_sm120.py`. The dispatch cases run on CPU; sparse-attention cases run on the GPU. The sanitizer and adapter results below retain their earlier source scope.

Historical author-run results on RTX PRO 6000 Blackwell SM120, using FlashInfer source `c35c4d12a6` and SGLang adapter source `6ccd5e37e4`:

| Test scope | Result |
|---|---|
| `tests/attention/test_sparse_mla_sm120.py` | 570 cases passed |
| Compact versus 656-byte output and LSE comparisons, included above | 18 cases passed bitwise |
| Masked-input tests, included above | 64 cases passed |
| Compute Sanitizer on the 64 masked-input cases plus 6 SGLang adapter cases | 70 cases passed; 0 errors |

Before the masked-read correction, six targeted tests with NaNs in unused cache slot zero produced NaNs in valid outputs. The masked-input tests cover partial tiles, holes, explicit length bounds, empty rows and CUDA graph replay with changed inputs. The adapter cases exercise both row layouts with 1/4/65 tokens and 8/32 heads.

```bash
python -m pytest -q tests/attention/test_sparse_mla_sm120.py
compute-sanitizer --tool memcheck --error-exitcode 99 --target-processes all python -m pytest -q tests/attention/test_sparse_mla_sm120.py::test_glm53_masked_cache_rows_ignore_poisoned_slot_zero
```

The sanitizer command above runs the 64 in-repository masked-input cases. The six adapter cases are additional cross-library validation. These kernel and adapter tests do not establish whole-model accuracy or a serving speedup.

Per-row storage decreases from 656 to 528 bytes, a 128-byte reduction (19.5%). Total storage saved is `128 bytes × cached token slots × affected layers`, before allocator padding. The FP8 values and FP32 scales are unchanged; reduced storage alone does not establish faster attention.

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag , the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->

Developed with AI assistance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for compact 528-byte-per-token GLM53 NoPE KV-cache layouts across 3D and 4D cache formats.
  - Added compatibility with compact and legacy cache layouts during sparse MLA decoding and prefill.
  - Added dedicated handling for the GLM53 NoPE eight-head configuration.

- **Bug Fixes**
  - Prevented invalid or out-of-range cache indices from reading unintended data.
  - Improved masked-cache handling for stable, finite outputs.

- **Tests**
  - Added coverage for compact caches, masked entries, CUDA graph replay, and cache-layout compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
