### PR TITLE
docs: document MiniMax-H3 prepared run parameters

### DIFF
--- a/flashinfer/cake_minimax_h3.py
+++ b/flashinfer/cake_minimax_h3.py
@@ -130,7 +130,44 @@ class MiniMaxH3Mxfp8PreAttention:
         debug_q_bf16: Optional[torch.Tensor] = None,
         debug_k_bf16: Optional[torch.Tensor] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Run the prepared pipeline into the caller-owned output tensors."""
+        """Run the prepared pipeline into the caller-owned output tensors.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            BF16 hidden states with shape ``[M, 5376]``.
+        x_norm_weight : torch.Tensor
+            BF16 RMSNorm weight with shape ``[5376]``.
+        adaln_scale, adaln_shift : torch.Tensor
+            BF16 AdaLN scale and shift tables with shape ``[9, 5376]``.
+        adaln_index : torch.Tensor
+            Contiguous int32 AdaLN row indices with shape ``[M]``.
+        qkv_weight_q : torch.Tensor
+            E4M3-quantized QKV projection weight with shape ``[21504, 5376]``.
+        qkv_weight_sf : torch.Tensor
+            Packed uint8 MXFP8 scales for ``qkv_weight_q``.
+        q_norm_weight, k_norm_weight : torch.Tensor
+            BF16 Q and K RMSNorm weights with shape ``[128]``.
+        rope_cos_sin : torch.Tensor
+            BF16 split-half NeoX RoPE values with shape ``[M, 96]``.
+        out_q : torch.Tensor
+            Caller-owned E4M3 output with shape ``[P, M, 56 / P, 3, 128]``.
+        out_sf : torch.Tensor
+            Caller-owned packed uint8 MXFP8 output scales.
+        debug_q_bf16, debug_k_bf16 : torch.Tensor, optional
+            Optional caller-owned BF16 Q and K debug outputs. Supply both or
+            neither.
+
+        Returns
+        -------
+        tuple[torch.Tensor, torch.Tensor]
+            The same ``(out_q, out_sf)`` objects supplied by the caller.
+
+        Notes
+        -----
+        Every tensor must be the same object passed when constructing this
+        prepared operation; rebinding any tensor requires a new instance.
+        """
 
         current = {
             "x": x,


### PR DESCRIPTION
## 📌 Description

Add a complete NumPy-style docstring for
`MiniMaxH3Mxfp8PreAttention.run`, including every runtime parameter, return
objects, and the prepared-operation tensor identity constraint.

This resolves the Docstring Completeness failure reported for the API since
2026-09-10 and also satisfies the argument-consistency check.

## 🔍 Related Issues

N/A — automated documentation-check finding.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

Validation performed:

- `pre-commit run --all-files`
- `python3 -m py_compile flashinfer/cake_minimax_h3.py`
- `python3 -m pr_checks.check_docstrings`: 339 APIs scanned, 0 completeness failures, 0 argument-consistency failures
- `python3 scripts/check_pr_document.py --base origin/main --head HEAD --strict`: 0 new findings

No behavioral tests were added because this change only expands an existing
docstring. The focused pytest could not be started in the local environment
because its Python interpreter does not have `pytest` installed.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

The parameter shapes and dtypes in the docstring mirror the validation contract
in `prepare_minimax_h3_mxfp8_pre_attention`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API documentation for the MiniMax H3 pre-attention operation, including tensor shapes, data types, ownership requirements, return values, and rebinding behavior.
  * No runtime behavior or public API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->