### PR TITLE
feat(moe): standalone trtllm-gen MoE activation gather (permuted -> expanded)

### DIFF
--- a/benchmarks/bench_trtllm_gen_moe_gather_activation.py
+++ b/benchmarks/bench_trtllm_gen_moe_gather_activation.py
@@ -1,0 +1,121 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+TRT-LLM Gen MoE activation-gather benchmark.
+
+Compares the two ways of bringing the permuted post-activation FC1 output back
+into expanded (token, slot) order:
+
+  torch:  the eager gather bgmv_moe_gemm2_lora_delta used to run --
+          zeros([P, I]) + index_select + masked scatter
+  fused:  trtllm_gen_moe_gather_activation
+
+over decode-shaped (T 1..256) and prefill-shaped (T 1024..8192) batches.
+
+Usage:
+    FLASHINFER_DISABLE_VERSION_CHECK=1 python benchmarks/bench_trtllm_gen_moe_gather_activation.py
+"""
+
+import os
+
+os.environ.setdefault("FLASHINFER_DISABLE_VERSION_CHECK", "1")
+
+import argparse
+
+import numpy as np
+import torch
+
+from flashinfer.fused_moe import trtllm_gen_moe_gather_activation
+from flashinfer.testing.utils import bench_gpu_time
+
+
+def make_case(num_tokens, top_k, intermediate_size, device):
+    num_slots = num_tokens * top_k
+    # Routing pads the permuted buffer past the expanded slot count.
+    num_padded = num_slots + 128
+    activation_output = (
+        torch.randn(num_padded, intermediate_size, device=device).to(torch.bfloat16)
+        * 0.1
+    )
+    e2p = torch.randperm(num_padded, dtype=torch.int32, device=device)[:num_slots]
+    # ~1/8 of the slots are routed outside the local expert shard.
+    e2p = torch.where(torch.rand(num_slots, device=device) < 0.125, -1, e2p)
+    out = torch.empty(
+        num_tokens, top_k, intermediate_size, dtype=torch.bfloat16, device=device
+    )
+    return activation_output, e2p, out
+
+
+def median_us(fn):
+    return float(np.median(bench_gpu_time(fn))) * 1e3
+
+
+def run_case(num_tokens, top_k, intermediate_size, device):
+    activation_output, e2p, out = make_case(
+        num_tokens, top_k, intermediate_size, device
+    )
+    num_slots = num_tokens * top_k
+
+    def torch_gather():
+        perm = e2p.reshape(-1).to(torch.int64)
+        valid = perm >= 0
+        gathered = torch.zeros(
+            num_slots, intermediate_size, dtype=torch.bfloat16, device=device
+        )
+        gathered[valid] = activation_output[perm[valid]]
+        return gathered
+
+    def fused_gather():
+        trtllm_gen_moe_gather_activation(activation_output, e2p, top_k, out=out)
+
+    t_torch = median_us(torch_gather)
+    t_fused = median_us(fused_gather)
+
+    # Read the gathered rows once, write the output once.
+    bytes_moved = 2 * 2 * num_slots * intermediate_size
+    gbps = bytes_moved / (t_fused * 1e-6) / 1e9
+
+    print(
+        f"| {num_tokens:>6} | {intermediate_size:>6} | {top_k:>2} "
+        f"| {t_torch:9.1f} | {t_fused:9.1f} | {t_torch / t_fused:7.2f}x | {gbps:7.0f} |"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--num-tokens",
+        type=int,
+        nargs="+",
+        default=[1, 8, 32, 64, 256, 1024, 4096, 8192],
+    )
+    parser.add_argument(
+        "--intermediate-size", type=int, nargs="+", default=[512, 1024, 2048]
+    )
+    parser.add_argument("--top-k", type=int, nargs="+", default=[8])
+    args = parser.parse_args()
+
+    device = torch.device("cuda")
+    print(f"GPU: {torch.cuda.get_device_name(device)}")
+    print("| tokens |  inter |  k | torch (us) | fused (us) | speedup | GB/s    |")
+    print("|--------|--------|----|------------|------------|---------|---------|")
+    for intermediate_size in args.intermediate_size:
+        for top_k in args.top_k:
+            for num_tokens in args.num_tokens:
+                run_case(num_tokens, top_k, intermediate_size, device)
+
+
+if __name__ == "__main__":
+    main()

--- a/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
+++ b/csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu
@@ -666,6 +666,100 @@ void run(Data const& data, void* stream) {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+namespace gatherActivation {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Copies one row of numElems elements, or zero-fills it when the slot is inactive
+// (inPtr == nullptr). The inactive test is hoisted out of the grid-stride loop because it is
+// uniform for the row.
+template <typename Elem>
+inline __device__ void copyOrZeroRow(Elem* outPtr, Elem const* inPtr, int numElems,
+                                     Elem const& zero) {
+  int const startIdx = threadIdx.x + blockDim.x * blockIdx.x;
+  int const strideIdx = blockDim.x * gridDim.x;
+  if (inPtr == nullptr) {
+    for (int idx = startIdx; idx < numElems; idx += strideIdx) {
+      outPtr[idx] = zero;
+    }
+  } else {
+    for (int idx = startIdx; idx < numElems; idx += strideIdx) {
+      outPtr[idx] = inPtr[idx];
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <typename KernelParams>
+__global__ void gatherActivationKernel(KernelParams params) {
+  using Type = typename KernelParams::Type;
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // Unlike the activation and permute kernels this one does not trigger the launch completion
+  // up front: the secondary kernel consumes the gathered rows, so releasing it before the
+  // copies land would race.
+  if constexpr (KernelParams::UsePdl) {
+    cudaGridDependencySynchronize();
+  }
+#endif
+
+  int const numElems = params.useVecCopy ? params.innerDim / NumEltsPerVec : params.innerDim;
+  // An all-zero float4 is 16 zero bytes, i.e. exactly +0 for both supported element dtypes.
+  float4 const zeroVec = make_float4(0.f, 0.f, 0.f, 0.f);
+  Type const zeroElt = Type(0.f);
+
+  for (int tokenIdx = blockIdx.z; tokenIdx < params.numTokens; tokenIdx += gridDim.z) {
+    // Loop over experts per token
+    for (int k = blockIdx.y; k < params.topK; k += gridDim.y) {
+      int const expandedIdx = tokenIdx * params.topK + k;
+      // The routing kernels write -1 for a slot routed outside the local expert shard.
+      int const permutedIdx = params.expandedIdxToPermutedIdx[expandedIdx];
+      assert(permutedIdx < params.numPaddedRows);
+
+      // Use int64_t to avoid overflow when permutedIdx * numElems > INT32_MAX
+      int64_t const outOffset = (int64_t)expandedIdx * numElems;
+      if (params.useVecCopy) {
+        auto* outVecPtr = reinterpret_cast<float4*>(params.outPtr) + outOffset;
+        auto const* inVecPtr = reinterpret_cast<float4 const*>(params.inPtr);
+        copyOrZeroRow(outVecPtr,
+                      permutedIdx < 0 ? nullptr : inVecPtr + (int64_t)permutedIdx * numElems,
+                      numElems, zeroVec);
+      } else {
+        copyOrZeroRow(params.outPtr + outOffset,
+                      permutedIdx < 0 ? nullptr : params.inPtr + (int64_t)permutedIdx * numElems,
+                      numElems, zeroElt);
+      }
+    }
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void run(Data const& data, void* stream) {
+  int const numElemsPerRow =
+      useVectorizedCopy(data) ? data.innerDim / NumEltsPerVec : data.innerDim;
+  // One block covers at most one row, so a block wider than the row would idle most of its
+  // threads: the common intermediate sizes are only 64-256 vectors wide.
+  int const numThreads = std::min(256, (numElemsPerRow + 31) / 32 * 32);
+  int const numBlocksX = (numElemsPerRow + numThreads - 1) / numThreads;
+  // Both the token and the slot loop stride over their grid dimension, so capping the grid
+  // (CUDA allows at most 65535 blocks in y and z) still covers the full extent.
+  dim3 numBlocks(numBlocksX, std::min(1024, data.topK), std::min(8192, data.numTokens));
+
+  LAUNCH_GATHER_ACTIVATION(data, gatherActivationKernel, numBlocks, numThreads, 0, stream);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace gatherActivation
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
 namespace finalize {
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/csrc/trtllm_fused_moe_gather_activation_binding.cu
+++ b/csrc/trtllm_fused_moe_gather_activation_binding.cu
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 by FlashInfer team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cstdint>
+
+#include "flashinfer/trtllm/fused_moe/DevKernel.h"
+#include "tvm_ffi_utils.h"
+
+namespace flashinfer::trtllm_gen_gather_activation {
+
+namespace tg = batchedGemm::trtllm::gen;
+using tvm::ffi::TensorView;
+
+/*!
+ * \brief TVM-FFI entry point for the permuted -> expanded gather of the trtllm-gen MoE
+ * post-activation FC1 output.
+ *
+ * The routed MoE ops return that output in the kernels' permuted layout together with
+ * expanded_idx_to_permuted_idx; every consumer of it (a LoRA down-projection, an expert-level
+ * probe) first has to bring the rows back into (token, slot) order. This runs that gather as a
+ * single copy kernel instead of the eager index_select + masked scatter it replaces.
+ *
+ *   activation_output           : [num_padded_rows, intermediate_size] bfloat16 or float16,
+ *                                 permuted post-activation FC1 rows. Rows no expanded index
+ *                                 points at (the routing padding) are never read.
+ *   expanded_idx_to_permuted_idx: num_tokens * top_k int32 elements; a negative entry marks an
+ *                                 inactive slot (an expert outside the local expert-parallel
+ *                                 shard), whose output row is zero-filled.
+ *   output                      : [num_tokens, top_k, intermediate_size], same dtype as
+ *                                 activation_output.
+ *
+ * out[t, k] = activation_output[perm(t, k)] if perm(t, k) >= 0 else 0.
+ *
+ * The permuted indices are only bounds-checked by a device-side assert, so a release build with
+ * an index at or past num_padded_rows reads out of bounds. Torch's advanced indexing raises
+ * instead; this op trades that check away for the fused copy.
+ */
+void trtllm_gen_moe_gather_activation(TensorView activation_output,
+                                      TensorView expanded_idx_to_permuted_idx, TensorView output,
+                                      bool enable_pdl) {
+  CHECK_INPUT(activation_output);
+  CHECK_INPUT(expanded_idx_to_permuted_idx);
+  CHECK_INPUT(output);
+  CHECK_DEVICE(activation_output, output);
+  CHECK_DEVICE(expanded_idx_to_permuted_idx, output);
+
+  CHECK_DIM(2, activation_output);
+  CHECK_DIM(3, output);
+
+  TVM_FFI_ICHECK(output.dtype() == dl_bfloat16 || output.dtype() == dl_float16)
+      << "output must be bfloat16 or float16";
+  TVM_FFI_ICHECK(activation_output.dtype() == output.dtype())
+      << "activation_output must have the same dtype as output";
+  TVM_FFI_ICHECK(expanded_idx_to_permuted_idx.dtype() == dl_int32)
+      << "expanded_idx_to_permuted_idx must be int32";
+
+  int64_t const num_tokens = output.size(0);
+  int64_t const top_k = output.size(1);
+  int64_t const inner_dim = output.size(2);
+
+  TVM_FFI_ICHECK_EQ(activation_output.size(1), inner_dim)
+      << "activation_output and output must have the same innermost dimension";
+  TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.numel(), num_tokens * top_k)
+      << "expanded_idx_to_permuted_idx must have num_tokens * top_k elements";
+
+  // Empty problem: nothing to gather, and a zero grid dimension is a CUDA error.
+  if (num_tokens == 0 || top_k == 0 || inner_dim == 0) {
+    return;
+  }
+
+  moe::dev::gatherActivation::Data data;
+  data.mDtypeElt = output.dtype() == dl_float16 ? tg::Dtype::Fp16 : tg::Dtype::Bfloat16;
+  data.mUsePdl = enable_pdl;
+  data.inPtr = activation_output.data_ptr();
+  data.outPtr = output.data_ptr();
+  data.expandedIdxToPermutedIdx =
+      static_cast<int32_t const*>(expanded_idx_to_permuted_idx.data_ptr());
+  data.innerDim = static_cast<int32_t>(inner_dim);
+  data.numTokens = static_cast<int32_t>(num_tokens);
+  data.topK = static_cast<int32_t>(top_k);
+  data.numPaddedRows = static_cast<int32_t>(activation_output.size(0));
+
+  ffi::CUDADeviceGuard device_guard(output.device().device_id);
+  auto stream = get_stream(output.device());
+  moe::dev::gatherActivation::run(data, stream);
+}
+
+}  // namespace flashinfer::trtllm_gen_gather_activation
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(
+    trtllm_gen_moe_gather_activation,
+    flashinfer::trtllm_gen_gather_activation::trtllm_gen_moe_gather_activation);

--- a/docs/api/fused_moe.rst
+++ b/docs/api/fused_moe.rst
@@ -203,6 +203,19 @@ can be used (and tested) independently of quantization and GEMM configuration.
     trtllm_gen_routing
     TrtllmGenRoutingResult
 
+Standalone TRT-LLM Gen Activation Gather
+----------------------------------------
+
+The permuted -> expanded reorder of the TRT-LLM Gen MoE post-activation FC1
+output, exposed on its own so consumers of the ``gemm1_activation_output``
+returned by the routed MoE ops (for example a LoRA down-projection delta) can
+undo the kernels' permutation with a single copy kernel.
+
+.. autosummary::
+    :toctree: ../generated
+
+    trtllm_gen_moe_gather_activation
+
 CuteDSL Fused MoE
 -----------------
 

--- a/flashinfer/aot.py
+++ b/flashinfer/aot.py
@@ -104,6 +104,7 @@ from .jit.fused_moe import (
     gen_cutlass_fused_moe_sm103_module,
     gen_cutlass_fused_moe_sm120_module,
     gen_trtllm_gen_fused_moe_sm100_module,
+    gen_trtllm_gen_moe_gather_activation_module,
     gen_trtllm_gen_routing_module,
 )
 from .jit.cake_fused_moe_warp_decode import (
@@ -748,6 +749,7 @@ def gen_all_modules(
             jit_specs.append(gen_trtllm_low_latency_gemm_module())
             jit_specs.append(gen_trtllm_gen_fused_moe_sm100_module())
             jit_specs.append(gen_trtllm_gen_routing_module())
+            jit_specs.append(gen_trtllm_gen_moe_gather_activation_module())
         if has_sm100f:
             # Add TGV GEMM modules compiled with SM100f flags for both bf16 and fp16
             jit_specs.append(

--- a/flashinfer/fused_moe/__init__.py
+++ b/flashinfer/fused_moe/__init__.py
@@ -147,6 +147,10 @@ from .trtllm_gen_routing import (  # noqa: F401
     trtllm_gen_routing as trtllm_gen_routing,
 )
 
+from .trtllm_gen_gather_activation import (  # noqa: F401
+    trtllm_gen_moe_gather_activation as trtllm_gen_moe_gather_activation,
+)
+
 from .bgmv_moe import (  # noqa: F401
     BGMVMoEBlackwellPlan as BGMVMoEBlackwellPlan,
     bgmv_moe as bgmv_moe,
@@ -305,6 +309,7 @@ __all__ = [
     "hash_topk",
     "TrtllmGenRoutingResult",
     "trtllm_gen_routing",
+    "trtllm_gen_moe_gather_activation",
     "bgmv_moe",
     "BGMVMoEBlackwellPlan",
     "bgmv_moe_shrink",

--- a/flashinfer/fused_moe/moe_lora_delta.py
+++ b/flashinfer/fused_moe/moe_lora_delta.py
@@ -34,7 +34,53 @@ from typing import Tuple
 import torch
 
 from ..api_logging import flashinfer_api
+from ..utils import get_compute_capability
 from .bgmv_moe import bgmv_moe_expand, bgmv_moe_shrink
+from .trtllm_gen_gather_activation import trtllm_gen_moe_gather_activation
+
+
+def _gather_permuted_activation(
+    gemm1_activation_output: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    top_k: int,
+    num_slots: int,
+    lora_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Reorder a permuted post-SwiGLU activation into expanded ``[T*top_k, I]`` order.
+
+    ``trtllm_gen_moe_gather_activation`` fuses this into a single copy kernel, but it is built
+    only for the trtllm-gen MoE architectures and for 16-bit activations. The eager gather is
+    kept for everything else, so the builder still runs wherever the BGMV kernels do.
+    """
+    if expanded_idx_to_permuted_idx.numel() != num_slots:
+        raise ValueError(
+            f"expanded_idx_to_permuted_idx must have T*top_k = {num_slots} elements, got "
+            f"{expanded_idx_to_permuted_idx.numel()}"
+        )
+    inter = gemm1_activation_output.shape[1]
+    device = gemm1_activation_output.device
+    major, minor = get_compute_capability(device)
+    if gemm1_activation_output.dtype in (
+        torch.bfloat16,
+        torch.float16,
+    ) and trtllm_gen_moe_gather_activation.is_compute_capability_supported(
+        major * 10 + minor
+    ):
+        return (
+            trtllm_gen_moe_gather_activation(
+                gemm1_activation_output,
+                expanded_idx_to_permuted_idx.to(torch.int32),
+                top_k,
+            )
+            .reshape(num_slots, inter)
+            .to(lora_dtype)
+        )
+
+    perm = expanded_idx_to_permuted_idx.reshape(-1).to(torch.int64)
+    valid = perm >= 0
+    a_exp = torch.zeros(num_slots, inter, dtype=lora_dtype, device=device)
+    a_exp[valid] = gemm1_activation_output[perm[valid]].to(lora_dtype)
+    return a_exp
 
 
 def _expanded_pairs(
@@ -212,8 +258,10 @@ def bgmv_moe_gemm2_lora_delta(
     """FC2 (down_proj) LoRA delta for a routed MoE, to be ADDED to the MoE output.
 
     Consumes the post-SwiGLU activation returned by ``trtllm_*_moe`` (called with
-    ``gemm1_lora_delta`` set and ``do_finalize=True``). For each routed pair
-    ``(token t, slot j)`` with expert ``e`` and adapter ``l``::
+    ``gemm1_lora_delta`` set and ``do_finalize=True``); the permuted -> expanded reorder
+    of that tensor runs on :func:`trtllm_gen_moe_gather_activation` where that op is
+    supported and eagerly everywhere else. For each routed pair ``(token t, slot j)``
+    with expert ``e`` and adapter ``l``::
 
         delta[t] = scale * Σ_j  w[t, j] * ( B_down[l,e] @ (A_down[l,e] @ a[t, j]) )
 
@@ -260,7 +308,6 @@ def bgmv_moe_gemm2_lora_delta(
     )
     T, k = topk_ids.shape
     P = T * k
-    inter = gemm1_activation_output.shape[1]
     hidden = hidden_size
     device = gemm1_activation_output.device
 
@@ -268,10 +315,9 @@ def bgmv_moe_gemm2_lora_delta(
     lora_idx = lora_ids.to(torch.int64)
 
     # Gather permuted activation into expanded [P, I] order; inactive slots (perm < 0) stay 0.
-    perm = expanded_idx_to_permuted_idx.to(torch.int64)
-    valid = perm >= 0
-    a_exp = torch.zeros(P, inter, dtype=lora_dtype, device=device)
-    a_exp[valid] = gemm1_activation_output[perm[valid]].to(lora_dtype)
+    a_exp = _gather_permuted_activation(
+        gemm1_activation_output, expanded_idx_to_permuted_idx, k, P, lora_dtype
+    )
 
     # Shrink: a_exp @ A_down -> [1, P, rank]. Per-pair input read (per_pair_input=True).
     shrink_out = torch.zeros(1, P, rank, dtype=lora_dtype, device=device)

--- a/flashinfer/fused_moe/trtllm_gen_gather_activation.py
+++ b/flashinfer/fused_moe/trtllm_gen_gather_activation.py
@@ -1,0 +1,206 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import functools
+from types import SimpleNamespace
+from typing import Optional
+
+import torch
+
+from flashinfer.api_logging import flashinfer_api
+from flashinfer.jit.fused_moe import gen_trtllm_gen_moe_gather_activation_module
+from flashinfer.trace.templates.moe import trtllm_gen_moe_gather_activation_trace
+from flashinfer.utils import (
+    backend_requirement,
+    device_support_pdl,
+    register_custom_op,
+    supported_compute_capability,
+)
+
+# The trtllm_gen_moe_gather_activation module is compiled for SM 10.x and 12.x
+# only (same gate as the fused_moe_trtllm_sm100 module the dev kernels ship in).
+_TRTLLM_GEN_MOE_GATHER_ACTIVATION_SUPPORTED_CC = [100, 103, 120, 121]
+
+
+@supported_compute_capability(_TRTLLM_GEN_MOE_GATHER_ACTIVATION_SUPPORTED_CC)
+def _check_trtllm_gen_moe_gather_activation_supported(
+    activation_output: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    top_k: int,
+    *,
+    out: Optional[torch.Tensor] = None,
+    enable_pdl: Optional[bool] = None,
+) -> bool:
+    if activation_output.dim() != 2:
+        raise ValueError(
+            f"activation_output must be 2D [num_padded_rows, intermediate_size], "
+            f"got {tuple(activation_output.shape)}"
+        )
+    if activation_output.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(
+            f"activation_output must be bfloat16 or float16, "
+            f"got {activation_output.dtype}"
+        )
+    if expanded_idx_to_permuted_idx.dtype != torch.int32:
+        raise ValueError(
+            f"expanded_idx_to_permuted_idx must be int32, "
+            f"got {expanded_idx_to_permuted_idx.dtype}"
+        )
+    if expanded_idx_to_permuted_idx.device != activation_output.device:
+        raise ValueError(
+            f"expanded_idx_to_permuted_idx must be on the same device as "
+            f"activation_output ({expanded_idx_to_permuted_idx.device} vs "
+            f"{activation_output.device})"
+        )
+    if top_k < 1:
+        raise ValueError(f"top_k must be at least 1, got {top_k}")
+    num_slots = expanded_idx_to_permuted_idx.numel()
+    if num_slots % top_k:
+        raise ValueError(
+            f"expanded_idx_to_permuted_idx must hold a whole number of tokens: "
+            f"{num_slots} elements is not a multiple of top_k ({top_k})"
+        )
+    if out is not None:
+        expected = (num_slots // top_k, top_k, activation_output.shape[1])
+        if tuple(out.shape) != expected:
+            raise ValueError(f"out must have shape {expected}, got {tuple(out.shape)}")
+        if out.dtype != activation_output.dtype:
+            raise ValueError(
+                f"out dtype ({out.dtype}) must match activation_output dtype "
+                f"({activation_output.dtype})"
+            )
+        if out.device != activation_output.device:
+            raise ValueError(
+                f"out must be on the same device as activation_output "
+                f"({out.device} vs {activation_output.device})"
+            )
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
+    return True
+
+
+@functools.cache
+def get_trtllm_gen_moe_gather_activation_module():
+    """Build, load, and cache the trtllm_gen_moe_gather_activation JIT module."""
+    module = gen_trtllm_gen_moe_gather_activation_module().build_and_load()
+
+    @register_custom_op(
+        "flashinfer::trtllm_gen_moe_gather_activation",
+        mutates_args=["out"],
+    )
+    def trtllm_gen_moe_gather_activation(
+        activation_output: torch.Tensor,
+        expanded_idx_to_permuted_idx: torch.Tensor,
+        out: torch.Tensor,
+        enable_pdl: bool,
+    ) -> None:
+        module.trtllm_gen_moe_gather_activation(
+            activation_output,
+            expanded_idx_to_permuted_idx,
+            out,
+            enable_pdl,
+        )
+
+    return SimpleNamespace(
+        trtllm_gen_moe_gather_activation=trtllm_gen_moe_gather_activation
+    )
+
+
+@backend_requirement({}, common_check=_check_trtllm_gen_moe_gather_activation_supported)
+@flashinfer_api(trace=trtllm_gen_moe_gather_activation_trace)
+def trtllm_gen_moe_gather_activation(
+    activation_output: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    top_k: int,
+    *,
+    out: Optional[torch.Tensor] = None,
+    enable_pdl: Optional[bool] = None,
+) -> torch.Tensor:
+    r"""Gather the trtllm-gen MoE post-activation FC1 output back into expanded order.
+
+    The routed MoE ops hand back the post-SwiGLU FC1 output
+    (``gemm1_activation_output``) in the kernels' permuted layout, plus the
+    ``expanded_idx_to_permuted_idx`` map. Any consumer of that tensor — a LoRA
+    down-projection delta such as
+    :func:`flashinfer.fused_moe.bgmv_moe_gemm2_lora_delta`, an expert-level
+    probe — first has to undo the permutation. This op does that in a single
+    copy kernel:
+
+    .. math::
+        \text{out}[t, k] = \begin{cases}
+            \text{activation\_output}[\pi(t, k)] & \pi(t, k) \ge 0 \\
+            0 & \text{otherwise}
+        \end{cases}
+
+    where :math:`\pi` is ``expanded_idx_to_permuted_idx``. Negative entries mark
+    slots routed to an expert outside the local expert-parallel shard; their
+    output rows are exactly zero.
+
+    Parameters
+    ----------
+    activation_output : torch.Tensor
+        Permuted post-activation FC1 output of shape
+        ``(num_padded_rows, intermediate_size)``, ``bfloat16`` or ``float16``.
+        The row count is the routing-padded count, which is larger than
+        ``num_tokens * top_k``; padding rows are never read.
+    expanded_idx_to_permuted_idx : torch.Tensor
+        ``int32`` tensor with ``num_tokens * top_k`` elements (any shape)
+        mapping each expanded ``(token, slot)`` index to its permuted row;
+        negative entries mark inactive slots.
+    top_k : int
+        Number of routed slots per token, i.e. the width of the map — with
+        fused shared experts that is ``top_k + num_fused_shared_experts``.
+        ``num_tokens`` is derived as
+        ``expanded_idx_to_permuted_idx.numel() // top_k``.
+    out : Optional[torch.Tensor]
+        Preallocated output of shape ``(num_tokens, top_k, intermediate_size)``,
+        same dtype as ``activation_output``. Allocated if not given.
+    enable_pdl : Optional[bool]
+        Whether to launch with programmatic dependent launch. Defaults to
+        auto-detection. The kernel reads every input after its grid-dependency
+        sync, so enabling it is safe for a producer on the same stream.
+
+    Returns
+    -------
+    torch.Tensor
+        The gathered activation of shape
+        ``(num_tokens, top_k, intermediate_size)``.
+
+    Notes
+    -----
+    The permuted indices are only bounds-checked by a device-side assert, so a
+    release build with an index at or past ``num_padded_rows`` reads out of
+    bounds; the equivalent torch gather raises instead.
+    ``num_tokens == 0`` is a no-op.
+    """
+    num_tokens = expanded_idx_to_permuted_idx.numel() // top_k
+    intermediate_size = activation_output.shape[1]
+    if out is None:
+        out = torch.empty(
+            (num_tokens, top_k, intermediate_size),
+            dtype=activation_output.dtype,
+            device=activation_output.device,
+        )
+    if enable_pdl is None:
+        enable_pdl = device_support_pdl(activation_output.device)
+
+    get_trtllm_gen_moe_gather_activation_module().trtllm_gen_moe_gather_activation(
+        activation_output.contiguous(),
+        expanded_idx_to_permuted_idx.contiguous(),
+        out,
+        enable_pdl,
+    )
+    return out

--- a/flashinfer/jit/fused_moe.py
+++ b/flashinfer/jit/fused_moe.py
@@ -364,13 +364,12 @@ def gen_trtllm_gen_fused_moe_sm100_module(enable_rubin: bool = False) -> JitSpec
     )
 
 
-def gen_trtllm_gen_routing_module() -> JitSpec:
-    """JitSpec for the standalone trtllm-gen MoE routing stage.
+def _fetch_bmm_export_headers() -> None:
+    """Fetch the trtllm-gen BMM export headers and symlink them for C++ includes.
 
-    Compiles only the routing kernels plus the Routing::Runner dispatcher
-    (trtllm_fused_moe_routing_runner.cu), so the routing stage can be built and
-    tested without the batched-GEMM stack of fused_moe_trtllm_sm100. Only the
-    BMM export headers are needed (for btg::Dtype et al.), not the GEMM cubins.
+    The standalone MoE-stage modules need those headers (for btg::Dtype et al.) but
+    none of the GEMM cubins, so they share one symlink root under the cubin dir rather
+    than the per-module gen_root the fused-MoE module builds for its filtered metainfo.
     """
     checksum = get_artifact(
         f"{ArtifactPath.TRTLLM_GEN_BMM}/checksums.txt", CheckSumHash.TRTLLM_GEN_BMM
@@ -389,6 +388,17 @@ def gen_trtllm_gen_routing_module() -> JitSpec:
     )
     ensure_symlink(symlink_path, jit_env.FLASHINFER_CUBIN_DIR / bmm_export_path)
     verify_symlinked_headers(symlink_path, BMM_EXPORT_HEADERS, checksum)
+
+
+def gen_trtllm_gen_routing_module() -> JitSpec:
+    """JitSpec for the standalone trtllm-gen MoE routing stage.
+
+    Compiles only the routing kernels plus the Routing::Runner dispatcher
+    (trtllm_fused_moe_routing_runner.cu), so the routing stage can be built and
+    tested without the batched-GEMM stack of fused_moe_trtllm_sm100. Only the
+    BMM export headers are needed (for btg::Dtype et al.), not the GEMM cubins.
+    """
+    _fetch_bmm_export_headers()
 
     nvcc_flags = [
         "-DTLLM_GEN_EXPORT_INTERFACE",
@@ -420,6 +430,44 @@ def gen_trtllm_gen_routing_module() -> JitSpec:
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_custom_entry.cu",
             jit_env.FLASHINFER_CSRC_DIR
             / "fused_moe/trtllm_backend/trtllm_fused_moe_routing_common.cu",
+        ],
+        extra_cuda_cflags=nvcc_flags,
+        extra_include_paths=[
+            jit_env.FLASHINFER_CSRC_DIR,
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal",
+            jit_env.FLASHINFER_CSRC_DIR / "nv_internal/include",
+            jit_env.FLASHINFER_CUBIN_DIR,
+        ],
+    )
+
+
+def gen_trtllm_gen_moe_gather_activation_module() -> JitSpec:
+    """JitSpec for the standalone trtllm-gen MoE activation gather.
+
+    Compiles only the dev kernels (trtllm_fused_moe_dev_kernel.cu) plus its
+    binding, so the permuted -> expanded gather can be built and tested without
+    the batched-GEMM stack of fused_moe_trtllm_sm100. Only the BMM export
+    headers are needed (for btg::Dtype et al.), not the GEMM cubins.
+    """
+    _fetch_bmm_export_headers()
+
+    nvcc_flags = [
+        "-DTLLM_GEN_EXPORT_INTERFACE",
+        "-DTLLM_ENABLE_CUDA",
+        "-DENABLE_BF16",
+        "-DENABLE_FP8",
+        "-DENABLE_FP4",
+    ] + current_compilation_context.get_nvcc_flags_list(
+        supported_major_versions=[10, 12]
+    )
+
+    return gen_jit_spec(
+        "trtllm_gen_moe_gather_activation",
+        [
+            jit_env.FLASHINFER_CSRC_DIR
+            / "trtllm_fused_moe_gather_activation_binding.cu",
+            jit_env.FLASHINFER_CSRC_DIR
+            / "fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu",
         ],
         extra_cuda_cflags=nvcc_flags,
         extra_include_paths=[

--- a/flashinfer/trace/templates/moe.py
+++ b/flashinfer/trace/templates/moe.py
@@ -4736,3 +4736,111 @@ cute_dsl_fused_moe_bf16_trace = TraceTemplate(
     },
     tags=["status:experimental", "backend:cute-dsl", "moe:sm90"],
 )
+
+
+# Standalone trtllm-gen activation gather
+# ---------------------------------------------------------------------------
+
+
+def _trtllm_gen_moe_gather_activation_reference(
+    *,
+    activation_output: torch.Tensor,
+    expanded_idx_to_permuted_idx: torch.Tensor,
+    top_k: int,
+    **_unused,
+):
+    """Reference for the trtllm-gen MoE activation gather.
+
+    out[t, k] = activation_output[perm(t, k)] if perm(t, k) >= 0 else 0.
+    """
+    intermediate_size = activation_output.shape[1]
+    perm = expanded_idx_to_permuted_idx.reshape(-1).long()
+    num_tokens = perm.numel() // top_k
+    active = (perm >= 0).unsqueeze(-1)
+    gathered = activation_output[perm.clamp(min=0)]
+    gathered = torch.where(active, gathered, torch.zeros_like(gathered))
+    return gathered.reshape(num_tokens, top_k, intermediate_size)
+
+
+def _trtllm_gen_moe_gather_activation_init(
+    *,
+    num_tokens: int,
+    intermediate_size: int = 1024,
+    top_k: int = 8,
+    # Both derived: the synthetic permutation below maps the num_tokens * top_k
+    # expanded slots into a slightly larger padded row space.
+    num_expanded: int = 0,
+    num_padded: int = 0,
+    device: str = "cuda",
+    seed: int = 0,
+):
+    """Build inputs for the standalone trtllm-gen MoE activation gather.
+
+    Mimics one expert-parallel shard: the expanded slots map to distinct rows of
+    a padded buffer, and ~1/8 of them are marked inactive (-1).
+    """
+    torch.manual_seed(seed)
+    num_expanded = num_tokens * top_k
+    num_padded = max(num_padded, num_expanded + 64)
+    activation_output = torch.randn(
+        num_padded, intermediate_size, dtype=torch.bfloat16, device=device
+    )
+    expanded_idx_to_permuted_idx = torch.randperm(num_padded, device=device)[
+        :num_expanded
+    ].to(torch.int32)
+    inactive = torch.rand(num_expanded, device=device) < 0.125
+    expanded_idx_to_permuted_idx = torch.where(
+        inactive, -1, expanded_idx_to_permuted_idx
+    )
+    return {
+        "activation_output": activation_output,
+        "expanded_idx_to_permuted_idx": expanded_idx_to_permuted_idx,
+        "top_k": top_k,
+    }
+
+
+trtllm_gen_moe_gather_activation_trace = TraceTemplate(
+    op_type="moe_gather_activation",
+    name_prefix="trtllm_gen_moe_gather_activation",
+    description=(
+        "Standalone trtllm-gen MoE activation gather: reorders the permuted "
+        "post-activation FC1 output into expanded (token, slot) order through "
+        "expanded_idx_to_permuted_idx, writing exact zeros for slots routed "
+        "outside the local expert-parallel shard (negative index). Padded rows "
+        "of the source, i.e. rows no expanded index points at, are never read."
+    ),
+    axes={
+        "num_tokens": Var(),
+        "intermediate_size": Const(abbrev="i"),
+        "top_k": Const(abbrev="k"),
+        "num_expanded": Var(description="num_tokens * top_k, the routed slot count."),
+        "num_padded": Var(
+            description="Number of permuted FC1 rows, the routing-padded count."
+        ),
+    },
+    inputs={
+        "activation_output": Tensor(
+            ["num_padded", "intermediate_size"],
+            dtype="bfloat16",
+            description="Permuted post-activation FC1 output rows.",
+        ),
+        # Flat, as the trtllm-gen launcher returns it: a "num_tokens, top_k" shape
+        # here would bind the top_k axis to a dimension the real tensor does not have.
+        "expanded_idx_to_permuted_idx": Tensor(
+            ["num_expanded"],
+            dtype="int32",
+            description="Expanded slot -> permuted row; negative marks an inactive slot.",
+        ),
+        "top_k": Scalar("int32", description="Routed slots per token."),
+    },
+    outputs={
+        "out": Tensor(
+            ["num_tokens", "top_k", "intermediate_size"],
+            dtype_from="activation_output",
+        ),
+    },
+    constraints=["num_expanded == num_tokens * top_k"],
+    tags=["status:verified", "moe"],
+    reference=_trtllm_gen_moe_gather_activation_reference,
+    init=_trtllm_gen_moe_gather_activation_init,
+)

--- a/include/flashinfer/trtllm/fused_moe/DevKernel.h
+++ b/include/flashinfer/trtllm/fused_moe/DevKernel.h
@@ -116,6 +116,19 @@ namespace moe::dev {
     FLASHINFER_WARN("Unsupported dtypeElt");                                                      \
   }
 
+// The MoE activation gather is a pure copy that keeps the element dtype of the FC1 output, and
+// the only unquantized post-activation dtypes the trtllm-gen MoE returns are Bfloat16 and Fp16.
+#define LAUNCH_GATHER_ACTIVATION(data, kernel, numBlocks, numThreads, smemSize, stream)            \
+  if (data.mDtypeElt == tg::Dtype::Fp16) {                                                         \
+    LAUNCH_PDL(data, false, cutlass::half_t, kernel, numBlocks, numThreads, smemSize, stream);     \
+  } else if (data.mDtypeElt == tg::Dtype::Bfloat16) {                                              \
+    LAUNCH_PDL(data, false, cutlass::bfloat16_t, kernel, numBlocks, numThreads, smemSize, stream); \
+  } else {                                                                                         \
+    FLASHINFER_CHECK(false,                                                                        \
+                     "Unsupported dtypeElt: the MoE activation gather only supports Bfloat16 "     \
+                     "and Fp16.");                                                                 \
+  }
+
 #define LAUNCH_EXPW(data, kernel, topK, numBlocks, numThreads, smemSize, stream)                  \
   if (data.mDtypeElt == tg::Dtype::Fp16 && data.mDtypeExpW == tg::Dtype::Fp32) {                  \
     LAUNCH_PDL(data, false, LAUNCH_ESC(cutlass::half_t, float, topK), kernel, numBlocks,          \
@@ -362,6 +375,91 @@ void run(Data const& data, void* stream);
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 }  // namespace permute
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace gatherActivation {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace tg = batchedGemm::trtllm::gen;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Number of elements moved by one 128-bit access. Both element dtypes this stage supports
+// (Bfloat16 and Fp16) are 16 bits wide.
+int32_t constexpr NumEltsPerVec = 8;
+
+struct Data {
+  tg::Dtype mDtypeElt{tg::Dtype::Bfloat16};
+  bool mUsePdl{false};
+
+  // Post-activation FC1 output in permuted layout, [numPaddedRows, innerDim]. Rows that no
+  // expanded index points at are never read.
+  void const* inPtr;
+  // Gathered output in expanded (token, slot) layout, [numTokens, topK, innerDim].
+  void* outPtr;
+  // [numTokens * topK] map from the expanded index to the permuted row. A negative entry (the
+  // routing kernels emit -1) marks a slot routed to an expert outside the local expert-parallel
+  // shard; its output row is filled with zeros.
+  int32_t const* expandedIdxToPermutedIdx;
+
+  int32_t innerDim;
+  int32_t numTokens;
+  int32_t topK;
+  // Row count of inPtr, i.e. the routing-padded token count. Only used to bounds-check the
+  // permuted indices in debug builds.
+  int32_t numPaddedRows;
+};
+
+// A row starts at permutedIdx * innerDim, so 128-bit accesses are only legal when innerDim is a
+// multiple of the vector width and both buffers are 16-byte aligned. A case that fails either
+// condition cannot be split into a vectorized body plus a scalar tail -- the row base itself
+// would be misaligned -- so it falls back to element-wise copies.
+inline bool useVectorizedCopy(Data const& data) {
+  return data.innerDim % NumEltsPerVec == 0 && reinterpret_cast<uintptr_t>(data.inPtr) % 16 == 0 &&
+         reinterpret_cast<uintptr_t>(data.outPtr) % 16 == 0;
+}
+
+template <typename Type_, bool UsePdl_>
+struct KernelParams {
+  using Type = Type_;
+  static constexpr bool UsePdl = UsePdl_;
+  static_assert(cutlass::sizeof_bits<Type>::value == 16,
+                "The MoE activation gather only supports 16-bit element types.");
+
+  Type const* inPtr;
+  Type* outPtr;
+  int32_t const* expandedIdxToPermutedIdx;
+
+  int32_t innerDim;
+  int32_t numTokens;
+  int32_t topK;
+  int32_t numPaddedRows;
+  bool useVecCopy;
+
+  static KernelParams setKernelParams(Data const& data) {
+    KernelParams params;
+
+    params.inPtr = (Type const*)data.inPtr;
+    params.outPtr = (Type*)data.outPtr;
+    params.expandedIdxToPermutedIdx = data.expandedIdxToPermutedIdx;
+
+    params.innerDim = data.innerDim;
+    params.numTokens = data.numTokens;
+    params.topK = data.topK;
+    params.numPaddedRows = data.numPaddedRows;
+    params.useVecCopy = useVectorizedCopy(data);
+
+    return params;
+  }
+};
+
+void run(Data const& data, void* stream);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+}  // namespace gatherActivation
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/tests/moe/test_bgmv_moe_lora_delta.py
+++ b/tests/moe/test_bgmv_moe_lora_delta.py
@@ -277,6 +277,67 @@ def test_gemm2_lora_delta(T, hidden, inter, rank, dtype):
     torch.testing.assert_close(out.float(), ref, atol=1e-2, rtol=1e-2)
 
 
+def test_gemm2_lora_delta_float32_activation():
+    """A float32 activation takes the eager gather: the fused one is bf16/fp16 only."""
+    _skip_if_unsupported_sm()
+    device = torch.device("cuda")
+    torch.manual_seed(4)
+    T, k, num_experts, max_loras, rank, hidden, inter = 8, 2, 8, 4, 32, 768, 768
+    scale = 0.5
+    P = T * k
+
+    lora_a = [
+        torch.randn(
+            max_loras, num_experts, rank, inter, dtype=torch.bfloat16, device=device
+        )
+        * 0.02
+    ]
+    lora_b = [
+        torch.randn(
+            max_loras, num_experts, hidden, rank, dtype=torch.bfloat16, device=device
+        )
+        * 0.02
+    ]
+    topk_ids, topk_weights, lora_ids = _make_routing(
+        T, k, num_experts, max_loras, device
+    )
+    act_perm = torch.randn(P, inter, dtype=torch.float32, device=device) * 0.1
+    perm = torch.randperm(P, dtype=torch.int64, device=device)
+
+    w_ptr_a, stride_a = _build_w_ptr(lora_a, num_experts)
+    w_ptr_b, stride_b = _build_w_ptr(lora_b, num_experts)
+    out = bgmv_moe_gemm2_lora_delta(
+        act_perm,
+        perm,
+        w_ptr_a,
+        stride_a,
+        w_ptr_b,
+        stride_b,
+        topk_ids,
+        topk_weights,
+        lora_ids,
+        rank,
+        hidden,
+        scale=scale,
+    )
+
+    # The gather narrows to lora_dtype, so the reference sees the rounded activation.
+    ref = _ref_fc2_delta(
+        act_perm.to(torch.bfloat16),
+        perm,
+        lora_a,
+        lora_b,
+        topk_ids,
+        topk_weights,
+        lora_ids,
+        scale,
+    )
+
+    assert out.shape == (T, hidden)
+    assert torch.count_nonzero(ref)
+    torch.testing.assert_close(out.float(), ref, atol=1e-2, rtol=1e-2)
+
+
 def test_gemm2_inactive_slot_zeroed():
     """`expanded_idx_to_permuted_idx < 0` (inactive slot) must contribute nothing."""
     _skip_if_unsupported_sm()

--- a/tests/moe/test_trtllm_gen_gather_activation.py
+++ b/tests/moe/test_trtllm_gen_gather_activation.py
@@ -35,6 +35,8 @@ import torch
 
 from flashinfer import shuffle_matrix_a
 from flashinfer.fused_moe import (
+    bgmv_moe_gemm2_lora_delta,
+    fill_w_ptr,
     WeightLayout,
     convert_to_block_layout,
     trtllm_bf16_routed_moe,
@@ -501,3 +503,118 @@ def test_gather_matches_fused_moe_activation_output(num_tokens, ep_shard):
     torch.testing.assert_close(out, ref, atol=0.0, rtol=0.0)
     # Rows for the routing kernels' own sentinel must be bitwise zero.
     assert (out.view(torch.int16)[inactive] == 0).all()
+
+
+def _build_w_ptr(weights, num_experts):
+    """[num_slices, num_experts] int64 base-pointer table + shared lora_stride."""
+    device = weights[0].device
+    w_ptr = torch.zeros(len(weights), num_experts, dtype=torch.int64, device=device)
+    stride = 0
+    for s, w in enumerate(weights):
+        stride = fill_w_ptr(w_ptr, w, num_experts, s)
+    return w_ptr, stride
+
+
+def _ref_fc2_delta(
+    act_perm, perm, lora_a, lora_b, topk_ids, topk_weights, lora_ids, scale
+):
+    """Independent reference for the whole FC2 delta:
+    delta[t] = scale * sum_j w[t,j] * ( B[l,e] @ (A[l,e] @ a[t,j]) ), where
+    a[t,j] = act_perm[perm[t*k+j]] for perm >= 0 and 0 otherwise."""
+    T, k = topk_ids.shape
+    inter = lora_a[0].shape[3]
+    hidden = lora_b[0].shape[2]
+    out = torch.zeros(T, hidden, dtype=torch.float32, device=act_perm.device)
+    af = act_perm.float()
+    flat = perm.reshape(-1)
+    zero_vec = torch.zeros(inter, device=act_perm.device)
+    for t in range(T):
+        lid = int(lora_ids[t])
+        if lid < 0:
+            continue
+        for j in range(k):
+            p = int(flat[t * k + j])
+            a_vec = af[p] if p >= 0 else zero_vec
+            e = int(topk_ids[t, j])
+            w = float(topk_weights[t, j])
+            a = lora_a[0][lid, e].float()
+            b = lora_b[0][lid, e].float()
+            out[t] += scale * w * (b @ (a @ a_vec))
+    return out
+
+
+@pytest.mark.parametrize("T", [4, 16])
+def test_gemm2_lora_delta_gather_equivalence(T):
+    """``bgmv_moe_gemm2_lora_delta`` now gathers with this op.
+
+    Two checks: the delta matches an independent torch reference, and feeding the
+    builder the already-gathered activation under an identity permutation
+    reproduces it — the second isolates the gather from the rest of the builder.
+    """
+    if get_compute_capability(torch.device("cuda"))[0] not in (10,):
+        pytest.skip("BGMV MoE kernels are validated on SM100/SM103")
+    device = torch.device("cuda")
+    torch.manual_seed(stable_seed("bgmv", T))
+    num_experts, k, max_loras = 8, 2, 4
+    rank, hidden, inter = 32, 768, 768
+    P = T * k
+
+    lora_a = [
+        torch.randn(
+            max_loras, num_experts, rank, inter, dtype=torch.bfloat16, device=device
+        )
+        * 0.02
+    ]
+    lora_b = [
+        torch.randn(
+            max_loras, num_experts, hidden, rank, dtype=torch.bfloat16, device=device
+        )
+        * 0.02
+    ]
+    w_ptr_a, stride_a = _build_w_ptr(lora_a, num_experts)
+    w_ptr_b, stride_b = _build_w_ptr(lora_b, num_experts)
+
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:k] for _ in range(T)]
+    )
+    topk_weights = torch.softmax(torch.randn(T, k, device=device), dim=-1)
+    lora_ids = torch.randint(0, max_loras, (T,), dtype=torch.int64, device=device)
+
+    activation_output, e2p, _ = make_case(
+        T, k, inter, inactive_frac=0.25, seed=stable_seed("bgmv-case", T)
+    )
+    # The reference feeds the pre-gathered rows, so the padding rows are gone and
+    # the NaN poison with them.
+    gathered = reference_gather(activation_output, e2p, k).reshape(P, inter)
+    identity = torch.arange(P, dtype=torch.int32, device=device)
+
+    def delta(act, perm):
+        return bgmv_moe_gemm2_lora_delta(
+            act,
+            perm,
+            w_ptr_a,
+            stride_a,
+            w_ptr_b,
+            stride_b,
+            topk_ids,
+            topk_weights,
+            lora_ids,
+            rank,
+            hidden,
+            scale=0.5,
+        )
+
+    out = delta(activation_output, e2p)
+    ref = delta(gathered, identity)
+    assert out.shape == (T, hidden)
+
+    # A dead gather (all-zero output) would make the two runs agree, so pin the
+    # magnitude against a reference that never touches the kernel first.
+    ref_torch = _ref_fc2_delta(
+        activation_output, e2p, lora_a, lora_b, topk_ids, topk_weights, lora_ids, 0.5
+    )
+    assert torch.count_nonzero(ref_torch), "the reference delta is degenerate"
+    torch.testing.assert_close(out.float(), ref_torch, atol=2e-3, rtol=2e-2)
+    # The identity-permutation run feeds the BGMV kernels bitwise-identical rows,
+    # so only the atomicAdd order can differ.
+    torch.testing.assert_close(out.float(), ref.float(), atol=1e-3, rtol=1e-3)

--- a/tests/moe/test_trtllm_gen_gather_activation.py
+++ b/tests/moe/test_trtllm_gen_gather_activation.py
@@ -1,0 +1,503 @@
+"""
+Copyright (c) 2026 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Standalone tests for the trtllm-gen MoE activation gather
+(``trtllm_gen_moe_gather_activation``).
+
+Notes on test construction:
+- The op is a pure copy, so every comparison against the torch reference is
+  bitwise (``atol=rtol=0``).
+- The synthetic permutation maps the ``num_tokens * top_k`` expanded slots into
+  a larger padded row space, exactly like the routing padding does. Unmapped
+  rows are filled with NaN, so any out-of-contract read (a padding row, or a
+  row an inactive slot used to point at) poisons the output and fails the
+  comparison rather than passing silently.
+- Widths are swept across and around the kernel's 128-bit vector width, so both
+  the vectorized and the element-wise path are exercised.
+"""
+
+import zlib
+
+import pytest
+import torch
+
+from flashinfer import shuffle_matrix_a
+from flashinfer.fused_moe import (
+    WeightLayout,
+    convert_to_block_layout,
+    trtllm_bf16_routed_moe,
+    trtllm_gen_moe_gather_activation,
+)
+from flashinfer.tllm_enums import RoutingMethodType
+from flashinfer.utils import device_support_pdl, get_compute_capability
+
+from .trtllm_gen_fused_moe_utils import pack_topk_for_routed_moe
+
+
+@pytest.fixture(autouse=True)
+def require_supported_gpu():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    major, minor = get_compute_capability(torch.device("cuda"))
+    sm = major * 10 + minor
+    if not trtllm_gen_moe_gather_activation.is_compute_capability_supported(sm):
+        pytest.skip(f"trtllm-gen activation gather is not supported on SM{sm}")
+
+
+def stable_seed(*parts):
+    """Deterministic across processes (unlike hash(), which salts strings)."""
+    return zlib.crc32(repr(parts).encode()) % (2**31)
+
+
+def reference_gather(activation_output, expanded_idx_to_permuted_idx, top_k):
+    """The eager gather this op replaces (``bgmv_moe_gemm2_lora_delta``), reshaped
+    to the op's ``[num_tokens, top_k, intermediate_size]`` output."""
+    intermediate_size = activation_output.shape[1]
+    perm = expanded_idx_to_permuted_idx.reshape(-1).to(torch.int64)
+    num_slots = perm.numel()
+    valid = perm >= 0
+    out = torch.zeros(
+        num_slots,
+        intermediate_size,
+        dtype=activation_output.dtype,
+        device=activation_output.device,
+    )
+    out[valid] = activation_output[perm[valid]]
+    return out.reshape(num_slots // top_k, top_k, intermediate_size)
+
+
+def make_case(
+    num_tokens,
+    top_k,
+    intermediate_size,
+    *,
+    extra_rows=64,
+    inactive_frac=0.0,
+    dtype=torch.bfloat16,
+    seed=0,
+):
+    """Synthetic permuted activation with NaN poison outside the contract.
+
+    Returns ``(activation_output, expanded_idx_to_permuted_idx, inactive)``.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(seed)
+    num_slots = num_tokens * top_k
+    num_padded = num_slots + extra_rows
+
+    # Map each expanded slot to a distinct padded row; NaN-fill the rows no slot
+    # points at so that reading the routing padding is caught.
+    row_of_slot = torch.randperm(num_padded, device=device)[:num_slots]
+    activation_output = torch.full(
+        (num_padded, intermediate_size), float("nan"), dtype=dtype, device=device
+    )
+    activation_output[row_of_slot] = torch.randn(
+        num_slots, intermediate_size, dtype=dtype, device=device
+    )
+
+    expanded_idx_to_permuted_idx = row_of_slot.to(torch.int32).reshape(
+        num_tokens, top_k
+    )
+    if inactive_frac > 0:
+        inactive = torch.rand(num_tokens, top_k, device=device) < inactive_frac
+        expanded_idx_to_permuted_idx = torch.where(
+            inactive, -1, expanded_idx_to_permuted_idx
+        )
+        # NaN-poison the rows the now-inactive slots pointed at: the kernel must
+        # not read them.
+        activation_output[row_of_slot.reshape(num_tokens, top_k)[inactive]] = float(
+            "nan"
+        )
+    else:
+        inactive = torch.zeros(num_tokens, top_k, dtype=torch.bool, device=device)
+    return activation_output, expanded_idx_to_permuted_idx, inactive
+
+
+def assert_gather_matches(activation_output, expanded_idx_to_permuted_idx, top_k):
+    out = trtllm_gen_moe_gather_activation(
+        activation_output, expanded_idx_to_permuted_idx, top_k
+    )
+    ref = reference_gather(activation_output, expanded_idx_to_permuted_idx, top_k)
+    assert out.shape == ref.shape
+    assert out.dtype == activation_output.dtype
+    assert not out.isnan().any(), "output poisoned by an out-of-contract read"
+    torch.testing.assert_close(out, ref, atol=0.0, rtol=0.0)
+    return out
+
+
+@pytest.mark.parametrize("num_tokens", [1, 2, 17, 1024, 8192])
+@pytest.mark.parametrize("top_k", [1, 2, 4, 6, 8])
+def test_gather_matches_reference(num_tokens, top_k):
+    activation_output, e2p, _ = make_case(
+        num_tokens,
+        top_k,
+        512,
+        inactive_frac=0.3,
+        seed=stable_seed(num_tokens, top_k),
+    )
+    assert_gather_matches(activation_output, e2p, top_k)
+
+
+@pytest.mark.parametrize("intermediate_size", [128, 512, 1536, 2048])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_gather_widths(intermediate_size, dtype):
+    activation_output, e2p, _ = make_case(
+        129,
+        4,
+        intermediate_size,
+        inactive_frac=0.3,
+        dtype=dtype,
+        seed=stable_seed(intermediate_size, str(dtype)),
+    )
+    assert_gather_matches(activation_output, e2p, 4)
+
+
+@pytest.mark.parametrize("intermediate_size", [1, 7, 100, 132, 1023])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_gather_widths_not_a_multiple_of_the_vector(intermediate_size, dtype):
+    """Widths the 128-bit path cannot handle fall back to element-wise copies."""
+    activation_output, e2p, _ = make_case(
+        33,
+        4,
+        intermediate_size,
+        inactive_frac=0.3,
+        dtype=dtype,
+        seed=stable_seed(intermediate_size, str(dtype), "unaligned"),
+    )
+    assert_gather_matches(activation_output, e2p, 4)
+
+
+@pytest.mark.parametrize("inactive_frac", [0.0, 0.5, 1.0])
+# 512 elements take the 128-bit path, 1023 the element-wise one; each has its own
+# zero constant, and only a bitwise check tells +0.0 from -0.0.
+@pytest.mark.parametrize("intermediate_size", [512, 1023])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_inactive_slots_are_bitwise_zero(inactive_frac, intermediate_size, dtype):
+    """Slots with a negative index must produce exactly zero, and only those."""
+    num_tokens, top_k = 65, 4
+    activation_output, e2p, inactive = make_case(
+        num_tokens,
+        top_k,
+        intermediate_size,
+        inactive_frac=inactive_frac,
+        dtype=dtype,
+        seed=stable_seed("inactive", inactive_frac, intermediate_size, str(dtype)),
+    )
+    if inactive_frac == 1.0:
+        # `torch.rand < 1.0` is almost surely all-True, but not by construction.
+        e2p = torch.full_like(e2p, -1)
+        inactive = torch.ones_like(inactive)
+
+    out = assert_gather_matches(activation_output, e2p, top_k)
+
+    assert (e2p < 0).equal(inactive)
+    # Bitwise zero, not just numerically zero (-0.0 would compare equal to 0.0).
+    bits = out.view(torch.int16)
+    assert (bits[inactive] == 0).all()
+    if not inactive.all():
+        # Active rows carry the source rows, which are non-zero with probability 1.
+        assert (bits[~inactive] != 0).float().mean() > 0.99
+
+
+def test_padded_source_rows_are_never_read():
+    """The source has strictly more rows than the permutation references; the
+    trailing rows hold NaN and must not appear in the output."""
+    num_tokens, top_k, intermediate_size = 128, 4, 512
+    device = torch.device("cuda")
+    torch.manual_seed(stable_seed("padded"))
+    num_slots = num_tokens * top_k
+    tail_rows = 257
+
+    # Every slot maps into the first num_slots rows, so the trailing rows are
+    # unreachable padding.
+    row_of_slot = torch.randperm(num_slots, device=device)
+    activation_output = torch.full(
+        (num_slots + tail_rows, intermediate_size),
+        float("nan"),
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    activation_output[:num_slots] = torch.randn(
+        num_slots, intermediate_size, dtype=torch.bfloat16, device=device
+    )
+    e2p = row_of_slot.to(torch.int32).reshape(num_tokens, top_k)
+    inactive = torch.rand(num_tokens, top_k, device=device) < 0.25
+    e2p = torch.where(inactive, -1, e2p)
+    activation_output[row_of_slot.reshape(num_tokens, top_k)[inactive]] = float("nan")
+
+    assert activation_output.shape[0] > int(e2p.max()) + 1
+    assert activation_output[num_slots:].isnan().all(), (
+        "the poison rows were not planted"
+    )
+    assert_gather_matches(activation_output, e2p, top_k)
+
+
+def test_gather_into_preallocated_out():
+    num_tokens, top_k, intermediate_size = 33, 4, 512
+    activation_output, e2p, _ = make_case(
+        num_tokens,
+        top_k,
+        intermediate_size,
+        inactive_frac=0.3,
+        seed=stable_seed("out"),
+    )
+    out = torch.full(
+        (num_tokens, top_k, intermediate_size),
+        float("inf"),
+        dtype=activation_output.dtype,
+        device=activation_output.device,
+    )
+    returned = trtllm_gen_moe_gather_activation(activation_output, e2p, top_k, out=out)
+    assert returned.data_ptr() == out.data_ptr()
+    ref = reference_gather(activation_output, e2p, top_k)
+    torch.testing.assert_close(out, ref, atol=0.0, rtol=0.0)
+
+
+def test_gather_rejects_bad_inputs():
+    # ValueError, not Exception: a JIT build failure or a device-side assert also
+    # satisfies Exception and would let these cases pass for the wrong reason.
+    num_tokens, top_k, intermediate_size = 8, 4, 512
+    activation_output, e2p, _ = make_case(
+        num_tokens, top_k, intermediate_size, seed=stable_seed("reject")
+    )
+    device = activation_output.device
+
+    with pytest.raises(ValueError, match="must be 2D"):
+        trtllm_gen_moe_gather_activation(activation_output.unsqueeze(0), e2p, top_k)
+    with pytest.raises(ValueError, match="int32"):
+        trtllm_gen_moe_gather_activation(activation_output, e2p.to(torch.int64), top_k)
+    with pytest.raises(ValueError, match="top_k must be at least 1"):
+        trtllm_gen_moe_gather_activation(activation_output, e2p, 0)
+    with pytest.raises(ValueError, match="multiple of top_k"):
+        trtllm_gen_moe_gather_activation(activation_output, e2p, 3)
+    with pytest.raises(ValueError, match="bfloat16 or float16"):
+        trtllm_gen_moe_gather_activation(activation_output.float(), e2p, top_k)
+    if torch.cuda.device_count() > 1:
+        with pytest.raises(ValueError, match="same device"):
+            trtllm_gen_moe_gather_activation(activation_output, e2p.to("cuda:1"), top_k)
+    with pytest.raises(ValueError, match="shape"):
+        trtllm_gen_moe_gather_activation(
+            activation_output,
+            e2p,
+            top_k,
+            out=torch.empty(
+                num_tokens,
+                top_k,
+                intermediate_size + 8,
+                dtype=activation_output.dtype,
+                device=device,
+            ),
+        )
+    with pytest.raises(ValueError, match="dtype"):
+        trtllm_gen_moe_gather_activation(
+            activation_output,
+            e2p,
+            top_k,
+            out=torch.empty(
+                num_tokens,
+                top_k,
+                intermediate_size,
+                dtype=torch.float32,
+                device=device,
+            ),
+        )
+    with pytest.raises(ValueError, match="device"):
+        trtllm_gen_moe_gather_activation(
+            activation_output,
+            e2p,
+            top_k,
+            out=torch.empty(
+                num_tokens,
+                top_k,
+                intermediate_size,
+                dtype=activation_output.dtype,
+                device="cpu",
+            ),
+        )
+    # A strided out= (a view into a wider workspace) must be caught in Python, not
+    # by the binding's CHECK_INPUT.
+    with pytest.raises(ValueError, match="contiguous"):
+        wide = torch.empty(
+            num_tokens,
+            top_k,
+            intermediate_size + 8,
+            dtype=activation_output.dtype,
+            device=device,
+        )
+        trtllm_gen_moe_gather_activation(
+            activation_output, e2p, top_k, out=wide[:, :, :intermediate_size]
+        )
+
+
+@pytest.mark.parametrize("enable_pdl", [True, False])
+def test_gather_pdl_toggle(enable_pdl):
+    activation_output, e2p, _ = make_case(
+        129, 4, 512, inactive_frac=0.3, seed=stable_seed("pdl", enable_pdl)
+    )
+    out = trtllm_gen_moe_gather_activation(
+        activation_output, e2p, 4, enable_pdl=enable_pdl
+    )
+    torch.testing.assert_close(
+        out, reference_gather(activation_output, e2p, 4), atol=0.0, rtol=0.0
+    )
+
+
+def test_gather_row_spans_multiple_blocks():
+    """A row wider than one block's worth of copy units splits over grid.x."""
+    activation_output, e2p, _ = make_case(
+        16, 2, 8192, inactive_frac=0.25, extra_rows=8, seed=stable_seed("wide")
+    )
+    assert_gather_matches(activation_output, e2p, 2)
+
+
+def test_gather_more_tokens_than_grid_z():
+    """More tokens than the gridDim.z cap (8192) drives the token grid-stride loop."""
+    activation_output, e2p, _ = make_case(
+        8193, 1, 128, inactive_frac=0.25, extra_rows=8, seed=stable_seed("gridz")
+    )
+    assert_gather_matches(activation_output, e2p, 1)
+
+
+@pytest.mark.parametrize("top_k", [1, 4])
+def test_gather_zero_tokens_is_a_noop(top_k):
+    """An idle expert-parallel rank calls this with an empty batch, and a zero grid
+    dimension is a CUDA error."""
+    device = torch.device("cuda")
+    activation_output = torch.randn(64, 512, dtype=torch.bfloat16, device=device)
+    e2p = torch.empty(0, dtype=torch.int32, device=device)
+    out = trtllm_gen_moe_gather_activation(activation_output, e2p, top_k)
+    assert out.shape == (0, top_k, 512)
+    assert out.dtype == activation_output.dtype
+    # A bad launch config surfaces here, not at the call.
+    torch.cuda.synchronize()
+
+
+@pytest.mark.parametrize("num_tokens", [8, 300])
+@pytest.mark.parametrize("ep_shard", [False, True])
+def test_gather_matches_fused_moe_activation_output(num_tokens, ep_shard):
+    """E2E: gather the activation output the fused MoE actually returns.
+
+    ``trtllm_bf16_routed_moe`` with a ``gemm1_lora_delta`` returns the permuted
+    post-activation FC1 output together with its permutation map; the op must
+    reorder that real buffer exactly like the torch gather does. The sharded case
+    routes half the slots outside the local experts, so the map carries the
+    routing kernels' own -1 rather than one this file planted.
+    """
+    if get_compute_capability(torch.device("cuda"))[0] != 10:
+        pytest.skip("trtllm_bf16_routed_moe is only supported on SM100/SM103")
+    device = torch.device("cuda")
+    torch.manual_seed(stable_seed("e2e", num_tokens, ep_shard))
+    enable_pdl = device_support_pdl(device)
+    hidden_size = 1024
+    intermediate_size = 1024
+    num_experts = 16
+    top_k = 4
+    local_num_experts = num_experts // 2 if ep_shard else num_experts
+
+    hidden_states = (
+        torch.randn(num_tokens, hidden_size, device=device).to(torch.bfloat16) * 0.1
+    )
+    gemm1_weights = torch.randn(
+        local_num_experts, 2 * intermediate_size, hidden_size, device=device
+    ).to(torch.bfloat16)
+    gemm2_weights = torch.randn(
+        local_num_experts, hidden_size, intermediate_size, device=device
+    ).to(torch.bfloat16)
+    block_k = 128
+    gemm1_weights = torch.stack(
+        [
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm1_weights[i].view(torch.uint8), 64), block_k
+            )
+            for i in range(local_num_experts)
+        ]
+    ).view(torch.bfloat16)
+    gemm2_weights = torch.stack(
+        [
+            convert_to_block_layout(
+                shuffle_matrix_a(gemm2_weights[i].view(torch.uint8), 64), block_k
+            )
+            for i in range(local_num_experts)
+        ]
+    ).view(torch.bfloat16)
+
+    # Distinct experts per token spanning the GLOBAL expert range, and a LoRA delta
+    # so the activation output is returned at all.
+    topk_ids = torch.stack(
+        [torch.randperm(num_experts, device=device)[:top_k] for _ in range(num_tokens)]
+    ).to(torch.int32)
+    topk_weights = torch.softmax(
+        torch.randn(num_tokens, top_k, device=device), dim=-1
+    ).to(torch.bfloat16)
+    gemm1_lora_delta = (
+        torch.randn(
+            num_tokens,
+            top_k,
+            2 * intermediate_size,
+            dtype=torch.bfloat16,
+            device=device,
+        )
+        * 0.01
+    )
+
+    _, e2p, activation_output = trtllm_bf16_routed_moe(
+        topk_ids=pack_topk_for_routed_moe(topk_ids, topk_weights),
+        hidden_states=hidden_states,
+        gemm1_weights=gemm1_weights,
+        gemm2_weights=gemm2_weights,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=local_num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=RoutingMethodType.Renormalize.value,
+        use_shuffled_weight=True,
+        weight_layout=WeightLayout.BlockMajorK,
+        do_finalize=True,
+        enable_pdl=enable_pdl,
+        gemm1_lora_delta=gemm1_lora_delta,
+    )
+
+    assert activation_output.shape[1] == intermediate_size
+    assert e2p.numel() == num_tokens * top_k
+    # Without these the comparison below is satisfied by an all-zero return, and by
+    # a source that carries no routing padding for the gather to skip.
+    assert torch.count_nonzero(activation_output), (
+        "the launcher returned an empty activation output"
+    )
+    assert activation_output.shape[0] > int(e2p.max()) + 1, (
+        "expected a routing-padded row count strictly above max(perm) + 1"
+    )
+
+    inactive = e2p.reshape(num_tokens, top_k) < 0
+    if ep_shard:
+        assert inactive.any(), "the expert-parallel shard produced no remote slots"
+        assert not inactive.all(), "the expert-parallel shard produced no local slots"
+    else:
+        assert not inactive.any()
+
+    out = trtllm_gen_moe_gather_activation(
+        activation_output, e2p, top_k, enable_pdl=enable_pdl
+    )
+    ref = reference_gather(activation_output, e2p, top_k)
+    assert out.shape == (num_tokens, top_k, intermediate_size)
+    assert out.dtype == activation_output.dtype
+    assert torch.count_nonzero(out)
+    torch.testing.assert_close(out, ref, atol=0.0, rtol=0.0)
+    # Rows for the routing kernels' own sentinel must be bitwise zero.
+    assert (out.view(torch.int16)[inactive] == 0).all()

