### PR TITLE
fix: guard BF16 warp Split-K availability and prune tactics

### DIFF
--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -735,11 +735,11 @@ def mm_bf16(
         explicitly. Without autotuning, M > 32 runs cuBLASLt; below, the
         direct kernel runs where its shape heuristic applies, otherwise the
         warp Split-K kernel whenever it is eligible (N % 16 == 0, K % 128 == 0
-        with at most 64 K tiles), and cluster Split-K otherwise. With
-        autotuning, one call profiles the low-M kernels on the M <= 32
-        buckets and the cuBLASLt fallback on the larger ones, so a single
-        large-M warm-up tunes both ranges; with bias the direct kernel is
-        excluded.
+        with at most 64 K tiles; requires CuTe DSL >= 4.7), and cluster Split-K
+        otherwise. With autotuning, one call profiles the available low-M
+        kernels on the M <= 32 buckets and the cuBLASLt fallback on the larger
+        ones, so a single large-M warm-up tunes both ranges; with bias the
+        direct kernel is excluded.
         ``"auto"`` allows selecting the best tactic from all available backends when autotune is enabled.
 
     Returns
@@ -1869,8 +1869,8 @@ def _cute_dsl_cublaslt_fallback_bf16_gemm_runner(compute_capability: int):
 def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
     """Return the runners of ``backend="cute-dsl"`` for ``inputs``, best first.
 
-    Every runner is listed whatever the real M, so that one autotune call
-    profiles the low-M kernels on the buckets M <= 32 and the cuBLASLt
+    Every available runner is listed whatever the real M, so that one autotune
+    call profiles the low-M kernels on the buckets M <= 32 and the cuBLASLt
     fallback on the buckets above (custom ``tuning_buckets`` are assigned the
     same way). ``[0]`` is the no-autotune default and the autotuner's
     fallback, so it must serve the real inputs: cuBLASLt above 32; below, the
@@ -1880,6 +1880,7 @@ def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
     cannot serve the real inputs (bias, N, K) are dropped: they serve no
     bucket either.
     """
+    from ..cute_dsl.availability import is_cute_dsl_experimental_available
     from .kernels.dense_bf16_gemm_direct import prefer_direct_bf16_gemm_sm100
 
     a, b, *_ = inputs
@@ -1888,12 +1889,21 @@ def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
     major, minor = torch.cuda.get_device_capability(a.device)
     compute_capability = major * 10 + minor
     direct = _cute_dsl_direct_bf16_gemm_runner(compute_capability)
-    warp_splitk = _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability)
+    # Older DSLs lack cutlass.experimental but can use the other runners.
+    warp_splitk = (
+        _cute_dsl_warp_splitk_bf16_gemm_runner(compute_capability)
+        if is_cute_dsl_experimental_available()
+        else None
+    )
     cluster_splitk = _cute_dsl_splitk_bf16_gemm_runner(compute_capability)
     fallback = _cute_dsl_cublaslt_fallback_bf16_gemm_runner(compute_capability)
 
     if m > _CUTE_DSL_BF16_MAX_M:
-        return [fallback, warp_splitk, cluster_splitk, direct]
+        return [
+            runner
+            for runner in (fallback, warp_splitk, cluster_splitk, direct)
+            if runner is not None
+        ]
     prefer_direct = direct.supports_inputs(inputs) and prefer_direct_bf16_gemm_sm100(
         m, n, k
     )
@@ -1902,7 +1912,11 @@ def _cute_dsl_bf16_runners(inputs: List[torch.Tensor]) -> List[TunableRunner]:
         if prefer_direct
         else (warp_splitk, cluster_splitk, direct)
     )
-    return [runner for runner in kernels if runner.supports_inputs(inputs)] + [fallback]
+    return [
+        runner
+        for runner in kernels
+        if runner is not None and runner.supports_inputs(inputs)
+    ] + [fallback]
 
 
 def bf16_gemm_sm100(

--- a/flashinfer/gemm/gemm_base.py
+++ b/flashinfer/gemm/gemm_base.py
@@ -1465,7 +1465,7 @@ def get_mm_bf16_cublaslt_module():
     )
 
 
-_CUTE_DSL_BF16_AUTOTUNE_VERSION = 11
+_CUTE_DSL_BF16_AUTOTUNE_VERSION = 12
 # M bound of the CuTe-DSL low-M kernels; larger M runs the cuBLASLt fallback.
 _CUTE_DSL_BF16_MAX_M = 32
 

--- a/flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py
+++ b/flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py
@@ -210,6 +210,11 @@ def _smem_bytes(tactic: WarpSplitKTactic) -> int:
     return cursor + tactic.stages * 8
 
 
