### PR TITLE
fix(attention): default skip_all_rows_active_check to true

### DIFF
--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5231,7 +5231,7 @@ def trtllm_ragged_attention_deepseek(
     kv_seq_lens_cpu: Optional[torch.Tensor] = None,
     use_fp16_softmax: Optional[bool] = None,
     uses_spcompress: Optional[bool] = None,
-    skip_all_rows_active_check: bool = False,
+    skip_all_rows_active_check: bool = True,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     """
     Parameters
@@ -5308,23 +5308,21 @@ def trtllm_ragged_attention_deepseek(
         Attention backend to use. "trtllm-gen" (default) or "cute-dsl".
     q_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row query lengths. When provided
-        together with ``kv_seq_lens_cpu``, the Python wrapper can keep the
-        all-active ragged fast path asynchronous while still compacting empty
-        rows (either ``q_len == 0`` or ``kv_len == 0``). If omitted, the
-        wrapper derives lengths from the device indptrs and may synchronize
-        to preserve correctness for direct callers. Under CUDA graph capture,
-        this device-side detection would require an illegal ``.item()``
-        readback, so both mirrors must be provided; without them the wrapper
-        cannot tell whether any row has ``q_len == 0`` or ``kv_len == 0`` and
-        will refuse to launch. Currently only consulted by the ``trtllm-gen``
-        backend.
+        together with ``kv_seq_lens_cpu``, the Python wrapper validates and
+        compacts empty rows (either ``q_len == 0`` or ``kv_len == 0``). Mirrors
+        take precedence over the omitted/default all-rows-active mode. Currently
+        only consulted by the ``trtllm-gen`` backend.
     kv_seq_lens_cpu : Optional[torch.Tensor]
         Optional trusted CPU mirror of the per-row KV lengths. Currently only
         consulted by the ``trtllm-gen`` backend.
     skip_all_rows_active_check : bool
-        Skip empty-row detection when the caller guarantees that every row has
-        positive query and KV lengths. Mutually exclusive with CPU length
-        mirrors. Currently only consulted by the ``trtllm-gen`` backend.
+        Controls empty-row detection. ``True`` (default) assumes every row has
+        positive query and KV lengths and avoids device-to-host synchronization.
+        Paired CPU length mirrors take precedence and request checked/compacting
+        behavior regardless of this setting. ``False`` without CPU mirrors
+        derives row activity from device tensors, which may synchronize outside
+        CUDA graph capture and requires CPU mirrors during capture. Currently
+        only consulted by the ``trtllm-gen`` backend.
 
     Returns
     -------
@@ -5493,13 +5491,7 @@ def trtllm_ragged_attention_deepseek(
         has_inactive_rows = False
         has_active_rows = True
 
-        if skip_all_rows_active_check:
-            if q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
-                raise ValueError(
-                    "skip_all_rows_active_check cannot be combined with CPU length "
-                    "mirrors"
-                )
-        elif q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
+        if q_seq_lens_cpu is not None or kv_seq_lens_cpu is not None:
             if q_seq_lens_cpu is None or kv_seq_lens_cpu is None:
                 raise ValueError(
                     "q_seq_lens_cpu and kv_seq_lens_cpu must be provided together"
@@ -5528,6 +5520,10 @@ def trtllm_ragged_attention_deepseek(
             if not bool(active_rows_cpu.all().item()):
                 has_inactive_rows = True
                 has_active_rows = bool(active_rows_cpu.any().item())
+        elif skip_all_rows_active_check:
+            # The default assumes all rows have positive Q and KV lengths.
+            # Keep the original tensors and avoid device-to-host row inspection.
+            pass
         else:
             # An active row requires q_len > 0 AND kv_len > 0; detecting
             # either kind of empty row from device indptrs needs an

--- a/flashinfer/trace/templates/gemm.py
+++ b/flashinfer/trace/templates/gemm.py
@@ -2263,7 +2263,15 @@ trtllm_ragged_attention_deepseek_trace = TraceTemplate(
         "return_lse": Scalar("bool"),
         "enable_pdl": Scalar("bool", optional=True),
         "skip_softmax_threshold_scale_factor": Scalar("float32", optional=True),
-        "skip_all_rows_active_check": Scalar("bool", optional=True),
+        "skip_all_rows_active_check": Scalar(
+            "bool",
+            optional=True,
+            description=(
+                "Defaults to True for the all-rows-active fast path; paired CPU "
+                "length mirrors take precedence, and False without mirrors "
+                "requests device-derived row checking."
+            ),
+        ),
     },
     outputs={
         "output": Tensor(

--- a/tests/attention/test_trtllm_ragged_kv_stride.py
+++ b/tests/attention/test_trtllm_ragged_kv_stride.py
@@ -48,9 +48,14 @@ def _run_trtllm_ragged(
     lse: torch.Tensor | None = None,
     q_lens_cpu: torch.Tensor | None = None,
     kv_lens_cpu: torch.Tensor | None = None,
-    skip_all_rows_active_check: bool = False,
+    skip_all_rows_active_check: bool | None = None,
 ):
     head_dim_qk = q.shape[2]
+    row_activity_kwargs = (
+        {}
+        if skip_all_rows_active_check is None
+        else {"skip_all_rows_active_check": skip_all_rows_active_check}
+    )
     return flashinfer.prefill.trtllm_ragged_attention_deepseek(
         query=q,
         key=k,
@@ -79,7 +84,7 @@ def _run_trtllm_ragged(
         lse=lse,
         q_seq_lens_cpu=q_lens_cpu,
         kv_seq_lens_cpu=kv_lens_cpu,
-        skip_all_rows_active_check=skip_all_rows_active_check,
+        **row_activity_kwargs,
     )
 
 
@@ -330,8 +335,8 @@ def test_trtllm_ragged_empty_kv_rows_are_neutral_and_match_compacted_call():
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_empty_kv_rows_direct_fallback_matches_cpu_mirror_path():
-    """Direct callers without CPU mirrors still get the same neutral semantics."""
+def test_trtllm_ragged_empty_kv_rows_explicit_check_matches_cpu_mirror_path():
+    """Explicit device checks retain the CPU-mirror path's neutral semantics."""
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     torch.manual_seed(42)
@@ -354,14 +359,18 @@ def test_trtllm_ragged_empty_kv_rows_direct_fallback_matches_cpu_mirror_path():
         q_indptr,
         kv_indptr,
         kv_lens,
+        skip_all_rows_active_check=False,
     )
 
     torch.testing.assert_close(fallback_output, mirror_output, atol=2e-2, rtol=2e-2)
     torch.testing.assert_close(fallback_lse, mirror_lse, atol=2e-2, rtol=2e-2)
 
 
