### PR TITLE
fix(bench): use float32 cos_sin_cache in apply_rope_with_cos_sin_cache

### DIFF
--- a/benchmarks/routines/rope.py
+++ b/benchmarks/routines/rope.py
@@ -878,8 +878,9 @@ def testApplyRopeWithCosSinCache(args):
     # Precomputed cos_sin_cache: (max_seq_len, rotary_dim)
     # First half is cos, second half is sin
     max_seq_len = seq_len
+    # API requires FP32 cache regardless of Q/K dtype (#5025).
     cos_sin_cache = torch.randn(
-        max_seq_len, rotary_dim, dtype=input_dtype, device=device
+        max_seq_len, rotary_dim, dtype=torch.float32, device=device
     )
 
     # positions: (total_tokens,)
@@ -936,7 +937,7 @@ def testApplyRopeWithCosSinCache(args):
                 * num_kv_heads
                 * head_dim
                 * input_dtype.itemsize  # k read
-                + max_seq_len * rotary_dim * input_dtype.itemsize  # cos_sin_cache read
+                + max_seq_len * rotary_dim * 4  # cos_sin_cache read (float32)
                 + total_tokens * 8  # positions read (int64)
                 + total_tokens
                 * num_qo_heads


### PR DESCRIPTION
## Summary
- `testApplyRopeWithCosSinCache` allocated `cos_sin_cache` with `input_dtype` (fp16/bf16), but `flashinfer.rope.apply_rope_with_cos_sin_cache` requires float32 and raised before any timing.
- Allocate the cache as `torch.float32` and count it as 4 bytes/elem in `problem_bytes`.

Fixes #5025

## Test plan
- [x] DGX Spark (GB10): issue repro with `--input_dtype float16` -> `[PERF] median 1.571 ms` (no `cos_sin_cache should be float32`)
- [x] Same with `--input_dtype bfloat16` -> `[PERF] median 1.572 ms`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Benchmarks**
  - Updated rotary-position-embedding benchmark calculations to use the required 32-bit floating-point cache format.
  - Adjusted memory-bandwidth measurements to accurately reflect the cache’s fixed 4-byte element size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->