### PR TITLE
fix: honor mask strides when merging attention states in place

### DIFF
--- a/csrc/cascade.cu
+++ b/csrc/cascade.cu
@@ -75,11 +75,13 @@ void merge_state_in_place(TensorView v, TensorView s, TensorView v_other, Tensor
   TVM_FFI_ICHECK_EQ(v.size(0), s.size(0));
   TVM_FFI_ICHECK_EQ(v.size(1), s.size(1));
   uint8_t* mask_ptr = nullptr;
+  int64_t mask_stride = 1;
   if (mask.has_value()) {
     CHECK_DIM(1, mask.value());
     TVM_FFI_ICHECK_EQ(v.size(0), mask.value().size(0));
     CHECK_DEVICE(mask.value(), v);
     mask_ptr = static_cast<uint8_t*>(mask.value().data_ptr());
+    mask_stride = mask.value().stride(0);
   }
   unsigned int seq_len = v.size(0);
   unsigned int num_heads = v.size(1);
@@ -91,7 +93,7 @@ void merge_state_in_place(TensorView v, TensorView s, TensorView v_other, Tensor
     cudaError_t status = MergeStateInPlace(
         static_cast<c_type*>(v.data_ptr()), static_cast<float*>(s.data_ptr()),
         static_cast<c_type*>(v_other.data_ptr()), static_cast<float*>(s_other.data_ptr()), seq_len,
-        num_heads, head_dim, mask_ptr, stream);
+        num_heads, head_dim, mask_ptr, stream, mask_stride);
     TVM_FFI_ICHECK(status == cudaSuccess)
         << "MergeStateInPlace kernel launch failed: " << cudaGetErrorString(status);
     return true;

--- a/include/flashinfer/attention/cascade.cuh
+++ b/include/flashinfer/attention/cascade.cuh
@@ -84,16 +84,17 @@ __global__ void MergeStateKernel(DTypeIn* __restrict__ v_a, float* __restrict__ 
  * \param mask Optional mask of whether to merge given sequences or not. (n)
  * \param num_heads The number of heads of v and v_other.
  * \param head_dim The dimension of each head.
+ * \param mask_stride The stride of the mask in elements.
  * \note Both s and s_other are logsumexp values with base 2.
  */
 template <uint32_t vec_size, typename DType>
 __global__ void MergeStateInPlaceKernel(DType* __restrict__ v, float* __restrict__ s,
                                         DType* __restrict__ v_other, float* __restrict__ s_other,
                                         uint8_t* __restrict__ mask, uint32_t num_heads,
-                                        uint32_t head_dim) {
+                                        uint32_t head_dim, int64_t mask_stride) {
   uint32_t pos = blockIdx.x;
 
-  if (mask != nullptr && mask[pos] == 0) return;
+  if (mask != nullptr && mask[pos * mask_stride] == 0) return;
 
   uint32_t tx = threadIdx.x, ty = threadIdx.y;
   uint32_t head_idx = ty;
@@ -604,13 +605,14 @@ cudaError_t MergeState(DTypeIn* v_a, float* s_a, DTypeIn* v_b, float* s_b, DType
  * \param head_dim The dimension of each head.
  * \param mask Optional mask of whether to merge given sequences or not. (n)
  * \param stream The CUDA stream to execute the kernel.
+ * \param mask_stride The stride of the mask in elements.
  * \return status Indicates whether CUDA calls are successful
  * \note Both s and s_other are logsumexp values with base 2.
  */
 template <typename DType>
 cudaError_t MergeStateInPlace(DType* v, float* s, DType* v_other, float* s_other, uint32_t seq_len,
                               uint32_t num_heads, uint32_t head_dim, uint8_t* mask = nullptr,
-                              cudaStream_t stream = nullptr) {
+                              cudaStream_t stream = nullptr, int64_t mask_stride = 1) {
   DISPATCH_HEAD_DIM(head_dim, HEAD_DIM, {
     constexpr uint32_t vec_size = std::max(16U / sizeof(DType), HEAD_DIM / 32U);
     uint32_t bdx = HEAD_DIM / vec_size;
@@ -618,7 +620,7 @@ cudaError_t MergeStateInPlace(DType* v, float* s, DType* v_other, float* s_other
     dim3 nblks(seq_len);
     dim3 nthrs(bdx, bdy);
     auto kernel = MergeStateInPlaceKernel<vec_size, DType>;
-    void* args[] = {&v, &s, &v_other, &s_other, &mask, &num_heads, &head_dim};
+    void* args[] = {&v, &s, &v_other, &s_other, &mask, &num_heads, &head_dim, &mask_stride};
     FLASHINFER_CUDA_CALL(cudaLaunchKernel((void*)kernel, nblks, nthrs, args, 0, stream));
   });
   return cudaSuccess;

--- a/tests/attention/test_cascade_mask.py
+++ b/tests/attention/test_cascade_mask.py
@@ -1,0 +1,79 @@
+"""
+Copyright (c) 2023 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+import torch
+
+import flashinfer
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("use_cuda_graph", [False, True])
+@pytest.mark.parametrize("mask_stride", [0, 1, 2, 3])
+@pytest.mark.parametrize("pattern", ["all_true", "all_false", "alternating"])
+def test_merge_state_in_place_mask_stride(dtype, use_cuda_graph, mask_stride, pattern):
+    if mask_stride == 0 and pattern == "alternating":
+        pytest.skip("A broadcast mask has the same value in every row")
+
+    seq_len = 17
+    # Keep padding opposite to selected entries and use a nonzero storage offset.
+    storage = torch.full(
+        (1 + seq_len * max(mask_stride, 1),),
+        pattern == "all_false",
+        dtype=torch.bool,
+        device="cuda",
+    )
+    if mask_stride == 0:
+        storage[1] = pattern == "all_true"
+        mask = storage[1:2].expand(seq_len)
+    else:
+        mask = storage[1::mask_stride]
+        if pattern == "alternating":
+            mask.copy_(torch.arange(seq_len, device="cuda") % 2 == 0)
+        else:
+            mask.fill_(pattern == "all_true")
+    assert mask.stride(0) == mask_stride
+    assert mask.storage_offset() == 1
+
+    v = torch.zeros((seq_len, 2, 64), dtype=dtype, device="cuda")
+    s = torch.zeros((seq_len, 2), dtype=torch.float32, device="cuda")
+    v_other = torch.ones_like(v)
+    s_other = torch.zeros_like(s)
+
+    # Warm up the JIT before capture.
+    flashinfer.merge_state_in_place(v, s, v_other, s_other, mask)
+    v.zero_()
+    s.zero_()
+    if use_cuda_graph:
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            flashinfer.merge_state_in_place(v, s, v_other, s_other, mask)
+
+    for _ in range(2):
+        v.zero_()
+        s.zero_()
+        if use_cuda_graph:
+            graph.replay()
+        else:
+            flashinfer.merge_state_in_place(v, s, v_other, s_other, mask)
+        # Equal logsumexp weights average the states and add one in base 2.
+        # Unselected rows must remain exactly unchanged.
+        expected_v = (mask.to(dtype) * 0.5)[:, None, None].expand_as(v)
+        expected_s = mask.to(s.dtype)[:, None].expand_as(s)
+        torch.testing.assert_close(v, expected_v, rtol=0, atol=0)
+        torch.testing.assert_close(s, expected_s, rtol=0, atol=0)
+        # Replays must read the current mask values through the original view.
+        storage.logical_not_()


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Fix `merge_state_in_place` silently reading the wrong rows for non-contiguous boolean masks. For example, a stride-2 view with logical values `[true, false, true, false]` merges only row 0 instead of rows 0 and 2 when the underlying padding is false.

Pass the mask's element stride from the tensor binding into the CUDA kernel and index `mask[pos * mask_stride]`. This supports sliced and expanded (stride-zero) masks without a contiguous copy or temporary allocation, including masks updated between CUDA graph replays.

## 🔍 Related Issues

No existing issue. Found while checking non-contiguous input handling.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Scope: the targeted GPU suites below, not the entire repository test matrix. Tested on **NVIDIA GeForce RTX 5060 Ti**, driver 595.84, CUDA 13.0, PyTorch 2.13.0+cu130, using this checkout's Python source and JIT-compiled CUDA source.

- New GPU regression before the fix: **32 failed, 12 passed, 4 skipped**; after the fix: **44 passed, 4 skipped**. Covers FP16/BF16, stride 0/1/2/3, nonzero storage offset, all-true/all-false/alternating masks, eager calls and CUDA graph replay after changing mask values. The four skipped cases are alternating values with stride zero, an impossible layout.
- `python -m pytest tests/attention/test_cascade_mask.py tests/trace/test_merge_state_reference_correctness.py tests/trace/test_merge_state_in_place_reference_correctness.py tests/trace/test_merge_states_reference_correctness.py -q`: **50 passed, 4 skipped**.
- `python -m pytest tests/attention/test_shared_prefix_kernels.py tests/trace/test_multi_level_cascade_run_reference_correctness.py -q`: **195 passed**.
- CUDA 13.0 C++ compile check: old calls with default arguments / mask / mask + stream and new explicit-stride calls all compile.
- `pre-commit install`, `pre-commit run --all-files`: passed.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Python, custom-op and TVM-FFI signatures are unchanged. The header-only C++ launcher adds a final defaulted `int64_t mask_stride = 1`, preserving existing ordinary call sites, including explicit stream arguments. The CUDA kernel argument list changes, so downstream C++/CUDA consumers must rebuild against the updated header; the local JIT tests compile the launcher and kernel together.

This is a correctness fix; no performance improvement is claimed. Broader GPU CI requires a maintainer/authorized CI user to trigger it under the repository policy. AI-assisted implementation, reviewed and validated locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved in-place state merging to correctly support masks with strided layouts.
  - Preserved expected mask behavior when using padded or offset mask storage.
  - Ensured mask values are read correctly during CUDA graph replay.

- **Tests**
  - Added coverage for multiple data types, mask strides, mask patterns, and CUDA graph execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->