### PR TITLE
fix(kda): dense recurrent_kda ssi==-1 must not wrap pool (#5042)

### DIFF
--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -346,6 +346,7 @@ def recurrent_kda_decode_kernel(
     HAS_DT_BIAS: cutlass.Constexpr[int],
     USE_LOWER_BOUND: cutlass.Constexpr[int],
     USE_CU_SEQLENS: cutlass.Constexpr[int],
+    HAS_SSM_STATE_INDICES: cutlass.Constexpr[int],
     NUM_TOKENS: cutlass.Constexpr[int],
     TILE_ROWS: cutlass.Constexpr[int],
     DOT_REDUCTION_SCHEDULE: cutlass.Constexpr[int],
@@ -389,7 +390,7 @@ def recurrent_kda_decode_kernel(
         padded_o_head[v_offset + tidx] = cutlass.BFloat16(0.0)
 
     init_seq_idx = batch_idx
-    if USE_CU_SEQLENS == 1:
+    if USE_CU_SEQLENS == 1 or HAS_SSM_STATE_INDICES == 1:
         init_raw_slot = gSsmStateIndices[batch_idx * NUM_TOKENS].to(cutlass.Int32)
         if NUM_TOKENS > 1 and HAS_NUM_ACCEPTED_TOKENS == 1:
             nat_raw = gNumAcceptedTokens[batch_idx].to(cutlass.Int32)
@@ -461,6 +462,14 @@ def recurrent_kda_decode_kernel(
             is_active = raw_slot >= 0 and has_token
             token_offset = token_offset if has_token else cutlass.Int32(0)
             seq_idx = cutlass.Int32(0) if raw_slot < 0 else raw_slot
+        elif HAS_SSM_STATE_INDICES == 1:
+            # Dense tokens stay on batch_idx; ssi remaps the state pool slot and
+            # skips negative padding entries (CUDA-graph null slots).
+            raw_slot = gSsmStateIndices[batch_idx * NUM_TOKENS + token_t].to(
+                cutlass.Int32
+            )
+            seq_idx = cutlass.Int32(0) if raw_slot < 0 else raw_slot
+            is_active = raw_slot >= 0
         else:
             seq_idx = batch_idx
             is_active = seq_len > 0
@@ -1073,6 +1082,7 @@ def recurrent_kda_launch(
     HAS_DT_BIAS: cutlass.Constexpr[int],
     USE_LOWER_BOUND: cutlass.Constexpr[int],
     USE_CU_SEQLENS: cutlass.Constexpr[int],
+    HAS_SSM_STATE_INDICES: cutlass.Constexpr[int],
     NUM_TOKENS: cutlass.Constexpr[int],
     TILE_ROWS: cutlass.Constexpr[int],
     DOT_REDUCTION_SCHEDULE: cutlass.Constexpr[int],
@@ -1109,6 +1119,7 @@ def recurrent_kda_launch(
         HAS_DT_BIAS,
         USE_LOWER_BOUND,
         USE_CU_SEQLENS,
+        HAS_SSM_STATE_INDICES,
         NUM_TOKENS,
         TILE_ROWS,
         DOT_REDUCTION_SCHEDULE,
@@ -1217,6 +1228,7 @@ def _get_compiled_kernel(
     DOT_REDUCTION_SCHEDULE,
     ZERO_PADDED_OUTPUT,
     HAS_NUM_ACCEPTED_TOKENS,
+    HAS_SSM_STATE_INDICES,
 ):
     """Compile a register-tile specialization."""
     return cute.compile(
@@ -1228,6 +1240,7 @@ def _get_compiled_kernel(
         HAS_DT_BIAS,
         USE_LOWER_BOUND,
         USE_CU_SEQLENS,
+        HAS_SSM_STATE_INDICES,
         NUM_TOKENS,
         TILE_ROWS,
         DOT_REDUCTION_SCHEDULE,
@@ -2165,13 +2178,12 @@ def run_recurrent_kda(
         if (
             initial_state is not None
             and not initial_state.is_contiguous()
+            and ssm_state_indices is None
             and backend != "cake"
-            # Only the indexed Cake convention tolerates a non-contiguous pool: it
-            # passes the pool through and gathers via ``ssi``. Without indices it
-            # would copy, so the check still applies to the "auto" candidate.
-            and not (
-                auto_unbounded_softplus_candidate and ssm_state_indices is not None
-            )
+            # Indexed dense decode and Cake pass the pool through (via ``ssi`` or
+            # identity). Without indices the wrapper would .contiguous()-copy, so
+            # the check still applies to the plain "auto" / cute-dsl candidate.
+            and not auto_unbounded_softplus_candidate
         ):
             raise ValueError(
                 "non-contiguous initial_state requires cu_seqlens: without cu_seqlens "
@@ -2191,14 +2203,11 @@ def run_recurrent_kda(
             )
         if initial_state is None:
             state = torch.zeros(B, HV, V, K, device=device, dtype=torch.bfloat16)
-        elif ssm_state_indices is not None and (
-            backend == "cake" or auto_unbounded_softplus_candidate
-        ):
+        elif ssm_state_indices is not None:
+            # Pool + ssi for every backend: negative slots stay padding (no Python
+            # gather/scatter wrap-around). Matches the cu_seqlens / Cake contract.
             state = initial_state
             ssi = ssm_state_indices.to(torch.int32).contiguous().view(-1)
-        elif ssm_state_indices is not None:
-            state = initial_state[ssm_state_indices].contiguous()
-            copy_back_indices = ssm_state_indices
         elif backend == "cake" or auto_unbounded_softplus_candidate:
             state = initial_state
         else:
@@ -2382,16 +2391,11 @@ def run_recurrent_kda(
             auto_unbounded_softplus
             and cu_seqlens_i32 is None
             and initial_state is not None
+            and ssm_state_indices is None
         ):
-            # The state convention above was chosen before the variant was known.
-            # Cake was not selected after all, so restore CuTe's convention before
-            # falling through to it.
-            if ssm_state_indices is not None:
-                state = initial_state[ssm_state_indices].contiguous()
-                copy_back_indices = ssm_state_indices
-                ssi = None
-            else:
-                state = initial_state.contiguous()
+            # Cake-candidate used a pass-through pool; CuTe without indices needs
+            # a contiguous buffer. Indexed dense already keeps pool + ssi.
+            state = initial_state.contiguous()
     if flash_kda_decode_variant is not None:
         _run_flash_kda_decode(
             flash_kda_decode_variant,
@@ -2420,6 +2424,7 @@ def run_recurrent_kda(
         USE_CU = 1 if cu_seqlens_i32 is not None else 0
         ZERO_PADDED_OUTPUT = 1 if zero_padded_output else 0
         HAS_NAT = 1 if num_accepted_tokens is not None else 0
+        HAS_SSI = 1 if ssi is not None else 0
         tile_rows, reduction_schedule = _select_kernel_schedule(
             K,
             NUM_TOKENS,
@@ -2440,6 +2445,7 @@ def run_recurrent_kda(
             reduction_schedule,
             ZERO_PADDED_OUTPUT,
             HAS_NAT,
+            HAS_SSI,
         )
         compiled(
             q,

--- a/flashinfer/kda_kernels/recurrent_kda.py
+++ b/flashinfer/kda_kernels/recurrent_kda.py
@@ -1890,10 +1890,12 @@ def run_recurrent_kda(
             ``"auto"`` selects Cake only for its native equal-head/D128/T1
             unbounded-softplus contract and otherwise preserves CuTe DSL.
             ``"auto"`` accepts exactly what ``"cute-dsl"`` accepts. Note that
-            with ``ssm_state_indices`` and ``output_final_state=True`` the
-            returned state follows whichever backend ran: the whole pool from
-            Cake, or the gathered ``[B, HV, V, K]`` rows from CuTe DSL. The
-            in-place pool update is the same either way.
+            with ``ssm_state_indices`` and ``output_final_state=True`` every
+            backend returns the caller-owned state pool (same object as
+            ``initial_state`` when provided). Negative indices are padding
+            (``null_min=0``: slot 0 stays valid) and are skipped in-kernel;
+            there is no Python gather/scatter. The in-place pool update is
+            the shared contract.
 
     Returns:
         Tuple[torch.Tensor, Optional[torch.Tensor]]:

--- a/tests/kda/test_recurrent_kda_dense_padded_ssi.py
+++ b/tests/kda/test_recurrent_kda_dense_padded_ssi.py
@@ -55,7 +55,7 @@ def test_dense_padded_ssm_state_indices_no_wrap(
     seq_heads = B * H
     assert (route == "one-warp") == (seq_heads >= 128), (route, seq_heads)
 
-    recurrent_kda(
+    _out, final_state = recurrent_kda(
         q=q,
         k=k,
         v=v,
@@ -69,6 +69,8 @@ def test_dense_padded_ssm_state_indices_no_wrap(
         ssm_state_indices=ssi,
         backend=backend,
     )
+    assert final_state is state_pool
+    assert tuple(final_state.shape) == (n_slots, H, D, D)
 
     last_delta = (state_pool[-1].float() - before[-1].float()).abs().max().item()
     assert last_delta == 0.0, (

--- a/tests/kda/test_recurrent_kda_dense_padded_ssi.py
+++ b/tests/kda/test_recurrent_kda_dense_padded_ssi.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2023-2026 FlashInfer contributors
+# Regression for flashinfer-ai/flashinfer#5042: dense T=1 ssi==-1 must not wrap.
+
+import torch
+import torch.nn.functional as F
+import pytest
+
+from flashinfer.kda_decode import _RECURRENT_KDA_AVAILABLE, recurrent_kda
+
+pytestmark = pytest.mark.skipif(
+    not _RECURRENT_KDA_AVAILABLE,
+    reason="recurrent_kda kernel not available (missing cutlass DSL deps)",
+)
+
+
+@pytest.mark.parametrize("backend", ["cute-dsl", "auto"])
+@pytest.mark.parametrize(
+    ("B", "H", "route"),
+    [
+        # sequence_heads = B * H; one-warp threshold is 128
+        pytest.param(2, 32, "grouped", id="grouped-B2-H32"),
+        pytest.param(4, 32, "one-warp", id="onewarp-B4-H32"),
+    ],
+)
+def test_dense_padded_ssm_state_indices_no_wrap(
+    backend: str, B: int, H: int, route: str
+):
+    """Dense T=1 with ssi==-1 must not wrap to the last pool slot."""
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    D = 64
+    n_slots = 5
+    SENTINEL = 7.0
+    state_pool = torch.zeros(n_slots, H, D, D, dtype=dtype, device=device)
+    state_pool[-1] = SENTINEL
+    if B == 2:
+        ssi = torch.tensor([-1, 3], device=device, dtype=torch.int32)
+        active_slots = [3]
+    else:
+        ssi = torch.tensor([-1, 1, -1, 3], device=device, dtype=torch.int32)
+        active_slots = [1, 3]
+
+    for slot in active_slots:
+        state_pool[slot] = torch.randn(H, D, D, dtype=dtype, device=device) * 0.01
+    before = state_pool.clone()
+
+    q = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    g = (F.logsigmoid(torch.randn(B, 1, H, D, device=device)) / 1.0).to(dtype)
+    beta = torch.rand(B, 1, H, dtype=dtype, device=device).sigmoid()
+    scale = 1.0 / D**0.5
+
+    seq_heads = B * H
+    assert (route == "one-warp") == (seq_heads >= 128), (route, seq_heads)
+
+    recurrent_kda(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=state_pool,
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        use_gate_in_kernel=False,
+        ssm_state_indices=ssi,
+        backend=backend,
+    )
+
+    last_delta = (state_pool[-1].float() - before[-1].float()).abs().max().item()
+    assert last_delta == 0.0, (
+        f"pool[-1] written (wrap-around): delta={last_delta} backend={backend} {route}"
+    )
+    if 0 not in active_slots:
+        slot0_delta = (state_pool[0].float() - before[0].float()).abs().max().item()
+        assert slot0_delta == 0.0, f"slot0 corrupted: {slot0_delta}"
+
+    for slot in active_slots:
+        changed = (state_pool[slot].float() - before[slot].float()).abs().max().item()
+        assert changed > 0.0, f"active slot {slot} not updated"
+
+
+@pytest.mark.parametrize("backend", ["cute-dsl", "auto"])
+def test_dense_padded_ssi_cuda_graph_safe(backend: str):
+    """Dense padded ssi path must remain CUDA-graph capturable (no bool-mask)."""
+    torch.manual_seed(1)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    B, H, D = 4, 32, 64
+    n_slots = 8
+    SENTINEL = 7.0
+    state_pool = torch.zeros(n_slots, H, D, D, dtype=dtype, device=device)
+    state_pool[-1] = SENTINEL
+    state_pool[1] = torch.randn(H, D, D, dtype=dtype, device=device) * 0.01
+    state_pool[3] = torch.randn(H, D, D, dtype=dtype, device=device) * 0.01
+    ssi = torch.tensor([-1, 1, -1, 3], device=device, dtype=torch.int32)
+
+    q = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    gate = (F.logsigmoid(torch.randn(B, 1, H, D, device=device)) / 1.0).to(dtype)
+    beta = torch.rand(B, 1, H, dtype=dtype, device=device).sigmoid()
+    scale = 1.0 / D**0.5
+    out = torch.empty(B, 1, H, D, dtype=dtype, device=device)
+
+    def run():
+        recurrent_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=gate,
+            beta=beta,
+            scale=scale,
+            initial_state=state_pool,
+            output=out,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=False,
+            ssm_state_indices=ssi,
+            backend=backend,
+        )
+
+    run()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run()
+    before_last = state_pool[-1].clone()
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(state_pool[-1], before_last), "graph replay wrote pool[-1]"

--- a/tests/kda/test_recurrent_kda_dense_padded_ssi.py
+++ b/tests/kda/test_recurrent_kda_dense_padded_ssi.py
@@ -12,6 +12,20 @@ pytestmark = pytest.mark.skipif(
     reason="recurrent_kda kernel not available (missing cutlass DSL deps)",
 )
 
+# Cake T1 unbounded-softplus is exported only for these compute capabilities.
+_CAKE_DECODE_CCS = {(10, 0), (10, 3)}
+
+
+def _assert_pool_slots(state_pool, before, active_slots, n_slots):
+    inactive_slots = set(range(n_slots)) - set(active_slots)
+    for slot in inactive_slots:
+        assert torch.equal(state_pool[slot], before[slot]), (
+            f"inactive slot {slot} was modified"
+        )
+    for slot in active_slots:
+        changed = (state_pool[slot].float() - before[slot].float()).abs().max().item()
+        assert changed > 0.0, f"active slot {slot} not updated"
+
 
 @pytest.mark.parametrize("backend", ["cute-dsl", "auto"])
 @pytest.mark.parametrize(
@@ -25,7 +39,11 @@ pytestmark = pytest.mark.skipif(
 def test_dense_padded_ssm_state_indices_no_wrap(
     backend: str, B: int, H: int, route: str
 ):
-    """Dense T=1 with ssi==-1 must not wrap to the last pool slot."""
+    """Dense T=1 with ssi==-1 must not wrap to the last pool slot.
+
+    D=64 with a precomputed gate makes backend=\"auto\" fall through to CuTe
+    (Cake-ineligible). That is the #5042 failure mode under auto.
+    """
     torch.manual_seed(0)
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -71,23 +89,75 @@ def test_dense_padded_ssm_state_indices_no_wrap(
     )
     assert final_state is state_pool
     assert tuple(final_state.shape) == (n_slots, H, D, D)
+    _assert_pool_slots(state_pool, before, active_slots, n_slots)
 
-    last_delta = (state_pool[-1].float() - before[-1].float()).abs().max().item()
-    assert last_delta == 0.0, (
-        f"pool[-1] written (wrap-around): delta={last_delta} backend={backend} {route}"
-    )
-    if 0 not in active_slots:
-        slot0_delta = (state_pool[0].float() - before[0].float()).abs().max().item()
-        assert slot0_delta == 0.0, f"slot0 corrupted: {slot0_delta}"
 
-    for slot in active_slots:
-        changed = (state_pool[slot].float() - before[slot].float()).abs().max().item()
-        assert changed > 0.0, f"active slot {slot} not updated"
+@pytest.mark.parametrize("backend", ["cake", "auto"])
+def test_dense_padded_ssi_cake_unbounded_softplus(backend: str):
+    """Cake equal-head D128 T1 unbounded-softplus must skip ssi==-1.
+
+    Matches the Cake / auto-Cake-eligible contract. Skips ``backend=\"cake\"``
+    on devices outside the exported Cake decode arch map.
+    """
+    cc = torch.cuda.get_device_capability()
+    if backend == "cake" and cc not in _CAKE_DECODE_CCS:
+        pytest.skip(f"Cake decode not mapped for compute capability {cc}")
+
+    torch.manual_seed(2)
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    B, H, D = 2, 32, 128
+    n_slots = 5
+    SENTINEL = 7.0
+    state_pool = torch.zeros(n_slots, H, D, D, dtype=dtype, device=device)
+    state_pool[-1] = SENTINEL
+    ssi = torch.tensor([-1, 3], device=device, dtype=torch.int32)
+    active_slots = [3]
+    state_pool[3] = torch.randn(H, D, D, dtype=dtype, device=device) * 0.01
+    before = state_pool.clone()
+
+    q = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    k = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    v = torch.rand(B, 1, H, D, dtype=dtype, device=device)
+    g = torch.randn(B, 1, H, D, dtype=dtype, device=device)
+    A_log = torch.log(torch.ones(H, dtype=torch.float32, device=device).uniform_(1, 16))
+    dt_bias = torch.randn(H * D, dtype=torch.float32, device=device)
+    beta = torch.rand(B, 1, H, dtype=dtype, device=device).sigmoid()
+    scale = 1.0 / D**0.5
+
+    try:
+        _out, final_state = recurrent_kda(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            scale=scale,
+            A_log=A_log,
+            dt_bias=dt_bias,
+            initial_state=state_pool,
+            output_final_state=True,
+            use_qk_l2norm_in_kernel=True,
+            use_gate_in_kernel=True,
+            ssm_state_indices=ssi,
+            backend=backend,
+        )
+    except ValueError as exc:
+        if backend == "cake" and "unsupported" in str(exc):
+            pytest.skip(str(exc))
+        raise
+
+    assert final_state is state_pool
+    assert tuple(final_state.shape) == (n_slots, H, D, D)
+    _assert_pool_slots(state_pool, before, active_slots, n_slots)
 
 
 @pytest.mark.parametrize("backend", ["cute-dsl", "auto"])
 def test_dense_padded_ssi_cuda_graph_safe(backend: str):
-    """Dense padded ssi path must remain CUDA-graph capturable (no bool-mask)."""
+    """Dense padded ssi path must remain CUDA-graph capturable (no bool-mask).
+
+    D=64 / precomputed gate: auto falls through to CuTe (Cake-ineligible).
+    """
     torch.manual_seed(1)
     device = torch.device("cuda")
     dtype = torch.bfloat16
@@ -99,6 +169,7 @@ def test_dense_padded_ssi_cuda_graph_safe(backend: str):
     state_pool[1] = torch.randn(H, D, D, dtype=dtype, device=device) * 0.01
     state_pool[3] = torch.randn(H, D, D, dtype=dtype, device=device) * 0.01
     ssi = torch.tensor([-1, 1, -1, 3], device=device, dtype=torch.int32)
+    active_slots = [1, 3]
 
     q = torch.rand(B, 1, H, D, dtype=dtype, device=device)
     k = torch.rand(B, 1, H, D, dtype=dtype, device=device)
@@ -127,10 +198,14 @@ def test_dense_padded_ssi_cuda_graph_safe(backend: str):
 
     run()
     torch.cuda.synchronize()
+    before = state_pool.clone()
     graph = torch.cuda.CUDAGraph()
     with torch.cuda.graph(graph):
         run()
-    before_last = state_pool[-1].clone()
     graph.replay()
     torch.cuda.synchronize()
-    assert torch.equal(state_pool[-1], before_last), "graph replay wrote pool[-1]"
+    inactive_slots = set(range(n_slots)) - set(active_slots)
+    for slot in inactive_slots:
+        assert torch.equal(state_pool[slot], before[slot]), (
+            f"graph replay modified inactive slot {slot}"
+        )


### PR DESCRIPTION
## Summary
- Dense `T=1` `cute-dsl`/`auto` used Python gather/scatter on `ssm_state_indices`; `-1` wrapped to `pool[-1]` and corrupted live cache slots.
- One-warp CuTe now honors `HAS_SSM_STATE_INDICES` on the dense path (skip `ssi < 0`; tokens stay on `batch_idx`).
- Dense dispatch always passes `state = pool` + `ssi` (no gather/copy-back). Grouped path already correct.
- Indexed dense `output_final_state=True` now returns the caller-owned state pool for CuTe DSL / auto as well (aligned with Cake). The previous gathered `[B, HV, V, K]` return was a side effect of the Python gather path; docstring updated. Padding remains negatives only (`null_min=0`; slot 0 valid).
- Regression: grouped + one-warp, `cute-dsl` + `auto`, CUDA-graph capture/replay, and returned-state pool identity/shape.

Fixes #5042

## Test plan
- [x] `pytest tests/kda/test_recurrent_kda_dense_padded_ssi.py` (6 passed, GB10)
- [x] Issue repro `ssi=[-1, 3]` / 5-slot pool: only slot 3 written
- [x] Remap non-identity ssi; `cu_seqlens` control unchanged
- [x] `final_state is state_pool` and pool shape under indexed dense decode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed indexed dense decoding so state pools are updated in place consistently across supported backends.
  - Corrected handling of padding indices (`-1`) to prevent unintended updates to the final state slot.
  - Preserved caller-provided state pools and ensured returned state shapes remain consistent.
  - Maintained CUDA Graph compatibility for indexed dense decoding.
- **Tests**
  - Added coverage for inactive state slots, varying head and dimension configurations, and CUDA Graph replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->