### PR TITLE
feat(attention): support FP8 K and NVFP4 V with TRTLLM-Gen

### DIFF
--- a/csrc/trtllm_fmha_kernel_launcher.cu
+++ b/csrc/trtllm_fmha_kernel_launcher.cu
@@ -167,11 +167,12 @@ void trtllm_paged_attention_launcher(
     void* workspace_buffer, void* multi_ctas_kv_counter_buffer, int64_t multi_ctas_kv_counter_size,
     int* block_tables, const void* k_block_scales_ptr, const void* v_block_scales_ptr,
     int* seq_lens, int* cum_seq_lens_q, int* cum_seq_lens_kv, float* attention_sinks, float* lse,
-    Data_type q_data_type, Data_type kv_data_type, Data_type o_data_type,
+    Data_type q_data_type, Data_type k_data_type, Data_type v_data_type, Data_type o_data_type,
     TllmPagedAttentionMode mode, int64_t batch_size, int64_t max_q_len, int64_t max_kv_len,
     int64_t num_pages_in_mem_pool, int64_t num_qo_heads, int64_t num_kv_heads, int64_t head_dim_qk,
     int64_t head_dim_vo, int64_t page_size, int64_t q_stride_tokens, int64_t q_stride_heads,
-    int64_t kv_stride_keys_values, int64_t kv_stride_heads, int64_t kv_stride_batch,
+    int64_t k_stride_keys_values, int64_t k_stride_heads, int64_t k_stride_batch,
+    int64_t v_stride_keys_values, int64_t v_stride_heads, int64_t v_stride_batch,
     int64_t max_num_blocks_per_seq, double bmm1_scale, double bmm2_scale,
     const float* bmm1_scale_log2_ptr, const float* bmm2_scale_ptr, double o_sf_scale,
     int64_t o_sf_vec_size, int64_t o_sf_start_index, int64_t window_left, int64_t sum_seq_q,
@@ -189,9 +190,8 @@ void trtllm_paged_attention_launcher(
     FLASHINFER_ERROR(err_msg.str());
   }
 
-  // For paged attention, K and V have the same dtype (kv_data_type).
   auto fmha_runner =
-      TllmGenFmhaRunnerCache::get(q_data_type, kv_data_type, kv_data_type, o_data_type);
+      TllmGenFmhaRunnerCache::get(q_data_type, k_data_type, v_data_type, o_data_type);
   TllmGenFmhaRunnerParams runner_params{};
   TVM_FFI_ICHECK(bf16q_fp8kv_transform_mode >= 0 && bf16q_fp8kv_transform_mode <= 2)
       << "bf16q_fp8kv_transform_mode must be 0, 1, or 2";
@@ -199,7 +199,8 @@ void trtllm_paged_attention_launcher(
   if (transform_mode != Bf16QFp8KvTransformMode::Full) {
     TVM_FFI_ICHECK(
         mode == TllmPagedAttentionMode::ForGen && q_data_type == Data_type::DATA_TYPE_BF16 &&
-        kv_data_type == Data_type::DATA_TYPE_E4M3 && o_data_type == Data_type::DATA_TYPE_BF16)
+        k_data_type == Data_type::DATA_TYPE_E4M3 && v_data_type == Data_type::DATA_TYPE_E4M3 &&
+        o_data_type == Data_type::DATA_TYPE_BF16)
         << "bf16q_fp8kv_transform_mode is only supported for BF16 query, FP8 E4M3 KV, "
            "BF16 output decode";
   }
@@ -228,12 +229,12 @@ void trtllm_paged_attention_launcher(
   runner_params.mMultiProcessorCount = sm_count;
   runner_params.qStrideTokens = q_stride_tokens;
   runner_params.qStrideHeads = q_stride_heads;
-  runner_params.kStrideKeysValues = kv_stride_keys_values;
-  runner_params.kStrideHeads = kv_stride_heads;
-  runner_params.kStrideBatch = kv_stride_batch;
-  runner_params.vStrideKeysValues = kv_stride_keys_values;
-  runner_params.vStrideHeads = kv_stride_heads;
-  runner_params.vStrideBatch = kv_stride_batch;
+  runner_params.kStrideKeysValues = k_stride_keys_values;
+  runner_params.kStrideHeads = k_stride_heads;
+  runner_params.kStrideBatch = k_stride_batch;
+  runner_params.vStrideKeysValues = v_stride_keys_values;
+  runner_params.vStrideHeads = v_stride_heads;
+  runner_params.vStrideBatch = v_stride_batch;
   runner_params.kSfStrideHeads = k_sf_stride_heads;
   runner_params.kSfStrideBatch = k_sf_stride_batch;
   runner_params.vSfStrideHeads = v_sf_stride_heads;
@@ -301,7 +302,10 @@ void trtllm_paged_attention_launcher(
     runner_params.mMaskType =
         is_causal ? TrtllmGenAttentionMaskType::Causal : TrtllmGenAttentionMaskType::Dense;
     runner_params.mKernelType = FmhaKernelType::Context;
-    runner_params.mTileScheduler = TileScheduler::Persistent;
+    bool const is_fp8_k_nvfp4_v =
+        k_data_type == Data_type::DATA_TYPE_E4M3 && v_data_type == Data_type::DATA_TYPE_E2M1;
+    runner_params.mTileScheduler =
+        is_fp8_k_nvfp4_v ? TileScheduler::Static : TileScheduler::Persistent;
     runner_params.mMultiCtasKvMode = false;
 
     runner_params.cumSeqLensQPtr = cum_seq_lens_q;
@@ -419,9 +423,10 @@ void trtllm_paged_attention_decode(
     Optional<TensorView> sparse_mla_top_k_lens, int64_t bf16q_fp8kv_transform_mode,
     Optional<bool> use_fp16_softmax) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
-  auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
+  auto k_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
+  auto v_data_type = dl_dtype_to_tllm_data_type(value_cache.dtype());
   TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
-  for (int i = 0; i < key_cache.ndim(); i++) {
+  for (int i = 0; i < key_cache.ndim() - 1; i++) {
     TVM_FFI_ICHECK_EQ(key_cache.size(i), value_cache.size(i));
   }
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
@@ -432,9 +437,9 @@ void trtllm_paged_attention_decode(
   int* cum_seq_lens_q_ptr =
       cum_seq_lens_q.has_value() ? static_cast<int*>(cum_seq_lens_q.value().data_ptr()) : nullptr;
   // Multiply by two for FP4 tensor as it is stored as UINT8 dtype. Assume the dim is even.
-  int head_dim_k = is_4bit(kv_data_type) ? key_cache.size(-1) * 2 : key_cache.size(-1);
+  int head_dim_k = is_4bit(k_data_type) ? key_cache.size(-1) * 2 : key_cache.size(-1);
   int head_dim_q = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
-  int head_dim_v = is_4bit(kv_data_type) ? value_cache.size(-1) * 2 : value_cache.size(-1);
+  int head_dim_v = is_4bit(v_data_type) ? value_cache.size(-1) * 2 : value_cache.size(-1);
   int head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
   TVM_FFI_ICHECK_EQ(head_dim_k, head_dim_q)
       << "head_dim_k and head_dim_q must be the same, got " << std::to_string(head_dim_k) << " and "
@@ -447,8 +452,10 @@ void trtllm_paged_attention_decode(
   int max_num_blocks_per_seq = block_tables.size(-1);
   bool is_shared_kv = key_cache.data_ptr() == value_cache.data_ptr();
   int num_pages_in_mem_pool = is_shared_kv ? key_cache.size(0) : key_cache.size(0) * 2;
-  bool is_fp4_kv = is_4bit(kv_data_type);
-  int stride_idx_factor = is_fp4_kv ? 2 : 1;
+  bool const is_fp4_k = is_4bit(k_data_type);
+  bool const is_fp4_v = is_4bit(v_data_type);
+  int const k_stride_idx_factor = is_fp4_k ? 2 : 1;
+  int const v_stride_idx_factor = is_fp4_v ? 2 : 1;
 
   // FlashInfer/vLLM layout -> true; TRT-LLM layout -> false.
   // Default to flashinfer/vLLM layout.
@@ -457,20 +464,25 @@ void trtllm_paged_attention_decode(
   // Assume HND layout after Python-side transpose: [..., H, N, D]
   int page_size = key_cache.size(-2);
   int num_kv_heads = key_cache.size(-3);
-  int kv_stride_keys_values = key_cache.stride(-2) * stride_idx_factor;  // key/values
-  int kv_stride_heads = key_cache.stride(-3) * stride_idx_factor;        // head
-  int kv_stride_batch = key_cache.stride(0) * stride_idx_factor;         // batch
+  int k_stride_keys_values = key_cache.stride(-2) * k_stride_idx_factor;
+  int k_stride_heads = key_cache.stride(-3) * k_stride_idx_factor;
+  int k_stride_batch = key_cache.stride(0) * k_stride_idx_factor;
+  int v_stride_keys_values = value_cache.stride(-2) * v_stride_idx_factor;
+  int v_stride_heads = value_cache.stride(-3) * v_stride_idx_factor;
+  int v_stride_batch = value_cache.stride(0) * v_stride_idx_factor;
 
   // Query stride: [num_tokens, num_heads, head_dim]
   int q_stride_tokens = query.stride(0);  // stride between tokens
   int q_stride_heads = query.stride(1);   // stride between heads
 
   // kv block scales
-  if (is_fp4_kv) {
+  if (is_fp4_k) {
     TVM_FFI_ICHECK(key_block_scales.has_value())
-        << "key_block_scales must be provided for FP4 kv cache";
+        << "key_block_scales must be provided for an FP4 key cache";
+  }
+  if (is_fp4_v) {
     TVM_FFI_ICHECK(value_block_scales.has_value())
-        << "value_block_scales must be provided for FP4 kv cache";
+        << "value_block_scales must be provided for an FP4 value cache";
   }
   const void* k_block_scales_ptr =
       key_block_scales.has_value() ? key_block_scales.value().data_ptr() : nullptr;
@@ -578,13 +590,13 @@ void trtllm_paged_attention_decode(
       multi_ctas_kv_counter_buffer.numel() * get_element_size(multi_ctas_kv_counter_buffer),
       static_cast<int*>(block_tables.data_ptr()), k_block_scales_ptr, v_block_scales_ptr,
       static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
-      /*cum_seq_lens_kv*/ nullptr, attention_sinks_ptr, lse_ptr, q_data_type, kv_data_type,
-      o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len, max_kv_len,
+      /*cum_seq_lens_kv*/ nullptr, attention_sinks_ptr, lse_ptr, q_data_type, k_data_type,
+      v_data_type, o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len, max_kv_len,
       num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q, head_dim_o, page_size,
-      q_stride_tokens, q_stride_heads, kv_stride_keys_values, kv_stride_heads, kv_stride_batch,
-      max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr,
-      bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
-      sparse_mla_top_k,
+      q_stride_tokens, q_stride_heads, k_stride_keys_values, k_stride_heads, k_stride_batch,
+      v_stride_keys_values, v_stride_heads, v_stride_batch, max_num_blocks_per_seq,
+      bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale,
+      o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q, sparse_mla_top_k,
       /*sliding_window_kv_pool=*/
       is_single_pool_dynamic_sparse_mla ? key_cache.data_ptr() : nullptr, sparse_mla_top_k_lens_ptr,
       /*has_sliding_window_kv_pool=*/is_single_pool_dynamic_sparse_mla,
@@ -608,14 +620,23 @@ void trtllm_paged_attention_context(
     Optional<bool> use_fp16_softmax, Optional<bool> uses_spcompress, bool is_causal,
     Optional<TensorView> lse, int64_t lse_stride_tokens, int64_t lse_stride_heads) {
   auto q_data_type = dl_dtype_to_tllm_data_type(query.dtype());
-  auto kv_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
+  auto k_data_type = dl_dtype_to_tllm_data_type(key_cache.dtype());
+  auto v_data_type = dl_dtype_to_tllm_data_type(value_cache.dtype());
   auto o_data_type = dl_dtype_to_tllm_data_type(out.dtype());
+  // FlashInfer/vLLM uses one page index for K and V by default. TRT-LLM's
+  // separate layout permits independently sized K/V pools and page tables.
+  bool const uses_shared_paged_kv_idx_value = uses_shared_paged_kv_idx.value_or(true);
+  TVM_FFI_ICHECK_EQ(key_cache.ndim(), value_cache.ndim());
+  int const first_matching_dim = uses_shared_paged_kv_idx_value ? 0 : 1;
+  for (int i = first_matching_dim; i < key_cache.ndim() - 1; i++) {
+    TVM_FFI_ICHECK_EQ(key_cache.size(i), value_cache.size(i));
+  }
   int num_qo_heads = query.size(1);
   int sum_seq_q = query.size(0);
   // Multiply by two for FP4 tensor as it is stored as UINT8 dtype. Assume the dim is even.
-  int head_dim_k = is_4bit(kv_data_type) ? key_cache.size(-1) * 2 : key_cache.size(-1);
+  int head_dim_k = is_4bit(k_data_type) ? key_cache.size(-1) * 2 : key_cache.size(-1);
   int head_dim_q = is_4bit(q_data_type) ? query.size(-1) * 2 : query.size(-1);
-  int head_dim_v = is_4bit(kv_data_type) ? value_cache.size(-1) * 2 : value_cache.size(-1);
+  int head_dim_v = is_4bit(v_data_type) ? value_cache.size(-1) * 2 : value_cache.size(-1);
   int head_dim_o = is_4bit(o_data_type) ? out.size(-1) * 2 : out.size(-1);
   TVM_FFI_ICHECK_EQ(head_dim_k, head_dim_q)
       << "head_dim_k and head_dim_q must be the same, got " << std::to_string(head_dim_k) << " and "
@@ -625,31 +646,35 @@ void trtllm_paged_attention_context(
       << std::to_string(head_dim_o);
   int max_num_blocks_per_seq = block_tables.size(-1);
   bool is_shared_kv = key_cache.data_ptr() == value_cache.data_ptr();
-  int num_pages_in_mem_pool = is_shared_kv ? key_cache.size(0) : key_cache.size(0) * 2;
-  bool is_fp4_kv = is_4bit(kv_data_type);
-  int stride_idx_factor = is_fp4_kv ? 2 : 1;
-
-  // FlashInfer/vLLM layout -> true; TRT-LLM layout -> false.
-  // Default to flashinfer/vLLM layout.
-  bool const uses_shared_paged_kv_idx_value = uses_shared_paged_kv_idx.value_or(true);
+  int num_pages_in_mem_pool =
+      is_shared_kv ? key_cache.size(0) : std::max(key_cache.size(0), value_cache.size(0)) * 2;
+  bool const is_fp4_k = is_4bit(k_data_type);
+  bool const is_fp4_v = is_4bit(v_data_type);
+  int const k_stride_idx_factor = is_fp4_k ? 2 : 1;
+  int const v_stride_idx_factor = is_fp4_v ? 2 : 1;
 
   // Assume HND layout after Python-side transpose: [..., H, N, D]
   int page_size = key_cache.size(-2);
   int num_kv_heads = key_cache.size(-3);
-  int kv_stride_keys_values = key_cache.stride(-2) * stride_idx_factor;  // key/values
-  int kv_stride_heads = key_cache.stride(-3) * stride_idx_factor;        // head
-  int kv_stride_batch = key_cache.stride(0) * stride_idx_factor;         // batch
+  int k_stride_keys_values = key_cache.stride(-2) * k_stride_idx_factor;
+  int k_stride_heads = key_cache.stride(-3) * k_stride_idx_factor;
+  int k_stride_batch = key_cache.stride(0) * k_stride_idx_factor;
+  int v_stride_keys_values = value_cache.stride(-2) * v_stride_idx_factor;
+  int v_stride_heads = value_cache.stride(-3) * v_stride_idx_factor;
+  int v_stride_batch = value_cache.stride(0) * v_stride_idx_factor;
 
   // Query stride: [num_tokens, num_heads, head_dim]
   int q_stride_tokens = query.stride(0);  // stride between tokens
   int q_stride_heads = query.stride(1);   // stride between heads
 
   // kv block scales
-  if (is_fp4_kv) {
+  if (is_fp4_k) {
     TVM_FFI_ICHECK(key_block_scales.has_value())
-        << "key_block_scales must be provided for FP4 kv cache";
+        << "key_block_scales must be provided for an FP4 key cache";
+  }
+  if (is_fp4_v) {
     TVM_FFI_ICHECK(value_block_scales.has_value())
-        << "value_block_scales must be provided for FP4 kv cache";
+        << "value_block_scales must be provided for an FP4 value cache";
   }
   const void* k_block_scales_ptr =
       key_block_scales.has_value() ? key_block_scales.value().data_ptr() : nullptr;
@@ -725,12 +750,13 @@ void trtllm_paged_attention_context(
       static_cast<int*>(seq_lens.data_ptr()),
       /*cum_seq_lens_q=*/static_cast<int*>(cum_seq_lens_q.data_ptr()),
       /*cum_seq_lens_kv=*/static_cast<int*>(cum_seq_lens_kv.data_ptr()), attention_sinks_ptr,
-      lse_ptr, q_data_type, kv_data_type, o_data_type, TllmPagedAttentionMode::Context, batch_size,
-      max_q_len, max_kv_len, num_pages_in_mem_pool, num_qo_heads, num_kv_heads, head_dim_q,
-      head_dim_o, page_size, q_stride_tokens, q_stride_heads, kv_stride_keys_values,
-      kv_stride_heads, kv_stride_batch, max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value,
-      bmm1_scale_log2_ptr, bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left,
-      sum_seq_q, /*sparse_mla_top_k=*/0, /*sliding_window_kv_pool=*/nullptr,
+      lse_ptr, q_data_type, k_data_type, v_data_type, o_data_type, TllmPagedAttentionMode::Context,
+      batch_size, max_q_len, max_kv_len, num_pages_in_mem_pool, num_qo_heads, num_kv_heads,
+      head_dim_q, head_dim_o, page_size, q_stride_tokens, q_stride_heads, k_stride_keys_values,
+      k_stride_heads, k_stride_batch, v_stride_keys_values, v_stride_heads, v_stride_batch,
+      max_num_blocks_per_seq, bmm1_scale_value, bmm2_scale_value, bmm1_scale_log2_ptr,
+      bmm2_scale_ptr, o_sf_scale, o_sf_vec_size, o_sf_start_index, window_left, sum_seq_q,
+      /*sparse_mla_top_k=*/0, /*sliding_window_kv_pool=*/nullptr,
       /*sparse_mla_top_k_lens=*/nullptr, /*has_sliding_window_kv_pool=*/false,
       skip_softmax_threshold_scale_factor_value, skips_softmax, uses_shared_paged_kv_idx_value,
       /*enable_block_sparse_attention=*/false, sm_count, enable_pdl, workspace_size,
@@ -1140,10 +1166,11 @@ void trtllm_paged_attention_decode_sparse_mla_dsv4(
       sparse_indices_ptr, /*k_block_scales_ptr=*/nullptr,
       /*v_block_scales_ptr=*/nullptr, static_cast<int*>(seq_lens.data_ptr()), cum_seq_lens_q_ptr,
       /*cum_seq_lens_kv=*/nullptr, attention_sinks_ptr, /*lse=*/nullptr, q_data_type, kv_data_type,
-      o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,
+      kv_data_type, o_data_type, TllmPagedAttentionMode::ForGen, batch_size, max_q_len,
       /*max_kv_len=*/sparse_mla_top_k, sparse_num_pages_in_mem_pool, num_qo_heads, num_kv_heads,
       head_dim_q, head_dim_o, sparse_page_size, q_stride_tokens, q_stride_heads,
-      kv_stride_keys_values, kv_stride_heads, sparse_kv_stride_batch,
+      kv_stride_keys_values, kv_stride_heads, sparse_kv_stride_batch, kv_stride_keys_values,
+      kv_stride_heads, sparse_kv_stride_batch,
       /*max_num_blocks_per_seq=*/sparse_mla_top_k, bmm1_scale_value, bmm2_scale_value,
       bmm1_scale_log2_ptr, bmm2_scale_ptr,
       /*o_sf_scale=*/-1.0, /*o_sf_vec_size=*/-1, /*o_sf_start_index=*/0,

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -3215,7 +3215,7 @@ def trtllm_batch_decode_with_kv_cache(
     max_q_len: Optional[int] = None,
     cum_seq_lens_q: Optional[torch.Tensor] = None,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
-    kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    kv_cache_sf: Optional[Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]] = None,
     uses_shared_paged_kv_idx: bool = True,
     lse: Optional[torch.Tensor] = None,
     return_lse: bool = False,
@@ -3238,9 +3238,11 @@ def trtllm_batch_decode_with_kv_cache(
     kv_cache : Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
         If kv_cache is a single tensor, it should be a tensor with shape [num_pages, 1 or 2, num_kv_heads, page_size, head_dim] if :attr:`kv_layout` is ``HND``,
         or [num_pages, 1 or 2, page_size, num_kv_heads, head_dim] if :attr:`kv_layout` is ``NHD``.
-        If kv_cache is a tuple of two tensors, it should be a tuple of two tensors with shape [num_pages, num_kv_heads, page_size, head_dim] if :attr:`kv_layout` is ``HND``,
-        or [num_pages, page_size, num_kv_heads, head_dim] if :attr:`kv_layout` is ``NHD``.
-        The first tensor is the key cache, and the second tensor is the value cache.
+        If kv_cache is a tuple, its K and V tensors must have matching page, head, and token
+        dimensions. Their physical last dimensions may differ for mixed formats, but their logical
+        head dimensions after unpacking (for example, two FP4 values per byte) must match the query
+        and output head dimensions. The layout is ``[num_pages, num_kv_heads, page_size, ...]`` for
+        ``HND`` or ``[num_pages, page_size, num_kv_heads, ...]`` for ``NHD``.
 
         **Contiguity requirements (trtllm-gen backend):**
 
@@ -3349,10 +3351,11 @@ def trtllm_batch_decode_with_kv_cache(
         Setting the threshold to a higher value generally increases kernel performance at the cost of accuracy degradation.
         The actual threshold value equals the provided threshold_scale_factor divided by the context length.
 
-    kv_cache_sf : Optional[Tuple[torch.Tensor, torch.Tensor]] = None
+    kv_cache_sf : Optional[Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]] = None
         Per-block scale factors for NVFP4 KV cache, as a tuple of ``(k_scales, v_scales)``.
-        Each scale tensor has shape ``[num_pages, num_kv_heads, page_size, head_dim // 16]``
-        in HND layout, with dtype ``torch.float8_e4m3fn``.
+        Use ``None`` for an operand that is not NVFP4. Each provided scale tensor has shape
+        ``[num_pages, num_kv_heads, page_size, head_dim // 16]`` in HND layout, with dtype
+        ``torch.float8_e4m3fn``.
 
         **Contiguity requirements (trtllm-gen backend):**
 
@@ -3473,28 +3476,23 @@ def trtllm_batch_decode_with_kv_cache(
             raise ValueError("KV Cache NVFP4 is not supported on SM107")
         if kv_cache_sf is None:
             raise ValueError("kv_cache_sf must be provided for NVFP4 KV cache.")
-    is_nvfp4_kvcache = (
-        k_cache.dtype == torch.uint8
-        and v_cache.dtype == torch.uint8
-        and kv_cache_sf is not None
-    )
+    is_nvfp4_k_cache = k_cache.dtype == torch.uint8
+    is_nvfp4_v_cache = v_cache.dtype == torch.uint8
+    is_fp8_k_nvfp4_v = k_cache.dtype == torch.float8_e4m3fn and is_nvfp4_v_cache
 
     k_block_scales = None
     v_block_scales = None
-    if is_nvfp4_kvcache:
-        if (
-            not isinstance(kv_cache_sf, (tuple, list))
-            or len(kv_cache_sf) != 2
-            or not all(torch.is_tensor(x) for x in kv_cache_sf)
-        ):
-            raise TypeError(
-                "kv_cache_sf must be a tuple/list of two tensors: (k_scales, v_scales)."
-            )
+    if kv_cache_sf is not None:
+        if not isinstance(kv_cache_sf, (tuple, list)) or len(kv_cache_sf) != 2:
+            raise TypeError("kv_cache_sf must be a tuple/list: (k_scales, v_scales).")
         k_block_scales, v_block_scales = kv_cache_sf
-        assert (
-            k_block_scales.dtype == torch.float8_e4m3fn
-            and v_block_scales.dtype == torch.float8_e4m3fn
-        ), "kv_cache_sf tensors should be float8 dtype."
+    if is_nvfp4_k_cache and k_block_scales is None:
+        raise ValueError("k_scales must be provided for an NVFP4 key cache.")
+    if is_nvfp4_v_cache and v_block_scales is None:
+        raise ValueError("v_scales must be provided for an NVFP4 value cache.")
+    for scale in (k_block_scales, v_block_scales):
+        if scale is not None and scale.dtype != torch.float8_e4m3fn:
+            raise TypeError("NVFP4 KV block scales must use torch.float8_e4m3fn.")
 
     dcp_spec_enabled = causal_seqlens_kv_global is not None
     if not dcp_spec_enabled and (cp_world != 1 or cp_rank != 0):
@@ -3516,7 +3514,7 @@ def trtllm_batch_decode_with_kv_cache(
             raise ValueError(
                 "DCP speculative decode currently requires kv_layout='HND'"
             )
-        if is_nvfp4_kvcache or kv_cache_sf is not None:
+        if is_nvfp4_k_cache or is_nvfp4_v_cache or kv_cache_sf is not None:
             raise ValueError(
                 "DCP speculative decode supports BF16 or FP8 e4m3 KV cache, "
                 "but not NVFP4 or block scale tensors"
@@ -3627,6 +3625,8 @@ def trtllm_batch_decode_with_kv_cache(
         )
 
     if backend == "xqa":
+        if k_cache.dtype != v_cache.dtype:
+            raise ValueError("xqa backend requires K and V to use the same dtype")
         # xqa backend doesn't support nvfp4 output
         if out_dtype == "nvfp4" or (out_dtype is None and isinstance(out, FP4Tensor)):
             raise ValueError("xqa backend does not support nvfp4 output")
@@ -3674,15 +3674,18 @@ def trtllm_batch_decode_with_kv_cache(
         if kv_layout == "NHD":
             k_cache = k_cache.transpose(-3, -2)
             v_cache = v_cache.transpose(-3, -2)
-            if is_nvfp4_kvcache:
+            if is_nvfp4_k_cache:
+                k_cache = k_cache.contiguous()
+                assert k_block_scales is not None
+                k_block_scales = k_block_scales.transpose(-3, -2).contiguous()
+            if is_nvfp4_v_cache:
                 print(
                     "[WARNING] NVFP4 KV cache with NHD layout will be converted to HND, "
                     "incurring extra transpose and contiguous copy overhead. "
                     "Use kv_layout='HND' for better performance."
                 )
-                k_cache = k_cache.contiguous()
                 v_cache = v_cache.contiguous()
-                k_block_scales = k_block_scales.transpose(-3, -2).contiguous()
+                assert v_block_scales is not None
                 v_block_scales = v_block_scales.transpose(-3, -2).contiguous()
 
         run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_decode
@@ -3778,6 +3781,43 @@ def trtllm_batch_decode_with_kv_cache(
             bf16q_fp8kv_transform_mode_value = _get_bf16q_fp8kv_transform_mode(
                 bf16q_fp8kv_transform_mode
             )
+
+        if is_fp8_k_nvfp4_v:
+            if query.dtype != torch.float8_e4m3fn:
+                raise ValueError("FP8-K/NVFP4-V decode requires FP8 query")
+            if out_dtype != torch.bfloat16:
+                raise ValueError("FP8-K/NVFP4-V decode requires BF16 output")
+            if kv_layout != "HND":
+                raise ValueError("FP8-K/NVFP4-V decode currently requires HND layout")
+            head_dim = query.shape[-1]
+            if (
+                head_dim not in (128, 256)
+                or k_cache.shape[-1] != head_dim
+                or v_cache.shape[-1] * 2 != head_dim
+            ):
+                raise ValueError(
+                    "FP8-K/NVFP4-V decode requires matching head dimensions "
+                    "of 128 or 256"
+                )
+            if k_cache.shape[-2] != 64:
+                raise ValueError("FP8-K/NVFP4-V decode requires page size 64")
+            if q_len_per_req != 1:
+                raise ValueError(
+                    "FP8-K/NVFP4-V decode currently requires q_len_per_req=1"
+                )
+            if (
+                window_left != -1
+                or not uses_shared_paged_kv_idx
+                or enable_block_sparse_attention
+                or skip_softmax_threshold_scale_factor is not None
+                or sinks is not None
+                or return_lse
+                or lse is not None
+            ):
+                raise ValueError(
+                    "FP8-K/NVFP4-V decode does not yet support sliding-window, "
+                    "separate page indices, sparse/skip-softmax, sinks, or LSE features"
+                )
 
         bmm1_scale = _get_trtllm_gen_bmm1_scale_arg(
             bmm1_scale, bmm1_scale_log2, query.device

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -5710,7 +5710,10 @@ def trtllm_batch_context_with_kv_cache(
     enable_pdl: Optional[bool] = None,
     sinks: Optional[List[torch.Tensor]] = None,
     kv_cache_sf: Optional[
-        Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+        Union[
+            torch.Tensor,
+            Tuple[Optional[torch.Tensor], Optional[torch.Tensor]],
+        ]
     ] = None,
     skip_softmax_threshold_scale_factor: Optional[float] = None,
     uses_shared_paged_kv_idx: bool = True,
@@ -5793,6 +5796,7 @@ def trtllm_batch_context_with_kv_cache(
         * a tuple ``(k_scales, v_scales)`` of 4-D tensors, each following
           :attr:`kv_layout`: ``[num_pages, num_kv_heads, page_size, head_dim // 16]`` for
           HND, or ``[num_pages, page_size, num_kv_heads, head_dim // 16]`` for NHD.
+          Either entry may be ``None`` when that cache uses a non-NVFP4 dtype.
         * a single 5-D tensor with shape ``[num_pages, 2, ...]`` matching the layout of
           ``kv_cache``, split on dim 1 to yield k (index 0) and v (index 1) scales.
 
@@ -5886,17 +5890,30 @@ def trtllm_batch_context_with_kv_cache(
             raise ValueError("KV Cache NVFP4 is not supported on SM107")
         if kv_cache_sf is None:
             raise ValueError("kv_cache_sf must be provided for NVFP4 KV cache.")
-    key_block_scales, value_block_scales = (
-        _unpack_paged_kv_cache(kv_cache_sf, kv_layout)
-        if kv_cache_sf is not None
-        else (None, None)
+    key_block_scales = None
+    value_block_scales = None
+    if kv_cache_sf is not None:
+        if isinstance(kv_cache_sf, (tuple, list)):
+            if len(kv_cache_sf) != 2:
+                raise ValueError("kv_cache_sf must contain K and V scales")
+            key_block_scales, value_block_scales = kv_cache_sf
+        else:
+            key_block_scales, value_block_scales = _unpack_paged_kv_cache(
+                kv_cache_sf, kv_layout
+            )
+    if k_cache.dtype == torch.uint8 and key_block_scales is None:
+        raise ValueError("k_scales must be provided for an NVFP4 key cache")
+    if v_cache.dtype == torch.uint8 and value_block_scales is None:
+        raise ValueError("v_scales must be provided for an NVFP4 value cache")
+    is_fp8_k_nvfp4_v = (
+        k_cache.dtype == torch.float8_e4m3fn and v_cache.dtype == torch.uint8
     )
 
     # Convert NHD layout to HND if necessary
     if kv_layout == "NHD":
         k_cache = k_cache.transpose(-3, -2)
         v_cache = v_cache.transpose(-3, -2)
-        if key_block_scales is not None:
+        if key_block_scales is not None or value_block_scales is not None:
             print(
                 "[WARNING] NVFP4 KV cache with NHD layout will be converted to HND, "
                 "incurring extra transpose and contiguous copy overhead. "
@@ -5904,8 +5921,10 @@ def trtllm_batch_context_with_kv_cache(
             )
             k_cache = k_cache.contiguous()
             v_cache = v_cache.contiguous()
-            key_block_scales = key_block_scales.transpose(-3, -2).contiguous()
-            value_block_scales = value_block_scales.transpose(-3, -2).contiguous()
+            if key_block_scales is not None:
+                key_block_scales = key_block_scales.transpose(-3, -2).contiguous()
+            if value_block_scales is not None:
+                value_block_scales = value_block_scales.transpose(-3, -2).contiguous()
 
     run_func = get_trtllm_gen_fmha_module().trtllm_paged_attention_context
     sm_count = get_device_sm_count(query.device)
@@ -5981,6 +6000,36 @@ def trtllm_batch_context_with_kv_cache(
         check_shape_dtype_device(out, query.shape, out_dtype, query.device, "out")
     else:
         raise ValueError(f"Invalid out_dtype: {out_dtype}")
+
+    if is_fp8_k_nvfp4_v:
+        if query.dtype != torch.float8_e4m3fn or out_dtype != torch.bfloat16:
+            raise ValueError("FP8-K/NVFP4-V context requires FP8 query and BF16 output")
+        if kv_layout != "HND":
+            raise ValueError("FP8-K/NVFP4-V context currently requires HND layout")
+        head_dim = query.shape[-1]
+        if (
+            head_dim not in (128, 256)
+            or k_cache.shape[-1] != head_dim
+            or v_cache.shape[-1] * 2 != head_dim
+            or k_cache.shape[-2] != 64
+        ):
+            raise ValueError(
+                "FP8-K/NVFP4-V context requires matching head dimensions "
+                "of 128 or 256 and page size 64"
+            )
+        if (
+            not causal
+            or window_left != -1
+            or not uses_shared_paged_kv_idx
+            or skip_softmax_threshold_scale_factor is not None
+            or sinks is not None
+            or return_lse
+            or lse is not None
+        ):
+            raise ValueError(
+                "FP8-K/NVFP4-V context does not yet support non-causal, sliding-window, "
+                "separate page indices, skip-softmax, sinks, or LSE features"
+            )
 
     if isinstance(bmm1_scale, torch.Tensor):
         assert bmm1_scale.dtype == torch.float32

--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -235,7 +235,7 @@ class TllmGenFmhaKernel {
   }
 
   inline bool supportsGqaGroupingTokensHeadsQ(SelectKernelParams const& selectKernelParams) const {
-    return mDtypeQ == mDtypeK ||
+    return (mDtypeQ == mDtypeK && mDtypeK == mDtypeV) ||
            (isBf16QFp8KvGeneration() &&
             selectKernelParams.mBf16QFp8KvTransformMode != Bf16QFp8KvTransformMode::Full);
   }
@@ -689,9 +689,13 @@ class TllmGenFmhaKernel {
 
       // Enable the CgaSmemReduction if the numCtasPerSeqKv <= 16 as the maximum cluster dimension
       // is 16. Only the swapsMmaAbForGeneration kernel supports the CgaSmemReduction for now.
-      // Other headDimV >= 512 shapes remain excluded because the cubin inventory is incomplete,
-      // and tileSizeQ >= 32 CGA variants can exceed the device shared-memory limit.
-      if (useCgaSmemReduction && numCtasPerSeqKv > 1 && numCtasPerSeqKv <= 16 &&
+      // SM103 cannot launch the H128 FP8-K/NVFP4-V Swaps CGA kernels: their measured
+      // shared-memory requirement exceeds the 228 KiB per-block limit. Keep the launch on the
+      // equivalent global-memory reduction path, which is exported for the same selector shape.
+      bool const supportsCgaSmemReduction = !(mSM == kSM_103 && mDtypeK == DATA_TYPE_E4M3 &&
+                                              mDtypeV == DATA_TYPE_E2M1 && params.mHeadDimV == 128);
+      if (useCgaSmemReduction && supportsCgaSmemReduction && numCtasPerSeqKv > 1 &&
+          numCtasPerSeqKv <= 16 &&
           isSwapsMmaAbForGenerationKernel(selectKernelParams.mKernelType) &&
           isGmemReduction(selectKernelParams.mMultiCtasKvMode) &&
           !selectKernelParams.mForceGmemReduction) {
@@ -1115,8 +1119,8 @@ class TllmGenFmhaKernel {
     int& tileSizeQ = selectKernelParams.mTileSizeQ;
     selectKernelParams.mGroupsTokensHeadsQ = false;
 
-    // Generic mixed precision kernels don't work with groupsTokensHeadsQ = true. BF16Q+FP8KV
-    // transform paths present BF16 K to BMM1, so they can use the grouped-token cubins.
+    // Generic mixed K/V kernels don't work with groupsTokensHeadsQ = true. BF16Q+FP8KV
+    // transform paths present BF16 K and V to the MMAs, so they can use grouped-token cubins.
     if (!supportsGqaGroupingTokensHeadsQ(selectKernelParams)) {
       selectKernelParams.mGroupsTokensHeadsQ = false;
       tileSizeQ = params.mNumHeadsQPerKv <= 8 ? 8 : 16;

--- a/include/flashinfer/trtllm/fmha/kernelParams.h
+++ b/include/flashinfer/trtllm/fmha/kernelParams.h
@@ -40,6 +40,39 @@ using FastModDivInt32 = cuda::fast_mod_div<int32_t>;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 using Dtype = Data_type;
 
+template <typename KernelMeta>
+auto enablesBf16QFp8KvKOnlyTransform(KernelMeta const& kernelMeta, int)
+    -> decltype(kernelMeta.mEnablesBf16QFp8KvKOnlyTransform) {
+  return kernelMeta.mEnablesBf16QFp8KvKOnlyTransform;
+}
+
+template <typename KernelMeta>
+bool enablesBf16QFp8KvKOnlyTransform(KernelMeta const&, long) {
+  return false;
+}
+
+template <typename KernelMeta>
+auto usesSeparateTransformedKv(KernelMeta const& kernelMeta, int)
+    -> decltype(kernelMeta.mSeparateTransformedKv) {
+  return kernelMeta.mSeparateTransformedKv;
+}
+
+template <typename KernelMeta>
+bool usesSeparateTransformedKv(KernelMeta const&, long) {
+  return false;
+}
+
+template <typename KernelMeta>
+auto storesTransformedKvInTmem(KernelMeta const& kernelMeta, int)
+    -> decltype(kernelMeta.mStoreTransformedKvInTmem) {
+  return kernelMeta.mStoreTransformedKvInTmem;
+}
+
+template <typename KernelMeta>
+bool storesTransformedKvInTmem(KernelMeta const&, long) {
+  return false;
+}
+
 struct KernelParams {
   // TMA descriptor for Q.
   CUtensorMap tmaQ_;
@@ -199,6 +232,9 @@ struct KernelParams {
   // Whether the indices for K & V pages are shared as unified index.
   // true -> vLLM/FlashInfer; false -> TRT-LLM.
   bool mUsesSharedPagedKvIdx{true};
+
+  // FlashInfer does not enable runtime skip correction.
+  float mSkipCorrThreshold{0.f};
 
   // Create the TMA shape/stride for Q.
   template <class FmhaOptions>
@@ -702,26 +738,48 @@ struct KernelParams {
     int32_t numKeysPerTile = isPagedKv(options.mQkvLayout)
                                  ? std::min(options.mNumTokensPerPage, kernelMeta.mTileSizeKv)
                                  : kernelMeta.mTileSizeKv;
-    // The number of elements in 128B for Q.
-    int32_t numEltsIn128BKv = (128 * 8) / get_size_in_bits(kernelMeta.mDataTypeK);
-    // The number of head elts (per token) in each block of shared memory (see above explanation).
+    auto getNumEltsInClampedHeadDim = [](Data_type dtype, int32_t headDim) {
+      int32_t const numEltsIn128B = (128 * 8) / get_size_in_bits(dtype);
+      return std::min({numEltsIn128B, headDim, 128});
+    };
+    int32_t const numEltsInClampedHeadDimK =
+        getNumEltsInClampedHeadDim(kernelMeta.mDataTypeK, options.mHeadDimQk);
+    int32_t const numEltsInClampedHeadDimV =
+        getNumEltsInClampedHeadDim(kernelMeta.mDataTypeV, options.mHeadDimV);
 
-    // HeadDim will be split into multiple headDimStages (128) if maxHeadDimKv > 128.
-    int32_t numEltsInClampedHeadDimKv = std::min({numEltsIn128BKv, maxHeadDimKv, 128});
-
-    // Do we have to transform K/V before MMA?
-    bool const transformsKv{kernelMeta.mDataTypeK != kernelMeta.mDataTypeQ};
+    // Determine the operand dtypes presented to BMM1 and BMM2.
+    Data_type dtypeBmm2 = kernelMeta.mDataTypeK != kernelMeta.mDataTypeQ ? kernelMeta.mDataTypeQ
+                                                                         : kernelMeta.mDataTypeV;
+    if (kernelMeta.mDataTypeK == DATA_TYPE_E4M3 && kernelMeta.mDataTypeV == DATA_TYPE_E2M1) {
+      dtypeBmm2 = DATA_TYPE_E4M3;
+    }
+    if (enablesBf16QFp8KvKOnlyTransform(kernelMeta, 0)) {
+      dtypeBmm2 = kernelMeta.mDataTypeV;
+    }
+    bool const transformsK{
+        kernelMeta.mDataTypeK != kernelMeta.mDataTypeQ ||
+        (usesSeparateTransformedKv(kernelMeta, 0) && kernelMeta.mDataTypeQ == DATA_TYPE_E4M3 &&
+         kernelMeta.mDataTypeK == DATA_TYPE_E4M3 && kernelMeta.mDataTypeV == DATA_TYPE_E2M1)};
+    bool const transformsV{kernelMeta.mDataTypeV != dtypeBmm2};
     // Whether store transformed K/V in TMEM.
     bool const isSwapsMmaAb =
         isSwapsMmaAbForGenerationKernel(static_cast<FmhaKernelType>(kernelMeta.mKernelType));
-    bool const storeTransformedKvInTmem{kernelMeta.mDataTypeKv == DATA_TYPE_E2M1 &&
-                                        kernelMeta.mDataTypeQ == DATA_TYPE_E4M3 &&
-                                        maxHeadDimKv >= 128 && isSwapsMmaAb};
+    // Older homogeneous NVFP4 packages predate the capability bit. Mixed-KV kernels must opt in:
+    // their inventory includes schedules that still consume packed V from SMEM.
+    bool const usesLegacyHomogeneousNvFp4Tmem{kernelMeta.mDataTypeKv == DATA_TYPE_E2M1 &&
+                                              kernelMeta.mDataTypeQ == DATA_TYPE_E4M3 &&
+                                              maxHeadDimKv >= 128 && isSwapsMmaAb};
+    bool const storeTransformedKvInTmem{usesLegacyHomogeneousNvFp4Tmem ||
+                                        storesTransformedKvInTmem(kernelMeta, 0)};
     // Whether swizzle is needed for K/V.
-    bool const swizzleKv{storeTransformedKvInTmem || !transformsKv};
+    bool const swizzleK{storeTransformedKvInTmem || !transformsK};
+    bool const swizzleV{storeTransformedKvInTmem || !transformsV};
+    bool const separateSmemKv{
+        (kernelMeta.mDataTypeK == DATA_TYPE_E4M3 && kernelMeta.mDataTypeV == DATA_TYPE_E2M1) ||
+        transformsK != transformsV};
     // Whether we can reshape the TMA box for K/V to widen it to 128B.
     bool const canReshapeTmaKv{isPagedKv(options.mQkvLayout) &&
-                               options.mHeadDimQk == options.mHeadDimV && !swizzleKv &&
+                               options.mHeadDimQk == options.mHeadDimV && !swizzleK && !swizzleV &&
                                canUseTmaKvReshape(options, kernelMeta.mDataTypeK, /*isK*/ true) &&
                                canUseTmaKvReshape(options, kernelMeta.mDataTypeV, /*isK*/ false)};
     // The reshape factor for K/V TMA box: aim for 128B box width.
@@ -745,13 +803,17 @@ struct KernelParams {
     auto [shapeV, strideV] =
         makeTmaShapeStrideKv(options, params, kernelMeta.mDataTypeV,
                              /*isK*/ false, storeTransformedKvInTmem, reshapeFactorKv);
-    // Note that for FP4 KV input, elements are stored as uint8_t, each packs 2 FP4 elements.
-    auto const numEltsDivisor =
-        kernelMeta.mDataTypeKv == DATA_TYPE_E2M1 && !storeTransformedKvInTmem ? 2 : 1;
-    // The tileShapes for K/V.
-    std::vector<uint32_t> tileShapeKv(shapeK.size(), 1);
-    tileShapeKv[0] = numEltsInClampedHeadDimKv / numEltsDivisor * reshapeFactorKv;
-    tileShapeKv[1] = numKeysPerTile / reshapeFactorKv;
+    // FP4 values are packed two per byte. Build the K/V boxes independently so kernels with
+    // separate raw-K/V pipelines preserve the compact V cache instead of padding it to K's size.
+    int32_t const numEltsDivisorK =
+        kernelMeta.mDataTypeK == DATA_TYPE_E2M1 && !storeTransformedKvInTmem ? 2 : 1;
+    int32_t const numEltsDivisorV =
+        kernelMeta.mDataTypeV == DATA_TYPE_E2M1 && !storeTransformedKvInTmem ? 2 : 1;
+    std::vector<uint32_t> tileShapeK(shapeK.size(), 1);
+    std::vector<uint32_t> tileShapeV(shapeV.size(), 1);
+    tileShapeK[0] = numEltsInClampedHeadDimK / numEltsDivisorK * reshapeFactorKv;
+    tileShapeV[0] = numEltsInClampedHeadDimV / numEltsDivisorV * reshapeFactorKv;
+    tileShapeK[1] = tileShapeV[1] = numKeysPerTile / reshapeFactorKv;
 
     // If sparse MLA is enabled, the shape and stride for K need to be updated for 2D layout
     // (numTokensKvInPagedKv, headDimQk).
@@ -759,23 +821,21 @@ struct KernelParams {
       shapeK = std::vector<uint64_t>{static_cast<uint64_t>(options.mHeadDimQk),
                                      static_cast<uint64_t>(INT_MAX)};
       strideK = std::vector<uint64_t>{1, static_cast<uint64_t>(options.mHeadDimQk)};
-      tileShapeKv[1] = 1;
+      tileShapeK[1] = 1;
     }
-    // K and V might use different tileShapes.
-    std::vector<uint32_t> tileShapeK(tileShapeKv);
-    std::vector<uint32_t> tileShapeV(tileShapeKv);
-    if (!storeTransformedKvInTmem && kernelMeta.mDataTypeK != kernelMeta.mDataTypeV) {
+    if (!storeTransformedKvInTmem && !separateSmemKv &&
+        kernelMeta.mDataTypeK != kernelMeta.mDataTypeV) {
       // tileShapeKv is in dtypeK elements. When dtypeV != dtypeK, we need to express tileShapeV in
       // terms of dtypeV elements so the V TMA descriptor transfers the same number of bytes as K to
       // match barrier expectations.
-      tileShapeV[0] = tileShapeV[0] * get_size_in_bits(kernelMeta.mDataTypeK) /
+      tileShapeV[0] = tileShapeK[0] * get_size_in_bits(kernelMeta.mDataTypeK) /
                       get_size_in_bits(kernelMeta.mDataTypeV);
     }
 
     // Build tma descriptor for K.
     params.tmaK_ = buildNdTmaDescriptor(
         options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK, const_cast<void*>(kPtr),
-        /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
+        /*swizzled = */ swizzleK, /*unpack4b = */ storeTransformedKvInTmem);
 
     bool const useSparseMlaSlidingWindowKvPool = options.mHasSlidingWindowKvPool &&
                                                  options.isSparseMla() &&
@@ -784,41 +844,35 @@ struct KernelParams {
       params.tmaKSlidingWindowKvPool_ =
           buildNdTmaDescriptor(options, kernelMeta.mDataTypeK, shapeK, strideK, tileShapeK,
                                const_cast<void*>(options.slidingWindowKvPoolPtr),
-                               /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
+                               /*swizzled = */ swizzleK, /*unpack4b = */ storeTransformedKvInTmem);
     }
 
     params.tmaV_ = buildNdTmaDescriptor(
         options, kernelMeta.mDataTypeV, shapeV, strideV, tileShapeV, const_cast<void*>(vPtr),
-        /*swizzled = */ swizzleKv, /*unpack4b = */ storeTransformedKvInTmem);
+        /*swizzled = */ swizzleV, /*unpack4b = */ storeTransformedKvInTmem);
 
-    // If the KV dtype is E2m1, additional scaling factors are needed for dequant.
-    if (kernelMeta.mDataTypeKv == DATA_TYPE_E2M1) {
+    // E2M1 inputs need independent block-scale descriptors.
+    if (kernelMeta.mDataTypeK == DATA_TYPE_E2M1 || kernelMeta.mDataTypeV == DATA_TYPE_E2M1) {
       // The number of elements per SF.
       int32_t NumEltsPerSf = 16;
       // The reshape factor for K/V SF: aim for box width 128B, limit to numKeysPerTile.
       int32_t const reshapeFactorKvSf =
           std::min(128 / (maxHeadDimKv / NumEltsPerSf), numKeysPerTile);
-      // Compute the shape and stride for SF tensor.
-      // FIXME: assume K and V uses the same shape.
-      auto [shapeKvSf, strideKvSf] =
-          makeTmaShapeStrideKvSf(options, params, /*isK*/ true, reshapeFactorKvSf);
-
-      // The tileShapes for K/V.
-      std::vector<uint32_t> tileShapeKvSf(shapeKvSf.size(), 1);
-      tileShapeKvSf[0] = maxHeadDimKv / NumEltsPerSf * reshapeFactorKvSf;
-      tileShapeKvSf[1] = numKeysPerTile / reshapeFactorKvSf;
-
-      // The tile box is reshaped from (headDim / NumEltsPerSf, tileSizeKv) into
-      // (headDim / NumEltsPerSf * reshapeFactorKvSf, tileSizeKv / reshapeFactorKvSf).
-      // Build tma descriptor for K SF.
-      params.tmaKSf_ = buildNdTmaDescriptor(options, DATA_TYPE_E4M3, shapeKvSf, strideKvSf,
-                                            tileShapeKvSf, const_cast<void*>(options.kSfBasePtr),
-                                            /*swizzled = */ false);
-
-      // Build tma descriptor for V SF.
-      params.tmaVSf_ = buildNdTmaDescriptor(options, DATA_TYPE_E4M3, shapeKvSf, strideKvSf,
-                                            tileShapeKvSf, const_cast<void*>(options.vSfBasePtr),
-                                            /*swizzled = */ false);
+      auto buildSfDescriptor = [&](bool isK, void const* sfBasePtr) {
+        auto [shapeSf, strideSf] = makeTmaShapeStrideKvSf(options, params, isK, reshapeFactorKvSf);
+        std::vector<uint32_t> tileShapeSf(shapeSf.size(), 1);
+        int32_t const headDim = isK ? options.mHeadDimQk : options.mHeadDimV;
+        tileShapeSf[0] = headDim / NumEltsPerSf * reshapeFactorKvSf;
+        tileShapeSf[1] = numKeysPerTile / reshapeFactorKvSf;
+        return buildNdTmaDescriptor(options, DATA_TYPE_E4M3, shapeSf, strideSf, tileShapeSf,
+                                    const_cast<void*>(sfBasePtr), /*swizzled = */ false);
+      };
+      if (kernelMeta.mDataTypeK == DATA_TYPE_E2M1) {
+        params.tmaKSf_ = buildSfDescriptor(/*isK=*/true, options.kSfBasePtr);
+      }
+      if (kernelMeta.mDataTypeV == DATA_TYPE_E2M1) {
+        params.tmaVSf_ = buildSfDescriptor(/*isK=*/false, options.vSfBasePtr);
+      }
     }
 
     // Shape/stride for gmem tensor O.
@@ -921,6 +975,7 @@ struct KernelParams {
     params.mUseBlockSparseAttention = options.mUseBlockSparseAttention;
     // Whether the indices for K & V pages are shared as unified index (vLLM/FlashInfer).
     params.mUsesSharedPagedKvIdx = options.mUsesSharedPagedKvIdx;
+    params.mSkipCorrThreshold = 0.f;
     return params;
   }
 };

--- a/tests/attention/test_trtllm_gen_attention_decode.py
+++ b/tests/attention/test_trtllm_gen_attention_decode.py
@@ -170,7 +170,7 @@ def create_kv_cache(
     num_pages_per_seq = (max_seq_len + page_size - 1) // page_size
     num_pages = num_pages_per_seq * batch_size
     ref_kv_dtype_torch = DTYPE_MAP[ref_kv_dtype]
-    if kv_dtype not in ("fp8", "nvfp4"):
+    if kv_dtype not in ("fp8", "nvfp4", "fp8_k_nvfp4_v"):
         assert kv_dtype == ref_kv_dtype, (
             "kv_dtype and ref_kv_dtype must be the same for non-fp8/nvfp4 kv_cache"
         )
@@ -238,6 +238,18 @@ def create_kv_cache(
         kv_cache, kv_cache_sf, k_scale, v_scale = nvfp4_quantize_paged_kv_cache(
             k_cache, v_cache, kv_layout=kv_layout
         )
+    elif kv_dtype == "fp8_k_nvfp4_v":
+        k_cache, k_scale = to_float8(k_cache)
+        v_ref = v_cache
+        (_, v_cache), (_, v_sf), _, v_scale = nvfp4_quantize_paged_kv_cache(
+            v_cache, v_cache, kv_layout=kv_layout
+        )
+        ref_kv_cache = torch.stack(
+            [k_cache.to(ref_kv_dtype_torch) * k_scale, v_ref],
+            dim=1,
+        )
+        kv_cache = (k_cache, v_cache)
+        kv_cache_sf = (None, v_sf)
     else:
         k_scale = v_scale = 1.0
         ref_kv_cache = torch.stack([k_cache, v_cache], dim=1)
@@ -1266,6 +1278,207 @@ def test_trtllm_batch_decode(
         non_contiguous_query=non_contiguous_query,
         skips_softmax=skips_softmax,
         uses_shared_paged_kv_idx=uses_shared_paged_kv_idx,
+    )
+
+
+@pytest.mark.parametrize("kv_dtype", [torch.bfloat16, torch.float8_e4m3fn])
+def test_trtllm_decode_dcp_homogeneous_validation(kv_dtype: torch.dtype) -> None:
+    """Homogeneous DCP must reach its validation after mixed-KV dispatch."""
+    _skip_if_not_blackwell()
+    query = torch.empty(1, 4, 128, device=GPU_DEVICE, dtype=torch.bfloat16)
+    cache = torch.empty(1, 1, 64, 128, device=GPU_DEVICE, dtype=kv_dtype)
+    seq_lens = torch.ones(1, device=GPU_DEVICE, dtype=torch.int32)
+    with pytest.raises(ValueError, match="requires uniform q_len_per_req"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query,
+            (cache, cache),
+            torch.empty(1, device=GPU_DEVICE, dtype=torch.uint8),
+            torch.zeros(1, 1, device=GPU_DEVICE, dtype=torch.int32),
+            seq_lens,
+            1,
+            kv_layout="HND",
+            enable_pdl=False,
+            causal_seqlens_kv_global=seq_lens,
+            q_len_per_req=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "pages_per_seq",
+    [2, 8, 128],
+    ids=["one_cta_persistent", "cga", "multi_cta_gmem"],
+)
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize(
+    "head_group_size",
+    [4, 16, 64],
+    ids=["ungrouped_q8", "ungrouped_q16", "ungrouped_ratio64"],
+)
+def test_trtllm_batch_decode_fp8_k_nvfp4_v(
+    pages_per_seq: int, head_dim: int, head_group_size: int
+) -> None:
+    """Resolve and launch ungrouped mixed-KV FP8-query selector targets."""
+    _skip_if_not_blackwell()
+    torch.manual_seed(0)
+
+    batch_size = 2
+    page_size = 64
+    num_kv_heads = 4
+    num_qo_heads = num_kv_heads * head_group_size
+    num_pages = batch_size * pages_per_seq
+
+    query = torch.randn(
+        batch_size,
+        num_qo_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=GPU_DEVICE,
+    )
+    key = torch.randn(
+        num_pages,
+        num_kv_heads,
+        page_size,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=GPU_DEVICE,
+    )
+    value = torch.randn_like(key)
+
+    query_fp8, fp8_query_scale = to_float8(query)
+    query_input = query_fp8
+    query_scale = float(fp8_query_scale.item())
+    query_ref = query_fp8.bfloat16() * query_scale
+    key_fp8, key_scale = to_float8(key)
+    (_, value_fp4), (_, value_block_scales), _, value_scale = (
+        nvfp4_quantize_paged_kv_cache(value, value, kv_layout="HND")
+    )
+    assert key_fp8.element_size() == 1
+    assert value_fp4.element_size() == 1
+    assert key_fp8.shape[-1] == head_dim
+    assert value_fp4.shape[-1] == head_dim // 2
+
+    block_tables = torch.arange(
+        num_pages, dtype=torch.int32, device=GPU_DEVICE
+    ).reshape(batch_size, pages_per_seq)
+    max_seq_len = pages_per_seq * page_size
+    seq_lens = torch.tensor(
+        [max_seq_len - page_size, max_seq_len],
+        dtype=torch.int32,
+        device=GPU_DEVICE,
+    )
+    workspace = torch.zeros(workspace_size, dtype=torch.uint8, device=GPU_DEVICE)
+
+    output = flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+        query_input,
+        (key_fp8, value_fp4),
+        workspace,
+        block_tables,
+        seq_lens,
+        int(seq_lens.max().item()),
+        bmm1_scale=query_scale * float(key_scale.item()) / math.sqrt(head_dim),
+        bmm2_scale=value_scale,
+        out_dtype=torch.bfloat16,
+        backend="trtllm-gen",
+        kv_layout="HND",
+        kv_cache_sf=(None, value_block_scales),
+    )
+
+    key_ref = key_fp8.bfloat16() * key_scale
+    output_ref = []
+    for batch_idx, seq_len in enumerate(seq_lens.tolist()):
+        page_ids = block_tables[batch_idx, : math.ceil(seq_len / page_size)]
+        key_seq = (
+            key_ref[page_ids]
+            .permute(1, 0, 2, 3)
+            .reshape(num_kv_heads, -1, head_dim)[:, :seq_len]
+            .repeat_interleave(head_group_size, dim=0)
+            .float()
+        )
+        value_seq = (
+            value[page_ids]
+            .permute(1, 0, 2, 3)
+            .reshape(num_kv_heads, -1, head_dim)[:, :seq_len]
+            .repeat_interleave(head_group_size, dim=0)
+            .float()
+        )
+        logits = torch.einsum("hd,hnd->hn", query_ref[batch_idx].float(), key_seq)
+        probs = torch.softmax(logits / math.sqrt(head_dim), dim=-1)
+        output_ref.append(torch.einsum("hn,hnd->hd", probs, value_seq))
+    output_ref = torch.stack(output_ref)
+
+    cosine = torch.nn.functional.cosine_similarity(
+        output.float().reshape(-1), output_ref.reshape(-1), dim=0
+    )
+    assert cosine.item() > 0.97
+
+    graph_output = torch.empty_like(output)
+    bmm1_scale = query_scale * float(key_scale.item()) / math.sqrt(head_dim)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query_input,
+            (key_fp8, value_fp4),
+            workspace,
+            block_tables,
+            seq_lens,
+            max_seq_len,
+            bmm1_scale=bmm1_scale,
+            bmm2_scale=value_scale,
+            out=graph_output,
+            backend="trtllm-gen",
+            kv_layout="HND",
+            kv_cache_sf=(None, value_block_scales),
+        )
+    for _ in range(2):
+        graph.replay()
+        torch.testing.assert_close(graph_output, output, atol=0, rtol=0)
+
+    with pytest.raises(ValueError, match="q_len_per_req=1"):
+        flashinfer.decode.trtllm_batch_decode_with_kv_cache(
+            query_input,
+            (key_fp8, value_fp4),
+            workspace,
+            block_tables,
+            seq_lens,
+            int(seq_lens.max().item()),
+            bmm1_scale=query_scale * float(key_scale.item()) / math.sqrt(head_dim),
+            bmm2_scale=value_scale,
+            out_dtype=torch.bfloat16,
+            backend="trtllm-gen",
+            kv_layout="HND",
+            kv_cache_sf=(None, value_block_scales),
+            q_len_per_req=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "kv_dtype,o_dtype",
+    [("fp8", "bf16"), ("nvfp4", "fp8")],
+)
+def test_trtllm_batch_decode_coherent_quantized_artifact(
+    kv_dtype: str, o_dtype: str
+) -> None:
+    """Keep homogeneous kernels compatible with the mixed-KV artifact ABI."""
+    _skip_if_not_blackwell()
+    _test_trtllm_batch_decode(
+        "trtllm-gen",
+        "HND",
+        batch_size=2,
+        q_len_per_req=1,
+        page_size=64,
+        num_kv_heads=4,
+        head_grp_size=4,
+        window_left=-1,
+        q_dtype="fp8",
+        o_dtype=o_dtype,
+        kv_dtype=kv_dtype,
+        enable_pdl=None,
+        enable_sink=False,
+        max_in_kv_len=512,
+        head_dim=128,
+        device_scale=True,
+        skips_softmax=False,
+        uses_shared_paged_kv_idx=True,
     )
 
 

--- a/tests/attention/test_trtllm_gen_attention_prefill.py
+++ b/tests/attention/test_trtllm_gen_attention_prefill.py
@@ -291,6 +291,11 @@ def _test_trtllm_batch_prefill(
             pytest.skip("NVFP4 KV cache requires FP8 query")
         if o_dtype != "fp8":
             pytest.skip("NVFP4 KV cache only supports FP8 output")
+    if kv_dtype == "fp8_k_nvfp4_v":
+        if q_dtype != "fp8" or o_dtype != "bf16":
+            pytest.skip("mixed KV context requires FP8 query and BF16 output")
+        if kv_layout != "HND" or not uses_shared_paged_kv_idx:
+            pytest.skip("mixed KV context currently targets the vLLM HND layout")
 
     # Cubin-variant selectors. trtllm-gen only exports the Fp16Softmax / Spcomp
     # variants for sm107a, and the Python layer raises rather than falling back.
@@ -482,7 +487,7 @@ def _test_trtllm_batch_prefill(
         not enable_sink
         and not skips_softmax
         and o_dtype != "nvfp4"
-        and kv_dtype != "nvfp4"
+        and kv_dtype not in ("nvfp4", "fp8_k_nvfp4_v")
         and q_dtype != "fp8"
         and not use_fp16_softmax
         and not uses_spcompress
@@ -588,12 +593,12 @@ def _test_trtllm_batch_prefill(
 
     # NVFP4 KV cache has significant quantization error, especially with
     # outlier channels that create large per-block dynamic range.
-    if kv_dtype == "nvfp4":
+    if kv_dtype in ("nvfp4", "fp8_k_nvfp4_v"):
         rtol, atol = 5e-1, 5e-1
 
     # NVFP4 KV cache has higher mismatch rate due to 4-bit quantization noise,
     # especially with outlier channels that stress per-block scaling.
-    allowed_mismatch_rate = 0.10 if kv_dtype == "nvfp4" else 1e-7
+    allowed_mismatch_rate = 0.10 if kv_dtype in ("nvfp4", "fp8_k_nvfp4_v") else 1e-7
     # Calculate max allowed mismatched elements based on tensor size
     total_elements = (output.float() * o_scale).numel()
     max_mismatched_elements = int(allowed_mismatch_rate * total_elements)
@@ -609,24 +614,24 @@ def _test_trtllm_batch_prefill(
 
     # NVFP4 KV cache: use cosine similarity to catch block-scale mismatches
     # (e.g. wrong swizzling) that element-wise tolerances miss.
-    if kv_dtype == "nvfp4":
+    if kv_dtype in ("nvfp4", "fp8_k_nvfp4_v"):
         cos = torch.nn.functional.cosine_similarity(
             (output.float() * o_scale).reshape(-1),
             output_ref.float().reshape(-1),
             dim=0,
         )
         assert cos.item() > 0.86, (
-            f"NVFP4 KV cache attention: cosine similarity {cos:.4f} < 0.86. "
+            f"NVFP4 V cache attention: cosine similarity {cos:.4f} < 0.86. "
             f"Block scale factors may be mismatched to FP4 data blocks."
         )
 
     if (
         o_dtype != "nvfp4"
-        and kv_dtype != "nvfp4"
+        and kv_dtype not in ("nvfp4", "fp8_k_nvfp4_v")
         and uses_shared_paged_kv_idx
         and not use_fp16_softmax
         and not uses_spcompress
-    ):  # wrapper api does not support fp4 output/kv, separate KV page indices, or the cubin-variant flags.
+    ):  # wrapper excludes FP4, separate page indices, and cubin-variant flags.
         # test wrapper with trtllm-gen backend
         wrapper_trtllm_gen = flashinfer.prefill.BatchPrefillWithPagedKVCacheWrapper(
             workspace_buffer, kv_layout, backend="trtllm-gen"
@@ -765,6 +770,135 @@ def test_trtllm_batch_prefill_lse_contract(return_lse, provide_lse):
         return_lse=return_lse,
         provide_lse=provide_lse,
     )
+
+
+@pytest.mark.parametrize("max_q_len,max_kv_len", [(127, 511), (511, 2047)])
+@pytest.mark.parametrize("head_dim", [128, 256])
+def test_trtllm_batch_prefill_fp8_k_nvfp4_v(max_q_len, max_kv_len, head_dim):
+    _skip_if_not_blackwell()
+    _test_trtllm_batch_prefill(
+        "HND",
+        batch_size=4,
+        page_size=64,
+        num_kv_heads=4,
+        head_grp_size=5,
+        causal=True,
+        window_left=-1,
+        q_dtype="fp8",
+        o_dtype="bf16",
+        kv_dtype="fp8_k_nvfp4_v",
+        enable_pdl=None,
+        enable_sink=False,
+        max_q_len=max_q_len,
+        max_kv_len=max_kv_len,
+        device_scale=True,
+        head_dim=head_dim,
+        uses_shared_paged_kv_idx=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "kv_dtype,o_dtype",
+    [("fp8", "bf16"), ("nvfp4", "fp8")],
+)
+def test_trtllm_batch_prefill_coherent_quantized_artifact(
+    kv_dtype: str, o_dtype: str
+) -> None:
+    """Keep homogeneous kernels compatible with the mixed-KV artifact ABI."""
+    _skip_if_not_blackwell()
+    _test_trtllm_batch_prefill(
+        "HND",
+        batch_size=2,
+        page_size=64,
+        num_kv_heads=4,
+        head_grp_size=4,
+        causal=True,
+        window_left=-1,
+        q_dtype="fp8",
+        o_dtype=o_dtype,
+        kv_dtype=kv_dtype,
+        enable_pdl=None,
+        enable_sink=False,
+        max_q_len=127,
+        max_kv_len=511,
+        device_scale=True,
+        head_dim=128,
+        uses_shared_paged_kv_idx=True,
+    )
+
+
+def test_trtllm_batch_prefill_separate_page_pool_sizes() -> None:
+    """Separate K/V page tables may address independently sized pools."""
+    _skip_if_not_blackwell()
+    torch.manual_seed(0)
+
+    page_size = 64
+    head_dim = 128
+    num_kv_heads = 2
+    num_qo_heads = 8
+    q_len = 64
+    kv_len = 128
+    fp8 = torch.float8_e4m3fn
+
+    query = torch.randn(
+        q_len, num_qo_heads, head_dim, device=GPU_DEVICE, dtype=torch.bfloat16
+    ).to(fp8)
+    key_cache = torch.randn(
+        2,
+        num_kv_heads,
+        page_size,
+        head_dim,
+        device=GPU_DEVICE,
+        dtype=torch.bfloat16,
+    ).to(fp8)
+    value_cache = torch.randn(
+        3,
+        num_kv_heads,
+        page_size,
+        head_dim,
+        device=GPU_DEVICE,
+        dtype=torch.bfloat16,
+    ).to(fp8)
+    block_tables = torch.tensor(
+        [[[0, 1], [1, 2]]], dtype=torch.int32, device=GPU_DEVICE
+    )
+    seq_lens = torch.tensor([kv_len], dtype=torch.int32, device=GPU_DEVICE)
+    cum_seq_lens_q = torch.tensor([0, q_len], dtype=torch.int32, device=GPU_DEVICE)
+    cum_seq_lens_kv = torch.tensor([0, kv_len], dtype=torch.int32, device=GPU_DEVICE)
+    workspace_buffer, _ = create_workspace_buffers(GPU_DEVICE)
+
+    output = flashinfer.prefill.trtllm_batch_context_with_kv_cache(
+        query,
+        (key_cache, value_cache),
+        workspace_buffer,
+        block_tables,
+        seq_lens,
+        q_len,
+        kv_len,
+        head_dim**-0.5,
+        1.0,
+        1,
+        cum_seq_lens_q,
+        cum_seq_lens_kv,
+        out_dtype=torch.bfloat16,
+        kv_layout="HND",
+        uses_shared_paged_kv_idx=False,
+    )
+
+    keys = key_cache.permute(1, 0, 2, 3).reshape(num_kv_heads, kv_len, head_dim)
+    values = value_cache[1:].permute(1, 0, 2, 3).reshape(num_kv_heads, kv_len, head_dim)
+    keys = keys.repeat_interleave(num_qo_heads // num_kv_heads, dim=0).float()
+    values = values.repeat_interleave(num_qo_heads // num_kv_heads, dim=0).float()
+    logits = torch.einsum("qhd,hnd->qhn", query.float(), keys) * head_dim**-0.5
+    prefix_len = kv_len - q_len
+    causal_mask = torch.arange(kv_len, device=GPU_DEVICE)[None, :] <= (
+        prefix_len + torch.arange(q_len, device=GPU_DEVICE)[:, None]
+    )
+    probs = torch.softmax(
+        logits.masked_fill(~causal_mask[:, None, :], float("-inf")), dim=-1
+    )
+    reference = torch.einsum("qhn,hnd->qhd", probs, values).to(torch.bfloat16)
+    torch.testing.assert_close(output, reference, rtol=0.05, atol=0.07)
 
 
 @pytest.mark.parametrize("kv_layout", ["HND", "NHD"])


### PR DESCRIPTION
## Description

Add native FP8-K / NVFP4-V paged attention through TRTLLM-Gen. K stays in its persistent FP8 cache; V stays packed as NVFP4 with FP8 block scales. This is not a BF16 shadow-cache fallback.

- Accept `(K_fp8, V_nvfp4)` and `kv_cache_sf=(None, V_scales)` in the context and decode APIs.
- Build independent K/V shapes, strides, TMA descriptors, and V scale descriptors.
- Select ungrouped mixed kernels and consume exported transform metadata while retaining homogeneous FP8/NVFP4 handling.
- Add mixed context/decode numerical tests, decode graph replay, homogeneous controls, and a DCP validation regression test.

Initial public API scope: SM100-family GPUs excluding SM107, H128/H256, P64, FP8 E4M3 queries, BF16 output, dense causal attention. Mixed decode accepts one query token per request; multi-token requests use context attention. BF16 queries, sinks, sliding windows, and DCP are not enabled for mixed KV.

This PR contains only the native API/launcher integration. Staged-V prefill optimizations and local packaging overrides are retained separately, not bundled into this diff.

## Related Issues

- Consumer: https://github.com/vllm-project/vllm/pull/53770
- TensorRT-LLM consumer: https://github.com/NVIDIA/TensorRT-LLM/pull/18206
- Related alternative backend: https://github.com/flashinfer-ai/flashinfer/pull/4414 (PrimTS; this PR targets TRTLLM-Gen).

## Pull Request Checklist

### Pre-commit Checks

- [ ] Installed all pre-commit hooks.
- [ ] Full `pre-commit run --all-files` passes.
- [x] Targeted Ruff 0.12.8 checks/format, clang-format 19.1.1, and `git diff --check`.

## Tests

- [x] Tests added/updated.
- [ ] All native attention tests pass against the final published package.

Current refresh: two DCP validation regressions passed on GB300. The native launcher compiled from source, but the stock FlashInfer 0.6.18 cubin registry lacks mixed decode, including H128/P64/Q8. This blocks the mixed numerical and graph test before launch. Homogeneous control validation did not complete before the test allocation failed. No fresh E2E or performance pass is claimed for this head.

## Reviewer Notes

Draft integration gate: publish mixed context/decode cubins and metadata from a compatible TRTLLM-Gen revision, update the artifact registry, and rebuild the JIT/AOT launcher against that package. A stock `flashinfer-jit-cache` must not override a source-built mixed launcher. Validation keeps `FLASHINFER_NO_DOWNLOAD=1`.

After packaging, rerun H128/H256 selectors (including head ratios 32/64), homogeneous controls, numerical tests, graph replay, and consumer generation. The final formatted/extracted head also needs that rerun.

Implementation and review assisted by AI.
