### PR TITLE
fix(kda): make recurrent_kda backend="auto" decode fall back to CuTe DSL

### DIFF
--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -2161,7 +2161,12 @@ def run_recurrent_kda(
             initial_state is not None
             and not initial_state.is_contiguous()
             and backend != "cake"
-            and not auto_unbounded_softplus_candidate
+            # Only the indexed Cake convention tolerates a non-contiguous pool: it
+            # passes the pool through and gathers via ``ssi``. Without indices it
+            # would copy, so the check still applies to the "auto" candidate.
+            and not (
+                auto_unbounded_softplus_candidate and ssm_state_indices is not None
+            )
         ):
             raise ValueError(
                 "non-contiguous initial_state requires cu_seqlens: without cu_seqlens "
@@ -2368,7 +2373,11 @@ def run_recurrent_kda(
             raise ValueError(
                 "the requested Cake recurrent_kda decode contract is unsupported"
             )
-        if auto_unbounded_softplus and cu_seqlens_i32 is None:
+        if (
+            auto_unbounded_softplus
+            and cu_seqlens_i32 is None
+            and initial_state is not None
+        ):
             # The state convention above was chosen before the variant was known.
             # Cake was not selected after all, so restore CuTe's convention before
             # falling through to it.
@@ -2376,7 +2385,7 @@ def run_recurrent_kda(
                 state = initial_state[ssm_state_indices].contiguous()
                 copy_back_indices = ssm_state_indices
                 ssi = None
-            elif initial_state is not None:
+            else:
                 state = initial_state.contiguous()
     if flash_kda_decode_variant is not None:
         _run_flash_kda_decode(

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -1876,6 +1876,11 @@ def run_recurrent_kda(
             raises rather than falling back when its contract is unsupported.
             ``"auto"`` selects Cake only for its native equal-head/D128/T1
             unbounded-softplus contract and otherwise preserves CuTe DSL.
+            ``"auto"`` accepts exactly what ``"cute-dsl"`` accepts. Note that
+            with ``ssm_state_indices`` and ``output_final_state=True`` the
+            returned state follows whichever backend ran: the whole pool from
+            Cake, or the gathered ``[B, HV, V, K]`` rows from CuTe DSL. The
+            in-place pool update is the same either way.
 
     Returns:
         Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -2363,12 +2363,21 @@ def run_recurrent_kda(
         if backend == "cake" or auto_unbounded_softplus
         else None
     )
-    if (
-        backend == "cake" or auto_unbounded_softplus
-    ) and flash_kda_decode_variant is None:
-        raise ValueError(
-            "the requested Cake recurrent_kda decode contract is unsupported"
-        )
+    if flash_kda_decode_variant is None:
+        if backend == "cake":
+            raise ValueError(
+                "the requested Cake recurrent_kda decode contract is unsupported"
+            )
+        if auto_unbounded_softplus and cu_seqlens_i32 is None:
+            # The state convention above was chosen before the variant was known.
+            # Cake was not selected after all, so restore CuTe's convention before
+            # falling through to it.
+            if ssm_state_indices is not None:
+                state = initial_state[ssm_state_indices].contiguous()
+                copy_back_indices = ssm_state_indices
+                ssi = None
+            elif initial_state is not None:
+                state = initial_state.contiguous()
     if flash_kda_decode_variant is not None:
         _run_flash_kda_decode(
             flash_kda_decode_variant,

--- a/tests/kda/test_recurrent_kda_decode_export.py
+++ b/tests/kda/test_recurrent_kda_decode_export.py
@@ -2001,17 +2001,19 @@ def test_t1_unbounded_softplus_auto_falls_back_to_cute_when_cake_cannot_serve(
     # The negative contract this test exists for: Cake is not servable here, so
     # "auto" must reach CuTe rather than raise.
     assert frozen_calls == []
+    # Bit-exact, not approximate: after the fallback both spellings launch the
+    # same kernel on the same inputs, so any drift is a convention mismatch.
     torch.testing.assert_close(
-        actual_state_result.float(), expected_state.float(), atol=1e-2, rtol=1e-2
+        actual_state_result.float(), expected_state.float(), atol=0, rtol=0
     )
     torch.testing.assert_close(
-        actual_output.float(), expected_output.float(), atol=1e-2, rtol=1e-2
+        actual_output.float(), expected_output.float(), atol=0, rtol=0
     )
     torch.testing.assert_close(
         actual_state[state_indices].float(),
         baseline_state[state_indices].float(),
-        atol=1e-2,
-        rtol=1e-2,
+        atol=0,
+        rtol=0,
     )
     untouched = torch.ones(state_slots, dtype=torch.bool, device=flash_kda_device)
     untouched[state_indices.to(torch.long)] = False
@@ -2029,6 +2031,132 @@ def test_t1_unbounded_softplus_auto_falls_back_to_cute_when_cake_cannot_serve(
             ),
             backend="cake",
         )
+
+
+def _unbounded_softplus_cake_ineligible_case(device, *, num_sequences, num_heads, seed):
+    """A T=1 unbounded-softplus decode case the Cake selector always rejects."""
+
+    generator = torch.Generator(device=device).manual_seed(seed)
+    case = _make_case(
+        device,
+        num_sequences=num_sequences,
+        num_heads=num_heads,
+        num_value_heads=num_heads,
+        num_tokens=1,
+        seed=seed,
+    )
+    case.update(
+        beta_is_logit=True,
+        A_log=torch.rand(
+            num_heads, dtype=torch.float32, device=device, generator=generator
+        )
+        - 1.5,
+        dt_bias=torch.randn(
+            num_heads * _D, dtype=torch.float32, device=device, generator=generator
+        ),
+        use_gate_in_kernel=True,
+        lower_bound=None,
+        use_qk_l2norm_in_kernel=False,
+    )
+    return case
+
+
+@pytest.mark.parametrize("num_sequences", [2, 4])
+def test_t1_unbounded_softplus_auto_fallback_handles_absent_and_strided_state(
+    flash_kda_device, num_sequences
+):
+    """The fallback's own edge branches must not diverge from "cute-dsl".
+
+    Straddles the one-warp threshold at 32 heads: 2 sequences is multi-warp,
+    4 is one-warp.
+    """
+
+    num_heads = 32
+    slots = 2 * num_sequences + 1
+    state_indices = (
+        2 * torch.arange(num_sequences, dtype=torch.int32, device=flash_kda_device) + 1
+    )
+
+    # No state pool at all: the gate seeds zeros, so there is nothing to restore
+    # and the indices must not be applied to a missing tensor.
+    case = _unbounded_softplus_cake_ineligible_case(
+        flash_kda_device, num_sequences=num_sequences, num_heads=num_heads, seed=4936
+    )
+    case.update(ssm_state_indices=state_indices, initial_state=None)
+    expected = recurrent_kda(
+        **_call_kwargs(dict(case), output=torch.empty_like(case["output"])),
+        backend="cute-dsl",
+    )
+    actual = recurrent_kda(
+        **_call_kwargs(dict(case), output=torch.empty_like(case["output"])),
+        backend="auto",
+    )
+    for actual_value, expected_value in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            actual_value.float(), expected_value.float(), atol=0, rtol=0
+        )
+
+    # A non-contiguous pool without indices cannot be updated in place, because
+    # the wrapper has to copy it. "auto" must report that rather than silently
+    # dropping the update, exactly as "cute-dsl" does.
+    strided_state, _ = _padded_slot_state(
+        num_sequences, num_heads, flash_kda_device, seed=4936
+    )
+    case = _unbounded_softplus_cake_ineligible_case(
+        flash_kda_device, num_sequences=num_sequences, num_heads=num_heads, seed=4937
+    )
+    case.update(ssm_state_indices=None)
+    for backend in ("cute-dsl", "auto"):
+        with pytest.raises(ValueError, match="non-contiguous initial_state"):
+            recurrent_kda(
+                **_call_kwargs(
+                    dict(case),
+                    state=strided_state,
+                    output=torch.empty_like(case["output"]),
+                ),
+                backend=backend,
+            )
+
+    # With indices the pool is gathered rather than copied, so a non-contiguous
+    # pool stays supported on the fallback and untouched slots stay untouched.
+    # "cute-dsl" rejects this layout outright, so the oracle is the same "auto"
+    # call over a dense pool holding the same values.
+    strided_pool, _ = _padded_slot_state(slots, num_heads, flash_kda_device, seed=4938)
+    case = _unbounded_softplus_cake_ineligible_case(
+        flash_kda_device, num_sequences=num_sequences, num_heads=num_heads, seed=4939
+    )
+    case.update(ssm_state_indices=state_indices)
+    baseline_pool = strided_pool.contiguous().clone()
+    expected = recurrent_kda(
+        **_call_kwargs(
+            dict(case),
+            state=baseline_pool,
+            output=torch.empty_like(case["output"]),
+        ),
+        backend="auto",
+    )
+    before = strided_pool.clone()
+    actual = recurrent_kda(
+        **_call_kwargs(
+            dict(case), state=strided_pool, output=torch.empty_like(case["output"])
+        ),
+        backend="auto",
+    )
+    for actual_value, expected_value in zip(actual, expected, strict=True):
+        torch.testing.assert_close(
+            actual_value.float(), expected_value.float(), atol=0, rtol=0
+        )
+    torch.testing.assert_close(
+        strided_pool[state_indices].float(),
+        baseline_pool[state_indices].float(),
+        atol=0,
+        rtol=0,
+    )
+    untouched = torch.ones(slots, dtype=torch.bool, device=flash_kda_device)
+    untouched[state_indices.to(torch.long)] = False
+    torch.testing.assert_close(
+        strided_pool[untouched], before[untouched], atol=0, rtol=0
+    )
 
 
 def test_cake_backend_rejects_unexported_precomputed_t3_without_entering_cute_dsl(

--- a/tests/kda/test_recurrent_kda_decode_export.py
+++ b/tests/kda/test_recurrent_kda_decode_export.py
@@ -2261,6 +2261,123 @@ def test_t1_unbounded_softplus_auto_falls_back_to_cute_with_explicit_cu_seqlens(
     )
 
 
+@pytest.mark.parametrize("emulated_capability", [(9, 0), (12, 0)])
+@pytest.mark.parametrize("num_heads", [64, 16])
+def test_t1_unbounded_softplus_auto_falls_back_to_cute_on_unservable_arch(
+    flash_kda_device, monkeypatch, num_heads, emulated_capability
+):
+    """Cake eligibility is irrelevant when the arch cannot run Cake at all.
+
+    The candidate gate carries no compute-capability term but the selector
+    requires exact CC 10.0/10.3, so off those two the gate commits to Cake's
+    state convention for every T=1 unbounded-softplus call, including
+    Cake-shaped ones. Emulating the capability keeps this pinned on the only
+    hardware the surrounding file runs on.
+    """
+
+    num_sequences = 2
+    generator = torch.Generator(device=flash_kda_device).manual_seed(4935 + num_heads)
+    state_slots = 2 * num_sequences + 1
+    case = _make_case(
+        flash_kda_device,
+        num_sequences=num_sequences,
+        num_heads=num_heads,
+        num_value_heads=num_heads,
+        num_tokens=1,
+        seed=4935 + num_heads,
+    )
+    A_log = (
+        torch.rand(
+            num_heads,
+            dtype=torch.float32,
+            device=flash_kda_device,
+            generator=generator,
+        )
+        - 1.5
+    )
+    dt_bias = torch.randn(
+        num_heads * _D,
+        dtype=torch.float32,
+        device=flash_kda_device,
+        generator=generator,
+    )
+    state_indices = (
+        2 * torch.arange(num_sequences, dtype=torch.int32, device=flash_kda_device) + 1
+    )
+    logical_initial = torch.randn(
+        (state_slots, num_heads, _D, _D),
+        dtype=torch.bfloat16,
+        device=flash_kda_device,
+        generator=generator,
+    )
+    # Deliberately Cake-eligible: l2norm on, unpadded, indexed.
+    case.update(
+        beta_is_logit=True,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        use_gate_in_kernel=True,
+        lower_bound=None,
+        ssm_state_indices=state_indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    # Patch before the baseline too, so both spellings route identically and the
+    # only variable is ``backend``.
+    monkeypatch.setattr(
+        recurrent_module,
+        "get_compute_capability",
+        lambda *args, **kwargs: emulated_capability,
+    )
+
+    baseline_state = logical_initial.clone()
+    expected_output, expected_state = recurrent_kda(
+        **_call_kwargs(
+            baseline_case := dict(case),
+            state=baseline_state,
+            output=torch.empty_like(case["output"]),
+        ),
+        backend="cute-dsl",
+    )
+
+    frozen_calls = []
+    run_frozen = recurrent_module._run_flash_kda_decode
+
+    def track_frozen_call(variant, **kwargs):
+        frozen_calls.append(variant)
+        return run_frozen(variant, **kwargs)
+
+    monkeypatch.setattr(recurrent_module, "_run_flash_kda_decode", track_frozen_call)
+    actual_state = logical_initial.clone()
+    actual_before = actual_state.clone()
+    actual_output, actual_state_result = recurrent_kda(
+        **_call_kwargs(
+            dict(baseline_case),
+            state=actual_state,
+            output=torch.empty_like(case["output"]),
+        ),
+        backend="auto",
+    )
+
+    assert frozen_calls == []
+    torch.testing.assert_close(
+        actual_output.float(), expected_output.float(), atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        actual_state_result.float(), expected_state.float(), atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        actual_state[state_indices].float(),
+        baseline_state[state_indices].float(),
+        atol=0,
+        rtol=0,
+    )
+    untouched = torch.ones(state_slots, dtype=torch.bool, device=flash_kda_device)
+    untouched[state_indices.to(torch.long)] = False
+    torch.testing.assert_close(
+        actual_state[untouched], actual_before[untouched], atol=0, rtol=0
+    )
+
+
 def test_cake_backend_rejects_unexported_precomputed_t3_without_entering_cute_dsl(
     flash_kda_device, monkeypatch
 ):

--- a/tests/kda/test_recurrent_kda_decode_export.py
+++ b/tests/kda/test_recurrent_kda_decode_export.py
@@ -1895,6 +1895,142 @@ def test_t1_unbounded_softplus_auto_route_tp_shapes_match_cute_with_strided_inpu
     assert actual_state_storage.numel() > actual_state.numel()
 
 
+@pytest.mark.parametrize(
+    ("ineligible", "num_heads", "num_sequences"),
+    [
+        # Straddle ONE_WARP_MIN_SEQUENCE_HEADS (128 sequence-heads): the two CuTe
+        # routes carry different state conventions, so a fallback correct on one
+        # can write zero rows on the other.
+        ("qk_l2norm_off", 32, 2),
+        ("qk_l2norm_off", 32, 4),
+        # A padded head dimension is a witness only below the threshold; the
+        # one-warp route rejects the layout under "cute-dsl" too, so there is no
+        # divergence to assert there.
+        ("padded_head_dim", 32, 2),
+    ],
+)
+def test_t1_unbounded_softplus_auto_falls_back_to_cute_when_cake_cannot_serve(
+    flash_kda_device, monkeypatch, num_heads, num_sequences, ineligible
+):
+    generator = torch.Generator(device=flash_kda_device).manual_seed(4935 + num_heads)
+    state_slots = 2 * num_sequences + 1
+    case = _make_case(
+        flash_kda_device,
+        num_sequences=num_sequences,
+        num_heads=num_heads,
+        num_value_heads=num_heads,
+        num_tokens=1,
+        seed=4935 + num_heads,
+    )
+
+    A_log = (
+        torch.rand(
+            num_heads,
+            dtype=torch.float32,
+            device=flash_kda_device,
+            generator=generator,
+        )
+        - 1.5
+    )
+    dt_bias = torch.randn(
+        num_heads * _D,
+        dtype=torch.float32,
+        device=flash_kda_device,
+        generator=generator,
+    )
+    # Non-identity indices are load-bearing: identity indices hide a state
+    # convention mismatch regardless of pool contents.
+    state_indices = (
+        2 * torch.arange(num_sequences, dtype=torch.int32, device=flash_kda_device) + 1
+    )
+    logical_initial = torch.randn(
+        (state_slots, num_heads, _D, _D),
+        dtype=torch.bfloat16,
+        device=flash_kda_device,
+        generator=generator,
+    )
+
+    case.update(
+        beta_is_logit=True,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        use_gate_in_kernel=True,
+        lower_bound=None,
+        ssm_state_indices=state_indices,
+    )
+    if ineligible == "qk_l2norm_off":
+        case["use_qk_l2norm_in_kernel"] = False
+    else:
+        padded = torch.randn(
+            (num_sequences, 1, num_heads, _D + 8),
+            dtype=torch.bfloat16,
+            device=flash_kda_device,
+            generator=generator,
+        )
+        case["q"] = padded[..., :_D]
+
+    baseline_state = logical_initial.clone()
+    expected_output, expected_state = recurrent_kda(
+        **_call_kwargs(
+            baseline_case := dict(case),
+            state=baseline_state,
+            output=torch.empty_like(case["output"]),
+        ),
+        backend="cute-dsl",
+    )
+
+    frozen_calls = []
+    run_frozen = recurrent_module._run_flash_kda_decode
+
+    def track_frozen_call(variant, **kwargs):
+        frozen_calls.append(variant)
+        return run_frozen(variant, **kwargs)
+
+    monkeypatch.setattr(recurrent_module, "_run_flash_kda_decode", track_frozen_call)
+    actual_state = logical_initial.clone()
+    actual_before = actual_state.clone()
+    actual_output, actual_state_result = recurrent_kda(
+        **_call_kwargs(
+            dict(baseline_case),
+            state=actual_state,
+            output=torch.empty_like(case["output"]),
+        ),
+        backend="auto",
+    )
+
+    # The negative contract this test exists for: Cake is not servable here, so
+    # "auto" must reach CuTe rather than raise.
+    assert frozen_calls == []
+    torch.testing.assert_close(
+        actual_state_result.float(), expected_state.float(), atol=1e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        actual_output.float(), expected_output.float(), atol=1e-2, rtol=1e-2
+    )
+    torch.testing.assert_close(
+        actual_state[state_indices].float(),
+        baseline_state[state_indices].float(),
+        atol=1e-2,
+        rtol=1e-2,
+    )
+    untouched = torch.ones(state_slots, dtype=torch.bool, device=flash_kda_device)
+    untouched[state_indices.to(torch.long)] = False
+    torch.testing.assert_close(
+        actual_state[untouched], actual_before[untouched], atol=0, rtol=0
+    )
+
+    # Explicitly naming Cake still reports the unsupported contract.
+    with pytest.raises(ValueError, match="contract is unsupported"):
+        recurrent_kda(
+            **_call_kwargs(
+                dict(baseline_case),
+                state=logical_initial.clone(),
+                output=torch.empty_like(case["output"]),
+            ),
+            backend="cake",
+        )
+
+
 def test_cake_backend_rejects_unexported_precomputed_t3_without_entering_cute_dsl(
     flash_kda_device, monkeypatch
 ):

--- a/tests/kda/test_recurrent_kda_decode_export.py
+++ b/tests/kda/test_recurrent_kda_decode_export.py
@@ -2159,6 +2159,108 @@ def test_t1_unbounded_softplus_auto_fallback_handles_absent_and_strided_state(
     )
 
 
+@pytest.mark.parametrize("use_qk_l2norm_in_kernel", [True, False])
+@pytest.mark.parametrize("num_sequences", [2, 4])
+def test_t1_unbounded_softplus_auto_falls_back_to_cute_with_explicit_cu_seqlens(
+    flash_kda_device, monkeypatch, num_sequences, use_qk_l2norm_in_kernel
+):
+    """Explicit T=1 ``cu_seqlens`` decode is unservable by Cake for any input.
+
+    The selector wants one accepted-token entry per sequence and this path
+    supplies a single scalar, so ``"auto"`` has to reach CuTe here even when the
+    contract otherwise looks Cake-shaped. Parametrised over
+    ``use_qk_l2norm_in_kernel`` for exactly that reason, and over the one-warp
+    threshold at 32 heads.
+    """
+
+    num_heads = 32
+    slots = 2 * num_sequences + 1
+    generator = torch.Generator(device=flash_kda_device).manual_seed(4940)
+    state_indices = (
+        2 * torch.arange(num_sequences, dtype=torch.int32, device=flash_kda_device) + 1
+    )
+    cu_seqlens = torch.arange(
+        num_sequences + 1, dtype=torch.int32, device=flash_kda_device
+    )
+
+    def packed(*shape):
+        return torch.randn(
+            shape, dtype=torch.bfloat16, device=flash_kda_device, generator=generator
+        )
+
+    call = dict(
+        q=packed(1, num_sequences, num_heads, _D),
+        k=packed(1, num_sequences, num_heads, _D),
+        v=packed(1, num_sequences, num_heads, _D),
+        g=packed(1, num_sequences, num_heads, _D),
+        beta=packed(1, num_sequences, num_heads),
+        A_log=torch.rand(
+            num_heads, dtype=torch.float32, device=flash_kda_device, generator=generator
+        )
+        - 1.5,
+        dt_bias=torch.randn(
+            num_heads * _D,
+            dtype=torch.float32,
+            device=flash_kda_device,
+            generator=generator,
+        ),
+        use_gate_in_kernel=True,
+        beta_is_logit=True,
+        lower_bound=None,
+        use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+        ssm_state_indices=state_indices,
+        cu_seqlens=cu_seqlens,
+        output_final_state=True,
+    )
+    pool = torch.randn(
+        (slots, num_heads, _D, _D),
+        dtype=torch.bfloat16,
+        device=flash_kda_device,
+        generator=generator,
+    )
+
+    baseline_pool = pool.clone()
+    expected_output, expected_state = recurrent_kda(
+        **call,
+        initial_state=baseline_pool,
+        output=torch.empty_like(call["q"]),
+        backend="cute-dsl",
+    )
+
+    frozen_calls = []
+    run_frozen = recurrent_module._run_flash_kda_decode
+
+    def track_frozen_call(variant, **kwargs):
+        frozen_calls.append(variant)
+        return run_frozen(variant, **kwargs)
+
+    monkeypatch.setattr(recurrent_module, "_run_flash_kda_decode", track_frozen_call)
+    actual_pool = pool.clone()
+    before = actual_pool.clone()
+    actual_output, actual_state = recurrent_kda(
+        **call,
+        initial_state=actual_pool,
+        output=torch.empty_like(call["q"]),
+        backend="auto",
+    )
+
+    assert frozen_calls == []
+    torch.testing.assert_close(
+        actual_output.float(), expected_output.float(), atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        actual_state.float(), expected_state.float(), atol=0, rtol=0
+    )
+    torch.testing.assert_close(
+        actual_pool.float(), baseline_pool.float(), atol=0, rtol=0
+    )
+    untouched = torch.ones(slots, dtype=torch.bool, device=flash_kda_device)
+    untouched[state_indices.to(torch.long)] = False
+    torch.testing.assert_close(
+        actual_pool[untouched], before[untouched], atol=0, rtol=0
+    )
+
+
 def test_cake_backend_rejects_unexported_precomputed_t3_without_entering_cute_dsl(
     flash_kda_device, monkeypatch
 ):


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fixes [#4935](https://github.com/flashinfer-ai/flashinfer/issues/4935). `flashinfer.recurrent_kda(..., backend="auto")` decode raises `ValueError: the requested Cake recurrent_kda decode contract is unsupported` on inputs that `backend="cute-dsl"` serves. `"auto"` is the top-level default, so this is the default path.

`run_recurrent_kda` chooses its state convention before it knows which kernel will run. The gate commits to Cake's convention on a *candidate* predicate, and the Cake variant is resolved about 180 lines later. When the selector returns `None`, the state has already been normalised for a kernel that will not run, so instead of falling through to CuTe the call raised.

The docstring already specifies the intended behaviour, and the code diverged from it: `"cake"` "raises rather than falling back when its contract is unsupported", while `"auto"` "selects Cake only for its native equal-head/D128/T1 unbounded-softplus contract **and otherwise preserves CuTe DSL**". This restores that contract rather than changing it.

### The fix

Drive the fallback off the **resolved selector result** rather than a second predicate that has to be kept in step with it. When no variant is selected under `"auto"`, restore CuTe's state convention before falling through. `backend="cake"` keeps raising, and the Cake happy path is untouched.

The subtlety worth reviewing is that the gate writes **three** coupled variables, so restoring only the obvious one is not enough:

- `state` — Cake passes the pool through; CuTe wants the gathered rows.
- `copy_back_indices` — unset by Cake's arm, required by CuTe's.
- `ssi` — set by Cake's arm and left unset by CuTe's. The one-warp CuTe route ignores it, but the **multi-warp** route consults it, and a patch that fixes `state` and `copy_back_indices` while leaving `ssi` set writes **zero rows** to the state pool. That is a silent wrong answer, not a crash, which is why the test below exercises both sides of the `B*HV = 128` threshold.

### Why not tighten the gate instead

Mirroring the selector's preconditions in the gate is the obvious cheaper fix. It was implemented and measured, and it leaves witnesses that still diverge — `initial_state_source` with `initial_state_indices`, a caller `output` aliasing an input, a state pool large enough to trip the int32-overflow guard, a fused-projection token row stride, and a padded head dimension. The reason is structural: `_select_flash_kda_decode_variant` decides on over a hundred predicates spanning dtypes, strides, alignment, overflow products and aliasing analysis, and some of what it reads — the output buffer it checks for aliasing, and the re-wrapped frozen layouts — is not constructed until after the gate. Most of its arguments *are* available at the gate; the point is that the aliasing and frozen-layout predicates structurally cannot be mirrored there, and that mirroring the rest is reimplementing it, with any drift reintroducing this bug.

Splitting the selector's contract predicates from its layout predicates is a reasonable follow-up on `main` after the cut, but it is not required for correctness once the fallback is driven by the resolved result. The rule worth keeping in review is that **no state convention may reach the kernel launch before the variant is resolved**.

## 🔍 Related Issues

- Fixes [#4935](https://github.com/flashinfer-ai/flashinfer/issues/4935)
- [#4936](https://github.com/flashinfer-ai/flashinfer/issues/4936) — KDA API unification audit; this is step 1, and step 2 (documenting `"auto"` as the top-level default) depends on it

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

All runs on a B200 (CC 10.0).

**The gap was a missing negative contract, not missing coverage.** The existing `test_t1_unbounded_softplus_auto_route_tp_shapes_match_cute_with_strided_inputs` already compares `"auto"` against `"cute-dsl"` on output, state pool and untouched slots with non-identity indices; every parametrisation it runs is simply Cake-servable. So this extends that file with the ineligible cases rather than adding a parallel harness. The new test asserts Cake is *not* selected, that output and the returned state match `"cute-dsl"`, that untouched pool slots are bit-identical, and that `backend="cake"` still raises.

- New test: 3 passed. Reverting only the source hunk makes all three fail with the exact `ValueError` from the issue.
- `pytest tests/kda/` — **1013 passed, 116 skipped**, no failures (12m34s), re-run on the current head.
- `pytest tests/kda/test_recurrent_kda_decode_export.py` — 214 passed.
- Direct measurement on the two trigger classes: output and state pool are **bit-identical** between `"auto"` and `"cute-dsl"` (max diff `0.0e+00` on both), with the correct non-identity rows mutated, on both sides of the one-warp threshold.
- Dispatch probe from the issue now reports `auto/l2norm=False -> no Cake selection` instead of `RAISED Cake-unsupported`, while `auto/l2norm=True` still selects Cake.

**A third class this PR fixes, found in review and now covered.** Explicit `T=1` `cu_seqlens` decode is unservable by Cake for *any* input: the selector requires one accepted-token entry per sequence (`recurrent_kda.py:1619`) and this path supplies a single scalar (`:2246`). So `backend="auto"` raised on every such call — including fully Cake-shaped ones — and the fallback repairs the whole class. `test_t1_unbounded_softplus_auto_falls_back_to_cute_with_explicit_cu_seqlens` parametrises `use_qk_l2norm_in_kernel` precisely because eligibility is irrelevant here; all four cases fail against `upstream/main` with the issue's `ValueError` and pass on this head, bit-identically to `"cute-dsl"` on output, returned state and pool.

**The widest class, found while self-reviewing: every GPU that is not CC 10.0 or 10.3.** `auto_unbounded_softplus_candidate` carries no compute-capability term, but `_select_flash_kda_decode_variant` returns `None` unless the arch is exactly CC 10.0 or CC 10.3 (`recurrent_kda.py:1484-1488`). So on H100, CC 12.0, CC 12.1 or Rubin the gate committed to Cake's state convention for the *entire* `T=1` unbounded-softplus class and then found no variant — a fully Cake-shaped call raised there just as an ineligible one did. Every test in `test_recurrent_kda_decode_export.py` requires CC 10.0/10.3 hardware, so nothing covered it, which is also the substance of CodeRabbit's note on the `cu_seqlens` test.

`test_t1_unbounded_softplus_auto_falls_back_to_cute_on_unservable_arch` closes that by emulating the capability rather than switching the fixture: it patches `get_compute_capability` to CC 9.0 and CC 12.0, before the `"cute-dsl"` baseline as well so both spellings route identically and `backend` is the only variable, across both sides of the one-warp threshold. All four cases fail against `upstream/main` with the issue's `ValueError`. A CUDA-only fixture would instead assert that the CuTe DSL decode kernels build on whatever device CI offers, which is a different claim and one this PR does not establish. **Reviewers with non-Blackwell hardware:** whether the CuTe DSL decode path runs there at all is unverified — I only have a B200 — and it decides whether this class was previously a spurious raise or a different error either way.

**A pre-existing `"cute-dsl"` defect surfaced, deliberately left alone.** With `ssm_state_indices` containing `-1` (the documented CUDA-graph padding signal), `"cute-dsl"` gathers `initial_state[-1]` and copies the result back over the *last* pool slot. Cake correctly skips inactive rows. Post-fix `"auto"` is bit-identical to `"cute-dsl"` here — out/state/pool all `0.0e+00` on both sides of the threshold — so this PR neither introduces nor worsens it, and masking negatives in the fallback would make `"auto"` accept what `"cute-dsl"` mishandles, breaking the accepted-set equality this PR establishes. Filed separately as [#5042](https://github.com/flashinfer-ai/flashinfer/issues/5042), since it affects `backend="cute-dsl"` directly and the fix needs the one-warp CuTe route to honor `ssm_state_indices` first — that route currently ignores them, so the dispatch half alone would write wrong slots on every one-warp decode.

## Reviewer Notes

**On "restoring the documented contract."** The documentation half holds — `recurrent_kda.py`, `kda_decode.py`, `kda.py` and `docs/api/kda_decode.rst` all describe fallback, and none documents raising. But `git blame` puts the docstring line and the raising gate in the same commit (#4535), so the documented behaviour never actually existed in any commit. This brings the code in line with documentation that was aspirational from birth; it is not a no-op restoration, and calling it one oversells it.

**Parametrisation asymmetry.** A padded head dimension is only tested below the one-warp threshold. At the one-warp size `"cute-dsl"` rejects that layout as well (`Mismatched mQ.strides[2]`), so there is no divergence to assert and the case would be testing the CuTe launcher, not this fix.

**Correction — an earlier revision of this note was wrong, and the second commit fixes what it dismissed.** It claimed the non-contiguous-`initial_state` residual was benign because the fallback "mirrors CuTe's own `.contiguous()` handling, so the result is correct." It does not. `.contiguous()` copies, `copy_back_indices` stayed unset, and the caller's in-place pool update was dropped **silently** — where `"cute-dsl"` raises. That is a worse failure mode than the bug this PR set out to fix, and CodeRabbit was right to flag it. Reviewers should not have to work around a note that argues against looking.

The second commit closes it, plus a second defect in the same fifteen lines:

- `initial_state=None` with `ssm_state_indices` set subscripted `None`, so `"auto"` raised `TypeError` where `"cute-dsl"` succeeds — i.e. #4935 was still open for that input class, merely re-spelled. The gate seeds zeros there and there is nothing to restore, so the restore is skipped.
- The contiguity guard was skipped for the entire `"auto"` candidate. Only the *indexed* Cake convention tolerates a strided pool, because it gathers through `ssi` rather than copying, so the skip is now narrowed to the indexed case and `"auto"` raises the same guard `"cute-dsl"` does. This also closes the identical silent drop on the **Cake-served** path, which predates this PR: before, `"auto"` over a strided pool with no indices discarded the update whether or not Cake was selected.

Both are covered by `test_t1_unbounded_softplus_auto_fallback_handles_absent_and_strided_state`, and each is independently pinned — reverting the `None` guard alone fails with `TypeError`, reverting the guard narrowing alone fails with `DID NOT RAISE ValueError`. The invariant the PR now upholds is that `"auto"`'s accepted input set equals `"cute-dsl"`'s, rather than merely overlapping it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic backend selection for recurrent decoding requests that cannot use the preferred backend, including explicit sequence-length inputs and unsupported hardware.
  * Preserved correct outputs and state updates for indexed, non-contiguous, or absent initial-state data during fallback processing.
  * Added clear errors for unsupported non-contiguous initial-state data without indices.

* **Documentation**
  * Clarified backend-dependent behavior for returned recurrent state.

* **Tests**
  * Added exact-output coverage across fallback, state preservation, and expected-error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