+@pytest.mark.parametrize("skip_value", [None, True])
 @pytest.mark.cuda
-def test_trtllm_ragged_skipped_active_check_matches_checked_path(monkeypatch):
+def test_trtllm_ragged_default_and_explicit_skip_match_checked_path(
+    monkeypatch, skip_value
+):
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     torch.manual_seed(42)
@@ -389,7 +398,7 @@ def test_trtllm_ragged_skipped_active_check_matches_checked_path(monkeypatch):
         q_indptr,
         kv_indptr,
         kv_lens,
-        skip_all_rows_active_check=True,
+        skip_all_rows_active_check=skip_value,
     )
     checked_output, checked_lse = _run_trtllm_ragged(
         q,
@@ -407,28 +416,44 @@ def test_trtllm_ragged_skipped_active_check_matches_checked_path(monkeypatch):
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_skipped_active_check_rejects_cpu_mirrors():
+def test_trtllm_ragged_cpu_mirrors_override_explicit_skip():
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     q, k, v, q_lens, kv_lens, q_indptr, kv_indptr = _empty_kv_case(device)
 
-    with pytest.raises(ValueError, match="cannot be combined"):
-        _run_trtllm_ragged(
-            q,
-            k,
-            v,
-            q_indptr,
-            kv_indptr,
-            kv_lens,
-            q_lens_cpu=q_lens.cpu(),
-            kv_lens_cpu=kv_lens.cpu(),
-            skip_all_rows_active_check=True,
-        )
+    mirror_output, mirror_lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        q_lens_cpu=q_lens.cpu(),
+        kv_lens_cpu=kv_lens.cpu(),
+    )
+    explicit_skip_output, explicit_skip_lse = _run_trtllm_ragged(
+        q,
+        k,
+        v,
+        q_indptr,
+        kv_indptr,
+        kv_lens,
+        q_lens_cpu=q_lens.cpu(),
+        kv_lens_cpu=kv_lens.cpu(),
+        skip_all_rows_active_check=True,
+    )
+
+    torch.testing.assert_close(
+        explicit_skip_output, mirror_output, atol=2e-2, rtol=2e-2
+    )
+    torch.testing.assert_close(explicit_skip_lse, mirror_lse, atol=2e-2, rtol=2e-2)
 
 
-@pytest.mark.parametrize("use_cpu_lens", [True, False])
+@pytest.mark.parametrize("row_validation_mode", ["cpu_mirrors", "explicit_check"])
 @pytest.mark.cuda
