### PR TITLE
test(kda): restore the frozen module-ident consistency check

### DIFF
--- a/tests/jit/test_flash_kda_frozen_idents_jit.py
+++ b/tests/jit/test_flash_kda_frozen_idents_jit.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 by FlashInfer team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+
+import hashlib
+
+import pytest
+
+from flashinfer.jit import flash_kda
+
+# Body compiled into each common-header variant. Bindings come from
+# _FLASH_KDA_BINDING_STEMS; the ones shared by several variants
+# (m128_n16 / m128_n16_short) pick their body with a -D flag.
+_COMMON_HEADER_VARIANT_BODIES = {
+    "m64": "flashkda_bf16_fused_m64.cu",
+    "m128": "flashkda_bf16_fused_m128.cu",
+    "m128_tensor_state_decay": "cake_flashkda_bf16_fused_m128_tensor_state_decay.cu",
+    "m128_h12_short": "cake_flashkda_bf16_fused_m128_h12_short.cu",
+    "m128_h12_long": "cake_flashkda_bf16_fused_m128_h12_long.cu",
+    "m128_n16": "cake_flashkda_bf16_fused_m128_n16.cu",
+    "m128_n16_checkpoint": "flashkda_bf16_fused_m128_n16_checkpoint.cu",
+    "m128_n16_short": "cake_flashkda_bf16_fused_m128_n16_short.cu",
+    "persistent_m128": "cake_flashkda_bf16_persistent_m128.cu",
+    "piece_persistent_m128": "cake_flashkda_bf16_piece_persistent_m128.cu",
+    "small_bh_m128": "cake_flashkda_bf16_small_bh_m128.cu",
+}
+
+# The bt16 routes seal a different source closure, so their idents are not
+# reproducible from the common-header formula below.
+_VARIANTS_WITHOUT_COMMON_HEADER_IDENTS = frozenset(
+    {
+        "bt16_prepare",
+        "bt16_prepare_beta_tma",
+        "bt16_chain_m64_s7",
+        "bt16_chain_m64_s8",
+        "bt16_chain_m64_s9",
+        "bt16_prepare_chain_m64_s8",
+    }
+)
+
+
+def _ident_from_sources(variant: str) -> str:
+    csrc_dir = flash_kda._get_flash_kda_csrc_dir()
+    stem = flash_kda._FLASH_KDA_BINDING_STEMS[variant]
+    sources = (
+        csrc_dir / _COMMON_HEADER_VARIANT_BODIES[variant],
+        csrc_dir / f"{stem}_binding.cu",
+        csrc_dir / "flashkda_binding_common.cuh",
+    )
+    return hashlib.sha256(
+        b"\0".join(source.read_bytes() for source in sources)
+    ).hexdigest()[:10]
+
+
+@pytest.mark.parametrize("variant", sorted(_COMMON_HEADER_VARIANT_BODIES))
+def test_frozen_module_ident_describes_its_sources(variant):
+    """The frozen ident is the JIT/AOT cache key, so it must track the sources.
+
+    A prebuilt module is loaded by name alone, and the ident is the only part of
+    that name carrying source identity.
+    """
+
+    assert flash_kda._FLASH_KDA_MODULE_IDENTS[variant] == _ident_from_sources(
+        variant
+    ), (
+        f"frozen ident for {variant!r} does not describe the sources on disk.\n"
+        f"  ident table read from: {flash_kda.__file__}\n"
+        f"  sources read from:     {flash_kda._get_flash_kda_csrc_dir()}\n"
+        "When those two paths are in different trees, the imported flashinfer "
+        "and its data/csrc symlink disagree and the package needs reinstalling. "
+        "When they are the same tree, regenerate the ident for this variant."
+    )
+
+
+def test_every_frozen_ident_is_accounted_for():
+    assert set(flash_kda._FLASH_KDA_MODULE_IDENTS) == (
+        set(_COMMON_HEADER_VARIANT_BODIES) | _VARIANTS_WITHOUT_COMMON_HEADER_IDENTS
+    )


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`_FLASH_KDA_MODULE_IDENTS` holds a hand-copied 10-hex digest of each KDA variant's sources, and `get_flash_kda_uri()` embeds it in the module name. On the prebuilt path that name is all that is checked — `JitSpecNvcc.try_load()` returns the AOT `.so` whenever one exists under that name, with no source comparison — so the ident is the only part of the cache key carrying source identity. If it stops describing the sources, a module compiled from different sources can be loaded against the current caller.

