### PR TITLE
feat: Test runner summary prints cudnn backend version

### DIFF
--- a/scripts/test_sharding/summary.py
+++ b/scripts/test_sharding/summary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import csv
+import importlib
 import importlib.metadata
 import io
 import json
@@ -693,6 +694,21 @@ def _torch_cuda_version() -> str:
         return "unavailable"
 
 
+def _cudnn_backend_version() -> str:
+    try:
+        cudnn = importlib.import_module("cudnn")
+    except ModuleNotFoundError as error:
+        if error.name != "cudnn":
+            return "unavailable"
+        return "not-installed"
+    except Exception:
+        return "unavailable"
+    try:
+        return str(cudnn.backend_version())
+    except Exception:
+        return "unavailable"
+
+
 @lru_cache(maxsize=1)
 def _runtime_version_line() -> str:
     versions = [
@@ -704,6 +720,7 @@ def _runtime_version_line() -> str:
         ("cuda-python", _package_version("cuda-python")),
         ("cuda-tile", _package_version("cuda-tile")),
         ("cuDNN-frontend", _package_version("nvidia-cudnn-frontend")),
+        ("cuDNN-backend", _cudnn_backend_version()),
         ("triton", _package_version("triton")),
         ("nccl-extensions", _package_version("nccl-extensions")),
         ("nccl4py", _package_version("nccl4py")),


### PR DESCRIPTION
## 📌 Description

Test runner summary prints cudnn backend version

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Runtime version summaries now report the installed cuDNN backend version.
  * Displays clear status information when cuDNN is not installed or its version cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->