### PR TITLE
fix(bench): quote benchmark CSV fields

### DIFF
--- a/benchmarks/flashinfer_benchmark.py
+++ b/benchmarks/flashinfer_benchmark.py
@@ -1,4 +1,5 @@
 import argparse
+import csv
 import sys
 
 # Only import utilities at module level - routine modules are imported lazily
@@ -89,7 +90,8 @@ def run_test(args):
 
     # Write results to output file if specified
     if args.output_path is not None:
-        with open(args.output_path, "a") as fout:
+        with open(args.output_path, "a", newline="") as fout:
+            writer = csv.writer(fout)
             for cur_res in res:
                 for key in full_output_columns:
                     # Backfill every output column the routine didn't set: from
@@ -99,10 +101,7 @@ def run_test(args):
                     if key not in cur_res or cur_res[key] == "":
                         cur_res[key] = getattr(args, key, "")
 
-                output_line = ",".join(
-                    [str(cur_res[col]) for col in full_output_columns]
-                )
-                fout.write(output_line + "\n")
+                writer.writerow([str(cur_res[col]) for col in full_output_columns])
             fout.flush()
     return
 
@@ -354,8 +353,8 @@ if __name__ == "__main__":
 
     # Setup output file if specified
     if testlist_args.output_path is not None:
-        with open(testlist_args.output_path, "w") as fout:
-            fout.write(",".join(full_output_columns) + "\n")
+        with open(testlist_args.output_path, "w", newline="") as fout:
+            csv.writer(fout).writerow(full_output_columns)
 
     # Process tests either from testlist file or command line arguments
     if testlist_args.testlist is not None:


### PR DESCRIPTION
## 📌 Description

Replaces manual comma-joined benchmark CSV output with Python csv.writer, so values containing commas—such as Unified MoE autotuner tactics like (202, 469)—remain a single field. This prevents column shifts that cause perf-ci to interpret dtype strings as Boolean values during Databricks upload.

## 🔍 Related Issues

N/A — fixes the Unified MoE benchmark CSV ingestion regression observed in perf-ci.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed pre-commit by running pip install pre-commit (or used my preferred method).
- [x] I have installed the hooks with pre-commit install.
- [x] I have run the relevant hooks manually and fixed all reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (unittest, etc.).


## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → Experimental APIs and Backends). Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under flashinfer/experimental/ and/or an @flashinfer_experimental_api. Tracking issue: #

```experimental-tests
# Not an experimental PR.
```

## Reviewer Notes

The fix preserves the previous string conversion for all values; it only delegates escaping and row serialization to the standard CSV writer.