### PR TITLE
fix(moe): Fix per-token quantization `fast-math` INF scale when activation contains all-zero row

### DIFF
--- a/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
+++ b/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh
@@ -834,7 +834,7 @@ __global__ void nvfp4QuantAndPerTokenScaleKernel(
     }
     __syncthreads();
     perTokenScale = perTokenScaleOutput[rowIdx];
-    globalEncodeScale = reciprocal_approximate_ftz(perTokenScale);
+    globalEncodeScale = perTokenScale != 0.0f ? reciprocal_approximate_ftz(perTokenScale) : 0.0f;
   }
 
   // quantize to fp4 with per-token scale, reading inputs from smem (each thread reads
@@ -950,7 +950,8 @@ __global__ void nvfp4QuantAndPerTokenScaleFP32Kernel(
   uint32_t num_sf_vecs_per_row = (n + SF_VEC_SIZE - 1) / SF_VEC_SIZE;
   for (uint32_t vecIdx = threadIdx.x; vecIdx < num_sf_vecs_per_row; vecIdx += blockDim.x) {
     float localScale = localScaleSmem[vecIdx];
-    float fp32Scale = reciprocal_approximate_ftz(perTokenScale * localScale);
+    float const denom = perTokenScale * localScale;
+    float fp32Scale = denom != 0.0f ? reciprocal_approximate_ftz(denom) : 0.0f;
     fp8Scale = __nv_fp8_e4m3(fp32Scale).__x;
     int64_t sfOffset;
     if constexpr (SF_LAYOUT == QuantizationSFLayout::LINEAR) {

--- a/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
+++ b/tests/moe/test_trtllm_gen_moe_autotune_tactics.py
@@ -406,6 +406,7 @@ def test_nvfp4_per_token_all_tactics_are_correct(
                     use_4over6=True,
                     weights_use_4over6=True,
                     activation_type=activation_type,
+                    zero_rows=False,
                 )
         except Exception as err:
             raise AssertionError(

--- a/tests/moe/test_trtllm_gen_per_token_moe.py
+++ b/tests/moe/test_trtllm_gen_per_token_moe.py
@@ -73,6 +73,7 @@ cache_permute_indices: Dict[tuple, torch.Tensor] = {}
         pytest.param(ActivationType.Relu2, id="Relu2"),
     ],
 )
+@pytest.mark.parametrize("zero_rows", [False, True])
 def test_routed_fused_moe(
     num_tokens: int,
     hidden_size: int,
@@ -82,6 +83,7 @@ def test_routed_fused_moe(
     use_4over6: bool,
     weights_use_4over6: bool,
     activation_type: ActivationType,
+    zero_rows: bool,
 ):
     device = torch.device("cuda:0")
     compute_capability = get_compute_capability(torch.device(device="cuda"))
@@ -109,6 +111,12 @@ def test_routed_fused_moe(
         )
         * 0.1
     )
+    if zero_rows:
+        if is_gated:
+            pytest.skip("zero_rows targets non-gated activations")
+        hidden_states_bf16 = hidden_states_bf16.abs() + 0.1
+        hidden_states_bf16[0] = 0  # all-zero input row for the input quant
+        w13_bf16 = -(w13_bf16.abs() + 0.01)
     w2_bf16 = (
         torch.randn(
             num_experts,
@@ -361,4 +369,9 @@ def test_routed_fused_moe(
 
     torch.cuda.synchronize()
 
+    if zero_rows:
+        assert torch.all(reference == 0)
+        assert torch.isfinite(result).all(), "NaN/inf from all-zero per-token rows"
+        assert torch.all(result == 0)
+        return
     check_accuracy(reference, result, atol=0.1, rtol=0.85, percent=0.9)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

This PR aims to fix a potential bug in per-token NVFP4 quantization kernel in the `fast-math` path. If the input tensor has a all-zero row, current non `fast-math` path generates 0 scale:
https://github.com/flashinfer-ai/flashinfer/blob/8bc3b578027791336c6ae87db5c9d76f82cef8bc/csrc/nv_internal/tensorrt_llm/kernels/quantization.cuh#L793-L802

But the `fast-math` path will produce INF scale, which ultimately leads to NaN activation. As ReLU2 happens to produce zero rows, this bug causes the accuracy regression in Nemotron-3 series models. 

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved FP4 quantization stability for zero-scale inputs, preventing invalid results such as NaN or infinity.
  - Ensured zero-valued inputs produce valid zero outputs in routed mixture-of-experts processing.

- **Tests**
  - Added coverage for zero-valued input rows and verified numerical stability and expected zero results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->