--- a/tests/trace/template_registry.py
+++ b/tests/trace/template_registry.py
@@ -61,6 +61,7 @@ _TRACE_REGISTRATION_MODULES = (
     "flashinfer.fused_moe.hash_topk",
     "flashinfer.fused_moe.monomoe",
     "flashinfer.fused_moe.prepare",
+    "flashinfer.fused_moe.trtllm_gen_gather_activation",
     "flashinfer.fused_moe.trtllm_gen_routing",
     "flashinfer.gdn_decode",
     "flashinfer.gdn_kernels.experimental.gdn_fused_decode",


### PR DESCRIPTION
## 📌 Description

Exposes the permuted → expanded gather of the trtllm-gen MoE post-activation FC1 output as a
standalone op, and uses it to replace the eager-PyTorch gather inside
`bgmv_moe_gemm2_lora_delta`.

**Background.** Since #3153, calling a routed trtllm-gen MoE op with `gemm1_lora_delta` returns the
post-SwiGLU FC1 output alongside the map:

```
[output, expanded_idx_to_permuted_idx, gemm1_activation_output]
```
(`csrc/trtllm_fused_moe_kernel_launcher.cu:1475-1489`)

`gemm1_activation_output` is in the kernels' **permuted** (expert-sorted, padded) layout, so every
consumer has to bring it back to `(token, slot)` order first. Our own FC2 LoRA builder does that in
eager torch today (`flashinfer/fused_moe/moe_lora_delta.py:262-274`):

```python
perm  = expanded_idx_to_permuted_idx.to(torch.int64)
valid = perm >= 0
a_exp = torch.zeros(P, inter, dtype=lora_dtype, device=device)
a_exp[valid] = gemm1_activation_output[perm[valid]].to(lora_dtype)
```

That is a `nonzero` + an `index_select` + a masked `index_put` + a `zeros` — four kernels and a
device-side sync-shaped allocation, per MoE layer, per forward. This PR replaces it with one copy
kernel.

**API** (`flashinfer/fused_moe/trtllm_gen_gather_activation.py`):

```python
trtllm_gen_moe_gather_activation(
    activation_output,             # [num_padded_rows, I], PERMUTED, bf16 or fp16
    expanded_idx_to_permuted_idx,  # [num_tokens * top_k] int32, negative = inactive slot
    top_k,
    *, out=None, enable_pdl=None,
) -> torch.Tensor                  # [num_tokens, top_k, I]
```

Semantics, exactly:

```
out[t, k] = activation_output[perm(t, k)]  if perm(t, k) >= 0
          = 0                              otherwise
```

The zero-fill is the contract, not an implementation detail: negative entries mark slots routed to
an expert outside the local expert-parallel shard
(`include/flashinfer/trtllm/fused_moe/RoutingKernel.cuh:516-519`, `:888-891`, `:1195-1196`), and
downstream reducers sum over all `top_k` slots unconditionally. Every destination row is written, so
`out=` may be uninitialized.

**Why a standalone op rather than a new launcher output.** For BF16, MXINT4, FP4-with-bf16-activations
and FP4-per-token, SwiGLU is fused into the FC1 epilogue inside the trtllm-gen cubin
(`workspace.activation_output = nullptr`, `launcher.cu:1746`) — there is no device kernel in which to
write an expanded copy, so any in-launcher implementation would itself be a post-pass gather. Keeping
it standalone also means this PR touches neither `trtllm_fused_moe_kernel_launcher.cu` nor
`_unpack_trtllm_moe_output`, so it takes no positional output slot and does not interact with #4574,
#4361 or #4566. It follows the same decomposition as #4082 (routing) and the finalize op.

**Scope.** 16-bit element dtypes only (`Bfloat16`, `Fp16`) — the configurations whose returned
activation is already unquantized. DSFp8, MxFp8 and FP4-per-tensor return `uint8` codes whose block
scale the launcher does not return at all (`launcher.cu:2701-2706`, `:2887-2900`); gathering those
needs the scale plumbing #4574 is adding, i.e. a different signature. The `static_assert` and the
`LAUNCH_GATHER_ACTIVATION` reject make that boundary loud rather than silent.

---

## Changes

**Commit 1 — the op.**
- `include/flashinfer/trtllm/fused_moe/DevKernel.h`: new `moe::dev::gatherActivation` namespace
  (`Data`, `KernelParams`, `useVectorizedCopy`, `run`) beside `activation`/`permute`/`finalize`, plus
  a `LAUNCH_GATHER_ACTIVATION` macro. No torch headers.
- `csrc/fused_moe/trtllm_backend/trtllm_fused_moe_dev_kernel.cu`: the kernel. Grid
  `(row-width, top_k, num_tokens)` with grid-stride loops on all three, so the `y`/`z` caps still
  cover the full extent. 128-bit `float4` path when `innerDim % 8 == 0` and both buffers are
  16B-aligned, element-wise otherwise — a vectorized-body-plus-scalar-tail split is impossible here
  because a misaligned `innerDim` misaligns every row *base*. PDL entry sync only, no early
  completion trigger (the consumer reads this op's output, so releasing it early would race — same
  shape as `finalizeKernel`).
- `csrc/trtllm_fused_moe_gather_activation_binding.cu`: TVM-FFI binding, structured after
  `trtllm_fused_moe_finalize_binding.cu`. Validates rank/dtype/device/`numel == num_tokens*top_k`,
  installs a `CUDADeviceGuard`, early-returns on an empty problem (a zero grid dim is a CUDA error).
- JitSpec, `__init__` export, `aot.py` registration, `docs/api/fused_moe.rst`, trace template +
  registry entry.

**Commit 2 — the consumer.**
- `flashinfer/fused_moe/moe_lora_delta.py`: `bgmv_moe_gemm2_lora_delta` now calls the op. It keeps
  the eager gather as a fallback when the activation dtype is not 16-bit or the device is outside the
  op's supported compute capabilities, so the public builder is **not** narrowed — it still runs on
  SM90 / SM107 / SM110 / SM111 and on fp32 activations exactly as before.

---

## Validation (B200, `lmsysorg/sglang:v0.5.18-cu130`, from source)

| Suite | Result |
|---|---|
| `tests/moe/test_trtllm_gen_gather_activation.py` | **70 passed** |
| `tests/moe/test_bgmv_moe_lora_delta.py` (the rewired consumer) | **26 passed** |
| `tests/moe/test_trtllm_gen_fused_moe.py -k "lora or unfinalized"` | **35 passed, 50 skipped** (the suite's own hardware/dtype gates) — unchanged from main |
| `tests/moe/test_da_trtllm_fused_moe.py` | **22 passed** — unchanged from main |
| `benchmarks/bench_trtllm_gen_moe_gather_activation.py` | **6.8× – 14.3×** over the eager gather (table below) |

Performance (B200, `top_k=8`, bf16, median µs). **torch** = the four-kernel eager gather this PR
deletes; **fused** = the new op. `GB/s` is the fused op's effective bandwidth (bytes read + written).

| tokens | inter | torch (µs) | fused (µs) | speedup | GB/s |
|---:|---:|---:|---:|---:|---:|
| 1 | 512 | 86.6 | 6.1 | **14.10×** | 3 |
| 8 | 512 | 85.2 | 6.1 | 13.87× | 21 |
| 32 | 512 | 88.1 | 6.2 | 14.27× | 85 |
| 64 | 512 | 91.2 | 6.2 | 14.70× | 169 |
| 256 | 512 | 95.9 | 8.2 | 11.71× | 512 |
| 1024 | 512 | 114.7 | 10.2 | 11.24× | 1644 |
| 4096 | 512 | 171.0 | 22.5 | 7.59× | 2979 |
| 8192 | 512 | 278.5 | 41.0 | 6.80× | 3277 |
| 1 | 1024 | 87.9 | 6.2 | 14.23× | 5 |
| 64 | 1024 | 93.2 | 8.1 | 11.47× | 258 |
| 1024 | 1024 | 136.2 | 12.3 | 11.08× | 2731 |
| 8192 | 1024 | 448.5 | 55.3 | 8.12× | 4857 |
| 1 | 2048 | 88.4 | 6.2 | 14.32× | 11 |
| 256 | 2048 | 105.5 | 10.2 | 10.33× | 1644 |
| 1024 | 2048 | 168.3 | 20.3 | 8.28× | 3303 |
| 8192 | 2048 | 796.7 | 104.4 | 7.63× | 5142 |

The eager path costs a near-constant ~87 µs at small token counts — it is launch- and
allocation-bound, not bandwidth-bound, which is why the win is largest exactly where MoE decode
lives. At prefill scale the fused op is bandwidth-bound and lands at 5.1 TB/s effective.

What the tests actually pin:
- bitwise equality against the exact eager expression this PR deletes, over T ∈ {1, 2, 17, 1024,
  8192} × top_k ∈ {1, 2, 4, 6, 8} × widths {128, 512, 1536, 2048} and the non-vector widths
  {1, 7, 100, 132, 1023} that take the element-wise path, in bf16 and fp16;
- inactive rows are **bitwise** zero, including the all-inactive and no-inactive cases, on both the
  vectorized and element-wise paths and both dtypes;
- NaN-poisoned padding rows never appear in the output;
- an end-to-end case that runs the real `trtllm_bf16_routed_moe(..., gemm1_lora_delta=...)`, takes
  its returned map and activation, and compares against the torch gather — parametrized over an
  expert-parallel shard so the `-1` entries are **routing-kernel-emitted**, not synthetic;
- `out=` supplied / allocated, and six rejection cases, each asserting `ValueError` specifically;
- grid edges: a row spanning multiple x-blocks (`I = 8192`), more tokens than the `gridDim.z` cap
  (8193), `enable_pdl` both ways, and `num_tokens == 0`;
- an FC2-delta equivalence test against an independent reference (not the rewired builder), with
  tolerances derived from a float64 simulation of the same shapes rather than copied.

---

## Notes for reviewers

1. **Naming.** `trtllm_gen_moe_gather_activation` mirrors `trtllm_gen_moe_finalize` and
   `trtllm_gen_routing`. Happy to rename to `..._unpermute_activation` if that reads better against
   the "unpermute" language in the ABI comment at `launcher.cu:1487-1489`.
2. **Stability.** `@flashinfer_api` (not experimental): it is a stage of an already-shipped op with
   no dtype/backend heuristics, so it does not meet CONTRIBUTING.md's experimental criteria. Say the
   word and it moves.
3. **Bounds.** Permuted indices are not range-checked in release builds (a debug `assert` guards
   `permutedIdx < numPaddedRows`). The eager gather it replaces got a device-side bounds check from
   torch; this trades that away for the fused copy. Flagged rather than hidden.
4. **Pre-existing, not fixed here:** `csrc/trtllm_fused_moe_routing_binding.cu:165` is missing the
   same `CUDADeviceGuard` this PR adds to its own binding. Left for a separate one-line PR.
5. **Rubin (cc 107):** the supported-cc list mirrors its merged sibling `trtllm_gen_routing`
   (`[100, 103, 120, 121]`). Adding `map_sm107_to_100f=True` is a real gap but a separate change;
   the eager fallback in commit 2 means nothing regresses there today.
