### PR TITLE
feat: enable large-head attention on SM80, for VLLM to run FP8 kv

### DIFF
--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -257,9 +257,9 @@ def gen_attention(
     head_dim_ckv = 512
     head_dim_kpe = 64
 
-    # For 16-bit KV, head_dim > 256 FA2 modules use the Ampere+ large-head path.
-    # NVFP4 KV large-head is validated for FA2 batch prefill on SM8+; other
-    # one-byte large-head modules stay SM100+-only until validated separately.
+    # For 16-bit and FP8 KV, head_dim > 256 FA2 modules use the Ampere+
+    # large-head path. NVFP4 KV large-head is validated for FA2 batch prefill
+    # on SM8+, while NVFP4 decode remains SM100+-only.
     from .jit.core import current_compilation_context
 
     has_sm8_or_newer = any(
@@ -268,7 +268,6 @@ def gen_attention(
     has_sm10_or_newer = any(
         major >= 10 for major, _ in current_compilation_context.TARGET_CUDA_ARCHS
     )
-
     # FA2 MHA / MQA / GQA
     for (
         (head_dim_qk, head_dim_vo),
@@ -285,12 +284,8 @@ def gen_attention(
     ):
         large_head = head_dim_qk > 256 or head_dim_vo > 256
         nvfp4_large_head = large_head and _is_nvfp4_kv_dtype(dtype_kv)
-        if large_head:
-            if dtype_kv.itemsize == 1 and not nvfp4_large_head:
-                if not has_sm10_or_newer:
-                    continue
-            elif not has_sm8_or_newer:
-                continue
+        if large_head and not has_sm8_or_newer:
+            continue
         yield from gen_fa2(
             dtype_qo=dtype_qo,
             dtype_kv=dtype_kv,
@@ -1123,7 +1118,7 @@ def parse_head_dim(head_dim: str) -> Tuple[int, int]:
 def get_default_config():
     """Get default AOT configuration"""
     return {
-        # Note: head_dim=512 (FA2 prefill/decode, SM100+) excluded to reduce
+        # Note: head_dim=512 (FA2 prefill/decode, SM80+) excluded to reduce
         # space in the jit-cache wheel.
         "fa2_head_dim": [(64, 64), (128, 128), (256, 256)],
         "fa3_head_dim": [(192, 128), (128, 128), (64, 64), (256, 256)],

--- a/flashinfer/jit/attention/modules.py
+++ b/flashinfer/jit/attention/modules.py
@@ -1258,14 +1258,13 @@ def _fa2_head_dim_nvcc_flags(
 ) -> Optional[List[str]]:
     """Return arch flags for FA2 large-head modules.
 
-    For 16-bit KV, head_dim > 256 uses the Ampere+ large-head path. NVFP4 KV
-    can opt into the same arch set only for validated FA2 prefill read paths.
-    Other one-byte large-head modules remain restricted to SM100+ until those
-    variants are validated separately.
+    For 16-bit and FP8 KV, head_dim > 256 uses the Ampere+ large-head path.
+    NVFP4 KV can opt into the same arch set only for validated FA2 prefill
+    read paths; NVFP4 large-head decode remains restricted to SM100+.
     """
     if head_dim_qk > 256 or head_dim_vo > 256:
-        if dtype_kv.itemsize == 1:
-            if not (allow_nvfp4_sm8_large_head and _is_nvfp4_kv_dtype(dtype_kv)):
+        if _is_nvfp4_kv_dtype(dtype_kv):
+            if not allow_nvfp4_sm8_large_head:
                 return current_compilation_context.get_nvcc_flags_list(
                     supported_major_versions=[10, 11, 12]
                 )

--- a/tests/attention/test_batch_decode_kernels.py
+++ b/tests/attention/test_batch_decode_kernels.py
@@ -39,16 +39,6 @@ def skip_if_head_dim_unsupported(head_dim: int):
         pytest.skip("16-bit FA2 head_dim > 256 is only supported on SM80 or newer")
 
 
-def skip_if_head_dim_dtype_unsupported(head_dim: int, kv_dtype: torch.dtype):
-    skip_if_head_dim_unsupported(head_dim)
-    if (
-        head_dim > 256
-        and kv_dtype in (torch.float8_e4m3fn, torch.float8_e5m2)
-        and get_compute_capability(torch.device("cuda:0"))[0] < 10
-    ):
-        pytest.skip("head_dim > 256 with FP8 KV is only validated on SM100 or newer")
-
-
 def skip_if_nvfp4_large_head_decode_unsupported(head_dim: int):
     if head_dim > 256 and get_compute_capability(torch.device("cuda:0"))[0] < 10:
         pytest.skip(
@@ -130,7 +120,7 @@ def _run_batch_decode_with_paged_kv_cache_case(
             pytest.skip("cuTile decode fp8 KV not covered yet.")
         if head_dim > 256:
             pytest.skip("cuTile decode head_dim>256 not covered yet.")
-    skip_if_head_dim_dtype_unsupported(head_dim, kv_dtype)
+    skip_if_head_dim_unsupported(head_dim)
     q = torch.randn(batch_size, num_qo_heads, head_dim, device="cuda:0", dtype=q_dtype)
     num_pages_per_seq = (kv_len + page_size - 1) // page_size
     total_num_pages = num_pages_per_seq * batch_size

--- a/tests/attention/test_fp8_prefill.py
+++ b/tests/attention/test_fp8_prefill.py
@@ -22,13 +22,13 @@ from flashinfer.utils import get_compute_capability
 
 
 def head_dim_512_supported() -> bool:
-    # head_dim > 256 is only supported on SM100+.
-    return get_compute_capability(torch.device("cuda:0"))[0] >= 10
+    # FP8 FA2 head_dim > 256 uses the Ampere+ large-head path.
+    return get_compute_capability(torch.device("cuda:0"))[0] >= 8
 
 
 def skip_if_head_dim_unsupported(head_dim: int):
     if head_dim > 256 and not head_dim_512_supported():
-        pytest.skip("head_dim > 256 is only supported on SM100 or newer")
+        pytest.skip("FP8 FA2 head_dim > 256 is only supported on SM80 or newer")
 
 
 @pytest.mark.parametrize("batch_size", [12, 17])

--- a/tests/attention/test_gemma4_fa2_accuracy.py
+++ b/tests/attention/test_gemma4_fa2_accuracy.py
@@ -1,0 +1,219 @@
+"""Focused FP8 KV accuracy coverage for Gemma 4's full-attention shape.
+
+These tests exercise the Ampere FA2 large-head path enabled for FP8 KV cache:
+16 query heads, 2 KV heads, and head dimension 512.  They use an independent
+PyTorch FP32 oracle over the exact dequantized FP8 cache instead of comparing
+one FlashInfer kernel with another.
+"""
+
+import math
+
+import pytest
+import torch
+
+import flashinfer
+from flashinfer.utils import get_compute_capability
+
+
+DEVICE = torch.device("cuda:0")
+Q_DTYPE = torch.bfloat16
+KV_DTYPE = torch.float8_e4m3fn
+NUM_QO_HEADS = 16
+NUM_KV_HEADS = 2
+HEAD_DIM = 512
+PAGE_SIZE = 16
+KV_LEN = 10_003
+SM_SCALE = 1.0
+K_SCALE = 0.02
+V_SCALE = 0.02
+LOG2_E = math.log2(math.e)
+
+
+def _require_ampere_or_newer() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if get_compute_capability(DEVICE)[0] < 8:
+        pytest.skip("FP8 KV head_dim=512 FA2 coverage requires SM80 or newer")
+
+
+def _make_inputs(
+    q_len: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    torch.manual_seed(42)
+    num_pages = (KV_LEN + PAGE_SIZE - 1) // PAGE_SIZE
+
+    # Gemma applies its query scaling before calling the attention backend.
+    q = (
+        torch.randn(
+            q_len,
+            NUM_QO_HEADS,
+            HEAD_DIM,
+            dtype=Q_DTYPE,
+            device=DEVICE,
+        )
+        / 16
+    )
+    cache_shape = (num_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM)
+    k_cache = (torch.randn(cache_shape, dtype=Q_DTYPE, device=DEVICE) / K_SCALE).to(
+        KV_DTYPE
+    )
+    v_cache = (torch.randn(cache_shape, dtype=Q_DTYPE, device=DEVICE) / V_SCALE).to(
+        KV_DTYPE
+    )
+    return q, k_cache, v_cache, num_pages
+
+
+def _reference(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return FP32 output and base-2 LSE for the causal query chunk."""
+    q_len = q.shape[0]
+    group_size = NUM_QO_HEADS // NUM_KV_HEADS
+    k = k_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)[:KV_LEN].float() * K_SCALE
+    v = v_cache.reshape(-1, NUM_KV_HEADS, HEAD_DIM)[:KV_LEN].float() * V_SCALE
+
+    q_positions = torch.arange(q_len, device=DEVICE) + KV_LEN - q_len
+    k_positions = torch.arange(KV_LEN, device=DEVICE)
+    causal_mask = k_positions.unsqueeze(0) <= q_positions.unsqueeze(1)
+
+    ref_out = torch.empty(
+        q_len, NUM_QO_HEADS, HEAD_DIM, dtype=torch.float32, device=DEVICE
+    )
+    ref_lse = torch.empty(q_len, NUM_QO_HEADS, dtype=torch.float32, device=DEVICE)
+
+    for kv_head in range(NUM_KV_HEADS):
+        head_lo = kv_head * group_size
+        head_hi = head_lo + group_size
+        q_group = q[:, head_lo:head_hi].float().permute(1, 0, 2)
+        scores = torch.matmul(q_group, k[:, kv_head].t()) * SM_SCALE
+        scores.masked_fill_(~causal_mask.unsqueeze(0), float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        ref_out[:, head_lo:head_hi] = torch.matmul(
+            probs, v[:, kv_head].unsqueeze(0)
+        ).permute(1, 0, 2)
+        ref_lse[:, head_lo:head_hi] = (
+            torch.logsumexp(scores, dim=-1).permute(1, 0) * LOG2_E
+        )
+
+    return ref_out, ref_lse
+
+
+def _assert_matches_reference(
+    actual_out: torch.Tensor,
+    actual_lse: torch.Tensor,
+    ref_out: torch.Tensor,
+    ref_lse: torch.Tensor,
+) -> None:
+    expected_out = ref_out.to(Q_DTYPE)
+    out_abs = (actual_out.float() - expected_out.float()).abs()
+    lse_abs = (actual_lse.float() - ref_lse.float()).abs()
+    diagnostics = (
+        f"output max={out_abs.max().item():.6g}, "
+        f"p99={torch.quantile(out_abs, 0.99).item():.6g}; "
+        f"LSE max={lse_abs.max().item():.6g}, "
+        f"p99={torch.quantile(lse_abs, 0.99).item():.6g}"
+    )
+    torch.testing.assert_close(
+        actual_out,
+        expected_out,
+        rtol=2e-2,
+        atol=2e-2,
+        msg=diagnostics,
+    )
+    torch.testing.assert_close(
+        actual_lse.float(),
+        ref_lse,
+        rtol=1e-3,
+        atol=2e-2,
+        msg=diagnostics,
+    )
+
+
+def _paged_metadata(
+    q_len: int, num_pages: int
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    qo_indptr = torch.tensor([0, q_len], dtype=torch.int32, device=DEVICE)
+    kv_indptr = torch.tensor([0, num_pages], dtype=torch.int32, device=DEVICE)
+    kv_indices = torch.arange(num_pages, dtype=torch.int32, device=DEVICE)
+    kv_last_page_len = torch.tensor(
+        [(KV_LEN - 1) % PAGE_SIZE + 1], dtype=torch.int32, device=DEVICE
+    )
+    return qo_indptr, kv_indptr, kv_indices, kv_last_page_len
+
+
+def test_gemma4_fp8_kv_head_dim_512_chunked_prefill_matches_torch() -> None:
+    _require_ampere_or_newer()
+    q_len = 17
+    q, k_cache, v_cache, num_pages = _make_inputs(q_len)
+    qo_indptr, kv_indptr, kv_indices, kv_last_page_len = _paged_metadata(
+        q_len, num_pages
+    )
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        workspace, kv_layout="NHD", backend="fa2"
+    )
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        causal=True,
+        sm_scale=SM_SCALE,
+        q_data_type=Q_DTYPE,
+        kv_data_type=KV_DTYPE,
+    )
+    out, lse = wrapper.run(
+        q,
+        (k_cache, v_cache),
+        k_scale=K_SCALE,
+        v_scale=V_SCALE,
+        return_lse=True,
+    )
+
+    ref_out, ref_lse = _reference(q, k_cache, v_cache)
+    _assert_matches_reference(out, lse, ref_out, ref_lse)
+
+
+def test_gemma4_fp8_kv_head_dim_512_tensor_core_decode_matches_torch() -> None:
+    _require_ampere_or_newer()
+    q, k_cache, v_cache, num_pages = _make_inputs(1)
+    _, kv_indptr, kv_indices, kv_last_page_len = _paged_metadata(1, num_pages)
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace,
+        kv_layout="NHD",
+        use_tensor_cores=True,
+        backend="fa2",
+    )
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        kv_last_page_len,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        pos_encoding_mode="NONE",
+        logits_soft_cap=0.0,
+        sm_scale=SM_SCALE,
+        q_data_type=Q_DTYPE,
+        kv_data_type=KV_DTYPE,
+    )
+    out, lse = wrapper.run(
+        q,
+        (k_cache, v_cache),
+        k_scale=K_SCALE,
+        v_scale=V_SCALE,
+        return_lse=True,
+    )
+
+    ref_out, ref_lse = _reference(q, k_cache, v_cache)
+    _assert_matches_reference(out, lse, ref_out, ref_lse)

--- a/tests/attention/test_gemma4_fa2_accuracy.py
+++ b/tests/attention/test_gemma4_fa2_accuracy.py
@@ -151,7 +151,7 @@ def test_gemma4_fp8_kv_head_dim_512_chunked_prefill_matches_torch() -> None:
         q_len, num_pages
     )
 
-    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
     wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
         workspace, kv_layout="NHD", backend="fa2"
     )
@@ -186,7 +186,7 @@ def test_gemma4_fp8_kv_head_dim_512_tensor_core_decode_matches_torch() -> None:
     q, k_cache, v_cache, num_pages = _make_inputs(1)
     _, kv_indptr, kv_indices, kv_last_page_len = _paged_metadata(1, num_pages)
 
-    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
+    workspace = torch.empty(512 * 1024 * 1024, dtype=torch.uint8, device=DEVICE)
     wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
         workspace,
         kv_layout="NHD",

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -272,6 +272,16 @@ def test_customize_batch_prefill_nvfp4_large_head_uses_prefill_flags(
         attention_modules._fa2_head_dim_nvcc_flags(512, 512, torch.uint8)
 
 
+def test_fa2_fp8_large_head_uses_sm80_flags(monkeypatch):
+    monkeypatch.setattr(
+        attention_modules.current_compilation_context, "TARGET_CUDA_ARCHS", {(8, 0)}
+    )
+
+    flags = attention_modules._fa2_head_dim_nvcc_flags(512, 512, torch.float8_e4m3fn)
+    assert flags is not None
+    assert any("sm_80" in flag for flag in flags)
+
+
 @pytest.mark.parametrize(
     ("head_dim_qk", "head_dim_vo", "supported"),
     [


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Enable FlashAttention-2 large-head FP8 KV-cache kernels on SM80+ so models with head dimension 512, including Gemma 4, can use FlashInfer FP8 KV cache on A100.

Changes:

- Generate and JIT-compile FA2 large-head FP8 KV modules for SM80+ instead of restricting them to SM100+.
- Enable the existing large-head FP8 prefill and tensor-core decode paths on Ampere while retaining the SM100+ restriction for NVFP4 large-head decode.
- Extend the existing FP8 prefill/decode test coverage to SM80.
- Add focused Gemma 4 head-dim-512 prefill and decode correctness tests against an independent FP32 PyTorch reference, plus a JIT architecture-flag regression test.

### A100 serving performance

NVIDIA A100-SXM4-80GB; fixed 128-request chat dataset; mean ISL 9,936; max OSL 300; MTP3; prefix caching disabled; concurrency 1–64. BF16 uses TP2 and quantized checkpoints use TP1. OTPS/GPU is aggregate output-token throughput divided by TP.

| Checkpoint | TP | KV cache | Attention | c1 OTPS/user | Best observed OTPS/GPU (c1–64) |
|---|---:|---|---|---:|---:|
| BF16-IT | 2 | BF16 | Triton | 158.12 | 241.08 (c64) |
| BF16-IT | 2 | BF16 | FlashInfer | 148.49 | **323.82 (c64)** |
| [FP8 dynamic][fp8-model] | 1 | BF16 | Triton | 154.52 | 267.01 (c16) |
| [FP8 dynamic][fp8-model] | 1 | BF16 | FlashInfer | **174.13** | 371.60 (c64) |
| [FP8 dynamic][fp8-model] | 1 | FP8 | FlashInfer | 170.90 | **389.46 (c64)** |
| NVFP4 | 1 | BF16 | Triton | 154.23 | 286.49 (c64) |
| NVFP4 | 1 | BF16 | FlashInfer | **175.11** | **415.74 (c64)** |
| NVFP4 | 1 | FP8 | FlashInfer | 173.01 | 412.56 (c64) |

<img width="3144" height="1922" alt="gemma4_26b_a4b_a100_260910_4line_mtp3_no_c128_no_sla_pareto" src="https://github.com/user-attachments/assets/1e559635-b636-4348-b2ef-01809c36f965" />

At the best observed points from concurrency 1–64, FlashInfer improves OTPS/GPU over Triton by 34% for BF16, 39–46% for the FP8 checkpoint, and 44–45% for NVFP4.

## 🔍 Related Issues

N/A

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Added/updated coverage:

- Gemma 4 FP8 KV head-dim-512 chunked prefill versus an FP32 PyTorch reference.
- Gemma 4 FP8 KV head-dim-512 tensor-core decode versus an FP32 PyTorch reference.
- SM80 JIT architecture flags and existing FP8 large-head prefill/decode coverage.
- End-to-end A100 serving sweeps and GPQA Diamond validation.

### GPQA Diamond

FP8 golden/reference checkpoint: [RedHatAI/gemma-4-31B-it-FP8-dynamic][fp8-model]. All runs use TP4, MTP3, and thinking. Each score covers 198 questions with 16 sampled solutions per question; pass@1 is the reported average of 16 runs.

| Checkpoint | Triton KV cache | Triton pass@1 (avg. of 16) | Triton pass@16 | FlashInfer KV cache | FlashInfer pass@1 (avg. of 16) | FlashInfer pass@16 |
|---|---|---:|---:|---|---:|---:|
| [FP8 dynamic][fp8-model] | BF16 | 79.36% ± 2.08% | **94.95%** | BF16 | **80.62% ± 1.69%** | 93.94% |
| NVFP4 | BF16 | 79.23% ± 1.84% | 93.43% | FP8 | **80.40% ± 1.00%** | **94.95%** |

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends".
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please focus on the SM80 architecture gating and the independent-reference tolerances in `tests/attention/test_gemma4_fa2_accuracy.py`.

[fp8-model]: https://huggingface.co/RedHatAI/gemma-4-31B-it-FP8-dynamic


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded large-head attention support for compatible KV data types on Ampere and newer GPUs.
  * Large-head FP8 prefill and paged decode paths now support SM80+ hardware.
  * NVFP4 large-head decode remains limited to newer GPU architectures.

* **Tests**
  * Added Gemma 4 FP8 KV accuracy coverage for prefill and decode.
  * Added validation for Ampere-compatible large-head kernel builds and expanded large-head test coverage on SM80+ GPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->