### PR TITLE
fix(jit): preserve source mtimes when staging rmsnorm_silu and monomoe sources

### DIFF
--- a/flashinfer/jit/monomoe.py
+++ b/flashinfer/jit/monomoe.py
@@ -107,7 +107,8 @@ def gen_monomoe_module():
             raise FileNotFoundError(f"monomoe source file not found: {src_path}")
         dest_path = gen_directory / rel_name
         os.makedirs(dest_path.parent, exist_ok=True)
-        shutil.copy(src_path, dest_path)
+        # copy2 keeps source mtimes; a fresh mtime forces a full ninja rebuild
+        shutil.copy2(src_path, dest_path)
         return dest_path
 
     sources = [_copy(fname) for fname in _SOURCE_FILES]

--- a/flashinfer/jit/rmsnorm_silu.py
+++ b/flashinfer/jit/rmsnorm_silu.py
@@ -417,7 +417,8 @@ def gen_rmsnorm_silu_module(
     sources = []
     for fname in ["rmsnorm_silu.cu", "flashinfer_rmsnorm_silu_binding.cu"]:
         dst = gen_directory / fname
-        shutil.copy(jit_env.FLASHINFER_CSRC_DIR / fname, dst)
+        # copy2 keeps source mtimes; a fresh mtime forces a full ninja rebuild
+        shutil.copy2(jit_env.FLASHINFER_CSRC_DIR / fname, dst)
         sources.append(dst)
 
     return gen_jit_spec(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->
Extends #4798 to the two remaining staging sites named in #4782: `shutil.copy` → `shutil.copy2` in `jit/rmsnorm_silu.py` and `jit/monomoe.py`. `shutil.copy` stamps a fresh mtime on staged sources every process; since JIT freshness is delegated to ninja's mtime scan, this forced a full rebuild of these modules on every process start. `copy2` preserves source mtimes so unchanged sources reuse the cached build.

Verified by running both generators and confirming staged files carry byte-exact source mtimes.

## 🔍 Related Issues

<!-- Link any related issues here -->

* Issue #4782 
* PR  #4798

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary JIT compilation rebuilds by preserving generated source file timestamps during copying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->