### PR TITLE
fix: preserve FP8 KV tails in FA2 asymmetric prefill

### DIFF
--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -384,8 +384,13 @@ struct KernelTraits {
   static constexpr uint32_t CTA_TILE_KV = NUM_MMA_KV * NUM_WARPS_KV * 16;
 
   static constexpr SwizzleMode SWIZZLE_MODE_Q = SwizzleMode::k128B;
+  // FP8 rows with a 64-byte tail need 64B swizzling to keep each row's columns in bounds.
   static constexpr SwizzleMode SWIZZLE_MODE_KV =
-      (sizeof(DTypeKV_) == 1 && HEAD_DIM_VO == 64) ? SwizzleMode::k64B : SwizzleMode::k128B;
+      (sizeof(DTypeKV_) == 1 &&
+       (HEAD_DIM_VO == 64 ||
+        (!is_fp4_type_v<DTypeKV_> && (HEAD_DIM_QK % 128 != 0 || HEAD_DIM_VO % 128 != 0))))
+          ? SwizzleMode::k64B
+          : SwizzleMode::k128B;
   static constexpr uint32_t KV_THR_LAYOUT_ROW = SWIZZLE_MODE_KV == SwizzleMode::k128B ? 4 : 8;
   static constexpr uint32_t KV_THR_LAYOUT_COL = SWIZZLE_MODE_KV == SwizzleMode::k128B ? 8 : 4;
   static constexpr PosEncodingMode POS_ENCODING_MODE = POS_ENCODING_MODE_;
@@ -575,7 +580,6 @@ __device__ __forceinline__ void produce_kv(smem_t<KTraits::SWIZZLE_MODE_KV> smem
                                            uint32_t* smem_offset, typename KTraits::DTypeKV** gptr,
                                            const uint32_t stride_n, const uint32_t kv_idx_base,
                                            const uint32_t kv_len, const dim3 tid = threadIdx) {
-  // NOTE: for fp8, this function doesn't work for head_dim = 64 at the moment
   using DTypeKV = typename KTraits::DTypeKV;
   constexpr bool IS_FP4 = is_fp4_type_v<DTypeKV>;
   constexpr uint32_t CTA_TILE_KV = KTraits::CTA_TILE_KV;
@@ -618,16 +622,23 @@ __device__ __forceinline__ void produce_kv(smem_t<KTraits::SWIZZLE_MODE_KV> smem
     static_assert(NUM_MMA_KV * 2 % NUM_WARPS_Q == 0);
 #pragma unroll
     for (uint32_t i = 0; i < NUM_MMA_KV * 2 / NUM_WARPS_Q; ++i) {
-      // FP4 GMEM rows are packed 2x denser; load 64b (upper 64b of smem slot zeroed).
-      if constexpr (IS_FP4) {
-        smem.template load_64b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
-      } else {
-        smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
+#pragma unroll
+      for (uint32_t j = 0; j < NUM_MMA_D / (4 / sizeof(DTypeKV)); ++j) {
+        // FP4 GMEM rows are packed 2x denser; load 64b (upper 64b of smem slot zeroed).
+        if constexpr (IS_FP4) {
+          smem.template load_64b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
+        } else {
+          smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
+        }
+        *smem_offset = smem.template advance_offset_by_column<4>(*smem_offset, j);
+        *gptr += (IS_FP4 ? 2 : 4) * upcast_size<DTypeKV>();
       }
       *smem_offset =
-          smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_STRIDE>(*smem_offset);
+          smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_STRIDE>(*smem_offset) -
+          sizeof(DTypeKV) * NUM_MMA_D;
       kv_idx += NUM_WARPS * 8;
-      *gptr += NUM_WARPS * 8 * stride_n;
+      *gptr += NUM_WARPS * 8 * stride_n -
+               (IS_FP4 ? 2 : 4) * upcast_size<DTypeKV>() * (NUM_MMA_D / (4 / sizeof(DTypeKV)));
     }
     *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
   }
@@ -640,7 +651,6 @@ __device__ __forceinline__ void page_produce_kv(SmemStorage* smem_storage, uint3
                                                 const size_t* thr_local_kv_offset,
                                                 const uint32_t kv_len, const uint32_t warp_idx,
                                                 const uint32_t lane_idx) {
-  // NOTE: for fp8, this function doesn't work for head_dim = 64 at the moment
   // K/V-shared path: V is loaded into k_smem (time-shared); v_smem is a [1] stub.
   smem_t<KTraits::SWIZZLE_MODE_KV> smem(
       (produce_v && !KTraits::USE_KV_SHARED_SMEM) ? smem_storage->v_smem : smem_storage->k_smem);
@@ -690,14 +700,20 @@ __device__ __forceinline__ void page_produce_kv(SmemStorage* smem_storage, uint3
 #pragma unroll
     for (uint32_t i = 0; i < NUM_MMA_KV * 2 / NUM_WARPS_Q; ++i) {
       DType* gptr = kv_ptr + thr_local_kv_offset[i];
-      if constexpr (IS_FP4) {
-        smem.load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
-      } else {
-        smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+#pragma unroll
+      for (uint32_t j = 0; j < NUM_MMA_D / (4 / sizeof(DType)); ++j) {
+        if constexpr (IS_FP4) {
+          smem.load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+        } else {
+          smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+        }
+        *smem_offset = smem.template advance_offset_by_column<4>(*smem_offset, j);
+        gptr += (IS_FP4 ? 2 : 4) * upcast_size<DType>();
       }
       kv_idx += NUM_WARPS * 8;
       *smem_offset =
-          smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_STRIDE>(*smem_offset);
+          smem.template advance_offset_by_row<NUM_WARPS * 8, UPCAST_STRIDE>(*smem_offset) -
+          sizeof(DType) * NUM_MMA_D;
     }
     *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
   }
@@ -784,14 +800,20 @@ __device__ __forceinline__ void page_produce_kv_on_the_fly(
       DType* gptr = kv_ptr + get_paged_kv_offset_for_logical_row<produce_v, KTraits>(
                                  paged_kv, packed_page_iter_base, last_indptr, kv_head_idx,
                                  logical_row, lane_idx);
-      if constexpr (IS_FP4) {
-        smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
-      } else {
-        smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+#pragma unroll
+      for (uint32_t j = 0; j < NUM_MMA_D / (4 / sizeof(DType)); ++j) {
+        if constexpr (IS_FP4) {
+          smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+        } else {
+          smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+        }
+        *smem_offset = smem.template advance_offset_by_column<4>(*smem_offset, j);
+        gptr += (IS_FP4 ? 2 : 4) * upcast_size<DType>();
       }
       kv_idx += NUM_WARPS * ROWS_PER_ITER;
       *smem_offset = smem.template advance_offset_by_row<NUM_WARPS * ROWS_PER_ITER, UPCAST_STRIDE>(
-          *smem_offset);
+                         *smem_offset) -
+                     sizeof(DType) * NUM_MMA_D;
     }
     *smem_offset -= KTraits::CTA_TILE_KV * UPCAST_STRIDE;
   }
@@ -1250,7 +1272,7 @@ __device__ __forceinline__ void k_smem_inplace_apply_rotary(
 }
 
 // Dequantize one FP8 K or V tile from its packed smem buffer into a BF16/FP16
-// staging buffer, laid out exactly as a native 16-bit tile (same k128B swizzle).
+// staging buffer, laid out as a native 16-bit tile with the same KV swizzle.
 // Shuffle-free, vectorized: each thread reads packed 16-byte (b128) chunks of 16
 // FP8 elements and writes two 16-byte chunks of 8 BF16 elements. Afterwards the
 // QK/PV MMAs use the standard 16-bit ldmatrix path (no per-fragment cross-lane
@@ -2527,8 +2549,7 @@ __device__ __forceinline__ void SinglePrefillWithKVCacheDevice(
       // has no staging buffer to spend in the first place.
       constexpr bool kRepackActive = KTraits::USE_KV_REPACK && is_fp4_type_v<DTypeKV>;
       // One-byte-KV repack path: 16-bit staging buffers + their (16-bit-strided) read offsets.
-      // Guard the offsets so the stride-8 get_permuted_offset isn't instantiated for the k64B
-      // swizzle (HEAD_DIM_VO == 64), which requires stride==4.
+      // Only initialize staging offsets when the repack buffer is present.
       smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
           v_smem_bf16(smem_storage.kv_smem_repack_ptr());
       uint32_t k_smem_offset_r_bf16 = 0, v_smem_offset_r_bf16 = 0;
@@ -3257,7 +3278,8 @@ __global__ __launch_bounds__(KTraits::NUM_THREADS) void BatchPrefillWithRaggedKV
       constexpr bool kRepackActive = KTraits::USE_KV_REPACK;
       // One-byte KV repack path: 16-bit staging buffers + their (16-bit-strided) read offsets.
       // Guard offsets by USE_KV_REPACK so the stride-8 get_permuted_offset isn't
-      // instantiated for the k64B swizzle (HEAD_DIM_VO == 64), which requires stride==4.
+      // instantiated for the k64B swizzle (HEAD_DIM_VO == 64), which does not use the repack
+      // buffer.
       smem_t<SWIZZLE_MODE_KV> k_smem_bf16(smem_storage.kv_smem_repack_ptr()),
           v_smem_bf16(smem_storage.kv_smem_repack_ptr());
       uint32_t k_smem_offset_r_bf16 = 0, v_smem_offset_r_bf16 = 0;

--- a/include/flashinfer/attention/prefill.cuh
+++ b/include/flashinfer/attention/prefill.cuh
@@ -628,7 +628,7 @@ __device__ __forceinline__ void produce_kv(smem_t<KTraits::SWIZZLE_MODE_KV> smem
         if constexpr (IS_FP4) {
           smem.template load_64b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
         } else {
-          smem.load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
+          smem.template load_128b_async<fill_mode>(*smem_offset, *gptr, kv_idx < kv_len);
         }
         *smem_offset = smem.template advance_offset_by_column<4>(*smem_offset, j);
         *gptr += (IS_FP4 ? 2 : 4) * upcast_size<DTypeKV>();
@@ -679,9 +679,9 @@ __device__ __forceinline__ void page_produce_kv(SmemStorage* smem_storage, uint3
       for (uint32_t j = 0; j < NUM_MMA_D / (8 / sizeof(DType)); ++j) {
         if constexpr (IS_FP4) {
           // Load 64b from packed GMEM into lower 64b of 128b SMEM slot (upper 64b zeroed)
-          smem.load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+          smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
         } else {
-          smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+          smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
         }
         *smem_offset = smem.template advance_offset_by_column<8>(*smem_offset, j);
         // FP4: GMEM row is HEAD_DIM/2 bytes wide (packed), so advance by half
@@ -703,9 +703,9 @@ __device__ __forceinline__ void page_produce_kv(SmemStorage* smem_storage, uint3
 #pragma unroll
       for (uint32_t j = 0; j < NUM_MMA_D / (4 / sizeof(DType)); ++j) {
         if constexpr (IS_FP4) {
-          smem.load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+          smem.template load_64b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
         } else {
-          smem.load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
+          smem.template load_128b_async<fill_mode>(*smem_offset, gptr, kv_idx < kv_len);
         }
         *smem_offset = smem.template advance_offset_by_column<4>(*smem_offset, j);
         gptr += (IS_FP4 ? 2 : 4) * upcast_size<DType>();

--- a/include/flashinfer/permuted_smem.cuh
+++ b/include/flashinfer/permuted_smem.cuh
@@ -77,7 +77,7 @@ struct smem_t {
       return i * stride + (j ^ (i % 8));
     } else {
       // swizzle_mode == SwizzleMode::k64B
-      static_assert(stride == 4);
+      static_assert(stride % 4 == 0);
       return i * stride + (j ^ ((i / 2) % 4));
     }
   }
@@ -98,8 +98,12 @@ struct smem_t {
       }
     } else {
       // swizzle_mode == SwizzleMode::k64B
-      static_assert(step_size == 2, "Unsupported step size");
-      return (offset ^ 0x2) + (step_idx % 2 == 1) * 4;
+      static_assert(step_size == 2 || step_size % 4 == 0, "Unsupported step size");
+      if constexpr (step_size == 2) {
+        return (offset ^ 0x2) + (step_idx % 2 == 1) * 4;
+      } else {
+        return offset + step_size;
+      }
     }
   }
 

--- a/tests/attention/test_fp8_prefill.py
+++ b/tests/attention/test_fp8_prefill.py
@@ -492,6 +492,143 @@ def test_ragged_fp8_calibration_scales(q_dtype, kv_dtype, causal, k_scale, v_sca
     torch.testing.assert_close(actual_lse, expected_lse, atol=1e-3, rtol=1e-3)
 
 
+@pytest.mark.parametrize(
+    "head_dim_qk,head_dim_vo,qo_len",
+    [(192, 128, 7), (192, 128, 99), (128, 192, 7), (128, 192, 31)],
+)
+@pytest.mark.parametrize("q_dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("kv_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("causal", [False, True])
+@pytest.mark.parametrize("kv_layout", ["single", "ragged", "NHD", "HND"])
+def test_fp8_prefill_asymmetric_head_dims(
+    head_dim_qk, head_dim_vo, q_dtype, kv_dtype, qo_len, causal, kv_layout
+):
+    """FP8 K/V tails must survive both direct and repacked FA2 prefill paths."""
+    # VO=192 uses shorter Q tiles to stay within the single-prefill register limit.
+    # The batch merge kernel does not support VO=192, so test it without split-KV.
+    torch.manual_seed(42)
+    kv_lens = [99, 131]
+    num_qo_heads, num_kv_heads, page_size = 4, 2, 16
+    q = torch.randn(2 * qo_len, num_qo_heads, head_dim_qk, device="cuda", dtype=q_dtype)
+    k = torch.randn(
+        sum(kv_lens), num_kv_heads, head_dim_qk, device="cuda", dtype=q_dtype
+    ).to(kv_dtype)
+    v = torch.randn(
+        sum(kv_lens), num_kv_heads, head_dim_vo, device="cuda", dtype=q_dtype
+    ).to(kv_dtype)
+    q_indptr = torch.tensor([0, qo_len, 2 * qo_len], dtype=torch.int32)
+    kv_indptr = torch.tensor([0, kv_lens[0], sum(kv_lens)], dtype=torch.int32)
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+
+    def run(kv_type):
+        if kv_layout == "single":
+            return torch.cat(
+                [
+                    flashinfer.single_prefill_with_kv_cache(
+                        q[i * qo_len : (i + 1) * qo_len],
+                        k[sum(kv_lens[:i]) : sum(kv_lens[: i + 1])].to(kv_type),
+                        v[sum(kv_lens[:i]) : sum(kv_lens[: i + 1])].to(kv_type),
+                        causal=causal,
+                        backend="fa2",
+                    )
+                    for i in range(len(kv_lens))
+                ]
+            )
+        if kv_layout == "ragged":
+            wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+                workspace, "NHD", backend="fa2"
+            )
+            wrapper.plan(
+                q_indptr,
+                kv_indptr,
+                num_qo_heads,
+                num_kv_heads,
+                head_dim_qk,
+                head_dim_vo=head_dim_vo,
+                causal=causal,
+                q_data_type=q_dtype,
+                kv_data_type=kv_type,
+                disable_split_kv=head_dim_vo == 192,
+            )
+            return wrapper.run(q, k.to(kv_type), v.to(kv_type))
+        num_pages = [(length + page_size - 1) // page_size for length in kv_lens]
+        k_pages = torch.zeros(
+            sum(num_pages),
+            page_size,
+            num_kv_heads,
+            head_dim_qk,
+            device="cuda",
+            dtype=q_dtype,
+        )
+        v_pages = torch.zeros(
+            sum(num_pages),
+            page_size,
+            num_kv_heads,
+            head_dim_vo,
+            device="cuda",
+            dtype=q_dtype,
+        )
+        for i, length in enumerate(kv_lens):
+            page_start, token_start = sum(num_pages[:i]), sum(kv_lens[:i])
+            k_pages[page_start : page_start + num_pages[i]].flatten(0, 1)[
+                :length
+            ].copy_(k[token_start : token_start + length])
+            v_pages[page_start : page_start + num_pages[i]].flatten(0, 1)[
+                :length
+            ].copy_(v[token_start : token_start + length])
+        if kv_layout == "HND":
+            k_pages = k_pages.transpose(1, 2).contiguous()
+            v_pages = v_pages.transpose(1, 2).contiguous()
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            workspace, kv_layout, backend="fa2"
+        )
+        wrapper.plan(
+            q_indptr,
+            torch.tensor([0, num_pages[0], sum(num_pages)], dtype=torch.int32),
+            torch.arange(sum(num_pages), dtype=torch.int32),
+            torch.tensor(
+                [(length - 1) % page_size + 1 for length in kv_lens], dtype=torch.int32
+            ),
+            num_qo_heads,
+            num_kv_heads,
+            head_dim_qk,
+            page_size,
+            head_dim_vo=head_dim_vo,
+            causal=causal,
+            q_data_type=q_dtype,
+            kv_data_type=kv_type,
+            disable_split_kv=head_dim_vo == 192,
+        )
+        return wrapper.run(q, (k_pages.to(kv_type), v_pages.to(kv_type)))
+
+    out, control = run(kv_dtype), run(q_dtype)
+    for i, length in enumerate(kv_lens):
+        token_start = sum(kv_lens[:i])
+        qi = q[i * qo_len : (i + 1) * qo_len].float()
+        ki = (
+            k[token_start : token_start + length]
+            .float()
+            .repeat_interleave(num_qo_heads // num_kv_heads, dim=1)
+        )
+        vi = (
+            v[token_start : token_start + length]
+            .float()
+            .repeat_interleave(num_qo_heads // num_kv_heads, dim=1)
+        )
+        scores = torch.einsum("qhd,khd->hqk", qi, ki) * head_dim_qk**-0.5
+        if causal:
+            mask = (
+                torch.arange(length, device="cuda")[None, :]
+                <= torch.arange(qo_len, device="cuda")[:, None] + length - qo_len
+            )
+            scores.masked_fill_(~mask, float("-inf"))
+        ref = torch.einsum("hqk,khd->qhd", torch.softmax(scores, dim=-1), vi)
+        for result in [out, control]:
+            torch.testing.assert_close(
+                result[i * qo_len : (i + 1) * qo_len].float(), ref, atol=1e-2, rtol=1e-2
+            )
+
+
 if __name__ == "__main__":
     test_batch_prefill_with_paged_kv_cache_fp8_calibration_scale(
         12, 7, 54, 1, 4, 4, 128, "NHD", torch.float8_e5m2


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

FA2 prefill can return incorrect attention outputs with FP8 KV caches when a head dimension has a 64-byte tail, including the QK=192/VO=128 shape in #4976. The 128B load loop truncates the final block, and its XOR swizzle does not fit the row stride.

Use 64B KV swizzling for these FP8 shapes and load every 64B block in the contiguous, paged, and on-the-fly paged producers. Allow the existing 64B shared-memory helpers to address multiple blocks per row. This preserves the layout used by direct dequantization and the existing 16-bit repack path, without adding shared-memory padding.

Add reference-based regression coverage for single, ragged, and NHD/HND paged prefill, both FP8 formats, FP16/BF16 queries, causal/non-causal attention, short/long queries, and both asymmetric dimension directions.

## 🔍 Related Issues

Closes #4976.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validated from this branch with an isolated JIT cache on an NVIDIA RTX 5060 Ti (SM120, 16 GB), PyTorch 2.13.0+cu130, and CUDA 13.0. The numerical reference uses FP32 attention on the same quantized KV values; native FP16/BF16 KV runs are additional controls.

- Regression command: `python -m pytest -q tests/attention/test_fp8_prefill.py -k asymmetric -x`.
- Before the change, the QK=192/VO=128 ragged regression failed with maximum absolute error 0.9121 (94.1% of elements outside tolerance).
- The full regression matrix passed: **128 passed** (single/ragged/NHD/HND, two dimension directions, two query dtypes, two FP8 formats, two query lengths, causal/non-causal).
- Independent rerun of the original 99-token, 16-head example: maximum absolute error **0.0003118**, equal to the FP16 control, using **181.53 MiB** peak allocated GPU memory.
- `pre-commit run --all-files` passed on an isolated snapshot with the identical patch; changed-file hooks also passed.
- Supplemental controls passed: **24 existing FP8 calibration checks** (head dimensions 64/128/256, E4M3/E5M2, NHD/HND, query lengths 7/53) and **6 NVFP4 checks** using the existing test functions/helpers with additional head dimension 64 (single/ragged/paged, query lengths 7/64). The supplemental harness peaked at 296.23 MiB allocated GPU memory.

- After the dependent-template follow-up, **10 targeted GPU checks passed**: FP8 single/ragged/NHD/HND at query lengths 7/99 and FP4 paged prefill at head dimensions 64/128. A representative C++17 syntax check fails before adding the disambiguators and passes afterward; full `pre-commit run --all-files` also passed again.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

AI-assisted implementation and testing (Codex).

VO=192 coverage uses supported query tile sizes and disables split-KV for batch APIs. The unchanged base also rejects single QK=128/VO=192 with 99 query tokens on this GPU, and the batch merge kernel does not support VO=192, including with native FP16 KV. Those dispatch/merge limitations are outside this change; the original QK=192/VO=128 case retains 99 query tokens and default split-KV planning.

Validation is limited to SM120. `compute-sanitizer` is unavailable in the local environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP8 KV-cache prefill support for asymmetric query and value head dimensions, including dimensions with 64-byte tails.
  * Extended compatibility across single, ragged, NHD, and HND layouts, causal and non-causal modes, and supported FP8 and query data types.

* **Tests**
  * Added comprehensive coverage comparing FP8 prefill results with FP16 reference calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
