### PR TITLE
Expose raster and swizzle choices for SM12x FP4 CUTLASS autotuning

### DIFF
--- a/include/flashinfer/gemm/cutlass_gemm_configs.h
+++ b/include/flashinfer/gemm/cutlass_gemm_configs.h
@@ -326,6 +326,8 @@ constexpr auto get_cluster_shape() {
 }
 
 struct CutlassGemmConfig {
+  enum class RasterOrder { Heuristic, AlongM, AlongN };
+
   enum CandidateConfigTypeParam : int {
     NONE = 0,
     WEIGHT_ONLY = 1u << 0,
@@ -356,6 +358,8 @@ struct CutlassGemmConfig {
   bool swap_ab = false;  // Default false only implemented for SM120/SM121, but generalizable
   bool use_stream_k =
       false;  // SM120/SM121: false = DP scheduler (default), true = StreamK scheduler
+  int max_swizzle_size = 1;
+  RasterOrder raster_order = RasterOrder::Heuristic;  // Original, unswapped problem axes.
 
   CutlassGemmConfig() = default;
 
@@ -424,6 +428,8 @@ struct CutlassGemmConfig {
       // SM120/SM121 specific: StreamK scheduler option
       if (sm_version == 120 || sm_version == 121) {
         tactic << "\n\tscheduler: " << (use_stream_k ? "StreamK (auto heuristic)" : "DP (default)");
+        tactic << "\n\tmax swizzle size: " << max_swizzle_size
+               << "\n\tlogical raster order: " << static_cast<int>(raster_order);
       }
     } else if (tile_config_sm80 != flashinfer::gemm::CutlassTileConfig::ChooseWithHeuristic) {
       assert(sm_version < 90 && "Invalid cutlass GEMM config");

--- a/include/flashinfer/gemm/fp4_gemm_cutlass_template_sm120.h
+++ b/include/flashinfer/gemm/fp4_gemm_cutlass_template_sm120.h
@@ -217,6 +217,19 @@ std::vector<CutlassGemmConfig> CutlassFp4GemmRunner<T, fp4GemmType>::getConfigs(
                                                  EpilogueScheduleType::AUTO, clusterShape, false,
                                                  true));
   }
+  // Append scheduler variants so persisted integer tactics retain their meaning.
+  // Limit the extra search to DP, where swizzle-8 raster choices are useful.
+  auto const legacyConfigCount = candidateConfigs.size();
+  for (size_t i = 0; i < legacyConfigCount; ++i) {
+    if (candidateConfigs[i].use_stream_k) continue;
+    for (auto raster :
+         {CutlassGemmConfig::RasterOrder::AlongM, CutlassGemmConfig::RasterOrder::AlongN}) {
+      auto config = candidateConfigs[i];
+      config.max_swizzle_size = 8;
+      config.raster_order = raster;
+      candidateConfigs.push_back(config);
+    }
+  }
   return candidateConfigs;
 }
 

--- a/include/flashinfer/gemm/fp4_gemm_template_sm120.h
+++ b/include/flashinfer/gemm/fp4_gemm_template_sm120.h
@@ -97,11 +97,12 @@ size_t genericFp4GemmKernelLauncherStreamK(void* D, void const* A, void const* B
 // ============================================================================
 
 // Unified prepareGemmArgs - works for both DP and StreamK schedulers
-template <typename Gemm>
+template <typename Gemm, bool SwapAB>
 inline typename Gemm::Arguments prepareGemmArgsImpl(void* D, void const* A, void const* B,
                                                     void const* input_sf, void const* weight_sf,
                                                     float const* global_sf, int m, int n, int k,
-                                                    int batch_count) {
+                                                    int batch_count,
+                                                    CutlassGemmConfig const& gemmConfig) {
   using Sm1xxBlkScaledConfig = typename Gemm::GemmKernel::CollectiveMainloop::Sm1xxBlkScaledConfig;
   using ElementC = void;
   using ElementD = typename Gemm::ElementD;
@@ -136,11 +137,22 @@ inline typename Gemm::Arguments prepareGemmArgsImpl(void* D, void const* A, void
       Sm1xxBlkScaledConfig::tile_atom_to_shape_SFB(operator_args.problem_shape);
 
   if constexpr (!std::is_const_v<decltype(operator_args.scheduler.max_swizzle_size)>) {
-    operator_args.scheduler.max_swizzle_size = 1;
+    operator_args.scheduler.max_swizzle_size = gemmConfig.max_swizzle_size;
   }
   if constexpr (!std::is_const_v<decltype(operator_args.scheduler.raster_order)>) {
     using Enum_t = decltype(operator_args.scheduler.raster_order);
-    operator_args.scheduler.raster_order = Enum_t::Heuristic;
+    auto raster = gemmConfig.raster_order;
+    if constexpr (SwapAB) {
+      if (raster == CutlassGemmConfig::RasterOrder::AlongM) {
+        raster = CutlassGemmConfig::RasterOrder::AlongN;
+      } else if (raster == CutlassGemmConfig::RasterOrder::AlongN) {
+        raster = CutlassGemmConfig::RasterOrder::AlongM;
+      }
+    }
+    operator_args.scheduler.raster_order =
+        raster == CutlassGemmConfig::RasterOrder::AlongM   ? Enum_t::AlongM
+        : raster == CutlassGemmConfig::RasterOrder::AlongN ? Enum_t::AlongN
+                                                           : Enum_t::Heuristic;
   }
   operator_args.hw_info.cluster_shape = dim3(1, 1, 1);
   operator_args.hw_info.cluster_shape_fallback = dim3(1, 1, 1);
@@ -149,14 +161,15 @@ inline typename Gemm::Arguments prepareGemmArgsImpl(void* D, void const* A, void
 }
 
 // Unified runGemm - works for both DP and StreamK schedulers
-template <typename Gemm>
+template <typename Gemm, bool SwapAB>
 inline size_t runFp4GemmImpl(void* D, void const* A, void const* B, void const* input_sf,
                              void const* weight_sf, float const* global_sf, int m, int n, int k,
-                             int batch_count, char* workspace, size_t const workspaceBytes,
-                             cudaStream_t stream, const char* scheduler_name) {
+                             int batch_count, CutlassGemmConfig const& gemmConfig, char* workspace,
+                             size_t const workspaceBytes, cudaStream_t stream,
+                             const char* scheduler_name) {
   Gemm gemm;
-  auto args =
-      prepareGemmArgsImpl<Gemm>(D, A, B, input_sf, weight_sf, global_sf, m, n, k, batch_count);
+  auto args = prepareGemmArgsImpl<Gemm, SwapAB>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,
+                                                batch_count, gemmConfig);
 
   // Return workspace size query
   if (!A && !B && !D) {
@@ -298,11 +311,13 @@ inline size_t runFp4GemmImpl(void* D, void const* A, void const* B, void const* 
       char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {                           \
     using Fp4GemmOperator = Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##SWAP_AB_;                                  \
     if constexpr (SWAP_AB_) {                                                                                        \
-      return runFp4GemmImpl<Fp4GemmOperator>(D, B, A, weight_sf, input_sf, global_sf, n, m, k,                       \
-                                             batch_count, workspace, workspaceBytes, stream, "");                    \
+      return runFp4GemmImpl<Fp4GemmOperator, SWAP_AB_>(D, B, A, weight_sf, input_sf, global_sf, n,                   \
+                                                       m, k, batch_count, gemmConfig, workspace,                     \
+                                                       workspaceBytes, stream, "");                                  \
     } else {                                                                                                         \
-      return runFp4GemmImpl<Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,                       \
-                                             batch_count, workspace, workspaceBytes, stream, "");                    \
+      return runFp4GemmImpl<Fp4GemmOperator, SWAP_AB_>(D, A, B, input_sf, weight_sf, global_sf, m,                   \
+                                                       n, k, batch_count, gemmConfig, workspace,                     \
+                                                       workspaceBytes, stream, "");                                  \
     }                                                                                                                \
   }                                                                                                                  \
                                                                                                                      \
@@ -316,13 +331,13 @@ inline size_t runFp4GemmImpl(void* D, void const* A, void const* B, void const* 
       char* workspace, const size_t workspaceBytes, cudaStream_t stream, int* occupancy) {                           \
     using Fp4GemmOperator = Fp4Gemm_##T##_##CTA_M_##_##CTA_N_##_##CTA_K_##SWAP_AB_##_StreamK;                        \
     if constexpr (SWAP_AB_) {                                                                                        \
-      return runFp4GemmImpl<Fp4GemmOperator>(D, B, A, weight_sf, input_sf, global_sf, n, m, k,                       \
-                                             batch_count, workspace, workspaceBytes, stream,                         \
-                                             " StreamK");                                                            \
+      return runFp4GemmImpl<Fp4GemmOperator, SWAP_AB_>(D, B, A, weight_sf, input_sf, global_sf, n,                   \
+                                                       m, k, batch_count, gemmConfig, workspace,                     \
+                                                       workspaceBytes, stream, " StreamK");                          \
     } else {                                                                                                         \
-      return runFp4GemmImpl<Fp4GemmOperator>(D, A, B, input_sf, weight_sf, global_sf, m, n, k,                       \
-                                             batch_count, workspace, workspaceBytes, stream,                         \
-                                             " StreamK");                                                            \
+      return runFp4GemmImpl<Fp4GemmOperator, SWAP_AB_>(D, A, B, input_sf, weight_sf, global_sf, m,                   \
+                                                       n, k, batch_count, gemmConfig, workspace,                     \
+                                                       workspaceBytes, stream, " StreamK");                          \
     }                                                                                                                \
   }
 

--- a/tests/gemm/test_mm_fp4.py
+++ b/tests/gemm/test_mm_fp4.py
@@ -259,6 +259,119 @@ def _nvfp4_operands(m, n, k):
     return a, b, a_fp4, a_s, b_fp4, b_s, 1.0 / (g_in * g_w)
 
 
+def _cutlass_scheduler_operands(m, n=1152, k=256):
+    # Integer-valued FP4 inputs make both the dot product and scaled reference exact.
+    values = torch.tensor([0, 1, -1, 2, -2], device="cuda", dtype=torch.float32)
+    codes = torch.tensor([0, 2, 10, 4, 12], device="cuda", dtype=torch.uint8)
+    column = torch.arange(k, device="cuda")
+    a_index = (torch.arange(m, device="cuda")[:, None] + column * 3) % 5
+    b_index = (torch.arange(n, device="cuda")[:, None] * 2 + column) % 5
+    a_codes, b_codes = codes[a_index], codes[b_index]
+    a = a_codes[:, ::2] | (a_codes[:, 1::2] << 4)
+    b = b_codes[:, ::2] | (b_codes[:, 1::2] << 4)
+    # Uniform E4M3 scale 1 has the same bytes in every 128x4 block-scale layout.
+    a_scale = torch.full(
+        ((m + 127) // 128 * 128, k // 16), 0x38, device="cuda", dtype=torch.uint8
+    )
+    b_scale = torch.full((n, k // 16), 0x38, device="cuda", dtype=torch.uint8)
+    reference = values[a_index] @ values[b_index].T
+    alpha = torch.tensor([1.25], device="cuda", dtype=torch.float32)
+    return a, b, a_scale, b_scale, alpha, reference
+
+
+@pytest.mark.parametrize("m", [4, 257, 1025])
+@pytest.mark.parametrize("out_dtype", [torch.float16, torch.bfloat16])
+def test_mm_fp4_cutlass_scheduler_tactics(m, out_dtype):
+    """All legacy and appended schedules preserve spatial output and live GPU alpha."""
+    if not is_sm12x_supported(torch.device("cuda")):
+        pytest.skip("CUTLASS scheduler variants require SM120/SM121.")
+    from flashinfer.jit.gemm import gen_gemm_sm120_module_cutlass_fp4
+
+    module = gen_gemm_sm120_module_cutlass_fp4().build_and_load()
+    assert module.fp4_gemm_tactic_num() == 64
+    a, b, sa, sb, alpha, reference = _cutlass_scheduler_operands(m)
+    out = torch.empty(reference.shape, device="cuda", dtype=out_dtype)
+    workspace = torch.empty(32 * 1024 * 1024, device="cuda", dtype=torch.uint8)
+    saved_inputs = [t.clone() for t in (a, b, sa, sb)]
+
+    for tactic in [-1, *range(64)]:
+        # The first 32 integer IDs remain valid, and each added schedule is explicit.
+        module.fp4_gemm(a, b, sa, sb, alpha, out, workspace, tactic)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            module.fp4_gemm(a, b, sa, sb, alpha, out, workspace, tactic)
+        for scale in (1.25, -0.75):
+            alpha.fill_(scale)
+            out.fill_(float("nan"))
+            graph.replay()
+            expected = (reference * scale).to(out_dtype)
+            assert torch.isfinite(out).all()
+            assert torch.equal(out.view(torch.int16), expected.view(torch.int16)), (
+                tactic
+            )
+        for actual, saved in zip((a, b, sa, sb), saved_inputs, strict=True):
+            assert torch.equal(actual, saved)
+
+
+@pytest.mark.parametrize("managed_cache", [False, True])
+def test_mm_fp4_cutlass_scheduler_autotune_cache(monkeypatch, tmp_path, managed_cache):
+    """Public tuning selects an appended integer tactic and replays it after reload."""
+    if not is_sm12x_supported(torch.device("cuda")):
+        pytest.skip("CUTLASS scheduler variants require SM120/SM121.")
+    from flashinfer import autotune_v2
+    from flashinfer.autotuner import AutoTuner
+
+    monkeypatch.setattr(AutoTuner, "_instance", None)
+    a, b, sa, sb, alpha, reference = _cutlass_scheduler_operands(4)
+    profiled = []
+
+    def profile(self, runner, inputs, tactic, tuning_config=None, **kwargs):
+        profiled.append(tactic)
+        runner(inputs, tactic=tactic)
+        # Deterministic selection tests cache plumbing, not hardware performance.
+        return 1.0 if tactic == 54 else 2.0
+
+    monkeypatch.setattr(AutoTuner, "_profile_single_kernel", profile)
+    context = (
+        autotune_v2(cache_root=tmp_path / "managed", tuning_buckets=(4,))
+        if managed_cache
+        else autotune(True, tuning_buckets=(4,))
+    )
+    with context:
+        out = mm_fp4(a, b.T, sa, sb.T, alpha, backend="cutlass")
+    assert set(profiled) == (set(range(64)) | ({-1} if managed_cache else set()))
+    expected = (reference * 1.25).to(torch.bfloat16)
+    assert torch.equal(out.view(torch.int16), expected.view(torch.int16))
+
+    cache = tmp_path / "tactics.json"
+    if not managed_cache:
+        AutoTuner.get().save_configs(cache)
+    monkeypatch.setattr(AutoTuner, "_instance", None)
+    if not managed_cache:
+        AutoTuner.get().load_configs(cache)
+    calls = []
+    original_choose = AutoTuner.choose_one
+
+    def choose(self, *args, **kwargs):
+        runner, tactic = original_choose(self, *args, **kwargs)
+        calls.append(tactic)
+        return runner, tactic
+
+    monkeypatch.setattr(AutoTuner, "choose_one", choose)
+    alpha.fill_(-0.75)
+    replay = (
+        autotune_v2(cache_root=tmp_path / "managed", mode="replay", tuning_buckets=(4,))
+        if managed_cache
+        else autotune(True, tuning_buckets=(4,))
+    )
+    with replay:
+        out = mm_fp4(a, b.T, sa, sb.T, alpha, backend="cutlass")
+    assert calls == [54]
+    assert len(profiled) == (65 if managed_cache else 64)
+    expected = (reference * -0.75).to(torch.bfloat16)
+    assert torch.equal(out.view(torch.int16), expected.view(torch.int16))
+
+
 def test_mm_fp4_b12x_short_k_multi_wave():
     # One K tile and more work tiles than SMs stress the epilogue smem
     # handoff between a persistent CTA's work tiles, a regime the


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

The SM120/SM121 FP4 CUTLASS runner fixes swizzle to 1 and raster order to the heuristic, so the existing autotuner cannot compare other traversal orders. This appends 32 DP tactics covering swizzle 8 with logical M and N raster order for each existing DP tile/swap configuration. The existing public runner discovers all 64 tactics through its tactic-count query.

Tactic IDs 0 through 31 and the default tactic retain their configurations. Workspace queries and launches share the scheduler arguments, and swapped A/B specializations translate logical raster axes to internal axes. Kernel math, template instantiations, Python APIs and backend selection are unchanged.

Matching cached tactics remain valid and skip the expanded search. Fresh FP4 tuning entries explore the appended choices without invalidating unrelated cached operators. Existing vLLM FlashInfer warmup already reaches this runner, including small-M buckets; no vLLM patch is needed.

Performance validation uses a single DGX Spark SM121, CUDA 13.0, PyTorch 2.13.0+cu130, vLLM nightly `2a02f6efe319c885e3ccbcecde402e0028f9ec1e`, and FlashInfer based on `dd12b73b4461c37b467f77133c17c770adfd3a7b`. The workload is Qwen3.8-27B-NVFP4, batch 1, with 8K/32K prompt tokens, an 8192-token prefill chunk limit and eight generated tokens.

| Startup measurement | FP4 tuning cache | Original 32 tactics | Expanded 64 tactics |
| --- | --- | ---: | ---: |
| Process to health (s) | Cold | 256.942 | 304.106 |
| FI outer autotune interval (s) | Cold | 71.692 | 111.946 |
| Reported model loading (s) | Cold | 110.800 | 118.590 |
| Process to health (s) | Warm | 190.983 | 192.545 |
| FI outer autotune interval (s) | Warm | 1.787 | 1.639 |
| Reported model loading (s) | Warm | 118.761 | 116.860 |

| Request measurement | FP4 tuning cache | Prompt tokens | Original 32 tactics | Expanded 64 tactics |
| --- | --- | ---: | ---: | ---: |
| TTFT (ms) | Cold | 8192 | 3273.628 | 2819.436 |
| Complete request (ms) | Cold | 8192 | 3858.770 | 3405.315 |
| Mean token arrival interval (ms) | Cold | 8192 | 83.711 | 83.845 |
| TTFT (ms) | Cold | 32768 | 15900.404 | 14097.240 |
| Complete request (ms) | Cold | 32768 | 16501.564 | 14698.970 |
| Mean token arrival interval (ms) | Cold | 32768 | 85.920 | 85.852 |
| TTFT (ms) | Warm | 8192 | 3252.481 | 2794.441 |
| Complete request (ms) | Warm | 8192 | 3842.265 | 3383.423 |
| Mean token arrival interval (ms) | Warm | 8192 | 84.038 | 84.314 |
| TTFT (ms) | Warm | 32768 | 15839.733 | 14016.976 |
| Complete request (ms) | Warm | 32768 | 16441.394 | 14619.406 |
| Mean token arrival interval (ms) | Warm | 32768 | 85.993 | 86.261 |

Request entries are medians of five timed requests after two warmups. The expanded tactics reduced median TTFT by 13.9% to 14.1% at 8K and 11.3% to 11.5% at 32K in these windows. Cold FP4 tuning added 40.254 s to the FI outer interval and 47.164 s to readiness. Warm readiness differed by 1.562 s. The short token arrival intervals show no established decode improvement.

Both C++ modules were precompiled before startup measurements. Cold-target runs removed only 42 FP4 tuning entries; warm runs reused that arm's completed cache. All 63 non-target FI choices and Triton/Inductor ancestry stayed fixed, and the measured runs added no compiler artifacts. The FI interval includes its dummy forward. OS model page-cache state was uncontrolled, and there was one sequential window per cohort, so small differences do not establish statistical significance.

Complete request latency includes the terminal stream marker and response closure. The mean token arrival interval is `(last token arrival - first token arrival) / 7`; all eight tokens arrived in separate streaming events. This includes transport and client scheduling and is not isolated GPU decode time. Eight generated tokens do not establish general decode throughput.

All 56 streaming requests, including warmups, preserved generated token IDs across the four cohorts; all four semantic smoke requests passed. Separate kernel microbenchmarks are ongoing and are not included in these serving or startup results. Earlier measurements on other FlashInfer revisions are not results for this patch.

<details>
<summary>Reproduce the serving, startup and kernel comparisons</summary>

Save the three Python code blocks below as `generate_inputs.py`, `client.py`
and `cold_fp4_cache.py` in one directory. Generate the exact prompt file once:

```bash
.venv/bin/python generate_inputs.py
```

The generator and request client use Python standard-library modules only.
Run these commands from the directory containing the saved scripts, and use
the FI checkout directory for the final kernel benchmark commands.

The measured stack used one NVIDIA GB10 (SM121, 48 SMs), driver 580.95.05,
Torch 2.13.0+cu130, Triton 3.7.1, CUTLASS DSL 4.6.2, and unmodified vLLM
[`2a02f6efe319c885e3ccbcecde402e0028f9ec1e`](https://github.com/vllm-project/vllm/tree/2a02f6efe319c885e3ccbcecde402e0028f9ec1e).
The ARM64 image was
`vllm/vllm-openai@sha256:9cbd898be1bf2d258767f923d2ee4fa6bc32eb95db3b8c97d3a7d43d37e7873c`.
Install the complete FlashInfer source and its pinned submodules at
[`dd12b73b4461c37b467f77133c17c770adfd3a7b`](https://github.com/flashinfer-ai/flashinfer/tree/dd12b73b4461c37b467f77133c17c770adfd3a7b)
in two isolated virtual environments with identical dependencies. Apply only
the scheduler PR's three header changes in the candidate. Keep vLLM unchanged.
Both measured FI builds used the same version string,
`0.7.0.dev20260910+sm12xscheduler.dd12b73`; changing it between arms invalidates
the shared tuning metadata. Record the actual imported source and loaded C++
library for each environment. The original image's installed FI wheel is not
the measured current-source baseline.

The checkpoint was
[`RadixArk/Qwen3.8-27B-NVFP4`](https://huggingface.co/RadixArk/Qwen3.8-27B-NVFP4/tree/319f741cce68d7914884900c138a1fbb70a42f30).
Revision `319f741cce68d7914884900c138a1fbb70a42f30` has byte-identical config,
tensor index, tokenizer config, model card and conversion manifest to the
retained measured metadata. The conversion manifest names source model
`Qwen/Qwen3.8-27B` at `e13a4f0e35203116364e3b3f3f0c82f6ef1afd3c`.
The quantized repository revision and source model revision are distinct.
Full weight payloads were not rehashed during the campaign; shard sizes and
all three safetensors headers were checked. The measured config SHA256 is
`7ff41ec6f96ad50efea3c92751cd261b63839d39936eb6e6ffc9066db8672740`.

Download the checkpoint before any startup measurement:

```bash
.venv/bin/python -c 'from huggingface_hub import snapshot_download; snapshot_download("RadixArk/Qwen3.8-27B-NVFP4", revision="319f741cce68d7914884900c138a1fbb70a42f30", local_dir="model")'
```

Keep the model path and shared vLLM, Triton, Inductor, CUDA and FI tuning
cache paths identical between serving runs. Set `PY` to the selected
environment's absolute `bin/python`, `MODEL` to the downloaded checkpoint,
and `REPRO_ROOT` to a new directory owned by this experiment.
The target FI compiler workspaces are separate, prebuilt paths for baseline
and candidate. Set `FLASHINFER_WORKSPACE_BASE` to the selected arm's
workspace before importing FlashInfer, and keep that path fixed for that arm. Prebuild both arms
outside the startup clock, including the helper first needed during a cold
tuning search:

```bash
"$PY" - <<'PY'
from flashinfer.jit.gemm import gen_gemm_sm120_module_cutlass_fp4
from flashinfer.tllm_utils import get_trtllm_utils_module
spec = gen_gemm_sm120_module_cutlass_fp4()
module = spec.build_and_load()
print(spec.get_library_path(), module.fp4_gemm_tactic_num())
get_trtllm_utils_module()
PY
```

Require 32 tactics in the baseline and 64 in the candidate. Repeat the prebuild
in a fresh process and verify that it adds no compiled files. The helper call
loads the module without calling its delay kernel. Record compiler preparation
separately; it is excluded from the reported startup comparison.

The serving command below is the measured argument list with portable paths.
No speculative decoding or prefix caching is enabled. `flashinfer_cutlass` is
a global linear selector, so also record the emitted FP8 and GDN choices and
require them to match between arms.

```bash
export PYTHONDONTWRITEBYTECODE=1 PYTHONNOUSERSITE=1
export VLLM_WORKER_MULTIPROC_METHOD=spawn VLLM_LOGGING_LEVEL=INFO
export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1
export VLLM_CACHE_ROOT="$REPRO_ROOT/cache_active/vllm"
export VLLM_FLASHINFER_AUTOTUNE_CACHE_DIR="$REPRO_ROOT/cache_active/fi_tuning"
export TRITON_CACHE_DIR="$REPRO_ROOT/cache_active/triton"
export TORCHINDUCTOR_CACHE_DIR="$REPRO_ROOT/cache_active/inductor"
export XDG_CACHE_HOME="$REPRO_ROOT/cache_active/xdg"
export CUDA_CACHE_PATH="$REPRO_ROOT/cache_active/cuda"
export FLASHINFER_NVCC_THREADS=1
"$PY" -m vllm.entrypoints.openai.api_server \
  --model "$MODEL" --served-model-name qwen-w4a4 \
  --host 127.0.0.1 --port 8018 \
  --quantization modelopt_mixed --dtype bfloat16 --kv-cache-dtype fp8 \
  --attention-backend FLASHINFER --gpu-memory-utilization 0.80 \
  --max-model-len 33024 --max-num-seqs 1 --max-num-batched-tokens 8192 \
  --enable-chunked-prefill --no-enable-prefix-caching \
  --linear-backend flashinfer_cutlass
```

After `/health` returns 200 and the log contains `Application startup complete`,
run `client.py` below in a separate terminal:

```bash
"$PY" client.py --output baseline_cold.jsonl
# After starting the corresponding candidate:
"$PY" client.py --output candidate_cold.jsonl --compare baseline_cold.jsonl
```

`generate_inputs.py` below creates `inputs.json` with the exact measured token IDs.
The literal 35-token period reproduces both complete prompt token lists and
checks their hashes without loading a tokenizer. The measured lists were constructed by
encoding the following passage with `add_special_tokens=False`, repeating its
token list and truncating to exactly 8192 or 32768 tokens:

```text
This technical document describes a deterministic inference test. The model reads a long document and produces a brief continuation. All requests use the same token sequence and the same sampling settings. 
```

The SHA256 values of `json.dumps(token_ids).encode()` are
`9c4a6b9f965ff628711195c70366e08a9e1a12643a08830835d6d2b988ec89f5`
and `6eff21a9fda1c2f5b617d4c8d992564002e59233d823f18ec2ae5b1a1169981a`.
One semantic chat check precedes the requests. At each length, send two warmups
then five timed requests sequentially, with temperature 0, seed 42,
`ignore_eos=true`, eight output tokens and streamed token IDs. Report the median
time to the first token-bearing SSE event from the five timed requests. Retain
all responses and require all seven generated-ID sequences per length to
match the baseline, including warmups. The embedded `client.py` preserves the
original measured HTTP request and stream functions.

For the four startup cohorts, use this cache procedure:

1. Complete an untimed baseline preparation and then candidate preparation with
   the same selected FI configurations. Warm every compiler path first. Freeze
   a common completed cache tree after a clean server shutdown. A new campaign
   establishes its own initial FP8/GDN/Triton choices once and preserves them.
2. Before each measured run, restore that complete tree at the same absolute
   `cache_active` path. Do not recreate all tuning or compiler caches from empty.
3. For each cold-target run, locate the single `autotune_configs.json` under
   `fi_tuning`. Run `cold_fp4_cache.py ORIGINAL NEW`, then replace only that file
   in the fresh copied tree with `NEW`. It removes exactly the parsed
   `fp4_gemm`/`CutlassFp4GemmRunner` entries and recomputes `_generation` using
   the pinned FI serialization. All metadata and non-target records survive.
4. Run baseline cold, candidate cold, candidate warm, then baseline warm. For
   each warm run, restore the common full tree and replace only its FI config
   with the completed cold config from the same arm. Keep the common non-target
   records equal. The measured run had 42 FP4 and 63 non-target FI entries.
5. Start the stopwatch immediately before spawning the original API process,
   after preflight/cache restoration. Poll health every 200 ms. Record
   process-to-health, the original `Model loading took ... seconds` log value,
   and timestamps of `[Autotuner]: Autotuning process starts/ends` separately.
6. Before accepting timing, require unchanged compiler/cache files outside the
   intended FI config, unchanged non-target choices, cached AOT loading, matching
   runtime/source/library identities and all generated IDs. Retain the live
   log used for audit and the full shutdown log. Freeze and preserve each output
   and cache before moving to the next run.

The FI outer interval includes its dummy forward. OS model page-cache state
was uncontrolled. One sequential window per cohort does not establish
statistical significance. No full cold-compiler or cross-node startup ratio is
claimed. The portable recipe has been source-checked; the measured qualification
used the retained full audit harness.

For a smaller public kernel reproduction, run the exact dd12
[`benchmarks/flashinfer_benchmark.py`](https://github.com/flashinfer-ai/flashinfer/blob/dd12b73b4461c37b467f77133c17c770adfd3a7b/benchmarks/flashinfer_benchmark.py)
from each FI checkout with that arm's interpreter. Use new per-arm tuning-cache
filenames, since reusing an old winner prevents searching the appended tactics:

```bash
"$PY" benchmarks/flashinfer_benchmark.py --routine mm_fp4 \
  --m 8192 --n 5120 --k 17408 --out_dtype bfloat16 \
  --backends cutlass --use_nvfp4 --use_128x4_sf_layout \
  --autotune --autotune_cache "$REPRO_ROOT/down-$ARM.json" \
  --random_seed 42 --dry_run_iters 10 --num_iters 100 --refcheck -v \
  --output_path "$REPRO_ROOT/down-$ARM.csv"

"$PY" benchmarks/flashinfer_benchmark.py --routine mm_fp4 \
  --m 8192 --n 34816 --k 5120 --out_dtype bfloat16 \
  --backends cutlass --use_nvfp4 --use_128x4_sf_layout \
  --autotune --autotune_cache "$REPRO_ROOT/gate-$ARM.json" \
  --random_seed 42 --dry_run_iters 10 --num_iters 100 --refcheck -v \
  --output_path "$REPRO_ROOT/gate-$ARM.csv"
```

Set `ARM` to `baseline` or `candidate`. Require an actual
`cutlass_autotune` performance/result row, since unsupported backends can be
filtered without a process error. The pinned CLI uses CUDA graphs, cold-L2
timing and CUPTI by default. Its `--refcheck` compares against the original
BF16 matrix product using cosine similarity 0.97; it is a convenient public
performance check, not a replacement for the PR's bit-equality and serving
qualification. These commands were parser/source-checked, not run as new GPU measurements.

**generate_inputs.py**

```python
"""Recreate the exact measured prompt IDs without a tokenizer dependency."""

import hashlib
import json
from pathlib import Path

PERIOD = [
    1919, 10597, 2128, 16067, 264, 69892, 42903, 1228, 13, 561, 1558, 15339,
    264, 1248, 2128, 321, 18082, 264, 9522, 39811, 13, 1942, 7154, 958, 279,
    1788, 3817, 8240, 321, 279, 1788, 24102, 4842, 13, 220,
]
EXPECTED = {
    8192: "9c4a6b9f965ff628711195c70366e08a9e1a12643a08830835d6d2b988ec89f5",
    32768: "6eff21a9fda1c2f5b617d4c8d992564002e59233d823f18ec2ae5b1a1169981a",
}

assert len(PERIOD) == 35
inputs = {}
for count, expected in EXPECTED.items():
    ids = (PERIOD * ((count + len(PERIOD) - 1) // len(PERIOD)))[:count]
    assert len(ids) == count
    digest = hashlib.sha256(json.dumps(ids).encode()).hexdigest()
    assert digest == expected
    inputs[str(count)] = {"token_ids": ids, "sha256": digest}

data = (json.dumps(inputs) + "\n").encode()
assert hashlib.sha256(data).hexdigest() == (
    "94c30013cdf25ff5021f575653ce2dc7ddd7a22c91712031344b9f373dafe280"
)
destination = Path(__file__).parent / "inputs.json"
with destination.open("xb") as handle:
    handle.write(data)
print(f"Wrote {destination}: 8192 and 32768 prompt IDs, all hashes verified")
```

**client.py**

```python
"""Replay the exact measured requests after server readiness."""

import argparse
import hashlib
import json
import os
from pathlib import Path
import statistics
import time
import urllib.request


def post(url, endpoint, body):
    return urllib.request.urlopen(
        urllib.request.Request(
            url + endpoint,
            data=json.dumps(body).encode(),
            headers={"Content-Type": "application/json"},
        ),
        timeout=600,
    )


def smoke(args):
    body = {
        "model": args.model,
        "messages": [
            {"role": "user", "content": "What is 2 + 3? Reply with only the number."}
        ],
        "temperature": 0,
        "seed": 42,
        "max_tokens": 32,
        "chat_template_kwargs": {"enable_thinking": False},
        "return_token_ids": True,
    }
    with post(args.url, "/v1/chat/completions", body) as response:
        result = json.load(response)
    choice = result["choices"][0]
    answer = choice["message"]["content"].strip()
    assert answer == "5", f"Semantic smoke failed: {answer!r}"
    assert choice["finish_reason"] == "stop", choice
    return {"kind": "semantic_smoke", "request": body, "response": result}


def stream(args, token_ids, warmup, index):
    body = {
        "model": args.model,
        "prompt": token_ids,
        "max_tokens": args.output_tokens,
        "temperature": 0,
        "seed": 42,
        "ignore_eos": True,
        "stream": True,
        "stream_options": {"include_usage": True},
        "return_token_ids": True,
    }
    events = []
    usage = None
    first_token = None
    first_text = None
    output_ids = []
    text = ""
    finished = False
    start_monotonic_ns = time.monotonic_ns()
    started = time.perf_counter()
    with post(args.url, "/v1/completions", body) as response:
        for raw in response:
            if not raw.startswith(b"data: "):
                continue
            payload = raw[len(b"data: ") :].strip()
            elapsed = time.perf_counter() - started
            if payload == b"[DONE]":
                finished = True
                break
            event = json.loads(payload)
            assert "error" not in event, event
            events.append({"elapsed_s": elapsed, "event": event})
            if event.get("usage") is not None:
                usage = event["usage"]
            for choice in event.get("choices", []):
                ids = choice.get("token_ids") or []
                piece = choice.get("text") or ""
                if ids and first_token is None:
                    first_token = elapsed
                if piece and first_text is None:
                    first_text = elapsed
                output_ids.extend(ids)
                text += piece
    duration = time.perf_counter() - started
    end_monotonic_ns = time.monotonic_ns()
    assert finished and usage is not None, "Missing terminal stream marker or usage"
    assert usage["prompt_tokens"] == len(token_ids), usage
    assert usage["completion_tokens"] == args.output_tokens, usage
    assert len(output_ids) == args.output_tokens, (len(output_ids), usage)
    assert first_token is not None, "No output token IDs observed"
    return {
        "kind": "prefill",
        "prompt_tokens": len(token_ids),
        "prompt_sha256": hashlib.sha256(json.dumps(token_ids).encode()).hexdigest(),
        "warmup": warmup,
        "index": index,
        "start_monotonic_ns": start_monotonic_ns,
        "end_monotonic_ns": end_monotonic_ns,
        "ttft_ms": first_token * 1000,
        "first_nonempty_text_ms": first_text * 1000 if first_text is not None else None,
        "duration_ms": duration * 1000,
        "usage": usage,
        "output_token_ids": output_ids,
        "output_text": text,
        "raw_events": events,
    }


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("--url", default="http://127.0.0.1:8018")
    parser.add_argument("--output", type=Path, required=True)
    parser.add_argument("--compare", type=Path)
    args = parser.parse_args()
    args.model, args.output_tokens = "qwen-w4a4", 8
    inputs = json.loads((Path(__file__).parent / "inputs.json").read_text())
    assert not args.output.exists()
    baseline = None
    if args.compare:
        baseline = [json.loads(line) for line in args.compare.read_text().splitlines()]
        assert len(baseline) == 16 and baseline[-1]["passed"]
    rows = []
    args.output.parent.mkdir(parents=True, exist_ok=True)
    with args.output.open("x") as output:

        def record(row):
            rows.append(row)
            output.write(json.dumps(row) + "\n")
            output.flush()
            os.fsync(output.fileno())

        record(smoke(args))
        for count in (8192, 32768):
            ids = inputs[str(count)]["token_ids"]
            assert len(ids) == count
            assert (
                hashlib.sha256(json.dumps(ids).encode()).hexdigest()
                == inputs[str(count)]["sha256"]
            )
            for index in range(7):
                record(stream(args, ids, index < 2, index))
        for count in (8192, 32768):
            selected = [row for row in rows if row.get("prompt_tokens") == count]
            assert len(selected) == 7
            assert all(
                row["output_token_ids"] == selected[0]["output_token_ids"]
                for row in selected
            )
            if baseline is not None:
                previous = [
                    row for row in baseline if row.get("prompt_tokens") == count
                ]
                assert len(previous) == 7
                for row, other in zip(selected, previous, strict=True):
                    assert row["prompt_sha256"] == other["prompt_sha256"]
                    assert row["output_token_ids"] == other["output_token_ids"]
            print(
                json.dumps(
                    {
                        "prompt_tokens": count,
                        "median_ttft_ms": statistics.median(
                            row["ttft_ms"] for row in selected if not row["warmup"]
                        ),
                    }
                ),
                flush=True,
            )
        record({"kind": "complete", "passed": True})
    print("DONE_PUBLIC_SCHEDULER_CLIENT rc=0", flush=True)


if __name__ == "__main__":
    main()
```

**cold_fp4_cache.py**

```python
"""Create a new cache JSON with only FP4 CUTLASS choices removed."""

import argparse
import ast
import hashlib
import json
from pathlib import Path


def parse_key(key):
    value = ast.parse(key, mode="eval").body
    assert isinstance(value, ast.Tuple) and len(value.elts) == 4
    assert all(isinstance(x, ast.Tuple) for x in value.elts[2:])
    for node in ast.walk(value):
        assert isinstance(
            node,
            (
                ast.Tuple,
                ast.Constant,
                ast.UnaryOp,
                ast.USub,
                ast.Attribute,
                ast.Name,
                ast.Load,
            ),
        )
        if isinstance(node, ast.Attribute):
            assert isinstance(node.value, ast.Name) and node.value.id == "torch"
            assert node.attr in {
                "float8_e4m3fn",
                "float8_e5m2",
                "float16",
                "bfloat16",
                "float32",
                "float64",
                "uint8",
                "int32",
                "int64",
            }
        if isinstance(node, ast.Name):
            assert node.id == "torch"
    prefix = tuple(ast.literal_eval(x) for x in value.elts[:2])
    assert all(isinstance(x, str) for x in prefix)
    return prefix


def split_configs(configs):
    assert isinstance(configs, dict) and isinstance(configs.get("_metadata"), dict)
    if "_generation" in configs:
        assert with_generation(configs)["_generation"] == configs["_generation"], (
            "Invalid FI cache generation hash"
        )
    target, other = {}, {"_metadata": configs["_metadata"]}
    for key, value in configs.items():
        if key in ("_metadata", "_generation"):
            continue
        if key == "_namespaced_records":
            assert isinstance(value, dict)
            other[key] = value
            continue
        parsed = parse_key(key)
        assert isinstance(value, list) and len(value) == 2
        assert isinstance(value[0], str)
        if parsed[0] == "fp4_gemm":
            assert parsed[1] == value[0] == "CutlassFp4GemmRunner"
            assert type(value[1]) is int and 0 <= value[1] < 64
            target[key] = value
        else:
            other[key] = value
    assert target or len(other) > 1
    return target, other


def cold_configs(configs):
    """Remove only entries whose parsed operation is exactly fp4_gemm."""
    target, other = split_configs(configs)
    assert target, "A cold-target seed must actually contain target entries"
    return with_generation(other), target


def with_generation(configs):
    result = {k: v for k, v in configs.items() if k != "_generation"}
    # Exact dd12 AutoTuner.save_configs generation serialization.
    content = json.dumps(result, sort_keys=True, separators=(",", ":")).encode()
    result["_generation"] = hashlib.sha256(content).hexdigest()
    return result


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument("source", type=Path)
    parser.add_argument("destination", type=Path)
    args = parser.parse_args()
    assert args.source.resolve() != args.destination.resolve()
    assert not args.destination.exists()
    original = args.source.read_bytes()
    source = json.loads(original)
    cold, removed = cold_configs(source)
    assert split_configs(source)[1] == split_configs(cold)[1]
    with args.destination.open("x") as handle:
        json.dump(cold, handle, sort_keys=True, indent=2)
        handle.write("\n")
    assert args.source.read_bytes() == original
    print(
        json.dumps(
            {
                "removed_fp4_choices": len(removed),
                "source_sha256": hashlib.sha256(original).hexdigest(),
                "destination_sha256": hashlib.sha256(
                    args.destination.read_bytes()
                ).hexdigest(),
            }
        )
    )


if __name__ == "__main__":
    main()
```

</details>

## 🔍 Related Issues

No direct open duplicate was found in six fully paginated searches covering 514 distinct issues/PRs, with complete diffs checked for 12 related PRs. [#3495](https://github.com/flashinfer-ai/flashinfer/pull/3495) adds SM120 tile N8/N16 in the same configuration table, but does not add raster/swizzle choices. [#3026](https://github.com/flashinfer-ai/flashinfer/pull/3026) is the merged optimization predecessor; [#1439](https://github.com/flashinfer-ai/flashinfer/pull/1439) changes legacy backend selection.

The target was refreshed on September 10 at 13:16 UTC to main `98eea5207b1febc2bd9b80fa55570f623f85a572`. The three headers, existing FP4 test file and autotuner remain byte-identical to the measured base. The intervening `gemm_base.py` changes from [#5089](https://github.com/flashinfer-ai/flashinfer/pull/5089) affect BF16 warp support and tuning; its FP4 definitions are unchanged.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

All applicable hooks passed on the four changed files, and their hashes stayed identical to the GPU-tested files:

```bash
pre-commit run --files \
  include/flashinfer/gemm/cutlass_gemm_configs.h \
  include/flashinfer/gemm/fp4_gemm_cutlass_template_sm120.h \
  include/flashinfer/gemm/fp4_gemm_template_sm120.h \
  tests/gemm/test_mm_fp4.py
```

`pre-commit` was installed through `uv tool run`, and the hooks were installed with `pre-commit install`. All applicable hooks passed again on the four changed files. A repository-wide `--all-files` run was not performed; that checkbox remains unchecked.

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

The focused regression run passed all eight cases, with no failures or skips, in 2.55 seconds on SM121. Reproduction from an installed source checkout:

```bash
.venv/bin/python -m pytest tests/gemm/test_mm_fp4.py -k cutlass_scheduler -v
```

The tests exercise all original, appended and default tactics at M4/M257/M1025, N1152, K256, with FP16 and BF16 outputs. Patterned integer-valued FP4 inputs provide exact full-output references. Poisoned graph replays check finite values and exact output bits after GPU alpha changes in place from 1.25 to -0.75, and input bytes remain unchanged. Two public-autotuner cases select appended tactic 54 and verify persisted selection and output through legacy reload and managed V2 replay. Their deterministic test timings validate cache behavior, not performance.

Both C++ modules built successfully. Single prebuild observations were 153.871 s for the original and 163.735 s for the candidate; these are compilation measurements, excluded from the startup-cost comparison above. The complete test suite and other GPU architectures have not been run. The four serving cohorts independently passed complete raw-output, source, library, cache and startup checks.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag. The experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

Please check the additive tactic ordering and the logical-to-internal raster mapping for swapped operands. No experimental backend or new API is introduced, so the Experimental Track section is left unselected.

AI assistance was used to prepare the patch and tests.
