### PR TITLE
feat(moe): standalone trtllm-gen MoE finalize op with optional fused LoRA delta

### DIFF
--- a/benchmarks/bench_trtllm_gen_moe_finalize.py
+++ b/benchmarks/bench_trtllm_gen_moe_finalize.py
@@ -1,0 +1,146 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+TRT-LLM Gen MoE finalize benchmark.
+
+Compares the MoE-LoRA FC2 combine flows downstream of the delta production
+(the bgmv delta GEMMs are identical in both flows and excluded):
+
+  separate: finalize (the fused launchers' do_finalize=True equivalent)
+            followed by a full-output add of the [T, H] LoRA delta
+  fused:    trtllm_gen_moe_finalize with the delta folded into the combine
+
+plus the fused per-slot [T, top_k, H] delta variant that a decomposed
+(combine=False) bgmv expand would produce.
+
+Usage:
+    FLASHINFER_DISABLE_VERSION_CHECK=1 python benchmarks/bench_trtllm_gen_moe_finalize.py
+"""
+
+import os
+
+os.environ.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
+
+import argparse
+
+import numpy as np
+import torch
+
+from flashinfer.fused_moe import trtllm_gen_moe_finalize
+from flashinfer.testing.utils import bench_gpu_time
+
+
+def make_case(num_tokens, top_k, hidden_size, device):
+    num_expanded = num_tokens * top_k
+    gemm2_output = (
+        torch.randn(num_expanded, hidden_size, device=device).to(torch.bfloat16) * 0.1
+    )
+    expert_weights = torch.rand(num_tokens, top_k, dtype=torch.bfloat16, device=device)
+    e2p = torch.randperm(num_expanded, dtype=torch.int32, device=device)
+    delta_2d = (
+        torch.randn(num_tokens, hidden_size, device=device).to(torch.bfloat16) * 0.01
+    )
+    delta_3d = (
+        torch.randn(num_tokens, top_k, hidden_size, device=device).to(torch.bfloat16)
+        * 0.01
+    )
+    out = torch.empty(num_tokens, hidden_size, dtype=torch.bfloat16, device=device)
+    return gemm2_output, expert_weights, e2p, delta_2d, delta_3d, out
+
+
+def median_us(fn):
+    return float(np.median(bench_gpu_time(fn))) * 1e3
+
+
+def run_case(num_tokens, top_k, hidden_size, device):
+    gemm2_output, expert_weights, e2p, delta_2d, delta_3d, out = make_case(
+        num_tokens, top_k, hidden_size, device
+    )
+
+    def finalize_only():
+        trtllm_gen_moe_finalize(gemm2_output, expert_weights, e2p, out=out)
+
+    def separate():  # current flow: finalize, then add the combined delta
+        trtllm_gen_moe_finalize(gemm2_output, expert_weights, e2p, out=out)
+        out.add_(delta_2d)
+
+    def fused_2d():
+        trtllm_gen_moe_finalize(
+            gemm2_output, expert_weights, e2p, lora_delta=delta_2d, out=out
+        )
+
+    def fused_3d():
+        trtllm_gen_moe_finalize(
+            gemm2_output,
+            expert_weights,
+            e2p,
+            lora_delta=delta_3d,
+            lora_apply_expert_weights=True,
+            out=out,
+        )
+
+    t_base = median_us(finalize_only)
+    t_sep = median_us(separate)
+    t_f2 = median_us(fused_2d)
+    t_f3 = median_us(fused_3d)
+
+    # Effective bandwidth of the fused 2D flow: read K permuted rows + delta,
+    # write the output once.
+    bytes_moved = 2 * (
+        num_tokens * top_k * hidden_size  # gathered gemm2 rows
+        + num_tokens * hidden_size  # delta_2d read
+        + num_tokens * hidden_size  # output write
+    )
+    gbps = bytes_moved / (t_f2 * 1e-6) / 1e9
+
+    print(
+        f"| {num_tokens:>6} | {hidden_size:>6} | {top_k:>2} "
+        f"| {t_base:9.1f} | {t_sep:12.1f} | {t_f2:8.1f} | {t_f3:8.1f} "
+        f"| {t_sep / t_f2:7.2f}x | {gbps:7.0f} |"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        nargs="+",
+        default=[1, 16, 64, 256, 1024, 4096, 8192],
+    )
+    parser.add_argument(
+        "--hidden-size", type=int, nargs="+", default=[2880, 4096, 7168]
+    )
+    parser.add_argument("--top-k", type=int, nargs="+", default=[8])
+    args = parser.parse_args()
+
+    device = torch.device("cuda")
+    print(f"GPU: {torch.cuda.get_device_name(device)}")
+    print(
+        "| tokens | hidden |  k | base (us) | sep add (us) | f2d (us) | f3d (us) "
+        "| speedup | GB/s    |"
+    )
+    print(
+        "|--------|--------|----|-----------|--------------|----------|----------"
+        "|---------|---------|"
+    )
+    for hidden_size in args.hidden_size:
+        for top_k in args.top_k:
+            for num_tokens in args.num_tokens:
+                run_case(num_tokens, top_k, hidden_size, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
@@ -711,6 +711,20 @@ __global__ void finalizeKernel(KernelParams params) {
         }
       }
 
+      // Optional fused delta (e.g. LoRA down-projection). Indexed by the expanded
+      // (token, slot) row, not the permutation: inactive slots contribute their
+      // (producer-zero-filled) rows unconditionally.
+      if (params.loraDeltaPtr != nullptr) {
+        for (int k = 0; k < params.loraTopK; k++) {
+          int64_t const deltaRow = int64_t{tokenIdx} * params.loraTopK + k;
+          float delta = float{params.loraDeltaPtr[deltaRow * params.hiddenDim + hiddenIdx]};
+          if (params.loraApplyExpertWeights) {
+            delta *= float{params.expertWeightsPtr[tokenIdx * params.topK + k]};
+          }
+          data += params.loraDeltaScale * delta;
+        }
+      }
+
       params.outPtr[tokenIdx * params.hiddenDim + hiddenIdx] = static_cast<Type>(data);
     }
   }
@@ -933,6 +947,28 @@ __global__ void finalizeKernelVecLoad(KernelParams params) {
         threadOutput = threadOutput + scale * expertResult;
       }
     }
+
+    // Optional fused delta (e.g. LoRA down-projection). Indexed by the expanded
+    // (token, slot) row, not the permutation: inactive slots contribute their
+    // (producer-zero-filled) rows unconditionally.
+    if (params.loraDeltaPtr != nullptr) {
+      auto const* deltaElemPtr = reinterpret_cast<InputElem const*>(params.loraDeltaPtr);
+      for (int k = 0; k < params.loraTopK; k++) {
+        int64_t const deltaRow = tokenIdx * params.loraTopK + k;
+        float4 deltaRaw = vectorizedLoadPtx(
+            reinterpret_cast<float4 const*>(&deltaElemPtr[deltaRow * numElemsInCol + elemIndex]));
+        ComputeElem deltaElem =
+            arrayConvert<InputElem, ComputeElem>(*reinterpret_cast<InputElem const*>(&deltaRaw));
+        float scale = params.loraDeltaScale;
+        if (params.loraApplyExpertWeights) {
+          auto scaleArr =
+              *reinterpret_cast<ScaleArrayType const*>(&scaleArrSmem[k / TopKUnrollFactor]);
+          scale *= float{scaleArr[k % TopKUnrollFactor]};
+        }
+        threadOutput = threadOutput + scale * deltaElem;
+      }
+    }
+
     OutputElem outputElem = arrayConvert<ComputeElem, OutputElem>(threadOutput);
     outElemPtr[elemIndex] = outputElem;
   }
@@ -1004,6 +1040,9 @@ __global__ void finalizeDeepSeekKernel(KernelParams params) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void run(Data const& data, void* stream) {
+  // The DeepSeek FP8 finalize kernel does not implement the fused delta path.
+  FLASHINFER_CHECK(data.loraDeltaPtr == nullptr || !data.mUseDeepSeekFp8,
+                   "The fused finalize delta is not supported with DeepSeek FP8 finalize.");
   if (data.mUseDeepSeekFp8) {
     int const numThreads = 128;
     int const numBlocksX = (data.hiddenDim - 1 + numThreads) / numThreads;

--- a/csrc/trtllm_fused_moe_finalize_binding.cu
+++ b/csrc/trtllm_fused_moe_finalize_binding.cu
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdint>
+
+#include "flashinfer/trtllm/fused_moe/DevKernel.h"
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer::trtllm_gen_finalize {
+
+namespace tg = batchedGemm::trtllm::gen;
+using tvm::ffi::Optional;
+using tvm::ffi::TensorView;
+
+/*!
+ * \brief Standalone TVM-FFI entry point for the trtllm-gen MoE finalize stage.
+ *
+ * Runs the same moe::dev::finalize kernels the fused MoE launchers invoke when
+ * do_finalize=true, so a caller holding the do_finalize=false outputs
+ * (gemm2_output, expert_weights, expanded_idx_to_permuted_idx) can complete
+ * the token combine as a separate op — optionally fusing in a per-token delta
+ * (e.g. a LoRA down-projection delta) that would otherwise cost an extra
+ * full-output read-modify-write pass.
+ *
+ *   gemm2_output                : [num_padded, hidden_padded] bfloat16 or float16,
+ *                                 permuted FC2 output rows
+ *   expert_weights              : [num_tokens, top_k] bfloat16 or float32
+ *   expanded_idx_to_permuted_idx: num_tokens * top_k int32 elements, -1 marks
+ *                                 inactive slots (e.g. experts outside the local
+ *                                 expert-parallel shard)
+ *   output                      : [num_tokens, hidden] same dtype as gemm2_output
+ *   lora_delta (optional)       : [num_tokens, top_k, hidden] per-slot rows, or
+ *                                 [num_tokens, hidden] pre-combined; same dtype
+ *                                 as output. Rows are addressed by the expanded
+ *                                 (token, slot) index, NOT the permutation, and
+ *                                 are accumulated unconditionally — the producer
+ *                                 must zero-fill rows of inactive slots.
+ *   lora_delta_scale            : scalar factor applied to the delta sum (e.g.
+ *                                 routed_scaling_factor)
+ *   lora_apply_expert_weights   : multiply each per-slot delta row by its
+ *                                 expert weight (requires the 3D delta layout)
+ *
+ * out[t, h] = sum_k w[t, k] * gemm2_output[perm(t, k), h]      (skipping -1)
+ *           + lora_delta_scale * sum_k s[t, k] * delta[t, k, h] (all k)
+ * with s[t, k] = w[t, k] if lora_apply_expert_weights else 1.
+ *
+ * PDL note: with enable_pdl=true the vectorized kernel prefetches expert_weights
+ * and expanded_idx_to_permuted_idx BEFORE its grid-dependency sync (same as the
+ * fused pipeline, where routing completed several kernels earlier). If either
+ * tensor is produced by the immediately preceding kernel on the stream, pass
+ * enable_pdl=false.
+ */
+void trtllm_gen_moe_finalize(TensorView gemm2_output, TensorView expert_weights,
+                             TensorView expanded_idx_to_permuted_idx, TensorView output,
+                             Optional<TensorView> lora_delta, double lora_delta_scale,
+                             bool lora_apply_expert_weights, bool enable_pdl) {
+  CHECK_INPUT(gemm2_output);
+  CHECK_INPUT(expert_weights);
+  CHECK_INPUT(expanded_idx_to_permuted_idx);
+  CHECK_INPUT(output);
+  CHECK_DEVICE(gemm2_output, output);
+  CHECK_DEVICE(expert_weights, output);
+  CHECK_DEVICE(expanded_idx_to_permuted_idx, output);
+
+  CHECK_DIM(2, gemm2_output);
+  CHECK_DIM(2, expert_weights);
+  CHECK_DIM(2, output);
+
+  TVM_FFI_ICHECK(output.dtype() == dl_bfloat16 || output.dtype() == dl_float16)
+      << "output must be bfloat16 or float16";
+  TVM_FFI_ICHECK(gemm2_output.dtype() == output.dtype())
+      << "gemm2_output must have the same dtype as output";
+  TVM_FFI_ICHECK(expert_weights.dtype() == dl_bfloat16 || expert_weights.dtype() == dl_float32)
+      << "expert_weights must be bfloat16 or float32";
+  TVM_FFI_ICHECK(expanded_idx_to_permuted_idx.dtype() == dl_int32)
+      << "expanded_idx_to_permuted_idx must be int32";
+
+  int64_t const num_tokens = output.size(0);
+  int64_t const hidden_size = output.size(1);
+  int64_t const hidden_size_padded = gemm2_output.size(1);
+  int64_t const top_k = expert_weights.size(1);
+
+  TVM_FFI_ICHECK_EQ(expert_weights.size(0), num_tokens)
+      << "expert_weights dim0 must equal num_tokens";
+  // The vectorized kernel caches the per-token weights/indices in MaxTopK-sized
+  // shared-memory arrays; enforce its bound upfront rather than letting the
+  // dispatch in finalize::run() turn top_k > 64 into a batch-size-dependent
+  // runtime failure (mirrors the routing binding's upfront top_k validation).
+  TVM_FFI_ICHECK(top_k >= 1 && top_k <= 64) << "top_k must be between 1 and 64, got " << top_k;
+  TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.numel(), num_tokens * top_k)
+      << "expanded_idx_to_permuted_idx must have num_tokens * top_k elements";
+  TVM_FFI_ICHECK_GE(hidden_size_padded, hidden_size)
+      << "gemm2_output hidden dimension must be >= output hidden dimension";
+  // Both finalize kernels may be dispatched; the vectorized one loads 128 bits
+  // per thread and requires the (padded) hidden extents to be multiples of it
+  // and every base pointer to be 16-byte aligned (fresh torch allocations are;
+  // contiguous-but-offset views may not be).
+  constexpr int64_t elems_per_128b = 128 / 16;  // both supported dtypes are 16-bit
+  TVM_FFI_ICHECK(hidden_size % elems_per_128b == 0 && hidden_size_padded % elems_per_128b == 0)
+      << "hidden dimensions must be multiples of " << elems_per_128b << ", got " << hidden_size
+      << " and " << hidden_size_padded;
+  auto check_aligned = [](void const* ptr, char const* name) {
+    TVM_FFI_ICHECK(reinterpret_cast<uintptr_t>(ptr) % 16 == 0)
+        << name << " must be 16-byte aligned";
+  };
+  check_aligned(gemm2_output.data_ptr(), "gemm2_output");
+  check_aligned(expert_weights.data_ptr(), "expert_weights");
+  check_aligned(expanded_idx_to_permuted_idx.data_ptr(), "expanded_idx_to_permuted_idx");
+  check_aligned(output.data_ptr(), "output");
+
+  void const* lora_delta_ptr = nullptr;
+  int64_t lora_top_k = 0;
+  if (lora_delta.has_value()) {
+    auto const& delta = lora_delta.value();
+    CHECK_INPUT(delta);
+    CHECK_DEVICE(delta, output);
+    TVM_FFI_ICHECK(delta.dtype() == output.dtype())
+        << "lora_delta must have the same dtype as output";
+    TVM_FFI_ICHECK(delta.ndim() == 2 || delta.ndim() == 3)
+        << "lora_delta must be [num_tokens, hidden] or [num_tokens, top_k, hidden]";
+    TVM_FFI_ICHECK_EQ(delta.size(0), num_tokens) << "lora_delta dim0 must equal num_tokens";
+    TVM_FFI_ICHECK_EQ(delta.size(delta.ndim() - 1), hidden_size)
+        << "lora_delta last dim must equal the output hidden dimension";
+    lora_top_k = delta.ndim() == 3 ? delta.size(1) : 1;
+    if (delta.ndim() == 3) {
+      TVM_FFI_ICHECK_EQ(delta.size(1), top_k) << "3D lora_delta dim1 must equal top_k";
+    }
+    check_aligned(delta.data_ptr(), "lora_delta");
+    lora_delta_ptr = delta.data_ptr();
+  }
+  TVM_FFI_ICHECK(!lora_apply_expert_weights || lora_top_k == top_k)
+      << "lora_apply_expert_weights requires the [num_tokens, top_k, hidden] delta layout";
+
+  // Empty batch: nothing to combine, and a zero grid dimension is a CUDA error.
+  if (num_tokens == 0) {
+    return;
+  }
+
+  moe::dev::finalize::Data data;
+  data.mDtypeElt = output.dtype() == dl_float16 ? tg::Dtype::Fp16 : tg::Dtype::Bfloat16;
+  data.mDtypeExpW = expert_weights.dtype() == dl_float32 ? tg::Dtype::Fp32 : tg::Dtype::Bfloat16;
+  data.mUsePdl = enable_pdl;
+  data.mUseDeepSeekFp8 = false;
+  data.inPtr = const_cast<void*>(gemm2_output.data_ptr());
+  data.outPtr = output.data_ptr();
+  data.inDqSfsPtr = nullptr;
+  data.outDqSfsPtr = nullptr;
+  data.expertWeightsPtr = const_cast<void*>(expert_weights.data_ptr());
+  data.expandedIdxToPermutedIdx =
+      static_cast<int32_t*>(const_cast<void*>(expanded_idx_to_permuted_idx.data_ptr()));
+  data.numTokens = static_cast<int32_t>(num_tokens);
+  data.numExperts = 0;  // unused by the non-DeepSeek finalize kernels
+  data.topK = static_cast<int32_t>(top_k);
+  data.hiddenDim = static_cast<int32_t>(hidden_size);
+  data.hiddenDimPadded = static_cast<int32_t>(hidden_size_padded);
+  data.totalNumPaddedTokens = nullptr;  // only read by the DeepSeek finalize kernel
+  data.loraDeltaPtr = lora_delta_ptr;
+  data.loraTopK = static_cast<int32_t>(lora_top_k);
+  data.loraDeltaScale = static_cast<float>(lora_delta_scale);
+  data.loraApplyExpertWeights = lora_apply_expert_weights;
+
+  auto stream = get_stream(output.device());
+  moe::dev::finalize::run(data, stream);
+}
+
+}  // namespace flashinfer::trtllm_gen_finalize
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(trtllm_gen_moe_finalize,
+                              flashinfer::trtllm_gen_finalize::trtllm_gen_moe_finalize);

--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -203,6 +203,19 @@ can be used (and tested) independently of quantization and GEMM configuration.
     trtllm_gen_routing
     TrtllmGenRoutingResult
 
+Standalone TRT-LLM Gen Finalize
+-------------------------------
+
+The token-combine (finalize) stage the TRT-LLM Gen fused MoE launchers run
+when ``do_finalize=True``, exposed on its own so callers holding the
+``do_finalize=False`` outputs can complete the combine separately — optionally
+fusing in a per-token delta such as a LoRA down-projection delta.
+
+.. autosummary::
+    :toctree: ../generated
+
+    trtllm_gen_moe_finalize
+
 CuteDSL Fused MoE
 -----------------
 

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -104,6 +104,7 @@ from .jit.fused_moe import (
     gen_cutlass_fused_moe_sm103_module,
     gen_cutlass_fused_moe_sm120_module,
     gen_trtllm_gen_fused_moe_sm100_module,
+    gen_trtllm_gen_moe_finalize_module,
     gen_trtllm_gen_routing_module,
 )
 from .jit.cake_fused_moe_warp_decode import (
@@ -748,6 +749,7 @@ def gen_all_modules(
             jit_specs.append(gen_trtllm_low_latency_gemm_module())
             jit_specs.append(gen_trtllm_gen_fused_moe_sm100_module())
             jit_specs.append(gen_trtllm_gen_routing_module())
+            jit_specs.append(gen_trtllm_gen_moe_finalize_module())
         if has_sm100f:
             # Add TGV GEMM modules compiled with SM100f flags for both bf16 and fp16
             jit_specs.append(

--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -147,6 +147,10 @@ from .trtllm_gen_routing import (  # noqa: F401
     trtllm_gen_routing as trtllm_gen_routing,
 )
 
+from .trtllm_gen_finalize import (  # noqa: F401
+    trtllm_gen_moe_finalize as trtllm_gen_moe_finalize,
+)
+
 from .bgmv_moe import (  # noqa: F401
     BGMVMoEBlackwellPlan as BGMVMoEBlackwellPlan,
     bgmv_moe as bgmv_moe,
@@ -305,6 +309,7 @@ __all__ = [
     "hash_topk",
     "TrtllmGenRoutingResult",
     "trtllm_gen_routing",
+    "trtllm_gen_moe_finalize",
     "bgmv_moe",
     "BGMVMoEBlackwellPlan",
     "bgmv_moe_shrink",

--- a/flashinfer/fused_moe/trtllm_gen_finalize.py
+++ b/flashinfer/fused_moe/trtllm_gen_finalize.py
@@ -1,0 +1,282 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from types import SimpleNamespace
+from typing import Optional, Tuple
+
+import torch
+
+from flashinfer.api_logging import flashinfer_api
+from flashinfer.jit.fused_moe import gen_trtllm_gen_moe_finalize_module
+from flashinfer.trace.templates.moe import trtllm_gen_moe_finalize_trace
+from flashinfer.utils import (
+    backend_requirement,
+    device_support_pdl,
+    register_custom_op,
+    supported_compute_capability,
+)
+
+# The trtllm_gen_moe_finalize module is compiled for SM 10.x and 12.x only
+# (same gate as the fused_moe_trtllm_sm100 module the finalize kernels ship in).
+_TRTLLM_GEN_MOE_FINALIZE_SUPPORTED_CC = [100, 103, 120, 121]
+
+# The vectorized finalize kernel loads 128 bits per thread; both supported
+# element dtypes (bfloat16 / float16) are 16-bit.
+_ELEMS_PER_128B = 8
+
+
+@supported_compute_capability(_TRTLLM_GEN_MOE_FINALIZE_SUPPORTED_CC)
+def _check_trtllm_gen_moe_finalize_supported(
+    gemm2_output: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    *,
+    lora_delta: Optional[torch.Tensor] = None,
+    lora_delta_scale: float = 1.0,
+    lora_apply_expert_weights: bool = False,
+    hidden_size: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    enable_pdl: Optional[bool] = None,
+) -> bool:
+    if gemm2_output.dim() != 2:
+        raise ValueError(
+            f"gemm2_output must be 2D [num_padded, hidden_padded], "
+            f"got {tuple(gemm2_output.shape)}"
+        )
+    if gemm2_output.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(
+            f"gemm2_output must be bfloat16 or float16, got {gemm2_output.dtype}"
+        )
+    if expert_weights.dim() != 2:
+        raise ValueError(
+            f"expert_weights must be 2D [num_tokens, top_k], "
+            f"got {tuple(expert_weights.shape)}"
+        )
+    if expert_weights.dtype not in (torch.bfloat16, torch.float32):
+        raise ValueError(
+            f"expert_weights must be bfloat16 or float32, got {expert_weights.dtype}"
+        )
+    num_tokens, top_k = expert_weights.shape
+    if not 1 <= top_k <= 64:
+        raise ValueError(
+            f"top_k must be in [1, 64] (the vectorized finalize kernel's "
+            f"shared-memory bound), got {top_k}"
+        )
+    if expanded_idx_to_permuted_idx.dtype != torch.int32:
+        raise ValueError(
+            f"expanded_idx_to_permuted_idx must be int32, "
+            f"got {expanded_idx_to_permuted_idx.dtype}"
+        )
+    if expanded_idx_to_permuted_idx.numel() != num_tokens * top_k:
+        raise ValueError(
+            f"expanded_idx_to_permuted_idx must have num_tokens * top_k "
+            f"({num_tokens * top_k}) elements, "
+            f"got {expanded_idx_to_permuted_idx.numel()}"
+        )
+    hidden = hidden_size if hidden_size is not None else gemm2_output.shape[1]
+    if not 0 < hidden <= gemm2_output.shape[1]:
+        raise ValueError(
+            f"hidden_size must be in (0, gemm2_output.shape[1]], got {hidden}"
+        )
+    if hidden % _ELEMS_PER_128B or gemm2_output.shape[1] % _ELEMS_PER_128B:
+        raise ValueError(
+            f"hidden dimensions must be multiples of {_ELEMS_PER_128B}, got "
+            f"{hidden} and {gemm2_output.shape[1]}"
+        )
+    if lora_delta is not None:
+        if lora_delta.dtype != gemm2_output.dtype:
+            raise ValueError(
+                f"lora_delta dtype ({lora_delta.dtype}) must match "
+                f"gemm2_output dtype ({gemm2_output.dtype})"
+            )
+        expected: Tuple[int, ...]
+        if lora_delta.dim() == 2:
+            expected = (num_tokens, hidden)
+        elif lora_delta.dim() == 3:
+            expected = (num_tokens, top_k, hidden)
+        else:
+            raise ValueError(
+                f"lora_delta must be 2D [num_tokens, hidden] or 3D "
+                f"[num_tokens, top_k, hidden], got {tuple(lora_delta.shape)}"
+            )
+        if tuple(lora_delta.shape) != expected:
+            raise ValueError(
+                f"lora_delta shape {tuple(lora_delta.shape)} does not match "
+                f"expected {expected}"
+            )
+        if lora_apply_expert_weights and lora_delta.dim() != 3:
+            raise ValueError(
+                "lora_apply_expert_weights requires the 3D "
+                "[num_tokens, top_k, hidden] lora_delta layout"
+            )
+    elif lora_apply_expert_weights:
+        raise ValueError("lora_apply_expert_weights requires lora_delta")
+    if out is not None:
+        if out.shape != (num_tokens, hidden):
+            raise ValueError(
+                f"out must have shape ({num_tokens}, {hidden}), got {tuple(out.shape)}"
+            )
+        if out.dtype != gemm2_output.dtype:
+            raise ValueError(
+                f"out dtype ({out.dtype}) must match gemm2_output dtype "
+                f"({gemm2_output.dtype})"
+            )
+    return True
+
+
+@functools.cache
+def get_trtllm_gen_moe_finalize_module():
+    """Build, load, and cache the trtllm_gen_moe_finalize JIT module."""
+    module = gen_trtllm_gen_moe_finalize_module().build_and_load()
+
+    @register_custom_op(
+        "flashinfer::trtllm_gen_moe_finalize",
+        mutates_args=["out"],
+    )
+    def trtllm_gen_moe_finalize(
+        gemm2_output: torch.Tensor,
+        expert_weights: torch.Tensor,
+        expanded_idx_to_permuted_idx: torch.Tensor,
+        out: torch.Tensor,
+        lora_delta: Optional[torch.Tensor],
+        lora_delta_scale: float,
+        lora_apply_expert_weights: bool,
+        enable_pdl: bool,
+    ) -> None:
+        module.trtllm_gen_moe_finalize(
+            gemm2_output,
+            expert_weights,
+            expanded_idx_to_permuted_idx,
+            out,
+            lora_delta,
+            lora_delta_scale,
+            lora_apply_expert_weights,
+            enable_pdl,
+        )
+
+    return SimpleNamespace(trtllm_gen_moe_finalize=trtllm_gen_moe_finalize)
+
+
+@backend_requirement({}, common_check=_check_trtllm_gen_moe_finalize_supported)
+@flashinfer_api(trace=trtllm_gen_moe_finalize_trace)
+def trtllm_gen_moe_finalize(
+    gemm2_output: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    *,
+    lora_delta: Optional[torch.Tensor] = None,
+    lora_delta_scale: float = 1.0,
+    lora_apply_expert_weights: bool = False,
+    hidden_size: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    r"""Standalone trtllm-gen MoE finalize (token combine), with optional fused delta.
+
+    Runs the same finalize kernels the trtllm-gen fused MoE launchers execute
+    when ``do_finalize=True`` (``moe::dev::finalize::run``): gathers the
+    permuted FC2 output rows through ``expanded_idx_to_permuted_idx``, applies
+    the expert weights, and reduces over the ``top_k`` slots. This completes
+    the documented ``do_finalize=False`` contract of the routed MoE ops as a
+    separate op, and can fuse a per-token delta — e.g. a LoRA down-projection
+    delta produced by :func:`bgmv_moe_gemm2_lora_delta` machinery — into the
+    combine, removing the extra full-output read-modify-write pass a separate
+    addition would cost.
+
+    .. math::
+        \text{out}[t] = \sum_k w[t, k] \cdot \text{gemm2\_output}[\pi(t, k)]
+        + s \cdot \sum_k \sigma[t, k] \cdot \Delta[t, k]
+
+    where :math:`\pi` is ``expanded_idx_to_permuted_idx`` (slots with
+    :math:`\pi = -1` are skipped in the first sum only), :math:`s` is
+    ``lora_delta_scale`` and :math:`\sigma[t, k]` is ``expert_weights`` when
+    ``lora_apply_expert_weights`` else 1.
+
+    Parameters
+    ----------
+    gemm2_output : torch.Tensor
+        Permuted, unfinalized FC2 output of shape
+        ``(num_padded, hidden_padded)``, ``bfloat16`` or ``float16`` — the
+        first tensor returned by the routed MoE ops with
+        ``do_finalize=False``.
+    expert_weights : torch.Tensor
+        Per-slot routing weights of shape ``(num_tokens, top_k)``,
+        ``bfloat16`` or ``float32``.
+    expanded_idx_to_permuted_idx : torch.Tensor
+        ``int32`` tensor with ``num_tokens * top_k`` elements mapping each
+        expanded (token, slot) index to its permuted row; ``-1`` marks
+        inactive slots (e.g. experts outside the local expert-parallel
+        shard).
+    lora_delta : Optional[torch.Tensor]
+        Optional delta fused into the combine, same dtype as
+        ``gemm2_output``. Either ``(num_tokens, top_k, hidden)`` with one row
+        per slot, or ``(num_tokens, hidden)`` pre-combined. Rows are
+        addressed by the expanded index, NOT the permutation, and are
+        accumulated unconditionally — rows of inactive slots must be
+        zero-filled by the producer.
+    lora_delta_scale : float
+        Scalar factor applied to the delta sum (e.g. a routed scaling
+        factor).
+    lora_apply_expert_weights : bool
+        Multiply each per-slot delta row by its expert weight. Requires the
+        3D ``lora_delta`` layout.
+    hidden_size : Optional[int]
+        Unpadded output hidden size. Defaults to ``gemm2_output.shape[1]``
+        (i.e. no padding). Must be a multiple of 8.
+    out : Optional[torch.Tensor]
+        Preallocated output of shape ``(num_tokens, hidden_size)``, same
+        dtype as ``gemm2_output``. Allocated if not given.
+    enable_pdl : Optional[bool]
+        Whether to launch with programmatic dependent launch. Defaults to
+        auto-detection. With PDL enabled the kernel prefetches
+        ``expert_weights`` and ``expanded_idx_to_permuted_idx`` before its
+        grid-dependency sync (matching the fused pipeline, where routing
+        completed several kernels earlier) — pass ``False`` if either tensor
+        is produced by the immediately preceding kernel on the stream.
+
+    Returns
+    -------
+    torch.Tensor
+        The combined MoE output of shape ``(num_tokens, hidden_size)``.
+
+    Notes
+    -----
+    ``top_k`` must be at most 64 (the vectorized kernel's shared-memory
+    bound). All tensors must be 16-byte aligned (fresh torch allocations
+    are; contiguous-but-offset views may not be). ``num_tokens == 0`` is a
+    no-op.
+    """
+    num_tokens = expert_weights.shape[0]
+    hidden = hidden_size if hidden_size is not None else gemm2_output.shape[1]
+    if out is None:
+        out = torch.empty(
+            (num_tokens, hidden), dtype=gemm2_output.dtype, device=gemm2_output.device
+        )
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(gemm2_output.device)
+
+    get_trtllm_gen_moe_finalize_module().trtllm_gen_moe_finalize(
+        gemm2_output.contiguous(),
+        expert_weights.contiguous(),
+        expanded_idx_to_permuted_idx.contiguous(),
+        out,
+        lora_delta.contiguous() if lora_delta is not None else None,
+        float(lora_delta_scale),
+        lora_apply_expert_weights,
+        enable_pdl,
+    )
+    return out

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -429,3 +429,56 @@ def gen_trtllm_gen_routing_module() -> JitSpec:
             jit_env.FLASHINFER_CUBIN_DIR,
         ],
     )
+
+
+def gen_trtllm_gen_moe_finalize_module() -> JitSpec:
+    """JitSpec for the standalone trtllm-gen MoE finalize stage.
+
+    Compiles only the finalize/dev kernels (trtllm_fused_moe_dev_kernel.cu)
+    plus its binding, so the token-combine stage can be built and tested
+    without the batched-GEMM stack of fused_moe_trtllm_sm100. Only the BMM
+    export headers are needed (for btg::Dtype et al.), not the GEMM cubins.
+    """
+    checksum = get_artifact(
+        f"{ArtifactPath.TRTLLM_GEN_BMM}/checksums.txt", CheckSumHash.TRTLLM_GEN_BMM
+    )
+    assert checksum, "Failed to get checksums.txt"
+    bmm_export_path = f"{ArtifactPath.TRTLLM_GEN_BMM}/include/trtllmGen_bmm_export"
+    for header in BMM_EXPORT_HEADERS:
+        h = get_artifact(f"{bmm_export_path}/{header}", get_meta_hash(checksum, header))
+        assert h, f"{header} not found"
+    symlink_path = (
+        jit_env.FLASHINFER_CUBIN_DIR
+        / "flashinfer"
+        / "trtllm"
+        / "batched_gemm"
+        / "trtllmGen_bmm_export"
+    )
+    ensure_symlink(symlink_path, jit_env.FLASHINFER_CUBIN_DIR / bmm_export_path)
+    verify_symlinked_headers(symlink_path, BMM_EXPORT_HEADERS, checksum)
+
+    nvcc_flags = [
+        "-DTLLM_GEN_EXPORT_INTERFACE",
+        "-DTLLM_ENABLE_CUDA",
+        "-DENABLE_BF16",
+        "-DENABLE_FP8",
+        "-DENABLE_FP4",
+    ] + current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[10, 12]
+    )
+
+    return gen_jit_spec(
+        "trtllm_gen_moe_finalize",
+        [
+            jit_env.FLASHINFER_CSRC_DIR / "trtllm_fused_moe_finalize_binding.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu",
+        ],
+        extra_cuda_cflags=nvcc_flags,
+        extra_include_paths=[
+            jit_env.FLASHINFER_CSRC_DIR,
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/include",
+            jit_env.FLASHINFER_CUBIN_DIR,
+        ],
+    )

--- a/flashinfer/trace/templates/moe.py
+++ b/flashinfer/trace/templates/moe.py
@@ -4736,3 +4736,145 @@ cute_dsl_fused_moe_bf16_trace = TraceTemplate(
     },
     tags=["status:experimental", "backend:cute-dsl", "moe:sm90"],
 )
+
+
+# Standalone trtllm-gen finalize stage
+# ---------------------------------------------------------------------------
+
+
+def _trtllm_gen_moe_finalize_reference(
+    *,
+    gemm2_output: torch.Tensor,
+    expert_weights: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    lora_delta=None,
+    lora_delta_scale: float = 1.0,
+    lora_apply_expert_weights: bool = False,
+    **_unused,
+):
+    """Reference for the trtllm-gen MoE finalize stage.
+
+    out[t] = sum_k w[t, k] * gemm2_output[perm(t, k)] (skipping -1 slots)
+           + lora_delta_scale * sum_k s[t, k] * lora_delta[t, k] (all slots),
+    with s[t, k] = w[t, k] if lora_apply_expert_weights else 1.
+    """
+    num_tokens, top_k = expert_weights.shape
+    hidden = gemm2_output.shape[1]
+    e2p = expanded_idx_to_permuted_idx.reshape(num_tokens * top_k).long()
+    active = (e2p >= 0).unsqueeze(-1)
+    gathered = gemm2_output[e2p.clamp(min=0)].float() * active
+    out = (
+        gathered.reshape(num_tokens, top_k, hidden)
+        * expert_weights.float().unsqueeze(-1)
+    ).sum(dim=1)
+    if lora_delta is not None:
+        delta = lora_delta.float()
+        if delta.dim() == 2:
+            delta = delta.unsqueeze(1)
+        if lora_apply_expert_weights:
+            delta = delta * expert_weights.float().unsqueeze(-1)
+        out = out + lora_delta_scale * delta.sum(dim=1)
+    return out.to(gemm2_output.dtype)
+
+
+def _trtllm_gen_moe_finalize_init(
+    *,
+    num_tokens: int,
+    hidden_size: int = 2880,
+    top_k: int = 8,
+    # Derived: the synthetic permutation below is a bijection over the
+    # num_tokens * top_k expanded slots, so num_padded tracks it exactly.
+    num_padded: int = 0,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for the standalone trtllm-gen MoE finalize stage.
+
+    Uses a synthetic bijective permutation over the expanded slots with ~1/8
+    of the slots marked inactive (-1), mimicking an expert-parallel shard.
+    Delta rows of inactive slots are zero-filled per the op contract.
+    """
+    torch.manual_seed(seed)
+    num_expanded = num_tokens * top_k
+    gemm2_output = torch.randn(
+        num_expanded, hidden_size, dtype=torch.bfloat16, device=device
+    )
+    expert_weights = torch.rand(num_tokens, top_k, dtype=torch.bfloat16, device=device)
+    expanded_idx_to_permuted_idx = torch.randperm(
+        num_expanded, dtype=torch.int32, device=device
+    ).reshape(num_tokens, top_k)
+    inactive = torch.rand(num_tokens, top_k, device=device) < 0.125
+    expanded_idx_to_permuted_idx = torch.where(
+        inactive, -1, expanded_idx_to_permuted_idx
+    )
+    lora_delta = torch.randn(
+        num_tokens, top_k, hidden_size, dtype=torch.bfloat16, device=device
+    )
+    lora_delta[inactive] = 0
+    return {
+        "gemm2_output": gemm2_output,
+        "expert_weights": expert_weights,
+        "expanded_idx_to_permuted_idx": expanded_idx_to_permuted_idx,
+        "lora_delta": lora_delta,
+        "lora_delta_scale": 1.0,
+        "lora_apply_expert_weights": False,
+    }
+
+
+trtllm_gen_moe_finalize_trace = TraceTemplate(
+    op_type="moe_finalize",
+    name_prefix="trtllm_gen_moe_finalize",
+    description=(
+        "Standalone trtllm-gen MoE finalize stage: gathers the permuted FC2 "
+        "output rows through expanded_idx_to_permuted_idx, applies the expert "
+        "weights, and reduces over the top_k slots — the same token combine "
+        "the fused MoE launchers run when do_finalize=true. Optionally fuses "
+        "in a per-(token, slot) delta (e.g. a LoRA down-projection delta) "
+        "scaled by lora_delta_scale; delta rows are addressed by the expanded "
+        "index and accumulated unconditionally, so inactive slots' rows must "
+        "be zero-filled by the producer. The single hidden_size axis is "
+        "resolved from gemm2_output's width, so the template only describes "
+        "unpadded calls (hidden_size == gemm2_output.shape[1]); padded-hidden "
+        "invocations pass an explicit hidden_size kwarg the template does not "
+        "model."
+    ),
+    axes={
+        "num_tokens": Var(),
+        "hidden_size": Const(abbrev="h"),
+        "top_k": Const(abbrev="k"),
+        "num_padded": Var(
+            description="Number of permuted FC2 rows (num_tokens * top_k here)."
+        ),
+    },
+    inputs={
+        "gemm2_output": Tensor(
+            ["num_padded", "hidden_size"],
+            dtype="bfloat16",
+            description="Permuted, unfinalized FC2 output rows.",
+        ),
+        "expert_weights": Tensor(
+            ["num_tokens", "top_k"],
+            dtype="bfloat16",
+            description="Per-slot routing weights.",
+        ),
+        "expanded_idx_to_permuted_idx": Tensor(
+            ["num_tokens", "top_k"],
+            dtype="int32",
+            description="Expanded slot -> permuted row; -1 marks inactive slots.",
+        ),
+        "lora_delta": Tensor(
+            ["num_tokens", "top_k", "hidden_size"],
+            dtype="bfloat16",
+            optional=True,
+            description="Optional fused delta; zero rows at inactive slots.",
+        ),
+        "lora_delta_scale": Scalar("float32"),
+        "lora_apply_expert_weights": Scalar("bool"),
+    },
+    outputs={
+        "out": Tensor(["num_tokens", "hidden_size"], dtype_from="gemm2_output"),
+    },
+    tags=["status:verified", "moe"],
+    reference=_trtllm_gen_moe_finalize_reference,
+    init=_trtllm_gen_moe_finalize_init,
+)

--- a/include/flashinfer/trtllm/fused_moe/DevKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/DevKernel.h
@@ -395,6 +395,22 @@ struct Data {
   // Hidden dimension output of FC2. It might be padded.
   int32_t hiddenDimPadded;
   int32_t const* totalNumPaddedTokens;
+
+  // Optional auxiliary delta fused into the token combine (e.g. a LoRA
+  // down-projection delta). Disabled when loraDeltaPtr is nullptr. The delta
+  // dtype matches the output dtype; rows are contiguous over the unpadded
+  // hiddenDim. loraTopK selects the layout:
+  //   1    -> [numTokens, hiddenDim], one pre-combined row per token
+  //   topK -> [numTokens, topK, hiddenDim], one row per (token, slot)
+  // Rows are addressed by expandedIdx = tokenIdx * loraTopK + k, NOT through
+  // the permutation: inactive slots (expandedIdxToPermutedIdx == -1) are still
+  // accumulated, so the producer must zero-fill their delta rows.
+  void const* loraDeltaPtr = nullptr;
+  int32_t loraTopK = 0;
+  float loraDeltaScale = 1.0f;
+  // Multiply each per-slot delta row by expertWeightsPtr[expandedIdx].
+  // Requires loraTopK == topK and expertWeightsPtr != nullptr.
+  bool loraApplyExpertWeights = false;
 };
 
 template <typename Type_, typename TypeExpW_, int TopKUnrollFactor_, bool UsePdl_>
@@ -420,6 +436,11 @@ struct KernelParams {
   int32_t topK;
   int32_t const* totalNumPaddedTokens;
 
+  Type const* loraDeltaPtr;
+  int32_t loraTopK;
+  float loraDeltaScale;
+  bool loraApplyExpertWeights;
+
   static KernelParams setKernelParams(Data const& data) {
     KernelParams params;
 
@@ -437,6 +458,11 @@ struct KernelParams {
     params.numExperts = data.numExperts;
     params.topK = data.topK;
     params.totalNumPaddedTokens = data.totalNumPaddedTokens;
+
+    params.loraDeltaPtr = (Type const*)data.loraDeltaPtr;
+    params.loraTopK = data.loraTopK;
+    params.loraDeltaScale = data.loraDeltaScale;
+    params.loraApplyExpertWeights = data.loraApplyExpertWeights;
 
     return params;
   }

--- a/tests/moe/test_bgmv_moe_lora_delta.py
+++ b/tests/moe/test_bgmv_moe_lora_delta.py
@@ -349,3 +349,69 @@ def _ref_fc2_delta_with_zeroed_inactive(
             b = lora_b[0][lid, e].float()
             out[t] += scale * w * (b @ (a @ a_vec))
     return out
+
+
+@pytest.mark.parametrize("T", [4, 16])
+@pytest.mark.parametrize("rank", [16, 32])
+def test_gemm2_delta_fused_finalize_equivalence(T, rank):
+    """The FC2 delta folded into trtllm_gen_moe_finalize must match the current
+    flow (finalize without delta, then a separate addition of the bgmv delta)."""
+    _skip_if_unsupported_sm()
+    major, _ = torch.cuda.get_device_capability()
+    if major != 10:
+        pytest.skip("trtllm_gen_moe_finalize requires SM100/SM103")
+    from flashinfer.fused_moe import trtllm_gen_moe_finalize
+
+    device = torch.device("cuda")
+    torch.manual_seed(4)
+    num_experts, k, max_loras = 8, 2, 4
+    hidden, inter = 768, 768
+    scale = 0.5
+    P = T * k
+
+    lora_a = [
+        torch.randn(
+            max_loras, num_experts, rank, inter, dtype=torch.bfloat16, device=device
+        )
+        * 0.02
+    ]
+    lora_b = [
+        torch.randn(
+            max_loras, num_experts, hidden, rank, dtype=torch.bfloat16, device=device
+        )
+        * 0.02
+    ]
+    topk_ids, topk_weights, lora_ids = _make_routing(
+        T, k, num_experts, max_loras, device
+    )
+    act_perm = torch.randn(P, inter, dtype=torch.bfloat16, device=device) * 0.1
+    perm = torch.randperm(P, dtype=torch.int64, device=device)
+
+    w_ptr_a, stride_a = _build_w_ptr(lora_a, num_experts)
+    w_ptr_b, stride_b = _build_w_ptr(lora_b, num_experts)
+    delta = bgmv_moe_gemm2_lora_delta(
+        act_perm,
+        perm,
+        w_ptr_a,
+        stride_a,
+        w_ptr_b,
+        stride_b,
+        topk_ids,
+        topk_weights,
+        lora_ids,
+        rank,
+        hidden,
+        scale=scale,
+    )
+
+    # Synthetic unfinalized FC2 output for the same routing.
+    gemm2_output = torch.randn(P, hidden, dtype=torch.bfloat16, device=device) * 0.1
+    expert_weights = topk_weights.to(torch.bfloat16)
+    e2p = perm.to(torch.int32)
+
+    base = trtllm_gen_moe_finalize(gemm2_output, expert_weights, e2p)
+    fused = trtllm_gen_moe_finalize(gemm2_output, expert_weights, e2p, lora_delta=delta)
+
+    torch.testing.assert_close(
+        fused.float(), base.float() + delta.float(), atol=2e-2, rtol=2e-2
+    )

--- a/tests/moe/test_trtllm_gen_finalize.py
+++ b/tests/moe/test_trtllm_gen_finalize.py
@@ -1,0 +1,328 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Standalone tests for the trtllm-gen MoE finalize stage (trtllm_gen_moe_finalize).
+
+Notes on test construction:
+- The synthetic permutation maps the num_tokens * top_k expanded slots into a
+  larger padded row space. Unmapped rows and padded hidden columns of
+  gemm2_output are filled with NaN, so any out-of-contract read (a -1 slot not
+  skipped, a padded row or column touched) poisons the output and fails the
+  comparison rather than passing silently.
+- The token-count sweep crosses the scalar -> vectorized-load dispatch boundary
+  in moe::dev::finalize::run (numBlocksX * numBlocksY >= 1184 selects
+  finalizeKernelVecLoad), so both kernels are exercised.
+- The E2E test checks the op against the fused launcher itself: running
+  trtllm_bf16_moe with do_finalize=True must equal do_finalize=False followed
+  by this op, since both run the same finalize kernels on the same buffers.
+"""
+
+import zlib
+
+import pytest
+import torch
+
+from flashinfer import shuffle_matrix_a
+from flashinfer.fused_moe import (
+    WeightLayout,
+    convert_to_block_layout,
+    trtllm_bf16_moe,
+    trtllm_gen_moe_finalize,
+)
+from flashinfer.tllm_enums import RoutingMethodType
+from flashinfer.utils import device_support_pdl, get_compute_capability
+
+
+@pytest.fixture(autouse=True)
+def require_supported_gpu():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, _ = get_compute_capability(torch.device("cuda"))
+    if major not in (10, 12):
+        pytest.skip("trtllm-gen finalize requires SM100/SM103/SM120/SM121")
+
+
+def stable_seed(*parts):
+    """Deterministic across processes (unlike hash(), which salts strings)."""
+    return zlib.crc32(repr(parts).encode()) % (2**31)
+
+
+def reference_finalize(
+    gemm2_output,
+    expert_weights,
+    expanded_idx_to_permuted_idx,
+    hidden_size,
+    lora_delta=None,
+    lora_delta_scale=1.0,
+    lora_apply_expert_weights=False,
+):
+    """Float32 reference. Skips -1 slots in the base term (robust to NaN rows);
+    accumulates the delta term unconditionally, per the op contract."""
+    num_tokens, top_k = expert_weights.shape
+    e2p = expanded_idx_to_permuted_idx.reshape(num_tokens * top_k).long()
+    active = (e2p >= 0).unsqueeze(-1)
+    gathered = gemm2_output[e2p.clamp(min=0), :hidden_size].float()
+    gathered = torch.where(active, gathered, torch.zeros_like(gathered))
+    out = (
+        gathered.reshape(num_tokens, top_k, hidden_size)
+        * expert_weights.float().unsqueeze(-1)
+    ).sum(dim=1)
+    if lora_delta is not None:
+        delta = lora_delta.float()
+        if delta.dim() == 2:
+            delta = delta.unsqueeze(1)
+        if lora_apply_expert_weights:
+            delta = delta * expert_weights.float().unsqueeze(-1)
+        out = out + lora_delta_scale * delta.sum(dim=1)
+    return out
+
+
+def make_case(
+    num_tokens,
+    top_k,
+    hidden_size,
+    *,
+    hidden_pad=0,
+    extra_rows=64,
+    inactive_frac=0.0,
+    dtype_out=torch.bfloat16,
+    dtype_expw=torch.bfloat16,
+    delta_kind="none",
+    seed=0,
+):
+    """Synthetic unfinalized-MoE buffers with NaN poison outside the contract."""
+    torch.manual_seed(seed)
+    device = torch.device("cuda")
+    num_expanded = num_tokens * top_k
+    num_padded = num_expanded + extra_rows
+
+    # Map each expanded slot to a distinct padded row; NaN-fill unmapped rows
+    # and padded hidden columns so out-of-contract reads are caught.
+    row_of_slot = torch.randperm(num_padded, device=device)[:num_expanded]
+    gemm2_output = torch.full(
+        (num_padded, hidden_size + hidden_pad),
+        float("nan"),
+        dtype=dtype_out,
+        device=device,
+    )
+    gemm2_output[row_of_slot, :hidden_size] = torch.randn(
+        num_expanded, hidden_size, dtype=dtype_out, device=device
+    )
+
+    expanded_idx_to_permuted_idx = row_of_slot.to(torch.int32).reshape(
+        num_tokens, top_k
+    )
+    if inactive_frac > 0:
+        inactive = torch.rand(num_tokens, top_k, device=device) < inactive_frac
+        expanded_idx_to_permuted_idx = torch.where(
+            inactive, -1, expanded_idx_to_permuted_idx
+        )
+        # NaN-poison the rows the now-inactive slots pointed to: the kernel
+        # must not read them.
+        gemm2_output[row_of_slot.reshape(num_tokens, top_k)[inactive].long()] = float(
+            "nan"
+        )
+    else:
+        inactive = torch.zeros(num_tokens, top_k, dtype=torch.bool, device=device)
+
+    expert_weights = torch.rand(num_tokens, top_k, dtype=dtype_expw, device=device)
+
+    if delta_kind == "none":
+        lora_delta = None
+    elif delta_kind == "2d":
+        lora_delta = torch.randn(
+            num_tokens, hidden_size, dtype=dtype_out, device=device
+        )
+    else:  # per-slot 3D; rows of inactive slots must be zero-filled
+        lora_delta = torch.randn(
+            num_tokens, top_k, hidden_size, dtype=dtype_out, device=device
+        )
+        lora_delta[inactive] = 0
+    return gemm2_output, expert_weights, expanded_idx_to_permuted_idx, lora_delta
+
+
+@pytest.mark.parametrize(
+    "num_tokens",
+    [1, 33, 256, 4096],  # crosses the scalar -> VecLoad dispatch boundary
+)
+@pytest.mark.parametrize("top_k", [1, 6, 8])  # TopKUnrollFactor 1, 2, 4
+@pytest.mark.parametrize("hidden_size", [512, 2880])
+@pytest.mark.parametrize("delta_kind", ["none", "2d", "3d", "3d_weighted"])
+def test_finalize_matches_reference(num_tokens, top_k, hidden_size, delta_kind):
+    apply_w = delta_kind == "3d_weighted"
+    gemm2_output, expert_weights, e2p, lora_delta = make_case(
+        num_tokens,
+        top_k,
+        hidden_size,
+        hidden_pad=64 if hidden_size == 2880 else 0,
+        inactive_frac=0.3,
+        delta_kind="3d" if apply_w else delta_kind,
+        seed=stable_seed(num_tokens, top_k, hidden_size, delta_kind),
+    )
+    lora_delta_scale = 0.5 if lora_delta is not None else 1.0
+
+    out = trtllm_gen_moe_finalize(
+        gemm2_output,
+        expert_weights,
+        e2p,
+        lora_delta=lora_delta,
+        lora_delta_scale=lora_delta_scale,
+        lora_apply_expert_weights=apply_w,
+        hidden_size=hidden_size,
+    )
+    ref = reference_finalize(
+        gemm2_output,
+        expert_weights,
+        e2p,
+        hidden_size,
+        lora_delta=lora_delta,
+        lora_delta_scale=lora_delta_scale,
+        lora_apply_expert_weights=apply_w,
+    )
+
+    assert out.shape == (num_tokens, hidden_size)
+    assert out.dtype == gemm2_output.dtype
+    assert not out.isnan().any(), "output poisoned by an out-of-contract read"
+    torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
+
+
+@pytest.mark.parametrize("dtype_out", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype_expw", [torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("num_tokens", [33, 256])  # scalar and VecLoad kernels
+def test_finalize_dtypes(dtype_out, dtype_expw, num_tokens):
+    gemm2_output, expert_weights, e2p, lora_delta = make_case(
+        num_tokens,
+        8,
+        2880,
+        hidden_pad=64,
+        inactive_frac=0.3,
+        dtype_out=dtype_out,
+        dtype_expw=dtype_expw,
+        delta_kind="3d",
+        seed=stable_seed(str(dtype_out), str(dtype_expw), num_tokens),
+    )
+    out = trtllm_gen_moe_finalize(
+        gemm2_output, expert_weights, e2p, lora_delta=lora_delta, hidden_size=2880
+    )
+    ref = reference_finalize(
+        gemm2_output, expert_weights, e2p, 2880, lora_delta=lora_delta
+    )
+    assert out.dtype == dtype_out
+    assert not out.isnan().any()
+    torch.testing.assert_close(out.float(), ref, atol=2e-2, rtol=2e-2)
+
+
+def test_finalize_rejects_bad_inputs():
+    gemm2_output, expert_weights, e2p, _ = make_case(8, 4, 512, seed=0)
+    with pytest.raises(Exception, match="lora_apply_expert_weights"):
+        trtllm_gen_moe_finalize(
+            gemm2_output,
+            expert_weights,
+            e2p,
+            lora_delta=torch.zeros(8, 512, dtype=torch.bfloat16, device="cuda"),
+            lora_apply_expert_weights=True,
+        )
+    with pytest.raises(Exception, match="dtype"):
+        trtllm_gen_moe_finalize(
+            gemm2_output,
+            expert_weights,
+            e2p,
+            lora_delta=torch.zeros(8, 4, 512, dtype=torch.float32, device="cuda"),
+        )
+
+
+@pytest.mark.parametrize("num_tokens", [8, 300])  # scalar and VecLoad kernels
+def test_finalize_matches_fused_moe(num_tokens):
+    """E2E identity: trtllm_bf16_moe(do_finalize=True) must equal
+    do_finalize=False + trtllm_gen_moe_finalize, which runs the same kernels."""
+    if get_compute_capability(torch.device("cuda"))[0] != 10:
+        pytest.skip("trtllm_bf16_moe is only supported on SM100/SM103")
+    from flashinfer.autotuner import AutoTuner
+
+    # The bitwise comparison requires both calls to pick the same GEMM tactic;
+    # a profiling cache warmed by an earlier test could differentiate them
+    # (do_finalize changes the cache key via the output placeholder).
+    AutoTuner.get().clear_cache()
+    torch.manual_seed(stable_seed("e2e", num_tokens))
+    device = torch.device("cuda")
+    enable_pdl = device_support_pdl(device)
+    hidden_size = 1024
+    intermediate_size = 1024
+    num_experts = 16
+    top_k = 4
+
+    routing_logits = torch.rand(num_tokens, num_experts, device=device).to(
+        torch.bfloat16
+    )
+    hidden_states = (
+        torch.randn(num_tokens, hidden_size, device=device).to(torch.bfloat16) * 0.1
+    )
+    gemm1_weights = torch.randn(
+        num_experts, 2 * intermediate_size, hidden_size, device=device
+    ).to(torch.bfloat16)
+    gemm2_weights = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device
+    ).to(torch.bfloat16)
+    block_k = 128
+    gemm1_weights = torch.stack(
+        [
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm1_weights[i].view(torch.uint8), 64), block_k
+            )
+            for i in range(num_experts)
+        ]
+    ).view(torch.bfloat16)
+    gemm2_weights = torch.stack(
+        [
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm2_weights[i].view(torch.uint8), 64), block_k
+            )
+            for i in range(num_experts)
+        ]
+    ).view(torch.bfloat16)
+
+    def run(do_finalize):
+        return trtllm_bf16_moe(
+            routing_logits=routing_logits,
+            routing_bias=None,
+            hidden_states=hidden_states,
+            gemm1_weights=gemm1_weights,
+            gemm2_weights=gemm2_weights,
+            num_experts=num_experts,
+            top_k=top_k,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=intermediate_size,
+            local_expert_offset=0,
+            local_num_experts=num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=RoutingMethodType.Renormalize.value,
+            use_shuffled_weight=True,
+            weight_layout=WeightLayout.BlockMajorK,
+            do_finalize=do_finalize,
+            enable_pdl=enable_pdl,
+        )
+
+    fused = run(do_finalize=True)
+    gemm2_output, expert_weights, e2p = run(do_finalize=False)
+
+    out = trtllm_gen_moe_finalize(
+        gemm2_output,
+        expert_weights,
+        e2p,
+        hidden_size=hidden_size,
+        enable_pdl=enable_pdl,
+    )
+    torch.testing.assert_close(out, fused, atol=0.0, rtol=0.0)

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -61,6 +61,7 @@ _TRACE_REGISTRATION_MODULES = (
     "flashinfer.fused_moe.hash_topk",
     "flashinfer.fused_moe.monomoe",
     "flashinfer.fused_moe.prepare",
+    "flashinfer.fused_moe.trtllm_gen_finalize",
     "flashinfer.fused_moe.trtllm_gen_routing",
     "flashinfer.gdn_decode",
     "flashinfer.gdn_kernels.experimental.gdn_fused_decode",


### PR DESCRIPTION
## 📌 Description

This exposes the `moe::dev::finalize` stage — the token combine the trtllm-gen fused MoE
launchers run when `do_finalize=true` — as a standalone op, `trtllm_gen_moe_finalize`, and
adds an optional per-token delta that is folded into the combine.

Motivation: the MoE-LoRA FC2 path. Today the down-projection LoRA delta from
`bgmv_moe_gemm2_lora_delta` is applied as a separate full-output addition after the fused
MoE call, costing an extra `[num_tokens, hidden]` read-modify-write pass and kernel launch.
SGLang's `experimental_sgl_trtllm` LoRA backend carries a private FlashInfer overlay whose
finalize kernel fuses that delta into the combine; this PR ports that capability onto the
existing (tuned, vectorized) finalize kernels instead of the overlay's scalar kernel, as one
dtype-agnostic op, so the overlay's duplicated `sgl_trtllm_{fp8,fp4}_block_scale_moe_lora_finalize`
ops can be retired. It also completes the documented `do_finalize=false` contract: the
returned `(gemm2_output, expert_weights, expanded_idx_to_permuted_idx)` triple can now be
finalized as a separate op, which makes the finalize stage unit-testable in isolation
(same decomposition as #4082 did for routing).

Semantics (delta term is LoRA-agnostic — any expanded-indexed residual works):

```
out[t, h] = sum_k w[t, k] * gemm2_output[perm(t, k), h]          # skips perm == -1
          + lora_delta_scale * sum_k s[t, k] * delta[t, k, h]    # all k, zero-filled rows
```

with `s = w` iff `lora_apply_expert_weights` (for unweighted per-slot deltas, e.g. a future
`combine=False` bgmv expand), else 1. `delta` is `[T, top_k, H]` per-slot or `[T, H]`
pre-combined (the current `bgmv_moe_gemm2_lora_delta` output).

Changes:
- `moe::dev::finalize`: optional expanded-indexed delta accumulation in `finalizeKernel`
  and `finalizeKernelVecLoad` (128-bit loads for the delta rows); `finalizeDeepSeekKernel`
  untouched and guarded. Default-initialized fields — the fused launcher paths are
  unchanged.
- New `csrc/trtllm_fused_moe_finalize_binding.cu` + `gen_trtllm_gen_moe_finalize_module`
  JitSpec (two TUs; the BMM export headers only, no GEMM cubins). No changes to
  `trtllm_fused_moe_kernel_launcher.cu` or `fused_moe/core.py`, so no conflict surface with
  #4566 / the DA autotuner.
- Python API `flashinfer.fused_moe.trtllm_gen_moe_finalize` + trace template + docs.
- Tests: reference tests with NaN-poisoned padding/unmapped rows (any out-of-contract read
  fails loudly), crossing the scalar→VecLoad dispatch boundary, both dtypes × both
  expert-weight dtypes; an E2E identity test (`trtllm_bf16_moe(do_finalize=True)` must equal
  `do_finalize=False` + this op, bitwise); a bgmv-delta equivalence test.
- Benchmark: `benchmarks/bench_trtllm_gen_moe_finalize.py` (separate-add flow vs fused).

Performance (B200, `top_k=8`, median µs over `bench_gpu_time`,
`benchmarks/bench_trtllm_gen_moe_finalize.py`). **before** = finalize + a separate
`[T, H]` add; **after (f2d)** = the same `[T, H]` delta folded into the combine:

| tokens | hidden | before (µs) | after (µs) | speedup |
|---:|---:|---:|---:|---:|
| 1 | 2880 | 11.3 | 8.2 | **1.38×** |
| 16 | 2880 | 11.3 | 8.2 | **1.38×** |
| 64 | 2880 | 13.3 | 10.2 | 1.30× |
| 256 | 2880 | 15.4 | 12.3 | 1.25× |
| 1024 | 2880 | 25.6 | 22.6 | 1.13× |
| 4096 | 2880 | 62.3 | 57.3 | 1.09× |
| 8192 | 2880 | 103.4 | 94.3 | 1.10× |
| 16 | 4096 | 13.2 | 8.2 | **1.62×** |
| 256 | 4096 | 15.4 | 12.4 | 1.23× |
| 8192 | 4096 | 134.1 | 116.9 | 1.15× |
| 16 | 7168 | 13.3 | 8.3 | **1.61×** |
| 256 | 7168 | 19.4 | 18.4 | 1.05× |
| 8192 | 7168 | 220.1 | 192.5 | 1.14× |

(Full 21-row sweep over hidden ∈ {2880, 4096, 7168} × tokens ∈ {1 … 8192} in the benchmark;
effective bandwidth reaches 6.1 TB/s at the largest shape.)

The win is largest exactly where MoE-LoRA serving lives — at decode-shaped batches the fused
finalize costs the *same* as a finalize with no delta at all (8.2 µs either way), so the
separate add's ~3 µs and its extra launch disappear entirely.

One honest caveat, visible in the benchmark's `f3d` column: the per-slot
`[T, top_k, H]` delta layout reads `top_k`× more delta bytes and is **slower than the
separate-add flow at large batch** (e.g. 8192 × 7168: 325.6 µs vs 220.1). It is not a drop-in
replacement for the 2-D flow — it exists so a future decomposed producer can skip its own
combine step, and that flow has to be measured as a whole before it is recommended. The 2-D
path above is what this PR proposes using today.

## 🔍 Related Issues

Related: #4082 (standalone routing decomposition — same pattern), #3746 / #3941 (MoE-LoRA
bgmv flow this fuses into the combine), #4566 (LoRA output ABI — no code overlap, cc for
sequencing).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing. On B200 (SM100), from source: `tests/moe/test_trtllm_gen_finalize.py`
  **107 passed** (including both E2E-identity cases, which assert bitwise equality with
  `trtllm_bf16_moe(do_finalize=True)`); `tests/moe/test_bgmv_moe_lora_delta.py` **29 passed**;
  regressions clean — `tests/moe/test_trtllm_gen_fused_moe.py -k "lora or unfinalized"`
  35 passed / 50 skipped (the suite's own hardware and dtype gates), and
  `tests/moe/test_da_trtllm_fused_moe.py` 22 passed.

## Reviewer Notes

- The delta accumulation is a runtime `if (loraDeltaPtr)` branch (uniform, hoisted); if you
  prefer zero overhead on the base path we can template it (`HasLora`) at 2× instantiation
  cost for the two kernels.
- The delta term deliberately does NOT skip `perm == -1` slots — the producer zero-fills
  those rows (this matches the bgmv helpers' behavior for inactive slots and keeps the
  kernel free of a second divergent branch). It's documented on the op and covered by the
  NaN-poisoning tests.
- `lora_delta_scale` exists so callers can fold a routed scaling factor into the delta term
  without baking model semantics into the op.
