### PR TITLE
fix(moe): guard Humming MXFP4xFP8 runner behind ENABLE_FP4

### DIFF
--- a/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
+++ b/csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu
@@ -151,6 +151,7 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
     mInnerDimMultiplier = 1;
 
     auto make_humming_runner = [&] {
+#ifdef ENABLE_FP4
       mInnerDimMultiplier = 2;
       mSm90Wfp4Afp8Mode = kernels::Sm90Wfp4Afp8ScaleMode::kHummingPreMmaE8M0;
       TVM_FFI_ICHECK(mActivationDtype == dl_float16 || mActivationDtype == dl_bfloat16)
@@ -162,6 +163,14 @@ class FusedMoeRunner : public tvm::ffi::ModuleObj {
       mKernelRunner =
           switch_output_type<__nv_fp8_e4m3, kernels::Fp4Type, true, false,
                              kernels::Sm90Wfp4Afp8ScaleMode::kHummingPreMmaE8M0>(mOutputDtype);
+#else
+      // kernels::Fp4Type only exists in FP4-enabled builds. This lambda referenced it
+      // unconditionally, so any module compiled without -DENABLE_FP4 failed to build --
+      // e.g. gen_cutlass_fused_moe_sm89_module, which enables only BF16/FP8. The Humming
+      // path is SM90-only at every call site, so a non-FP4 build can never reach it;
+      // fail loudly instead of failing to compile.
+      TVM_FFI_ICHECK(false) << "Humming-style MXFP4 x FP8 requires an FP4-enabled build (SM90).";
+#endif
     };
 
     // keep consistent with cpp/tensorrt_llm/plugins/mixtureOfExperts/mixtureOfExpertsPlugin.cpp


### PR DESCRIPTION
### Description

`make_humming_runner` in `csrc/fused_moe/cutlass_backend/flashinfer_cutlass_fused_moe_binding.cu`
references `kernels::Fp4Type` unconditionally. That type only exists in FP4-enabled builds, so any
CUTLASS fused-MoE module compiled without `-DENABLE_FP4` fails to compile.

`gen_cutlass_fused_moe_sm89_module` (`flashinfer/jit/fused_moe.py:133`) sets only `-DENABLE_BF16`,
`-DENABLE_FP8`, `-DENABLE_FP8_BLOCK_SCALE` and `-DUSING_OSS_CUTLASS_MOE_GEMM` — no `-DENABLE_FP4`.
So SM89 builds of this module are broken on `main` today.

The Humming path is SM90-only at every call site, so a non-FP4 build can never legitimately reach
it. This guards the lambda body with `#ifdef ENABLE_FP4` and fails with a clear runtime message
otherwise, so SM89 compiles again without changing behaviour on FP4-enabled builds.

**Reproduction:** run anything that triggers the SM89 CUTLASS fused-MoE module on an
sm89 device (e.g. an L4), such as `tests/moe/test_trtllm_cutlass_fused_moe.py`; the JIT build fails
in `flashinfer_cutlass_fused_moe_binding.cu` on `kernels::Fp4Type`.

Found while building the SM89 module on an L4 host.

## 🔍 Related Issues

<!-- none -->

## 🚀 Pull Request Checklist

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No new tests: this is a build-time fix with no behavioural change on FP4-enabled builds. It is
verified by the SM89 module compiling again — on an L4, `tests/moe/` cases that JIT
`fused_moe_89` build and run, where previously the build aborted.

## Notes for reviewers

The `#else` branch uses `TVM_FFI_ICHECK(false)` rather than `#error`, so a non-FP4 build still
links; the failure only surfaces if something actually calls the Humming path, which no SM89 call
site does.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation for builds without FP4 support.
  * Added a clear runtime failure when an FP4-only execution path is requested in an unsupported build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->