### PR TITLE
feat(attention): accept caller-supplied ALiBi slopes for tensor parallelism

### DIFF
--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -70,7 +70,10 @@ from .utils import (
     _check_workspace_buffer_alignment,
     check_shape_dtype_device,
     get_alibi_slopes,
-    _get_cache_alibi_slopes_buf,
+    _check_alibi_slopes,
+    _check_alibi_slopes_backend,
+    _resolve_alibi_slopes,
+    _stage_alibi_slopes,
     _get_trtllm_gen_multi_ctas_kv_counter_buffer,
     _resolve_trtllm_gen_multi_ctas_kv_counter_buffer,
     _get_range_buf,
@@ -576,6 +579,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: Literal[False] = False,
+    alibi_slopes: Optional[torch.Tensor] = None,
 ) -> torch.Tensor: ...
 
 
@@ -596,6 +600,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: Literal[True] = True,
+    alibi_slopes: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
 
@@ -616,6 +621,7 @@ def single_decode_with_kv_cache(
     rope_scale: Optional[float] = None,
     rope_theta: Optional[float] = None,
     return_lse: bool = False,
+    alibi_slopes: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Decode attention with KV Cache for single request, return attention output.
 
@@ -663,6 +669,13 @@ def single_decode_with_kv_cache(
         The theta used in RoPE, if not provided, will be set to ``1e4``.
     return_lse : bool
         Whether to return the log sum exp value of the attention logits.
+    alibi_slopes : Optional[torch.Tensor]
+        Caller-supplied ALiBi slopes, one ``float32`` value per query head,
+        shape: ``[num_qo_heads]``, contiguous, on the same device as ``q``. Only
+        valid with ``pos_encoding_mode="ALIBI"``. ``None`` (default) uses the
+        slopes :func:`flashinfer.utils.get_alibi_slopes` computes for
+        ``num_qo_heads`` heads. Under tensor parallelism pass this rank's slice
+        of the slopes computed for the global head count.
 
     Returns
     -------
@@ -712,6 +725,11 @@ def single_decode_with_kv_cache(
     if rope_theta is None:
         rope_theta = 1e4
     num_qo_heads = q.shape[0]
+    alibi_slopes = _check_alibi_slopes(
+        alibi_slopes, num_qo_heads, q.device, pos_encoding_mode
+    )
+    if alibi_slopes is None and pos_encoding_mode == "ALIBI":
+        alibi_slopes = get_alibi_slopes(num_qo_heads, device=q.device)
 
     lse = None
     if return_lse:
@@ -741,9 +759,7 @@ def single_decode_with_kv_cache(
             TensorLayout[kv_layout].value,
             window_left,
             None,  # packed_custom_mask
-            get_alibi_slopes(num_qo_heads, device=q.device)
-            if pos_encoding_mode == "ALIBI"
-            else None,
+            alibi_slopes,
             logits_soft_cap,
             sm_scale,
             None,  # scale_q, not supported yet
@@ -773,9 +789,7 @@ def single_decode_with_kv_cache(
             tmp,
             out,
             lse,
-            get_alibi_slopes(num_qo_heads, device=q.device)
-            if pos_encoding_mode == "ALIBI"
-            else None,
+            alibi_slopes,
             TensorLayout[kv_layout].value,
             window_left,
             logits_soft_cap,
@@ -1021,6 +1035,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     device=float_workspace_buffer.device,
                 )
         self._backend = backend
+        self._alibi_slopes: Optional[torch.Tensor] = None
+        self._alibi_slopes_buf: Optional[torch.Tensor] = None
 
         self._cute_dsl_wrapper = None
         if backend == "cute-dsl":
@@ -1420,6 +1436,19 @@ class BatchDecodeWithPagedKVCacheWrapper:
         rope_theta : Optional[float]
             Base value for the RoPE frequencies.  Only consulted when
             ``pos_encoding_mode != "NONE"``.  Defaults to ``1e4`` when ``None``.
+        alibi_slopes : Optional[torch.Tensor]
+            Caller-supplied ALiBi slopes, one ``float32`` value per query head,
+            shape: ``[num_qo_heads]``, contiguous, on the wrapper's device. Only
+            valid with ``pos_encoding_mode="ALIBI"`` and only supported by the
+            ``fa2`` backend; a custom JIT module receives the tensor as its
+            ``maybe_alibi_slopes`` input regardless of ``pos_encoding_mode`` and
+            must declare it. ``None`` (default) uses the slopes
+            :func:`flashinfer.utils.get_alibi_slopes` computes for
+            ``num_qo_heads`` heads. Under tensor parallelism pass this rank's
+            slice of the slopes computed for the global head count. The values
+            are copied into a wrapper-owned buffer, so the tensor may be freed or
+            reused afterwards and a later :meth:`plan` with new slopes also
+            updates a captured CUDA graph.
         non_blocking : bool
             Whether to copy the input tensors to the device asynchronously, defaults to ``True``.
         seq_lens: Optional[torch.Tensor]
@@ -1529,6 +1558,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
         disable_split_kv: bool = False,
         q_len_per_req: int = 1,
         is_causal: Optional[bool] = None,
+        alibi_slopes: Optional[torch.Tensor] = None,
     ) -> None:
         """Shared plan() implementation for the paged-decode wrapper across backends."""
         _check_workspace_buffer_alignment(
@@ -1545,6 +1575,17 @@ class BatchDecodeWithPagedKVCacheWrapper:
         batch_size = len(last_page_len)
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
+        jit_tensor_names = (
+            self._jit_additional_tensor_names if self._jit_module is not None else None
+        )
+        alibi_slopes = _check_alibi_slopes(
+            alibi_slopes,
+            num_qo_heads,
+            self.device,
+            pos_encoding_mode,
+            require_alibi_mode=jit_tensor_names is None,
+        )
+        _check_alibi_slopes_backend(alibi_slopes, self._backend, jit_tensor_names)
         if window_right != 0 and self._backend != "cute-dsl":
             raise NotImplementedError(
                 "BatchDecodeWithPagedKVCacheWrapper only supports window_right != 0 "
@@ -1752,6 +1793,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
             self._sm_scale = sm_scale
             self._rope_scale = rope_scale
             self._rope_theta = rope_theta
+            self._alibi_slopes, self._alibi_slopes_buf = _stage_alibi_slopes(
+                alibi_slopes, self._alibi_slopes_buf
+            )
             return
         if self._backend == "cute-dsl":
             if logits_soft_cap is not None and logits_soft_cap > 0:
@@ -1962,6 +2006,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         "q_len_per_req > 1 is currently only supported on the "
                         "fa2 tensor-core backend."
                     )
+                _check_alibi_slopes_backend(alibi_slopes, self._backend, None)
                 self._cached_module = get_batch_prefill_module(
                     self._backend,
                     q_data_type,
@@ -2042,6 +2087,9 @@ class BatchDecodeWithPagedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
+        self._alibi_slopes, self._alibi_slopes_buf = _stage_alibi_slopes(
+            alibi_slopes, self._alibi_slopes_buf
+        )
         self._q_len_per_req = q_len_per_req
         self._is_causal = is_causal
 
@@ -2522,8 +2570,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                         {
                             "maybe_custom_mask": None,
                             "maybe_mask_indptr": None,
-                            "maybe_alibi_slopes": lambda: _get_cache_alibi_slopes_buf(
-                                q.shape[1], q.device
+                            "maybe_alibi_slopes": lambda: _resolve_alibi_slopes(
+                                self._alibi_slopes, q.shape[1], q.device
                             ),
                         },
                         args,
@@ -2541,7 +2589,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 run_args += [
                     None,  # packed_custom_mask
                     None,  # mask_indptr_buf
-                    _get_cache_alibi_slopes_buf(q.shape[1], q.device),
+                    _resolve_alibi_slopes(self._alibi_slopes, q.shape[1], q.device),
                     None,  # maybe_prefix_len_ptr
                     None,  # maybe_token_pos_in_items_ptr
                     None,  # maybe_max_item_len_ptr
@@ -2632,8 +2680,8 @@ class BatchDecodeWithPagedKVCacheWrapper:
                     prepare_jit_additional_args(
                         self._jit_additional_tensor_names,
                         {
-                            "maybe_alibi_slopes": lambda: _get_cache_alibi_slopes_buf(
-                                q.shape[1], q.device
+                            "maybe_alibi_slopes": lambda: _resolve_alibi_slopes(
+                                self._alibi_slopes, q.shape[1], q.device
                             ),
                         },
                         args,
@@ -2641,7 +2689,7 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 )
             else:
                 run_args += [
-                    _get_cache_alibi_slopes_buf(q.shape[1], q.device),
+                    _resolve_alibi_slopes(self._alibi_slopes, q.shape[1], q.device),
                     logits_soft_cap,
                     sm_scale,
                     rope_scale,

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -62,7 +62,10 @@ from .utils import (
     _check_kv_layout,
     _check_pos_encoding_mode,
     _check_workspace_buffer_alignment,
-    _get_cache_alibi_slopes_buf,
+    _check_alibi_slopes,
+    _check_alibi_slopes_backend,
+    _resolve_alibi_slopes,
+    _stage_alibi_slopes,
     _get_cache_buf,
     _get_trtllm_gen_multi_ctas_kv_counter_buffer,
     _resolve_trtllm_gen_multi_ctas_kv_counter_buffer,
@@ -1152,6 +1155,7 @@ def single_prefill_with_kv_cache(
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    alibi_slopes: Optional[torch.Tensor] = None,
 ) -> torch.Tensor: ...
 
 
@@ -1180,6 +1184,7 @@ def single_prefill_with_kv_cache(
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    alibi_slopes: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]: ...
 
 
@@ -1208,6 +1213,7 @@ def single_prefill_with_kv_cache(
     kv_cache_sf: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    alibi_slopes: Optional[torch.Tensor] = None,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""Prefill/Append attention with KV cache for single request, return the attention
     output.
@@ -1292,6 +1298,14 @@ def single_prefill_with_kv_cache(
         The calibration scale of key for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
     v_scale : Optional[Union[float, torch.Tensor]]
         The calibration scale of value for fp8 or nvfp4 input, if not provided, will be set to ``1.0``.
+    alibi_slopes : Optional[torch.Tensor]
+        Caller-supplied ALiBi slopes, one ``float32`` value per query head,
+        shape: ``[num_qo_heads]``, contiguous, on the same device as ``q``. Only
+        valid with ``pos_encoding_mode="ALIBI"`` and only supported by the
+        ``fa2`` backend. ``None`` (default) uses the slopes
+        :func:`flashinfer.utils.get_alibi_slopes` computes for ``num_qo_heads``
+        heads. Under tensor parallelism pass this rank's slice of the slopes
+        computed for the global head count.
 
     Returns
     -------
@@ -1348,6 +1362,11 @@ def single_prefill_with_kv_cache(
         logits_soft_cap = 0.0
     if sm_scale is None:
         sm_scale = 1.0 / math.sqrt(q.size(-1))
+    alibi_slopes = _check_alibi_slopes(
+        alibi_slopes, q.shape[1], q.device, pos_encoding_mode
+    )
+    if backend != "auto":
+        _check_alibi_slopes_backend(alibi_slopes, backend, None)
     if rope_scale is None:
         rope_scale = 1.0
     if rope_theta is None:
@@ -1406,6 +1425,10 @@ def single_prefill_with_kv_cache(
             head_dim_qk=q.shape[-1],
             head_dim_vo=out_head_dim,
         )
+    _check_alibi_slopes_backend(alibi_slopes, backend, None)
+    kernel_alibi_slopes = alibi_slopes
+    if kernel_alibi_slopes is None and pos_encoding_mode == "ALIBI":
+        kernel_alibi_slopes = get_alibi_slopes(q.shape[1], device=q.device)
 
     # Unpack NVFP4 scale factors
     k_sf, v_sf = None, None
@@ -1444,9 +1467,7 @@ def single_prefill_with_kv_cache(
         TensorLayout[kv_layout].value,
         window_left,
         packed_custom_mask,
-        get_alibi_slopes(q.shape[1], device=q.device)
-        if pos_encoding_mode == "ALIBI"
-        else None,
+        kernel_alibi_slopes,
         logits_soft_cap,
         sm_scale,
         scale_q,
@@ -1889,6 +1910,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows: Optional[int] = None
         self._backend = backend
+        self._alibi_slopes: Optional[torch.Tensor] = None
+        self._alibi_slopes_buf: Optional[torch.Tensor] = None
         self._plan_info = None
         self._cached_module = None
         self._seq_lens_kv = None
@@ -2247,6 +2270,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
         max_sequence_kv: Optional[int] = None,
         fixed_split_size: Optional[int] = None,
         disable_split_kv: bool = False,
+        alibi_slopes: Optional[torch.Tensor] = None,
     ) -> None:
         r"""Plan batch prefill/append attention on Paged KV-Cache for given problem specification.
 
@@ -2317,6 +2341,19 @@ class BatchPrefillWithPagedKVCacheWrapper:
             ``1.0``.
         rope_theta : Optional[float]
             The theta used in RoPE, if not provided, will be set to ``1e4``.
+        alibi_slopes : Optional[torch.Tensor]
+            Caller-supplied ALiBi slopes, one ``float32`` value per query head,
+            shape: ``[num_qo_heads]``, contiguous, on the wrapper's device. Only
+            valid with ``pos_encoding_mode="ALIBI"`` and only supported by the
+            ``fa2`` backend; a custom JIT module receives the tensor as its
+            ``maybe_alibi_slopes`` input regardless of ``pos_encoding_mode`` and
+            must declare it. ``None`` (default) uses the slopes
+            :func:`flashinfer.utils.get_alibi_slopes` computes for
+            ``num_qo_heads`` heads. Under tensor parallelism pass this rank's
+            slice of the slopes computed for the global head count. The values
+            are copied into a wrapper-owned buffer, so the tensor may be freed or
+            reused afterwards and a later :meth:`plan` with new slopes also
+            updates a captured CUDA graph.
         q_data_type : Union[str, torch.dtype]
             The data type of the query tensor, defaults torch.float16.
         kv_data_type : Optional[Union[str, torch.dtype]]
@@ -2391,6 +2428,17 @@ class BatchPrefillWithPagedKVCacheWrapper:
             head_dim_vo = head_dim_qk
         if fixed_split_size is None:
             fixed_split_size = -1
+        jit_tensor_names = (
+            self._jit_additional_tensor_names if self._jit_module is not None else None
+        )
+        alibi_slopes = _check_alibi_slopes(
+            alibi_slopes,
+            num_qo_heads,
+            self.device,
+            pos_encoding_mode,
+            require_alibi_mode=jit_tensor_names is None,
+        )
+        _check_alibi_slopes_backend(alibi_slopes, self._backend, jit_tensor_names)
 
         batch_size = len(qo_indptr) - 1
         self._batch_size = batch_size
@@ -2661,6 +2709,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     head_dim_qk=head_dim_qk,
                     head_dim_vo=head_dim_vo,
                 )
+            _check_alibi_slopes_backend(alibi_slopes, self._backend, None)
             if self._backend != "cudnn":
                 get_module_args = (
                     q_data_type,
@@ -2751,6 +2800,9 @@ class BatchPrefillWithPagedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
+        self._alibi_slopes, self._alibi_slopes_buf = _stage_alibi_slopes(
+            alibi_slopes, self._alibi_slopes_buf
+        )
         self._seq_lens_kv = seq_lens
         self._seq_lens_q = seq_lens_q if seq_lens_q is not None else seq_lens
 
@@ -3228,8 +3280,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
                     {
                         "maybe_custom_mask": self._custom_mask_buf,
                         "maybe_mask_indptr": self._mask_indptr_buf,
-                        "maybe_alibi_slopes": lambda: _get_cache_alibi_slopes_buf(
-                            q.shape[1], q.device
+                        "maybe_alibi_slopes": lambda: _resolve_alibi_slopes(
+                            self._alibi_slopes, q.shape[1], q.device
                         ),
                         "maybe_prefix_len_ptr": self._prefix_len_ptr,
                         "maybe_token_pos_in_items_ptr": self._token_pos_in_items_ptr,
@@ -3287,7 +3339,7 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 run_args += [
                     self._custom_mask_buf,
                     self._mask_indptr_buf,
-                    _get_cache_alibi_slopes_buf(q.shape[1], q.device),
+                    _resolve_alibi_slopes(self._alibi_slopes, q.shape[1], q.device),
                     self._prefix_len_ptr,
                     self._token_pos_in_items_ptr,
                     self._max_item_len_ptr,
@@ -3650,6 +3702,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._mask_indptr_buf = mask_indptr_buf
         self._max_total_num_rows: Optional[int] = None
         self._backend = backend
+        self._alibi_slopes: Optional[torch.Tensor] = None
+        self._alibi_slopes_buf: Optional[torch.Tensor] = None
         self._cached_module = None
 
     @property
@@ -3715,6 +3769,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         max_sequence_kv: Optional[int] = None,
         v_indptr: Optional[torch.Tensor] = None,
         o_indptr: Optional[torch.Tensor] = None,
+        alibi_slopes: Optional[torch.Tensor] = None,
     ) -> None:
         r"""Plan batch prefill/append attention on Ragged KV-Cache for given problem specification.
 
@@ -3782,6 +3837,19 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             ``1.0``.
         rope_theta : Optional[float]
             The theta used in RoPE, if not provided, will be set to ``1e4``.
+        alibi_slopes : Optional[torch.Tensor]
+            Caller-supplied ALiBi slopes, one ``float32`` value per query head,
+            shape: ``[num_qo_heads]``, contiguous, on the wrapper's device. Only
+            valid with ``pos_encoding_mode="ALIBI"`` and only supported by the
+            ``fa2`` backend; a custom JIT module receives the tensor as its
+            ``maybe_alibi_slopes`` input regardless of ``pos_encoding_mode`` and
+            must declare it. ``None`` (default) uses the slopes
+            :func:`flashinfer.utils.get_alibi_slopes` computes for
+            ``num_qo_heads`` heads. Under tensor parallelism pass this rank's
+            slice of the slopes computed for the global head count. The values
+            are copied into a wrapper-owned buffer, so the tensor may be freed or
+            reused afterwards and a later :meth:`plan` with new slopes also
+            updates a captured CUDA graph.
         q_data_type : Union[str, torch.dtype]
             The data type of the query tensor, defaults to torch.float16.
         kv_data_type : Optional[Union[str, torch.dtype]]
@@ -3851,6 +3919,17 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             fixed_split_size = -1
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
+        jit_tensor_names = (
+            self._jit_additional_tensor_names if self._jit_module is not None else None
+        )
+        alibi_slopes = _check_alibi_slopes(
+            alibi_slopes,
+            num_qo_heads,
+            self.device,
+            pos_encoding_mode,
+            require_alibi_mode=jit_tensor_names is None,
+        )
+        _check_alibi_slopes_backend(alibi_slopes, self._backend, jit_tensor_names)
 
         batch_size = len(qo_indptr) - 1
         if len(kv_indptr) != batch_size + 1:
@@ -4194,6 +4273,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 ):
                     self._backend = "fmha_v2"
 
+            _check_alibi_slopes_backend(alibi_slopes, self._backend, None)
             get_module_args = (
                 q_data_type,
                 kv_data_type,
@@ -4284,6 +4364,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         self._sm_scale = sm_scale
         self._rope_scale = rope_scale
         self._rope_theta = rope_theta
+        self._alibi_slopes, self._alibi_slopes_buf = _stage_alibi_slopes(
+            alibi_slopes, self._alibi_slopes_buf
+        )
 
     begin_forward = plan
 
@@ -4783,8 +4866,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                     {
                         "maybe_custom_mask": self._custom_mask_buf,
                         "maybe_mask_indptr": self._mask_indptr_buf,
-                        "maybe_alibi_slopes": lambda: _get_cache_alibi_slopes_buf(
-                            q.shape[1], self.device
+                        "maybe_alibi_slopes": lambda: _resolve_alibi_slopes(
+                            self._alibi_slopes, q.shape[1], self.device
                         ),
                     },
                     args,
@@ -4794,7 +4877,7 @@ class BatchPrefillWithRaggedKVCacheWrapper:
             run_args += [
                 self._custom_mask_buf,
                 self._mask_indptr_buf,
-                _get_cache_alibi_slopes_buf(q.shape[1], self.device),
+                _resolve_alibi_slopes(self._alibi_slopes, q.shape[1], self.device),
                 self._prefix_len_ptr,
                 self._token_pos_in_items_ptr,
                 self._max_item_len_ptr,

--- a/flashinfer/trace/templates/attention.py
+++ b/flashinfer/trace/templates/attention.py
@@ -314,6 +314,7 @@ gqa_paged_decode_plan_trace = _BatchDecodePlanTraceTemplate(
         "fixed_split_size": Scalar("int32", optional=True),
         "disable_split_kv": Scalar("bool", optional=True),
         "seq_lens": Tensor(["batch_size"], dtype="int32", optional=True),
+        "alibi_slopes": Tensor(["num_qo_heads"], dtype="float32", optional=True),
         "block_tables": Tensor(
             ["batch_size", "max_num_blocks_per_seq"],
             dtype="int32",

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -274,6 +274,104 @@ def _get_cache_alibi_slopes_buf(
     return buf
 
 
+def _check_alibi_slopes(
+    alibi_slopes: Optional[torch.Tensor],
+    num_qo_heads: int,
+    device: torch.device,
+    pos_encoding_mode: str,
+    *,
+    require_alibi_mode: bool = True,
+) -> Optional[torch.Tensor]:
+    r"""Validate caller-supplied ALiBi slopes and return them unchanged.
+
+    ``alibi_slopes`` must hold one ``float32`` slope per local query head
+    (shape ``[num_qo_heads]``), be contiguous and live on ``device``. Unless
+    ``require_alibi_mode`` is false (a custom JIT module decides itself how the
+    tensor is used) it also requires ``pos_encoding_mode="ALIBI"``. ``None``
+    means the built-in slopes of :func:`get_alibi_slopes` are used.
+    """
+    if alibi_slopes is None:
+        return None
+    if not isinstance(alibi_slopes, torch.Tensor):
+        raise TypeError(
+            f"alibi_slopes must be a torch.Tensor, got {type(alibi_slopes).__name__}"
+        )
+    if require_alibi_mode and pos_encoding_mode != "ALIBI":
+        raise ValueError(
+            'alibi_slopes requires pos_encoding_mode="ALIBI", got '
+            f"pos_encoding_mode={pos_encoding_mode!r}"
+        )
+    check_shape_dtype_device(
+        alibi_slopes, (num_qo_heads,), torch.float32, device, "alibi_slopes"
+    )
+    if not alibi_slopes.is_contiguous():
+        raise ValueError("alibi_slopes must be contiguous")
+    return alibi_slopes
+
+
+def _check_alibi_slopes_backend(
+    alibi_slopes: Optional[torch.Tensor],
+    backend: str,
+    jit_tensor_names: Optional[Sequence[str]],
+) -> None:
+    r"""Reject caller-supplied ALiBi slopes where no kernel would read them.
+
+    A custom JIT module (``jit_tensor_names`` is its additional tensor list)
+    reads the tensor only if it declares ``maybe_alibi_slopes``. Otherwise only
+    the ``fa2`` kernels do; ``"auto"`` is accepted because it resolves to
+    ``fa2`` for ALiBi.
+    """
+    if alibi_slopes is None:
+        return
+    if jit_tensor_names is not None:
+        if "maybe_alibi_slopes" in jit_tensor_names:
+            return
+        raise NotImplementedError(
+            "alibi_slopes was passed but the JIT module does not declare the "
+            "maybe_alibi_slopes additional tensor"
+        )
+    if backend in ("auto", "fa2"):
+        return
+    raise NotImplementedError(
+        f"alibi_slopes is only supported by the fa2 backend, got backend={backend!r}"
+    )
+
+
+def _resolve_alibi_slopes(
+    alibi_slopes: Optional[torch.Tensor], num_qo_heads: int, device: torch.device
+) -> torch.Tensor:
+    r"""Slopes handed to a kernel: the caller's tensor, else the cached built-in ones."""
+    if alibi_slopes is None:
+        return _get_cache_alibi_slopes_buf(num_qo_heads, device)
+    if alibi_slopes.numel() != num_qo_heads:
+        raise ValueError(
+            f"alibi_slopes has {alibi_slopes.numel()} entries but q has "
+            f"{num_qo_heads} heads"
+        )
+    return alibi_slopes
+
+
+def _stage_alibi_slopes(
+    alibi_slopes: Optional[torch.Tensor], buf: Optional[torch.Tensor]
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor]]:
+    r"""Copy validated slopes into a wrapper-owned buffer with a stable address.
+
+    Returns ``(active, buf)``: ``active`` is ``buf`` holding the new values, or
+    ``None`` when no slopes were passed. Reusing ``buf`` keeps the pointer that
+    a captured CUDA graph reads valid across ``plan()`` calls.
+    """
+    if alibi_slopes is None:
+        return None, buf
+    if (
+        buf is None
+        or buf.shape != alibi_slopes.shape
+        or buf.device != alibi_slopes.device
+    ):
+        buf = torch.empty_like(alibi_slopes)
+    buf.copy_(alibi_slopes)
+    return buf, buf
+
+
 def canonicalize_torch_dtype(dtype: Union[torch.dtype, str]) -> torch.dtype:
     if isinstance(dtype, str):
         return getattr(torch, dtype)

--- a/tests/attention/test_alibi.py
+++ b/tests/attention/test_alibi.py
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+import itertools
+
 import pytest
 import torch
 from tests.test_helpers.alibi_reference import alibi_attention
@@ -23,7 +25,7 @@ from tests.test_helpers.jit_utils import (
 )
 
 import flashinfer
-from flashinfer.utils import has_flashinfer_jit_cache
+from flashinfer.utils import get_alibi_slopes, has_flashinfer_jit_cache
 
 
 @pytest.fixture(
@@ -100,6 +102,604 @@ def test_single_prefill_alibi(
     torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)
 
 
+def _tp_slopes(num_global_heads: int, tp_size: int, rank: int) -> torch.Tensor:
+    """This rank's slice of the slopes computed for the global head count."""
+    slopes = get_alibi_slopes(num_global_heads, device="cuda:0")
+    num_local_heads = num_global_heads // tp_size
+    return slopes[rank * num_local_heads : (rank + 1) * num_local_heads]
+
+
+def _causal_mask(q_len: int, kv_len: int) -> torch.Tensor:
+    mask = torch.ones(q_len, kv_len, dtype=torch.bool, device="cuda:0")
+    return torch.tril(mask, diagonal=kv_len - q_len)
+
+
+def _build_paged_kv(kv_lens, num_heads, head_dim, page_size):
+    """Random paged K/V for ``kv_lens`` plus the dense per-request views."""
+    num_pages = [(kv_len + page_size - 1) // page_size for kv_len in kv_lens]
+    total_pages = sum(num_pages)
+    k_cache = torch.randn(
+        total_pages,
+        page_size,
+        num_heads,
+        head_dim,
+        device="cuda:0",
+        dtype=torch.float16,
+    )
+    v_cache = torch.randn_like(k_cache)
+    indptr = [0] + list(itertools.accumulate(num_pages))
+    kv_indptr = torch.tensor(indptr, dtype=torch.int32, device="cuda:0")
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor(
+        [(kv_len - 1) % page_size + 1 for kv_len in kv_lens],
+        dtype=torch.int32,
+        device="cuda:0",
+    )
+    dense_k, dense_v = [], []
+    for i, kv_len in enumerate(kv_lens):
+        pages = slice(indptr[i], indptr[i + 1])
+        dense_k.append(k_cache[pages].reshape(-1, num_heads, head_dim)[:kv_len])
+        dense_v.append(v_cache[pages].reshape(-1, num_heads, head_dim)[:kv_len])
+    return k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, dense_k, dense_v
+
+
+@pytest.mark.parametrize("num_global_heads", [8, 12, 32])
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("head_dim", [128, 256])
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_single_decode_alibi_slopes_tp(
+    num_global_heads, tp_size, head_dim, use_tensor_cores
+):
+    kv_len = 81
+    num_local_heads = num_global_heads // tp_size
+    for rank in range(tp_size):
+        slopes = _tp_slopes(num_global_heads, tp_size, rank)
+        q = torch.randn(num_local_heads, head_dim, device="cuda:0", dtype=torch.float16)
+        k = torch.randn(
+            kv_len, num_local_heads, head_dim, device="cuda:0", dtype=torch.float16
+        )
+        v = torch.randn_like(k)
+        o = flashinfer.single_decode_with_kv_cache(
+            q,
+            k,
+            v,
+            pos_encoding_mode="ALIBI",
+            use_tensor_cores=use_tensor_cores,
+            alibi_slopes=slopes,
+        )
+        mask = torch.ones(1, kv_len, dtype=torch.bool, device="cuda:0")
+        o_ref = alibi_attention(q.unsqueeze(0), k, v, mask, slopes=slopes).squeeze(0)
+        torch.testing.assert_close(o, o_ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("q_len,kv_len", [(17, 81), (128, 128), (81, 17)])
+@pytest.mark.parametrize("num_global_heads", [8, 12, 32])
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("causal", [False, True])
+def test_single_prefill_alibi_slopes_tp(
+    q_len, kv_len, num_global_heads, tp_size, causal
+):
+    if causal and q_len > kv_len:
+        pytest.skip("Causal attention requires q_len <= kv_len")
+    head_dim = 128
+    num_local_heads = num_global_heads // tp_size
+    for rank in range(tp_size):
+        slopes = _tp_slopes(num_global_heads, tp_size, rank)
+        q = torch.randn(
+            q_len, num_local_heads, head_dim, device="cuda:0", dtype=torch.float16
+        )
+        k = torch.randn(
+            kv_len, num_local_heads, head_dim, device="cuda:0", dtype=torch.float16
+        )
+        v = torch.randn_like(k)
+        o = flashinfer.single_prefill_with_kv_cache(
+            q, k, v, causal=causal, pos_encoding_mode="ALIBI", alibi_slopes=slopes
+        )
+        mask = (
+            _causal_mask(q_len, kv_len)
+            if causal
+            else torch.ones(q_len, kv_len, dtype=torch.bool, device="cuda:0")
+        )
+        o_ref = alibi_attention(q, k, v, mask, slopes=slopes)
+        torch.testing.assert_close(o, o_ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("num_global_heads", [8, 12, 32])
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_batch_decode_alibi_slopes_tp(num_global_heads, tp_size, use_tensor_cores):
+    head_dim, page_size = 128, 16
+    kv_lens = [37, 5, 64]
+    num_local_heads = num_global_heads // tp_size
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    for rank in range(tp_size):
+        slopes = _tp_slopes(num_global_heads, tp_size, rank)
+        k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, dense_k, dense_v = (
+            _build_paged_kv(kv_lens, num_local_heads, head_dim, page_size)
+        )
+        q = torch.randn(
+            len(kv_lens),
+            num_local_heads,
+            head_dim,
+            device="cuda:0",
+            dtype=torch.float16,
+        )
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace, "NHD", use_tensor_cores=use_tensor_cores
+        )
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_local_heads,
+            num_local_heads,
+            head_dim,
+            page_size,
+            pos_encoding_mode="ALIBI",
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+        o = wrapper.run(q, (k_cache, v_cache))
+        for i, kv_len in enumerate(kv_lens):
+            mask = torch.ones(1, kv_len, dtype=torch.bool, device="cuda:0")
+            o_ref = alibi_attention(
+                q[i : i + 1], dense_k[i], dense_v[i], mask, slopes=slopes
+            )
+            torch.testing.assert_close(o[i : i + 1], o_ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("num_global_heads", [8, 12, 32])
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("page_size", [1, 16])
+@pytest.mark.parametrize("causal", [False, True])
+def test_batch_prefill_paged_alibi_slopes_tp(
+    num_global_heads, tp_size, page_size, causal
+):
+    head_dim = 128
+    qo_lens = [17, 1, 33]
+    kv_lens = [37, 5, 64]
+    num_local_heads = num_global_heads // tp_size
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(qo_lens)), dtype=torch.int32, device="cuda:0"
+    )
+    for rank in range(tp_size):
+        slopes = _tp_slopes(num_global_heads, tp_size, rank)
+        k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, dense_k, dense_v = (
+            _build_paged_kv(kv_lens, num_local_heads, head_dim, page_size)
+        )
+        q = torch.randn(
+            sum(qo_lens),
+            num_local_heads,
+            head_dim,
+            device="cuda:0",
+            dtype=torch.float16,
+        )
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, "NHD")
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_local_heads,
+            num_local_heads,
+            head_dim,
+            page_size,
+            causal=causal,
+            pos_encoding_mode="ALIBI",
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+        o = wrapper.run(q, (k_cache, v_cache))
+        for i, (q_len, kv_len) in enumerate(zip(qo_lens, kv_lens, strict=True)):
+            rows = slice(int(qo_indptr[i]), int(qo_indptr[i + 1]))
+            mask = (
+                _causal_mask(q_len, kv_len)
+                if causal
+                else torch.ones(q_len, kv_len, dtype=torch.bool, device="cuda:0")
+            )
+            o_ref = alibi_attention(
+                q[rows], dense_k[i], dense_v[i], mask, slopes=slopes
+            )
+            torch.testing.assert_close(o[rows], o_ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("num_global_heads", [8, 12, 32])
+@pytest.mark.parametrize("tp_size", [2, 4])
+@pytest.mark.parametrize("causal", [False, True])
+def test_batch_prefill_ragged_alibi_slopes_tp(num_global_heads, tp_size, causal):
+    head_dim = 128
+    qo_lens = [17, 1, 33]
+    kv_lens = [37, 5, 64]
+    num_local_heads = num_global_heads // tp_size
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(qo_lens)), dtype=torch.int32, device="cuda:0"
+    )
+    kv_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(kv_lens)), dtype=torch.int32, device="cuda:0"
+    )
+    for rank in range(tp_size):
+        slopes = _tp_slopes(num_global_heads, tp_size, rank)
+        q = torch.randn(
+            sum(qo_lens),
+            num_local_heads,
+            head_dim,
+            device="cuda:0",
+            dtype=torch.float16,
+        )
+        k = torch.randn(
+            sum(kv_lens),
+            num_local_heads,
+            head_dim,
+            device="cuda:0",
+            dtype=torch.float16,
+        )
+        v = torch.randn_like(k)
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace, "NHD")
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            num_local_heads,
+            num_local_heads,
+            head_dim,
+            causal=causal,
+            pos_encoding_mode="ALIBI",
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+        o = wrapper.run(q, k, v)
+        for i, (q_len, kv_len) in enumerate(zip(qo_lens, kv_lens, strict=True)):
+            rows = slice(int(qo_indptr[i]), int(qo_indptr[i + 1]))
+            kv_rows = slice(int(kv_indptr[i]), int(kv_indptr[i + 1]))
+            mask = (
+                _causal_mask(q_len, kv_len)
+                if causal
+                else torch.ones(q_len, kv_len, dtype=torch.bool, device="cuda:0")
+            )
+            o_ref = alibi_attention(
+                q[rows], k[kv_rows], v[kv_rows], mask, slopes=slopes
+            )
+            torch.testing.assert_close(o[rows], o_ref, rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("num_heads", [8, 12])
+def test_alibi_slopes_explicit_default_matches_builtin(num_heads):
+    head_dim, q_len, kv_len = 128, 33, 81
+    slopes = get_alibi_slopes(num_heads, device="cuda:0")
+    q = torch.randn(q_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    k = torch.randn(kv_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    v = torch.randn_like(k)
+    o_default = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, causal=True, pos_encoding_mode="ALIBI"
+    )
+    o_explicit = flashinfer.single_prefill_with_kv_cache(
+        q, k, v, causal=True, pos_encoding_mode="ALIBI", alibi_slopes=slopes
+    )
+    assert torch.equal(o_default, o_explicit)
+
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor([0, q_len], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda:0")
+    outputs = []
+    for explicit in (None, slopes):
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace, "NHD")
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            num_heads,
+            num_heads,
+            head_dim,
+            causal=True,
+            pos_encoding_mode="ALIBI",
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=explicit,
+        )
+        outputs.append(wrapper.run(q, k, v))
+    assert torch.equal(outputs[0], outputs[1])
+
+
+def _alibi_entry_points(num_heads):
+    """Callables ``f(pos_encoding_mode, alibi_slopes)`` for every public entry point."""
+    head_dim, q_len, kv_len, page_size = 128, 17, 37, 16
+    q_decode = torch.randn(num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    q_prefill = torch.randn(
+        q_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k = torch.randn(kv_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    v = torch.randn_like(k)
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    k_cache, v_cache, kv_indptr, kv_indices, kv_last_page_len, _, _ = _build_paged_kv(
+        [kv_len], num_heads, head_dim, page_size
+    )
+    qo_indptr = torch.tensor([0, q_len], dtype=torch.int32, device="cuda:0")
+    ragged_kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda:0")
+
+    def single_decode(mode, slopes):
+        return flashinfer.single_decode_with_kv_cache(
+            q_decode, k, v, pos_encoding_mode=mode, alibi_slopes=slopes
+        )
+
+    def single_prefill(mode, slopes):
+        return flashinfer.single_prefill_with_kv_cache(
+            q_prefill, k, v, pos_encoding_mode=mode, alibi_slopes=slopes
+        )
+
+    def batch_decode(mode, slopes):
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(workspace, "NHD")
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_heads,
+            num_heads,
+            head_dim,
+            page_size,
+            pos_encoding_mode=mode,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+
+    def batch_prefill_paged(mode, slopes):
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(workspace, "NHD")
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            kv_indices,
+            kv_last_page_len,
+            num_heads,
+            num_heads,
+            head_dim,
+            page_size,
+            pos_encoding_mode=mode,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+
+    def batch_prefill_ragged(mode, slopes):
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace, "NHD")
+        wrapper.plan(
+            qo_indptr,
+            ragged_kv_indptr,
+            num_heads,
+            num_heads,
+            head_dim,
+            pos_encoding_mode=mode,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+
+    return {
+        "single_decode": single_decode,
+        "single_prefill": single_prefill,
+        "batch_decode": batch_decode,
+        "batch_prefill_paged": batch_prefill_paged,
+        "batch_prefill_ragged": batch_prefill_ragged,
+    }
+
+
+def _bad_slopes(num_heads):
+    good = get_alibi_slopes(num_heads, device="cuda:0")
+    return {
+        "wrong_length": (good[:-1], "Invalid shape of alibi_slopes"),
+        "wrong_dtype": (good.half(), "Invalid dtype of alibi_slopes"),
+        "wrong_device": (good.cpu(), "Invalid device of alibi_slopes"),
+        "non_contiguous": (good.repeat_interleave(2)[::2], "must be contiguous"),
+        "not_a_tensor": (good.tolist(), "must be a torch.Tensor"),
+    }
+
+
+@pytest.mark.parametrize(
+    "entry_point",
+    [
+        "single_decode",
+        "single_prefill",
+        "batch_decode",
+        "batch_prefill_paged",
+        "batch_prefill_ragged",
+    ],
+)
+@pytest.mark.parametrize(
+    "case",
+    [
+        "wrong_length",
+        "wrong_dtype",
+        "wrong_device",
+        "non_contiguous",
+        "not_a_tensor",
+        "mode_none",
+    ],
+)
+def test_alibi_slopes_validation(entry_point, case):
+    num_heads = 8
+    call = _alibi_entry_points(num_heads)[entry_point]
+    expected = ValueError
+    if case == "mode_none":
+        slopes = get_alibi_slopes(num_heads, device="cuda:0")
+        mode, match = "NONE", 'requires pos_encoding_mode="ALIBI"'
+    else:
+        slopes, match = _bad_slopes(num_heads)[case]
+        mode = "ALIBI"
+        if case == "not_a_tensor":
+            expected = TypeError
+    with pytest.raises(expected, match=match):
+        call(mode, slopes)
+
+
+@pytest.mark.parametrize(
+    "entry_point",
+    ["single_prefill", "batch_decode", "batch_prefill_paged", "batch_prefill_ragged"],
+)
+def test_alibi_slopes_rejected_on_non_fa2_backend(entry_point):
+    """The rejection happens before any JIT lookup, so it needs no fa3-capable GPU."""
+    num_heads, head_dim, q_len, kv_len, page_size = 8, 128, 17, 37, 16
+    slopes = get_alibi_slopes(num_heads, device="cuda:0")
+    q = torch.randn(q_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    k = torch.randn(kv_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    v = torch.randn_like(k)
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor([0, q_len], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda:0")
+    kv_indices = torch.arange(3, dtype=torch.int32, device="cuda:0")
+    kv_last_page_len = torch.tensor([5], dtype=torch.int32, device="cuda:0")
+    paged_kv_indptr = torch.tensor([0, 3], dtype=torch.int32, device="cuda:0")
+    common = dict(
+        pos_encoding_mode="ALIBI",
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+        alibi_slopes=slopes,
+    )
+    if entry_point == "single_prefill":
+
+        def call():
+            flashinfer.single_prefill_with_kv_cache(
+                q, k, v, pos_encoding_mode="ALIBI", backend="fa3", alibi_slopes=slopes
+            )
+
+    elif entry_point == "batch_decode":
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            workspace, "NHD", backend="fa3"
+        )
+
+        def call():
+            wrapper.plan(
+                paged_kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_heads,
+                num_heads,
+                head_dim,
+                page_size,
+                **common,
+            )
+
+    elif entry_point == "batch_prefill_paged":
+        wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            workspace, "NHD", backend="fa3"
+        )
+
+        def call():
+            wrapper.plan(
+                qo_indptr,
+                paged_kv_indptr,
+                kv_indices,
+                kv_last_page_len,
+                num_heads,
+                num_heads,
+                head_dim,
+                page_size,
+                **common,
+            )
+
+    else:
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            workspace, "NHD", backend="fa3"
+        )
+
+        def call():
+            wrapper.plan(qo_indptr, kv_indptr, num_heads, num_heads, head_dim, **common)
+
+    with pytest.raises(NotImplementedError, match="only supported by the fa2 backend"):
+        call()
+
+
+def test_alibi_slopes_run_rejects_head_count_mismatch():
+    num_heads, head_dim, q_len, kv_len = 8, 128, 17, 37
+    workspace = torch.empty(32 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor([0, q_len], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(workspace, "NHD")
+    wrapper.plan(
+        qo_indptr,
+        kv_indptr,
+        num_heads,
+        num_heads,
+        head_dim,
+        pos_encoding_mode="ALIBI",
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+        alibi_slopes=get_alibi_slopes(num_heads, device="cuda:0"),
+    )
+    q = torch.randn(
+        q_len, 2 * num_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k = torch.randn(
+        kv_len, 2 * num_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    v = torch.randn_like(k)
+    with pytest.raises(ValueError, match="entries but q has"):
+        wrapper.run(q, k, v)
+
+
+def test_alibi_slopes_cuda_graph_replan():
+    """A captured graph must follow the slopes of a later plan(): the wrapper
+    copies them into a buffer whose address the graph keeps reading."""
+    num_heads, head_dim, q_len, kv_len = 8, 128, 33, 81
+    workspace = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0")
+    qo_indptr = torch.tensor([0, q_len], dtype=torch.int32, device="cuda:0")
+    kv_indptr = torch.tensor([0, kv_len], dtype=torch.int32, device="cuda:0")
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        workspace,
+        "NHD",
+        use_cuda_graph=True,
+        qo_indptr_buf=qo_indptr.clone(),
+        kv_indptr_buf=kv_indptr.clone(),
+    )
+    q = torch.randn(q_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    k = torch.randn(kv_len, num_heads, head_dim, device="cuda:0", dtype=torch.float16)
+    v = torch.randn_like(k)
+    out = torch.empty_like(q)
+    mask = _causal_mask(q_len, kv_len)
+
+    def plan(slopes):
+        wrapper.plan(
+            qo_indptr,
+            kv_indptr,
+            num_heads,
+            num_heads,
+            head_dim,
+            causal=True,
+            pos_encoding_mode="ALIBI",
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=slopes,
+        )
+
+    global_slopes = get_alibi_slopes(32, device="cuda:0")
+    plan(global_slopes[8:16].clone())
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        for _ in range(2):
+            wrapper.run(q, k, v, out=out)
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        wrapper.run(q, k, v, out=out)
+    graph.replay()
+    torch.cuda.synchronize()
+    o_ref = alibi_attention(q, k, v, mask, slopes=global_slopes[8:16])
+    torch.testing.assert_close(out, o_ref, rtol=1e-2, atol=1e-2)
+
+    # Replan from a temporary tensor without recapturing; the temporary is
+    # freed before the replay.
+    plan(global_slopes[24:32].clone())
+    junk = torch.full((num_heads,), 1000.0, device="cuda:0")
+    graph.replay()
+    torch.cuda.synchronize()
+    del junk
+    o_ref = alibi_attention(q, k, v, mask, slopes=global_slopes[24:32])
+    torch.testing.assert_close(out, o_ref, rtol=1e-2, atol=1e-2)
+
+
 if __name__ == "__main__":
     test_single_decode_alibi(4096, 32, 128)
     test_single_prefill_alibi(128, 128, 8, 128, False)
+    test_batch_prefill_paged_alibi_slopes_tp(12, 4, 16, True)

--- a/tests/test_helpers/alibi_reference.py
+++ b/tests/test_helpers/alibi_reference.py
@@ -59,18 +59,24 @@ def get_slopes(n_heads: int):
 
 
 @torch.no_grad()
-def get_alibi_biases(n_heads: int, mask: torch.Tensor):
+def get_alibi_biases(
+    n_heads: int, mask: torch.Tensor, slopes: Optional[torch.Tensor] = None
+):
     """
     ## Calculate the attention biases matrix
 
     * `n_heads` is the number of heads in the attention layer
     * `mask` is the attention mask of shape `[seq_len_q, seq_len_k]`
+    * `slopes` optionally overrides the per-head slopes, shape `[n_heads]`
 
     This returns a matrix of shape `[seq_len_q, seq_len_k, n_heads, ]` with ALiBi attention biases.
     """
 
     # Get slopes $m$ for each head
-    m = get_slopes(n_heads).to(mask.device)
+    if slopes is None:
+        m = get_slopes(n_heads).to(mask.device)
+    else:
+        m = slopes.to(device=mask.device, dtype=torch.float32)
 
     # Calculate distances $[0, 1, \dots, N]$
     # Here we calculate the distances using the mask.
@@ -89,12 +95,14 @@ def alibi_attention(
     key: torch.Tensor,
     value: torch.Tensor,
     mask: Optional[torch.Tensor] = None,
+    slopes: Optional[torch.Tensor] = None,
 ):
     """
     query: [q_len, num_heads, head_dim]
     key: [kv_len, num_heads, head_dim]
     value: [kv_len, num_heads, head_dim]
     mask: [q_len, kv_len]
+    slopes: optional per-head slopes, [num_heads]; defaults to the standard ALiBi slopes
     """
     q_len, num_heads, head_dim = query.shape
 
@@ -103,7 +111,7 @@ def alibi_attention(
     scores *= 1.0 / math.sqrt(head_dim)
 
     # Create AliBi biases if it's not cached
-    alibi_biases = get_alibi_biases(num_heads, mask)
+    alibi_biases = get_alibi_biases(num_heads, mask, slopes)
 
     # Add AliBi biases to attention scores.
     # ALiBi biases has shape `[seq_len, seq_len, n_heads]`

--- a/tests/utils/test_jit_example.py
+++ b/tests/utils/test_jit_example.py
@@ -11,7 +11,14 @@ from flashinfer.jit.attention import (
     gen_customize_single_prefill_module,
 )
 from flashinfer.prefill import single_prefill_with_kv_cache_with_jit_module
-from flashinfer.utils import MaskMode, get_compute_capability, is_sm90a_supported
+from tests.test_helpers.alibi_reference import alibi_attention
+
+from flashinfer.utils import (
+    MaskMode,
+    get_alibi_slopes,
+    get_compute_capability,
+    is_sm90a_supported,
+)
 
 
 def test_single_decode_mask():
@@ -989,14 +996,7 @@ struct FlashCustomMask : AttentionVariantBase {
     )
 
 
-@pytest.mark.parametrize("use_tensor_cores", [False, True])
-def test_batch_decode_jit_wellknown_alibi_buffer(use_tensor_cores):
-    """Issue #1044 (decode): JIT variants using well-known additional tensor name
-    (maybe_alibi_slopes) should auto-inject the internal buffer without the user
-    having to pass it via *args."""
-    torch.manual_seed(42)
-
-    variant_decl = r"""
+flash_alibi_decode_decl = r"""
 struct FlashAlibiDecode : AttentionVariantBase {
   static constexpr bool use_softmax = true;
 
@@ -1021,14 +1021,10 @@ struct FlashAlibiDecode : AttentionVariantBase {
   });
 };
 """
-    num_qo_heads = 32
-    num_kv_heads = 32
-    head_dim = 128
-    batch_size = 4
-    seq_len = 128
-    page_size = 1
 
-    jit_args = (
+
+def flash_alibi_decode_jit_args(use_tensor_cores, head_dim=128):
+    return (
         f"batch_decode_alibi_wellknown_{use_tensor_cores}",
         torch.float16,
         torch.float16,
@@ -1041,8 +1037,25 @@ struct FlashAlibiDecode : AttentionVariantBase {
         ["sm_scale"],
         ["double"],
         "FlashAlibiDecode",
-        variant_decl,
+        flash_alibi_decode_decl,
     )
+
+
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_batch_decode_jit_wellknown_alibi_buffer(use_tensor_cores):
+    """Issue #1044 (decode): JIT variants using well-known additional tensor name
+    (maybe_alibi_slopes) should auto-inject the internal buffer without the user
+    having to pass it via *args."""
+    torch.manual_seed(42)
+
+    num_qo_heads = 32
+    num_kv_heads = 32
+    head_dim = 128
+    batch_size = 4
+    seq_len = 128
+    page_size = 1
+
+    jit_args = flash_alibi_decode_jit_args(use_tensor_cores, head_dim)
 
     workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
     wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
@@ -1082,6 +1095,105 @@ struct FlashAlibiDecode : AttentionVariantBase {
     sm_scale = 1.0 / math.sqrt(head_dim)
     o = wrapper.run(q, (k_cache, v_cache), sm_scale)
     assert o.shape == (batch_size, num_qo_heads, head_dim)
+
+
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_batch_decode_jit_custom_alibi_slopes(use_tensor_cores):
+    """A JIT module that declares maybe_alibi_slopes receives the caller's
+    alibi_slopes instead of the auto-injected built-in buffer."""
+    torch.manual_seed(42)
+    num_heads, head_dim, batch_size, seq_len = 32, 128, 4, 128
+
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout="NHD",
+        use_tensor_cores=use_tensor_cores,
+        jit_args=flash_alibi_decode_jit_args(use_tensor_cores, head_dim),
+        backend="fa2",
+    )
+    kv_indptr = torch.arange(0, batch_size * seq_len + 1, seq_len, dtype=torch.int32)
+    kv_indices = torch.arange(0, batch_size * seq_len, dtype=torch.int32)
+    last_page_len = torch.full((batch_size,), 1, dtype=torch.int32)
+    # This rank's slice of a 64-head model's slopes, which differs from the
+    # built-in slopes for 32 heads. No pos_encoding_mode: the variant decides
+    # how the tensor is used.
+    slopes = get_alibi_slopes(2 * num_heads, device="cuda")[num_heads:]
+    wrapper.plan(
+        kv_indptr,
+        kv_indices,
+        last_page_len,
+        num_heads,
+        num_heads,
+        head_dim,
+        1,
+        q_data_type=torch.float16,
+        kv_data_type=torch.float16,
+        alibi_slopes=slopes,
+    )
+    q = torch.randn(batch_size, num_heads, head_dim, dtype=torch.float16, device="cuda")
+    k_cache = torch.randn(
+        batch_size * seq_len, num_heads, head_dim, dtype=torch.float16, device="cuda"
+    )
+    v_cache = torch.randn_like(k_cache)
+    sm_scale = 1.0 / math.sqrt(head_dim)
+    o = wrapper.run(q, (k_cache, v_cache), sm_scale)
+    # The variant adds the bias before the softmax scale, so the reference
+    # (which scales the scores by 1/sqrt(head_dim) but not the bias) needs the
+    # scaled slopes.
+    mask = torch.ones(1, seq_len, dtype=torch.bool, device="cuda")
+    for i in range(batch_size):
+        rows = slice(i * seq_len, (i + 1) * seq_len)
+        o_ref = alibi_attention(
+            q[i : i + 1], k_cache[rows], v_cache[rows], mask, slopes=slopes * sm_scale
+        )
+        torch.testing.assert_close(o[i : i + 1], o_ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_batch_decode_jit_rejects_alibi_slopes_without_tensor(use_tensor_cores):
+    """A JIT module that does not declare maybe_alibi_slopes cannot honor
+    alibi_slopes, so plan() must reject them instead of dropping them."""
+    jit_args = (
+        f"batch_decode_flash_sigmoid_sm80_{use_tensor_cores}",  # uri
+        torch.float16,  # dtype_q
+        torch.float16,  # dtype_kv
+        torch.float16,  # dtype_o
+        torch.int32,  # idtype
+        128,  # hidden_dim_qk
+        128,  # hidden_dim_vo
+        [],  # additional_tensor_names
+        [],  # additional_tensor_dtypes
+        ["logits_scale", "sigmoid_bias"],  # additional_scalar_names
+        ["double", "double"],  # additional_scalar_dtypes
+        "FlashSigmoid",
+        flash_sigmoid_sm80_decl,
+    )
+    workspace_buffer = torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device="cuda")
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        workspace_buffer,
+        kv_layout="NHD",
+        use_tensor_cores=use_tensor_cores,
+        jit_args=jit_args,
+        backend="fa2",
+    )
+    batch_size, seq_len, num_heads = 4, 128, 32
+    kv_indptr = torch.arange(0, batch_size * seq_len + 1, seq_len, dtype=torch.int32)
+    kv_indices = torch.arange(0, batch_size * seq_len, dtype=torch.int32)
+    last_page_len = torch.full((batch_size,), 1, dtype=torch.int32)
+    with pytest.raises(NotImplementedError, match="does not declare"):
+        wrapper.plan(
+            kv_indptr,
+            kv_indices,
+            last_page_len,
+            num_heads,
+            num_heads,
+            128,
+            1,
+            q_data_type=torch.float16,
+            kv_data_type=torch.float16,
+            alibi_slopes=get_alibi_slopes(num_heads, device="cuda"),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

FlashInfer applies ALiBi with slopes it computes from the local head count (`get_alibi_slopes(num_qo_heads)`), indexing heads from 0. Under tensor parallelism each rank owns a slice of the global heads, so every rank but the first uses the wrong slopes (#1606). The FA2 kernels already take a per-head `maybe_alibi_slopes` pointer (`include/flashinfer/attention/variants.cuh`); only the Python layer hid it.

This PR adds an optional `alibi_slopes` argument:

- `single_decode_with_kv_cache` and `single_prefill_with_kv_cache` (and its `_return_lse` partial): a keyword argument appended after the existing ones, so positional callers are unaffected.
- `BatchDecodeWithPagedKVCacheWrapper.plan`, `BatchPrefillWithPagedKVCacheWrapper.plan`, `BatchPrefillWithRaggedKVCacheWrapper.plan`: a keyword argument. The values are copied into a wrapper-owned buffer whose address stays fixed across `plan()` calls, so a captured CUDA graph follows a later plan with new slopes and the caller may free or reuse the tensor. The buffer is passed at every `run`, including the custom JIT module path (`prepare_jit_additional_args`).
- Contract: float32, 1-D, contiguous, shape `[num_qo_heads]`, on the query (or wrapper) device, only together with `pos_encoding_mode="ALIBI"`. Frameworks pass `get_alibi_slopes(global_num_heads)[rank * n : (rank + 1) * n]`, the convention of FlashAttention's `alibi_slopes`.
- `_check_alibi_slopes` (`flashinfer/utils.py`) raises `ValueError` (or `TypeError` for a non-tensor) before any JIT lookup or launch. `_check_alibi_slopes_backend` raises `NotImplementedError` where nothing would read the tensor: every backend other than `fa2` (fa3, cudnn, trtllm-gen, cute-dsl, cute-dsl-prims, cutlass, fmha_v2, cutile, prims-ts), both for an explicit backend and after `auto` resolution, and a custom JIT module that does not declare `maybe_alibi_slopes`. A JIT module that declares it receives the tensor in place of the auto-injected built-in buffer, whatever `pos_encoding_mode` says, since its variant decides how the tensor is used.
- `run()` checks the slopes length against the query head count, so a mismatched `q` cannot read past the tensor.
- The default (`None`) is unchanged: the built-in slopes for `num_qo_heads`. No kernel, JIT template or C++ change. The batch decode plan trace template records the new optional input.

## Related Issues

Closes #1606.

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New tests in `tests/attention/test_alibi.py`:

- `test_single_decode_alibi_slopes_tp`, `test_single_prefill_alibi_slopes_tp`, `test_batch_decode_alibi_slopes_tp`, `test_batch_prefill_paged_alibi_slopes_tp`, `test_batch_prefill_ragged_alibi_slopes_tp`: 8, 12 and 32 global heads split over 2 and 4 ranks; each rank's output is checked against a reference computed with that rank's slice (fp16; decode with and without tensor cores; page sizes 1 and 16; causal and not). The built-in slopes for the local head count differ from every rank's slice, so these fail if the tensor is ignored.
- `test_alibi_slopes_explicit_default_matches_builtin`: passing the built-in slopes explicitly reproduces the default output bit for bit (single prefill and the ragged wrapper).
- `test_alibi_slopes_cuda_graph_replan`: a captured ragged-prefill graph is replayed after a `plan()` with different slopes held in a temporary tensor and matches the new reference.
- `test_alibi_slopes_validation`: wrong length, dtype, device, non-contiguous, non-tensor, and slopes with `pos_encoding_mode="NONE"` raise on all five entry points before any launch.
- `test_alibi_slopes_rejected_on_non_fa2_backend`: an explicit `backend="fa3"` raises `NotImplementedError` from the single prefill function and the three wrappers.
- `test_alibi_slopes_run_rejects_head_count_mismatch`: `run()` with more query heads than slopes raises before the launch.
- `tests/test_helpers/alibi_reference.py` takes an optional `slopes` argument; its default is unchanged.

New tests in `tests/utils/test_jit_example.py`:

- `test_batch_decode_jit_custom_alibi_slopes`: a JIT module that declares `maybe_alibi_slopes` computes with the caller's slopes (checked against the reference).
- `test_batch_decode_jit_rejects_alibi_slopes_without_tensor`: a JIT module without that tensor rejects `alibi_slopes` instead of dropping them.

Mutation check: with `_check_alibi_slopes` changed to drop the caller's tensor, the six selected tensor-parallel tests fail; with the change restored they pass.

Runs on an NVIDIA GH200 480GB (SM90), CUDA 12.8, torch 2.7.0+cu128, from an empty JIT cache (the skips in `test_alibi.py` are the causal cases with q_len > kv_len that the file skips by design):

```
pytest tests/attention/test_alibi.py                                                        320 passed, 42 skipped, 21 warnings in 102.87s
pytest tests/utils/test_jit_example.py                                                      18 passed, 21 warnings in 219.29s
pytest tests/attention/test_decode_fp8_calibration_scale.py                                 394 passed, 21 warnings in 141.36s
pytest tests/attention/test_batch_prefill_kernels.py -k ALIBI                               768 passed, 15109 deselected, 21 warnings in 54.58s
pytest tests/trace/test_fi_trace_template_consistency.py tests/trace/test_template_init.py tests/trace/test_template_registry.py   1225 passed, 192 skipped, 22 warnings in 72.19s
pytest tests/attention/test_batch_decode_kernels.py                                         3081 passed, 181 skipped, 21 warnings in 530.19s
```

## Reviewer Notes

- The cute-dsl (Blackwell) path rejects custom slopes instead of threading them into `ALiBiAttention`, which already takes a slopes tensor, because that backend cannot be exercised on the SM90 machine used here; the pass-through is a one-line follow-up.
- Still using the built-in slopes, as follow-ups: the POD wrappers (`flashinfer/pod.py`), the block-sparse wrappers (`flashinfer/sparse.py`) and `MultiLevelCascadeAttentionWrapper` (`flashinfer/cascade.py`, which forwards an explicit `plan()` argument list).
- Pre-existing, not changed here: an explicit `backend="fa3"` with `pos_encoding_mode="ALIBI"` builds an fa3 module whose Hopper variant has no ALiBi term, so the bias is silently not applied (single prefill, fp16, 64 x 64 causal, 8 heads: the fa3 "ALiBi" output equals the fa2 output without ALiBi within 1e-3, while fa2 with ALiBi differs by 2.8). `backend="auto"` already routes ALiBi to fa2, and this PR rejects custom slopes on fa3; adding ALiBi to the Hopper variants is a follow-up.

Made in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for caller-supplied ALiBi slopes across single-request and batched prefill/decode attention APIs.
  * Added support for per-query-head ALiBi slopes in batch decode tracing.
  * Added validation for slope shape, type, device, contiguity, backend compatibility, and head-count matching.
  * Added support for custom ALiBi slopes with CUDA graph replanning and supported JIT modules.

* **Tests**
  * Expanded coverage for custom slopes, tensor-parallel execution, validation errors, backend restrictions, and JIT behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->