### PR TITLE
fix(moe): bound routing_replay_out dim0 from below in both validators

### DIFF
--- a/csrc/trtllm_fused_moe_kernel_launcher.cu
+++ b/csrc/trtllm_fused_moe_kernel_launcher.cu
@@ -949,8 +949,12 @@ void cast_fp32_to_bf16(void* output, void const* input, int64_t num_elements, cu
 }  // namespace
 
 // Validate routing_replay_out tensor properties.
-// NOTE: dim0 >= num_tokens is intentionally NOT checked — with CUDA graphs the buffer
-// is pre-allocated at maximum batch size and reused across steps with varying num_tokens.
+// NOTE: dim0 is only bounded from below. The routing kernels write one replay row per
+// token unconditionally (DeepSeek launches numBlocks == num_tokens and writes row
+// blockIdx.x; the custom and llama4 kernels write row tokenIdx), so a buffer with fewer
+// rows than tokens is written past its end. Oversized buffers stay legal: with CUDA
+// graphs the buffer is pre-allocated at maximum batch size and reused across steps with
+// varying num_tokens.
 static void validate_routing_replay_out(TensorView const& replay, TensorView const& hidden_states,
                                         int64_t top_k) {
   TVM_FFI_ICHECK(replay.device().device_type == kDLCUDA)
@@ -959,6 +963,9 @@ static void validate_routing_replay_out(TensorView const& replay, TensorView con
       << "routing_replay_out must be on the same device as hidden_states";
   TVM_FFI_ICHECK(replay.ndim() == 2) << "routing_replay_out must be 2D [num_tokens, top_k]";
   TVM_FFI_ICHECK(replay.size(1) == top_k) << "routing_replay_out dim1 must equal top_k";
+  TVM_FFI_ICHECK(replay.size(0) >= hidden_states.size(0))
+      << "routing_replay_out dim0 must be >= num_tokens (" << hidden_states.size(0) << "), got "
+      << replay.size(0) << "; the routing kernel writes one replay row per token";
   TVM_FFI_ICHECK((replay.dtype() == DLDataType{kDLInt, 16, 1}))
       << "routing_replay_out must be int16 dtype";
   TVM_FFI_ICHECK(replay.IsContiguous())

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -5447,8 +5447,14 @@ def _validate_routing_replay_out(
     routing_replay_out: Optional[torch.Tensor],
     top_k: int,
     num_fused_shared_experts: int = 0,
+    num_tokens: Optional[int] = None,
 ) -> None:
-    """Validate routing_replay_out tensor properties before passing to C++ kernels."""
+    """Validate routing_replay_out tensor properties before passing to C++ kernels.
+
+    ``num_tokens`` bounds dim0 from below: the routing kernels write one replay row per
+    token unconditionally, so a shorter buffer is written past its end. Oversized buffers
+    stay legal for CUDA-graph capture at a fixed maximum batch size.
+    """
     if routing_replay_out is None:
         return
     if num_fused_shared_experts > 0:
@@ -5467,6 +5473,12 @@ def _validate_routing_replay_out(
     if routing_replay_out.shape[1] != top_k:
         raise ValueError(
             f"routing_replay_out dim1 must equal top_k={top_k}, got {routing_replay_out.shape[1]}"
+        )
+    if num_tokens is not None and routing_replay_out.shape[0] < num_tokens:
+        raise ValueError(
+            f"routing_replay_out dim0 must be >= num_tokens={num_tokens}, "
+            f"got {routing_replay_out.shape[0]}; the routing kernel writes one replay "
+            "row per token"
         )
     if not routing_replay_out.is_contiguous():
         raise ValueError("routing_replay_out must be contiguous (packed row-major)")
@@ -5650,7 +5662,9 @@ def trtllm_bf16_moe(
         scalar return; will become ``[output]`` in v0.8.0).  Otherwise returns
         ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
-    _validate_routing_replay_out(routing_replay_out, top_k)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, num_tokens=hidden_states.shape[0]
+    )
     _validate_bf16_gemm1_activation_params(
         activation_type,
         gemm1_alpha,
@@ -5867,7 +5881,9 @@ def trtllm_bf16_routed_moe(
         ``False``      ``Tensor``          ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx, gemm1_activation_output]``
         =============  ==================  =========================================================================
     """
-    _validate_routing_replay_out(routing_replay_out, top_k)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, num_tokens=hidden_states.shape[0]
+    )
     _validate_bf16_gemm1_activation_params(
         activation_type,
         gemm1_alpha,
@@ -6040,7 +6056,9 @@ def trtllm_fp8_per_tensor_scale_moe(
         Final MoE output when ``do_finalize`` is ``True``, otherwise
         ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
-    _validate_routing_replay_out(routing_replay_out, top_k)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, num_tokens=hidden_states.shape[0]
+    )
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_tensor_scale_moe(
         routing_logits,
         routing_bias,
@@ -6179,7 +6197,9 @@ def trtllm_fp8_per_tensor_scale_routed_moe(
         Final MoE output when ``do_finalize`` is ``True``, otherwise
         ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
-    _validate_routing_replay_out(routing_replay_out, top_k)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, num_tokens=hidden_states.shape[0]
+    )
     topk_ids_tensor, topk_weights, routing_mode = _split_precomputed_routing(topk_ids)
     result = get_trtllm_moe_sm100_module().trtllm_fp8_per_tensor_scale_routed_moe(
         routing_mode,
@@ -6663,7 +6683,9 @@ def trtllm_fp8_block_scale_moe(
             "Fused shared experts (num_fused_shared_experts > 0) are only supported "
             f"with DeepSeekV3 routing; got routing_method_type={routing_method_type}."
         )
-    _validate_routing_replay_out(routing_replay_out, top_k, nfse)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, nfse, num_tokens=hidden_states.shape[0]
+    )
     _validate_fp8_block_scale_gemm1_activation_params(
         fp8_quantization_type,
         activation_type,
@@ -7176,7 +7198,9 @@ def trtllm_fp4_block_scale_moe(
             "Fused shared experts (num_fused_shared_experts > 0) are only supported "
             f"with DeepSeekV3 routing; got routing_method_type={routing_method_type}."
         )
-    _validate_routing_replay_out(routing_replay_out, top_k, nsfe)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, nsfe, num_tokens=hidden_states.shape[0]
+    )
     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
         RoutingInputMode.FromLogits,
         routing_logits,
@@ -7602,7 +7626,9 @@ def trtllm_mxint4_block_scale_moe(
         ``[output]`` when ``do_finalize`` is ``True``, otherwise
         ``[gemm2_output, expert_weights, expanded_idx_to_permuted_idx]``.
     """
-    _validate_routing_replay_out(routing_replay_out, top_k)
+    _validate_routing_replay_out(
+        routing_replay_out, top_k, num_tokens=hidden_states.shape[0]
+    )
     return get_trtllm_moe_sm100_module().trtllm_mxint4_block_scale_moe(
         routing_logits,
         routing_bias,

--- a/flashinfer/fused_moe/core.py
+++ b/flashinfer/fused_moe/core.py
@@ -5446,14 +5446,15 @@ def _validate_bf16_gemm1_activation_params(
 def _validate_routing_replay_out(
     routing_replay_out: Optional[torch.Tensor],
     top_k: int,
+    num_tokens: int,
     num_fused_shared_experts: int = 0,
-    num_tokens: Optional[int] = None,
 ) -> None:
     """Validate routing_replay_out tensor properties before passing to C++ kernels.
 
     ``num_tokens`` bounds dim0 from below: the routing kernels write one replay row per
     token unconditionally, so a shorter buffer is written past its end. Oversized buffers
-    stay legal for CUDA-graph capture at a fixed maximum batch size.
+    stay legal for CUDA-graph capture at a fixed maximum batch size. It is required rather
+    than defaulted so that a new entry point cannot silently opt out of the bound.
     """
     if routing_replay_out is None:
         return
@@ -5474,7 +5475,7 @@ def _validate_routing_replay_out(
         raise ValueError(
             f"routing_replay_out dim1 must equal top_k={top_k}, got {routing_replay_out.shape[1]}"
         )
-    if num_tokens is not None and routing_replay_out.shape[0] < num_tokens:
+    if routing_replay_out.shape[0] < num_tokens:
         raise ValueError(
             f"routing_replay_out dim0 must be >= num_tokens={num_tokens}, "
             f"got {routing_replay_out.shape[0]}; the routing kernel writes one replay "
@@ -6684,7 +6685,10 @@ def trtllm_fp8_block_scale_moe(
             f"with DeepSeekV3 routing; got routing_method_type={routing_method_type}."
         )
     _validate_routing_replay_out(
-        routing_replay_out, top_k, nfse, num_tokens=hidden_states.shape[0]
+        routing_replay_out,
+        top_k,
+        num_tokens=hidden_states.shape[0],
+        num_fused_shared_experts=nfse,
     )
     _validate_fp8_block_scale_gemm1_activation_params(
         fp8_quantization_type,
@@ -7199,7 +7203,10 @@ def trtllm_fp4_block_scale_moe(
             f"with DeepSeekV3 routing; got routing_method_type={routing_method_type}."
         )
     _validate_routing_replay_out(
-        routing_replay_out, top_k, nsfe, num_tokens=hidden_states.shape[0]
+        routing_replay_out,
+        top_k,
+        num_tokens=hidden_states.shape[0],
+        num_fused_shared_experts=nsfe,
     )
     return get_trtllm_moe_sm100_module().trtllm_fp4_block_scale_moe(
         RoutingInputMode.FromLogits,

--- a/tests/moe/test_trtllm_gen_fused_moe.py
+++ b/tests/moe/test_trtllm_gen_fused_moe.py
@@ -2471,6 +2471,71 @@ def test_fused_shared_experts_reject_replay_and_non_deepseek_routing():
                 )
 
 
+def test_routing_replay_out_rejects_undersized_dim0():
+    """An undersized replay buffer must be rejected, not written out of bounds.
+
+    Routing launches one block per token and writes row ``blockIdx.x``
+    unconditionally, so ``dim0 < num_tokens`` is a device-side buffer overflow
+    rather than a truncated result. Oversized buffers stay legal for CUDA-graph
+    pre-allocation, hence the ``>=`` bound. Host-side check, so no GPU needed.
+    """
+    num_experts = 4
+    num_tokens = 4
+    top_k = 1
+    fp8_kwargs = {
+        "routing_logits": torch.empty((num_tokens, num_experts), dtype=torch.bfloat16),
+        "routing_bias": None,
+        "hidden_states": torch.empty((num_tokens, 1), dtype=torch.bfloat16),
+        "hidden_states_scale": torch.empty((1, 1), dtype=torch.float32),
+        "gemm1_weights": torch.empty((1, 2, 1), dtype=torch.bfloat16),
+        "gemm1_weights_scale": torch.empty((1, 1, 1), dtype=torch.float32),
+        "gemm2_weights": torch.empty((1, 1, 1), dtype=torch.bfloat16),
+        "gemm2_weights_scale": torch.empty((1, 1, 1), dtype=torch.float32),
+    }
+    fp4_kwargs = {
+        "routing_logits": torch.empty((num_tokens, num_experts), dtype=torch.bfloat16),
+        "routing_bias": None,
+        "hidden_states": torch.empty((num_tokens, 2), dtype=torch.bfloat16),
+        "hidden_states_scale": None,
+        "gemm1_weights": torch.empty((1, 2, 1), dtype=torch.uint8),
+        "gemm1_weights_scale": torch.empty((1, 1, 1), dtype=torch.float8_e4m3fn),
+        "gemm1_bias": None,
+        "gemm1_alpha": None,
+        "gemm1_beta": None,
+        "gemm1_clamp_limit": None,
+        "gemm2_weights": torch.empty((1, 1, 1), dtype=torch.uint8),
+        "gemm2_weights_scale": torch.empty((1, 1, 1), dtype=torch.float8_e4m3fn),
+        "gemm2_bias": None,
+        "output1_scale_scalar": None,
+        "output1_scale_gate_scalar": None,
+        "output2_scale_scalar": None,
+    }
+    common_kwargs = {
+        "num_experts": num_experts,
+        "top_k": top_k,
+        "n_group": None,
+        "topk_group": None,
+        "intermediate_size": 1,
+        "local_expert_offset": 0,
+        "local_num_experts": num_experts,
+        "routed_scaling_factor": None,
+        "routing_method_type": RoutingMethodType.DeepSeekV3.value,
+    }
+
+    for op, op_kwargs in (
+        (trtllm_fp8_block_scale_moe, fp8_kwargs),
+        (trtllm_fp4_block_scale_moe, fp4_kwargs),
+    ):
+        with pytest.raises(ValueError, match=r"dim0 must be >= num_tokens"):
+            op(
+                **op_kwargs,
+                **common_kwargs,
+                routing_replay_out=torch.empty(
+                    (num_tokens - 1, top_k), dtype=torch.int16
+                ),
+            )
+
+
 def test_fp4_block_scale_moe_fused_shared_experts_reject_routed_only_tensors():
     """Routed-only expert-major tensors must fail host-side, not OOB on the GPU.
 


### PR DESCRIPTION
## 📌 Description

The trtllm routing kernels write one replay row per token unconditionally — `routingDeepSeek`
launches `numBlocks == num_tokens` and writes row `blockIdx.x`, and the custom/llama4 kernels write
row `tokenIdx` — so the kernel touches rows `[0, num_tokens)` regardless of the buffer's actual
`dim0`.

Neither validator checked that lower bound. The C++ one receives `hidden_states` but only compared
`device_id`; the Python one never saw `num_tokens` at all. A caller that passes a shorter buffer
(e.g. `num_tokens=1024` against a `[8, 2]` replay tensor) is accepted by both, and the kernel then
writes past the end of the allocation. Under the caching allocator that lands silently in a
neighbouring tensor; `compute-sanitizer` only sees it with `PYTORCH_NO_CUDA_MEMORY_CACHING=1`.

This adds `dim0 >= num_tokens` to both validators. Oversized buffers stay legal, which is what
CUDA-graph capture at a fixed maximum batch size actually needs — the original "dim0 is
intentionally NOT checked" comment conflated the two directions.

## 🔍 Related Issues

Addresses part 2 of #5009.

Part 1 of that issue — the fused-shared-experts replay stride — is deliberately **not** in this PR.
It removes host-side rejections in order to enable a currently unreachable feature combination
(`routing_replay_out` together with `num_fused_shared_experts > 0`), which is a larger change with a
different review surface. The OOB it describes is unreachable today precisely because those
rejections exist.

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Validated on B300 (SM103), CUDA 13.0, against this branch:

```
tests/moe/test_trtllm_gen_fused_moe.py tests/moe/test_trtllm_gen_routed_fused_moe.py
  -k 'replay or shared_expert'          46 passed, 4459 deselected
tests/model_optimizations/test_dsv3_fused_routing.py -k replay
                                        84 passed, 60 skipped, 4681 deselected
```

Existing callers were checked against the new bound before it was added, since a new rejection is
exactly the kind of change that breaks a test quietly:

- `test_dsv3_fused_routing.py` and `test_trtllm_gen_fused_moe.py` allocate `(num_tokens, top_k)`,
  so the bound holds exactly.
- `test_trtllm_gen_routed_fused_moe.py` uses `replay_capacity = num_tokens + 5`, deliberately
  oversized — which this change keeps legal.
- `test_trtllm_gen_fused_moe.py:2461` passes `torch.empty((1, 1))` and asserts
  `match="routing_replay_out is not supported"`. A `(1, 1)` buffer would also fail the new bound,
  so the raised message could have changed; it does not, because the
  `num_fused_shared_experts > 0` rejection sits first in `_validate_routing_replay_out` and the new
  check is second-to-last.

**No new test is added.** #5009 suggests FP8/FP4 host-side rejection tests for the new bound; happy
to add them here if a reviewer prefers that over a follow-up.

AI-assisted (Claude Opus 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Routing replay buffers are now validated to ensure they contain at least one row per input token.
  * Undersized buffers now produce a clear error showing the required minimum and received size, preventing potential out-of-bounds writes.
  * Oversized buffers remain supported for CUDA graph pre-allocation.
  * Validation is consistently applied across supported Mixture-of-Experts operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
