### PR TITLE
fix(pod): stop silently ignoring decode-side run() arguments

### DIFF
--- a/benchmarks/bench_mixed_attention.py
+++ b/benchmarks/bench_mixed_attention.py
@@ -208,7 +208,6 @@ def run_bench(
                 q_d,
                 kv_d,
                 causal_p=causal,
-                causal_d=causal,
             )
         )
         ms_pod = np.median(measurements)

--- a/flashinfer/pod.py
+++ b/flashinfer/pod.py
@@ -16,6 +16,7 @@ limitations under the License.
 
 import functools
 import math
+import warnings
 from types import SimpleNamespace
 from typing import Any, List, Optional, Tuple, Union
 
@@ -56,6 +57,41 @@ def get_pod_module(*args):
 def get_batch_pod_module(*args):
     module = gen_batch_pod_module(*args).build_and_load()
     return SimpleNamespace(run_tensor=module.batch_pod_with_kv_cache_tensor)
+
+
+def _check_deprecated_decode_run_args(passed: dict, planned: dict) -> None:
+    """Warn for decode-side settings passed to run() and reject values that
+    differ from plan(); the decode kernel is selected at plan() time, so they
+    can only be validated here."""
+    given = {name: value for name, value in passed.items() if value is not None}
+    if not given:
+        return
+    warnings.warn(
+        f"Passing {sorted(given)} to PODWithPagedKVCacheWrapper.run() is "
+        "deprecated; set the decode-side settings in plan() instead. Scheduled "
+        "for removal in a future release.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    for name, value in given.items():
+        if value != planned[name]:
+            raise ValueError(
+                f"{name}={value!r} differs from the value planned for the decode "
+                f"side ({planned[name]!r}); decode-side settings are fixed by plan()"
+            )
+
+
+def _check_decode_mask_args(
+    custom_mask_d: Optional[torch.Tensor],
+    packed_custom_mask_d: Optional[torch.Tensor],
+    causal_d: bool,
+) -> None:
+    if custom_mask_d is not None or packed_custom_mask_d is not None or causal_d:
+        raise NotImplementedError(
+            "the decode side of PODWithPagedKVCacheWrapper runs non-causal "
+            "attention without a custom mask; custom_mask_d, packed_custom_mask_d "
+            "and causal_d are not supported"
+        )
 
 
 class PODWithPagedKVCacheWrapper:
@@ -320,8 +356,7 @@ class PODWithPagedKVCacheWrapper:
             The data type of both the query and key/value tensors. Defaults to torch.float16.
             data_type is deprecated, please use q_data_type and kv_data_type instead.
         sm_scale : Optional[float]
-            Softmax scale.  If ``None``, defaults to ``1 / sqrt(head_dim)``.  Cached on
-            the wrapper and reused at :meth:`run` time.
+            Softmax scale.  If ``None``, defaults to ``1 / sqrt(head_dim)``.
         rope_scale : Optional[float]
             Scale factor applied during RoPE interpolation.  Only consulted when
             ``pos_encoding_mode != "NONE"``.  Defaults to ``1.0`` when ``None``.
@@ -343,6 +378,11 @@ class PODWithPagedKVCacheWrapper:
         `grouped query attention <https://arxiv.org/abs/2305.13245>`_.
 
         The :meth:`plan` method cannot be used in Cuda Graph or in ``torch.compile``.
+
+        The ``pos_encoding_mode``, ``window_left``, ``sm_scale``, ``rope_scale`` and
+        ``rope_theta`` given here are also the decode-side settings used by
+        :meth:`run`, which has no decode-side overrides.  Logits soft-capping is
+        not supported by this wrapper.
         """
         # Logits soft cap is not supported currently
         batch_size = len(last_page_len)
@@ -473,10 +513,10 @@ class PODWithPagedKVCacheWrapper:
         custom_mask_d: Optional[torch.Tensor] = None,
         packed_custom_mask_d: Optional[torch.Tensor] = None,
         causal_d: bool = False,
-        kv_layout_d: str = "NHD",
-        pos_encoding_mode_d: str = "NONE",
+        kv_layout_d: Optional[str] = None,
+        pos_encoding_mode_d: Optional[str] = None,
         sm_scale_d: Optional[float] = None,
-        window_left_d: int = -1,
+        window_left_d: Optional[int] = None,
         rope_scale_d: Optional[float] = None,
         rope_theta_d: Optional[float] = None,
         q_scale: Optional[float] = None,
@@ -533,27 +573,16 @@ class PODWithPagedKVCacheWrapper:
             limitation of the current POD wrapper (kernel API exists, Python
             wrapper does not yet plumb LSE through the return value).
         custom_mask_d, packed_custom_mask_d : Optional[torch.Tensor]
-            Optional dense / bit-packed custom mask for the decode side.
+            Deprecated and unsupported: the decode side runs without a custom
+            mask, so a value other than ``None`` raises ``NotImplementedError``.
         causal_d : bool
-            Whether to apply a causal mask to the decode side.  Defaults to
-            ``False``.
-        kv_layout_d : str
-            **Currently ignored**: the decode KV layout is always taken from
-            the wrapper's ``kv_layout`` (set in :meth:`__init__`); this
-            argument is accepted for signature symmetry with ``kv_layout_p``
-            but the value is not consulted by the kernel.
-        pos_encoding_mode_d : str
-            **Currently ignored**: overridden by ``self._pos_encoding_mode``
-            from :meth:`plan`.
-        sm_scale_d : Optional[float]
-            **Currently ignored**: overridden by ``self._sm_scale`` from
-            :meth:`plan` (which itself defaults to ``1 / sqrt(head_dim)``).
-        window_left_d : int
-            **Currently ignored**: overridden by ``self._window_left`` from
-            :meth:`plan`.
-        rope_scale_d, rope_theta_d : Optional[float]
-            **Currently ignored**: overridden by ``self._rope_scale`` /
-            ``self._rope_theta`` from :meth:`plan`.
+            Deprecated and unsupported: the decode side runs non-causal
+            attention, so ``True`` raises ``NotImplementedError``.
+        kv_layout_d, pos_encoding_mode_d, sm_scale_d, window_left_d, rope_scale_d, rope_theta_d : optional
+            Deprecated: the decode-side settings are fixed by :meth:`plan` and
+            the layout by :meth:`__init__`.  A value passed here emits a
+            ``DeprecationWarning`` and must equal the planned value
+            (``ValueError`` otherwise); these arguments will be removed.
         q_scale, k_scale, v_scale : Optional[float]
             FP8 calibration scales applied to the decode side.  Folded into the
             decode ``sm_scale`` (``q_scale``, ``k_scale``) or the kernel output
@@ -570,6 +599,15 @@ class PODWithPagedKVCacheWrapper:
             wrapper auto-detects support from the query device.
         *args
             Reserved for forward-compat with future kernel parameters.
+
+        Note
+        ----
+        The decode-side ``pos_encoding_mode``, ``window_left``, ``sm_scale``,
+        ``rope_scale`` and ``rope_theta`` are taken from :meth:`plan`; the
+        ``*_d`` arguments above only validate against them and are deprecated.
+        Logits soft-capping is not supported by this wrapper.  The decode KV
+        layout is fixed by ``kv_layout`` in :meth:`__init__`.  The decode side
+        always runs non-causal attention without a custom mask.
 
         Returns
         -------
@@ -625,28 +663,47 @@ class PODWithPagedKVCacheWrapper:
         _check_cached_qkv_data_type(
             q_d, k_cache_d, self._cached_q_data_type, self._cached_kv_data_type
         )
-        # TODO_AK: Where are these coming from?
-        pos_encoding_mode_d = self._pos_encoding_mode
-        window_left_d = self._window_left
-        logits_soft_cap_d = self._logits_soft_cap
-        sm_scale_d = self._sm_scale
-        rope_scale_d = self._rope_scale
-        rope_theta_d = self._rope_theta
-        _check_pos_encoding_mode(pos_encoding_mode_d)
-        # What are the above for and what are the below?
-        if logits_soft_cap_d is None:
-            logits_soft_cap_d = 0.0
-        if sm_scale_d is None:
-            head_dim = q_d.shape[-1]
-            sm_scale_d = 1.0 / math.sqrt(head_dim)
+        planned_pos_encoding_mode: str = self._pos_encoding_mode
+        planned_window_left: int = self._window_left
+        planned_sm_scale: float = (
+            self._sm_scale
+            if self._sm_scale is not None
+            else 1.0 / math.sqrt(q_d.shape[-1])
+        )
+        planned_rope_scale: float = (
+            1.0 if self._rope_scale is None else self._rope_scale
+        )
+        planned_rope_theta: float = (
+            1e4 if self._rope_theta is None else self._rope_theta
+        )
+        _check_deprecated_decode_run_args(
+            {
+                "kv_layout_d": kv_layout_d,
+                "pos_encoding_mode_d": pos_encoding_mode_d,
+                "sm_scale_d": sm_scale_d,
+                "window_left_d": window_left_d,
+                "rope_scale_d": rope_scale_d,
+                "rope_theta_d": rope_theta_d,
+            },
+            {
+                "kv_layout_d": self._kv_layout,
+                "pos_encoding_mode_d": planned_pos_encoding_mode,
+                "sm_scale_d": planned_sm_scale,
+                "window_left_d": planned_window_left,
+                "rope_scale_d": planned_rope_scale,
+                "rope_theta_d": planned_rope_theta,
+            },
+        )
+        _check_decode_mask_args(custom_mask_d, packed_custom_mask_d, causal_d)
+        _check_pos_encoding_mode(planned_pos_encoding_mode)
+        logits_soft_cap_d = (
+            0.0 if self._logits_soft_cap is None else self._logits_soft_cap
+        )
+        decode_sm_scale = planned_sm_scale
         if q_scale is not None:
-            sm_scale_d *= q_scale
+            decode_sm_scale *= q_scale
         if k_scale is not None:
-            sm_scale_d *= k_scale
-        if rope_scale_d is None:
-            rope_scale_d = 1.0
-        if rope_theta_d is None:
-            rope_theta_d = 1e4
+            decode_sm_scale *= k_scale
 
         lse_d = None
         if return_lse_d:
@@ -672,8 +729,8 @@ class PODWithPagedKVCacheWrapper:
             self._indptr_type,
             # head_dim,  # head_dim_qk
             # head_dim,  # head_dim_vo
-            PosEncodingMode[pos_encoding_mode_d].value,
-            window_left_d != -1,  # use_sliding_window
+            PosEncodingMode[planned_pos_encoding_mode].value,
+            planned_window_left != -1,  # use_sliding_window
             logits_soft_cap_d > 0,  # use_logits_soft_cap
         )
         module_getter.run_tensor(
@@ -708,14 +765,14 @@ class PODWithPagedKVCacheWrapper:
             lse_d,
             MaskMode.NON_CAUSAL.value,
             TensorLayout[self._kv_layout].value,
-            window_left_d,
+            planned_window_left,
             None,  # packed_custom_mask
             None,  # mask_indptr_buf
             _get_cache_alibi_slopes_buf(q_d.shape[1], q_d.device),
             logits_soft_cap_d,
-            sm_scale_d,
-            1.0 / rope_scale_d,
-            1.0 / rope_theta_d,
+            decode_sm_scale,
+            1.0 / planned_rope_scale,
+            1.0 / planned_rope_theta,
             enable_pdl,
         )
 

--- a/tests/utils/test_pod_kernels.py
+++ b/tests/utils/test_pod_kernels.py
@@ -37,8 +37,8 @@ def warmup_jit():
             [torch.float16],  # kv_dtypes
             [128],  # head_dims
             [0],  # pos_encoding_modes
-            [False],  # use_sliding_windows
-            [False],  # use_fp16_qk_reductions
+            [False, True],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
         )
         + gen_prefill_attention_modules(
             [torch.float16],  # q_dtypes
@@ -47,7 +47,7 @@ def warmup_jit():
             ],  # kv_dtypes
             [128],  # head_dims
             [0],  # pos_encoding_modes
-            [False],  # use_sliding_windows
+            [False, True],  # use_sliding_windows
             [False],  # use_logits_soft_cap
             [False],  # use_fp16_qk_reductions
         )
@@ -65,7 +65,21 @@ def warmup_jit():
                 0,  # pos_encoding_mode_d
                 False,  # use_sliding_window_d
                 False,  # use_logits_soft_cap_d
-            )
+            ),
+            gen_pod_module(
+                torch.float16,  # dtype_q
+                torch.float16,  # dtype_kv
+                torch.float16,  # dtype_o
+                128,  # head_dim
+                0,  # pos_encoding_mode_p
+                False,  # use_sliding_window_p
+                False,  # use_logits_soft_cap_p
+                False,  # use_fp16_qk_reduction
+                torch.int32,  # dtype_idx
+                0,  # pos_encoding_mode_d
+                True,  # use_sliding_window_d
+                False,  # use_logits_soft_cap_d
+            ),
         ],
         verbose=False,
     )
@@ -221,6 +235,116 @@ def test_pod_with_paged_kv_cache(
     torch.testing.assert_close(
         o_d, o_ref_d, rtol=1e-3, atol=1e-3, msg="Decode mismatch"
     )
+
+
+def test_pod_with_paged_kv_cache_decode_plan_settings():
+    r"""Decode-side settings come from plan() (issue #3509).
+
+    Plans with a non-default ``window_left`` and ``sm_scale`` and checks the
+    decode output against ``BatchDecodeWithPagedKVCacheWrapper`` planned with
+    the same values.
+    """
+    head_dim = 128
+    num_qo_heads = 8
+    num_kv_heads = 8
+    page_size_d = 16
+    batch_size_d = 4
+    kv_len_d = 128  # > window_left, so the window actually clips history
+    window_left = 32
+    sm_scale = 0.5 / (head_dim**0.5)  # non-default: default is head_dim**-0.5
+    pos_encoding_mode = "NONE"
+    q_dtype = torch.float16
+    kv_dtype = torch.float16
+
+    # The prefill side is not under test; keep it minimal.
+    qo_len_p = kv_len_p = 32
+    q_p = torch.randn(
+        qo_len_p, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    k_p = torch.randn(
+        kv_len_p, num_kv_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    v_p = torch.randn(
+        kv_len_p, num_kv_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+
+    q_d = torch.randn(
+        batch_size_d, num_qo_heads, head_dim, device="cuda:0", dtype=torch.float16
+    )
+    num_pages_per_seq = (kv_len_d + page_size_d - 1) // page_size_d
+    total_num_pages = num_pages_per_seq * batch_size_d
+    kv_shape = [total_num_pages, 2, page_size_d, num_kv_heads, head_dim]
+    kv_data = torch.randn(*kv_shape, device="cuda:0", dtype=torch.float32).to(kv_dtype)
+    kv_indptr_d = (
+        torch.arange(0, batch_size_d + 1, device="cuda:0", dtype=torch.int32)
+        * num_pages_per_seq
+    )
+    kv_indices_d = torch.arange(0, total_num_pages, device="cuda:0", dtype=torch.int32)
+    kv_last_page_len = torch.full(
+        (batch_size_d,),
+        (kv_len_d - 1) % page_size_d + 1,
+        device="cuda:0",
+        dtype=torch.int32,
+    )
+
+    # Reference: BatchDecodeWithPagedKVCacheWrapper planned with the same
+    # non-default window_left / sm_scale.
+    decode_workspace_buffer = torch.empty(
+        32 * 1024 * 1024, device="cuda:0", dtype=torch.int8
+    )
+    decode_wrapper = flashinfer.decode.BatchDecodeWithPagedKVCacheWrapper(
+        decode_workspace_buffer, "NHD"
+    )
+    decode_wrapper.plan(
+        kv_indptr_d,
+        kv_indices_d,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size_d,
+        pos_encoding_mode=pos_encoding_mode,
+        window_left=window_left,
+        sm_scale=sm_scale,
+        data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    o_ref_d = decode_wrapper.run(q_d, kv_data)
+
+    workspace_buffer = torch.empty(32 * 1024 * 1024, device="cuda:0", dtype=torch.int8)
+    pod_wrapper = flashinfer.PODWithPagedKVCacheWrapper(workspace_buffer, "NHD")
+    pod_wrapper.plan(
+        kv_indptr_d,
+        kv_indices_d,
+        kv_last_page_len,
+        num_qo_heads,
+        num_kv_heads,
+        head_dim,
+        page_size_d,
+        pos_encoding_mode=pos_encoding_mode,
+        window_left=window_left,
+        sm_scale=sm_scale,
+        data_type=kv_dtype,
+        q_data_type=q_dtype,
+    )
+    _, o_d = pod_wrapper.run(q_p, k_p, v_p, q_d, kv_data)
+    torch.testing.assert_close(
+        o_d, o_ref_d, rtol=1e-3, atol=1e-3, msg="Decode mismatch"
+    )
+
+    # The deprecated run-time settings warn and must equal the planned values.
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        _, o_d_again = pod_wrapper.run(
+            q_p, k_p, v_p, q_d, kv_data, window_left_d=window_left, sm_scale_d=sm_scale
+        )
+    torch.testing.assert_close(o_d_again, o_d, rtol=1e-3, atol=1e-3)
+    with (
+        pytest.raises(ValueError, match="differs from the value planned"),
+        pytest.warns(DeprecationWarning),
+    ):
+        pod_wrapper.run(q_p, k_p, v_p, q_d, kv_data, window_left_d=-1)
+    with pytest.raises(NotImplementedError, match="non-causal"):
+        pod_wrapper.run(q_p, k_p, v_p, q_d, kv_data, causal_d=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

`PODWithPagedKVCacheWrapper.run()` accepts decode-side arguments (`kv_layout_d`, `pos_encoding_mode_d`, `sm_scale_d`, `window_left_d`, `rope_scale_d`, `rope_theta_d`) and then overwrites them with the values cached by `plan()` (the `TODO_AK` block), so a caller tuning them sees no effect and no error (#3509); `kv_layout_d` is never read at all. Three more decode-side arguments, `custom_mask_d`, `packed_custom_mask_d` and `causal_d`, are documented as functional, but the decode launch hardcodes a non-causal mask mode and passes no custom mask, so they never reach the kernel either.

The decode kernel is selected at plan time (`pos_encoding_mode`, `window_left` and the soft-cap flag pick the compiled module), so these settings cannot change per call. This PR keeps the signature compatible (every parameter stays in its position) and makes the contract explicit instead of silent:

- The six settings become optional (`None` by default). A value passed to `run()` emits a `DeprecationWarning` and must equal the planned value, defaults resolved; otherwise `run()` raises `ValueError`. This is the pattern `BatchDecodeWithPagedKVCacheWrapper.run` already uses for `window_left` and `q_len_per_req`.
- `custom_mask_d`, `packed_custom_mask_d` and `causal_d` raise `NotImplementedError` when set; their defaults pass silently, as before. Wiring a decode-side custom mask through the binding parameters that already exist in `csrc/pod.cu` would be a separate feature.
- The override block and its two `TODO_AK` comments are gone; `run()` resolves the plan-time values once, and `q_scale`/`k_scale` still fold into the decode `sm_scale`.
- Docstrings: `run()` marks the nine arguments as deprecated and states what each does now; `plan()` says its `pos_encoding_mode`, `window_left`, `sm_scale`, `rope_scale` and `rope_theta` are also the decode-side settings of `run()`, and that logits soft-capping is not supported by this wrapper (it is hardcoded off in `plan()`).
- `benchmarks/bench_mixed_attention.py` no longer passes `causal_d=True`, which was silently ignored and would now raise.

Migration: pass the decode-side settings to `plan()` and drop the `*_d` arguments from `run()`. Removing the parameters, the option the issue recommends, is left for a later release so that existing callers get a warning first. `BatchPODWithPagedKVCacheWrapper.run()` never had these arguments and is unchanged.

## Related Issues

Closes #3509.

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

- New `tests/utils/test_pod_kernels.py::test_pod_with_paged_kv_cache_decode_plan_settings`: plans the POD wrapper with a non-default decode `window_left` (32 over 128-token histories) and `sm_scale` (0.5 / sqrt(head_dim)) and checks the decode output against `BatchDecodeWithPagedKVCacheWrapper` planned with the same values; then checks that passing the same values to `run()` warns and gives the same output, that a different `window_left_d` raises `ValueError`, and that `causal_d=True` raises `NotImplementedError`. The JIT warmup fixture gains the sliding-window decode, prefill and POD variants the test needs.
- Mutation check: making `run()` fall back to `window_left = -1` makes the new test fail (`Decode mismatch`); restored, it passes.

Runs on an NVIDIA GH200 480GB (SM90), CUDA 12.8, torch 2.7.0+cu128:

```
pytest tests/utils/test_pod_kernels.py                                                                   169 passed, 24 skipped, 21 warnings in 476.81s
pytest tests/trace/test_pod_with_paged_kv_cache_run_reference_correctness.py tests/trace/test_batch_pod_run_reference_correctness.py tests/trace/test_fi_trace_template_consistency.py tests/trace/test_template_init.py tests/trace/test_template_registry.py   1229 passed, 192 skipped, 22 warnings in 26.12s
```

## Reviewer Notes

- The first version of this PR removed the nine arguments; the public API check asked for a deprecation path, so this version keeps them with a warning and validation. Removing them later is a small follow-up.
- Pre-existing and unchanged: `return_lse_p` and `return_lse_d` allocate an LSE buffer that `run()` does not return (already documented in the docstring).

Made in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Decode attention now consistently uses the settings configured during planning, including scaling, positional encoding, layout, and sliding-window behavior.
  - Added validation to prevent conflicting decode-time settings and provide clear warnings for deprecated overrides.
  - Decode operations now explicitly reject custom masks and causal mode, which are unsupported for this path.

- **Documentation**
  - Updated attention API documentation to clarify planning requirements, decode behavior, and unsupported logits soft-capping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->