### PR TITLE
fix(sparse): correct SM100 blk64 output when seqlen_k % 64 != 0

### DIFF
--- a/flashinfer/cute_dsl/sparse/bsa_attn_sm100_blk64.py
+++ b/flashinfer/cute_dsl/sparse/bsa_attn_sm100_blk64.py
@@ -34,6 +34,7 @@ from .sm100_blk64.dispatch_helpers import (
     torch2cute_dtype_map,
     validate_sm100_blk64_int32_bounds,
     sm100_blk64_requires_int64_kv_strides,
+    sm100_blk64_has_partial_kv_tail,
     dynamic_tensors_compile_key,
     sm100_blk64_auto_kv_splits,
     sm100_blk64_auto_fp8_kv_splits,
@@ -199,7 +200,8 @@ def bsa_attn_sm100_blk64_fwd(
     assert q2k_block_index.shape[:3] == (batch_size, num_head, num_q_blocks)
     q2k_block_index = maybe_contiguous(q2k_block_index)
 
-    has_block_sizes = block_sizes is not None and block_sizes.numel() > 0
+    user_provided_block_sizes = block_sizes is not None and block_sizes.numel() > 0
+    has_block_sizes = user_provided_block_sizes
     if has_block_sizes:
         block_sizes = maybe_contiguous(block_sizes)
         assert block_sizes.dtype == torch.int32
@@ -233,10 +235,31 @@ def bsa_attn_sm100_blk64_fwd(
     # last real block.  Phantom blocks are only masked correctly when
     # HasBlockSizes=True.  Passing a full-block sizes tensor (all 64)
     # activates that path and ensures phantom blocks are zeroed in softmax.
-    if block_sizes is None and has_variable_block_nums:
+    if not user_provided_block_sizes and has_variable_block_nums:
         block_sizes = torch.full(
             (num_kv_blocks,), 64, dtype=torch.int32, device=q_bhsd.device
         )
+        has_block_sizes = True
+
+    # Partial KV tail masking: when seqlen_k is not divisible by 64, the last
+    # KV block has fewer than 64 valid tokens. Without masking, the kernel
+    # computes attention scores for out-of-bounds positions. K=0 (from TMA
+    # zero-fill) gives score=0 → exp(0)=1 weight, which corrupts softmax.
+    #
+    # Fix: set block_sizes[-1] = seqlen_k % 64 so apply_block_size_mask_64
+    # sets out-of-bounds scores to -inf, giving them zero softmax weight.
+    #
+    # Applied when: BF16 path (FP8 rejects non-64-multiple seqlen_k), and
+    # only when the user did not explicitly provide block_sizes (trust theirs).
+    # Also updates auto-generated block_sizes (phantom masking above) so both
+    # corrections are in effect simultaneously.
+    kv_tail_size = seqlen_k % 64
+    if kv_tail_size != 0 and not is_sage_fp8 and not user_provided_block_sizes:
+        if block_sizes is None:
+            block_sizes = torch.full(
+                (num_kv_blocks,), 64, dtype=torch.int32, device=q_bhsd.device
+            )
+        block_sizes[-1] = kv_tail_size
         has_block_sizes = True
 
     validate_sm100_blk64_int32_bounds(
@@ -249,6 +272,20 @@ def bsa_attn_sm100_blk64_fwd(
         q2k_block_nums,
     )
     use_int64_kv_strides = sm100_blk64_requires_int64_kv_strides(k_bhsd, v_bhsd)
+    # Partial KV tail TMA safety: seqlen_k not divisible by 64. The packed
+    # rank-6 Int32 TMA view rounds up to ceil_div(seqlen_k, 64) full blocks,
+    # causing TMA to read beyond the actual buffer for the last partial block.
+    # Exact-boundary layout uses true seqlen_k so TMA zero-fills out-of-bounds
+    # positions rather than reading garbage. Combined with the block_sizes
+    # masking above (which sets those scores to -inf), this ensures both
+    # memory safety and numerical correctness.
+    # Not applicable to Sage FP8 (D-major layout; seqlen_k % 64 != 0 is
+    # rejected by validate_sm100_blk64_fp8_sage above).
+    use_exact_kv_layout = (
+        not is_sage_fp8
+        and not use_int64_kv_strides
+        and sm100_blk64_has_partial_kv_tail(k_bhsd, v_bhsd)
+    )
 
     if softmax_scale is None:
         softmax_scale = head_dim**-0.5
@@ -364,6 +401,7 @@ def bsa_attn_sm100_blk64_fwd(
             use_clc_scheduler,
             "bhsd_native",
             use_int64_kv_strides,
+            use_exact_kv_layout,
             is_sage_fp8,
             "tvm_ffi_env_stream_v1",
         ),
@@ -418,6 +456,7 @@ def bsa_attn_sm100_blk64_fwd(
             has_block_sizes=has_block_sizes,
             num_splits=kv_splits_i,
             use_int64_kv_strides=use_int64_kv_strides,
+            use_exact_kv_layout=use_exact_kv_layout,
         )
 
         with constexpr_tvm_ffi_converter_patched():

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/bsa_fwd_sm100.py
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/bsa_fwd_sm100.py
@@ -67,6 +67,7 @@ class BlockSparseAttnForwardSm100Blk64:
         has_block_sizes: cutlass.Constexpr[bool] = True,
         num_splits: cutlass.Constexpr[int] = 1,
         use_int64_kv_strides: cutlass.Constexpr[bool] = False,
+        use_exact_kv_layout: cutlass.Constexpr[bool] = False,
     ):
         # padding head_dim to a multiple of 16 as k_block_size
         hdim_multiple_of = 16
@@ -136,6 +137,7 @@ class BlockSparseAttnForwardSm100Blk64:
         self.allow_empty_block_nums = allow_empty_block_nums
         self.has_block_sizes = has_block_sizes
         self.use_int64_kv_strides = use_int64_kv_strides
+        self.use_exact_kv_layout = use_exact_kv_layout
         self.qhead_per_kvhead = qhead_per_kvhead
         self.pack_gqa = pack_gqa
         if pack_gqa:
@@ -343,7 +345,10 @@ class BlockSparseAttnForwardSm100Blk64:
         # The fast rank-6 view matches the sparse-block layout. CuTe DSL
         # cannot lower an Int64 basis in that rank-6 TMA view, so layouts with
         # large active strides use a rank-5 Int64 view and divide it into
-        # sparse blocks in the device kernel instead.
+        # sparse blocks in the device kernel instead. When seqlen_k is not
+        # divisible by 64, the exact-boundary path (use_exact_kv_layout) also
+        # uses a rank-5 view with the true seqlen_k extent so TMA zero-fills
+        # the partial last block rather than reading beyond the buffer.
         k_dim_half = self.head_dim_padded // 2
         v_dim_part = self.head_dim_v_padded // 2
         if const_expr(self.use_int64_kv_strides):
@@ -374,6 +379,56 @@ class BlockSparseAttnForwardSm100Blk64:
             v_stride_d = Int64(mV_seq.layout.stride[1])
             v_stride_h = Int64(mV_seq.layout.stride[2])
             v_stride_b = Int64(mV_seq.layout.stride[3])
+            mV = cute.make_tensor(
+                mV_seq.iterator,
+                cute.make_layout(
+                    (
+                        v_dim_part,
+                        mV_seq.shape[0],
+                        2,
+                        mV_seq.shape[2],
+                        mV_seq.shape[3],
+                    ),
+                    stride=(
+                        v_stride_d,
+                        v_stride_s,
+                        v_dim_part * v_stride_d,
+                        v_stride_h,
+                        v_stride_b,
+                    ),
+                ),
+            )
+        elif const_expr(self.use_exact_kv_layout):
+            # Exact-boundary layout: true seqlen_k extent with Int32 strides.
+            # Same 5D shape as the Int64 path so the kernel body can share the
+            # zipped_divide code path, but strides stay Int32 for performance.
+            k_stride_s = Int32(mK_seq.layout.stride[0])
+            k_stride_d = Int32(mK_seq.layout.stride[1])
+            k_stride_h = Int32(mK_seq.layout.stride[2])
+            k_stride_b = Int32(mK_seq.layout.stride[3])
+            mK = cute.make_tensor(
+                mK_seq.iterator,
+                cute.make_layout(
+                    (
+                        mK_seq.shape[0],
+                        k_dim_half,
+                        2,
+                        mK_seq.shape[2],
+                        mK_seq.shape[3],
+                    ),
+                    stride=(
+                        k_stride_s,
+                        k_stride_d,
+                        k_dim_half * k_stride_d,
+                        k_stride_h,
+                        k_stride_b,
+                    ),
+                ),
+            )
+            v_stride_s = Int32(mV_seq.layout.stride[0])
+            v_stride_d = Int32(mV_seq.layout.stride[1])
+            v_stride_h = Int32(mV_seq.layout.stride[2])
+            v_stride_b = Int32(mV_seq.layout.stride[3])
             mV = cute.make_tensor(
                 mV_seq.iterator,
                 cute.make_layout(
@@ -1529,7 +1584,10 @@ class BlockSparseAttnForwardSm100Blk64:
                 if const_expr(not self.pack_gqa)
                 else head_idx
             )
-            if const_expr(self.use_int64_kv_strides):
+            if const_expr(self.use_int64_kv_strides or self.use_exact_kv_layout):
+                # Both the Int64-stride path and the exact-boundary Int32 path build a
+                # 5D tensor with true seqlen_k as the first dimension; zipped_divide
+                # partitions it into sparse blocks with the correct TMA extent.
                 mK_cur = mK[None, None, None, head_idx_kv, batch_idx]
                 mV_cur = mV[None, None, None, head_idx_kv, batch_idx]
                 gK_tma = cute.zipped_divide(

--- a/flashinfer/cute_dsl/sparse/sm100_blk64/dispatch_helpers.py
+++ b/flashinfer/cute_dsl/sparse/sm100_blk64/dispatch_helpers.py
@@ -146,6 +146,24 @@ def sm100_blk64_requires_int64_kv_strides(
     return False
 
 
+def sm100_blk64_has_partial_kv_tail(
+    k: torch.Tensor,
+    v: torch.Tensor,
+) -> bool:
+    """Return whether the final physical KV block is shorter than 64 rows.
+
+    When seqlen_k is not divisible by 64, the packed rank-6 KV view used by
+    the Int32 TMA path declares ceil_div(seqlen_k, 64) full 64-token blocks.
+    TMA then treats the last partial block as having 64 valid rows and reads
+    beyond the actual buffer, producing address-dependent NaN/Inf outputs.
+
+    The fix routes these cases through use_exact_kv_layout=True, which builds
+    the TMA descriptor from the true seqlen_k extent so TMA hardware
+    zero-fills the out-of-bounds rows of the partial last block.
+    """
+    return k.shape[2] % 64 != 0 or v.shape[2] % 64 != 0
+
+
 def _tensor_dynamic_layout_compile_key(t: torch.Tensor, leading_dim: int = -1):
     """Match the static rank/dtype/broadcast parts of mark_layout_dynamic()."""
     if leading_dim == -1:
@@ -858,6 +876,11 @@ def validate_sm100_blk64_fp8_sage(
         raise ValueError(
             "Sage FP8 blk64 requires full 64-token KV blocks (block_sizes must "
             "be None); partial/padded KV blocks are not supported yet"
+        )
+    if seqlen_k % 64 != 0:
+        raise ValueError(
+            f"Sage FP8 blk64 requires seqlen_k divisible by 64 (got {seqlen_k}); "
+            "the D-major KV layout does not support partial 64-token tail blocks"
         )
     if (
         q_scale.dtype != torch.float32

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -553,7 +553,9 @@ class BlockSparseAttentionWrapper:
         M : int
             The number of rows of the block-sparse matrix, ``MB = ceil_div(M, R)``.
         N : int
-            The number of columns of the block-sparse matrix, ``NB = N // C``, ``N`` should be divisible by ``C``.
+            The number of columns of the block-sparse matrix, ``NB = ceil_div(N, C)``.
+            For most backends ``N`` must be divisible by ``C``; the ``vsa_sm100_blk64``
+            backend additionally supports a partial last KV block (``N % C != 0``).
         R : int
             The number of rows in each block.
         C : int

--- a/flashinfer/sparse.py
+++ b/flashinfer/sparse.py
@@ -212,6 +212,7 @@ def _vsa_common_checks(
     causal: bool,
     pos_encoding_mode: str,
     logits_soft_cap,
+    require_n_aligned: bool = True,
 ) -> None:
     """Validate the arguments that are identical across all VSA backends."""
     if num_qo_heads % num_kv_heads != 0:
@@ -220,7 +221,7 @@ def _vsa_common_checks(
         )
     if M % R != 0:
         raise ValueError(f"M={M} must be divisible by block size R={R}")
-    if N % C != 0:
+    if require_n_aligned and N % C != 0:
         raise ValueError(f"N={N} must be divisible by block size C={C}")
     if mask is not None or packed_mask is not None:
         raise ValueError(
@@ -999,10 +1000,11 @@ class BlockSparseAttentionWrapper:
                 causal,
                 pos_encoding_mode,
                 logits_soft_cap,
+                require_n_aligned=False,  # blk64 supports partial last KV block
             )
 
             MB = M // R
-            NB = N // C
+            NB = (N + C - 1) // C
             H = num_qo_heads
 
             if block_mask is not None:

--- a/tests/attention/test_vsa_block_sparse.py
+++ b/tests/attention/test_vsa_block_sparse.py
@@ -828,6 +828,137 @@ def test_vsa_blk64_accuracy_vs_dense(seqlen, topk_frac, workspace):
 
 
 @_requires_sm100_or_sm103
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k",
+    [
+        (64, 65),  # 1 full block + 1-token partial tail
+        (64, 127),  # 1 full block + 63-token partial tail
+        (128, 193),  # 2 full Q-blocks, 3 full KV blocks + 1-token partial tail
+    ],
+)
+def test_vsa_blk64_partial_kv_tail(seqlen_q, seqlen_k, workspace):
+    """blk64 kernel must produce finite, correct output when seqlen_k % 64 != 0.
+
+    Previously the packed rank-6 TMA view rounded the KV block count up to
+    ceil_div(seqlen_k, 64) full 64-token blocks.  TMA read beyond the actual
+    buffer for the last partial block, producing NaN/Inf outputs.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(42)
+    num_heads = 4
+    dtype = torch.bfloat16
+
+    q = torch.randn(seqlen_q, num_heads, HEAD_DIM_BLK64, dtype=dtype, device=device)
+    k = torch.randn(seqlen_k, num_heads, HEAD_DIM_BLK64, dtype=dtype, device=device)
+    v = torch.randn(seqlen_k, num_heads, HEAD_DIM_BLK64, dtype=dtype, device=device)
+
+    mb = (seqlen_q + R64 - 1) // R64
+    nb = (seqlen_k + C64 - 1) // C64
+
+    # Dense pattern: every Q-block attends to all KV blocks (including partial tail).
+    indptr = torch.arange(mb + 1, dtype=torch.int32, device=device) * nb
+    indices = torch.cat(
+        [torch.arange(nb, dtype=torch.int32, device=device) for _ in range(mb)]
+    )
+
+    # Dense PyTorch reference: plain scaled-dot-product attention.
+    scale = HEAD_DIM_BLK64**-0.5
+    qf = q.float().permute(1, 0, 2)  # [H, Sq, D]
+    kf = k.float().permute(1, 0, 2)  # [H, Sk, D]
+    vf = v.float().permute(1, 0, 2)  # [H, Sk, D]
+    scores = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+    probs = torch.softmax(scores, dim=-1)
+    o_ref = torch.matmul(probs, vf).permute(1, 0, 2).to(dtype)  # [Sq, H, D]
+
+    wrapper = _make_wrapper_blk64(workspace)
+    wrapper.plan(
+        indptr,
+        indices,
+        seqlen_q,
+        seqlen_k,
+        R64,
+        C64,
+        num_heads,
+        num_heads,
+        HEAD_DIM_BLK64,
+        q_data_type=dtype,
+    )
+    o = wrapper.run(q, k, v)
+
+    assert torch.isfinite(o).all(), (
+        f"blk64 output contains non-finite values for seqlen_k={seqlen_k} (% 64 != 0)"
+    )
+    torch.testing.assert_close(o_ref, o, atol=1e-2, rtol=1e-2)
+
+
+@_requires_sm100_or_sm103
+@pytest.mark.parametrize(
+    "seqlen_q,seqlen_k,kv_splits",
+    [
+        (128, 65, 2),  # partial tail (1 token), explicit split=2
+        (128, 193, 2),  # partial tail (1 token), 3 full + 1 partial block, split=2
+        (128, 193, 4),  # same, split=4
+    ],
+)
+def test_vsa_blk64_partial_kv_tail_kv_splits(seqlen_q, seqlen_k, kv_splits, workspace):
+    """blk64 split-KV path must produce correct output when seqlen_k % 64 != 0.
+
+    kv_splits > 1 activates a separate combine kernel after the main forward
+    pass.  The block_sizes partial-tail masking must be in effect inside each
+    split's forward pass so that out-of-bounds KV positions don't contaminate
+    the per-split softmax statistics fed into the combine step.
+    """
+    device = torch.device("cuda")
+    torch.manual_seed(7)
+    num_heads = 4
+    dtype = torch.bfloat16
+
+    q = torch.randn(seqlen_q, num_heads, HEAD_DIM_BLK64, dtype=dtype, device=device)
+    k = torch.randn(seqlen_k, num_heads, HEAD_DIM_BLK64, dtype=dtype, device=device)
+    v = torch.randn(seqlen_k, num_heads, HEAD_DIM_BLK64, dtype=dtype, device=device)
+
+    mb = (seqlen_q + R64 - 1) // R64
+    nb = (seqlen_k + C64 - 1) // C64
+
+    # Dense pattern: every Q-block attends to all KV blocks including partial tail.
+    indptr = torch.arange(mb + 1, dtype=torch.int32, device=device) * nb
+    indices = torch.cat(
+        [torch.arange(nb, dtype=torch.int32, device=device) for _ in range(mb)]
+    )
+
+    # Dense SDPA reference over all seqlen_k tokens.
+    scale = HEAD_DIM_BLK64**-0.5
+    qf = q.float().permute(1, 0, 2)  # [H, Sq, D]
+    kf = k.float().permute(1, 0, 2)  # [H, Sk, D]
+    vf = v.float().permute(1, 0, 2)  # [H, Sk, D]
+    scores = torch.matmul(qf, kf.transpose(-1, -2)) * scale
+    probs = torch.softmax(scores, dim=-1)
+    o_ref = torch.matmul(probs, vf).permute(1, 0, 2).to(dtype)  # [Sq, H, D]
+
+    wrapper = _make_wrapper_blk64(workspace)
+    wrapper.plan(
+        indptr,
+        indices,
+        seqlen_q,
+        seqlen_k,
+        R64,
+        C64,
+        num_heads,
+        num_heads,
+        HEAD_DIM_BLK64,
+        q_data_type=dtype,
+        kv_splits=kv_splits,
+    )
+    o = wrapper.run(q, k, v)
+
+    assert torch.isfinite(o).all(), (
+        f"blk64 kv_splits={kv_splits} output contains non-finite values "
+        f"for seqlen_k={seqlen_k} (% 64 != 0)"
+    )
+    torch.testing.assert_close(o_ref, o, atol=1e-2, rtol=1e-2)
+
+
+@_requires_sm100_or_sm103
 @pytest.mark.parametrize("kv_splits", [1, 2, 4, "auto"])
 def test_vsa_blk64_kv_splits(kv_splits, workspace):
     """blk64 output must match the dense reference across kv_splits values."""


### PR DESCRIPTION
When seqlen_k is not divisible by 64, the last KV block contains fewer than 64 valid tokens. The packed rank-6 TMA view rounded up to ceil_div(seqlen_k, 64) full blocks, causing TMA to read beyond the allocated buffer. Out-of-bounds K values (zero-filled) produced score=0, giving exp(0)=1 softmax weight and corrupting the output.

Two-part fix:

1. Auto-inject block_sizes[-1] = seqlen_k % 64 (primary correctness fix) When seqlen_k % 64 != 0 and the user did not provide block_sizes, generate a block_sizes tensor with 64 for full blocks and seqlen_k%64 for the partial tail. This triggers apply_block_size_mask_64 which sets out-of-bounds attention scores to -inf, giving them zero softmax weight. Handles the interaction with phantom-block masking (variable block nums) by checking user_provided_block_sizes rather than has_block_sizes so both corrections apply simultaneously.

2. Add use_exact_kv_layout kernel variant (TMA safety fix) Builds a 5D TMA descriptor with the true seqlen_k extent and Int32 strides so TMA zero-fills out-of-bounds positions instead of reading arbitrary memory beyond the allocation.

Also relax the wrapper N % C == 0 requirement for vsa_sm100_blk64 (other backends still require alignment) and switch NB to ceiling division so plan() accepts partial seqlen_k without raising ValueError. Sage FP8 continues to reject seqlen_k % 64 != 0 via validate_sm100_blk64_fp8_sage (D-major layout incompatible with partial tail masking).

Tests: add test_vsa_blk64_partial_kv_tail (seqlen_k=65/127/193) and test_vsa_blk64_partial_kv_tail_kv_splits (kv_splits=2/4) to cover the single-kernel and split-KV combine paths.

AI-assisted

<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

## 🔍 Related Issues

<!-- Link any related issues here -->

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed block-sparse attention for key/value sequence lengths that are not multiples of 64.
  - Prevented out-of-bounds data from affecting softmax calculations, avoiding invalid outputs such as NaN or Inf.
  - Ensured correct results when processing attention with multiple KV splits.

- **Compatibility**
  - Added support for partial final KV blocks in the SM100 block-sparse attention backend.
  - Partial KV tails remain unsupported for Sage FP8 layouts and now produce a validation error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->