The check that enforced this for the 11 common-header prefill variants was `tests/jit/test_flash_kda_prefill_jit.py::test_common_header_prefill_variant_cache_key`. That file was deleted in #4845 and the check was not carried over, so the invariant is currently unguarded. This PR restores just that check, in its own file.

Two deliberate differences from the deleted version, which is why this one should not rot the same way. First, nothing is pinned: each ident is recomputed from the sources on disk and compared to the table, so legitimate kernel edits never require touching this test. The deleted file also pinned literal idents, literal per-file SHA-256s, and literal constants like `#define SMEM_TOTAL 112256` in its `@parametrize` data, and 8 of its cases fail against today's `main` purely because of that churn. Second, `test_every_frozen_ident_is_accounted_for` asserts the table's key set equals the covered variants plus an explicit exclusion set, so adding a variant forces a conscious choice about coverage instead of silently escaping it.

The failure message names both resolved paths — where the table was imported from and where the sources were read from — because the two realistic causes need different responses. Same tree means an ident needs regenerating. Different trees means the imported `flashinfer` and its `data/csrc` symlink disagree and the package needs reinstalling; `get_kda_csrc_dir()` prefers `<package>/data/csrc/kda`, which `build_backend._create_data_dir` writes as an absolute build-time symlink, so a stale editable install silently pairs one tree's table with another tree's sources.

Scope: this adds coverage only. No library code changes, and the underlying source-resolution behaviour is left alone.

## 🔍 Related Issues

Internal: IKL-404. No linked GitHub issue.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

```
pytest tests/jit/test_flash_kda_frozen_idents_jit.py -q   # 12 passed
pytest tests/jit/ -k kda -q                               # 149 passed
```

Both negative cases were checked, since a tripwire that cannot fire is worthless. Appending a comment to `csrc/kda/flashkda_bf16_fused_m64.cu` fails the `m64` case with `assert 'f7f6a7e1f4' == 'd3c6b5f6fb'` and prints both resolved trees. Adding an uncovered entry to the ident table fails `test_every_frozen_ident_is_accounted_for` and names the new key.

Run on a B200 (CC 10.0), but these cases only hash files and build `JitSpec` objects, so they compile nothing and are arch-independent.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

## Reviewer Notes

The 6 `bt16_*` idents are excluded rather than covered. They seal a different source closure, and I could not reproduce their digests from the common-header formula or from any of ~30 plausible body/binding/header permutations I tried. Someone who knows how those idents are generated should extend `_COMMON_HEADER_VARIANT_BODIES` or add a second formula; the exclusion set makes the gap explicit in the meantime.

`_COMMON_HEADER_VARIANT_BODIES` is the one piece of structural data the test still carries, because the variant-to-body mapping is not derivable: bindings shared by several variants (`cake_flashkda_bf16_fused_m128_n16_binding.cu`) `#include` more than one body and select between them with a `-D` flag. It could reasonably live next to `_FLASH_KDA_BINDING_STEMS` in `flashinfer/jit/flash_kda.py` instead; I kept it in the test to avoid adding a library constant with no library consumer.

Worth noting for whoever owns the KDA cache: nothing in the tree regenerates these idents, so they are maintained by hand. A small `scripts/` regenerator that this test could then verify against would be a better end state than either.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify FlashInfer’s `flash_kda` JIT module identifiers remain consistent with their associated CUDA sources.
  * Added checks ensuring all supported module variants are represented and correctly validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->