### PR TITLE
fix(comm): construct FusedOp after the PDL grid dependency sync

### DIFF
--- a/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
+++ b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh
@@ -1507,7 +1507,6 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(AllReduceFusionParams<T>
   int tot_access = index_helper.tot_access;
   vec_t<T, VEC_SIZE> clear_vec;
   clear_vec.fill(neg_zero_v<T>);
-  FusedOp<Pattern, T> fused_op(params, access_id, access_id_in_token);
 
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
@@ -1515,6 +1514,10 @@ __global__ void allreduce_fusion_kernel_oneshot_lamport(AllReduceFusionParams<T>
     cudaTriggerProgrammaticLaunchCompletion();
   }
 #endif
+  // Constructed after the grid dependency sync: the constructor loads rms_gamma and
+  // residual_in, and under PDL this kernel can start before the producer that writes
+  // residual_in has completed.
+  FusedOp<Pattern, T> fused_op(params, access_id, access_id_in_token);
   LamportComm<NRanks> comm(params.workspace, params.rank);
   int clear_access = comm.clear_size / VEC_SIZE;
 
@@ -1575,10 +1578,12 @@ __global__ void allreduce_fusion_kernel_twoshot_sync(AllReduceFusionParams<T> pa
   int access_id = index_helper.access_id;
   int access_stride = index_helper.access_stride;
   int tot_access = index_helper.tot_access;
-  FusedOp<Pattern, T> fused_op(params, access_id, access_id_in_token);
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
   cudaGridDependencySynchronize();
 #endif
+  // Constructed after the grid dependency sync, for the same reason as the one-shot
+  // kernel above.
+  FusedOp<Pattern, T> fused_op(params, access_id, access_id_in_token);
   SyncComm<NRanks> comm(params.workspace);
 #pragma unroll
   for (int r = 0; r < NRanks; ++r) {

--- a/scripts/task_test_multi_gpu_comm_kernels.sh
+++ b/scripts/task_test_multi_gpu_comm_kernels.sh
@@ -27,7 +27,7 @@ MPI_TEST_FILES="tests/comm/test_allreduce_unified_api.py"
 # These tests create their own distributed workers with torch.multiprocessing.spawn.
 # Running them under mpirun would start multiple pytest parents and can collide on
 # TCPStore ports.
-SPAWN_MANAGED_TEST_FILES="tests/comm/test_quantized_allreduce.py"
+SPAWN_MANAGED_TEST_FILES="tests/comm/test_quantized_allreduce.py tests/comm/test_trtllm_allreduce_fusion_pdl.py"
 
 # Tests that require torchrun instead of mpirun
 TORCHRUN_TEST_FILES="tests/attention/test_parallel_attention.py tests/gemm/test_multi_gpu_cute_dsl_blockscaled_gemm_fusion.py"

--- a/tests/comm/test_trtllm_allreduce_fusion_pdl.py
+++ b/tests/comm/test_trtllm_allreduce_fusion_pdl.py
@@ -1,0 +1,292 @@
+"""Ordering test for the fused all-reduce kernels under Programmatic Dependent Launch.
+
+With ``launch_with_pdl=True`` the fused kernel may start executing before the
+kernel that produces ``residual_in`` has finished writing it, so every read of
+``residual_in`` has to be issued after ``cudaGridDependencySynchronize()``.
+
+The producer kernel below widens that window on purpose: it triggers the
+dependent launch first, spins, and only then writes ``residual_in``. A read
+issued before the sync therefore observes whatever was in the buffer
+beforehand, which this test sets to NaN so a stale read shows up in the output
+rather than being merely numerically wrong.
+"""
+
+import multiprocessing as mp
+import pathlib
+import socket
+from typing import Any
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch.utils.cpp_extension import load_inline
+
+import flashinfer.comm as comm
+from flashinfer.utils import get_compute_capability
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or get_compute_capability(torch.device("cuda:0"))[0] not in (9, 10, 12),
+    reason="trtllm_comm kernels support SM90/SM100/SM12x only",
+)
+
+MAX_TOKEN_NUM = 128
+TOKEN_NUM = 128
+SF_VEC_SIZE = 16
+TEST_LOOP = 20
+# Long enough that the fused kernel is resident and past its prologue before the
+# producer writes anything, short enough to keep the test quick.
+SPIN_CYCLES = 4_000_000
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_FLASHINFER_INCLUDE = str(_REPO_ROOT / "include")
+_SPDLOG_INCLUDE = str(_REPO_ROOT / "3rdparty" / "spdlog" / "include")
+_CUDA_FLAGS = [
+    "-U__CUDA_NO_HALF_OPERATORS__",
+    "-U__CUDA_NO_HALF_CONVERSIONS__",
+    "-U__CUDA_NO_HALF2_OPERATORS__",
+    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+]
+
+_CPP_SOURCE = r"""
+void pdl_delayed_producer(at::Tensor out, at::Tensor value, int64_t spin_cycles);
+"""
+
+# The copy is done on raw 16-bit words, so one kernel serves both float16 and
+# bfloat16 without a dtype dispatch.
+_CUDA_SOURCE = r"""
+#include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAException.h>
+#include <torch/extension.h>
+
+#include <cstdint>
+
+__global__ void trigger_then_write_kernel(uint16_t* out, const uint16_t* value, int64_t n,
+                                          int64_t spin_cycles) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
+  // Let the dependent fused kernel start now, before anything is written.
+  asm volatile("griddepcontrol.launch_dependents;");
+#endif
+  int64_t start = clock64();
+  while (clock64() - start < spin_cycles) {
+  }
+  for (int64_t i = blockIdx.x * static_cast<int64_t>(blockDim.x) + threadIdx.x; i < n;
+       i += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    out[i] = value[i];
+  }
+}
+
+void pdl_delayed_producer(at::Tensor out, at::Tensor value, int64_t spin_cycles) {
+  TORCH_CHECK(out.is_cuda() && value.is_cuda(), "expected CUDA tensors");
+  TORCH_CHECK(out.is_contiguous() && value.is_contiguous(), "expected contiguous tensors");
+  TORCH_CHECK(out.scalar_type() == value.scalar_type(), "dtype mismatch");
+  TORCH_CHECK(out.element_size() == 2, "expected a 16-bit dtype");
+  TORCH_CHECK(out.numel() == value.numel(), "size mismatch");
+  trigger_then_write_kernel<<<64, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+      static_cast<uint16_t*>(out.data_ptr()), static_cast<const uint16_t*>(value.data_ptr()),
+      out.numel(), spin_cycles);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+}
+"""
+
+
+def _load_producer():
+    major, minor = torch.cuda.get_device_capability()
+    gencode = f"-gencode=arch=compute_{major}{minor},code=sm_{major}{minor}"
+    return load_inline(
+        name="test_trtllm_allreduce_fusion_pdl_producer",
+        cpp_sources=[_CPP_SOURCE],
+        cuda_sources=[_CUDA_SOURCE],
+        extra_include_paths=[_FLASHINFER_INCLUDE, _SPDLOG_INCLUDE],
+        extra_cuda_cflags=[*_CUDA_FLAGS, gencode],
+        functions=["pdl_delayed_producer"],
+        verbose=False,
+    )
+
+
+def _run_pdl_ordering_worker(
+    world_size,
+    rank,
+    dtype,
+    hidden_dim,
+    distributed_init_port,
+    launch_with_pdl=True,
+    gpu_offset=0,
+):
+    device = torch.device(f"cuda:{rank + gpu_offset}")
+    torch.cuda.set_device(device)
+    distributed_init_method = f"tcp://localhost:{distributed_init_port}"
+    dist.init_process_group(
+        backend="nccl",
+        init_method=distributed_init_method,
+        rank=rank,
+        world_size=world_size,
+    )
+    group = dist.group.WORLD
+    producer = _load_producer()
+
+    try:
+        ipc_handles, workspace_tensor, workspace_metadata = (
+            comm.trtllm_create_ipc_workspace_for_all_reduce_fusion(
+                rank,
+                world_size,
+                MAX_TOKEN_NUM,
+                hidden_dim,
+                group=group,
+                use_fp32_lamport=False,
+                create_metadata=True,
+            )
+        )
+
+        message_size = TOKEN_NUM * hidden_dim
+        allreduce_in = torch.randn(message_size, dtype=dtype, device=device)
+        residual_value = torch.randn(message_size, dtype=dtype, device=device)
+        rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
+        rms_eps = 1e-3
+
+        residual_in = torch.empty(message_size, dtype=dtype, device=device)
+        allreduce_out = torch.empty(message_size, dtype=dtype, device=device)
+        residual_out = torch.empty(message_size, dtype=dtype, device=device)
+        norm_out = torch.empty(message_size, dtype=dtype, device=device)
+        quant_out = torch.empty(message_size, dtype=dtype, device=device)
+        scale_out = torch.empty(message_size // SF_VEC_SIZE, dtype=dtype, device=device)
+
+        # use_oneshot True and False select the two kernels that read
+        # residual_in ahead of the grid dependency sync.
+        for use_oneshot in (True, False):
+            stale = 0
+            for _ in range(TEST_LOOP):
+                residual_in.fill_(float("nan"))
+                dist.barrier(group=group)
+                torch.cuda.synchronize()
+
+                producer.pdl_delayed_producer(residual_in, residual_value, SPIN_CYCLES)
+                comm.trtllm_allreduce_fusion(
+                    allreduce_in=allreduce_in,
+                    world_size=world_size,
+                    world_rank=rank,
+                    token_num=TOKEN_NUM,
+                    hidden_dim=hidden_dim,
+                    workspace_ptrs=workspace_tensor,
+                    launch_with_pdl=launch_with_pdl,
+                    use_oneshot=use_oneshot,
+                    trigger_completion_at_end=False,
+                    fp32_acc=False,
+                    pattern_code=comm.AllReduceFusionPattern.kARResidualRMSNorm,
+                    allreduce_out=allreduce_out,
+                    residual_in=residual_in,
+                    residual_out=residual_out,
+                    norm_out=norm_out,
+                    quant_out=quant_out,
+                    scale_out=scale_out,
+                    rms_gamma=rms_gamma,
+                    rms_eps=rms_eps,
+                    weight_bias=0.0,
+                    scale_factor=None,
+                    layout_code=comm.QuantizationSFLayout.LINEAR,
+                    metadata=workspace_metadata,
+                )
+                torch.cuda.synchronize()
+
+                if not (
+                    torch.isfinite(residual_out).all()
+                    and torch.isfinite(norm_out).all()
+                ):
+                    stale += 1
+
+            assert stale == 0, (
+                f"rank {rank}: residual_in was read before the PDL grid "
+                f"dependency sync in {stale}/{TEST_LOOP} iterations "
+                f"(use_oneshot={use_oneshot}, launch_with_pdl={launch_with_pdl})"
+            )
+            dist.barrier(group=group)
+    finally:
+        dist.barrier(group=group)
+        comm.trtllm_destroy_ipc_workspace_for_all_reduce_fusion(
+            ipc_handles, group=group
+        )
+        dist.destroy_process_group(group=group)
+
+
+def get_open_port() -> int:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+    except OSError:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:
+            s.bind(("::1", 0))
+            return s.getsockname()[1]
+
+
+def multi_process_parallel(
+    world_size: int,
+    dtype: torch.dtype,
+    hidden_dim: int,
+    test_target: Any,
+    target_args: tuple = (),
+    gpu_offset: int = 0,
+) -> None:
+    mp.set_start_method("spawn", force=True)
+
+    procs = []
+    distributed_init_port = get_open_port()
+    for i in range(world_size):
+        proc_args = (
+            (
+                world_size,
+                i,
+                dtype,
+                hidden_dim,
+                distributed_init_port,
+            )
+            + target_args
+            + (gpu_offset,)
+        )
+        proc = mp.Process(target=test_target, args=proc_args, name=f"Worker-{i}")
+        proc.start()
+        procs.append(proc)
+
+    for i in range(world_size):
+        procs[i].join()
+        assert procs[i].exitcode == 0, (
+            f"Process {i} failed with exit code {procs[i].exitcode}"
+        )
+
+
+# Run as: pytest tests/comm/test_trtllm_allreduce_fusion_pdl.py
+@pytest.mark.parametrize("world_size", [2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("hidden_dim", [4096])
+@pytest.mark.parametrize("launch_with_pdl", [True, False])
+def test_trtllm_allreduce_fusion_pdl_ordering(
+    world_size, dtype, hidden_dim, launch_with_pdl
+):
+    """residual_in must not be read before cudaGridDependencySynchronize().
+
+    launch_with_pdl=False is the control arm: plain stream ordering makes the
+    producer's writes visible regardless, so it passes either way and shows the
+    harness is not simply reporting NaN unconditionally.
+    """
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+    available_gpus = torch.cuda.device_count()
+    if world_size > available_gpus:
+        pytest.skip(
+            f"world_size {world_size} is greater than available_gpus {available_gpus}"
+        )
+    # Warm the extension cache in the parent so the workers do not all compile.
+    _load_producer()
+
+    multi_process_parallel(
+        world_size,
+        dtype,
+        hidden_dim,
+        _run_pdl_ordering_worker,
+        target_args=(launch_with_pdl,),
+    )
+    print(f"pdl ordering tp={world_size} launch_with_pdl={launch_with_pdl}: OK")
+
+
+if __name__ == "__main__":
+    test_trtllm_allreduce_fusion_pdl_ordering(2, torch.bfloat16, 4096, True)

--- a/tests/comm/test_trtllm_allreduce_fusion_pdl.py
+++ b/tests/comm/test_trtllm_allreduce_fusion_pdl.py
@@ -153,6 +153,12 @@ def _run_pdl_ordering_worker(
 
         # use_oneshot True and False select the two kernels that read
         # residual_in ahead of the grid dependency sync.
+        #
+        # A failure is recorded rather than raised here: the race can be lost on
+        # one rank and not another, and leaving the loop early would strand the
+        # passing rank on a barrier nobody else reaches, turning the regression
+        # into a hang instead of a failure.
+        failures = []
         for use_oneshot in (True, False):
             stale = 0
             for _ in range(TEST_LOOP):
@@ -194,12 +200,14 @@ def _run_pdl_ordering_worker(
                 ):
                     stale += 1
 
-            assert stale == 0, (
-                f"rank {rank}: residual_in was read before the PDL grid "
-                f"dependency sync in {stale}/{TEST_LOOP} iterations "
-                f"(use_oneshot={use_oneshot}, launch_with_pdl={launch_with_pdl})"
-            )
+            if stale:
+                failures.append(f"use_oneshot={use_oneshot}: {stale}/{TEST_LOOP}")
             dist.barrier(group=group)
+
+        assert not failures, (
+            f"rank {rank}: residual_in was read before the PDL grid dependency "
+            f"sync (launch_with_pdl={launch_with_pdl}) in " + ", ".join(failures)
+        )
     finally:
         dist.barrier(group=group)
         comm.trtllm_destroy_ipc_workspace_for_all_reduce_fusion(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

`FusedOp`'s constructor loads `rms_gamma` and this thread's first `residual_in` row, and for the quantized patterns it dereferences `scale_factor`. In both `allreduce_fusion_kernel_oneshot_lamport` and `allreduce_fusion_kernel_twoshot_sync` it is constructed **before** `cudaGridDependencySynchronize()`:

https://github.com/flashinfer-ai/flashinfer/blob/dd12b73b4461c37b467f77133c17c770adfd3a7b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh#L1510-L1513

https://github.com/flashinfer-ai/flashinfer/blob/dd12b73b4461c37b467f77133c17c770adfd3a7b/include/flashinfer/comm/trtllm_allreduce_fusion.cuh#L1578-L1580

Launched with PDL, the kernel can begin before its stream predecessor has finished writing `residual_in`, so those constructor loads may observe the producer's pre-completion state. `FusedOp::update()` reloads only when `m_access_id` changes, so each thread's first access is never re-read and the stale value reaches `residual_out` and `norm_out`.

This PR moves both constructions after the grid dependency sync. Nothing else moves. Without PDL, and below SM90 where the sync is compiled out, the ordering is unchanged.

**Where it shows up.** vLLM's layer-0 `AllReduceRMSNormPattern` is exactly this shape: one kernel writes the embedding output and a freshly zeroed residual, then the fused op runs on that with `launch_with_pdl=True`. How visible the stale read is depends on what the residual buffer held before: zeros are invisible, a previous occupant's values decode as subtly wrong text, and non-finite bytes give NaN `norm_out` and a tail of token 0.

**Measured** on 4xH100, bf16, hidden 2688, 128 tokens, one-shot, one CUDA graph per step, with a producer that triggers PDL early and then writes zeros over a NaN-filled residual buffer (flashinfer 0.6.11.post2, torch 2.11.0+cu128), 2000 steps per rank on all 4 ranks:

| Arm | steps with a non-finite `norm_out` |
|---|---|
| PDL on, unpatched | **2000 / 2000** on every rank |
| PDL on, both constructions moved | **0 / 2000** |
| PDL off, unpatched | **0 / 2000** |

The third row is the control: with the same producer and the same buffer, disabling PDL alone removes the failure, which is what points at the ordering rather than at the producer.

That harness drives the installed wheel rather than a source build, so those particular numbers are not a re-run of this commit. They no longer carry the argument on their own: the test added below reproduces the same failure from source, on this branch, and is what I would ask you to judge the change by.

**Compiled.** Both changed kernels build clean with `nvcc` 12.9 for `sm_90`, `sm_100a` and `sm_120a`. I used explicit instantiations so the kernel bodies are type-checked rather than only parsed: patterns `kARResidualRMSNorm` and `kARResidualRMSNormFP8Quant`, `NRanks` 2, 4 and 8, both `TriggerCompletionAtEnd` values, bf16 and fp16. Stock `main` compiles the same way as a control, and the resulting objects differ, so the moved statement reaches codegen rather than being folded away. Within each kernel every use of `fused_op` already follows the new construction point.

**Scope.** These are the only two `FusedOp` constructions in the repository; `trtllm_moe_allreduce_fusion.cuh` does not use `FusedOp`. I did **not** audit the other `cudaGridDependencySynchronize()` call sites for the same source-ordering hazard.

## 🔍 Related Issues

I did not find an existing issue for this. Two neighbours, neither reporting it:

- #2558 is the same hazard family, PDL correctness, but a different mechanism: `griddepcontrol.wait` written as inline asm without the `"memory"` clobber in `norm.cuh` and `activation.cuh`. It closes by asking for a general check for "this kind of issue"; this PR is a source-ordering instance rather than a compiler-barrier one, in a file that already uses the wrappers.
- #2887 concerns `trigger_completion_at_end` on this same kernel, as a performance question.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

Scope of that second box, so it is not read wider than I earned it: I ran the test added by this PR, both arms, on 2xH100 with `world_size=2`. I have not run the rest of the comm suite, and the `world_size=4` parametrization skipped for want of free devices on the machine I have.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

**On the test.** `tests/comm/test_trtllm_allreduce_fusion_pdl.py`, in the shape of #3880: a focused `load_inline` test beside the existing `tests/comm/` coverage.

`test_trtllm_allreduce_fusion.py` already parametrizes `launch_with_pdl=[True, False]` and passes either way, because nothing there puts a slow PDL producer in front of the fused op. What was missing is the producer, not the flag. So the new test supplies one: a kernel that issues `griddepcontrol.launch_dependents`, spins for a fixed number of cycles, and only then writes `residual_in`. The buffer is NaN-filled first, so a read issued before `cudaGridDependencySynchronize()` reaches `residual_out` and `norm_out` as a non-finite value rather than as a subtly wrong number, and the assertion does not depend on a tolerance. Both constructions are covered, through `use_oneshot` True and False.

Measured on 2xH100, bf16, hidden 4096, 128 tokens, `world_size=2`, 20 iterations per arm, running the same source tree twice with only this patch differing:

| Header | `launch_with_pdl=True` | `launch_with_pdl=False` |
|---|---|---|
| without this patch | **fails** | passes |
| with this patch | **passes** | passes |

`launch_with_pdl=False` is the control: plain stream ordering makes the producer's writes visible regardless, so it passes on both headers. That is what distinguishes an ordering bug from a broken producer or a bad harness.

On the timing worry I would have raised myself: the spin is about 2 ms, against a fused kernel that runs in microseconds, so the window is not marginal. If you would still rather not have a race-shaped test in CI, say so and I will drop it to a manual marker or remove it — I would rather you have the reproduction than have it merged over an objection.

One thing to flag while I was there: the comm CI scripts enumerate test files rather than globbing `tests/comm/`, so a new file does not run until it is listed. I added this one to `SPAWN_MANAGED_TEST_FILES` in `scripts/task_test_multi_gpu_comm_kernels.sh`, which is the lane documented for tests that create their own distributed workers. Please move it if that is the wrong lane.

**On what is still not covered.** The `world_size=4` parametrization skipped: the machine I have did not have four free devices, so the four-rank path is exercised only by the original harness on the pinned build, not from source. Please run CI rather than taking my word for any of it.

**Rationale I can defend.** The claim is narrow: the constructor performs global loads, PDL permits the kernel to start before the producer's writes are visible, and the sync is the barrier that makes them visible, so the loads belong after it. The measured arms above are what convinced me it is real rather than theoretical.

---

AI assistance: this change was drafted with Claude Code, and the commit carries a `Co-authored-by:` trailer. Opening as a draft while I do my own line-by-line review; I will mark it ready once I have, and not before.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fused all-reduce operations to wait for dependent GPU work to finish before reading input data, preventing stale or invalid results when programmatic dependent launches are used.

* **Tests**
  * Added multi-GPU coverage for synchronization ordering across supported launch modes, data types, world sizes, and kernel variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->