-def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
+def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(
+    row_validation_mode,
+):
     device = torch.device("cuda")
     _require_trtllm_ragged(device)
     torch.manual_seed(42)
@@ -458,10 +483,10 @@ def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
     )
     lse = torch.full((q.shape[0], num_heads), 3.0, device=device)
 
-    cpu_lens_kwargs = (
+    row_validation_kwargs = (
         {"q_lens_cpu": q_lens.cpu(), "kv_lens_cpu": kv_lens.cpu()}
-        if use_cpu_lens
-        else {}
+        if row_validation_mode == "cpu_mirrors"
+        else {"skip_all_rows_active_check": False}
     )
     output, lse_out = _run_trtllm_ragged(
         q,
@@ -473,7 +498,7 @@ def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
         max_kv_len=0,
         out=out,
         lse=lse,
-        **cpu_lens_kwargs,
+        **row_validation_kwargs,
     )
 
     assert output.data_ptr() == out.data_ptr()
@@ -483,7 +508,7 @@ def test_trtllm_ragged_all_empty_kv_rows_with_queries_are_neutral(use_cpu_lens):
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_capture_without_cpu_lens_raises(monkeypatch):
+def test_trtllm_ragged_explicit_check_capture_without_cpu_lens_raises(monkeypatch):
     """Capture without CPU seq-len mirrors must refuse to launch.
 
     Regression for https://github.com/flashinfer-ai/flashinfer/issues/4609:
@@ -531,11 +556,22 @@ def test_trtllm_ragged_capture_without_cpu_lens_raises(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="must be provided during CUDA graph capture"):
-        _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens, return_lse=False)
+        _run_trtllm_ragged(
+            q,
+            k,
+            v,
+            q_indptr,
+            kv_indptr,
+            kv_lens,
+            return_lse=False,
+            skip_all_rows_active_check=False,
+        )
 
 
 @pytest.mark.cuda
-def test_trtllm_ragged_capture_q_empty_row_needs_cpu_mirrors(monkeypatch):
+def test_trtllm_ragged_capture_q_empty_row_explicit_check_needs_cpu_mirrors(
+    monkeypatch,
+):
     """A ``q_len == 0, kv_len > 0`` row still requires CPU mirrors under capture.
 
     The documentation used to imply mirrors were needed only for empty-KV
@@ -582,10 +618,21 @@ def test_trtllm_ragged_capture_q_empty_row_needs_cpu_mirrors(monkeypatch):
     )
 
     with pytest.raises(ValueError, match="must be provided during CUDA graph capture"):
