### PR TITLE
feat(sm120): runtime KV row stride + canonical 528B GLM53_NOPE rows + NaN-safe masked gathers in sparse MLA

### DIFF
--- a/csrc/sparse_mla_sm120.cu
+++ b/csrc/sparse_mla_sm120.cu
@@ -93,41 +93,71 @@ inline int d_v_for(ModelType mt) { return mt == ModelType::DOTS3_SWA ? 1024 : 51
 struct PagedKVLayout {
   int page_block_size;
   size_t stride_kv_block;
+  // Per-token advance in bytes. Equals bytes_per_token for a packed cache, but
+  // may be larger when the caller pads rows (e.g. a legacy 656B vLLM pool
+  // serving a 528B GLM53_NOPE payload). The payload always sits at the row
+  // start, so only the advance changes.
+  size_t stride_kv_row;
 };
 
-inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, const char* name) {
+// inline_scale: the model stores scales inside the row (DSV3_2 / GLM_NSA /
+// GLM53_NOPE). Inline rows may be padded (advance >= width >= bpt); footer
+// models address scale data relative to packed rows and must stay exact.
+inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool inline_scale,
+                                           const char* name) {
   const size_t elem_bytes = static_cast<size_t>(kv.dtype().bits / 8);
   if (kv.ndim() == 2) {
     const size_t block_bytes = static_cast<size_t>(kv.size(1)) * elem_bytes;
     TVM_FFI_ICHECK_EQ(block_bytes % static_cast<size_t>(bpt), 0)
         << name << " 2D block width " << block_bytes
         << " is not divisible by bytes_per_token=" << bpt;
-    return {static_cast<int>(block_bytes / static_cast<size_t>(bpt)), block_bytes};
+    // A flat 2D block carries no row padding to infer, so the row advance is
+    // exactly bytes_per_token.
+    return {static_cast<int>(block_bytes / static_cast<size_t>(bpt)), block_bytes,
+            static_cast<size_t>(bpt)};
   }
+  auto row_advance = [&](int64_t token_axis) {
+    TVM_FFI_ICHECK_EQ(kv.stride(-1), 1) << name << " last dim must be contiguous";
+    const size_t bytes = static_cast<size_t>(kv.size(-1)) * elem_bytes;
+    if (inline_scale) {
+      TVM_FFI_ICHECK_GE(bytes, static_cast<size_t>(bpt))
+          << name << " row width " << bytes << " is smaller than bytes_per_token=" << bpt;
+    } else {
+      TVM_FFI_ICHECK_EQ(bytes, static_cast<size_t>(bpt))
+          << name << " row width " << bytes << " must equal bytes_per_token=" << bpt
+          << " (footer-scale rows must stay packed)";
+    }
+    // The per-token advance is the token axis's real stride: a caller slicing
+    // the last dim of a wider buffer (padded rows) changes the size but not
+    // the stride, and the kernel must step by the stride.
+    const size_t advance = static_cast<size_t>(kv.stride(token_axis)) * elem_bytes;
+    TVM_FFI_ICHECK_GE(advance, bytes)
+        << name << " token-axis stride " << advance << " is smaller than the row width " << bytes;
+    if (inline_scale) {
+      TVM_FFI_ICHECK_EQ(advance % 16, 0) << name << " token-axis stride " << advance
+                                         << " is not 16B-aligned (cp.async.bulk requirement)";
+    }
+    return advance;
+  };
   if (kv.ndim() == 3) {
-    TVM_FFI_ICHECK_EQ(kv.size(-1), bpt)
-        << name << " 3D form must be [num_pages, page_block_size, " << bpt
-        << "]; prefill requires tightly packed rows — padded-row KV caches are "
-           "decode-only (the decode-v32 kernel honors stride_kv_row)";
-    return {static_cast<int>(kv.size(1)), static_cast<size_t>(kv.stride(0)) * elem_bytes};
+    return {static_cast<int>(kv.size(1)), static_cast<size_t>(kv.stride(0)) * elem_bytes,
+            row_advance(1)};
   }
   TVM_FFI_ICHECK_EQ(kv.ndim(), 4) << name << " must be 2D [num_pages, page_bytes], 3D "
                                   << "[num_pages, page_block_size, bytes_per_token], HND "
                                   << "[num_pages, 1, page_block_size, bytes_per_token], or NHD "
                                   << "[num_pages, page_block_size, 1, bytes_per_token]";
-  TVM_FFI_ICHECK_EQ(kv.size(-1), bpt)
-      << name << " last dim must be bytes_per_token=" << bpt << ", got " << kv.size(-1)
-      << "; prefill requires tightly packed rows — padded-row KV caches are "
-         "decode-only (the decode-v32 kernel honors stride_kv_row)";
   if (kv.size(1) == 1) {
-    return {static_cast<int>(kv.size(2)), static_cast<size_t>(kv.stride(0)) * elem_bytes};
+    return {static_cast<int>(kv.size(2)), static_cast<size_t>(kv.stride(0)) * elem_bytes,
+            row_advance(2)};
   }
   if (kv.size(2) == 1) {
-    return {static_cast<int>(kv.size(1)), static_cast<size_t>(kv.stride(0)) * elem_bytes};
+    return {static_cast<int>(kv.size(1)), static_cast<size_t>(kv.stride(0)) * elem_bytes,
+            row_advance(1)};
   }
   TVM_FFI_ICHECK(false) << name << " 4D form must have singleton KV-head axis at dim 1 "
                         << "(HND) or dim 2 (NHD)";
-  return {0, 0};
+  return {0, 0, 0};
 }
 
 inline int check_dense_indices_2d_or_s_q_3d(const TensorView& idx, const char* name,
@@ -184,25 +214,30 @@ void SparseMlaSm120PagedAttention(
   const int d_qk = static_cast<int>(q.size(2));
   const int topk = check_dense_indices_2d_or_s_q_3d(indices, "indices", num_tokens);
   const ModelType mt = resolve_model_type(d_qk, model_type);
-  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bytes_per_token(mt), "kv_cache");
+  const bool inline_scale =
+      (mt == ModelType::DSV3_2 || mt == ModelType::GLM_NSA || mt == ModelType::GLM53_NOPE);
+  const PagedKVLayout kv_layout =
+      parse_paged_kv_layout(kv_cache, bytes_per_token(mt), inline_scale, "kv_cache");
   const int page_block_size = kv_layout.page_block_size;
   // Inline-scale models (DSV3_2 / GLM_NSA / GLM53_NOPE) are addressed by the
-  // prefill kernels as a flat token array (prefill_kv_entry_base), so a
-  // padded block stride would be silently misread; only footer-scale models
-  // honor stride_kv_block. Padded strides remain a decode-path capability.
-  if (mt == ModelType::DSV3_2 || mt == ModelType::GLM_NSA || mt == ModelType::GLM53_NOPE) {
+  // prefill kernels as a flat token array with a runtime row advance
+  // (prefill_kv_entry_base), so rows may be padded but blocks must stay
+  // contiguous; only footer-scale models honor a padded stride_kv_block.
+  if (inline_scale) {
     TVM_FFI_ICHECK_EQ(kv_layout.stride_kv_block,
-                      static_cast<size_t>(page_block_size) * bytes_per_token(mt))
-        << "prefill for inline-scale KV caches (DSv3.2/GLM) requires densely packed blocks "
-           "(stride_kv_block == page_block_size * bytes_per_token); padded block strides are "
-           "decode-only";
+                      static_cast<size_t>(page_block_size) * kv_layout.stride_kv_row)
+        << "prefill for inline-scale KV caches (DSv3.2/GLM) requires contiguous blocks "
+           "(stride_kv_block == page_block_size * row stride); the row stride itself may "
+           "exceed bytes_per_token for padded-row pools";
   }
 
   TVM_FFI_ICHECK_GT(num_heads, 0);
   TVM_FFI_ICHECK_LE(num_heads, 128);
   TVM_FFI_ICHECK_GT(topk, 0);
-  // The prefill kernels issue whole BI=64-wide index tiles (the tail tile is
-  // not masked), so the indices row width must be a multiple of 64.
+  // The prefill kernels stage whole index tiles through the math warps, so
+  // the indices row width must be a multiple of 64. (The gather itself is
+  // masked at topk_len granularity; this requirement is about the allocation
+  // width, not the runtime length.)
   TVM_FFI_ICHECK_EQ(topk % 64, 0)
       << "sparse-MLA SM120 prefill requires topk % 64 == 0 (BI=64: index tiles "
          "are issued whole, the tail tile is not masked); got topk="
@@ -263,7 +298,7 @@ void SparseMlaSm120PagedAttention(
     CHECK_INPUT_TYPE(ekv, dl_uint8);
     CHECK_INPUT_AND_TYPE(eidx, dl_int32);
     const PagedKVLayout extra_layout =
-        parse_paged_kv_layout(ekv, bytes_per_token(mt), "extra_kv_cache");
+        parse_paged_kv_layout(ekv, bytes_per_token(mt), inline_scale, "extra_kv_cache");
     extra_page_block_size = extra_layout.page_block_size;
     extra_stride_kv_block = extra_layout.stride_kv_block;
     extra_topk = check_dense_indices_2d_or_s_q_3d(eidx, "extra_indices", num_tokens);

--- a/csrc/sparse_mla_sm120.cu
+++ b/csrc/sparse_mla_sm120.cu
@@ -106,6 +106,14 @@ struct PagedKVLayout {
 inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool inline_scale,
                                            const char* name) {
   const size_t elem_bytes = static_cast<size_t>(kv.dtype().bits / 8);
+  TVM_FFI_ICHECK_EQ(kv.stride(-1), 1) << name << " last dim must be contiguous";
+  // Bulk gathers require aligned addresses, including sliced cache origins
+  // and the first row of each block.
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(kv.data_ptr()) % 16, 0)
+      << name << " data pointer must be 16B-aligned (cp.async.bulk requirement)";
+  const size_t block_stride = static_cast<size_t>(kv.stride(0)) * elem_bytes;
+  TVM_FFI_ICHECK_EQ(block_stride % 16, 0)
+      << name << " block stride must be 16B-aligned (cp.async.bulk requirement)";
   if (kv.ndim() == 2) {
     const size_t block_bytes = static_cast<size_t>(kv.size(1)) * elem_bytes;
     TVM_FFI_ICHECK_EQ(block_bytes % static_cast<size_t>(bpt), 0)
@@ -113,11 +121,12 @@ inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool i
         << " is not divisible by bytes_per_token=" << bpt;
     // A flat 2D block carries no row padding to infer, so the row advance is
     // exactly bytes_per_token.
-    return {static_cast<int>(block_bytes / static_cast<size_t>(bpt)), block_bytes,
+    TVM_FFI_ICHECK_GE(block_stride, block_bytes)
+        << name << " block stride is smaller than the packed block width";
+    return {static_cast<int>(block_bytes / static_cast<size_t>(bpt)), block_stride,
             static_cast<size_t>(bpt)};
   }
   auto row_advance = [&](int64_t token_axis) {
-    TVM_FFI_ICHECK_EQ(kv.stride(-1), 1) << name << " last dim must be contiguous";
     const size_t bytes = static_cast<size_t>(kv.size(-1)) * elem_bytes;
     if (inline_scale) {
       TVM_FFI_ICHECK_GE(bytes, static_cast<size_t>(bpt))
@@ -136,6 +145,9 @@ inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool i
     if (inline_scale) {
       TVM_FFI_ICHECK_EQ(advance % 16, 0) << name << " token-axis stride " << advance
                                          << " is not 16B-aligned (cp.async.bulk requirement)";
+    } else {
+      TVM_FFI_ICHECK_EQ(advance, static_cast<size_t>(bpt))
+          << name << " footer-scale rows must stay packed (token-axis stride == " << bpt << ")";
     }
     return advance;
   };

--- a/csrc/sparse_mla_sm120_decode_dsv3_2.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv3_2.cu
@@ -9,7 +9,7 @@
 // Supports the V32-family dispatch grid: dedicated instantiations at
 //   num_heads ∈ {8, 16, 32, 64, 128}
 // plus one runtime-H instantiation (any num_heads <= 128 off the grid) and
-// GLM53_NOPE dedicated 8/32/64 + runtime-H. topk is a runtime argument — one
+// GLM53_NOPE dedicated 8/16/32/64 + runtime-H. topk is a runtime argument — one
 // instantiation serves every indices-row width.
 
 #include <cuda_runtime.h>
@@ -186,12 +186,13 @@ bool launch_sparse_mla_decode_dsv3_2(ModelType mt, int num_heads, int topk, int 
     DSV3_2_DISPATCH_RT_MT(ModelType::GLM_NSA)
   }
   // GLM-5.3 combines its 2048 sparse selection with the 128-token
-  // indexer window. The TP1 (64-head) and TP2 (32-head) shapes keep
+  // indexer window. The TP1/TP2/TP4/TP8 (64/32/16/8-head) shapes keep
   // dedicated instantiations; any other shard rides the runtime-H fallback.
   if (mt == ModelType::GLM53_NOPE) {
     // The public scratch allocator uses eight rows for H=8. A dedicated
     // instantiation preserves that ABI instead of the runtime-H padded stride.
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 8)
+    DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 16)
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 32)
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 64)
     DSV3_2_DISPATCH_RT_MT(ModelType::GLM53_NOPE)

--- a/csrc/sparse_mla_sm120_decode_dsv3_2.cu
+++ b/csrc/sparse_mla_sm120_decode_dsv3_2.cu
@@ -9,7 +9,7 @@
 // Supports the V32-family dispatch grid: dedicated instantiations at
 //   num_heads ∈ {8, 16, 32, 64, 128}
 // plus one runtime-H instantiation (any num_heads <= 128 off the grid) and
-// GLM53_NOPE dedicated 32/64 + runtime-H. topk is a runtime argument — one
+// GLM53_NOPE dedicated 8/32/64 + runtime-H. topk is a runtime argument — one
 // instantiation serves every indices-row width.
 
 #include <cuda_runtime.h>
@@ -189,6 +189,9 @@ bool launch_sparse_mla_decode_dsv3_2(ModelType mt, int num_heads, int topk, int 
   // indexer window. The TP1 (64-head) and TP2 (32-head) shapes keep
   // dedicated instantiations; any other shard rides the runtime-H fallback.
   if (mt == ModelType::GLM53_NOPE) {
+    // The public scratch allocator uses eight rows for H=8. A dedicated
+    // instantiation preserves that ABI instead of the runtime-H padded stride.
+    DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 8)
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 32)
     DSV3_2_DISPATCH_MT(ModelType::GLM53_NOPE, 64)
     DSV3_2_DISPATCH_RT_MT(ModelType::GLM53_NOPE)

--- a/csrc/sparse_mla_sm120_jit_binding.cu
+++ b/csrc/sparse_mla_sm120_jit_binding.cu
@@ -53,14 +53,20 @@ struct PagedKVLayout {
   int stride_kv_row;
 };
 
-// inline_scale: the model stores scales inside the row (DSV3_2 / GLM_NSA /
-// GLM53_NOPE) and gathers whole rows with cp.async.bulk, so the row advance
-// must be 16B-aligned. Footer-scale models (DSV4 / DOTS3_SWA) address data
-// rows by the packed data stride and skip the check (584 % 16 != 0 is legal
-// there).
+// Inline-scale rows may be padded, with a 16B-aligned row advance.
+// Footer-scale caches must keep data and scale sections packed. Their data
+// rows use an aligned stride (e.g. 576B for DSV4), separate from the total
+// payload per token (584B including footer scales). Both families require
+// 16B-aligned cache origins and block strides for cp.async.bulk.
 inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool inline_scale,
                                            const char* name) {
   const size_t elem_bytes = static_cast<size_t>(kv.dtype().bits / 8);
+  TVM_FFI_ICHECK_EQ(kv.stride(-1), 1) << name << " last dim must be contiguous";
+  TVM_FFI_ICHECK_EQ(reinterpret_cast<uintptr_t>(kv.data_ptr()) % 16, 0)
+      << name << " data pointer must be 16B-aligned (cp.async.bulk requirement)";
+  const size_t block_stride = static_cast<size_t>(kv.stride(0)) * elem_bytes;
+  TVM_FFI_ICHECK_EQ(block_stride % 16, 0)
+      << name << " block stride must be 16B-aligned (cp.async.bulk requirement)";
   if (kv.ndim() == 2) {
     const size_t block_bytes = static_cast<size_t>(kv.size(1)) * elem_bytes;
     TVM_FFI_ICHECK_EQ(block_bytes % static_cast<size_t>(bpt), 0)
@@ -68,10 +74,11 @@ inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool i
         << " is not divisible by bytes_per_token=" << bpt;
     // A flat 2D block carries no row padding to infer, so the row advance is
     // exactly bytes_per_token.
-    return {static_cast<int>(block_bytes / static_cast<size_t>(bpt)), block_bytes, bpt};
+    TVM_FFI_ICHECK_GE(block_stride, block_bytes)
+        << name << " block stride is smaller than the packed block width";
+    return {static_cast<int>(block_bytes / static_cast<size_t>(bpt)), block_stride, bpt};
   }
   auto row_advance = [&](int64_t token_axis) {
-    TVM_FFI_ICHECK_EQ(kv.stride(-1), 1) << name << " last dim must be contiguous";
     const size_t bytes = static_cast<size_t>(kv.size(-1)) * elem_bytes;
     TVM_FFI_ICHECK_GE(bytes, static_cast<size_t>(bpt))
         << name << " row width " << bytes << " is smaller than bytes_per_token=" << bpt;

--- a/csrc/sparse_mla_sm120_jit_binding.cu
+++ b/csrc/sparse_mla_sm120_jit_binding.cu
@@ -53,7 +53,13 @@ struct PagedKVLayout {
   int stride_kv_row;
 };
 
-inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, const char* name) {
+// inline_scale: the model stores scales inside the row (DSV3_2 / GLM_NSA /
+// GLM53_NOPE) and gathers whole rows with cp.async.bulk, so the row advance
+// must be 16B-aligned. Footer-scale models (DSV4 / DOTS3_SWA) address data
+// rows by the packed data stride and skip the check (584 % 16 != 0 is legal
+// there).
+inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, bool inline_scale,
+                                           const char* name) {
   const size_t elem_bytes = static_cast<size_t>(kv.dtype().bits / 8);
   if (kv.ndim() == 2) {
     const size_t block_bytes = static_cast<size_t>(kv.size(1)) * elem_bytes;
@@ -75,6 +81,10 @@ inline PagedKVLayout parse_paged_kv_layout(const TensorView& kv, int bpt, const 
     const size_t advance = static_cast<size_t>(kv.stride(token_axis)) * elem_bytes;
     TVM_FFI_ICHECK_GE(advance, bytes)
         << name << " token-axis stride " << advance << " is smaller than the row width " << bytes;
+    if (inline_scale) {
+      TVM_FFI_ICHECK_EQ(advance % 16, 0) << name << " token-axis stride " << advance
+                                         << " is not 16B-aligned (cp.async.bulk requirement)";
+    }
     return static_cast<int>(advance);
   };
   if (kv.ndim() == 3) {
@@ -162,7 +172,8 @@ void SparseMlaSm120DecodeDsv4(TensorView q, TensorView kv_cache, TensorView indi
   // nothing beyond the window itself. Unused slots must still carry -1, which
   // the QK mask turns into -inf.
   const int bpt = bytes_per_token(mt);
-  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bpt, "kv_cache");
+  const PagedKVLayout kv_layout =
+      parse_paged_kv_layout(kv_cache, bpt, /*inline_scale=*/false, "kv_cache");
   // Footer-scale kernels (DSV4, DOTS3_SWA) gather with a tightly packed row
   // advance; only the decode-v32 path honors stride_kv_row. Reject padded rows
   // loudly instead of reading the wrong bytes.
@@ -201,7 +212,8 @@ void SparseMlaSm120DecodeDsv4(TensorView q, TensorView kv_cache, TensorView indi
     extra_topk_arg = static_cast<int>(eidx.size(-1));
     stride_extra_indices_token = static_cast<size_t>(eidx.stride(0));
     // The extra (dual) cache carries the same per-token layout as the main one.
-    const PagedKVLayout extra_layout = parse_paged_kv_layout(ekv, bpt, "extra_kv_cache");
+    const PagedKVLayout extra_layout =
+        parse_paged_kv_layout(ekv, bpt, /*inline_scale=*/false, "extra_kv_cache");
     TVM_FFI_ICHECK_EQ(extra_layout.stride_kv_row, bpt)
         << "decode-dsv4 extra_kv_cache requires tightly packed KV rows "
         << "(stride_kv_row == bytes_per_token=" << bpt
@@ -263,7 +275,8 @@ void SparseMlaSm120DecodeDsv3_2(TensorView q, TensorView kv_cache, TensorView in
       << "decode-v32 expects DSV3_2/GLM_NSA d_qk=576 or GLM53_NOPE d_qk=512; got d_qk=" << d_qk
       << " model_type=" << model_type;
 
-  const PagedKVLayout kv_layout = parse_paged_kv_layout(kv_cache, bytes_per_token(mt), "kv_cache");
+  const PagedKVLayout kv_layout =
+      parse_paged_kv_layout(kv_cache, bytes_per_token(mt), /*inline_scale=*/true, "kv_cache");
 
   const int* topk_len_ptr =
       topk_length.has_value() ? static_cast<const int*>(topk_length.value().data_ptr()) : nullptr;

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -697,12 +697,13 @@ def _check_sm120_sparse_v32_kv_cache(
             "SM120 sparse MLA v32/GLM backend expects packed uint8 kv_cache, "
             f"got {kv_cache.dtype}"
         )
-    # v32/GLM_NSA rows are exactly 656B. GLM-5.3 NoPE has a 528B payload and
-    # the kernels take the row advance as a runtime stride, so padded rows
-    # (e.g. a legacy 656B vLLM pool) are accepted as long as the row starts
-    # with the 528B payload.
+    # Inline-scale caches may pad rows beyond the model's payload. GLM NoPE
+    # stores 512 FP8 values and four FP32 scales (528B); v32/GLM_NSA also
+    # stores 128B of RoPE. The binding validates the actual row stride.
     min_row_bytes = 528 if glm53_nope else 656
-    layout_desc = ">=528 (528B payload, padded rows allowed)" if glm53_nope else "656"
+    layout_desc = (
+        f">={min_row_bytes} ({min_row_bytes}B payload, 16B-aligned padded rows allowed)"
+    )
     if kv_cache.ndim == 3:
         if kv_cache.size(-1) < min_row_bytes:
             raise ValueError(

--- a/flashinfer/mla/_core.py
+++ b/flashinfer/mla/_core.py
@@ -689,25 +689,33 @@ def _trtllm_batch_decode_sparse_mla_sm120(
     return out
 
 
-def _check_sm120_sparse_v32_kv_cache(kv_cache: torch.Tensor) -> torch.Tensor:
+def _check_sm120_sparse_v32_kv_cache(
+    kv_cache: torch.Tensor, *, glm53_nope: bool = False
+) -> torch.Tensor:
     if kv_cache.dtype != torch.uint8:
         raise ValueError(
             "SM120 sparse MLA v32/GLM backend expects packed uint8 kv_cache, "
             f"got {kv_cache.dtype}"
         )
+    # v32/GLM_NSA rows are exactly 656B. GLM-5.3 NoPE has a 528B payload and
+    # the kernels take the row advance as a runtime stride, so padded rows
+    # (e.g. a legacy 656B vLLM pool) are accepted as long as the row starts
+    # with the 528B payload.
+    min_row_bytes = 528 if glm53_nope else 656
+    layout_desc = ">=528 (528B payload, padded rows allowed)" if glm53_nope else "656"
     if kv_cache.ndim == 3:
-        if kv_cache.size(-1) != 656:
+        if kv_cache.size(-1) < min_row_bytes:
             raise ValueError(
-                "SM120 sparse MLA v32/GLM expects packed kv_cache last dim 656, "
-                f"got {tuple(kv_cache.shape)}"
+                "SM120 sparse MLA v32/GLM expects packed kv_cache last dim "
+                f"{layout_desc}, got {tuple(kv_cache.shape)}"
             )
         return kv_cache
     if kv_cache.ndim == 4:
-        if kv_cache.size(1) != 1 or kv_cache.size(-1) != 656:
+        if kv_cache.size(1) != 1 or kv_cache.size(-1) < min_row_bytes:
             raise ValueError(
                 "SM120 sparse MLA v32/GLM expects public HND kv_cache shape "
-                "[num_pages, 1, page_size, 656] or 3D shorthand "
-                f"[num_pages, page_size, 656], got {tuple(kv_cache.shape)}"
+                f"[num_pages, 1, page_size, {layout_desc}] or 3D shorthand "
+                f"[num_pages, page_size, {layout_desc}], got {tuple(kv_cache.shape)}"
             )
         return kv_cache
     raise ValueError(f"Expected kv_cache.ndim == 3 or 4, got {kv_cache.ndim}")
@@ -824,7 +832,7 @@ def _trtllm_batch_decode_sparse_mla_v32_sm120(
             f"{expected_block_tables_shape}, got {tuple(block_tables.shape)}"
         )
 
-    kv_cache = _check_sm120_sparse_v32_kv_cache(kv_cache)
+    kv_cache = _check_sm120_sparse_v32_kv_cache(kv_cache, glm53_nope=glm53_nope)
     topk_length = _normalize_sm120_sparse_v32_topk_length(
         seq_lens,
         batch_size=batch_size,
@@ -3450,7 +3458,9 @@ def trtllm_batch_decode_with_kv_cache_mla(
         ``[num_pages, 1, page_size, kv_lora_rank + qk_rope_head_dim]`` and uses
         the query-compatible dense dtype. For the SM120/SM121 v32/GLM sparse
         backend, this is a packed uint8 cache with 656 bytes per token, shaped
-        ``[num_pages, page_size, 656]`` or ``[num_pages, 1, page_size, 656]``.
+        ``[num_pages, page_size, 656]`` or ``[num_pages, 1, page_size, 656]``;
+        for GLM-5.3 NoPE the payload is 528 bytes per token and padded rows
+        (any last dim >= 528, including a legacy 656 pool) are accepted.
     workspace_buffer : torch.Tensor
         Pre-allocated workspace buffer. Must be zero-initialized on first use
         by kernels that use semaphore state.

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -95,6 +95,7 @@ from ._sparse_mla_sm120_plan import (
     _BPT_DSV3_2,
     _BPT_DSV4,
     _BPT_DOTS3_SWA,
+    _BPT_GLM53_NOPE,
     _DECODE_DSV3_2_DISPATCH,  # noqa: F401  (vLLM probe surface)
     _DECODE_DSV4_DISPATCH,  # noqa: F401  (vLLM probe surface)
     _DECODE_MAX_HEADS,
@@ -176,7 +177,9 @@ class SparseMLASm120DecodeConfig:
         Packed cache format described by this entry (``"fp8"`` or
         ``"nvfp4"``).
     bytes_per_token : int
-        Logical packed-cache bytes per token.
+        Logical packed-cache bytes per token. For inline-scale models this is
+        the payload minimum: callers may allocate wider padded rows since the
+        kernels take the gmem row advance as a runtime stride.
     head_counts : Optional[frozenset[int]]
         Exact instantiated head counts when the kernel has no runtime-head
         fallback. ``None`` means every count in ``[1, max_num_heads]``.
@@ -335,7 +338,9 @@ def supported_sparse_mla_sm120_configs(
             topks=frozenset({_DECODE_GLM53_NOPE_TOPK}),
             min_topk=1,
             max_num_heads=_DECODE_MAX_HEADS,
-            bytes_per_token=_BPT_DSV3_2,
+            # 528B payload; the gmem row advance is a runtime stride, so a
+            # legacy 656B vLLM pool keeps working unchanged.
+            bytes_per_token=_BPT_GLM53_NOPE,
         ),
         "dots3_swa": SparseMLASm120DecodeConfig(
             d_qk=1088,
@@ -503,13 +508,34 @@ def _resolve_model_type(d_qk: int, kv_scale_format: str) -> int:
 
 
 def _bytes_per_token_for_model_type(model_type: int) -> int:
-    if model_type in (_MODEL_TYPE_DSV3_2, _MODEL_TYPE_GLM_NSA, _MODEL_TYPE_GLM53_NOPE):
+    if model_type in (_MODEL_TYPE_DSV3_2, _MODEL_TYPE_GLM_NSA):
         return _BPT_DSV3_2
+    if model_type == _MODEL_TYPE_GLM53_NOPE:
+        return _BPT_GLM53_NOPE
     if model_type == _MODEL_TYPE_DSV4:
         return _BPT_DSV4
     if model_type == _MODEL_TYPE_DOTS3_SWA:
         return _BPT_DOTS3_SWA
     raise ValueError(f"Unsupported SM120 sparse-MLA model_type={model_type}")
+
+
+def _inline_cache_block_contiguous(kv_cache: torch.Tensor) -> bool:
+    """Block-contiguity predicate for inline-scale (DSv3.2/GLM) caches.
+
+    Inline-scale kernels address the cache as a flat token array with a
+    runtime row stride, so padded *rows* (a wider last dim or a sliced view)
+    are fine, but pages must pack rows back-to-back. The FFI binding
+    re-checks the same invariant; this only produces an earlier, clearer
+    error at the wrapper layer.
+    """
+    if kv_cache.is_contiguous():
+        return True
+    if kv_cache.ndim == 2 or kv_cache.stride(-1) != 1:
+        return False
+    token_axis = 2 if kv_cache.ndim == 4 and kv_cache.shape[1] == 1 else 1
+    return kv_cache.stride(0) == kv_cache.shape[token_axis] * kv_cache.stride(
+        token_axis
+    )
 
 
 def _packed_kv_page_block_size(
@@ -644,29 +670,22 @@ def get_sparse_mla_sm120_module():
         kv_pbs = _packed_kv_page_block_size(
             kv_cache, model_type=model_type, name="kv_cache"
         )
-        if (
-            model_type
-            in (
-                _MODEL_TYPE_DSV3_2,
-                _MODEL_TYPE_GLM_NSA,
-                _MODEL_TYPE_GLM53_NOPE,
-            )
-            and not kv_cache.is_contiguous()
-        ):
+        if model_type in (
+            _MODEL_TYPE_DSV3_2,
+            _MODEL_TYPE_GLM_NSA,
+            _MODEL_TYPE_GLM53_NOPE,
+        ) and not _inline_cache_block_contiguous(kv_cache):
             # Inline-scale prefill kernels address the cache as a flat token
-            # array, so a padded block stride would be silently misread — and
-            # crossover can route any decode-form call there, so the
-            # restriction cannot wait for a prefill-routed call to fire.
-            # Contiguous padded-row caches (wider last dim) stay allowed:
-            # decode-v32 honors their row stride, and a prefill-routed call
-            # rejects them loudly at the binding.
+            # array with a runtime row stride — and crossover can route any
+            # decode-form call there, so the restriction cannot wait for a
+            # prefill-routed call to fire. Padded rows are honored everywhere;
+            # only inter-block gaps are rejected.
             raise ValueError(
-                "inline-scale (DSv3.2/GLM) KV caches must be contiguous "
-                "through this entry: prefill-routed calls address the cache "
-                "as a flat token array, and the calibrated crossover can "
-                "route decode-form calls to prefill. Padded block strides are "
-                "supported only by the standalone decode entry "
-                "(sparse_mla_sm120_decode_dsv3_2)"
+                "inline-scale (DSv3.2/GLM) KV caches must pack rows "
+                "contiguously within each block through this entry (padded "
+                "rows are fine): prefill-routed calls address the cache as a "
+                "flat token array, and the calibrated crossover can route "
+                "decode-form calls to prefill"
             )
         extra_topk = int(extra_indices.size(-1)) if extra_indices is not None else 0
         planned = plan(
@@ -804,19 +823,20 @@ def _sparse_mla_sm120_paged_attention(
         ``[num_blocks, page_block_size, 1, bytes]``. The SM120 binding derives
         page size and block stride from the tensor metadata without
         materializing a layout conversion. Padded block strides are honored
-        only for footer-scale models (DSv4 / DOTS3_SWA); inline-scale
-        (DSv3.2 / GLM) caches must be contiguous through this entry, since
-        crossover can route any decode-form call to the flat-addressing
-        prefill kernels. Contiguous caches with padded rows (a wider last
-        dim) are served by the decode-v32 kernel and rejected loudly if a
-        call routes to prefill.
+        only for footer-scale models (DSv4 / DOTS3_SWA). Inline-scale
+        (DSv3.2 / GLM) caches take the row advance as a runtime stride, so
+        padded rows (a wider last dim, e.g. a legacy 656B pool serving the
+        528B GLM53_NOPE payload) work in both decode and prefill as long as
+        blocks pack rows contiguously.
     indices : torch.Tensor
         Paged slot IDs per query token, shape ``[num_tokens, topk]`` or
         ``[num_tokens, 1, topk]``, dtype int32. ``-1`` marks invalid /
-        out-of-window slots (kernel skips). Prefill-routed calls require
-        ``topk % 64 == 0`` (whole 64-wide index tiles; the tail tile is not
-        masked) and, for DOTS3_SWA, ``topk >= 513`` so the sliding window
-        fits the buffer.
+        out-of-window slots; masked slots gather a dedicated zero row, so
+        arbitrary cache contents (including NaNs) cannot contaminate valid
+        outputs, and slots past ``topk_length`` are never gathered regardless
+        of the padding contents. Prefill-routed calls require
+        ``topk % 64 == 0`` (whole 64-wide index tiles) and, for DOTS3_SWA,
+        ``topk >= 513`` so the sliding window fits the buffer.
     output : torch.Tensor
         In-place output, shape ``[num_tokens, num_heads, d_v]``, dtype bf16.
     out_lse : torch.Tensor

--- a/flashinfer/mla/_sparse_mla_sm120.py
+++ b/flashinfer/mla/_sparse_mla_sm120.py
@@ -827,7 +827,11 @@ def _sparse_mla_sm120_paged_attention(
         (DSv3.2 / GLM) caches take the row advance as a runtime stride, so
         padded rows (a wider last dim, e.g. a legacy 656B pool serving the
         528B GLM53_NOPE payload) work in both decode and prefill as long as
-        blocks pack rows contiguously.
+        blocks pack rows contiguously. Cache origins and block strides must
+        be 16-byte aligned; inline-scale row strides must also be aligned.
+        Footer-scale rows must remain packed. Flat 2D GLM53_NOPE caches use
+        528 bytes per token; expose the token axis in a 3D/4D view to use
+        an existing 656-byte pool without repacking.
     indices : torch.Tensor
         Paged slot IDs per query token, shape ``[num_tokens, topk]`` or
         ``[num_tokens, 1, topk]``, dtype int32. ``-1`` marks invalid /

--- a/flashinfer/mla/_sparse_mla_sm120_cpb.py
+++ b/flashinfer/mla/_sparse_mla_sm120_cpb.py
@@ -86,7 +86,7 @@ _HPB = 16  # head tile per block
 _SCHEMA_VERSION = 1
 # Only current-schema files load; any other version counts as absent and the
 # families recalibrate on the next tuning-mode pass.
-_BYTES_PER_TOKEN = {"dsv4": 584, "dsv3_2": 656, "glm53_nope": 656, "dots3_swa": 1160}
+_BYTES_PER_TOKEN = {"dsv4": 584, "dsv3_2": 656, "glm53_nope": 528, "dots3_swa": 1160}
 _D_QK = {"dsv4": 512, "dsv3_2": 576, "glm53_nope": 512, "dots3_swa": 1088}
 _D_V = {"dsv4": 512, "dsv3_2": 512, "glm53_nope": 512, "dots3_swa": 1024}
 # Kernel candidate-tile width per family: DOTS3_SWA decodes at BI=32 (its

--- a/flashinfer/mla/_sparse_mla_sm120_cpb.py
+++ b/flashinfer/mla/_sparse_mla_sm120_cpb.py
@@ -83,9 +83,11 @@ logger = logging.getLogger(__name__)
 _BI = 64  # chunk width in candidates (BLOCK_SIZE_N)
 _HPB = 16  # head tile per block
 
-_SCHEMA_VERSION = 1
+_SCHEMA_VERSION = 2
 # Only current-schema files load; any other version counts as absent and the
-# families recalibrate on the next tuning-mode pass.
+# families recalibrate on the next tuning-mode pass. v2: glm53_nope rows went
+# 656B -> 528B, halving the persisted bytes_per_chunk; a stale v1 entry would
+# silently overstate the L2 footprint in the cpb guard.
 _BYTES_PER_TOKEN = {"dsv4": 584, "dsv3_2": 656, "glm53_nope": 528, "dots3_swa": 1160}
 _D_QK = {"dsv4": 512, "dsv3_2": 576, "glm53_nope": 512, "dots3_swa": 1088}
 _D_V = {"dsv4": 512, "dsv3_2": 512, "glm53_nope": 512, "dots3_swa": 1024}

--- a/flashinfer/mla/_sparse_mla_sm120_cpb.py
+++ b/flashinfer/mla/_sparse_mla_sm120_cpb.py
@@ -86,8 +86,9 @@ _HPB = 16  # head tile per block
 _SCHEMA_VERSION = 2
 # Only current-schema files load; any other version counts as absent and the
 # families recalibrate on the next tuning-mode pass. v2: glm53_nope rows went
-# 656B -> 528B, halving the persisted bytes_per_chunk; a stale v1 entry would
-# silently overstate the L2 footprint in the cpb guard.
+# 656B -> 528B — constants and measured overrides can otherwise retain the old
+# 656B footprint, and a stale entry would silently overstate the L2 footprint
+# in the cpb guard.
 _BYTES_PER_TOKEN = {"dsv4": 584, "dsv3_2": 656, "glm53_nope": 528, "dots3_swa": 1160}
 _D_QK = {"dsv4": 512, "dsv3_2": 576, "glm53_nope": 512, "dots3_swa": 1088}
 _D_V = {"dsv4": 512, "dsv3_2": 512, "glm53_nope": 512, "dots3_swa": 1024}
@@ -984,10 +985,12 @@ def _maybe_load_disk() -> None:
         return
     try:
         payload = json.loads(path.read_text())
-        if (
-            not isinstance(payload, dict)
-            or payload.get("schema_version") != _SCHEMA_VERSION
-        ):
+        if not isinstance(payload, dict):
+            return
+        if payload.get("schema_version") != _SCHEMA_VERSION:
+            # This file version cannot supply entries. Retry only after it
+            # changes, rather than reparsing stale tuning on every lookup.
+            _cache_mtime = mtime
             return
         devices = payload["devices"]
         if not isinstance(devices, dict):

--- a/flashinfer/mla/_sparse_mla_sm120_plan.py
+++ b/flashinfer/mla/_sparse_mla_sm120_plan.py
@@ -70,13 +70,16 @@ _MODEL_TYPE_DSV4 = 1
 _MODEL_TYPE_GLM_NSA = 2
 _MODEL_TYPE_GLM53_NOPE = 3
 _MODEL_TYPE_DOTS3_SWA = 4
-# The V32 kernel family: the 656B/token inline-scale cache ABI. GLM53_NOPE is
-# the rope-free member (d_qk=512; bytes [528:656) are reserved padding).
+# The V32 kernel family: the inline-scale cache ABI. DSV3_2/GLM_NSA rows are
+# 656B; GLM53_NOPE is the rope-free member (d_qk=512) with a 528B payload and
+# a runtime gmem row stride (a legacy 656B vLLM pool works unchanged — the
+# [528:656) pad is never read).
 # swapAB is instantiated for all V32 model types.
 _V32_MODEL_TYPES = frozenset(
     {_MODEL_TYPE_DSV3_2, _MODEL_TYPE_GLM_NSA, _MODEL_TYPE_GLM53_NOPE}
 )
 _BPT_DSV3_2 = 656
+_BPT_GLM53_NOPE = 528
 _BPT_DSV4 = 584
 _BPT_DOTS3_SWA = 1160
 

--- a/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/kv_cache_io.cuh
@@ -31,6 +31,7 @@
 #include "../arch/barrier.cuh"
 #include "../arch/cp_async.cuh"
 #include "../model/kv_cache_traits.cuh"
+#include "zero_row.cuh"
 
 // KV cache IO: gather BI entries from global KV pool to smem.
 //
@@ -41,9 +42,16 @@
 //           576 % 16 = 0 ✓ for cp.async.bulk
 //
 // DSV3_2 uses flat addressing: kv_ptr + global_idx * 656.
+// GLM53_NOPE is likewise flat but takes the row advance at runtime
+// (stride_kv_block / PAGE_BLOCK_SIZE): a legacy 656B vLLM pool and a compact
+// 528B pool share the payload prefix, only the advance differs.
 // DSV4 uses block-structured addressing (footer layout):
 //   data:  kv_ptr + block_idx * stride_kv_block + local_idx * 576
 //   scale: kv_ptr + block_idx * stride_kv_block + page_block_size * 576 + local_idx * 8
+//
+// Masked candidates (idx < 0) gather the shared zero row, never a mutable
+// cache slot: a NaN in an unrelated slot would leak through 0 * NaN in the
+// value MMA.
 //
 // Reference: FlashMLA SM90 splitkv_mla.cuh / SM100 kernel.cuh.
 
@@ -52,10 +60,28 @@ struct KVIOTraits {
   using KV = KVCacheTraits<MT>;
   // DSV3_2: IO_STRIDE = KV_GMEM_STRIDE = 656 (inline, bulk copy includes scale)
   // DSV4: IO_STRIDE = D_NOPE + D_ROPE*2 = 576 (footer, data portion only)
+  // GLM53_NOPE: 528 is the payload/prefetch size; the gmem row advance is the
+  // runtime stride_kv_block / PAGE_BLOCK_SIZE, not this constant.
   static constexpr int IO_STRIDE =
       KV::SCALE_IN_KV_SMEM ? KV::KV_GMEM_STRIDE : (KV::D_NOPE + KV::D_ROPE * sizeof(bf16));
   static_assert(IO_STRIDE % 16 == 0, "IO stride must be 16B aligned for cp.async.bulk");
 };
+
+// Flat-array row advance for inline-scale models: the binding guarantees
+// stride_kv_block == page_block_size * row_advance, so the quotient is the
+// exact per-token advance (packed 528/656 pools and padded legacy pools alike).
+__device__ __forceinline__ size_t inline_row_advance(size_t stride_kv_block, int page_block_size) {
+  return stride_kv_block / page_block_size;
+}
+
+// Math-side index normalization: lanes at or past the tile's runtime length
+// carry stale caller padding, and the math-side rope reads are real loads
+// (not hints), so a garbage positive index would form a wild gmem address.
+// Returning -1 routes the lane to the zero row (prefill_kv_entry_base) or a
+// zero value (xv_rope_mma), matching the IO-side staging in load_idx.
+__device__ __forceinline__ int mask_idx_past_len(int idx, int pos, int len) {
+  return pos < len ? idx : -1;
+}
 
 // Bulk gather token nope data (and inline scales for DSV3_2) from global to smem.
 // DSV3_2: flat addressing (idx * 656). DSV4: block-structured (footer layout).
@@ -81,17 +107,18 @@ __device__ __forceinline__ void io_bulk_gather_tile(uint8_t* dst, int idx,
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, TILE_BI * COPY_BYTES);
   if (io_tid >= TILE_BI) return;
 
-  idx = (idx >= 0) ? idx : 0;
+  static_assert(COPY_BYTES <= SPARSE_MLA_ZERO_ROW_BYTES);
+  const bool valid = idx >= 0;
+  idx = valid ? idx : 0;
 
   const uint8_t* src;
   if constexpr (KV::SCALE_IN_KV_SMEM) {
-    src = kv_ptr + (size_t)idx * IO::IO_STRIDE;
+    src = kv_ptr + (size_t)idx * inline_row_advance(stride_kv_block, PAGE_BLOCK_SIZE);
   } else {
     constexpr int pbs = PAGE_BLOCK_SIZE;
-    int block_idx = idx / pbs;
-    int local_idx = idx % pbs;
-    src = kv_ptr + (size_t)block_idx * stride_kv_block + (size_t)local_idx * IO::IO_STRIDE;
+    src = kv_ptr + (size_t)(idx / pbs) * stride_kv_block + (size_t)(idx % pbs) * IO::IO_STRIDE;
   }
+  src = valid ? src : sparse_mla_zero_row;
   if constexpr (USE_L2_HINT)
     cp_async_bulk_g2s_l2hint(dst + io_tid * SMEM_STRIDE, src, COPY_BYTES, mbar, cache_policy);
   else
@@ -114,7 +141,7 @@ __device__ __forceinline__ void io_bulk_prefetch_l2(int idx, const uint8_t* __re
 
   const uint8_t* src;
   if constexpr (KV::SCALE_IN_KV_SMEM) {
-    src = kv_ptr + (size_t)idx * IO::IO_STRIDE;
+    src = kv_ptr + (size_t)idx * inline_row_advance(stride_kv_block, PAGE_BLOCK_SIZE);
   } else {
     constexpr int pbs = PAGE_BLOCK_SIZE;
     src = kv_ptr + (size_t)(idx / pbs) * stride_kv_block + (size_t)(idx % pbs) * IO::IO_STRIDE;
@@ -150,12 +177,16 @@ __device__ __forceinline__ void io_gather_scales(uint8_t* scale_dst, int idx,
                 "per-thread index staging assumes at most one candidate per IO thread");
   if (io_tid >= TILE_BI) return;
 
-  idx = (idx >= 0) ? idx : 0;
+  // Masked candidates read the zero row: a zero UE8M0 scale is finite and the
+  // associated values are zero, so masked lanes contribute nothing. (Slot 0
+  // is not safe to borrow here: a poisoned 0xFF footer byte converts to fp32
+  // +inf, and 0 x inf = NaN.)
+  const bool valid = idx >= 0;
+  idx = valid ? idx : 0;
 
-  int block_idx = idx / pbs;
-  int local_idx = idx % pbs;
-  const uint8_t* src = kv_ptr + (size_t)block_idx * stride_kv_block + (size_t)pbs * IO::IO_STRIDE +
-                       (size_t)local_idx * SCALE_BYTES;
+  const uint8_t* src = kv_ptr + (size_t)(idx / pbs) * stride_kv_block +
+                       (size_t)pbs * IO::IO_STRIDE + (size_t)(idx % pbs) * SCALE_BYTES;
+  src = valid ? src : sparse_mla_zero_row;
   *reinterpret_cast<uint64_t*>(scale_dst + io_tid * SCALE_BYTES) =
       __ldg(reinterpret_cast<const uint64_t*>(src));
 }

--- a/include/flashinfer/attention/sparse_mla_sm120/common/smem_layout.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/smem_layout.cuh
@@ -255,11 +255,14 @@ struct SmemLayoutSwapAB {
   using KV = KVCacheTraits<MT>;
   using CT = ComputeTraitsSwapAB<MT>;
 
-  static constexpr int KV_STRIDE = KV::KV_GMEM_STRIDE;          // 656
+  // Smem rows pack the payload only: 656 for DSV3_2/GLM_NSA (nope + inline
+  // scales + rope), 528 for GLM53_NOPE (no rope). The gmem row advance is a
+  // runtime stride passed to the gather, decoupled from this smem stride.
+  static constexpr int KV_STRIDE = KV::KV_GMEM_STRIDE;
   static constexpr int P_TILE_BYTES = CT::HEADS_PER_WARP * BI;  // 512
 
-  // nope + inline scales + rope, one linear tile per candidate.
-  static constexpr size_t SMEM_KV_BUF = BI * KV_STRIDE;  // 41984
+  // nope + inline scales + rope (where present), one linear tile per candidate.
+  static constexpr size_t SMEM_KV_BUF = BI * KV_STRIDE;  // 41984 (DSV3_2)
 
   // The epilogue's [dim, head] to [head, dim] transpose stays inside a warp, one
   // V chunk at a time. Padding keeps each head row aligned for the uint4 readback.

--- a/include/flashinfer/attention/sparse_mla_sm120/common/xv_rope_mma.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/xv_rope_mma.cuh
@@ -51,8 +51,9 @@
 template <ModelType MT, int PAGE_BLOCK_SIZE>
 __device__ __forceinline__ void xv_rope_mma(float acc_rope[4], float w0, float w1, float w2,
                                             float w3, const int32_t* __restrict__ tile_indices,
-                                            const uint8_t* __restrict__ KV_cache, int mwarp,
-                                            int lane, size_t stride_kv_block, bf16* weight_smem) {
+                                            int valid_len, const uint8_t* __restrict__ KV_cache,
+                                            int mwarp, int lane, size_t stride_kv_block,
+                                            bf16* weight_smem) {
   if constexpr (!KVCacheTraits<MT>::V_HAS_ROPE) return;
 
   using KV = KVCacheTraits<MT>;
@@ -80,14 +81,15 @@ __device__ __forceinline__ void xv_rope_mma(float acc_rope[4], float w0, float w
     uint32_t a0, a1, a2, a3;
     ldmatrix_load_A_bf16(a0, a1, a2, a3, weight_smem + k_base, BI, lane);
 
-    // B operand: 4 scalar loads from global (L2 cached). Invalid entries
-    // (idx < 0) return v=0 directly rather than reading slot 0 — if slot 0
-    // holds non-finite KV (unwritten BF16 NaN/inf from prior workload),
-    // 0 * NaN = NaN would propagate through the MMA. The QK side masks
-    // invalid entries to -1e30 so weights round to 0, but that's not safe
-    // against non-finite V.
+    // B operand: 4 scalar loads from global (L2 cached). Invalid entries —
+    // idx < 0, or entry_offset at/past the tile's runtime length (stale
+    // caller padding) — return v=0 directly rather than reading slot 0: if
+    // slot 0 holds non-finite KV (unwritten BF16 NaN/inf from prior
+    // workload), 0 * NaN = NaN would propagate through the MMA. The QK side
+    // masks invalid entries to -1e30 so weights round to 0, but that's not
+    // safe against non-finite V.
     auto load_rope_v = [&](int entry_offset) -> uint16_t {
-      int idx = tile_indices[entry_offset];
+      int idx = mask_idx_past_len(tile_indices[entry_offset], entry_offset, valid_len);
       if (idx < 0) return 0;
       const uint8_t* base;
       if constexpr (KV::SCALE_IN_KV_SMEM) {
@@ -125,8 +127,8 @@ __device__ __forceinline__ void xv_rope_mma(float acc_rope[4], float w0, float w
 template <ModelType MT, int PAGE_BLOCK_SIZE, int N_HG>
 __device__ __forceinline__ void xv_rope_mma_mg(float acc_rope[N_HG][4], const float w_grp[N_HG][4],
                                                const int32_t* __restrict__ tile_indices,
-                                               const uint8_t* __restrict__ KV_cache, int mwarp,
-                                               int lane, size_t stride_kv_block,
+                                               int valid_len, const uint8_t* __restrict__ KV_cache,
+                                               int mwarp, int lane, size_t stride_kv_block,
                                                bf16* weight_smem) {
   if constexpr (!KVCacheTraits<MT>::V_HAS_ROPE) return;
 
@@ -156,7 +158,7 @@ __device__ __forceinline__ void xv_rope_mma_mg(float acc_rope[N_HG][4], const fl
     int k_base = ks * 16;
 
     auto load_rope_v = [&](int entry_offset) -> uint16_t {
-      int idx = tile_indices[entry_offset];
+      int idx = mask_idx_past_len(tile_indices[entry_offset], entry_offset, valid_len);
       if (idx < 0) return 0;
       const uint8_t* base;
       if constexpr (KV::SCALE_IN_KV_SMEM) {

--- a/include/flashinfer/attention/sparse_mla_sm120/common/zero_row.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/common/zero_row.cuh
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+// Shared zero row for masked (-1) sparse candidates. Gathering a real cache
+// slot for a masked lane would make the value MMA read mutable cache contents:
+// a NaN in that slot contaminates valid outputs through 0 * NaN. A zeroed row
+// keeps every masked value and scale finite (0.0), so masked lanes contribute
+// exactly nothing. Sized to the largest single gather in the family
+// (DOTS3_SWA decode: 1024-byte nope + 128-byte rope); use sites
+// static_assert against it. `static` gives each translation unit its own
+// zero-initialized .rodata copy; it is never written.
+constexpr int SPARSE_MLA_ZERO_ROW_BYTES = 1152;
+static __device__ __align__(16) const uint8_t sparse_mla_zero_row[SPARSE_MLA_ZERO_ROW_BYTES] = {};

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv3_2_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv3_2_kernel.cuh
@@ -13,6 +13,7 @@
 #include "common/fp8_quant.cuh"
 #include "common/online_softmax.cuh"
 #include "common/scale_mma.cuh"
+#include "common/zero_row.cuh"
 #include "model/kv_cache_traits.cuh"
 #include "model/scale_convert.cuh"
 
@@ -23,12 +24,14 @@ namespace flashinfer::sparse_mla_sm120 {
 // adapted to 656B inline-scale traits (D_NOPE=512, V_CHUNK=128,
 // N_V_CHUNKS=4, V_HAS_ROPE=false). No dual cache.
 //
-// KV gmem layout per token (KV_GMEM_STRIDE=656):
+// KV gmem layout per token (DSV3_2/GLM_NSA row = 656B):
 //   [0     : 512)  FP8 e4m3 nope, 4 tiles × 128 elements
 //   [512   : 528)  4 × FP32 scale (one per 128-elem tile)
 //   [528   : 656)  BF16 rope, 64 elements × 2B
 // DSv3.2 stores power-of-2 FP32 scales; GLM_NSA stores arbitrary FP32 scales.
-// GLM53_NOPE reuses the 656 B row with [528:656) as reserved padding — never read as rope.
+// GLM53_NOPE has a 528B payload (no rope); its gmem row advance is the runtime
+// stride_kv_row, so a legacy 656B vLLM pool and a compact 528B pool both work —
+// the [528:656) pad of a 656B row is never read.
 // The IO warp does a single bulk per token that covers both nope and inline
 // scales in one go (528 B), then a second bulk for rope (128 B). No scalar
 // scale gather phase.
@@ -263,11 +266,16 @@ __global__ void __launch_bounds__(DSV3_2_BLOCK_THREADS) sparse_mla_decode_dsv3_2
       if (entry_idx >= DSV3_2_BI) break;
       const int cand_pos = g_start + entry_idx;
       const int idx_raw = (cand_pos < g_end) ? idx_base[cand_pos] : -1;
+      // Masked candidates gather the shared zero row, never a mutable cache
+      // slot: a NaN there would leak through 0 * NaN in the value MMA. The
+      // zero row is wide enough to cover the rope tail as well.
+      static_assert(KV_SMEM_STRIDE + D_ROPE_C * (int)sizeof(bf16) <= SPARSE_MLA_ZERO_ROW_BYTES);
       const int idx = (idx_raw >= 0) ? idx_raw : 0;
       const int block_idx_g = idx / pbs;
       const int local_idx_g = idx - block_idx_g * pbs;
-      const uint8_t* data_base = KV_cache + (size_t)block_idx_g * stride_kv_block +
-                                 (size_t)local_idx_g * (size_t)stride_kv_row;
+      const uint8_t* data_base = (idx_raw >= 0) ? KV_cache + (size_t)block_idx_g * stride_kv_block +
+                                                      (size_t)local_idx_g * (size_t)stride_kv_row
+                                                : sparse_mla_zero_row;
       // Bulk 1: NoPE + INLINE scales (528 B) → sm_kv_fp8 slot.
       cp_async_bulk_g2s(kv_fp8_dst + (size_t)entry_idx * KV_SMEM_STRIDE, data_base,
                         V2_BULK_NOPESC_BYTES, sm.mbar_full(buf));

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_kernel.cuh
@@ -12,6 +12,7 @@
 #include "common/d2_load_b.cuh"
 #include "common/fp8_quant.cuh"
 #include "common/online_softmax.cuh"
+#include "common/zero_row.cuh"
 #include "model/kv_cache_traits.cuh"
 #include "model/scale_convert.cuh"
 
@@ -403,11 +404,16 @@ __global__ void __launch_bounds__(DecodeTileCfg<MT>::BLOCK_THREADS) sparse_mla_d
 #pragma unroll
     for (int e = 0; e < EPW; e++) {
       const int entry_idx = e * Cfg::IO_THREADS + lane;
-      const int idx = (idx_raw[e] >= 0) ? idx_raw[e] : 0;
+      // Masked candidates gather the shared zero row, never a mutable cache
+      // slot: a NaN there would leak through 0 * NaN in the value MMA.
+      const bool valid = idx_raw[e] >= 0;
+      const int idx = valid ? idx_raw[e] : 0;
       const int block_idx_g = idx / section_pbs;
       const int local_idx_g = idx - block_idx_g * section_pbs;
-      const uint8_t* data_base =
-          section_kv + (size_t)block_idx_g * section_stride + (size_t)local_idx_g * IO_STRIDE;
+      const uint8_t* data_base = valid ? section_kv + (size_t)block_idx_g * section_stride +
+                                             (size_t)local_idx_g * IO_STRIDE
+                                       : sparse_mla_zero_row;
+      static_assert(DSV4_BULK_NOPE_BYTES + DSV4_BULK_ROPE_BYTES <= SPARSE_MLA_ZERO_ROW_BYTES);
       cp_async_bulk_g2s(kv_fp8_dst + (size_t)entry_idx * KV_SMEM_STRIDE, data_base,
                         DSV4_BULK_NOPE_BYTES, sm.mbar_full(buf));
       cp_async_bulk_g2s(kv_rope_dst + (size_t)entry_idx * D_ROPE_C, data_base + D_NOPE,

--- a/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/decode_dsv4_nvfp4_kernel.cuh
@@ -24,6 +24,7 @@
 #include "common/d2_load_b_nvfp4.cuh"
 #include "common/nvfp4_quant.cuh"
 #include "common/nvfp4_vt.cuh"
+#include "common/zero_row.cuh"
 #include "model/nvfp4_cache_traits.cuh"
 
 namespace flashinfer::sparse_mla_sm120::nvfp4 {
@@ -282,7 +283,11 @@ __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_n
       __threadfence_block();
     }
 
-    const int idx = idx_raw >= 0 ? idx_raw : 0;
+    // Masked candidates gather the shared zero row, never a mutable cache
+    // slot: the BF16 rope tail has no scale in its path, so a NaN there
+    // would leak through 0 * NaN in the value MMA.
+    const bool valid = idx_raw >= 0;
+    const int idx = valid ? idx_raw : 0;
     int page;
     int slot;
     if constexpr (DUAL_CACHE) {
@@ -297,8 +302,10 @@ __global__ void __launch_bounds__(DECODE_BLOCK_THREADS) sparse_mla_decode_dsv4_n
       page = idx / PAGE_BLOCK_SIZE;
       slot = idx - page * PAGE_BLOCK_SIZE;
     }
-    const uint8_t* data_src =
-        section_kv + (size_t)page * section_stride + (size_t)slot * DECODE_DATA_BYTES_PER_TOKEN;
+    const uint8_t* data_src = valid ? section_kv + (size_t)page * section_stride +
+                                          (size_t)slot * DECODE_DATA_BYTES_PER_TOKEN
+                                    : sparse_mla_zero_row;
+    static_assert(BULK_NOPE_BYTES + BULK_ROPE_BYTES <= SPARSE_MLA_ZERO_ROW_BYTES);
     if (io_warp == 0 && lane == 0) mbarrier_arrive_expect_tx(sm.mbar_full(buf), BULK_TX_BYTES);
     bar_sync_t<4, DECODE_IO_WARPS * 32>();
     cp_async_bulk_g2s(fp4_dst + (size_t)entry * DECODE_KV_SMEM_STRIDE, data_src, BULK_NOPE_BYTES,

--- a/include/flashinfer/attention/sparse_mla_sm120/model/kv_cache_traits.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/kv_cache_traits.cuh
@@ -30,11 +30,17 @@
 
 #include "../arch/common.cuh"
 #include "model_type.h"
+#include "scale_spec.cuh"
 
 // KVCacheTraits<ModelType>: compile-time constants for KV cache layout.
 //
 // These determine smem strides, MMA loop counts, IO gather sizes,
 // and all dimension-dependent kernel parameters.
+//
+// Each model composes a ScaleSpec (format / group size / inline-vs-footer
+// placement) and forwards the derived constants; consumers read the forwarded
+// members (QUANT_TILE, NUM_SCALES, SCALE_FORMAT, SCALE_INLINE, ...) and never
+// the spec directly.
 //
 // The DeepSeek-family model types share: D_ROPE=64, D_V=512, HPB=16, BI=64.
 // GLM53_NOPE diverges on D_ROPE (0); DOTS3_SWA diverges on D_V (1024) and runs
@@ -51,21 +57,22 @@ struct KVCacheTraits<ModelType::DSV3_2> {
   static constexpr int D_QK = D_NOPE + D_ROPE;  // 576
   static constexpr int D_V = 512;
 
-  // FP8 quantization
-  static constexpr int QUANT_TILE = 128;
-  static constexpr int NUM_SCALES = D_NOPE / QUANT_TILE;  // 4
-  static constexpr ScaleFormat SCALE_FORMAT = ScaleFormat::POW2_FP32;
+  // FP8 quantization: power-of-2 FP32 scales, inline, 128-wide groups.
+  using Scales = ScaleSpec<ScaleFormat::POW2_FP32, 128, true>;
+  static constexpr int QUANT_TILE = Scales::GROUP;
+  static constexpr int NUM_SCALES = Scales::count(D_NOPE);  // 4
+  static constexpr ScaleFormat SCALE_FORMAT = Scales::FORMAT;
 
   // KV cache layout (FlashMLA ABI): INLINE, 656 bytes per token
   //   [0:512)   FP8 E4M3 nope (4 tiles × 128)
   //   [512:528) 4 × FP32 scale
   //   [528:656) BF16 rope (64 elements × 2B)
-  static constexpr bool SCALE_INLINE = true;
-  static constexpr int SCALE_BYTES_PER_TOKEN = NUM_SCALES * sizeof(float);  // 16
+  static constexpr bool SCALE_INLINE = Scales::INLINE;
+  static constexpr int SCALE_BYTES_PER_TOKEN = Scales::bytes_per_token(D_NOPE);  // 16
   static constexpr int KV_GMEM_STRIDE =
-      D_NOPE + SCALE_BYTES_PER_TOKEN + D_ROPE * sizeof(bf16);                 // 656
-  static constexpr int KV_SCALE_GMEM_OFFSET = D_NOPE;                         // 512
-  static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE + SCALE_BYTES_PER_TOKEN;  // 528
+      D_NOPE + SCALE_BYTES_PER_TOKEN + D_ROPE * sizeof(bf16);                  // 656
+  static constexpr int KV_SCALE_GMEM_OFFSET = Scales::gmem_offset(D_NOPE, 0);  // 512
+  static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE + SCALE_BYTES_PER_TOKEN;   // 528
 
   // Smem layout: bulk copy includes nope + scales (528B)
   // stride=528: 528/4=132, 132%32=4 → 4-way bank conflict (acceptable)
@@ -85,13 +92,15 @@ struct KVCacheTraits<ModelType::DSV3_2> {
   // FP32→UE8M0 scale conversion for block-scaled MMA
   // FlashMLA stores power-of-2 FP32 scales → bit-shift gives exact UE8M0
   __device__ static __forceinline__ uint8_t scale_to_ue8m0(float scale) {
-    return static_cast<uint8_t>((__float_as_uint(scale) >> 23) & 0xFF);
+    return ScaleConvert<Scales::FORMAT>::to_ue8m0(scale);
   }
 };
 
 template <>
 struct KVCacheTraits<ModelType::GLM_NSA> : KVCacheTraits<ModelType::DSV3_2> {
-  static constexpr ScaleFormat SCALE_FORMAT = ScaleFormat::ARBITRARY_FP32;
+  // Same geometry and inline layout as DSV3_2, with arbitrary FP32 scales.
+  using Scales = ScaleSpec<ScaleFormat::ARBITRARY_FP32, 128, true>;
+  static constexpr ScaleFormat SCALE_FORMAT = Scales::FORMAT;
 };
 
 template <>
@@ -103,18 +112,21 @@ struct KVCacheTraits<ModelType::GLM53_NOPE> {
   static constexpr int D_QK = D_NOPE;
   static constexpr int D_V = 512;
 
-  static constexpr int QUANT_TILE = 128;
-  static constexpr int NUM_SCALES = D_NOPE / QUANT_TILE;
-  static constexpr ScaleFormat SCALE_FORMAT = ScaleFormat::ARBITRARY_FP32;
+  // FP8 quantization: arbitrary FP32 scales, inline, 128-wide groups.
+  using Scales = ScaleSpec<ScaleFormat::ARBITRARY_FP32, 128, true>;
+  static constexpr int QUANT_TILE = Scales::GROUP;
+  static constexpr int NUM_SCALES = Scales::count(D_NOPE);
+  static constexpr ScaleFormat SCALE_FORMAT = Scales::FORMAT;
 
-  // vLLM's fp8_ds_mla cache ABI remains 656 bytes/token. The first 528
-  // bytes contain the 512 FP8 latent values plus four inline FP32 scales;
-  // the trailing 128 bytes are reserved padding and must never be treated as
-  // RoPE data by this specialization.
-  static constexpr bool SCALE_INLINE = true;
-  static constexpr int SCALE_BYTES_PER_TOKEN = NUM_SCALES * sizeof(float);
-  static constexpr int KV_GMEM_STRIDE = 656;
-  static constexpr int KV_SCALE_GMEM_OFFSET = D_NOPE;
+  // The packed payload is 528 bytes/token: 512 FP8 latent values plus four
+  // inline FP32 scales. vLLM's fp8_ds_mla ABI pads the gmem row to 656B with
+  // reserved bytes that must never be treated as RoPE data; the kernels take
+  // the gmem row advance as a runtime stride, so KV_GMEM_STRIDE below is only
+  // the payload (== smem copy size), not the gmem advance.
+  static constexpr bool SCALE_INLINE = Scales::INLINE;
+  static constexpr int SCALE_BYTES_PER_TOKEN = Scales::bytes_per_token(D_NOPE);
+  static constexpr int KV_GMEM_STRIDE = D_NOPE + SCALE_BYTES_PER_TOKEN;  // 528
+  static constexpr int KV_SCALE_GMEM_OFFSET = Scales::gmem_offset(D_NOPE, 0);
   static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE + SCALE_BYTES_PER_TOKEN;
   static constexpr int KV_SMEM_STRIDE = D_NOPE + SCALE_BYTES_PER_TOKEN;
   static constexpr int KV_SMEM_COPY_BYTES = KV_SMEM_STRIDE;
@@ -125,7 +137,7 @@ struct KVCacheTraits<ModelType::GLM53_NOPE> {
   static constexpr bool V_HAS_ROPE = false;
 
   __device__ static __forceinline__ uint8_t scale_to_ue8m0(float scale) {
-    return static_cast<uint8_t>((__float_as_uint(scale) >> 23) & 0xFF);
+    return ScaleConvert<Scales::FORMAT>::to_ue8m0(scale);
   }
 };
 
@@ -138,11 +150,13 @@ struct KVCacheTraits<ModelType::DOTS3_SWA> {
   static constexpr int D_QK = D_NOPE + D_ROPE;  // 1088
   static constexpr int D_V = D_NOPE;            // 1024, rope excluded (V_HAS_ROPE=false)
 
-  // FP8 quantization. QUANT_TILE=128 (not DSV4's 64) keeps NUM_SCALES a power
-  // of two, so the footer is 8B with no pad — unlike DSV4's 7+1.
-  static constexpr int QUANT_TILE = 128;
-  static constexpr int NUM_SCALES = D_NOPE / QUANT_TILE;  // 8
-  static constexpr ScaleFormat SCALE_FORMAT = ScaleFormat::UE8M0_BYTE;
+  // FP8 quantization: UE8M0 scales, footer, 128-wide groups (not DSV4's 64),
+  // keeping NUM_SCALES a power of two so the footer is 8B with no pad —
+  // unlike DSV4's 7+1.
+  using Scales = ScaleSpec<ScaleFormat::UE8M0_BYTE, 128, false>;
+  static constexpr int QUANT_TILE = Scales::GROUP;
+  static constexpr int NUM_SCALES = Scales::count(D_NOPE);  // 8
+  static constexpr ScaleFormat SCALE_FORMAT = Scales::FORMAT;
 
   // KV cache layout (FlashMLA ABI): FOOTER, 1160 logical bytes per token.
   // Physical layout per block (page_block_size tokens):
@@ -151,12 +165,13 @@ struct KVCacheTraits<ModelType::DOTS3_SWA> {
   //   [block_size*1152 : block_size*1160)   scale footer (8B each: 8×UE8M0)
   //
   // IO stride = 1152 (data only), 1152 % 16 = 0 ✓ for cp.async.bulk.
-  static constexpr bool SCALE_INLINE = false;
-  static constexpr int SCALE_BYTES_PER_TOKEN = 8;
+  static constexpr bool SCALE_INLINE = Scales::INLINE;
+  static constexpr int SCALE_BYTES_PER_TOKEN = Scales::bytes_per_token(D_NOPE);  // 8
   static constexpr int KV_GMEM_STRIDE =
-      D_NOPE + D_ROPE * sizeof(bf16) + SCALE_BYTES_PER_TOKEN;                  // 1160
-  static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE;                           // 1024
-  static constexpr int KV_SCALE_GMEM_OFFSET = D_NOPE + D_ROPE * sizeof(bf16);  // 1152
+      D_NOPE + D_ROPE * sizeof(bf16) + SCALE_BYTES_PER_TOKEN;  // 1160
+  static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE;           // 1024
+  static constexpr int KV_SCALE_GMEM_OFFSET =
+      Scales::gmem_offset(D_NOPE, D_ROPE*(int)sizeof(bf16));  // 1152
 
   // Smem layout (nope only + padding, no rope, no inline scales).
   // stride=1040: 1040/4=260, 260%32=4 → same 4-way conflict class as DSV3_2's
@@ -177,7 +192,9 @@ struct KVCacheTraits<ModelType::DOTS3_SWA> {
   static constexpr bool V_HAS_ROPE = false;
 
   // UE8M0 scales are native — no conversion needed
-  __device__ static __forceinline__ uint8_t scale_to_ue8m0(uint8_t scale) { return scale; }
+  __device__ static __forceinline__ uint8_t scale_to_ue8m0(uint8_t scale) {
+    return ScaleConvert<Scales::FORMAT>::to_ue8m0(scale);
+  }
 };
 
 template <>
@@ -188,10 +205,11 @@ struct KVCacheTraits<ModelType::DSV4> {
   static constexpr int D_QK = D_NOPE + D_ROPE;  // 512
   static constexpr int D_V = 512;               // = D_NOPE + D_ROPE
 
-  // FP8 quantization
-  static constexpr int QUANT_TILE = 64;
-  static constexpr int NUM_SCALES = 7;  // D_NOPE / QUANT_TILE = 448/64
-  static constexpr ScaleFormat SCALE_FORMAT = ScaleFormat::UE8M0_BYTE;
+  // FP8 quantization: UE8M0 scales, footer, 64-wide groups.
+  using Scales = ScaleSpec<ScaleFormat::UE8M0_BYTE, 64, false>;
+  static constexpr int QUANT_TILE = Scales::GROUP;
+  static constexpr int NUM_SCALES = Scales::count(D_NOPE);  // 7 = 448/64
+  static constexpr ScaleFormat SCALE_FORMAT = Scales::FORMAT;
 
   // KV cache layout (FlashMLA ABI): FOOTER, 584 logical bytes per token
   // Physical layout per block (page_block_size tokens):
@@ -201,12 +219,13 @@ struct KVCacheTraits<ModelType::DSV4> {
   //
   // stride_kv_row = 584 = logical bytes_per_token (PyTorch API stride, NOT IO stride)
   // IO stride = 576 (data only, 16B aligned for cp.async.bulk)
-  static constexpr bool SCALE_INLINE = false;  // scales in footer, not inline
-  static constexpr int SCALE_BYTES_PER_TOKEN = 8;
+  static constexpr bool SCALE_INLINE = Scales::INLINE;  // scales in footer, not inline
+  static constexpr int SCALE_BYTES_PER_TOKEN = Scales::bytes_per_token(D_NOPE);  // 8
   static constexpr int KV_GMEM_STRIDE =
-      D_NOPE + D_ROPE * sizeof(bf16) + SCALE_BYTES_PER_TOKEN;                  // 584
-  static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE;                           // 448
-  static constexpr int KV_SCALE_GMEM_OFFSET = D_NOPE + D_ROPE * sizeof(bf16);  // 576
+      D_NOPE + D_ROPE * sizeof(bf16) + SCALE_BYTES_PER_TOKEN;  // 584
+  static constexpr int KV_ROPE_GMEM_OFFSET = D_NOPE;           // 448
+  static constexpr int KV_SCALE_GMEM_OFFSET =
+      Scales::gmem_offset(D_NOPE, D_ROPE*(int)sizeof(bf16));  // 576
 
   // Smem layout (nope only + padding, no rope, no inline scales)
   // stride=464: 464/4=116, 116%32=20 → clean (M4b benchmark verified: 12.9 ns/MMA)
@@ -226,7 +245,9 @@ struct KVCacheTraits<ModelType::DSV4> {
   static constexpr bool V_HAS_ROPE = true;
 
   // UE8M0 scales are native — no conversion needed
-  __device__ static __forceinline__ uint8_t scale_to_ue8m0(uint8_t scale) { return scale; }
+  __device__ static __forceinline__ uint8_t scale_to_ue8m0(uint8_t scale) {
+    return ScaleConvert<Scales::FORMAT>::to_ue8m0(scale);
+  }
 };
 
 // ============================================================================
@@ -256,6 +277,24 @@ static_assert(KVCacheTraits<ModelType::DOTS3_SWA>::D_ROPE == D_ROPE);
 static_assert(KVCacheTraits<ModelType::DOTS3_SWA>::D_V != D_V,
               "DOTS3_SWA is the D_V opt-out; if it ever equals 512, fold it back "
               "into the shared assert above");
+
+// ScaleSpec composition pins: the composed constants must keep the exact
+// values the hand-written layouts had (FlashMLA ABI compatibility).
+static_assert(KVCacheTraits<ModelType::DSV3_2>::NUM_SCALES == 4);
+static_assert(KVCacheTraits<ModelType::DSV3_2>::SCALE_BYTES_PER_TOKEN == 16);
+static_assert(KVCacheTraits<ModelType::DSV3_2>::KV_GMEM_STRIDE == 656);
+static_assert(KVCacheTraits<ModelType::GLM_NSA>::KV_GMEM_STRIDE == 656);
+static_assert(KVCacheTraits<ModelType::GLM_NSA>::SCALE_FORMAT == ScaleFormat::ARBITRARY_FP32);
+static_assert(KVCacheTraits<ModelType::GLM53_NOPE>::NUM_SCALES == 4);
+static_assert(KVCacheTraits<ModelType::GLM53_NOPE>::SCALE_BYTES_PER_TOKEN == 16);
+static_assert(KVCacheTraits<ModelType::GLM53_NOPE>::KV_GMEM_STRIDE == 528);
+static_assert(KVCacheTraits<ModelType::DSV4>::NUM_SCALES == 7);
+static_assert(KVCacheTraits<ModelType::DSV4>::SCALE_BYTES_PER_TOKEN == 8);
+static_assert(KVCacheTraits<ModelType::DSV4>::KV_GMEM_STRIDE == 584);
+static_assert(KVCacheTraits<ModelType::DSV4>::KV_SCALE_GMEM_OFFSET == 576);
+static_assert(KVCacheTraits<ModelType::DOTS3_SWA>::NUM_SCALES == 8);
+static_assert(KVCacheTraits<ModelType::DOTS3_SWA>::SCALE_BYTES_PER_TOKEN == 8);
+static_assert(KVCacheTraits<ModelType::DOTS3_SWA>::KV_GMEM_STRIDE == 1160);
 
 // Warp configuration
 static constexpr int N_MATH_WARPS = 8;

--- a/include/flashinfer/attention/sparse_mla_sm120/model/model_type.h
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/model_type.h
@@ -34,8 +34,11 @@
 //   DSV3_2:  d_nope=512, power-of-2 FP32 scale inline, 656B/token
 //   DSV4:    d_nope=448, UE8M0 scale footer, 584B/token
 //   GLM_NSA: d_nope=512, d_rope=64, arbitrary FP32 scale inline, 656B/token
-//   GLM53_NOPE: d_nope=512, d_rope=0, arbitrary FP32 scale inline,
-//               656B/token (the final 128 bytes are reserved cache padding)
+//   GLM53_NOPE: d_nope=512, d_rope=0, arbitrary FP32 scale inline, 528B/token.
+//               The vLLM fp8_ds_mla ABI pads the row to 656B; the kernels take
+//               the gmem row advance as a runtime stride, so a legacy 656B pool
+//               and a compact 528B pool are the same kernel (the payload prefix
+//               is identical). A flat 2D cache must be packed at 528B.
 //   DOTS3_SWA: d_nope=1024, d_rope=64, UE8M0 scale footer, 1160B/token
 //
 // DOTS3_SWA is the sliding-window family: its candidate list is a 513-token
@@ -44,13 +47,15 @@
 // in kv_cache_traits.cuh.
 enum class ModelType { DSV3_2, DSV4, GLM_NSA, GLM53_NOPE, DOTS3_SWA };
 
-// Bytes per packed KV cache token row, per model type.
+// Bytes per packed KV cache token row, per model type. For GLM53_NOPE this is
+// the payload; the gmem row advance is a runtime stride >= this value.
 constexpr int bytes_per_token(ModelType mt) {
   switch (mt) {
     case ModelType::DSV3_2:
     case ModelType::GLM_NSA:
-    case ModelType::GLM53_NOPE:
       return 656;
+    case ModelType::GLM53_NOPE:
+      return 528;
     case ModelType::DSV4:
       return 584;
     case ModelType::DOTS3_SWA:

--- a/include/flashinfer/attention/sparse_mla_sm120/model/scale_spec.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/model/scale_spec.cuh
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "model_type.h"
+#include "scale_convert.cuh"
+
+// ScaleSpec: the scale configuration of a packed KV cache row, decoupled from
+// model geometry. Three axes — numeric FORMAT, quantization GROUP size, and
+// placement INLINE (between nope and rope inside the row) vs footer (a padded
+// footer after the block's data rows). KVCacheTraits composes one spec per
+// model and forwards the derived constants, so a new (geometry, scale)
+// combination is one traits row rather than a traits rewrite.
+//
+// All helpers take the geometry as arguments so the spec stays usable for any
+// D_NOPE / D_ROPE.
+template <ScaleFormat F_, int GROUP_, bool INLINE_>
+struct ScaleSpec {
+  static constexpr ScaleFormat FORMAT = F_;
+  static constexpr int GROUP = GROUP_;
+  static constexpr bool INLINE = INLINE_;
+  static constexpr int BYTES_PER_SCALE = (F_ == ScaleFormat::UE8M0_BYTE) ? 1 : 4;
+
+  static constexpr int count(int d_nope) { return d_nope / GROUP; }
+  // Footer layouts round the per-token scale bytes up to 8B (one uint64
+  // gather); inline layouts are exact FP32 arrays.
+  static constexpr int bytes_per_token(int d_nope) {
+    return INLINE ? count(d_nope) * BYTES_PER_SCALE : (count(d_nope) * BYTES_PER_SCALE + 7) / 8 * 8;
+  }
+  // Offset of the scale payload within the packed token row (inline) or block
+  // (footer, after all data rows).
+  static constexpr int gmem_offset(int d_nope, int rope_bytes) {
+    return INLINE ? d_nope : d_nope + rope_bytes;
+  }
+};
+
+// Per-format scale -> UE8M0 conversion for block-scaled MMA. UE8M0 caches
+// need no conversion; both FP32 formats reduce to the exponent byte.
+template <ScaleFormat F>
+struct ScaleConvert {
+  static_assert(F == ScaleFormat::POW2_FP32 || F == ScaleFormat::ARBITRARY_FP32,
+                "add a ScaleConvert specialization for this scale format");
+  __device__ static __forceinline__ uint8_t to_ue8m0(float scale) { return fp32_to_ue8m0(scale); }
+};
+
+template <>
+struct ScaleConvert<ScaleFormat::UE8M0_BYTE> {
+  __device__ static __forceinline__ uint8_t to_ue8m0(uint8_t scale) { return scale; }
+};

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_common.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_common.cuh
@@ -190,18 +190,26 @@ __device__ __forceinline__ const uint8_t* prefill_kv_entry_base(
     const uint8_t* __restrict__ kv_global, int idx, size_t stride_kv_block) {
   using KV = KVCacheTraits<MT>;
   using IO = KVIOTraits<MT>;
-  idx = (idx >= 0) ? idx : 0;
   // Addressing mode follows the scale layout, not V_HAS_ROPE: an inline-scale
   // model (DSV3_2 / GLM_NSA / GLM53_NOPE) is a flat token array, a footer-scale
   // model (DSV4 / DOTS3_SWA) is paged with the footer after the block's data.
   // This matches io_bulk_gather_tile. Keying it on V_HAS_ROPE happened to agree
   // for the three DeepSeek-family models and disagrees for DOTS3_SWA, which is
   // footer-scaled with no rope in V.
+  // Masked lanes redirect to the zero row, not slot 0: rope segments read
+  // through this base feed MMAs whose result is only partially masked
+  // downstream, so a poisoned slot-0 payload would leak NaN.
+  const bool valid = idx >= 0;
+  idx = valid ? idx : 0;
+  const uint8_t* base;
   if constexpr (!KV::SCALE_IN_KV_SMEM) {
     const int bi = idx / PAGE_BLOCK_SIZE;
     const int li = idx % PAGE_BLOCK_SIZE;
-    return kv_global + (size_t)bi * stride_kv_block + (size_t)li * IO::IO_STRIDE;
+    base = kv_global + (size_t)bi * stride_kv_block + (size_t)li * IO::IO_STRIDE;
   } else {
-    return kv_global + (size_t)idx * IO::IO_STRIDE;
+    // Flat inline array: the row advance is the runtime stride (payload 528
+    // for GLM53_NOPE; a legacy 656B vLLM pool advances by 656).
+    base = kv_global + (size_t)idx * inline_row_advance(stride_kv_block, PAGE_BLOCK_SIZE);
   }
+  return valid ? base : sparse_mla_zero_row;
 }

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_mg_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_mg_kernel.cuh
@@ -126,7 +126,7 @@ __device__ __forceinline__ void sparse_mla_prefill_math_pc(
     static_assert(Cfg::BI < 64, "a BI=64 split tile should re-examine staging");
     int idx_rope_cur = 0, mask0_cur = 0, mask1_cur = 0;
     if (actual_ni > 0) {
-      idx_rope_cur = idx_base[qk_nb + gid];
+      idx_rope_cur = mask_idx_past_len(idx_base[qk_nb + gid], qk_nb + gid, topk_len);
       mask0_cur = idx_base[qk_nb + tid * 2];
       mask1_cur = idx_base[qk_nb + tid * 2 + 1];
     }
@@ -150,7 +150,8 @@ __device__ __forceinline__ void sparse_mla_prefill_math_pc(
       int idx_rope_nxt = 0, mask0_nxt = 0, mask1_nxt = 0;
       if (ti + 1 < actual_ni) {
         const int32_t* ibn = idx_base + (ti + 1) * Cfg::BI;
-        idx_rope_nxt = ibn[qk_nb + gid];
+        idx_rope_nxt =
+            mask_idx_past_len(ibn[qk_nb + gid], (ti + 1) * Cfg::BI + qk_nb + gid, topk_len);
         mask0_nxt = ibn[qk_nb + tid * 2];
         mask1_nxt = ibn[qk_nb + tid * 2 + 1];
       }
@@ -574,8 +575,13 @@ __global__ void __launch_bounds__(PrefillTileCfg<MT>::BLOCK_THREADS, 1)
 
     // This thread's candidate index for tile t, staged a tile ahead of use so
     // the index LDG latency is hidden behind the previous tile's gather.
+    // Bound by topk_len, not just actual_ni * BI: the last tile is partial and
+    // caller padding past topk_len may be stale, and a garbage index would
+    // gather a wild gmem address.
     auto load_idx = [&](int t) -> int {
-      return (t < actual_ni && io_tid < Cfg::BI) ? __ldg(idx_base + t * Cfg::BI + io_tid) : -1;
+      return (t < actual_ni && io_tid < Cfg::BI && t * Cfg::BI + io_tid < topk_len)
+                 ? __ldg(idx_base + t * Cfg::BI + io_tid)
+                 : -1;
     };
     // Scales first (plain stores, no mbar signal), then bulk gather
     // (cp.async.bulk signals mbar_kv on completion). Math warps wake on
@@ -679,7 +685,8 @@ __global__ void __launch_bounds__(PrefillTileCfg<MT>::BLOCK_THREADS, 1)
       if (qk_warp) {
         uint8_t* kv_warp_base = kv_smem + qk_nb * KV::KV_SMEM_STRIDE;
 
-        const int idx_rope = ib[qk_nb + gid];
+        const int idx_rope =
+            mask_idx_past_len(ib[qk_nb + gid], ti * Cfg::BI + qk_nb + gid, topk_len);
         const int mask0 = ib[qk_nb + tid * 2];
         const int mask1 = ib[qk_nb + tid * 2 + 1];
 
@@ -1019,8 +1026,9 @@ __global__ void __launch_bounds__(PrefillTileCfg<MT>::BLOCK_THREADS, 1)
         static_assert(Cfg::BI == BI && Cfg::MATH_WARPS == N_MATH_WARPS,
                       "xv_rope_mma is hardcoded to the 64/8 tile; parameterize it before running a "
                       "V_HAS_ROPE model at a different BI");
-        xv_rope_mma<MT, PAGE_BLOCK_SIZE>(acc_rope, w0, w1, w2, w3, ib, KV_cache, mwarp, lane,
-                                         stride_kv_block, reinterpret_cast<bf16*>(sm.w_fp8));
+        xv_rope_mma<MT, PAGE_BLOCK_SIZE>(acc_rope, w0, w1, w2, w3, ib,
+                                         min(Cfg::BI, topk_len - ti * Cfg::BI), KV_cache, mwarp,
+                                         lane, stride_kv_block, reinterpret_cast<bf16*>(sm.w_fp8));
       }
 
       bar_arrive_alt<1, 5, Cfg::BLOCK_THREADS>(ti & 1);
@@ -1257,15 +1265,21 @@ __device__ __forceinline__ void prefill_mg_impl(
     // This thread's candidate index for logical tile t, staged a tile ahead of
     // use so the index LDG latency is hidden behind the previous tile's
     // gather. main_ni equals NI under ASSUME_FULL_TILES, so the main/extra
-    // split needs no branch on the tile-length mode.
+    // split needs no branch on the tile-length mode. Lanes past the runtime
+    // topk length are masked out: the last tile is partial and caller padding
+    // may be stale, and a garbage index would gather a wild gmem address.
     auto load_idx = [&](int t) -> int {
       if (t >= loop_bound || io_tid >= BI) return -1;
       if constexpr (DUAL_CACHE) {
         const bool is_main = t < main_ni;
+        if (is_main ? (t * BI + io_tid >= topk_len)
+                    : ((t - main_ni) * BI + io_tid >= topk_len_extra)) {
+          return -1;
+        }
         const int32_t* p = is_main ? (idx_base + t * BI) : (idx_base_extra + (t - main_ni) * BI);
         return __ldg(p + io_tid);
       } else {
-        return __ldg(idx_base + t * BI + io_tid);
+        return (t * BI + io_tid < topk_len) ? __ldg(idx_base + t * BI + io_tid) : -1;
       }
     };
     // Scales first (plain stores, no mbar signal), then bulk gather
@@ -1400,7 +1414,10 @@ __device__ __forceinline__ void prefill_mg_impl(
       // Entry base: only gid's entry needed (rope prefetch + QK rope)
       const uint8_t* entry_base_gid;
       {
-        const int idx = ib[qk_nb + gid];
+        // Position and runtime length are phase-relative under dual cache.
+        const int phase_ti = (DUAL_CACHE && !is_main) ? (ti - main_ni) : ti;
+        const int len_now = (DUAL_CACHE && !is_main) ? topk_len_extra : topk_len;
+        const int idx = mask_idx_past_len(ib[qk_nb + gid], phase_ti * BI + qk_nb + gid, len_now);
         if constexpr (DUAL_CACHE) {
           if (is_main) {
             entry_base_gid =
@@ -1985,19 +2002,24 @@ __device__ __forceinline__ void prefill_mg_impl(
       // ── XV rope BF16 MMA (DSV4, both groups) ──────────────
       if constexpr (KV::V_HAS_ROPE) {
         bar_sync_t<2, MATH_THREADS>();
+        // Entries past the phase's runtime length carry stale caller padding;
+        // the rope reads re-derive gmem addresses from `ib`, so pass the bound.
+        const int valid_len = (DUAL_CACHE && !is_main)
+                                  ? min(BI, topk_len_extra - (ti - main_ni) * BI)
+                                  : min(BI, topk_len - ti * BI);
         if constexpr (DUAL_CACHE) {
           if (is_main) {
-            xv_rope_mma_mg<MT, PAGE_BLOCK_SIZE, MG_N_HG>(acc_rope, w_grp, ib, kv_global, mwarp,
-                                                         lane, stride_kv_block_now,
+            xv_rope_mma_mg<MT, PAGE_BLOCK_SIZE, MG_N_HG>(acc_rope, w_grp, ib, valid_len, kv_global,
+                                                         mwarp, lane, stride_kv_block_now,
                                                          reinterpret_cast<bf16*>(sm.w_fp8()));
           } else {
-            xv_rope_mma_mg<MT, PAGE_BLOCK_SIZE_EXTRA, MG_N_HG>(acc_rope, w_grp, ib, kv_global,
-                                                               mwarp, lane, stride_kv_block_now,
-                                                               reinterpret_cast<bf16*>(sm.w_fp8()));
+            xv_rope_mma_mg<MT, PAGE_BLOCK_SIZE_EXTRA, MG_N_HG>(
+                acc_rope, w_grp, ib, valid_len, kv_global, mwarp, lane, stride_kv_block_now,
+                reinterpret_cast<bf16*>(sm.w_fp8()));
           }
         } else {
-          xv_rope_mma_mg<MT, PAGE_BLOCK_SIZE, MG_N_HG>(acc_rope, w_grp, ib, kv_global, mwarp, lane,
-                                                       stride_kv_block_now,
+          xv_rope_mma_mg<MT, PAGE_BLOCK_SIZE, MG_N_HG>(acc_rope, w_grp, ib, valid_len, kv_global,
+                                                       mwarp, lane, stride_kv_block_now,
                                                        reinterpret_cast<bf16*>(sm.w_fp8()));
         }
       }

--- a/include/flashinfer/attention/sparse_mla_sm120/prefill_swapab_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/prefill_swapab_kernel.cuh
@@ -56,14 +56,21 @@ template <ModelType MT>
 __device__ __forceinline__ void io_bulk_gather_tile_swapab(uint8_t* dst, int idx,
                                                            const uint8_t* __restrict__ kv_ptr,
                                                            uint64_t* mbar, int io_tid,
+                                                           size_t stride_kv_block,
                                                            uint64_t cache_policy) {
   constexpr int STRIDE = SmemLayoutSwapAB<MT>::KV_STRIDE;
   static_assert(BI <= IO_THREADS, "per-thread index staging assumes one candidate per IO thread");
+  static_assert(STRIDE <= SPARSE_MLA_ZERO_ROW_BYTES);
 
   if (io_tid == 0) mbarrier_arrive_expect_tx(mbar, BI * STRIDE);
   if (io_tid >= BI) return;
 
-  const uint8_t* src = kv_ptr + (size_t)(idx >= 0 ? idx : 0) * STRIDE;
+  // The smem row packs the payload only (KV_STRIDE); the gmem row advance is
+  // the runtime stride, which may be wider than the payload (a legacy 656B
+  // vLLM pool serving a 528B GLM53_NOPE payload). swapAB is only eligible at
+  // page_block_size 64, so the advance is stride_kv_block / 64.
+  const uint8_t* src = idx >= 0 ? kv_ptr + (size_t)idx * inline_row_advance(stride_kv_block, 64)
+                                : sparse_mla_zero_row;
   cp_async_bulk_g2s_l2hint(dst + io_tid * STRIDE, src, STRIDE, mbar, cache_policy);
 }
 
@@ -72,10 +79,12 @@ __device__ __forceinline__ void io_bulk_gather_tile_swapab(uint8_t* dst, int idx
 template <ModelType MT>
 __device__ __forceinline__ void io_bulk_prefetch_l2_swapab(int idx,
                                                            const uint8_t* __restrict__ kv_ptr,
-                                                           int io_tid, uint64_t cache_policy) {
+                                                           int io_tid, size_t stride_kv_block,
+                                                           uint64_t cache_policy) {
   constexpr int STRIDE = SmemLayoutSwapAB<MT>::KV_STRIDE;
   if (io_tid >= BI || idx < 0) return;
-  cp_async_bulk_prefetch_l2_hint(kv_ptr + (size_t)idx * STRIDE, STRIDE, cache_policy);
+  cp_async_bulk_prefetch_l2_hint(kv_ptr + (size_t)idx * inline_row_advance(stride_kv_block, 64),
+                                 STRIDE, cache_policy);
 }
 
 template <ModelType MT, int NUM_HEADS>
@@ -131,7 +140,11 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
     // `pf` (tile ti+1) warms L2 after the gather issue: this pipeline is one
     // tile deep, so the prefetch must not delay the gather the math waits on.
     auto ld_idx = [&](int t) -> int {
-      return (t < actual_ni && io_tid < BI) ? __ldg(idx_base + t * BI + io_tid) : -1;
+      // Bound by topk_len: the last tile is partial and caller padding past
+      // topk_len may be stale; a garbage index would gather a wild address.
+      return (t < actual_ni && io_tid < BI && t * BI + io_tid < topk_len)
+                 ? __ldg(idx_base + t * BI + io_tid)
+                 : -1;
     };
     int staged = ld_idx(0);
     int pf = ld_idx(1);
@@ -142,8 +155,8 @@ __global__ void __launch_bounds__(BLOCK_THREADS, 1)
       const int next = ld_idx(ti + 2);
       mbarrier_wait_parity(sm.mbar_wr + buf, wr_phase);
       io_bulk_gather_tile_swapab<MT>(sm.kv_bufs[buf], staged, KV_cache, sm.mbar_kv + buf, io_tid,
-                                     kv_l2_policy);
-      io_bulk_prefetch_l2_swapab<MT>(pf, KV_cache, io_tid, kv_l2_policy);
+                                     cold.stride_kv_block, kv_l2_policy);
+      io_bulk_prefetch_l2_swapab<MT>(pf, KV_cache, io_tid, cold.stride_kv_block, kv_l2_policy);
       staged = pf;
       pf = next;
       if (buf == 1) wr_phase ^= 1;

--- a/include/flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh
+++ b/include/flashinfer/attention/sparse_mla_sm120/streaming_dsv4_nvfp4_kernel.cuh
@@ -24,6 +24,7 @@
 #include "common/d2_load_b_nvfp4.cuh"
 #include "common/nvfp4_quant.cuh"
 #include "common/nvfp4_vt.cuh"
+#include "common/zero_row.cuh"
 #include "model/nvfp4_cache_traits.cuh"
 
 namespace flashinfer::sparse_mla_sm120::nvfp4 {
@@ -324,7 +325,11 @@ __global__ void __launch_bounds__(STREAMING_BLOCK_THREADS, 1)
                               sizeof(uint4)) = s1;
     __threadfence_block();
 
-    const int idx = idx_raw >= 0 ? idx_raw : 0;
+    // Masked candidates gather the shared zero row, never a mutable cache
+    // slot: the BF16 rope tail has no scale in its path, so a NaN there
+    // would leak through 0 * NaN in the value MMA.
+    const bool valid = idx_raw >= 0;
+    const int idx = valid ? idx_raw : 0;
     int page;
     int slot;
     if constexpr (DUAL_CACHE) {
@@ -339,8 +344,10 @@ __global__ void __launch_bounds__(STREAMING_BLOCK_THREADS, 1)
       page = idx / PAGE_BLOCK_SIZE;
       slot = idx - page * PAGE_BLOCK_SIZE;
     }
-    const uint8_t* data_src =
-        section_kv + (size_t)page * section_stride + (size_t)slot * STREAMING_DATA_BYTES_PER_TOKEN;
+    const uint8_t* data_src = valid ? section_kv + (size_t)page * section_stride +
+                                          (size_t)slot * STREAMING_DATA_BYTES_PER_TOKEN
+                                    : sparse_mla_zero_row;
+    static_assert(BULK_NOPE_BYTES + BULK_ROPE_BYTES <= SPARSE_MLA_ZERO_ROW_BYTES);
     if (io_warp == 0 && lane == 0) mbarrier_arrive_expect_tx(sm.mbar_full(buf), BULK_TX_BYTES);
     bar_sync_t<4, STREAMING_GATHER_WARPS * 32>();
     cp_async_bulk_g2s(fp4_dst + (size_t)entry * STREAMING_KV_SMEM_STRIDE, data_src, BULK_NOPE_BYTES,

--- a/tests/attention/test_sparse_mla_nvfp4_sm120.py
+++ b/tests/attention/test_sparse_mla_nvfp4_sm120.py
@@ -719,6 +719,68 @@ def test_nvfp4_sparse_mla_decode_matches_dequantized_reference(
     torch.testing.assert_close(prefill_lse, reference_lse, atol=2e-2, rtol=2e-2)
 
 
+def test_nvfp4_sparse_mla_masked_rows_ignore_poisoned_slot_zero() -> None:
+    """Masked (-1) candidates gather the shared zero row, never cache slot 0:
+    the slot is poisoned with 0xFF (the BF16 rope tail decodes as NaN) and
+    must not leak into valid outputs through 0 * NaN in the value MMA."""
+    _require_sm120()
+    torch.manual_seed(0)
+    num_tokens, num_heads, topk = 2, 128, 512
+    num_pages, page_size = 16, 64
+    kv_bf16 = (
+        torch.randn(
+            num_pages,
+            page_size,
+            1,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    q = (
+        torch.randn(
+            num_tokens,
+            num_heads,
+            _D_NOPE + _D_ROPE,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    # Slot 0 is never a valid candidate, so the reference is unaffected by
+    # the poisoning below.
+    indices = torch.randint(
+        1,
+        num_pages * page_size,
+        (num_tokens, topk),
+        dtype=torch.int32,
+        device="cuda",
+    )
+    indices[:, topk // 2 :] = -1
+    sm_scale = (_D_NOPE + _D_ROPE) ** -0.5
+
+    cache = nvfp4_quantize_pack_sparse_mla_cache(kv_bf16.squeeze(2))
+    q_dequant = _dequantize_nvfp4_query(q)
+    kv_dequant = _dequantize_nvfp4_cache(cache)
+    reference, reference_lse = _reference_sparse_attention(
+        q_dequant, kv_dequant, indices, sm_scale
+    )
+
+    # Poison slot 0 (page 0, token 0): its 352B data row (packed NoPE + BF16
+    # rope tail) and its 32B scale row.
+    page0 = cache[0].view(-1)
+    page0[:_DATA_BYTES_PER_TOKEN].fill_(0xFF)
+    scale_base = page_size * _DATA_BYTES_PER_TOKEN
+    page0[scale_base : scale_base + _SCALE_BYTES_PER_TOKEN].fill_(0xFF)
+
+    for attention in (_nvfp4_sparse_mla_decode, _nvfp4_sparse_mla_prefill):
+        output, lse = attention(q, cache, indices, sm_scale)
+        assert torch.isfinite(output.float()).all()
+        torch.testing.assert_close(output, reference, atol=5e-2, rtol=5e-2)
+        torch.testing.assert_close(lse, reference_lse, atol=2e-2, rtol=2e-2)
+
+
 @pytest.mark.parametrize("num_tokens", [2, 65])
 def test_nvfp4_sparse_mla_shared_wrapper_matches_reference(num_tokens: int) -> None:
     """The existing SM120 wrapper routes NVFP4 through its independent planner."""

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -1701,9 +1701,9 @@ def test_sparse_mla_sm120_prefill_glm_nsa_arbitrary_fp32(num_heads: int) -> None
     torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
 
 
-# num_heads=8 exercises the runtime-H instantiation (GLM53_NOPE has dedicated
-# 32/64 only), e.g. a 64-head layer at TP8.
-@pytest.mark.parametrize("num_heads", [8, 32, 64])
+# GLM53_NOPE has dedicated instantiations at 8/16/32/64 (the TP8/TP4/TP2/TP1
+# shards of the 64-head layer); num_heads=24 exercises the runtime-H fallback.
+@pytest.mark.parametrize("num_heads", [8, 16, 24, 32, 64])
 def test_sparse_mla_sm120_decode_glm53_nope(num_heads: int) -> None:
     torch.manual_seed(3)
     device = torch.device("cuda")

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -1868,16 +1868,23 @@ def test_sparse_mla_sm120_prefill_glm53_nope_swapab(num_heads: int) -> None:
 
 
 @pytest.mark.parametrize("num_tokens,num_heads", [(4, 32), (65, 32), (128, 64)])
+@pytest.mark.parametrize("row_stride", [656, 672])
+@pytest.mark.parametrize("layout", ["3d", "hnd", "nhd"])
 def test_sparse_mla_sm120_glm53_nope_compact_rows(
-    num_tokens: int, num_heads: int
+    num_tokens: int, num_heads: int, row_stride: int, layout: str
 ) -> None:
     """GLM53_NOPE reads only the 528B payload; the gmem row advance is runtime.
 
-    A legacy 656B pool, a packed 528B cache, and a 528B slice of the 656B
-    pool (row stride 656, non-contiguous) must produce bitwise-identical
-    outputs. Shapes cover decode (T=4), prefill MG (T=65, H=32) and prefill
-    swapAB (T=128, H=64).
+    Packed and padded rows, including sliced views with an aligned storage
+    offset, must produce bitwise-identical outputs. The 672B stride checks
+    that padding is independent of the legacy 656B layout. Shapes cover
+    decode, prefill MG, and prefill swapAB in each supported 3D/4D layout.
     """
+    from flashinfer.mla._sparse_mla_sm120 import (
+        _MODEL_TYPE_GLM53_NOPE,
+        sparse_mla_sm120_decode_dsv3_2,
+    )
+
     torch.manual_seed(5)
     device = torch.device("cuda")
     d_qk = d_v = 512
@@ -1892,7 +1899,15 @@ def test_sparse_mla_sm120_glm53_nope_compact_rows(
     ).clamp(-1, 1)
     packed_656 = quantize_kv_glm53_nope(kv_bf16)  # [nb, pbs, 1, 656]
     packed_528 = packed_656[..., :528].contiguous()
-    sliced_528 = packed_656[..., :528]  # 528-wide view, row stride stays 656
+    storage = torch.full(
+        (num_blocks * page_block_size * row_stride + 16,),
+        0xFF,
+        dtype=torch.uint8,
+        device=device,
+    )
+    padded = storage[16:].view(num_blocks, page_block_size, 1, row_stride)
+    padded[..., :528] = packed_528
+    sliced_528 = padded[..., :528]  # Keep the padded row stride and aligned offset.
 
     q = (
         torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
@@ -1912,22 +1927,44 @@ def test_sparse_mla_sm120_glm53_nope_compact_rows(
             (num_tokens, num_heads), dtype=torch.float32, device=device
         )
         mid = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
-        sparse_mla_sm120_paged_attention(
-            q,
-            kv_cache,
-            indices,
-            output,
-            out_lse,
-            sm_scale,
-            d_v=d_v,
-            kv_scale_format="arbitrary_fp32",
-            mid_out=mid[0],
-            mid_lse=mid[1],
-        )
+        if layout == "3d":
+            kv_cache = kv_cache.squeeze(2)
+        elif layout == "hnd":
+            kv_cache = kv_cache.transpose(1, 2)
+        if num_tokens <= 64:
+            sparse_mla_sm120_decode_dsv3_2(
+                q,
+                kv_cache,
+                indices,
+                mid[0],
+                mid[1],
+                output,
+                out_lse,
+                sm_scale,
+                model_type=_MODEL_TYPE_GLM53_NOPE,
+                chunks_per_block=1,
+            )
+        else:
+            sparse_mla_sm120_paged_attention(
+                q,
+                kv_cache,
+                indices,
+                output,
+                out_lse,
+                sm_scale,
+                d_v=d_v,
+                kv_scale_format="arbitrary_fp32",
+                mid_out=mid[0],
+                mid_lse=mid[1],
+            )
         return output, out_lse
 
     ref_out, ref_lse = run(packed_656)
-    for name, kv in (("packed-528", packed_528), ("sliced-528", sliced_528)):
+    for name, kv in (
+        ("packed-528", packed_528),
+        ("padded", padded),
+        ("sliced-528", sliced_528),
+    ):
         out, lse = run(kv)
         assert torch.equal(out, ref_out), f"{name} output diverged from the 656B pool"
         assert torch.equal(lse, ref_lse), f"{name} LSE diverged from the 656B pool"
@@ -3533,14 +3570,287 @@ def test_sparse_mla_sm120_inline_scale_rejects_padded_block_stride() -> None:
         )
 
 
-@pytest.mark.parametrize("num_tokens,num_heads", [(128, 64), (16, 64)])
+@pytest.mark.parametrize("prefill", [False, True])
+@pytest.mark.parametrize("model_type,bpt", [(1, 584), (3, 528)])
+@pytest.mark.parametrize("layout", ["2d", "3d"])
+@pytest.mark.parametrize("misaligned", ["origin", "block"])
+def test_sparse_mla_sm120_cache_alignment_rejected(
+    prefill: bool, model_type: int, bpt: int, layout: str, misaligned: str
+) -> None:
+    """Aligned row strides alone do not make sliced cache addresses safe."""
+    from flashinfer.mla._sparse_mla_sm120 import _get_sparse_mla_sm120_decode_module
+
+    block_stride = 64 * bpt + (8 if misaligned == "block" else 0)
+    storage = torch.zeros(2 * block_stride + 1, dtype=torch.uint8, device="cuda")
+    offset = 1 if misaligned == "origin" else 0
+    kv = storage.as_strided((2, 64, bpt), (block_stride, bpt, 1), offset)
+    if layout == "2d":
+        kv = kv.view(2, 64 * bpt)
+    q = torch.zeros(1, 64, 512, dtype=torch.bfloat16, device="cuda")
+    indices = torch.full((1, 64), 64, dtype=torch.int32, device="cuda")
+    output = torch.empty_like(q)
+    lse = torch.empty(1, 64, dtype=torch.float32, device="cuda")
+    mid_out, mid_lse = _make_decode_scratch(1, 64, 64, 512, q.device)
+    module = _get_sparse_mla_sm120_decode_module()
+    message = "data pointer" if misaligned == "origin" else "block stride"
+    with pytest.raises(RuntimeError, match=message + ".*16B-aligned"):
+        if prefill:
+            module.sparse_mla_sm120_paged_attention(
+                q,
+                kv,
+                indices,
+                output,
+                lse,
+                512**-0.5,
+                model_type,
+                2,
+                None,
+                None,
+                None,
+                None,
+                None,
+            )
+        elif model_type == 3:
+            module.sparse_mla_sm120_decode_dsv3_2(
+                q,
+                kv,
+                indices,
+                mid_out,
+                mid_lse,
+                output,
+                lse,
+                1,
+                512**-0.5,
+                None,
+                None,
+                model_type,
+                -1,
+            )
+        else:
+            module.sparse_mla_sm120_decode_dsv4(
+                q,
+                kv,
+                indices,
+                mid_out,
+                mid_lse,
+                output,
+                lse,
+                1,
+                512**-0.5,
+                None,
+                None,
+                None,
+                None,
+                None,
+                -1,
+            )
+
+
+@pytest.mark.parametrize("layout", ["3d", "hnd", "nhd"])
+def test_sparse_mla_sm120_prefill_footer_row_gap_rejected(layout: str) -> None:
+    """A payload-width view must not hide row padding from footer validation."""
+    kv = torch.zeros(2, 64, 600, dtype=torch.uint8, device="cuda")[..., :584]
+    if layout == "hnd":
+        kv = kv.unsqueeze(1)
+    elif layout == "nhd":
+        kv = kv.unsqueeze(2)
+    q = torch.zeros(65, 64, 512, dtype=torch.bfloat16, device="cuda")
+    indices = torch.zeros(65, 128, dtype=torch.int32, device="cuda")
+    output = torch.empty_like(q)
+    lse = torch.empty(65, 64, dtype=torch.float32, device="cuda")
+    with pytest.raises(RuntimeError, match="footer-scale rows must stay packed"):
+        sparse_mla_sm120_paged_attention(
+            q, kv, indices, output, lse, 512**-0.5, d_v=512, prefill_impl="mg"
+        )
+
+
+@pytest.mark.parametrize("layout", ["3d", "hnd", "nhd"])
+@pytest.mark.parametrize("bpt", [584])
+@pytest.mark.parametrize("padded_width", [False, True])
+@pytest.mark.parametrize("extra_cache", [False, True])
+def test_sparse_mla_sm120_decode_footer_row_gap_rejected(
+    layout: str, bpt: int, padded_width: bool, extra_cache: bool
+) -> None:
+    """The standalone decode binding validates both footer cache views."""
+    from flashinfer.mla._sparse_mla_sm120 import _get_sparse_mla_sm120_decode_module
+
+    kv = torch.zeros(2, 64, bpt + 16, dtype=torch.uint8, device="cuda")
+    if not padded_width:
+        kv = kv[..., :bpt]
+    if layout == "hnd":
+        kv = kv.unsqueeze(1)
+    elif layout == "nhd":
+        kv = kv.unsqueeze(2)
+    packed = torch.zeros(2, 64 * bpt, dtype=torch.uint8, device="cuda")
+    q = torch.zeros(1, 64, 512, dtype=torch.bfloat16, device="cuda")
+    indices = torch.zeros(1, 64, dtype=torch.int32, device="cuda")
+    output = torch.empty_like(q)
+    lse = torch.empty(1, 64, dtype=torch.float32, device="cuda")
+    mid_out, mid_lse = _make_decode_scratch(
+        1, 64, 64, 512, q.device, extra_topk=64 if extra_cache else 0
+    )
+    module = _get_sparse_mla_sm120_decode_module()
+    with pytest.raises(RuntimeError, match="tightly packed KV rows"):
+        module.sparse_mla_sm120_decode_dsv4(
+            q,
+            packed if extra_cache else kv,
+            indices,
+            mid_out,
+            mid_lse,
+            output,
+            lse,
+            2 if extra_cache else 1,
+            512**-0.5,
+            None,
+            None,
+            kv if extra_cache else None,
+            indices if extra_cache else None,
+            None,
+            -1,
+        )
+
+
+@pytest.mark.parametrize("num_tokens", [4, 65])
+@pytest.mark.parametrize("dual_cache", [False, True])
+def test_sparse_mla_sm120_footer_flat_block_stride(
+    num_tokens: int, dual_cache: bool
+) -> None:
+    """Flat cache views preserve aligned gaps between main and extra pages."""
+    from flashinfer.mla._sparse_mla_sm120 import sparse_mla_sm120_decode_dsv4
+
+    torch.manual_seed(13)
+    device = torch.device("cuda")
+    q = torch.randn(num_tokens, 64, 512, dtype=torch.bfloat16, device=device) / 10
+    packed = quantize_kv_dsv4(
+        torch.randn(4, 64, 1, 512, dtype=torch.bfloat16, device=device) / 10
+    ).view(4, 64 * 584)
+    extra = quantize_kv_dsv4(
+        torch.randn(4, 2, 1, 512, dtype=torch.bfloat16, device=device) / 10
+    ).view(4, 2 * 584)
+
+    def padded_blocks(cache: torch.Tensor) -> torch.Tensor:
+        storage = torch.full(
+            (cache.shape[0], cache.shape[1] + 16),
+            0xFF,
+            dtype=torch.uint8,
+            device=device,
+        )
+        view = storage[:, : cache.shape[1]]
+        view.copy_(cache)
+        return view
+
+    indices = torch.randint(
+        64, 256, (num_tokens, 128), dtype=torch.int32, device=device
+    )
+    extra_indices = torch.randint(
+        2, 8, (num_tokens, 64), dtype=torch.int32, device=device
+    )
+    mid = _make_decode_scratch(
+        num_tokens, 64, 128, 512, device, extra_topk=64 if dual_cache else 0
+    )
+
+    def run(cache: torch.Tensor, extra_cache: torch.Tensor):
+        output = torch.empty_like(q)
+        lse = torch.empty(num_tokens, 64, dtype=torch.float32, device=device)
+        if num_tokens <= 64:
+            # Bypass crossover calibration so both binding parsers are exercised.
+            sparse_mla_sm120_decode_dsv4(
+                q,
+                cache,
+                indices,
+                mid[0],
+                mid[1],
+                output,
+                lse,
+                512**-0.5,
+                extra_kv_cache=extra_cache if dual_cache else None,
+                extra_indices=extra_indices if dual_cache else None,
+                chunks_per_block=1,
+            )
+        else:
+            sparse_mla_sm120_paged_attention(
+                q,
+                cache,
+                indices,
+                output,
+                lse,
+                512**-0.5,
+                d_v=512,
+                mid_out=mid[0],
+                mid_lse=mid[1],
+                extra_kv_cache=extra_cache if dual_cache else None,
+                extra_indices=extra_indices if dual_cache else None,
+            )
+        return output, lse
+
+    expected = run(packed, extra)
+    for actual, reference in zip(
+        run(padded_blocks(packed), padded_blocks(extra)), expected, strict=True
+    ):
+        torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+
+
+def test_glm53_decode_flat_block_stride() -> None:
+    """GLM decode preserves gaps between flat pages, independently of row stride."""
+    from flashinfer.mla._sparse_mla_sm120 import (
+        _MODEL_TYPE_GLM53_NOPE,
+        sparse_mla_sm120_decode_dsv3_2,
+    )
+
+    torch.manual_seed(14)
+    device = torch.device("cuda")
+    num_tokens, num_heads, topk = 4, 32, 2176
+    q = (
+        torch.randn(num_tokens, num_heads, 512, dtype=torch.bfloat16, device=device)
+        / 10
+    )
+    packed = (
+        quantize_kv_glm53_nope(
+            torch.randn(4, 64, 1, 512, dtype=torch.bfloat16, device=device) / 10
+        )[..., :528]
+        .contiguous()
+        .view(4, 64 * 528)
+    )
+    storage = torch.full((4, 64 * 528 + 16), 0xFF, dtype=torch.uint8, device=device)
+    gapped = storage[:, : 64 * 528]
+    gapped.copy_(packed)
+    # Every read uses a later page, making the incorrect dense stride observable.
+    indices = torch.randint(
+        64, 256, (num_tokens, topk), dtype=torch.int32, device=device
+    )
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, 512, device)
+
+    def run(cache: torch.Tensor):
+        output = torch.empty_like(q)
+        lse = torch.empty(num_tokens, num_heads, dtype=torch.float32, device=device)
+        sparse_mla_sm120_decode_dsv3_2(
+            q,
+            cache,
+            indices,
+            mid_out,
+            mid_lse,
+            output,
+            lse,
+            512**-0.5,
+            model_type=_MODEL_TYPE_GLM53_NOPE,
+            chunks_per_block=1,
+        )
+        return output, lse
+
+    expected = run(packed)
+    for actual, reference in zip(run(gapped), expected, strict=True):
+        torch.testing.assert_close(actual, reference, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "num_tokens,num_heads", [(65, 8), (65, 32), (128, 64), (16, 64)]
+)
 def test_sparse_mla_sm120_inline_scale_prefill_accepts_padded_rows(
     num_tokens: int, num_heads: int
 ) -> None:
-    """Padded-row inline-scale caches work in both prefill and decode: the
-    kernels take the gmem row advance as a runtime stride and read only the
-    packed payload at the row start. num_tokens=16 additionally exercises the
-    decode-form path (the same runtime-stride addressing)."""
+    """Padded RoPE rows work in SG, MG, swapAB, and standalone decode."""
+    from flashinfer.mla._sparse_mla_sm120 import sparse_mla_sm120_decode_dsv3_2
+
     q, kv_packed, indices, sm_scale, d_v, ref_out, ref_lse = _make_dsv3_2_prefill_case(
         num_heads, num_tokens=num_tokens
     )
@@ -3559,17 +3869,30 @@ def test_sparse_mla_sm120_inline_scale_prefill_accepts_padded_rows(
     mid_out, mid_lse = _make_decode_scratch(
         num_tokens, num_heads, indices.shape[-1], d_v, q.device
     )
-    sparse_mla_sm120_paged_attention(
-        q,
-        kv,
-        indices,
-        output,
-        out_lse,
-        sm_scale,
-        d_v=d_v,
-        mid_out=mid_out,
-        mid_lse=mid_lse,
-    )
+    if num_tokens <= 64:
+        sparse_mla_sm120_decode_dsv3_2(
+            q,
+            kv,
+            indices,
+            mid_out,
+            mid_lse,
+            output,
+            out_lse,
+            sm_scale,
+            chunks_per_block=1,
+        )
+    else:
+        sparse_mla_sm120_paged_attention(
+            q,
+            kv,
+            indices,
+            output,
+            out_lse,
+            sm_scale,
+            d_v=d_v,
+            mid_out=mid_out,
+            mid_lse=mid_lse,
+        )
     torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
     torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
 
@@ -4155,3 +4478,234 @@ def test_sparse_mla_sm120_envelope_consistency(
     else:
         with pytest.raises(RuntimeError, match="sparse-MLA"):
             call()
+
+
+@pytest.mark.parametrize("layout", ["3d", "nhd", "hnd"])
+@pytest.mark.parametrize(
+    "num_tokens,num_heads,impl",
+    [
+        (1, 32, None),
+        (6, 64, None),
+        (65, 32, None),
+        (65, 8, None),
+        (65, 64, "mg"),
+        (65, 64, "swapab"),
+    ],
+)
+def test_glm53_compact_rows_match_padded_rows(layout, num_tokens, num_heads, impl):
+    """Compaction preserves payload bits, attention, LSE and graph replay."""
+    torch.manual_seed(53)
+    device = torch.device("cuda")
+    pages, page_size, topk = 32, 64, 2176
+    kv = torch.randn(pages, page_size, 1, 512, device=device, dtype=torch.bfloat16) / 10
+    padded = quantize_kv_glm53_nope(kv)
+    compact = padded[..., :528].contiguous()
+    assert compact.numel() * 656 == padded.numel() * 528
+    # Poison the unused padded bytes. Neither layout may use them as values.
+    padded[..., 528:] = 255
+    q = (
+        torch.randn(num_tokens, num_heads, 512, device=device, dtype=torch.bfloat16)
+        / 10
+    )
+    indices = torch.randint(
+        pages * page_size, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, 0] = pages * page_size - 1
+    counts = torch.arange(num_tokens, device=device, dtype=torch.int32) % 3
+    lengths = torch.where(counts == 0, 1, torch.where(counts == 1, 70, topk)).to(
+        torch.int32
+    )
+    indices.masked_fill_(
+        torch.arange(topk, device=device)[None, :] >= lengths[:, None], -1
+    )
+    scratch = (
+        _make_decode_scratch(num_tokens, num_heads, topk, 512, device)
+        if num_tokens <= 64
+        else (None, None)
+    )
+
+    def reshape(cache):
+        if layout == "3d":
+            return cache.squeeze(2)
+        if layout == "hnd":
+            return cache.transpose(1, 2)
+        return cache
+
+    def run(cache, out, lse):
+        sparse_mla_sm120_paged_attention(
+            q,
+            reshape(cache),
+            indices,
+            out,
+            lse,
+            512**-0.5,
+            d_v=512,
+            kv_scale_format="arbitrary_fp32",
+            prefill_impl=impl,
+            topk_length=lengths,
+            mid_out=scratch[0],
+            mid_lse=scratch[1],
+        )
+
+    a, b = torch.empty_like(q), torch.empty_like(q)
+    la = torch.empty((num_tokens, num_heads), device=device, dtype=torch.float32)
+    lb = torch.empty_like(la)
+    run(padded, a, la)
+    run(compact, b, lb)
+    torch.testing.assert_close(b, a, rtol=0, atol=0)
+    torch.testing.assert_close(lb, la, rtol=0, atol=0)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run(compact, b, lb)
+    q.mul_(0.75)
+    graph.replay()
+    run(padded, a, la)
+    torch.testing.assert_close(b, a, rtol=0, atol=0)
+    torch.testing.assert_close(lb, la, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("num_tokens", [1, 4])
+def test_glm53_eight_head_decode_preserves_scratch_guards(num_tokens: int) -> None:
+    """The dedicated H8 kernel must stay within the caller's eight-row scratch."""
+    from flashinfer.mla._sparse_mla_sm120 import (
+        _MODEL_TYPE_GLM53_NOPE,
+        sparse_mla_sm120_decode_dsv3_2,
+    )
+
+    device = torch.device("cuda")
+    num_heads, topk, d_v = 8, 2176, 512
+    num_splits = (topk + 63) // 64
+
+    def guarded(shape, dtype):
+        size = 1
+        for dim in shape:
+            size *= dim
+        storage = torch.full((2 * size,), 37, device=device, dtype=dtype)
+        return storage[:size].view(shape), storage[size:]
+
+    mid_out, out_guard = guarded(
+        (num_tokens, num_heads, num_splits, d_v), torch.bfloat16
+    )
+    mid_lse, lse_guard = guarded((num_tokens, num_heads, num_splits), torch.float32)
+    kv = quantize_kv_glm53_nope(
+        torch.full((1, 64, 1, 512), 0.5, dtype=torch.bfloat16, device=device)
+    )[..., :528].contiguous()
+    q = torch.zeros(num_tokens, num_heads, 512, dtype=torch.bfloat16, device=device)
+    indices = torch.full((num_tokens, topk), -1, dtype=torch.int32, device=device)
+    indices[:, 0] = 1
+    output = torch.empty_like(q)
+    lse = torch.empty(num_tokens, num_heads, dtype=torch.float32, device=device)
+    sparse_mla_sm120_decode_dsv3_2(
+        q,
+        kv,
+        indices,
+        mid_out,
+        mid_lse,
+        output,
+        lse,
+        512**-0.5,
+        model_type=_MODEL_TYPE_GLM53_NOPE,
+        chunks_per_block=1,
+    )
+    assert torch.all(out_guard == 37)
+    assert torch.all(lse_guard == 37)
+    torch.testing.assert_close(
+        output, torch.full_like(output, 0.5), atol=1e-3, rtol=1e-3
+    )
+
+
+@pytest.mark.parametrize("layout", [528, 656])
+@pytest.mark.parametrize(
+    "num_tokens,num_heads,impl",
+    [
+        (1, 8, None),
+        (4, 8, None),
+        (1, 32, None),
+        (1, 64, None),
+        (65, 8, "mg"),
+        (65, 32, "mg"),
+        (65, 64, "swapab"),
+        (65, 128, "swapab"),
+    ],
+)
+@pytest.mark.parametrize("pattern", ["partial", "holes", "bounded", "empty"])
+def test_glm53_masked_cache_rows_ignore_poisoned_slot_zero(
+    layout, num_tokens, num_heads, impl, pattern
+):
+    from flashinfer.mla import SparseMLASm120Wrapper
+
+    kv = torch.full((1, 64, 1, 512), 0.5, device="cuda", dtype=torch.bfloat16)
+    packed = quantize_kv_glm53_nope(kv)[..., :layout].contiguous()
+    q = torch.zeros((num_tokens, num_heads, 512), device="cuda", dtype=torch.bfloat16)
+    indices = torch.full((num_tokens, 2176), -1, device="cuda", dtype=torch.int32)
+    lengths = torch.ones(num_tokens, device="cuda", dtype=torch.int32)
+    if pattern == "empty":
+        lengths.zero_()
+    else:
+        indices[:, 0] = 1
+        if pattern == "holes":
+            indices[:, 2048:2051] = torch.tensor(
+                [2, 3, 4], device="cuda", dtype=torch.int32
+            )
+            lengths.fill_(2051)
+        elif pattern == "bounded":
+            # Even non-negative candidates beyond topk_length must be ignored.
+            indices[:, 1:] = 0
+    wrapper = SparseMLASm120Wrapper(
+        max_num_tokens=num_tokens,
+        max_num_heads=num_heads,
+        d_v=512,
+        kv_scale_format="arbitrary_fp32",
+        device="cuda",
+    )
+    clean, poisoned = torch.empty_like(q), torch.empty_like(q)
+    clean_lse = torch.empty((num_tokens, num_heads), device="cuda", dtype=torch.float32)
+    poisoned_lse = torch.empty_like(clean_lse)
+    wrapper.run(
+        q,
+        packed,
+        indices,
+        clean,
+        512**-0.5,
+        topk_length=lengths,
+        prefill_impl=impl,
+        out_lse=clean_lse,
+    )
+    expected = torch.full_like(clean, 0.0 if pattern == "empty" else 0.5)
+    torch.testing.assert_close(clean, expected, atol=1e-3, rtol=1e-3)
+    # E4M3 0x7f is NaN. Cache slot zero is never a valid candidate here.
+    packed.reshape(-1, layout)[0, :512] = 0x7F
+    wrapper.run(
+        q,
+        packed,
+        indices,
+        poisoned,
+        512**-0.5,
+        topk_length=lengths,
+        prefill_impl=impl,
+        out_lse=poisoned_lse,
+    )
+    assert torch.isfinite(poisoned).all()
+    torch.testing.assert_close(poisoned, clean, atol=0, rtol=0)
+    torch.testing.assert_close(poisoned_lse, clean_lse, atol=0, rtol=0)
+
+    if pattern == "holes":
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            wrapper.run(
+                q,
+                packed,
+                indices,
+                poisoned,
+                512**-0.5,
+                topk_length=lengths,
+                prefill_impl=impl,
+                out_lse=poisoned_lse,
+            )
+        # Preserve addresses while changing valid payloads between replays.
+        packed.copy_(quantize_kv_glm53_nope(kv * 0.5)[..., :layout])
+        packed.reshape(-1, layout)[0, :512] = 0x7F
+        graph.replay()
+        torch.testing.assert_close(
+            poisoned, torch.full_like(poisoned, 0.25), atol=1e-3, rtol=1e-3
+        )

--- a/tests/attention/test_sparse_mla_sm120.py
+++ b/tests/attention/test_sparse_mla_sm120.py
@@ -1867,6 +1867,555 @@ def test_sparse_mla_sm120_prefill_glm53_nope_swapab(num_heads: int) -> None:
     assert torch.equal(results["swapab"][1], results[None][1])
 
 
+@pytest.mark.parametrize("num_tokens,num_heads", [(4, 32), (65, 32), (128, 64)])
+def test_sparse_mla_sm120_glm53_nope_compact_rows(
+    num_tokens: int, num_heads: int
+) -> None:
+    """GLM53_NOPE reads only the 528B payload; the gmem row advance is runtime.
+
+    A legacy 656B pool, a packed 528B cache, and a 528B slice of the 656B
+    pool (row stride 656, non-contiguous) must produce bitwise-identical
+    outputs. Shapes cover decode (T=4), prefill MG (T=65, H=32) and prefill
+    swapAB (T=128, H=64).
+    """
+    torch.manual_seed(5)
+    device = torch.device("cuda")
+    d_qk = d_v = 512
+    page_block_size, num_blocks, topk = 64, 64, 2176
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    packed_656 = quantize_kv_glm53_nope(kv_bf16)  # [nb, pbs, 1, 656]
+    packed_528 = packed_656[..., :528].contiguous()
+    sliced_528 = packed_656[..., :528]  # 528-wide view, row stride stays 656
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+    sm_scale = d_qk**-0.5
+
+    def run(kv_cache: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        output = torch.zeros(
+            (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+        )
+        out_lse = torch.zeros(
+            (num_tokens, num_heads), dtype=torch.float32, device=device
+        )
+        mid = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+        sparse_mla_sm120_paged_attention(
+            q,
+            kv_cache,
+            indices,
+            output,
+            out_lse,
+            sm_scale,
+            d_v=d_v,
+            kv_scale_format="arbitrary_fp32",
+            mid_out=mid[0],
+            mid_lse=mid[1],
+        )
+        return output, out_lse
+
+    ref_out, ref_lse = run(packed_656)
+    for name, kv in (("packed-528", packed_528), ("sliced-528", sliced_528)):
+        out, lse = run(kv)
+        assert torch.equal(out, ref_out), f"{name} output diverged from the 656B pool"
+        assert torch.equal(lse, ref_lse), f"{name} LSE diverged from the 656B pool"
+
+
+@pytest.mark.parametrize("num_tokens,num_heads", [(4, 32), (65, 32), (128, 64)])
+def test_sparse_mla_sm120_glm53_nope_masked_rows_ignore_poisoned_slot_zero(
+    num_tokens: int, num_heads: int
+) -> None:
+    """Masked (-1) candidates gather a zero row, never mutable cache slot 0.
+
+    Slot 0 is poisoned with NaNs (values and scales); valid indices exclude
+    slot 0. A kernel that clamps masked indices to slot 0 would leak NaN into
+    valid outputs through 0 * NaN in the value MMA.
+    """
+    torch.manual_seed(6)
+    device = torch.device("cuda")
+    d_qk = d_v = 512
+    page_block_size, num_blocks, topk = 64, 64, 2176
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_glm53_nope(kv_bf16)
+    kv_dequant = dequantize_kv_dsv3_2(kv_packed)[..., :d_qk]
+    # Poison slot 0 after computing the reference: NaN values + NaN scales.
+    kv_packed.view(-1, 656)[0].fill_(0xFF)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        1, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+    sm_scale = d_qk**-0.5
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        kv_scale_format="arbitrary_fp32",
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+    )
+
+    assert torch.isfinite(output.float()).all()
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+def test_sparse_mla_sm120_decode_dsv4_masked_rows_ignore_poisoned_slot_zero() -> None:
+    """The footer-scale decode kernel applies the same zero-row masking."""
+    torch.manual_seed(7)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    page_block_size, num_blocks, topk = 64, 64, 1024
+    num_tokens, num_heads = 16, 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dsv4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4(kv_packed)
+    # Poison slot 0 (block 0 token 0): data row plus its footer scale.
+    flat = kv_packed.view(num_blocks, -1)
+    flat[0, :576].fill_(0xFF)
+    flat[0, page_block_size * 576 : page_block_size * 576 + 8].fill_(0xFF)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        1, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+    sm_scale = d_qk**-0.5
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    mid_out, mid_lse = _make_decode_scratch(num_tokens, num_heads, topk, d_v, device)
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+    )
+
+    assert torch.isfinite(output.float()).all()
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+def test_sparse_mla_sm120_prefill_dsv4_masked_rows_ignore_poisoned_slot_zero() -> None:
+    """The footer-scale prefill gather (data + scale footer) applies the same
+    zero-row masking. num_tokens=128 forces the prefill route."""
+    torch.manual_seed(9)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    page_block_size, num_blocks, topk = 64, 64, 1024
+    num_tokens, num_heads = 128, 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dsv4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4(kv_packed)
+    # Poison slot 0 (block 0 token 0): data row plus its footer scale.
+    flat = kv_packed.view(num_blocks, -1)
+    flat[0, :576].fill_(0xFF)
+    flat[0, page_block_size * 576 : page_block_size * 576 + 8].fill_(0xFF)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        1, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+    sm_scale = d_qk**-0.5
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    sparse_mla_sm120_paged_attention(
+        q, kv_packed, indices, output, out_lse, sm_scale, d_v=d_v
+    )
+
+    assert torch.isfinite(output.float()).all()
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+def test_sparse_mla_sm120_prefill_dsv3_2_masked_rows_ignore_poisoned_slot_zero() -> (
+    None
+):
+    """The inline-scale prefill path with a real RoPE tail applies the same
+    zero-row masking; a masked lane's rope read must not see the poisoned
+    slot either. num_tokens=128 forces the prefill route."""
+    torch.manual_seed(10)
+    device = torch.device("cuda")
+    d_qk, d_v = 576, 512
+    page_block_size, num_blocks, topk = 64, 64, 2048
+    num_tokens, num_heads = 128, 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dsv3_2(kv_bf16)
+    kv_dequant = dequantize_kv_dsv3_2(kv_packed)
+    # Poison slot 0: NaN values, NaN scales, NaN rope.
+    kv_packed.view(-1, 656)[0].fill_(0xFF)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        1, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk // 2 :] = -1
+    sm_scale = d_qk**-0.5
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    sparse_mla_sm120_paged_attention(
+        q, kv_packed, indices, output, out_lse, sm_scale, d_v=d_v
+    )
+
+    assert torch.isfinite(output.float()).all()
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+@pytest.mark.parametrize("num_heads", [32, 64])
+def test_sparse_mla_sm120_prefill_glm53_nope_bounds_stale_padding(
+    num_heads: int,
+) -> None:
+    """Prefill never gathers past topk_length, whatever the padding holds.
+
+    Slots in [topk_length, topk) carry huge in-range-looking garbage rather
+    than -1; a kernel reading them would gather a wild gmem address. The
+    reference sees the same candidates with -1 padding. num_heads=32 routes
+    to MG, 64 to swapAB.
+    """
+    torch.manual_seed(8)
+    device = torch.device("cuda")
+    d_qk = d_v = 512
+    num_tokens, topk = 65, 2176
+    topk_len = topk - 32  # partial last tile
+    page_block_size, num_blocks = 64, 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_glm53_nope(kv_bf16)
+    kv_dequant = dequantize_kv_dsv3_2(kv_packed)[..., :d_qk]
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk_len:] = 1 << 30  # stale garbage, not -1
+    topk_length = torch.full((num_tokens,), topk_len, dtype=torch.int32, device=device)
+    sm_scale = d_qk**-0.5
+
+    ref_indices = indices.clone()
+    ref_indices[:, topk_len:] = -1
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, ref_indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        kv_scale_format="arbitrary_fp32",
+        topk_length=topk_length,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+def _stale_padding_indices(
+    num_tokens: int, topk: int, topk_len: int, s_kv: int, device: torch.device
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Indices with garbage (not -1) past topk_len, plus the -1-padded twin
+    the reference consumes and the runtime topk_length."""
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, topk_len:] = 1 << 30  # stale garbage, not -1
+    topk_length = torch.full((num_tokens,), topk_len, dtype=torch.int32, device=device)
+    ref_indices = indices.clone()
+    ref_indices[:, topk_len:] = -1
+    return indices, ref_indices, topk_length
+
+
+@pytest.mark.parametrize("num_heads,prefill_impl", [(16, None), (32, "mg")])
+def test_sparse_mla_sm120_prefill_dsv3_2_bounds_stale_padding(
+    num_heads: int, prefill_impl
+) -> None:
+    """Stale-padding bounds for a rope model on the SG and MG prefill routes.
+
+    The GLM53_NOPE stale-padding case has no rope tail; rope models
+    additionally form gmem rope addresses from the raw indices on the math
+    side (the QK rope operand loads are real loads, not prefetch hints), so
+    stale positive padding must be normalized there as well, not only at the
+    IO gather."""
+    torch.manual_seed(12)
+    device = torch.device("cuda")
+    d_qk, d_v = 576, 512
+    page_block_size, num_blocks, topk = 64, 64, 2048
+    num_tokens = 128
+    topk_len = topk - 32  # partial last tile
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dsv3_2(kv_bf16)
+    kv_dequant = dequantize_kv_dsv3_2(kv_packed)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices, ref_indices, topk_length = _stale_padding_indices(
+        num_tokens, topk, topk_len, s_kv, device
+    )
+    sm_scale = d_qk**-0.5
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, ref_indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    kwargs = {"prefill_impl": prefill_impl} if prefill_impl is not None else {}
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        topk_length=topk_length,
+        **kwargs,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+@pytest.mark.parametrize("dual", [False, True])
+def test_sparse_mla_sm120_prefill_dsv4_bounds_stale_padding(dual: bool) -> None:
+    """DSv4 MG prefill (single and dual cache) with stale positive padding.
+
+    Covers the footer-scale rope addressing: the QK rope operand and the XV
+    rope MMA both re-derive gmem addresses from the raw indices on the math
+    side, per cache phase for dual."""
+    torch.manual_seed(13)
+    device = torch.device("cuda")
+    d_qk, d_v = 512, 512
+    num_heads, num_tokens = 64, 128
+    topk, topk_len = 1024, 992  # partial last tile
+    page_block_size, num_blocks = 64, 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dsv4(kv_bf16)
+    kv_dequant = dequantize_kv_dsv4(kv_packed)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices, ref_indices, topk_length = _stale_padding_indices(
+        num_tokens, topk, topk_len, s_kv, device
+    )
+    sm_scale = d_qk**-0.5
+    kwargs: dict = {}
+    if dual:
+        extra_topk, extra_len = 512, 480  # partial last extra tile
+        extra_bf16 = (
+            torch.randn(
+                num_blocks,
+                page_block_size,
+                1,
+                d_qk,
+                device=device,
+                dtype=torch.bfloat16,
+            )
+            / 10.0
+        ).clamp(-1, 1)
+        extra_packed = quantize_kv_dsv4(extra_bf16)
+        extra_dequant = dequantize_kv_dsv4(extra_packed)
+        extra_idx, extra_ref_idx, extra_topk_length = _stale_padding_indices(
+            num_tokens, extra_topk, extra_len, s_kv, device
+        )
+        virtual_kv = torch.cat(
+            [kv_dequant.reshape(-1, d_qk), extra_dequant.reshape(-1, d_qk)], dim=0
+        ).reshape(-1, 1, 1, d_qk)
+        extra_ref_shifted = torch.where(
+            extra_ref_idx < 0, extra_ref_idx, extra_ref_idx + s_kv
+        )
+        ref_idx_all = torch.cat([ref_indices, extra_ref_shifted], dim=-1)
+        kwargs = dict(
+            extra_kv_cache=extra_packed,
+            extra_indices=extra_idx,
+            extra_topk_length=extra_topk_length,
+        )
+        ref_out, ref_lse = _ref_sparse_attn(q, virtual_kv, ref_idx_all, sm_scale, d_v)
+    else:
+        ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, ref_indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv_packed,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        topk_length=topk_length,
+        **kwargs,
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
+def test_sparse_mla_sm120_prefill_dots3_swa_bounds_stale_padding() -> None:
+    """DOTS3_SWA (SG/BI=32 split producer-consumer path) with stale padding.
+
+    No topk_length is passed: the sliding-window cap (513) itself is the
+    runtime bound, so slots in [513, 576) are past the effective length. The
+    reference masks them with -1."""
+    torch.manual_seed(14)
+    device = torch.device("cuda")
+    d_qk, d_v, topk, window = 1088, 1024, 576, 513
+    num_tokens, num_heads = 65, 32
+    page_block_size, num_blocks = 64, 64
+    s_kv = num_blocks * page_block_size
+
+    kv_bf16 = (
+        torch.randn(
+            num_blocks, page_block_size, 1, d_qk, device=device, dtype=torch.bfloat16
+        )
+        / 10.0
+    ).clamp(-1, 1)
+    kv_packed = quantize_kv_dots3_swa(kv_bf16)
+    kv_dequant = dequantize_kv_dots3_swa(kv_packed)
+
+    q = (
+        torch.randn(num_tokens, num_heads, d_qk, device=device, dtype=torch.bfloat16)
+        / 10.0
+    ).clamp(-1, 1)
+    indices = torch.randint(
+        0, s_kv, (num_tokens, topk), device=device, dtype=torch.int32
+    )
+    indices[:, window:] = 1 << 30  # stale garbage past the window, not -1
+    ref_indices = indices.clone()
+    ref_indices[:, window:] = -1
+
+    sm_scale = d_qk**-0.5
+    ref_out, ref_lse = _ref_sparse_attn(q, kv_dequant, ref_indices, sm_scale, d_v)
+
+    output = torch.zeros(
+        (num_tokens, num_heads, d_v), dtype=torch.bfloat16, device=device
+    )
+    out_lse = torch.zeros((num_tokens, num_heads), dtype=torch.float32, device=device)
+    sparse_mla_sm120_paged_attention(
+        q, kv_packed, indices, output, out_lse, sm_scale, d_v=d_v
+    )
+
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
+
+
 _DSV4_PREFILL_CONFIGS = [
     (8, 128),
     (8, 192),
@@ -2957,11 +3506,11 @@ def test_sparse_mla_sm120_prefill_impl_mg_matches_swapab(num_heads: int) -> None
 
 
 def test_sparse_mla_sm120_inline_scale_rejects_padded_block_stride() -> None:
-    """Non-contiguous inline-scale caches fail at the entry.
+    """Inline-scale caches with inter-block gaps fail at the entry.
 
     The prefill kernels address inline-scale caches as a flat token array, so
-    a padded block stride would be silently misread — and crossover can route
-    any decode-form call there, so the rejection cannot wait for a
+    blocks must pack rows back-to-back — and crossover can route any
+    decode-form call there, so the rejection cannot wait for a
     prefill-routed call.
     """
     q, kv_packed, indices, sm_scale, d_v, _, _ = _make_dsv3_2_prefill_case(
@@ -2978,17 +3527,22 @@ def test_sparse_mla_sm120_inline_scale_rejects_padded_block_stride() -> None:
 
     output = torch.zeros(128, 64, d_v, dtype=torch.bfloat16, device=q.device)
     out_lse = torch.zeros(128, 64, dtype=torch.float32, device=q.device)
-    with pytest.raises(ValueError, match="must be contiguous"):
+    with pytest.raises(ValueError, match="pack rows"):
         sparse_mla_sm120_paged_attention(
             q, kv, indices, output, out_lse, sm_scale, d_v=d_v
         )
 
 
-def test_sparse_mla_sm120_inline_scale_prefill_rejects_padded_rows() -> None:
-    """Padded-row inline-scale caches are decode-only: decode-v32 honors the
-    row stride, and a prefill-routed call fails loudly at the binding."""
-    q, kv_packed, indices, sm_scale, d_v, _, _ = _make_dsv3_2_prefill_case(
-        64, num_tokens=128
+@pytest.mark.parametrize("num_tokens,num_heads", [(128, 64), (16, 64)])
+def test_sparse_mla_sm120_inline_scale_prefill_accepts_padded_rows(
+    num_tokens: int, num_heads: int
+) -> None:
+    """Padded-row inline-scale caches work in both prefill and decode: the
+    kernels take the gmem row advance as a runtime stride and read only the
+    packed payload at the row start. num_tokens=16 additionally exercises the
+    decode-form path (the same runtime-stride addressing)."""
+    q, kv_packed, indices, sm_scale, d_v, ref_out, ref_lse = _make_dsv3_2_prefill_case(
+        num_heads, num_tokens=num_tokens
     )
     kv = torch.zeros(
         *kv_packed.shape[:-1],
@@ -2998,12 +3552,26 @@ def test_sparse_mla_sm120_inline_scale_prefill_rejects_padded_rows() -> None:
     )
     kv[..., : kv_packed.shape[-1]] = kv_packed
 
-    output = torch.zeros(128, 64, d_v, dtype=torch.bfloat16, device=q.device)
-    out_lse = torch.zeros(128, 64, dtype=torch.float32, device=q.device)
-    with pytest.raises(RuntimeError, match="tightly packed rows"):
-        sparse_mla_sm120_paged_attention(
-            q, kv, indices, output, out_lse, sm_scale, d_v=d_v
-        )
+    output = torch.zeros(
+        num_tokens, num_heads, d_v, dtype=torch.bfloat16, device=q.device
+    )
+    out_lse = torch.zeros(num_tokens, num_heads, dtype=torch.float32, device=q.device)
+    mid_out, mid_lse = _make_decode_scratch(
+        num_tokens, num_heads, indices.shape[-1], d_v, q.device
+    )
+    sparse_mla_sm120_paged_attention(
+        q,
+        kv,
+        indices,
+        output,
+        out_lse,
+        sm_scale,
+        d_v=d_v,
+        mid_out=mid_out,
+        mid_lse=mid_lse,
+    )
+    torch.testing.assert_close(output, ref_out, atol=5e-2, rtol=5e-2)
+    torch.testing.assert_close(out_lse, ref_lse, atol=5e-2, rtol=5e-2)
 
 
 @pytest.mark.parametrize("num_heads", [64, 128])
@@ -3541,7 +4109,13 @@ def test_sparse_mla_sm120_envelope_consistency(
     )
 
     d_qk = 576 if model_type in (0, 2) else (1088 if model_type == 4 else 512)
-    bpt = 656 if model_type in (0, 2, 3) else (1160 if model_type == 4 else 584)
+    # 2D flat fixtures must pack rows at the model's payload bytes_per_token;
+    # GLM53_NOPE's payload is 528B (656B pools are padded-row 3D/4D only).
+    bpt = (
+        656
+        if model_type in (0, 2)
+        else (528 if model_type == 3 else (1160 if model_type == 4 else 584))
+    )
     d_v = 1024 if model_type == 4 else 512
     num_tokens = 2
     kv_cache = torch.zeros(4, page_block_size * bpt, dtype=torch.uint8, device=device)

--- a/tests/attention/test_sparse_mla_sm120_cpb_model.py
+++ b/tests/attention/test_sparse_mla_sm120_cpb_model.py
@@ -288,6 +288,79 @@ def test_missing_or_corrupt_cache_falls_back(clean_cpb_state, tmp_path) -> None:
     assert _resolve_cpb(device, "dsv4", 1, 16, 1024, 0) == -1
 
 
+def test_stale_schema_is_read_once_until_file_changes(
+    clean_cpb_state, monkeypatch
+) -> None:
+    """Repeated misses skip stale JSON, but a replaced tuning file is picked up."""
+    from unittest.mock import patch
+    import os
+
+    device = torch.device("cpu")
+    path = cpb_mod.default_cache_path()
+    path.write_text('{"schema_version": 1, "devices": {}}')
+    old_mtime = path.stat().st_mtime
+    read_text = type(path).read_text
+    with patch.object(
+        type(path), "read_text", autospec=True, side_effect=read_text
+    ) as read:
+        for _ in range(3):
+            assert cpb_mod.get_constants(device, "glm53_nope") is None
+            assert cpb_mod.get_cpb_override(device, "glm53_nope", 32, 512, 4) is None
+            assert cpb_mod.get_decode_max_tokens(device, "glm53_nope", 32, 512) is None
+        assert read.call_count == 1
+        path.write_text(
+            cpb_mod.json.dumps(
+                {
+                    "schema_version": cpb_mod._SCHEMA_VERSION,
+                    "devices": {
+                        cpb_mod._device_key(device): {"dsv4": cpb_mod.asdict(_C)}
+                    },
+                }
+            )
+        )
+        os.utime(path, (old_mtime + 1, old_mtime + 1))
+        assert cpb_mod.get_constants(device, "dsv4") == _C
+        assert read.call_count == 2
+
+
+def test_legacy_glm_layout_calibration_is_invalidated(clean_cpb_state) -> None:
+    """A payload-layout change invalidates constants and measured tuning picks."""
+    from flashinfer.mla._sparse_mla_sm120 import _resolve_cpb
+
+    device = torch.device("cpu")
+    legacy = CpbConstants(**{**_C.__dict__, "bytes_per_chunk": 64 * 656})
+    cpb_mod.default_cache_path().write_text(
+        cpb_mod.json.dumps(
+            {
+                "schema_version": 1,
+                "devices": {
+                    cpb_mod._device_key(device): {
+                        "glm53_nope": cpb_mod.asdict(legacy),
+                        cpb_mod._CPB_OVERRIDES_KEY: {"glm53_nope|32|512|4": 7},
+                        cpb_mod._DECODE_MAX_TOKENS_KEY: {"glm53_nope|32|512": 16},
+                    }
+                },
+            }
+        )
+    )
+    assert cpb_mod.get_constants(device, "glm53_nope") is None
+    assert cpb_mod.get_cpb_override(device, "glm53_nope", 32, 512, 4) is None
+    assert cpb_mod.get_decode_max_tokens(device, "glm53_nope", 32, 512) is None
+    assert _resolve_cpb(device, "glm53_nope", 4, 32, 512, 0) == -1
+
+    current = CpbConstants(**{**_C.__dict__, "bytes_per_chunk": 64 * 528})
+    cpb_mod.save_constants(device, "glm53_nope", current)
+    cpb_mod._constants.clear()
+    cpb_mod._cache_mtime = -1.0
+    assert cpb_mod.get_constants(device, "glm53_nope") == current
+    payload = cpb_mod.json.loads(cpb_mod.default_cache_path().read_text())
+    assert payload["schema_version"] == cpb_mod._SCHEMA_VERSION
+    assert (
+        cpb_mod._CPB_OVERRIDES_KEY
+        not in payload["devices"][cpb_mod._device_key(device)]
+    )
+
+
 def _skip_if_low_vram(needed_gib: int) -> None:
     """Skip when the GPU cannot fit the multi-GiB KV pool (mirrors the
     torch.cuda.mem_get_info precedent in test_mla_decode_kernel.py)."""

--- a/tests/attention/test_sparse_mla_sm120_dispatch.py
+++ b/tests/attention/test_sparse_mla_sm120_dispatch.py
@@ -59,6 +59,7 @@ from flashinfer.mla._sparse_mla_sm120 import (
     _MODEL_TYPE_DOTS3_SWA,
     _decode_scratch_views,
     _decode_dispatch_error_message,
+    _packed_kv_page_block_size,
     _resolve_model_type,
 )
 from flashinfer.mla._sparse_mla_sm120_plan import (
@@ -143,6 +144,26 @@ def test_supported_configs_nvfp4_envelope() -> None:
 
     with pytest.raises(ValueError, match="kv_cache_format"):
         supported_sparse_mla_sm120_configs(kv_cache_format="int4")
+
+
+@pytest.mark.parametrize("layout", ["2d", "3d", "hnd", "nhd"])
+def test_glm53_canonical_payload_is_scoped_to_model(layout: str) -> None:
+    """A 528-byte row is valid only with GLM NoPE geometry and scale semantics."""
+    glm = _resolve_model_type(512, "arbitrary_fp32")
+    assert glm == _MODEL_TYPE_GLM53_NOPE
+    assert _resolve_model_type(512, "auto") == _MODEL_TYPE_DSV4
+    assert supported_sparse_mla_sm120_configs()["glm53_nope"].bytes_per_token == 528
+    shape = {
+        "2d": (2, 64 * 528),
+        "3d": (2, 64, 528),
+        "hnd": (2, 1, 64, 528),
+        "nhd": (2, 64, 1, 528),
+    }[layout]
+    cache = torch.empty(shape, dtype=torch.uint8, device="meta")
+    assert _packed_kv_page_block_size(cache, model_type=glm, name="kv") == 64
+    for model_type in (_MODEL_TYPE_DSV4, _MODEL_TYPE_DSV3_2, _MODEL_TYPE_GLM_NSA):
+        with pytest.raises(ValueError):
+            _packed_kv_page_block_size(cache, model_type=model_type, name="kv")
 
 
 def test_nvfp4_exact_head_scratch_view() -> None:


### PR DESCRIPTION
## 📌 Description

Three changes to the SM120 sparse-MLA cache handling, motivated by the compact-row discussion in flashinfer-ai/flashinfer#5022. This is an alternative design for the same goals. It also carries follow-up fixes from community review: cache-view validation hardening and the GLM NoPE eight-head decode instantiation from ormandj's branch (lucifer1004/flashinfer#3, retaining the #5022 implementation), and the calibration-cache invalidation reported by qsang-nv.

**Runtime gmem row stride ("stride is data, not format").** GLM53_NOPE's packed
payload is 528B/token (512 FP8 values + 4 inline FP32 scales); the 656B row came
from inheriting vLLM's fp8_ds_mla ABI, whose trailing 128B are RoPE bytes the
NoPE model never uses. Instead of adding a second layout selected by shape
sniffing, this PR makes the payload canonical (`bytes_per_token = 528`) and takes
the gmem row advance as a runtime stride everywhere:

- decode already honored `stride_kv_row`; prefill now derives the advance from
  `stride_kv_block / page_block_size` (no new kernel parameter), and swapAB
  decouples its smem row stride (528B payload) from the gmem advance.
- A legacy 656B pool (vLLM fp8_ds_mla) and a compact 528B pool are the same
  kernel with a different stride; the payload prefix is identical, so existing
  callers keep working unchanged. Per-token KV storage drops 19.5% for callers
  that switch to 528B rows.
- Binding validation: inline-scale models accept padded rows (advance >= width
  >= payload, 16B-aligned, blocks contiguous); footer-scale models keep the
  packed-rows requirement. Flat 2D caches must be packed at 528B for GLM53_NOPE
  (a flat block carries no stride to infer); GLM53_NOPE has no released
  downstream, so this is the last moment the canonical width can flip.
- The cpb calibration store bumps to schema v2 for the flip: a pre-PR cache
  entry persists `bytes_per_chunk = 41984` for glm53_nope and would silently
  overstate the L2 footprint in the cpb guard by ~24%, potentially excluding
  valid candidates. Stale files count as absent and recalibrate on the next
  tuning-mode pass (review feedback from qsang-nv on this PR), and a stale
  file's mtime is remembered so repeated lookups no longer reread it.

**Cache-view validation hardening** (carried from ormandj's review branch,
lucifer1004/flashinfer#3):

- Flat 2D caches derived the block advance from the dim-1 *size* instead of
  the real `stride(0)`, so a view with gaps between pages read the wrong
  page. The physical block stride is now honored (and must be >= the packed
  block width).
- Cache origins and block strides must be 16B-aligned (cp.async.bulk);
  footer-scale 3D/4D views must keep token rows packed (previously only the
  row *width* was checked, not the stride).
- GLM53_NOPE H=8 decode now has a dedicated instantiation: the runtime-H
  fallback strides split-K scratch by the 16-head tile while the public
  allocator reserves only 8 rows for H=8 (the #5022 eight-head fix, carried).
  H=16 joins the dedicated grid for symmetry with DSV3_2/GLM_NSA — it was
  already correct via runtime-H (its scratch stride equals the true head
  count there), this just drops the runtime loop bounds.



**Universal NaN-safe masked gathers.** Masked (-1) candidates were clamped to
mutable cache slot 0 in seven places (prefill MG/SG gather + scale gather,
swapAB gather, decode-v32, decode-dsv4, and the two NVFP4 kernels from
flashinfer-ai/flashinfer#4955). A NaN in that slot leaks into valid
outputs through `0 * NaN` in the value MMA (and `0 * inf` from a poisoned
0xFF footer scale on footer-scale models). All seven now gather a shared
zero-initialized row (`sparse_mla_zero_row`), which is mbar-compatible and adds
no synchronization. The NVFP4 case is narrower but real: the masked scale
load there is explicitly zeroed, which covers the E2M1 NoPE values, but the
128B BF16 rope tail rides the same clamped pointer with no scale in its path
(review feedback from qsang-nv on this PR). The property now holds
unconditionally for every model type — no opt-in and no contract version to
negotiate. This is a live bug on main for every family, not only the new one:
this PR's seven poison tests each fail against a build without the fix
(glm53_nope, dsv4 decode, dsv4 prefill, dsv3_2 prefill verified on main
fb961281; nvfp4 verified against the pre-fix kernels, which are main's).

**Unconditional topk bounds in prefill index staging.** The prefill `load_idx`
lambdas (MG, MG dual-cache, swapAB) bounded lanes by `actual_ni * BI` but not by
`topk_len`, so lanes in the last partial tile read caller padding. Callers that
leave stale values there (instead of -1) would gather wild gmem addresses —
the new `bounds_stale_padding` tests crash a main build with a CUDA illegal
memory access on both the MG and the swapAB route. Lanes past `topk_len` now
stage -1 for every model type. The math side normalizes the same way before
forming gmem addresses from the raw index row: the QK rope operand loads
(SG/MG/producer-consumer) are real loads, and DSV4's XV rope MMA reads rope
straight from gmem, so stale positive padding past `topk_len` could form a
wild address there as well (review feedback from coderabbit on this PR; the
initial stale-padding test only covered rope-free GLM53_NOPE).

**ScaleSpec extraction (layout groundwork).** Each model's scale configuration
(numeric format, group size, inline-vs-footer placement) is now a composed
`ScaleSpec` row in `model/scale_spec.cuh` instead of hand-spelled constants per
`KVCacheTraits` specialization, with the conversion helpers shared through
`ScaleConvert`. Consumers keep reading the forwarded members
(`QUANT_TILE`/`NUM_SCALES`/`SCALE_FORMAT`/`SCALE_INLINE`/...) unchanged, and
static asserts pin every derived constant to its pre-refactor value. A future
DSv4-MXFP8 (group-32 UE8M0) or GLM53-NVFP4 cache becomes one traits row plus
its dispatch entry, not another parallel traits/kernel copy; combined with the
runtime row stride, the container side needs no kernel change at all.

Relation to flashinfer-ai/flashinfer#5022: same goals (compact rows, masked-read correction); different
mechanism — one canonical layout + runtime stride instead of dual layouts +
`shape[-1] == 528` sniffing + `compact_bytes_per_token`/`glm53_nope_contract_version`
advertisement fields. flashinfer-ai/flashinfer#5022 constexpr-gates its masked-read and bounds fixes
to GLM53_NOPE; this PR applies them to every family, and the on-main
reproduction above shows the hazards are not glm53-specific. If this PR lands,
it is intended to supersede #5022's compact-row and masked-read changes; the
8-head decode instantiation from #5022 is now carried here (via ormandj's
branch, with its regression coverage).

## 🧪 Tests

RTX PRO 6000 (SM120):

```bash
python -m pytest -q tests/attention/test_sparse_mla_sm120.py \
  tests/attention/test_sparse_mla_sm120_dispatch.py \
  tests/attention/test_sparse_mla_sm120_cpb_model.py \
  tests/attention/test_sparse_mla_nvfp4_sm120.py \
  tests/attention/test_sparse_mla_nvfp4_sm120_plan.py
# 782 passed
```

Performance (RTX PRO 6000; paired same-session A/B vs upstream main
fb961281, per-arm forced JIT rebuilds, isolated autotune caches, CUDA-graph
replay timing for the runner suite plus direct-binding timing with explicit
cpb for the DRAM-pool rows):

- Decode (dsv4/dsv3_2/glm53_nope, T=1..64, single and dual cache): flat
  within ±1% on dsv3_2 and glm53_nope; dsv4 dual-cache decode carries +2-3%
  at small T, cleanly attributable to the zero-row select in the issue loop
  (a probe with main's clamp instead matches main exactly). At 11-16us per
  call this is ~0.3us of added predication in the latency-bound regime.
- Prefill: dsv3_2/glm_nsa MG+swapAB flat across a 57-row matrix
  (0.986-1.013x); dsv4 MG prefill (H=128, topk=1024) on the pre-review build
  was +0.7% at T=128 and +2.4% at T=2048 (3855us vs main's 3761-3776us). An
  earlier revision spilled 8B to stack in the DSV4 MG
  instantiation and lost +4.6% there; restructuring the zero-row selects to
  clamp-first form removed the spill (register/stack usage is now identical
  to main). The residual resists micro-optimization: five formulations of the
  bounds/zero-row predication — including a fused per-lane limit that is
  strictly fewer instructions per tile than main's original guard — all
  measure identically (+2.2-2.5%). On this shape the IO warps sit exactly at
  a per-tile issue edge where a handful of added instructions cost the full
  delta and the cost saturates: spreading the bulk gather from 64 to 128 IO
  threads (3870us vs 3855us), staging fully resolved row pointers and footer
  scale values a tile ahead so the issue point is a bare cp.async.bulk
  (3880us, +2.6% at T=128), address-clamped unconditional index loads
  (3862-3866us), and a full-tile fast branch whose executed loop body differs
  from main only by the three zero-row selects (3855-3864us) all measure the
  same; only a loop body with zero added instructions — no protection at
  all — recovers main's 3761-3776us. NCU stall attribution puts the delta
  on long-scoreboard (gmem dependency) cycles in the gather/index path:
  +0.19 cycles per issued instruction on +0.7% more issued instructions, with
  barrier, MIO, and short-scoreboard stalls unchanged. Static compute/MMA/LSU
  SASS opcode counts are identical to main. Two closing controls (separate
  event-timed harness, same GPU): (a) adding a single always-true per-lane
  select to main's staging loop reproduces nearly the whole delta by itself
  (3895us vs main's 3795us; the PR adds only ~10-25us on top of that), so
  the loop has no slack for any added instruction — this is not specific to
  the protection logic; (b) the +2.2-2.5% is a property of the 10MB
  L2-resident pool used above, not of production shapes: with a 4.9GB
  DRAM-resident pool the same change costs +0.4% (3940us vs 3924us), because
  the longer per-tile gather latency restores the slack the L2-resident
  microbenchmark lacks. The math-side topk_len normalization added during
  review shifted the same equilibrium the other way — the final build
  measures 3808-3815us at T=2048 (+1.3% vs main) and 250.9-251.1us at T=128
  (-0.9%, i.e. slightly faster than main) — consistent with the reading that
  small instruction changes anywhere in this kernel move this L2-resident
  shape by ~1% in either direction.
- GLM53_NOPE 528B rows are time-neutral on the measured shapes: at the
  production decode shape (T=64, H=64, topk=2176, 640MiB pool, cpb=16) both
  row widths run ~220us at a ~415 GB/s unique-byte rate — not DRAM-byte-bound
  on this GPU. The 528B row's benefit is the -19.5% KV footprint and the
  layout compatibility, not local kernel time.

New tests:

- `test_sparse_mla_sm120_glm53_nope_compact_rows`: 656B pool vs packed 528B vs
  a 528B slice of the 656B pool (row stride 656) are bitwise-identical across
  decode, prefill-MG, and prefill-swapAB shapes.
- `test_sparse_mla_sm120_{glm53_nope,decode_dsv4}_masked_rows_ignore_poisoned_slot_zero`:
  slot 0 poisoned with NaN values and scales; masked candidates keep outputs
  finite and on-reference (inline and footer gather paths).
- `test_sparse_mla_sm120_prefill_glm53_nope_bounds_stale_padding`: garbage
  (huge positive) indices past `topk_length` are never gathered (MG + swapAB).
- `test_sparse_mla_sm120_prefill_{dsv3_2,dsv4,dots3_swa}_bounds_stale_padding`:
  the same stale-padding discipline for rope models — SG, MG, MG dual-cache,
  and the BI=32 producer-consumer route — covering the math-side rope address
  formation. Each crashes the pre-fix build of this PR with an illegal memory
  access and passes after.

Carried from ormandj's branch (lucifer1004/flashinfer#3):

- `test_sparse_mla_sm120_footer_flat_block_stride` /
  `test_glm53_decode_flat_block_stride`: flat 2D caches with aligned gaps
  between pages decode bit-identically to packed pages (the size-vs-stride
  regression).
- `test_sparse_mla_sm120_cache_alignment_rejected`,
  `test_sparse_mla_sm120_{decode,prefill}_footer_row_gap_rejected`,
  `test_sparse_mla_sm120_inline_scale_rejects_padded_block_stride`: the new
  binding rejections (misaligned origin/block stride, footer row padding,
  inter-block gaps).
- `test_glm53_eight_head_decode_preserves_scratch_guards`: the H=8 scratch
  ABI, with guard regions.
- `test_glm53_compact_rows_match_padded_rows`,
  `test_glm53_masked_cache_rows_ignore_poisoned_slot_zero`,
  `test_glm53_canonical_payload_is_scoped_to_model`: #5022's compact-row and
  masked-row regression coverage on the canonical-payload design.
- `test_legacy_glm_layout_calibration_is_invalidated` /
  `test_stale_schema_is_read_once_until_file_changes`: schema-v1 caches are
  retired and a stale file is not reparsed until it changes.

Updated tests:

- `test_sparse_mla_sm120_inline_scale_prefill_accepts_padded_rows` (was
  `..._rejects_padded_rows`): padded-row inline caches now work in prefill;
  the inter-block-gap rejection test keeps its semantics with the new message.
- `test_sparse_mla_sm120_envelope_consistency`: 2D fixtures pack GLM53_NOPE at
  its 528B payload.

pre-commit (clang-format, ruff, mypy) passes on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for GLM-5.3 NoPE sparse MLA KV caches with compact 528-byte payloads and padded rows.
  - Added runtime row-stride handling for inline-scale KV caches.
  - Masked or out-of-range KV entries now use safe zero values instead of reading cache slot 0.

- **Bug Fixes**
  - Prevented stale padding and invalid cache indices from producing unintended memory reads or non-finite attention results.
  - Improved support for padded KV rows across prefill, decode, and dual-cache workflows.

- **Tests**
  - Added coverage for compact rows, padded layouts, masked entries, and multiple sparse MLA model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->