+def _k_tile_count_supported(k_tile: int, k_tile_count: int) -> bool:
+    # The two-tile 256-wide schedule can generate an invalid hinted LDGSTS.
+    return k_tile != 256 or k_tile_count != 2
+
+
 def _legal_stages(
     output_tile: int,
     token_tile: int,
@@ -219,12 +224,12 @@ def _legal_stages(
 ) -> tuple[int, ...]:
     # A single-stage ring only makes sense when K is one tile; with ring reuse it
     # cannot overlap anything, and ptxas mis-encodes its hinted LDGSTS.
-    if k // k_tile > _MAX_K_TILES:
+    k_tile_count = k // k_tile
+    if k_tile_count > _MAX_K_TILES or not _k_tile_count_supported(k_tile, k_tile_count):
         return ()
-    min_stages = _min_stages(k, k_tile)
     return tuple(
         stages
-        for stages in range(min_stages, min(_MAX_STAGES, k // k_tile) + 1)
+        for stages in range(_min_stages(k, k_tile), min(_MAX_STAGES, k_tile_count) + 1)
         if _smem_bytes(
             WarpSplitKTactic(output_tile, token_tile, k_tile, stages, b_loader_warps)
         )
@@ -255,14 +260,15 @@ def validate_tactic(tactic: WarpSplitKTactic, m: int, n: int, k: int) -> None:
         raise ValueError(f"unsupported shape {(m, n, k)}")
     if k <= 0 or k % tactic.k_tile:
         raise ValueError(f"K={k} must be divisible by k_tile={tactic.k_tile}")
-    if k // tactic.k_tile > _MAX_K_TILES:
+    k_tile_count = k // tactic.k_tile
+    if k_tile_count > _MAX_K_TILES:
         raise ValueError(
             f"K={k} spans more than {_MAX_K_TILES} tiles of {tactic.k_tile}"
         )
+    if not _k_tile_count_supported(tactic.k_tile, k_tile_count):
+        raise ValueError(f"unsupported k_tile={tactic.k_tile} for K={k}")
     if not (
-        _min_stages(k, tactic.k_tile)
-        <= tactic.stages
-        <= min(_MAX_STAGES, k // tactic.k_tile)
+        _min_stages(k, tactic.k_tile) <= tactic.stages <= min(_MAX_STAGES, k_tile_count)
     ):
         raise ValueError(f"invalid stages={tactic.stages}")
     required_smem = _smem_bytes(tactic)
@@ -380,6 +386,15 @@ def autotune_tactics(m: int, n: int, k: int) -> list[WarpSplitKTactic]:
                 continue  # a 32-token tile only pays for M > 16
             for k_tile in _SUPPORTED_K_TILES:
                 if k % k_tile:
+                    continue
+                # Prune same-grid token padding for multi-tile K.
+                # Wider tiles can win when K fits one tile.
+                if k // k_tile > 1 and any(
+                    smaller_token_tile < token_tile
+                    and (m + smaller_token_tile - 1) // smaller_token_tile
+                    == (m + token_tile - 1) // token_tile
+                    for smaller_token_tile in _SUPPORTED_TOKEN_TILES
+                ):
                     continue
                 for b_loader_warps in _SUPPORTED_B_LOADER_WARPS:
                     tactics.extend(


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

Guard BF16 warp Split-K runner creation with the existing `is_cute_dsl_experimental_available()` probe. CuTe DSL 4.6.2 lacks `cutlass.experimental`; skip only this runner before importing its kernel, keeping Direct, cluster Split-K, and the cuBLASLt fallback available.

Also include the retained BF16 warp Split-K tactic-pruning heuristic:
- For multi-tile K, prune larger token tiles when a smaller supported tile produces the same CTA grid. Keep single-K-tile alternatives, which can still win, and preserve the default tactic.
- Exclude `k_tile=256, k_tile_count=2` from candidate generation and explicit validation: this schedule can produce an invalid hinted `LDGSTS`.
- Bump the BF16 CuTe DSL autotune cache version from 11 to 12 so earlier selections are not reused.

The GPU mainloop, JIT/launch implementation, default-selection heuristic, dependencies, and test files are unchanged. Document the warp runner's CuTe DSL >= 4.7 requirement without raising the package dependency floor.

## 🔍 Related Issues

Follow-up to #4908.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

All hooks passed for both changed files: `pre-commit run --files flashinfer/gemm/gemm_base.py flashinfer/gemm/kernels/dense_bf16_gemm_warp_splitk.py`. Repository-wide hooks were not run.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

No test files added or modified. Reused the existing accuracy tests on NVIDIA B200 (SM100), CUDA 13.0, PyTorch 2.13.0+cu130:

```bash
python -m pytest -q tests/gemm/test_mm_bf16.py -k 'cute and not cutile'
```

- CuTe DSL 4.6.2: 10 passed; verified the warp kernel module was never imported.
- CuTe DSL 4.7.0: 10 passed; verified the warp kernel remained available.

Additionally verified the public K=512, N=256 path: autotune at M=64 with bias and PDL, then run M=8/25/33 and compare with an FP32 reference. No test files were added for these validation runs.

Validation is scoped to these existing BF16 CuTe DSL cases and the stated runtime checks, not the full repository suite.

### Autotuning cost

Before = `31a6926b` (availability guard only); after = this heuristic update.

| Metric | Before | After |
|---|---:|---:|
| Warp tactic evaluations across the full-table harness's 77 tuning profiles | 9,714 | 5,834 |
| Existing B200 accuracy/autotune suite wall time, one run per version | 247.26 s | 124.38 s |

Candidate counts follow the 210-cell, 16-family workload from vllm-project/vllm#54524: tune once at M=16 per family, or M=8 when the family's largest M is 8. The 39.9% reduction measures the search space, not kernel latency.

The wall-time rows use the exact pytest command and B200/CUDA/PyTorch/CuTe DSL 4.7.0 environment above, including JIT compilation, autotuning, setup, and correctness checks. They are single-run observations, not a steady-state kernel benchmark or a general speedup guarantee.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Missing experimental support silently excludes the warp runner from both default selection and autotuning; it does not disable the whole `cute-dsl` backend or suppress unrelated import failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with older CuTe DSL versions by omitting unsupported experimental warp Split-K runners.
  - Prevented unavailable runners from being included in BF16 matrix multiplication execution paths.
  - Prevented selection of an invalid BF16 GEMM schedule that could produce incorrect GPU instructions.
  - Improved autotuning by excluding redundant token-tile options when they provide no additional grid coverage.
- **Documentation**
  - Clarified CuTe DSL version requirements and available BF16 runner behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
