### PR TITLE
Add ci: health label to DLQA-filed issues

### DIFF
--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -18,3 +18,26 @@ jobs:
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
           LABELS: needs-triage
+
+      - name: Add CI health label to DLQA filings
+        if: >-
+          ${{
+            github.event.issue.body &&
+            contains(
+              github.event.issue.body,
+              '<!-- dlqa-triage:flashinfer-ci:v1 -->'
+            )
+          }}
+        run: |
+          actor="$(gh api user --jq .login)"
+          if [[ "$actor" != "$EXPECTED_ACTOR" ]]; then
+            echo "::error::FLASHINFER_GITHUB_TOKEN belongs to $actor, expected $EXPECTED_ACTOR"
+            exit 1
+          fi
+          gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.FLASHINFER_GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: "ci: health"
+          EXPECTED_ACTOR: kangbintNV


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Recognize the hidden `<!-- dlqa-triage:flashinfer-ci:v1 -->` marker on newly opened issues and add the `ci: health` label with `FLASHINFER_GITHUB_TOKEN`.

Before writing, the workflow verifies that the token actor is exactly `kangbintNV`; otherwise it fails without adding the label. The existing `needs-triage` behavior remains unchanged, and the issue author remains the actual filing user.

## 🔍 Related Issues

Companion DLQA MR: https://gitlab-master.nvidia.com/dlswqa/cudnn/dlqa_triage/-/merge_requests/276

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validation: `pre-commit run --files .github/workflows/new-issue.yml`, actionlint v1.7.7, YAML parse, and `git diff --check` all pass.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

`FLASHINFER_GITHUB_TOKEN` must remain a token owned by `kangbintNV` with Issues write permission. The workflow checks the actor at runtime and fails closed if the secret is missing or belongs to another account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Qualifying issues are now automatically labeled `ci: health` when they include the supported triage marker.

- **Bug Fixes**
  - Automated labeling now verifies the authorized workflow actor before applying the label, preventing unintended issue updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->