### PR TITLE
fix(cake_kda): fix C16 forward triangular matrix orientation

### DIFF
--- a/csrc/kda/cake_aligned_training_export/cake_flashkda_training_c16_aligned_forward_36075669f2.cu
+++ b/csrc/kda/cake_aligned_training_export/cake_flashkda_training_c16_aligned_forward_36075669f2.cu
@@ -2873,7 +2873,7 @@ __global__ __launch_bounds__(512, 1) void kernel_cake_flashkda_forward_checkpoin
           mbarrier_wait(y_inp_ready_addr, state_phase_tcgen);
           int _mma_b_lo_3 = make_warp_uniform(((((smem_tinv_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
                                               (intermediate_stage_tcgen) * 64);
-          mma_ts_step(tmem_tmem_u_acc, tmem_tmem_y_inp, _mma_b_lo_3, 0xC0004010, 134546576, 0);
+          mma_ts_step(tmem_tmem_u_acc, tmem_tmem_y_inp, _mma_b_lo_3, 0xC0004010, 134481040, 0);
           elect_commit2(tinv_done_addr + (intermediate_stage_tcgen) * 8, u_acc_ready_addr);
           mbarrier_wait(u_inp_ready_addr, state_phase_tcgen);
           int _mma_b_lo_4 = make_warp_uniform(
@@ -2885,7 +2885,7 @@ __global__ __launch_bounds__(512, 1) void kernel_cake_flashkda_forward_checkpoin
           int _mma_b_lo_5 = make_warp_uniform(((((smem_a_mn_addr) >> 4) & 0x3FFF) | 0x200000) +
                                               (intermediate_stage_tcgen) * 64);
           mma_ts_step((tmem_tmem_q_state + ((int)o_stage_tcgen * 16)), tmem_tmem_u_inp, _mma_b_lo_5,
-                      0xC0004010, 134546576, 1);
+                      0xC0004010, 134481040, 1);
           elect_commit2(o_acc_ready_addr, a_done_addr + (intermediate_stage_tcgen) * 8);
         }
         cumulative_chunk_tcgen += chunks_tcgen;

--- a/tests/kda/test_recurrent_kda_training.py
+++ b/tests/kda/test_recurrent_kda_training.py
@@ -339,6 +339,43 @@ def _make_fixed_inputs(
     }
 
 
+def _make_c16_causality_inputs():
+    batch_size, seq_len, num_heads, head_dim = 1, 16, 8, 128
+    shape = (batch_size, seq_len, num_heads, head_dim)
+    q = torch.zeros(shape, device="cuda", dtype=torch.bfloat16)
+    k = torch.zeros_like(q)
+    for token in range(seq_len):
+        q[:, token, :, token] = 1
+        k[:, token, :, token] = 1
+
+    # A[15, 0] is nonzero. A transposed intra-chunk multiply would therefore
+    # leak V[15] into O[0], while the causal lower triangle keeps O[:15] zero.
+    q[:, 15].zero_()
+    q[:, 15, :, 0] = 1
+    v = torch.zeros_like(q)
+    v[:, 15, :, 0] = 1
+    return {
+        "q": q,
+        "k": k,
+        "v": v,
+        "g": torch.full_like(q, -6),
+        "beta": torch.zeros(
+            (batch_size, seq_len, num_heads),
+            device="cuda",
+            dtype=torch.bfloat16,
+        ),
+        "A_log": torch.zeros((num_heads,), device="cuda", dtype=torch.float32),
+        "dt_bias": torch.zeros(
+            (num_heads, head_dim), device="cuda", dtype=torch.float32
+        ),
+        "initial_state": torch.zeros(
+            (batch_size, num_heads, head_dim, head_dim),
+            device="cuda",
+            dtype=torch.float32,
+        ),
+    }
+
+
 @pytest.mark.arch_blackwell
 def test_packed_forward_validates_trusted_cpu_cu_seqlens():
     _require_blackwell()
@@ -487,6 +524,63 @@ def _assert_training_matches_fla(inputs, expected_route):
 def test_training_forward_context_backward_matches_fla():
     _require_blackwell()
     _assert_training_matches_fla(_make_inputs(), "c16")
+
+
+@pytest.mark.arch_blackwell
+def test_c16_forward_does_not_read_future_values(monkeypatch):
+    _require_blackwell()
+    inputs = _make_c16_causality_inputs()
+    monkeypatch.setattr(
+        kda_training_impl,
+        "_select_training_route",
+        lambda *_args, **_kwargs: kda_training_impl._TrainingRouteSpec(
+            "c16", "checkpoint_recurrent_c16", False
+        ),
+    )
+
+    output, _, context = recurrent_kda_training_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["g"],
+        inputs["beta"],
+        inputs["A_log"],
+        inputs["dt_bias"],
+        inputs["initial_state"],
+    )
+
+    assert context._route.tag == "c16"
+    assert torch.count_nonzero(output[:, :15]).item() == 0
+
+    # Make the K Gram matrix lower triangular and non-diagonal, while choosing
+    # Q as a dual basis so the causal output matrix A stays diagonal. V[0]
+    # must then reach O[1] through the lower-triangular solve U = T^-1 Y. A
+    # transposed T^-1 operand would instead leave U[1], and therefore O[1], zero.
+    solve_inputs = _make_c16_causality_inputs()
+    solve_inputs["q"].zero_()
+    solve_inputs["k"].zero_()
+    solve_inputs["v"].zero_()
+    for token in range(16):
+        solve_inputs["q"][:, token, :, token] = 1
+        solve_inputs["k"][:, token, :, token] = 1
+    diagonal = torch.tensor(2**-0.5, device="cuda", dtype=torch.bfloat16)
+    solve_inputs["q"][:, 0, :, 0] = diagonal
+    solve_inputs["q"][:, 0, :, 1] = -diagonal
+    solve_inputs["k"][:, 1, :, 0] = diagonal
+    solve_inputs["k"][:, 1, :, 1] = diagonal
+    solve_inputs["v"][:, 0, :, 0] = 1
+
+    solve_output, _, _ = recurrent_kda_training_forward(
+        solve_inputs["q"],
+        solve_inputs["k"],
+        solve_inputs["v"],
+        solve_inputs["g"],
+        solve_inputs["beta"],
+        solve_inputs["A_log"],
+        solve_inputs["dt_bias"],
+        solve_inputs["initial_state"],
+    )
+    assert torch.count_nonzero(solve_output[:, 1]).item() > 0
 
 
 @pytest.mark.arch_blackwell


### PR DESCRIPTION
## 📌 Description

The aligned C16 recurrent KDA training forward consumes two lower-triangular BF16 matrices as `tcgen05.mma` B operands. Both instruction descriptors set bit 16 even though the shared-memory tiles are already in the required MN orientation. The hardware therefore computes

$$
U_{\mathrm{old}}=(T^{-1})^\top Y, \qquad O_{\mathrm{intra,old}}=A^\top U_{\mathrm{old}}
$$

instead of

$$
U=T^{-1}Y, \qquad O_{\mathrm{intra}}=AU.
$$

For the lower-triangular intra-chunk matrix $A$, the extra transpose lets future values contribute to earlier outputs. This change clears the B-transpose bit in both instruction descriptors:

```text
0x08050490 -> 0x08040490
```

It also adds deterministic C16 tests for both operands. The first makes an $A^\top$ multiply leak `V[15]` into `O[0]`. The second keeps $A$ diagonal while making $T$ non-diagonal, so it isolates the direction of the triangular solve $U=T^{-1}Y$.

On SM100, using the same exported CUDA source as this repository:

- the forbidden `O[0]` value changes from `0.036865234375` to exactly zero;
- the isolated triangular-solve probe changes `O[1]` from zero to the expected nonzero value (`-0.010986328125` per head);
- for H64 / 8K tokens / 15 sequences, output relative RMS against an FP64 recurrence improves from `12.0192%` to `0.4556%` (FLA C64: `0.3232%`).

## 🔍 Related Issues

None.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation completed so far:

- `pre-commit install`
- `pre-commit run --all-files`
- `pre-commit run --files tests/kda/test_recurrent_kda_training.py csrc/kda/cake_aligned_training_export/cake_flashkda_training_c16_aligned_forward_36075669f2.cu`
- SM100 deterministic causality and triangular-solve probes against the byte-identical exported CUDA source
- SM100 H64 / 8K / 15-sequence precision comparison against an FP64 recurrence and FLA

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

The implementation file is a frozen Cake export. The code change is intentionally limited to the two incorrect instruction descriptors; the semantic tests protect both matrix directions if the export is regenerated later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the Blackwell C16 recurrent forward computation to use the appropriate operation descriptors, improving accumulation and Q-state updates.
  - Ensured the C16 forward path respects causality and does not read future values.
  - Corrected application of the lower-triangular solve for C16 inputs.

- **Tests**
  - Added regression coverage for C16 causal behavior and route selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->