### PR TITLE
fix(moe): avoid FP8 scale overflow in the Humming MXFP4 path

### DIFF
--- a/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
+++ b/csrc/fused_moe/cutlass_backend/cutlass_fused_moe_kernels.cuh
@@ -80,6 +80,17 @@ namespace tensorrt_llm::kernels::cutlass_kernels {
 constexpr int WARP_SIZE = 32;
 constexpr int CVT_ELTS_PER_THREAD = 8;
 
+__device__ __forceinline__ float computeSafeFP8QuantScale(float row_amax) {
+  if (!(row_amax > 0.0f)) {
+    return 1.0f;
+  }
+
+  constexpr float FP8_E4M3_MAX = 448.0f;
+  constexpr float MIN_AMAX_FOR_FINITE_SCALE = FP8_E4M3_MAX / FLT_MAX;
+  // A tiny nonzero amax can make FP8_E4M3_MAX / row_amax overflow to infinity.
+  return FP8_E4M3_MAX / fmaxf(row_amax, MIN_AMAX_FOR_FINITE_SCALE);
+}
+
 struct FloatMaxOp {
   __device__ float operator()(float a, float b) const { return fmaxf(a, b); }
 };
@@ -1730,7 +1741,7 @@ __global__ void expandInputRowsKernel(
       float const row_amax =
           BlockReduce(reduce_storage).Reduce(AmaxOp::to_float(thread_amax), FloatMaxOp{});
       if (threadIdx.x == 0) {
-        float const quant = row_amax > 0.0f ? (448.0f / row_amax) : 1.0f;
+        float const quant = computeSafeFP8QuantScale(row_amax);
         float residual = 1.0f;
         if (fp8_expert_residual_scale) {
           int const expert = permuted_token_selected_experts[permuted_row];
@@ -2518,7 +2529,7 @@ __global__ __launch_bounds__(MAX_ACTIVATION_THREADS_PER_BLOCK) void doActivation
       __shared__ float shared_token_quant_scale;
       float const row_amax = BlockReduce(reduce_storage).Reduce(thread_amax, FloatMaxOp{});
       if (tid == 0) {
-        float const quant = row_amax > 0.0f ? (448.0f / row_amax) : 1.0f;
+        float const quant = computeSafeFP8QuantScale(row_amax);
         float residual = 1.0f;
         // The GEMM1 profiler passes no expert map and does not consume the generated FC2 scale.
         if (fp8_expert_residual_scale && permuted_token_selected_experts) {

--- a/tests/moe/test_trtllm_cutlass_fused_moe.py
+++ b/tests/moe/test_trtllm_cutlass_fused_moe.py
@@ -3483,6 +3483,74 @@ def test_moe_fp8_mxfp4_humming_prescale_hopper_correctness(
         assert_flash_output(profile_label, run_flash())
 
 
+@pytest.mark.skipif(
+    not is_sm90a_supported(torch.device("cuda")),
+    reason="FP8xMXFP4 Humming tiny-amax regression requires SM90",
+)
+@pytest.mark.parametrize("tiny_stage", ["input", "post_activation"])
+def test_moe_fp8_mxfp4_humming_tiny_amax_stays_finite(tiny_stage):
+    """A tiny nonzero row must not overflow its dynamic FP8 scale."""
+    torch.manual_seed(29)
+    device = torch.device("cuda")
+    e, m, n, k = 1, 1, 512, 512
+
+    if tiny_stage == "input":
+        x = torch.full((m, k), 3e-37, device=device, dtype=torch.bfloat16)
+        fc1_expert_residual_scale = torch.ones(e, device=device)
+    else:
+        x = (torch.randn(m, k, device=device) * 0.05).to(torch.bfloat16)
+        fc1_expert_residual_scale = torch.full((e,), 3e-18, device=device)
+    w1 = torch.randint(0, 256, (e, 2 * n, k // 2), device=device, dtype=torch.uint8)
+    w2 = torch.randint(0, 256, (e, k, n // 2), device=device, dtype=torch.uint8)
+    w1_raw_scale = torch.full(
+        (e, 2 * n, k // 32), 122, device=device, dtype=torch.uint8
+    )
+    w2_raw_scale = torch.full((e, k, n // 32), 122, device=device, dtype=torch.uint8)
+
+    w1_processed, w1_exp_offset, _ = (
+        fused_moe.preprocess_moe_weights_for_sm90_mixed_gemm_humming(
+            w1, w1_raw_scale, interleave=False
+        )
+    )
+    w2_processed, w2_exp_offset, w2_residual = (
+        fused_moe.preprocess_moe_weights_for_sm90_mixed_gemm_humming(
+            w2, w2_raw_scale, interleave=False
+        )
+    )
+    w1_il = fused_moe.interleave_moe_weights_for_sm90_mixed_gemm(
+        w1_processed, "fp4_fp8"
+    )
+    w2_il = fused_moe.interleave_moe_weights_for_sm90_mixed_gemm(
+        w2_processed, "fp4_fp8"
+    )
+    w1_scale_il = fused_moe.interleave_moe_scales_for_sm90_mixed_gemm(w1_exp_offset)
+    w2_scale_il = fused_moe.interleave_moe_scales_for_sm90_mixed_gemm(w2_exp_offset)
+
+    selected_experts = torch.zeros((m, 1), device=device, dtype=torch.int32)
+    routing_weights = torch.ones((m, 1), device=device, dtype=torch.float32)
+    output = torch.zeros((m, k), device=device, dtype=torch.bfloat16)
+    fused_moe.cutlass_fused_moe(
+        x,
+        selected_experts,
+        routing_weights,
+        w1_il,
+        w2_il,
+        torch.bfloat16,
+        quant_scales=[
+            w1_scale_il.view(torch.int32),
+            fc1_expert_residual_scale,
+            torch.ones((), device=device, dtype=torch.float32),
+            w2_scale_il.view(torch.int32),
+            w2_residual * 64.0,
+        ],
+        use_w4_group_scaling=True,
+        use_wfp4afp8_humming=True,
+        output=output,
+    )
+
+    assert torch.isfinite(output).all()
+
+
 # W4A8 Hopper interleaved path.
 #
 # Strict-tolerance envelope: h == intermediate_size == 512 with e == 2 only.


### PR DESCRIPTION
## 📌 Description

The Humming MXFP4 x FP8 fused-MoE path dynamically quantizes each routed
activation row to FP8 E4M3 at two points:

1. when the input rows are expanded for GEMM1; and
2. after the fused activation, before GEMM2.

For a row with maximum absolute value `row_amax`, both sites previously used:

```text
quant_scale = row_amax > 0 ? 448 / row_amax : 1
```

This expression is not finite for every positive FP32 input. If
`0 < row_amax < 448 / FLT_MAX` (approximately `1.317e-36`), the quotient
overflows to infinity. Scaling the row by that value can then produce Inf/NaN
FP8 inputs (`0 * Inf` is NaN), and a single routed expert can contaminate the
complete top-k-combined MoE output row.

This edge case was exposed by the Humming MXFP4 representation. Weight
preprocessing decomposes each expert's MXFP4 E8M0 block exponents into encoded
block-local offsets and a common FP32 expert residual scale. Runtime folds that
residual into the activation dequantization scale. In Qwen3.5-397B, an
effectively dormant expert produced a real post-activation row with an amax of
about `6.3e-38`, which enters the overflowing branch above.

This PR derives the smallest safe denominator from FP32 limits and applies the
same helper at both dynamic-quantization sites:

```text
min_amax = 448 / FLT_MAX
quant_scale = 448 / max(row_amax, min_amax)
```

The result is finite and at most `FLT_MAX`. Rows in the ordinary range retain
the original calculation exactly, and zero rows retain the previous scale of
one. For signals too small to survive the FP8/FP32 representation after all
scales are applied, the route may still round to zero; the purpose of this
minimal fix is to prevent such a negligible route from becoming non-finite and
poisoning the token.

The issue and fix are specific to the dynamic FP8 activation-scaling code used
by this Humming MXFP4 fused-MoE path. They are not an inherent limitation of the
MXFP4 format.

### Qwen3.5-397B model-level impact

We found the overflow while evaluating Qwen3.5-397B-A17B with MXFP4 expert
weights and FP8 activations on 8 x H200. The following runs used the same 1,314
GSM8K examples, 5-shot prompts, completion API, and greedy decoding:

| Configuration | Correct | Accuracy |
|---|---:|---:|
| BF16 | 1264 / 1314 | 96.1948% |
| Official FP8 checkpoint | 1247 / 1314 | 94.9011% |
| Calibrated WINT4 x FP8 | 1251 / 1314 | 95.2055% |
| MXFP4 x FP8, overflowing path | 1155 / 1314 | 87.8995% |
| MXFP4 x FP8, this PR (`a70bda3c`) | 1245 / 1314 | 94.7489% |

The fix recovered 90 answers, or 6.8493 percentage points. The corrected
MXFP4 result is within two answers of the FP8 checkpoint and six answers of the
calibrated WINT4 x FP8 checkpoint.

The failure was localized to a routed expert in layer 5. Its gate/up and down
projection weights had RMS values around `1e-20`, producing a post-SwiGLU row
around `1e-38`. The old quotient generated 4,096 non-finite values and poisoned
one complete hidden row. Replaying the saved layer input with the finite-scale
guard removed all 4,096 non-finite values. Against an independently computed
finite reference, the corrected local-MoE output had 1.455% relative RMSE and
0.999894 cosine similarity.

This PR:

- adds one shared finite-scale helper for dynamic FP8 row quantization;
- uses it for both the GEMM1 input and post-activation GEMM2 input paths; and
- adds Hopper regressions for tiny nonzero rows at both sites.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] Changed Python file passes `ruff check --no-cache`.
- [x] Changed Python file passes `ruff format --check`.
- [x] Changed CUDA ranges pass the repository's clang-format 19.1.1 formatter.
- [x] `git diff --check` passes.

## 🧪 Tests

- [x] H200: `test_moe_fp8_mxfp4_humming_tiny_amax_stays_finite` — 2/2
  parameterized cases passed (`input` and `post_activation`).
- [x] H200: existing
  `test_moe_fp8_mxfp4_humming_prescale_hopper_correctness[False-small]` —
  passed.
- [x] H200, 8 GPUs: full Qwen3.5-397B GSM8K run — 1245/1314
  (94.7489%), with all 1,314 evaluation requests returning HTTP 200.

The regression constructs tiny nonzero rows at each online FP8 quantization
site and asserts that the fused-MoE output remains finite. Before this fix, the
input-stage case was confirmed to produce an all-NaN output row.

## 🔬 Experimental Track

Not applicable; this PR does not add or change an experimental API/backend.

## Reviewer Notes

This is intentionally a minimal common-path change. It adds a single `fmaxf`
before the existing division and does not introduce residual-dependent scale
selection or exact-division/FMA instructions. The threshold is derived directly
from `FP8_E4M3_MAX / FLT_MAX`, rather than chosen empirically.
