### PR TITLE
fix(jit): resolve CUDA lib dirs and versioned cudart for pip toolkits

### DIFF
--- a/flashinfer/jit/cpp_ext.py
+++ b/flashinfer/jit/cpp_ext.py
@@ -44,6 +44,39 @@ def _get_glibcxx_abi_build_flags() -> List[str]:
     return glibcxx_abi_cflags
 
 
+def _cuda_lib_dirs(cuda_home: str) -> List[str]:
+    """Return existing CUDA library directory names under ``cuda_home``.
+
+    System toolkits ship ``lib64/``; pip ``nvidia-cuda-*`` cu13 wheels ship
+    ``lib/`` only. Hardcoding ``lib64`` makes every JIT link fail with
+    ``cannot find -lcudart`` against a wheel-only toolkit (#5064).
+    """
+    return [name for name in ("lib64", "lib") if (Path(cuda_home) / name).is_dir()]
+
+
+def _cuda_shared_lib_flag(cuda_home: str, libdirs: List[str], stem: str) -> str:
+    """Return an ``ld`` flag that resolves ``lib{stem}`` under ``cuda_home``.
+
+    Pip CUDA wheels often ship only a versioned soname (``libcudart.so.13``)
+    without an unversioned ``libcudart.so`` symlink. Plain ``-lcudart`` then
+    fails even when ``-L`` points at the right directory; ``-l:libcudart.so.13``
+    links by exact filename instead.
+    """
+    candidates: List[Path] = []
+    for name in libdirs:
+        lib_dir = Path(cuda_home) / name
+        unversioned = lib_dir / f"lib{stem}.so"
+        if unversioned.exists():
+            return f"-l{stem}"
+        candidates.extend(sorted(lib_dir.glob(f"lib{stem}.so.*")))
+    if not candidates:
+        # Keep the conventional flag so the linker error still names the library.
+        return f"-l{stem}"
+    # Prefer the shortest versioned soname (libcudart.so.13 over .so.13.0.96).
+    chosen = min(candidates, key=lambda path: (len(path.name), path.name))
+    return f"-l:{chosen.name}"
+
+
 @functools.cache
 def get_cuda_path() -> str:
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
@@ -252,11 +285,22 @@ def generate_ninja_build_for_op(
     cflags = build_cflags(common_cflags, extra_cflags)
     cuda_cflags = build_cuda_cflags(common_cflags, extra_cuda_cflags)
 
-    ldflags = [
-        "-shared",
-        "-L$cuda_home/lib64",
-        "-L$cuda_home/lib64/stubs",
-        "-lcudart",
+    libdirs = _cuda_lib_dirs(cuda_home)
+    if not libdirs:
+        raise RuntimeError(
+            f"No CUDA library directory found under {cuda_home!r} "
+            f"(expected lib64/ or lib/). pip nvidia-cuda-* cu13 wheels use lib/; "
+            f"system toolkits typically use lib64/ (#5064)."
+        )
+
+    ldflags = ["-shared"]
+    for libdir in libdirs:
+        ldflags.append(f"-L$cuda_home/{libdir}")
+        stubs = Path(cuda_home) / libdir / "stubs"
+        if stubs.is_dir():
+            ldflags.append(f"-L$cuda_home/{libdir}/stubs")
+    ldflags += [
+        _cuda_shared_lib_flag(cuda_home, libdirs, "cudart"),
         "-lcuda",
     ]
 
@@ -266,6 +310,16 @@ def generate_ninja_build_for_op(
 
     if extra_ldflags is not None:
         ldflags += extra_ldflags
+
+    # Rewrite -lcudart / -lnvrtc from callers/env so pip wheels without
+    # unversioned .so symlinks still link (#5064).
+    resolved = []
+    for flag in ldflags:
+        if flag in ("-lcudart", "-lnvrtc"):
+            resolved.append(_cuda_shared_lib_flag(cuda_home, libdirs, flag[2:]))
+        else:
+            resolved.append(flag)
+    ldflags = resolved
 
     cxx = os.environ.get("CXX", "c++")
     nvcc = os.environ.get("FLASHINFER_NVCC", "$cuda_home/bin/nvcc")

--- a/tests/jit/test_jit_cpp_ext.py
+++ b/tests/jit/test_jit_cpp_ext.py
@@ -58,6 +58,110 @@ def test_generate_ninja_uses_sccache_compatible_nvcc_depfile_flag(
     assert "--dependency-output" not in ninja
 
 
+def _ldflags_block(ninja: str) -> str:
+    """Return the multiline ``ldflags = ...`` assignment from a ninja file."""
+    lines = ninja.splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith("ldflags ="))
+    end = start + 1
+    while end < len(lines) and lines[end].startswith("    "):
+        end += 1
+    return "\n".join(lines[start:end])
+
+
+def test_generate_ninja_supports_pip_cuda_wheel_lib_layout(monkeypatch, tmp_path):
+    # pip nvidia-cuda-* cu13 wheels ship lib/ only with versioned sonames (#5064).
+    cuda_home = tmp_path / "pip_cuda"
+    (cuda_home / "lib").mkdir(parents=True)
+    (cuda_home / "lib" / "libcudart.so.13").touch()
+    (cuda_home / "lib" / "libnvrtc.so.13").touch()
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: str(cuda_home))
+    monkeypatch.setattr(cpp_ext.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setenv("FLASHINFER_CUDA_ARCH_LIST", "7.5")
+
+    ninja = cpp_ext.generate_ninja_build_for_op(
+        name="test_module",
+        sources=[tmp_path / "generated" / "kernel.cu"],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_dirs=None,
+    )
+    ldflags = _ldflags_block(ninja)
+
+    assert "name = test_module" in ninja
+    assert "-L$cuda_home/lib" in ldflags
+    assert "-L$cuda_home/lib64" not in ldflags
+    assert "-l:libcudart.so.13" in ldflags
+    assert "-lcudart" not in ldflags.replace("-l:libcudart.so.13", "")
+
+
+def test_generate_ninja_keeps_system_lib64_and_stubs(monkeypatch, tmp_path):
+    cuda_home = tmp_path / "system_cuda"
+    (cuda_home / "lib64" / "stubs").mkdir(parents=True)
+    (cuda_home / "lib64" / "libcudart.so").touch()
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: str(cuda_home))
+    monkeypatch.setattr(cpp_ext.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setenv("FLASHINFER_CUDA_ARCH_LIST", "7.5")
+
+    ninja = cpp_ext.generate_ninja_build_for_op(
+        name="test_module",
+        sources=[tmp_path / "generated" / "kernel.cu"],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=None,
+        extra_include_dirs=None,
+    )
+    ldflags = _ldflags_block(ninja)
+
+    assert "-L$cuda_home/lib64" in ldflags
+    assert "-L$cuda_home/lib64/stubs" in ldflags
+    assert "-lcudart" in ldflags
+    assert "-l:libcudart" not in ldflags
+
+
+def test_generate_ninja_rewrites_versioned_nvrtc_from_extra_ldflags(
+    monkeypatch, tmp_path
+):
+    cuda_home = tmp_path / "pip_cuda"
+    (cuda_home / "lib").mkdir(parents=True)
+    (cuda_home / "lib" / "libcudart.so.13").touch()
+    (cuda_home / "lib" / "libnvrtc.so.13").touch()
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: str(cuda_home))
+    monkeypatch.setattr(cpp_ext.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setenv("FLASHINFER_CUDA_ARCH_LIST", "7.5")
+
+    ninja = cpp_ext.generate_ninja_build_for_op(
+        name="test_module",
+        sources=[tmp_path / "generated" / "kernel.cu"],
+        extra_cflags=None,
+        extra_cuda_cflags=None,
+        extra_ldflags=["-lnvrtc"],
+        extra_include_dirs=None,
+    )
+    ldflags = _ldflags_block(ninja)
+
+    assert "-l:libnvrtc.so.13" in ldflags
+    assert "-lnvrtc" not in ldflags.replace("-l:libnvrtc.so.13", "")
+
+
+def test_generate_ninja_errors_when_cuda_lib_dirs_missing(monkeypatch, tmp_path):
+    cuda_home = tmp_path / "empty_cuda"
+    cuda_home.mkdir(parents=True)
+    monkeypatch.setattr(cpp_ext, "get_cuda_path", lambda: str(cuda_home))
+    monkeypatch.setattr(cpp_ext.jit_env, "FLASHINFER_JIT_DIR", tmp_path / "jit")
+    monkeypatch.setenv("FLASHINFER_CUDA_ARCH_LIST", "7.5")
+
+    with pytest.raises(RuntimeError, match="No CUDA library directory"):
+        cpp_ext.generate_ninja_build_for_op(
+            name="test_module",
+            sources=[tmp_path / "generated" / "kernel.cu"],
+            extra_cflags=None,
+            extra_cuda_cflags=None,
+            extra_ldflags=None,
+            extra_include_dirs=None,
+        )
+
+
 def test_debug_jit_uses_sccache_compatible_nvcc_device_debug_flag(monkeypatch):
     monkeypatch.setenv("FLASHINFER_JIT_DEBUG", "1")
     monkeypatch.setattr(core, "check_cuda_arch", lambda: None)


### PR DESCRIPTION
## Summary
- Probe `$cuda_home/lib64` and `$cuda_home/lib` instead of hardcoding `lib64` in `generate_ninja_build_for_op` (pip `nvidia-cuda-*` cu13 wheels only ship `lib/`).
- Add stubs `-L` entries only when the stubs directory exists.
- When `libcudart.so` / `libnvrtc.so` are missing, link by versioned soname (`-l:libcudart.so.13`) so `ld` can resolve the wheel layout.
- Avoid shadowing the JIT op `name` when iterating lib dir names (would rewrite the module to `lib`).

Fixes #5064

## Test plan
- [x] DGX Spark (GB10): `CUDA_HOME=<venv>/.../nvidia/cu13` full JIT `apply_rope_with_cos_sin_cache` succeeds; `build.ninja` has `name = rope`, `-L$cuda_home/lib`, `-l:libcudart.so.13`
- [x] Same box: `CUDA_HOME=/usr/local/cuda` full JIT still succeeds; `build.ninja` has `-L$cuda_home/lib64`, stubs, `-lcudart`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved CUDA library discovery across installations using either `lib` or `lib64` directory layouts.
  - JIT compilation now supports versioned CUDA libraries when unversioned links are unavailable.
  - CUDA runtime and NVRTC linker settings are resolved more reliably from supplied configuration.
  - Added a clear error when the expected CUDA library directories cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->