### PR TITLE
fix(quantization): normalize segment_packbits input dtype

### DIFF
--- a/flashinfer/quantization/packbits.py
+++ b/flashinfer/quantization/packbits.py
@@ -132,6 +132,7 @@ def segment_packbits(
     output_nnzs = indptr_new[-1].item()
 
     device = x.device
+    x = x.to(torch.bool)
     indptr = indptr.to(torch.int32)
     indptr_new = indptr_new.to(torch.int32)
     y = torch.empty(output_nnzs, dtype=torch.uint8, device=device)

--- a/tests/utils/test_quantization.py
+++ b/tests/utils/test_quantization.py
@@ -60,6 +60,27 @@ def test_segment_packbits(batch_size, bitorder):
         assert torch.equal(y_gpu[new_indptr[i] : new_indptr[i + 1]], y_segment_i_ref)
 
 
+@pytest.mark.parametrize("dtype", [torch.bool, torch.uint8, torch.int32, torch.int64])
+@pytest.mark.parametrize("bitorder", ["big", "little"])
+def test_segment_packbits_input_dtype(dtype, bitorder):
+    x_cpu = torch.tensor([1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0, 1], dtype=dtype)
+    offsets = [0, 0, 3, 11, 13]
+    expected_segments = [
+        numpy_packbits_ref(x_cpu[start:end], bitorder)
+        for start, end in zip(offsets[:-1], offsets[1:], strict=True)
+    ]
+    expected_indptr = [0]
+    for segment in expected_segments:
+        expected_indptr.append(expected_indptr[-1] + segment.numel())
+
+    packed, indptr = flashinfer.segment_packbits(
+        x_cpu.to("cuda"), torch.tensor(offsets, device="cuda"), bitorder
+    )
+
+    assert torch.equal(packed.cpu(), torch.cat(expected_segments))
+    assert indptr.cpu().tolist() == expected_indptr
+
+
 if __name__ == "__main__":
     test_packbits(999999, "big")
     test_segment_packbits(77, "little")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`segment_packbits` reads non-boolean binary-valued inputs as raw boolean bytes. For `[1,0,1,1,0,0,1,1]` with int32/int64 dtype, it returns 128 instead of 179, while `packbits` returns 179.

Normalize the input to bool before the CUDA call, matching `packbits`. Add NumPy-backed GPU regressions for bool, uint8, int32 and int64, both bit orders, and empty/partial/full-byte segments.

## 🔍 Related Issues

Found by local GPU reproduction; no existing issue.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation on an RTX 5060 Ti (SM120), PyTorch 2.13.0+cu130, CUDA 13.0:

- Before the fix, the new regression had 4 failing integer cases and 4 passing bool/uint8 controls.
- After the fix, `pytest tests/utils/test_quantization.py -q`: **36 passed**.
- `pre-commit run --all-files`: passed.
- The full multi-architecture test suite was not run locally.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

This is a correctness fix to an existing API; no CUDA kernel or signature changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved segmented bit packing to consistently handle boolean and integer input values.
  - Corrected behavior for inputs containing empty segments and supported bit-order options.

- **Tests**
  - Added coverage for multiple input types, bit orders, segment offsets, packed results, and returned indices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->