### PR TITLE
feat(attention): add REGISTER_OUTPUT_TRANSFORM to the Hopper (FA3) variant helper

### DIFF
--- a/include/flashinfer/attention/hopper/epilogue.cuh
+++ b/include/flashinfer/attention/hopper/epilogue.cuh
@@ -14,6 +14,7 @@
 #include "cutlass/gemm/collective/collective_builder.hpp"
 #include "named_barrier.cuh"
 #include "utils.cuh"
+#include "variant_helper.cuh"
 
 namespace flashinfer {
 
@@ -61,6 +62,55 @@ __forceinline__ __device__ void write_O(ElemO* O, const TiledCopyO& tiled_copy_O
                                         int write_warp_idx) {
   write_tiled<NUM_COPY_THREADS>(O, tiled_copy_O, layout_O, tile_shape_O, sO, thread_idx,
                                 qo_tile_idx, qo_head_idx, qo_indptr, qo_len);
+}
+
+// Applies the variant's OutputTransform to the accumulator fragment. tOrO and its coordinate
+// tensor tOcO are viewed as (row, col) through convert_layout_acc_rowcol, like rescale_o does,
+// so row mi matches lse(mi). Rows at or beyond qo_len are skipped, as in write_O.
+template <int CTA_Q, typename AttentionVariant, typename MainloopParams, typename FrgTensorO,
+          typename FrgTensorCoord, typename FrgTensorLSE>
+__forceinline__ __device__ void transform_output_fragment(
+    AttentionVariant& variant, const MainloopParams& mainloop_params, FrgTensorO& tOrO,
+    FrgTensorCoord const& tOcO, FrgTensorLSE const& lse, int qo_tile_idx, int qo_len,
+    int qo_head_idx, int batch_idx) {
+  Tensor tOrO_rowcol = make_tensor(tOrO.data(), convert_layout_acc_rowcol(tOrO.layout()));
+  Tensor tOcO_rowcol = make_tensor(tOcO.data(), convert_layout_acc_rowcol(tOcO.layout()));
+  CUTE_STATIC_ASSERT_V(size<0>(tOrO_rowcol) == size(lse));
+  CUTE_STATIC_ASSERT_V(size<0>(tOrO_rowcol) == size<0>(tOcO_rowcol));
+  CUTE_STATIC_ASSERT_V(size<1>(tOrO_rowcol) == size<1>(tOcO_rowcol));
+  const int valid_rows = qo_len - qo_tile_idx * CTA_Q;
+#pragma unroll
+  for (int mi = 0; mi < size<0>(tOrO_rowcol); ++mi) {
+    const int row = get<0>(tOcO_rowcol(mi, _0{}));
+    if (row < valid_rows) {
+      const uint32_t qo_idx = qo_tile_idx * CTA_Q + row;
+#pragma unroll
+      for (int ni = 0; ni < size<1>(tOrO_rowcol); ++ni) {
+        tOrO_rowcol(mi, ni) = variant.OutputTransform(
+            mainloop_params, tOrO_rowcol(mi, ni), uint32_t(batch_idx), qo_idx,
+            uint32_t(qo_head_idx), uint32_t(get<1>(tOcO_rowcol(mi, ni))), lse(mi));
+      }
+    }
+  }
+}
+
+// Same for the cleared fragment of a query tile that attends to no keys: output 0, lse -inf.
+template <typename AttentionVariant, typename MainloopParams, typename FrgTensorO,
+          typename FrgTensorCoord>
+__forceinline__ __device__ void transform_zero_fragment(
+    AttentionVariant& variant, const MainloopParams& mainloop_params, FrgTensorO& tOrO,
+    FrgTensorCoord const& tOcO, int qo_tile_base, int valid_rows, int qo_head_idx, int batch_idx) {
+  using DTypeO = typename FrgTensorO::value_type;
+  CUTE_STATIC_ASSERT_V(size(tOrO) == size(tOcO));
+#pragma unroll
+  for (int i = 0; i < size(tOrO); ++i) {
+    const int row = get<0>(tOcO(i));
+    if (row < valid_rows) {
+      tOrO(i) = DTypeO(variant.OutputTransform(mainloop_params, 0.f, uint32_t(batch_idx),
+                                               uint32_t(qo_tile_base + row), uint32_t(qo_head_idx),
+                                               uint32_t(get<1>(tOcO(i))), -math::inf));
+    }
+  }
 }
 
 template <typename Ktraits>
@@ -149,15 +199,23 @@ struct CollectiveEpilogue {
   static void prefetch_tma_descriptors(Params const& epilogue_params) {}
 
   template <typename BlockCoord, typename SharedStorage, typename FrgTensorO, typename FrgTensorLSE,
-            typename TiledMma>
-  CUTLASS_DEVICE void store(Params const& epilogue_params, FrgTensorO const& tOrO,
+            typename TiledMma, typename AttentionVariant, typename MainloopParams>
+  CUTLASS_DEVICE void store(Params const& epilogue_params, FrgTensorO& tOrO,
                             FrgTensorLSE const& lse, SharedStorage& shared_storage,
-                            TiledMma tiled_mma, int thread_idx, BlockCoord const& block_coord) {
+                            TiledMma tiled_mma, int thread_idx, BlockCoord const& block_coord,
+                            AttentionVariant& variant, MainloopParams const& mainloop_params) {
     auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
         block_coord;
     Tensor sO = make_tensor(make_smem_ptr(shared_storage.smem_o.data()), SmemLayoutO{});
     auto smem_tiled_copy_O = make_tiled_copy_C(SmemCopyAtomO{}, tiled_mma);
     auto smem_thr_copy_O = smem_tiled_copy_O.get_thread_slice(thread_idx);
+
+    if constexpr (has_output_transform_v<AttentionVariant, MainloopParams>) {
+      Tensor cO = cute::make_identity_tensor(select<0, 1>(TileShape_PDV{}));
+      Tensor tOcO = tiled_mma.get_thread_slice(thread_idx).partition_C(cO);  // (MMA,MMA_M,MMA_K)
+      transform_output_fragment<CTA_Q>(variant, mainloop_params, tOrO, tOcO, lse, qo_tile_idx,
+                                       qo_len, qo_head_idx, batch_idx);
+    }
 
     Tensor tOrO_out = convert_type<DTypeO>(tOrO);
     Tensor tOrO_retile = smem_thr_copy_O.retile_S(tOrO_out);  // ((Atom,AtomNum), MMA_M, MMA_N)
@@ -208,10 +266,12 @@ struct CollectiveEpilogue {
     // tma_store_wait<0>();
   }
 
-  // Write 0 to output and -inf to LSE
-  template <typename BlockCoord, typename SharedStorage>
+  // Write 0 to output and -inf to LSE, through the variant's output transform when it has one.
+  template <typename BlockCoord, typename SharedStorage, typename AttentionVariant,
+            typename MainloopParams>
   CUTLASS_DEVICE void store_zero(Params const& epilogue_params, SharedStorage& shared_storage,
-                                 int thread_idx, BlockCoord const& block_coord) {
+                                 int thread_idx, BlockCoord const& block_coord,
+                                 AttentionVariant& variant, MainloopParams const& mainloop_params) {
     auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
         block_coord;
     Tensor mO = make_tensor(make_gmem_ptr(epilogue_params.O_ptr), epilogue_params.layout_O);
@@ -228,9 +288,15 @@ struct CollectiveEpilogue {
     Tensor tOrO = make_fragment_like(tOgO);    // (CPY, CPY_O, CPY_D)
     clear(tOrO);
     Tensor tOcO = thr_copy_O.partition_D(cO);  // (CPY, CPY_O, CPY_D)
-    Tensor tOgOGroup = flatten_1(tOgO);        // (CPY, (CPY_O, CPY_D))
-    Tensor tOrOGroup = flatten_1(tOrO);        // (CPY, (CPY_O, CPY_D))
-    Tensor tOcOGroup = flatten_1(tOcO);        // (CPY, (CPY_O, CPY_D))
+    if constexpr (has_output_transform_v<AttentionVariant, MainloopParams>) {
+      // Before the flattened views below copy the fragment.
+      const int qo_tile_base = qo_tile_idx * get<0>(TileShape_PDV{});
+      transform_zero_fragment(variant, mainloop_params, tOrO, tOcO, qo_tile_base,
+                              qo_len - qo_tile_base, qo_head_idx, batch_idx);
+    }
+    Tensor tOgOGroup = flatten_1(tOgO);  // (CPY, (CPY_O, CPY_D))
+    Tensor tOrOGroup = flatten_1(tOrO);  // (CPY, (CPY_O, CPY_D))
+    Tensor tOcOGroup = flatten_1(tOcO);  // (CPY, (CPY_O, CPY_D))
 
     const int qo_tile_size = get<0>(TileShape_PDV{});
     int valid_qo_tile_size = std::min<int>(qo_len - qo_tile_idx * qo_tile_size, qo_tile_size);

--- a/include/flashinfer/attention/hopper/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/prefill_sm90.cuh
@@ -244,7 +244,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           collective_mainloop.get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
       if (num_kv_tiles <= 0) {  // We exit early and write 0 to gO and -inf to gLSE.
         collective_epilogue.store_zero(epilogue_params, shared_storage,
-                                       threadIdx.x - NUM_COPY_THREADS, block_coord);
+                                       threadIdx.x - NUM_COPY_THREADS, block_coord, variant,
+                                       mainloop_params);
         continue;
       }
 
@@ -281,7 +282,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           qo_head_idx, kv_head_idx, prefix_len, token_pos_in_items,
           num_kv_tiles_outside_items_window, num_kv_tiles_prefix);
       collective_epilogue.store(epilogue_params, tOrO, attention_updater.get_lse(), shared_storage,
-                                tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord);
+                                tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord, variant,
+                                mainloop_params);
 
       ++work_idx;
     }

--- a/include/flashinfer/attention/hopper/quantization/epilogue.cuh
+++ b/include/flashinfer/attention/hopper/quantization/epilogue.cuh
@@ -106,10 +106,11 @@ struct FP8CollectiveEpilogue {
   static void prefetch_tma_descriptors(Params const& epilogue_params) {}
 
   template <typename BlockCoord, typename SharedStorage, typename FrgTensorO, typename FrgTensorLSE,
-            typename TiledMma>
-  CUTLASS_DEVICE void store(Params const& epilogue_params, FrgTensorO const& tOrO,
+            typename TiledMma, typename AttentionVariant, typename MainloopParams>
+  CUTLASS_DEVICE void store(Params const& epilogue_params, FrgTensorO& tOrO,
                             FrgTensorLSE const& lse, SharedStorage& shared_storage,
-                            TiledMma tiled_mma, int thread_idx, BlockCoord const& block_coord) {
+                            TiledMma tiled_mma, int thread_idx, BlockCoord const& block_coord,
+                            AttentionVariant& variant, MainloopParams const& mainloop_params) {
     auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
         block_coord;
 
@@ -118,6 +119,13 @@ struct FP8CollectiveEpilogue {
     Tensor sO = make_tensor(make_smem_ptr(shared_storage.smem_o.data()), SmemLayoutO{});
     auto smem_tiled_copy_O = make_tiled_copy_C(SmemCopyAtomO{}, tiled_mma);
     auto smem_thr_copy_O = smem_tiled_copy_O.get_thread_slice(thread_idx);
+
+    if constexpr (has_output_transform_v<AttentionVariant, MainloopParams>) {
+      Tensor caccO = cute::make_identity_tensor(select<0, 2>(TileShape_QKD{}));
+      Tensor taccOcO = tiled_mma.get_thread_slice(thread_idx).partition_C(caccO);
+      transform_output_fragment<CTA_Q>(variant, mainloop_params, tOrO, taccOcO, lse, qo_tile_idx,
+                                       qo_len, qo_head_idx, batch_idx);
+    }
 
     Tensor tOrO_out = convert_type<DTypeO>(tOrO);
     Tensor taccOrO = smem_thr_copy_O.retile_S(tOrO_out);  // ((Atom,AtomNum), MMA_M, MMA_N)
@@ -166,10 +174,12 @@ struct FP8CollectiveEpilogue {
     // tma_store_wait<0>();
   }
 
-  // Write 0 to output and -inf to LSE
-  template <typename BlockCoord, typename SharedStorage>
+  // Write 0 to output and -inf to LSE, through the variant's output transform when it has one.
+  template <typename BlockCoord, typename SharedStorage, typename AttentionVariant,
+            typename MainloopParams>
   CUTLASS_DEVICE void store_zero(Params const& epilogue_params, SharedStorage& shared_storage,
-                                 int thread_idx, BlockCoord const& block_coord) {
+                                 int thread_idx, BlockCoord const& block_coord,
+                                 AttentionVariant& variant, MainloopParams const& mainloop_params) {
     auto [qo_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
         block_coord;
     Tensor mO = make_tensor(make_gmem_ptr(epilogue_params.O_ptr), epilogue_params.layout_O);
@@ -186,9 +196,15 @@ struct FP8CollectiveEpilogue {
     Tensor tOrO = make_fragment_like(tOgO);    // (CPY, CPY_O, CPY_D)
     clear(tOrO);
     Tensor tOcO = thr_copy_O.partition_D(cO);  // (CPY, CPY_O, CPY_D)
-    Tensor tOgOGroup = flatten_1(tOgO);        // (CPY, (CPY_O, CPY_D))
-    Tensor tOrOGroup = flatten_1(tOrO);        // (CPY, (CPY_O, CPY_D))
-    Tensor tOcOGroup = flatten_1(tOcO);        // (CPY, (CPY_O, CPY_D))
+    if constexpr (has_output_transform_v<AttentionVariant, MainloopParams>) {
+      // Before the flattened views below copy the fragment.
+      const int qo_tile_base = qo_tile_idx * get<0>(TileShape_QKD{});
+      transform_zero_fragment(variant, mainloop_params, tOrO, tOcO, qo_tile_base,
+                              qo_len - qo_tile_base, qo_head_idx, batch_idx);
+    }
+    Tensor tOgOGroup = flatten_1(tOgO);  // (CPY, (CPY_O, CPY_D))
+    Tensor tOrOGroup = flatten_1(tOrO);  // (CPY, (CPY_O, CPY_D))
+    Tensor tOcOGroup = flatten_1(tOcO);  // (CPY, (CPY_O, CPY_D))
 
     const int qo_tile_size = get<0>(TileShape_QKD{});
     int valid_qo_tile_size = std::min<int>(qo_len - qo_tile_idx * qo_tile_size, qo_tile_size);

--- a/include/flashinfer/attention/hopper/quantization/prefill_sm90.cuh
+++ b/include/flashinfer/attention/hopper/quantization/prefill_sm90.cuh
@@ -220,7 +220,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           collective_mainloop.get_num_kv_tiles(mainloop_params, q_tile_idx, qo_len, kv_len);
       if (num_kv_tiles <= 0) {  // We exit early and write 0 to gO and -inf to gLSE.
         collective_epilogue.store_zero(epilogue_params, shared_storage,
-                                       threadIdx.x - NUM_COPY_THREADS, block_coord);
+                                       threadIdx.x - NUM_COPY_THREADS, block_coord, variant,
+                                       mainloop_params);
         continue;
       }
 
@@ -241,7 +242,8 @@ __global__ void __launch_bounds__(Ktraits::NUM_WARPS* cutlass::NumThreadsPerWarp
           qo_head_idx, kv_head_idx, batch_idx);
 
       collective_epilogue.store(epilogue_params, tOrO, attention_updater.get_lse(), shared_storage,
-                                tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord);
+                                tiled_mma_pv, threadIdx.x - NUM_COPY_THREADS, block_coord, variant,
+                                mainloop_params);
 
       ++work_idx;
     }

--- a/include/flashinfer/attention/hopper/variant_helper.cuh
+++ b/include/flashinfer/attention/hopper/variant_helper.cuh
@@ -19,6 +19,8 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
+#include <type_traits>
+#include <utility>
 
 namespace flashinfer {
 
@@ -50,6 +52,39 @@ namespace flashinfer {
                                              uint32_t qo_head_idx, uint32_t kv_head_idx) {     \
     __VA_ARGS__                                                                                \
   }
+
+// Transforms one output element after normalization (1 / row_sum and, for FP8, the PV
+// dequantization scale are already applied), right before it is converted to DTypeO and
+// written. Unlike the FA2 hook it does not own normalization.
+//   output       fp32 value of query row qo_idx, head qo_head_idx, column d_idx
+//   batch_idx    request index within the batch (0 for single-request prefill)
+//   qo_idx       request-local query position, as in LogitsTransform
+//   d_idx        column of the value head dimension
+//   lse          the row's log2-domain log-sum-exp as stored in the lse output; meaningful
+//                for softmax updaters only
+// Rows that attend to no keys also pass through (output 0, lse -inf). Variants without the
+// hook compile exactly as before: the epilogues detect it with has_output_transform_v.
+#define REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, d_idx, lse, ...) \
+  template <typename MainloopParams, typename T>                                                   \
+  __device__ __forceinline__ T OutputTransform(const MainloopParams& params, T output,             \
+                                               uint32_t batch_idx, uint32_t qo_idx,                \
+                                               uint32_t qo_head_idx, uint32_t d_idx, float lse) {  \
+    __VA_ARGS__                                                                                    \
+  }
+
+// True when AttentionVariant registered an output transform callable with MainloopParams.
+template <typename AttentionVariant, typename MainloopParams, typename = void>
+struct has_output_transform : std::false_type {};
+
+template <typename AttentionVariant, typename MainloopParams>
+struct has_output_transform<AttentionVariant, MainloopParams,
+                            std::void_t<decltype(std::declval<AttentionVariant&>().OutputTransform(
+                                std::declval<const MainloopParams&>(), 0.f, uint32_t(0),
+                                uint32_t(0), uint32_t(0), uint32_t(0), 0.f))>> : std::true_type {};
+
+template <typename AttentionVariant, typename MainloopParams>
+inline constexpr bool has_output_transform_v =
+    has_output_transform<AttentionVariant, MainloopParams>::value;
 
 struct AttentionVariantBase {
   REGISTER_LOGITS_TRANSFORM(params, logits, batch_idx, qo_idx, kv_idx, qo_head_idx, kv_head_idx,

--- a/tests/utils/test_jit_example.py
+++ b/tests/utils/test_jit_example.py
@@ -11,7 +11,13 @@ from flashinfer.jit.attention import (
     gen_customize_single_prefill_module,
 )
 from flashinfer.prefill import single_prefill_with_kv_cache_with_jit_module
-from flashinfer.utils import MaskMode, get_compute_capability, is_sm90a_supported
+from flashinfer.utils import (
+    SINGLE_KERNEL_TMP_SIZE,
+    MaskMode,
+    TensorLayout,
+    get_compute_capability,
+    is_sm90a_supported,
+)
 
 
 def test_single_decode_mask():
@@ -1084,6 +1090,423 @@ struct FlashAlibiDecode : AttentionVariantBase {
     assert o.shape == (batch_size, num_qo_heads, head_dim)
 
 
+# Issue #2765: REGISTER_OUTPUT_TRANSFORM on the Hopper (fa3) variant helper. The variants add a
+# per-(query, head) correction to the normalized output, o[q, h, :] += corr[q, h] * hvec[h, :]
+# with q the global query row, which exercises the row, head and column coordinates of the hook.
+
+corrected_attention_sm90_decl = r"""
+struct CorrectedAttention : AttentionVariantBase {
+  float sm_scale_log2;
+  uint32_t qo_start, corr_stride;
+
+  template <typename MainloopParams, typename BlockCoord>
+  __device__ __host__ CorrectedAttention(const MainloopParams& params,
+                                         const BlockCoord& block_coord) {
+    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
+        block_coord;
+    sm_scale_log2 = params.additional_params.sm_scale * math::log2e;
+    qo_start = qo_indptr;
+    corr_stride = params.additional_params.corr_stride;
+  }
+
+  template <int NUM_ROWS_PER_THREAD>
+  __device__ auto GetAttentionUpdater() {
+    return OnlineSoftmax<NUM_ROWS_PER_THREAD, /*WITH_SCALE=*/true>(sm_scale_log2);
+  }
+
+  // qo_idx is request-local; qo_start makes it the global row that indexes corr.
+  REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, d_idx, lse, {
+    const float corr =
+        params.additional_params.corr[(qo_start + qo_idx) * corr_stride + qo_head_idx];
+    const float h = params.additional_params.hvec[qo_head_idx * HEAD_DIM_VO + d_idx];
+    return output + corr * h;
+  })
+};
+"""
+
+# The same correction through the FA2 hook, which also owns the softmax normalization and has
+# no column index, so this twin adds a per-(query, head) term only.
+corrected_attention_sm80_decl = r"""
+struct CorrectedAttention : AttentionVariantBase {
+  static constexpr bool use_softmax = true;
+  uint32_t window_left, qo_len, kv_len;
+  float sm_scale_log2;
+
+  template <typename Params>
+  __device__ __host__ CorrectedAttention(const Params& params, uint32_t batch_idx,
+                                         uint8_t* smem_ptr) {
+    qo_len = params.get_qo_len(batch_idx);
+    kv_len = params.get_kv_len(batch_idx);
+    window_left = (params.window_left >= 0) ? params.window_left : kv_len;
+    sm_scale_log2 = params.sm_scale * math::log2e;
+  }
+
+  REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, m, d, scale, {
+    float d_rcp = (m != -math::inf) ? math::ptx_rcp(d) : 0.f;
+    return output * d_rcp + params.corr[qo_idx * params.corr_stride + qo_head_idx];
+  })
+};
+"""
+
+# FP8 twin: the built-in FP8 variant plus the hook, to cover the FP8 epilogue.
+corrected_attention_fp8_sm90_decl = r"""
+#include <flashinfer/attention/hopper/variants.cuh>
+
+struct CorrectedFP8Attention : StandardFP8Attention {
+  uint32_t qo_start, corr_stride;
+
+  template <typename MainloopParams, typename BlockCoord>
+  __device__ CorrectedFP8Attention(const MainloopParams& params, const BlockCoord& block_coord)
+      : StandardFP8Attention(params, block_coord) {
+    auto [q_tile_idx, qo_head_idx, kv_head_idx, qo_indptr, kv_indptr, qo_len, kv_len, batch_idx] =
+        block_coord;
+    qo_start = qo_indptr;
+    corr_stride = params.additional_params.corr_stride;
+  }
+
+  REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, d_idx, lse, {
+    const float corr =
+        params.additional_params.corr[(qo_start + qo_idx) * corr_stride + qo_head_idx];
+    const float h = params.additional_params.hvec[qo_head_idx * HEAD_DIM_VO + d_idx];
+    return output + corr * h;
+  })
+};
+"""
+
+# (tensor names, tensor dtypes, scalar names, scalar dtypes) shared by the fa3 variants above.
+_OUTPUT_TRANSFORM_PARAMS = (
+    ["corr", "hvec"],
+    ["float", "float"],
+    ["sm_scale", "corr_stride"],
+    ["double", "int64_t"],
+)
+
+
+def _skip_unless_sm90a():
+    """Skip unless the current device runs the fa3 (SM90a) kernels."""
+    if not is_sm90a_supported(torch.device("cuda")):
+        pytest.skip("SM90A is not supported")
+
+
+def _random_correction(nnz_qo, num_qo_heads, head_dim):
+    """Per-(query, head) factors and per-(head, column) vectors, uniform in [-1, 1)."""
+    corr = torch.rand(nnz_qo, num_qo_heads, dtype=torch.float32, device="cuda") * 2 - 1
+    hvec = (
+        torch.rand(num_qo_heads, head_dim, dtype=torch.float32, device="cuda") * 2 - 1
+    )
+    return corr, hvec
+
+
+def _attention_reference(q, k, v, causal, sm_scale):
+    """fp32 softmax attention with GQA by head repetition and a causal mask aligned to the
+    bottom right. Returns (o, lse) with lse in the log2 domain, which is what the kernels
+    store. An empty KV yields zeros and -inf."""
+    qo_len, kv_len, num_qo_heads = q.size(0), k.size(0), q.size(1)
+    if kv_len == 0:
+        o = torch.zeros(
+            qo_len, num_qo_heads, v.size(-1), dtype=torch.float32, device=q.device
+        )
+        lse = torch.full((qo_len, num_qo_heads), float("-inf"), device=q.device)
+        return o, lse
+    group_size = num_qo_heads // k.size(1)
+    kf = k.float().repeat_interleave(group_size, dim=1)
+    vf = v.float().repeat_interleave(group_size, dim=1)
+    s = torch.einsum("qhd,khd->hqk", q.float(), kf) * sm_scale
+    if causal:
+        keep = torch.ones(qo_len, kv_len, dtype=torch.bool, device=q.device)
+        s = s.masked_fill(~keep.tril(kv_len - qo_len), float("-inf"))
+    o = torch.einsum("hqk,khd->qhd", torch.softmax(s, dim=-1), vf)
+    lse = torch.logsumexp(s, dim=-1).t() * math.log2(math.e)
+    return o, lse
+
+
+def _sm90_output_transform_module(dtype):
+    """fa3 single-prefill module for CorrectedAttention with head_dim 128, cached by uri."""
+    return gen_customize_single_prefill_module(
+        "fa3",
+        f"single_prefill_output_transform_{str(dtype).split('.')[-1]}",
+        dtype,  # dtype_q
+        dtype,  # dtype_kv
+        dtype,  # dtype_o
+        128,  # head_dim_qk
+        128,  # head_dim_vo
+        *_OUTPUT_TRANSFORM_PARAMS,
+        "CorrectedAttention",
+        corrected_attention_sm90_decl,
+    ).build_and_load()
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("causal", [False, True])
+def test_single_prefill_sm90_output_transform(dtype, causal):
+    """fa3 single prefill through a variant whose REGISTER_OUTPUT_TRANSFORM adds
+    corr[q, h] * hvec[h, :] to the normalized output. The output must match an fp32 reference
+    and the LSE must be untouched, so it is compared with the built-in fa3 kernel."""
+    _skip_unless_sm90a()
+    torch.manual_seed(42)
+    # 333 rows = two full 128-row tiles plus a partial one; 8 query heads over 2 kv heads.
+    qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim = 333, 1027, 8, 2, 128
+    f = functools.partial(
+        single_prefill_with_kv_cache_with_jit_module,
+        _sm90_output_transform_module(dtype),
+    )
+
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=dtype, device="cuda")
+    k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device="cuda")
+    v = torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device="cuda")
+    corr, hvec = _random_correction(qo_len, num_qo_heads, head_dim)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
+
+    o, lse = f(
+        q,
+        k,
+        v,
+        corr,
+        hvec,
+        sm_scale,
+        corr.stride(0),
+        mask_mode=mask_mode,
+        return_lse=True,
+    )
+
+    o_ref, _ = _attention_reference(q, k, v, causal, sm_scale)
+    o_ref = o_ref + corr[:, :, None] * hvec[None, :, :]
+    _, lse_builtin = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, causal=causal, backend="fa3", return_lse=True
+    )
+    # Values are O(1); the error budget is dominated by the 16-bit output rounding.
+    tol = 2e-2 if dtype == torch.float16 else 4e-2
+    torch.testing.assert_close(o.float(), o_ref, rtol=tol, atol=tol)
+    torch.testing.assert_close(lse, lse_builtin, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_batch_prefill_sm90_output_transform(causal):
+    """fa3 batch prefill, ragged and paged, through the same variant. The batch mixes a partial
+    128-row tile, a request with an empty KV (its rows come from the epilogue's zero path, so
+    the output must be exactly the correction term and the LSE -inf), a decode-like request
+    and a request spanning two tiles. corr is indexed by the global query row."""
+    _skip_unless_sm90a()
+    torch.manual_seed(42)
+    dtype = torch.float16
+    num_qo_heads, num_kv_heads, head_dim, page_size = 8, 2, 128, 16
+    qo_lens = [77, 300, 5, 130]
+    kv_lens = [77, 0, 640, 130]
+    nnz_qo, nnz_kv = sum(qo_lens), sum(kv_lens)
+    jit_args = (
+        "batch_prefill_output_transform",  # uri
+        dtype,  # dtype_q
+        dtype,  # dtype_kv
+        dtype,  # dtype_o
+        torch.int32,  # idtype
+        head_dim,  # hidden_dim_qk
+        head_dim,  # hidden_dim_vo
+        *_OUTPUT_TRANSFORM_PARAMS,
+        "CorrectedAttention",
+        corrected_attention_sm90_decl,
+    )
+
+    q = torch.randn(nnz_qo, num_qo_heads, head_dim, dtype=dtype, device="cuda")
+    k = torch.randn(nnz_kv, num_kv_heads, head_dim, dtype=dtype, device="cuda")
+    v = torch.randn(nnz_kv, num_kv_heads, head_dim, dtype=dtype, device="cuda")
+    corr, hvec = _random_correction(nnz_qo, num_qo_heads, head_dim)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    qo_indptr = torch.tensor([0] + qo_lens).cumsum(0).int()
+    kv_indptr = torch.tensor([0] + kv_lens).cumsum(0).int()
+
+    o_ref = torch.empty(
+        nnz_qo, num_qo_heads, head_dim, dtype=torch.float32, device="cuda"
+    )
+    lse_ref = torch.empty(nnz_qo, num_qo_heads, dtype=torch.float32, device="cuda")
+    for i in range(len(qo_lens)):
+        q0, q1 = qo_indptr[i].item(), qo_indptr[i + 1].item()
+        k0, k1 = kv_indptr[i].item(), kv_indptr[i + 1].item()
+        o_ref[q0:q1], lse_ref[q0:q1] = _attention_reference(
+            q[q0:q1], k[k0:k1], v[k0:k1], causal, sm_scale
+        )
+    o_ref += corr[:, :, None] * hvec[None, :, :]
+
+    ragged = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        kv_layout="NHD",
+        backend="fa3",
+        jit_args=jit_args,
+    )
+    ragged.plan(
+        qo_indptr,
+        kv_indptr,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+    )
+    o, lse = ragged.run(q, k, v, corr, hvec, sm_scale, corr.stride(0), return_lse=True)
+    torch.testing.assert_close(o.float(), o_ref, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(lse, lse_ref, rtol=1e-2, atol=1e-2)
+
+    # The same KV in 16-token pages; the empty request owns no page.
+    num_pages = [(n + page_size - 1) // page_size for n in kv_lens]
+    page_indptr = torch.tensor([0] + num_pages).cumsum(0).int()
+    last_page_len = torch.tensor(
+        [
+            n - (p - 1) * page_size if p > 0 else 0
+            for n, p in zip(kv_lens, num_pages, strict=True)
+        ],
+        dtype=torch.int32,
+    )
+    k_paged = torch.zeros(
+        sum(num_pages), page_size, num_kv_heads, head_dim, dtype=dtype, device="cuda"
+    )
+    v_paged = torch.zeros_like(k_paged)
+    for i, n in enumerate(kv_lens):
+        k0, t0 = kv_indptr[i].item(), page_indptr[i].item() * page_size
+        k_paged.view(-1, num_kv_heads, head_dim)[t0 : t0 + n] = k[k0 : k0 + n]
+        v_paged.view(-1, num_kv_heads, head_dim)[t0 : t0 + n] = v[k0 : k0 + n]
+    paged = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda"),
+        kv_layout="NHD",
+        backend="fa3",
+        jit_args=jit_args,
+    )
+    paged.plan(
+        qo_indptr,
+        page_indptr,
+        torch.arange(sum(num_pages), dtype=torch.int32),
+        last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size,
+        causal=causal,
+        q_data_type=dtype,
+        kv_data_type=dtype,
+        seq_lens=torch.tensor(kv_lens, dtype=torch.int32),
+    )
+    o_paged, lse_paged = paged.run(
+        q, (k_paged, v_paged), corr, hvec, sm_scale, corr.stride(0), return_lse=True
+    )
+    torch.testing.assert_close(o_paged.float(), o_ref, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(lse_paged, lse_ref, rtol=1e-2, atol=1e-2)
+
+    # Rows of the empty request: exactly the correction term (up to fp16 rounding) and -inf.
+    q0, q1 = qo_indptr[1].item(), qo_indptr[2].item()
+    expected = corr[q0:q1, :, None] * hvec[None, :, :]
+    for out, out_lse in ((o, lse), (o_paged, lse_paged)):
+        torch.testing.assert_close(out[q0:q1].float(), expected, rtol=2e-3, atol=2e-3)
+        assert torch.isneginf(out_lse[q0:q1]).all()
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_output_transform_fa2_fa3_parity(causal):
+    """The same per-(query, head) correction written against the FA2 hook (which also
+    normalizes) and the fa3 hook (post-normalization, hvec set to ones) must agree with each
+    other and with the fp32 reference."""
+    _skip_unless_sm90a()
+    torch.manual_seed(42)
+    dtype = torch.float16
+    qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim = 333, 1027, 8, 2, 128
+    fa2_module = gen_customize_single_prefill_module(
+        "fa2",
+        "single_prefill_output_transform_fa2",
+        dtype,  # dtype_q
+        dtype,  # dtype_kv
+        dtype,  # dtype_o
+        head_dim,  # head_dim_qk
+        head_dim,  # head_dim_vo
+        ["corr"],  # additional_tensor_names
+        ["float"],  # additional_tensor_dtypes
+        ["sm_scale", "corr_stride"],  # additional_scalar_names
+        ["double", "int64_t"],  # additional_scalar_dtypes
+        "CorrectedAttention",
+        corrected_attention_sm80_decl,
+    ).build_and_load()
+    fa3_module = _sm90_output_transform_module(dtype)
+
+    q = torch.randn(qo_len, num_qo_heads, head_dim, dtype=dtype, device="cuda")
+    k = torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device="cuda")
+    v = torch.randn(kv_len, num_kv_heads, head_dim, dtype=dtype, device="cuda")
+    corr, _ = _random_correction(qo_len, num_qo_heads, head_dim)
+    ones = torch.ones(num_qo_heads, head_dim, dtype=torch.float32, device="cuda")
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
+
+    o_fa2 = single_prefill_with_kv_cache_with_jit_module(
+        fa2_module, q, k, v, corr, sm_scale, corr.stride(0), mask_mode=mask_mode
+    )
+    o_fa3 = single_prefill_with_kv_cache_with_jit_module(
+        fa3_module, q, k, v, corr, ones, sm_scale, corr.stride(0), mask_mode=mask_mode
+    )
+
+    o_ref, _ = _attention_reference(q, k, v, causal, sm_scale)
+    o_ref = o_ref + corr[:, :, None]
+    torch.testing.assert_close(o_fa2.float(), o_ref, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(o_fa3.float(), o_ref, rtol=2e-2, atol=2e-2)
+    torch.testing.assert_close(o_fa2, o_fa3, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("causal", [False, True])
+def test_single_prefill_sm90_fp8_output_transform(causal):
+    """The hook also runs in the fa3 FP8 epilogue, which stores the accumulator through its own
+    column handling. With the built-in FP8 variant extended by the hook, the transformed output
+    minus the built-in FP8 output must be exactly the correction term."""
+    _skip_unless_sm90a()
+    torch.manual_seed(42)
+    qo_len, kv_len, num_qo_heads, num_kv_heads, head_dim = 333, 1027, 8, 2, 128
+    fp8, out_dtype = torch.float8_e4m3fn, torch.float16
+    jit_module = gen_customize_single_prefill_module(
+        "fa3",
+        "single_prefill_output_transform_fp8",
+        fp8,  # dtype_q
+        fp8,  # dtype_kv
+        out_dtype,  # dtype_o
+        head_dim,  # head_dim_qk
+        head_dim,  # head_dim_vo
+        *_OUTPUT_TRANSFORM_PARAMS,
+        "CorrectedFP8Attention",
+        corrected_attention_fp8_sm90_decl,
+        fp8_enabled=True,  # select the FP8 kernel template
+    ).build_and_load()
+
+    q = torch.randn(qo_len, num_qo_heads, head_dim, device="cuda").to(fp8)
+    k = torch.randn(kv_len, num_kv_heads, head_dim, device="cuda").to(fp8)
+    v = torch.randn(kv_len, num_kv_heads, head_dim, device="cuda").to(fp8)
+    corr, hvec = _random_correction(qo_len, num_qo_heads, head_dim)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    mask_mode = MaskMode.CAUSAL.value if causal else MaskMode.NON_CAUSAL.value
+
+    # single_prefill_with_kv_cache_with_jit_module allocates the output in q's dtype, so call
+    # the module directly with a 16-bit output buffer.
+    o = torch.empty(qo_len, num_qo_heads, head_dim, dtype=out_dtype, device="cuda")
+    tmp = torch.empty(SINGLE_KERNEL_TMP_SIZE, dtype=torch.uint8, device="cuda")
+    jit_module.run(
+        q,
+        k,
+        v,
+        tmp,
+        o,
+        None,
+        mask_mode,
+        TensorLayout.NHD.value,
+        -1,
+        corr,
+        hvec,
+        sm_scale,
+        corr.stride(0),
+    )
+    o_builtin = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, causal=causal, backend="fa3", o_dtype=out_dtype
+    )
+    torch.testing.assert_close(
+        o.float() - o_builtin.float(),
+        corr[:, :, None] * hvec[None, :, :],
+        rtol=2e-2,
+        atol=2e-2,
+    )
+
+
 if __name__ == "__main__":
     test_single_decode_mask()
     test_flash_sigmoid()
@@ -1095,3 +1518,7 @@ if __name__ == "__main__":
     test_batch_prefill_jit_wellknown_mask_buffers()
     test_batch_decode_jit_wellknown_alibi_buffer(False)
     test_batch_decode_jit_wellknown_alibi_buffer(True)
+    test_single_prefill_sm90_output_transform(torch.float16, False)
+    test_batch_prefill_sm90_output_transform(False)
+    test_output_transform_fa2_fa3_parity(False)
+    test_single_prefill_sm90_fp8_output_transform(False)


### PR DESCRIPTION
## Description

The FA2 variant helper exposes `REGISTER_OUTPUT_TRANSFORM`; the Hopper (FA3) helper in `include/flashinfer/attention/hopper/variant_helper.cuh` does not, and the FA3 epilogue writes the accumulator to global memory with no per-element hook. A custom `fa3` variant therefore cannot touch its output, which #2765 asks for (a per-(query, head) correction added after attention without changing the mainloop).

This PR adds the hook to the Hopper helper and applies it in both FA3 epilogues.

- `REGISTER_OUTPUT_TRANSFORM(params, output, batch_idx, qo_idx, qo_head_idx, d_idx, lse, ...)`. It runs after normalization, which FA3 already folds into the accumulator in `finalize` and `rescale_o` (including the FP8 PV scale), so it receives the final fp32 value of each element with its request-local row, head, column and the row's log2-domain LSE. The contract is documented on the macro.
- `CollectiveEpilogue::store` (16-bit and FP8) applies it to the accumulator fragment right before the `DTypeO` conversion, viewing the fragment and its coordinate tensor through `convert_layout_acc_rowcol` like `rescale_o`, and skipping rows past `qo_len` like the LSE write.
- `store_zero` (query tiles with no keys) applies it to the zero fragment with `lse = -inf`, so a variant sees every element the kernel writes exactly once.
- The epilogues detect the hook at compile time (`has_output_transform_v`, expression SFINAE on `OutputTransform`). Variants without it, including every built-in variant, compile exactly as before.

No Python or code generation changes: the SM90 customize templates already include the helper and pass additional tensors and scalars through `params.additional_params`.

The default path costs nothing: the default fa3 batch prefill module built from this branch has byte-identical SASS to the one built from the base commit, and throughput is unchanged (numbers below).

## Related Issues

Closes #2765.

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New tests in `tests/utils/test_jit_example.py` (skipped without SM90a):

- `test_single_prefill_sm90_output_transform` (fp16, bf16; causal and not): output against an fp32 reference, LSE against the built-in fa3 kernel.
- `test_batch_prefill_sm90_output_transform` (causal and not): ragged and paged wrappers over a batch with a partial 128-row tile, an empty-KV request (its rows must equal the correction term with LSE `-inf`), a decode-like request and a two-tile request; `corr` indexed by global row.
- `test_output_transform_fa2_fa3_parity`: the same correction through the FA2 hook (which also normalizes) and the fa3 hook.
- `test_single_prefill_sm90_fp8_output_transform`: FP8 epilogue; transformed minus built-in FP8 output equals the correction term.

Runs on an NVIDIA GH200 480GB (SM90), CUDA 12.8, torch 2.7.0+cu128, `FLASHINFER_CUDA_ARCH_LIST="9.0a"`; the skips are head-count combinations those files skip by design:

```
pytest tests/utils/test_jit_example.py -k output_transform                                               10 passed, 14 deselected, 21 warnings
pytest tests/utils/test_jit_example.py                                                                   24 passed, 21 warnings
pytest tests/attention/test_hopper_fp8_attention.py -k 'not block_sparse'                                248 passed, 3456 deselected, 21 warnings
pytest tests/attention/test_hopper_fp8_sliding_window.py                                                 18 passed, 21 warnings
pytest tests/attention/test_attention_sink.py                                                            1336 passed, 72 skipped, 96 xfailed, 23 warnings
pytest tests/jit/test_jit_cpp_ext.py                                                                     26 passed, 21 warnings
pytest tests/utils/test_jit_warmup.py                                                                    2 passed, 21 warnings
pytest tests/attention/test_batch_decode_kernels.py -k test_tensor_core_decode_rejects_mismatched_q_len  1 passed, 3261 deselected, 21 warnings
pytest tests/attention/test_hopper.py                                                                    4596 passed, 2184 skipped, 21 warnings
```

Default-kernel throughput, `python benchmarks/bench_hopper_attention.py`, fa3 template, TFLOPs/s, same GPU:

| benchmark | shape | base commit | this branch |
|---|---|---:|---:|
| batch_paged_prefill | page_size=1 batch_size=128, num_heads=32, seq_len=1024, causal=True, head_dim=128 | 295.8 | 295.9 |
| batch_paged_prefill | page_size=1 batch_size=64, num_heads=32, seq_len=2048, causal=True, head_dim=128 | 373.2 | 371.5 |
| batch_paged_prefill | page_size=1 batch_size=32, num_heads=32, seq_len=4096, causal=True, head_dim=128 | 433.2 | 429.5 |
| batch_paged_prefill | page_size=1 batch_size=16, num_heads=32, seq_len=8192, causal=True, head_dim=128 | 460.7 | 457.9 |
| batch_paged_prefill | page_size=1 batch_size=1, num_heads=32, seq_len=32768, causal=True, head_dim=128 | 501.4 | 504.2 |
| batch_paged_prefill | page_size=16 batch_size=128, num_heads=32, seq_len=1024, causal=True, head_dim=128 | 301.0 | 298.4 |
| batch_paged_prefill | page_size=16 batch_size=64, num_heads=32, seq_len=2048, causal=True, head_dim=128 | 378.9 | 375.7 |
| batch_paged_prefill | page_size=16 batch_size=32, num_heads=32, seq_len=4096, causal=True, head_dim=128 | 429.5 | 429.7 |
| batch_paged_prefill | page_size=16 batch_size=16, num_heads=32, seq_len=8192, causal=True, head_dim=128 | 468.9 | 467.6 |
| batch_paged_prefill | page_size=16 batch_size=1, num_heads=32, seq_len=32768, causal=True, head_dim=128 | 504.3 | 497.4 |
| batch_ragged_prefill | batch_size=128, num_heads=32, seq_len=1024, causal=True, head_dim=128 | 378.2 | 377.5 |
| batch_ragged_prefill | batch_size=64, num_heads=32, seq_len=2048, causal=True, head_dim=128 | 466.4 | 459.5 |
| batch_ragged_prefill | batch_size=32, num_heads=32, seq_len=4096, causal=True, head_dim=128 | 527.2 | 515.9 |
| batch_ragged_prefill | batch_size=16, num_heads=32, seq_len=8192, causal=True, head_dim=128 | 564.0 | 552.3 |
| batch_ragged_prefill | batch_size=1, num_heads=32, seq_len=32768, causal=True, head_dim=128 | 596.3 | 588.7 |

Ratio this branch / base commit: median 0.992 (min 0.979, max 1.006). The two binaries are byte-identical (below), so this is measurement noise: two consecutive runs of the same binary on this GPU differ by a median ratio of 1.000 (min 0.986, max 1.018).

SASS of the default fa3 batch prefill module `batch_prefill_..._sm90` (16 kernels: paged and ragged, four mask modes, CTA_KV 128 and 192), `cuobjdump -sass` of the module built from this branch versus the same module built from the base commit into a separate cache: identical, byte for byte. The register, stack and spill counts (`cuobjdump --dump-resource-usage`) of that module and of the `FlashSigmoid` custom-variant module are identical as well.

## Reviewer Notes

- The signature differs from the FA2 hook on purpose (`d_idx` and `lse` instead of `m`, `d`, `scale`; no normalization duty) because FA3 normalizes in the mainloop.
- The mainloop passes `batch_idx = 0` to `LogitsTransform` even in batch kernels; the new hook receives the real `batch_idx` from the block coordinate. The existing behaviour is untouched.
- Detection instead of a base-class identity default: an identity default compiled into every variant changed the stack frame of three of the sixteen default kernels in an earlier version of this change; the compile-time gate keeps the default kernels byte-identical.

Made in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional per-element output transforms for Hopper attention prefill results.
  * Output transforms can use batch, query position, attention head, dimension, and normalization data.
  * Supported standard and FP8 output paths, including query tiles without keys.
  * Preserved compatibility for attention variants that do not define an output transform.

* **Tests**
  * Added coverage for single, batched, ragged, paged, FP8, and FA2/FA3 prefill scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->