### PR TITLE
fix(mla): halve sparse-MLA cpb L2 guard-rail window on integrated GPUs (Spark)

### DIFF
--- a/flashinfer/mla/_sparse_mla_sm120_cpb.py
+++ b/flashinfer/mla/_sparse_mla_sm120_cpb.py
@@ -555,6 +555,10 @@ def calibrate(
     props = torch.cuda.get_device_properties(device)
     sm_count = int(props.multi_processor_count)
     l2_cache_bytes = int(getattr(props, "L2_cache_size", 0) or 0)
+    # On integrated-memory devices (GB10) the L2 is shared with the CPU fabric
+    # and the effective streaming window measures ~half the reported size.
+    if int(getattr(props, "is_integrated", 0) or 0):
+        l2_cache_bytes //= 2
     bi = _CHUNK_WIDTH[family]
     w = bi * _BYTES_PER_TOKEN[family]
     # Families whose decode is instantiated at a single topk have a fixed N,

--- a/tests/attention/test_sparse_mla_sm120_cpb_model.py
+++ b/tests/attention/test_sparse_mla_sm120_cpb_model.py
@@ -329,7 +329,10 @@ def test_calibration_smoke(family_constants: tuple[str, CpbConstants]) -> None:
     )
     props = torch.cuda.get_device_properties(torch.device("cuda"))
     if getattr(props, "L2_cache_size", None):
-        assert c.l2_cache_bytes == props.L2_cache_size
+        expected_l2 = props.L2_cache_size
+        if getattr(props, "is_integrated", 0):
+            expected_l2 //= 2  # calibrate() halves the rail window on SoCs
+        assert c.l2_cache_bytes == expected_l2
     bw_gbps = 1.0 / c.inv_bw / 1e9
     print(f"\ncalibrated {family} constants: {c}")
     print(f"implied aggregate DRAM bandwidth: {bw_gbps:.0f} GB/s")


### PR DESCRIPTION
<!-- .github/pull_request_template.md -->

## 📌 Description

<!-- What does this PR do? Briefly describe the changes and why they’re needed. -->

Fixes #4999 (`test_model_cpb_accuracy_guard_dual_cache` fails on DGX Spark).

On GB10 the cpb model's per-chunk time is flat in `cpb`, so only the L2 guard rail limits over-splitting. The reported 24 MiB L2 admits cpb ≤ 14 (the observed bad picks), but the measured knee is at cpb 5–6 (~11 MB footprint): the SoC's L2 is shared with the CPU fabric, so the effective window is ~half the reported size.

`calibrate()` now halves the rail window when `props.is_integrated` is set. Discrete GPUs (RTX PRO 6000 etc.) take a bit-identical path, so SM120 picks cannot change.

**Validation (DGX Spark / GB10):** `test_sparse_mla_sm120_cpb_model.py` passes 33/33 in two consecutive runs (was 2 deterministic failures); the failing nodes improve from 1.32× over best to 1.00× and 1.05×.
## 🔍 Related Issues

<!-- Link any related issues here -->

#4999

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [ ] Tests have been added or updated as needed.
- [ ] All tests are passing (`unittest`, etc.).

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

<!-- Optional: anything you'd like reviewers to focus on, concerns, etc. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved performance calibration on integrated GPUs by accounting for their shared L2 cache when determining effective cache capacity.
  * Updated L2 cache safeguards to use the adjusted capacity for more accurate operation selection.

* **Tests**
  * Updated calibration checks to validate effective L2 cache sizing on integrated GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->