### PR TITLE
perf(attention): stop doubling the paged K/V offset registers when K/V strides match

### DIFF
--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -289,6 +289,20 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
       RaggedParams, PagedParams, [&] {
         PagedParams params;
 
+        if constexpr (HEAD_DIM_QK == HEAD_DIM_VO && HEAD_DIM_VO < 512) {
+          // These caches address K and V through a single set of page offsets in the
+          // kernel (KernelTraits::SEPARATE_KV_OFFSETS), so the two pools must agree on
+          // strides. Independent K/V strides stay supported for the asymmetric (NVFP4
+          // VO-split) layout and for the large-head configurations that reach the
+          // shared-KV-smem on-the-fly producer.
+          for (int i = 0; i < paged_k_cache.ndim(); ++i) {
+            TVM_FFI_ICHECK_EQ(paged_k_cache.stride(i), paged_v_cache.stride(i))
+                << "k/v strides differ at dim " << i
+                << "; independent K/V strides require head_dim_qk != head_dim_vo or head_dim >= "
+                   "512";
+          }
+        }
+
         params.q = static_cast<DTypeQ*>(q.data_ptr());
         paged_kv_t<DTypeKV, IdType> paged_kv(
             num_kv_heads, page_size, HEAD_DIM_VO, batch_size, kv_layout,

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -406,6 +406,16 @@ struct KernelTraits {
   static constexpr uint32_t REPACK_STRIDE_QK = HEAD_DIM_QK / upcast_size<DTypeQ_>();
   static constexpr uint32_t REPACK_STRIDE_VO = HEAD_DIM_VO / upcast_size<DTypeQ_>();
 
+  // Whether the K and V pools can carry different page strides. Two families can:
+  // the asymmetric NVFP4 VO-split cache (head_dim_qk != head_dim_vo), and the
+  // large-head configurations, which reach the shared-KV-smem on-the-fly producer
+  // (USE_VO_SPLIT requires head_dim >= 512) and route V through the V strides
+  // there. Everywhere else the launcher requires the two pools to share strides,
+  // so a V page offset is bit-identical to the K one; keeping a second in-register
+  // offset array for that case costs NUM_PAGED_KV_OFFSETS extra 64-bit registers
+  // per thread and drops occupancy (~26% on B300 fa2_tc decode, NVBug 6634590).
+  static constexpr bool SEPARATE_KV_OFFSETS = (HEAD_DIM_QK != HEAD_DIM_VO) || (HEAD_DIM_VO >= 512);
+
   static constexpr bool IsInvalid() {
     // The first clause prunes (CTA_TILE_Q, head_dim) pairs FA2DetermineCtaTileQ
     // never selects: it picks from {16, 32} when head_dim_vo >= 512 (VO-split),
@@ -4008,10 +4018,15 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
       // Separate K/V page offsets: the K and V pools may carry different strides
       // (e.g. NVFP4 VO-split caches where head_dim_qk != head_dim_vo). The K/V-shared
       // smem path computes offsets on the fly, so the arrays collapse to [1] stubs there.
+      // With shared strides (KTraits::SEPARATE_KV_OFFSETS == false) the V offsets equal
+      // the K offsets, so the V array collapses to a [1] stub as well rather than
+      // doubling this thread's 64-bit offset registers.
+      constexpr uint32_t NUM_PAGED_V_OFFSETS =
+          KTraits::SEPARATE_KV_OFFSETS ? NUM_PAGED_KV_OFFSETS : 1;
       [[maybe_unused]] size_t
           thr_local_kv_offset_k[KTraits::USE_KV_SHARED_SMEM ? 1 : NUM_PAGED_KV_OFFSETS];
       [[maybe_unused]] size_t
-          thr_local_kv_offset_v[KTraits::USE_KV_SHARED_SMEM ? 1 : NUM_PAGED_KV_OFFSETS];
+          thr_local_kv_offset_v[KTraits::USE_KV_SHARED_SMEM ? 1 : NUM_PAGED_V_OFFSETS];
 
       uint32_t k_smem_offset_r = k_smem.template get_permuted_offset<UPCAST_STRIDE_K>(
                    get_warp_idx_kv<KTraits>(tid.z) * NUM_MMA_KV * 16 + 8 * (lane_idx / 16) +
@@ -4070,8 +4085,10 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
               (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>() / fp4_pack_factor;
           thr_local_kv_offset_k[i] = paged_kv.protective_get_k_offset(
               page_iter, kv_head_idx, entry_idx, feat_idx, last_indptr);
-          thr_local_kv_offset_v[i] = paged_kv.protective_get_v_offset(
-              page_iter, kv_head_idx, entry_idx, feat_idx, last_indptr);
+          if constexpr (KTraits::SEPARATE_KV_OFFSETS) {
+            thr_local_kv_offset_v[i] = paged_kv.protective_get_v_offset(
+                page_iter, kv_head_idx, entry_idx, feat_idx, last_indptr);
+          }
         }
         page_produce_kv<false, KTraits>(&smem_storage, &k_smem_offset_w, paged_kv.k_data, 0,
                                         thr_local_kv_offset_k, chunk_size, warp_idx, lane_idx);
@@ -4083,8 +4100,15 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
       cp_async::commit_group();
       // Shared K/V loads V(0) inside iter 0 after Q.K^T; preloading it would clobber K(0).
       if constexpr (!KTraits::USE_KV_SHARED_SMEM) {
-        page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data, 0,
-                                       thr_local_kv_offset_v, chunk_size, warp_idx, lane_idx);
+        // With shared K/V strides the V rows sit at the K offsets, so the V
+        // producer reads the K array and the V offsets never reach a register.
+        if constexpr (KTraits::SEPARATE_KV_OFFSETS) {
+          page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data, 0,
+                                         thr_local_kv_offset_v, chunk_size, warp_idx, lane_idx);
+        } else {
+          page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data, 0,
+                                         thr_local_kv_offset_k, chunk_size, warp_idx, lane_idx);
+        }
         page_produce_kv_sf<true, KTraits>(&smem_storage, maybe_v_cache_sf, packed_page_iter_base,
                                           last_indptr * (uint32_t)paged_kv.page_size, kv_head_idx,
                                           v_sf_stride_page, v_sf_stride_h, v_sf_stride_n,
@@ -4177,8 +4201,10 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
                 (lane_idx % KV_THR_LAYOUT_COL) * upcast_size<DTypeKV>() / fp4_pack_factor;
             thr_local_kv_offset_k[i] = paged_kv.protective_get_k_offset(
                 page_iter, kv_head_idx, entry_idx, feat_idx, last_indptr);
-            thr_local_kv_offset_v[i] = paged_kv.protective_get_v_offset(
-                page_iter, kv_head_idx, entry_idx, feat_idx, last_indptr);
+            if constexpr (KTraits::SEPARATE_KV_OFFSETS) {
+              thr_local_kv_offset_v[i] = paged_kv.protective_get_v_offset(
+                  page_iter, kv_head_idx, entry_idx, feat_idx, last_indptr);
+            }
           }
         }
         // Shared K/V serializes loads (no K/V prefetch overlap) -> drain fully.
@@ -4331,9 +4357,15 @@ __device__ __forceinline__ void BatchPrefillWithPagedKVCacheDevice(
           cp_async::commit_group();
           packed_page_iter_base = next_packed_page_iter_base;
         } else {
-          page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data,
-                                         (iter + 1) * CTA_TILE_KV, thr_local_kv_offset_v,
-                                         chunk_size, warp_idx, lane_idx);
+          if constexpr (KTraits::SEPARATE_KV_OFFSETS) {
+            page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data,
+                                           (iter + 1) * CTA_TILE_KV, thr_local_kv_offset_v,
+                                           chunk_size, warp_idx, lane_idx);
+          } else {
+            page_produce_kv<true, KTraits>(&smem_storage, &v_smem_offset_w, paged_kv.v_data,
+                                           (iter + 1) * CTA_TILE_KV, thr_local_kv_offset_k,
+                                           chunk_size, warp_idx, lane_idx);
+          }
           page_produce_kv_sf<true, KTraits>(
               &smem_storage, maybe_v_cache_sf, packed_page_iter_base,
               last_indptr * (uint32_t)paged_kv.page_size, kv_head_idx, v_sf_stride_page,


### PR DESCRIPTION
## 📌 Description

#3684 gave the FA2 paged kernels independent K/V page strides so the asymmetric NVFP4 VO-split
cache (`head_dim_qk=512`, `head_dim_vo=256`) could address its two pools separately. It did so
unconditionally: the per-thread offset array `thr_local_kv_offset` was split into `_k` and `_v`
copies of `NUM_MMA_KV * KV_THR_LAYOUT_COL / 2 / NUM_WARPS_Q` 64-bit entries each, and the
persistent kernel gained a second `prefetch_offest` pass to fill it.

Every symmetric configuration pays for that. At `head_dim` 128 the array is 16 entries, so the
split costs ~32 extra registers per thread on the hot producer path, and the occupancy loss shows
up directly in decode and prefill latency.

This gates the second array on `KernelTraits::SEPARATE_KV_OFFSETS`, true for the two families that
can actually see different K/V strides:

- `head_dim_qk != head_dim_vo` — the asymmetric NVFP4 cache #3684 added, and
- `head_dim_vo >= 512` — large heads, which reach the shared-KV-smem on-the-fly producer and route
  V through the V strides there (`test_batch_prefill_paged_shared_kv_smem_unequal_kv_strides` covers
  exactly this with symmetric 512/512 fp16 pools).

Everywhere else the V rows sit at the K offsets, so the V producer reads the K array and the V
offsets never reach a register. `csrc/batch_prefill.cu` regains the K/V stride-equality check for
that remaining set — the host-side contract that makes the compile-time choice sound. It was dropped
wholesale in #3684; the decode launcher never dropped its equivalent.

`persistent.cuh` is **deliberately left alone**, though the same transformation applies there. The
holistic `BatchAttention` launcher (`csrc/batch_attention.cu:90-101`) reads K and V strides from two
independent tensors and never compares them, so gating the persistent kernel's V offsets without
also adding that host check would make it address V through the K offsets *silently* rather than
fail loudly. That is a second contract change on a path this PR does not measure, so it belongs in
its own change. An earlier revision of this PR did include it; that was a mistake.

## 🔍 Related Issues

Fixes NVBug 6634590 (`BatchDecodeWithPagedKVCacheWrapper` fa2_tc batch-64 latency regression) and
NVBug 6634592 (`BatchPrefillWithPagedKVCacheWrapper` fa2 GPT-OSS latency regression). Both were
bisected by the perf suite to `8f9ad200` (#3684). No GitHub issue exists for either.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No new test is added: `test_batch_prefill_paged_shared_kv_smem_unequal_kv_strides` (added by #3684)
already pins the large-head unequal-stride behaviour this change has to preserve, and it is what
caught an earlier, too-broad version of this patch.

Validated on B300 (SM103), CUDA 13.0:

| build | fa2_tc decode median |
| --- | --- |
| `8f9ad200^` (pre-regression) | 0.801 / 0.804 ms |
| `8f9ad200` (first bad) | 0.859 ms |
| `main` (`dbb52c8a`) | 0.860 / 0.860 ms |
| `main` + this patch | 0.787 / 0.797 / 0.803 ms |

Benchmark: `BatchDecodeWithPagedKVCacheWrapper`, `--backends fa2_tc --page_size 16 --batch_size 64
--s_qo 1 --s_kv 8192 --num_qo_heads 64 --num_kv_heads 8 --head_dim_qk 128 --head_dim_vo 128
--q_dtype bfloat16 --kv_dtype bfloat16 --num_iters 100`, i.e. NVBug 6634590's own repro command.
The patch returns `main` to the pre-#3684 baseline.

Correctness on the same board:

```
tests/attention/test_batch_prefill_kernels.py -k 'paged and not fp8 and not nvfp4'
    5442 passed, 1140 skipped, 5760 xfailed
tests/attention/test_batch_decode_kernels.py -k 'not fp8 and not nvfp4'
    2972 passed
tests/attention/test_batch_prefill_kernels.py -k unequal_kv_strides
    4 passed
```

Note this fix is deliberately narrower than the regression: symmetric configurations at
`head_dim >= 512` still carry #3684's register cost, because that is where the shared-KV-smem
producer legitimately needs the V strides. Removing it there too would require dispatching on
runtime stride equality — a second kernel instantiation — which seemed worse than the benefit.

The CI B300 reports a larger step for these NVBugs (25.8% on decode) than this engineering-sample
board does; the bisected commit and the full recovery are the same.

AI-assisted (Claude Opus 5): root-cause, patch, and B300 validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure matching K/V cache strides when using matching, smaller attention head dimensions.
  * Provides a clearer error when incompatible cache strides are supplied.

* **Performance**
  * Reduced memory overhead and improved paged attention efficiency for configurations that share K/V cache strides.
  * Preserved independent K/V stride support for asymmetric layouts and larger head dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