-        _run_trtllm_ragged(q, k, v, q_indptr, kv_indptr, kv_lens, return_lse=False)
+        _run_trtllm_ragged(
+            q,
+            k,
+            v,
+            q_indptr,
+            kv_indptr,
+            kv_lens,
+            return_lse=False,
+            skip_all_rows_active_check=False,
+        )
 
 
-@pytest.mark.parametrize("row_activity_mode", ["cpu_mirrors", "assumed_active"])
+@pytest.mark.parametrize(
+    "row_activity_mode", ["default", "assumed_active", "cpu_mirrors"]
+)
 @pytest.mark.cuda
 def test_trtllm_ragged_all_active_cuda_graph_capture_replay(row_activity_mode):
     """Trusted row metadata lets an active batch capture and replay.
@@ -633,11 +680,15 @@ def test_trtllm_ragged_all_active_cuda_graph_capture_replay(row_activity_mode):
     out = torch.empty(
         (q.shape[0], num_heads, head_dim_vo), device=device, dtype=torch.bfloat16
     )
-    row_activity_kwargs = (
-        {"q_lens_cpu": q_lens_cpu, "kv_lens_cpu": kv_lens_cpu}
-        if row_activity_mode == "cpu_mirrors"
-        else {"skip_all_rows_active_check": True}
-    )
+    if row_activity_mode == "cpu_mirrors":
+        row_activity_kwargs = {
+            "q_lens_cpu": q_lens_cpu,
+            "kv_lens_cpu": kv_lens_cpu,
+        }
+    elif row_activity_mode == "assumed_active":
+        row_activity_kwargs = {"skip_all_rows_active_check": True}
+    else:
+        row_activity_kwargs = {}
 
     def _call():
         _run_trtllm_ragged(

--- a/tests/trace/test_fi_trace_template_consistency.py
+++ b/tests/trace/test_fi_trace_template_consistency.py
@@ -68,6 +68,26 @@ def test_svdquant_trace_activation_scale_tracks_variable_m():
     )
 
 
+def test_trtllm_ragged_attention_deepseek_trace_row_check_is_optional_bool():
+    from flashinfer.prefill import trtllm_ragged_attention_deepseek
+    from flashinfer.trace.templates.gemm import (
+        trtllm_ragged_attention_deepseek_trace,
+    )
+
+    row_check = trtllm_ragged_attention_deepseek_trace.inputs[
+        "skip_all_rows_active_check"
+    ]
+    assert isinstance(row_check, Scalar)
+    assert row_check.dtype == "bool"
+    assert row_check.optional is True
+    assert (
+        inspect.signature(trtllm_ragged_attention_deepseek)
+        .parameters["skip_all_rows_active_check"]
+        .default
+        is True
+    )
+
+
 def _resolved_param(json_key: str, descriptor) -> str:
     """Return the function-parameter name that descriptor maps to."""
     p = getattr(descriptor, "param", None)


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

PR #3779 introduced a host synchronization when CPU sequence-length
mirrors are absent. PR #4931 made that check skippable, but left it enabled by
default, so frameworks must opt in to recover the previous performance.

This changes `skip_all_rows_active_check` to default to `True`. Paired CPU
length mirrors still take precedence for checked empty-row compaction, while
explicit `False` without mirrors retains device-derived checking. Calls using
the default fast path must have positive query and KV lengths for every row.

On B200/SM100, the new default measured 38.051 µs/call versus 94.927 µs/call
for the checked path (2.495× faster), using batch 32, query length 4, KV length
512, 16 heads, BF16, and the median of 9 randomized trials.

## 🔍 Related Issues

Fixes #4928. Follow-up to #4931; regression from #3779.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Focused B200/SM100 validation passed 14 ragged-attention tests and 4 trace
tests. Scoped pre-commit hooks and diff hygiene also passed.

Full GPU CI is gated until an authorized contributor comments
`@flashinfer-bot run`; the repository-wide suite was not run locally.

