### PR TITLE
[bench] Add low-M BF16 default-versus-tuned graph diagnostic

### DIFF
--- a/benchmarks/bench_bf16_low_m.py
+++ b/benchmarks/bench_bf16_low_m.py
@@ -20,7 +20,12 @@ import statistics
 import subprocess
 
 
+class BenchmarkGateError(RuntimeError):
+    """A fixed, benchmark-authored message safe to include in a shared receipt."""
+
+
 def positive_int(value):
+    """Parse a strictly positive CLI dimension or iteration count."""
     value = int(value)
     if value <= 0:
         raise argparse.ArgumentTypeError("must be positive")
@@ -28,6 +33,7 @@ def positive_int(value):
 
 
 def parse_args(argv=None):
+    """Parse one low-M shape without importing or initializing CUDA."""
     parser = argparse.ArgumentParser(description=__doc__)
     for axis in ("m", "n", "k"):
         parser.add_argument(f"--{axis}", type=positive_int, required=True)
@@ -41,6 +47,7 @@ def parse_args(argv=None):
 
 
 def check_rows(actual, reference):
+    """Validate every row against FP32, including zero-reference edge cases."""
     import torch
 
     if actual.ndim != 2 or actual.shape != reference.shape:
@@ -67,6 +74,7 @@ def check_rows(actual, reference):
 
 
 def bracket(before, candidate, after):
+    """Summarize one A/B/A trial using the mean of the two control medians."""
     medians = [statistics.median(v) for v in (before, candidate, after)]
     if not all(
         math.isfinite(x) and x > 0
@@ -86,8 +94,9 @@ def bracket(before, candidate, after):
 
 
 def run(args, result):
+    """Validate and time frozen default/tuned graphs, retaining partial results."""
     if os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE", "0") != "0":
-        raise RuntimeError(
+        raise BenchmarkGateError(
             "disable inherited file-based tuning for a default comparison"
         )
     import torch
@@ -103,11 +112,13 @@ def run(args, result):
     from cupti import cupti  # noqa: F401 -- require CUPTI, never silently time events
 
     if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
-        raise RuntimeError("requires SM100 or SM103")
+        raise BenchmarkGateError("requires SM100 or SM103")
     if not is_cute_dsl_experimental_available():
-        raise RuntimeError("requires the current warp-capable CuTe DSL >=4.7 runtime")
+        raise BenchmarkGateError(
+            "requires the current warp-capable CuTe DSL >=4.7 runtime"
+        )
     if int(importlib.metadata.version("cupti-python").split(".")[0]) < 13:
-        raise RuntimeError("requires cupti-python >=13")
+        raise BenchmarkGateError("requires cupti-python >=13")
     root = Path(flashinfer.__file__).resolve().parent.parent
     sha = subprocess.check_output(
         ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
@@ -152,6 +163,7 @@ def run(args, result):
     checks = result.setdefault("correctness", {})
 
     def capture(name, fn, out, tune=False):
+        """Check eager output and freeze the selected kernels before cache changes."""
         print(json.dumps({"event": "prepare", "arm": name}), flush=True)
         with autotune(tune):
             fn()
@@ -176,6 +188,7 @@ def run(args, result):
             out = torch.empty(args.m, args.n, device="cuda", dtype=torch.bfloat16)
 
             def call(backend=backend, out=out):
+                """Bind each backend and output before the surrounding loop advances."""
                 return mm_bf16(a, b, out=out, backend=backend, pdl=False)
 
             capture(name, call, out, tuned)
@@ -197,6 +210,7 @@ def run(args, result):
     result["timings"] = {}
 
     def measure(name):
+        """Collect complete cold-L2 graph replay durations in microseconds."""
         times = bench_gpu_time_with_cupti(
             graphs[name].replay,
             dry_run_iters=20,
@@ -205,7 +219,7 @@ def run(args, result):
             cold_l2_cache=True,
         )
         if len(times) != args.iterations:
-            raise RuntimeError("CUPTI did not report every requested replay")
+            raise BenchmarkGateError("CUPTI did not report every requested replay")
         return [float(t) * 1000 for t in times]
 
     for name in graphs:
@@ -218,9 +232,10 @@ def run(args, result):
                 measure(name),
                 measure("cublaslt_tuned"),
             )
+            summary = bracket(a1, candidate, a2)
             trials.append(
                 {
-                    **bracket(a1, candidate, a2),
+                    **summary,
                     "samples_us": {"before": a1, "candidate": candidate, "after": a2},
                 }
             )
@@ -230,7 +245,7 @@ def run(args, result):
                         "event": "bracket",
                         "arm": name,
                         "trial": len(trials),
-                        **bracket(a1, candidate, a2),
+                        **summary,
                     }
                 ),
                 flush=True,
@@ -239,6 +254,7 @@ def run(args, result):
 
 
 def main(argv=None):
+    """Write a non-overwriting receipt while preserving any failure traceback."""
     args = parse_args(argv)
     result = {
         "shape": {a: getattr(args, a) for a in ("m", "n", "k")},
@@ -253,6 +269,12 @@ def main(argv=None):
             run(args, result)
         except Exception as exc:
             result["error_type"] = type(exc).__name__
+            # Third-party exception text can contain paths or command arguments.
+            result["error_message"] = (
+                str(exc)
+                if isinstance(exc, BenchmarkGateError)
+                else "Failure details are available in stderr."
+            )
             raise
         finally:
             json.dump(result, output, indent=2, allow_nan=False)

--- a/benchmarks/bench_bf16_low_m.py
+++ b/benchmarks/bench_bf16_low_m.py
@@ -1,0 +1,263 @@
+"""Synthetic low-M BF16 GEMM: frozen default graphs versus autotuned graphs.
+
+Run each shape in a fresh process on an exclusively allocated SM100/SM103 GPU:
+    python benchmarks/bench_bf16_low_m.py --m 1 --n 43008 --k 5376 --output wide.json
+    python benchmarks/bench_bf16_low_m.py --m 1 --n 5376 --k 21504 --output deep.json
+
+Requires CuTe DSL >=4.7 and cupti-python >=13. No private model data is needed.
+No dispatch changes are made. Timings include all kernels in each GEMM call,
+exclude L2 eviction, and are not end-to-end serving throughput measurements.
+"""
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import subprocess
+
+
+def positive_int(value):
+    value = int(value)
+    if value <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return value
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    for axis in ("m", "n", "k"):
+        parser.add_argument(f"--{axis}", type=positive_int, required=True)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--iterations", type=positive_int, default=100)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args(argv)
+    if args.m > 32:
+        parser.error("this reproduction is limited to M <= 32")
+    return args
+
+
+def check_rows(actual, reference):
+    import torch
+
+    if actual.ndim != 2 or actual.shape != reference.shape:
+        raise ValueError("expected matching two-dimensional outputs")
+    x, y = actual.float(), reference.float()
+    if not bool(torch.isfinite(x).all() & torch.isfinite(y).all()):
+        raise AssertionError("non-finite output or reference")
+    xnorm = torch.linalg.vector_norm(x, dim=1)
+    ynorm = torch.linalg.vector_norm(y, dim=1)
+    errnorm = torch.linalg.vector_norm(x - y, dim=1)
+    zero = ynorm == 0
+    exact_zero = zero & (xnorm == 0)
+    nrmse = torch.where(
+        zero,
+        torch.where(exact_zero, 0.0, float("inf")),
+        errnorm / ynorm.clamp_min(1e-30),
+    )
+    cosine = torch.where(
+        zero, exact_zero.float(), (x * y).sum(1) / (xnorm * ynorm).clamp_min(1e-30)
+    )
+    if not bool(((nrmse <= 1 / 256) & (cosine >= 0.99999)).all()):
+        raise AssertionError("FP32 per-row NRMSE/cosine gate failed")
+    return {"max_nrmse": nrmse.max().item(), "min_cosine": cosine.min().item()}
+
+
+def bracket(before, candidate, after):
+    medians = [statistics.median(v) for v in (before, candidate, after)]
+    if not all(
+        math.isfinite(x) and x > 0
+        for values in (before, candidate, after)
+        for x in values
+    ):
+        raise ValueError("timings must be finite and positive")
+    a1, b, a2 = medians
+    control = (a1 + a2) / 2
+    return {
+        "before_us": a1,
+        "candidate_us": b,
+        "after_us": a2,
+        "speedup": control / b,
+        "control_drift": abs(a1 - a2) / control,
+    }
+
+
+def run(args, result):
+    if os.environ.get("FLASHINFER_AUTOTUNER_LOAD_FROM_FILE", "0") != "0":
+        raise RuntimeError(
+            "disable inherited file-based tuning for a default comparison"
+        )
+    import torch
+    import flashinfer
+    from flashinfer import autotune, mm_bf16
+    from flashinfer.autotuner import AutoTuner
+    from flashinfer.cute_dsl.availability import is_cute_dsl_experimental_available
+    from flashinfer.gemm.kernels.dense_bf16_gemm_direct import (
+        default_tactic,
+        run_direct_dense,
+    )
+    from flashinfer.testing.utils import bench_gpu_time_with_cupti
+    from cupti import cupti  # noqa: F401 -- require CUPTI, never silently time events
+
+    if torch.cuda.get_device_capability() not in ((10, 0), (10, 3)):
+        raise RuntimeError("requires SM100 or SM103")
+    if not is_cute_dsl_experimental_available():
+        raise RuntimeError("requires the current warp-capable CuTe DSL >=4.7 runtime")
+    if int(importlib.metadata.version("cupti-python").split(".")[0]) < 13:
+        raise RuntimeError("requires cupti-python >=13")
+    root = Path(flashinfer.__file__).resolve().parent.parent
+    sha = subprocess.check_output(
+        ["git", "-C", str(root), "rev-parse", "HEAD"], text=True
+    ).strip()
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(root),
+            "diff",
+            "--exit-code",
+            "--quiet",
+            "HEAD",
+            "--",
+            "flashinfer",
+        ],
+        check=True,
+    )
+    result["environment"] = {
+        "source_sha": sha,
+        "flashinfer": flashinfer.__version__,
+        "benchmark_sha256": hashlib.sha256(Path(__file__).read_bytes()).hexdigest(),
+        "torch": torch.__version__,
+        "cuda": torch.version.cuda,
+        "cutlass_dsl": importlib.metadata.version("nvidia-cutlass-dsl"),
+        "cupti": importlib.metadata.version("cupti-python"),
+        "gpu": torch.cuda.get_device_name(),
+        "compute_capability": torch.cuda.get_device_capability(),
+        "timer": "CUPTI, cold-L2, complete CUDA-graph replay, microseconds",
+    }
+    torch.manual_seed(args.seed)
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cuda.matmul.allow_bf16_reduced_precision_reduction = False
+    # Only this fresh process's in-memory tuning state is cleared; no disk cache.
+    AutoTuner.get().clear_cache()
+    a = torch.randn(args.m, args.k, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(args.n, args.k, device="cuda", dtype=torch.bfloat16).T
+    initial_a = a.clone()
+    b_fp32 = b.float()
+    reference = a.float() @ b_fp32
+    graphs, outputs = {}, {}
+    checks = result.setdefault("correctness", {})
+
+    def capture(name, fn, out, tune=False):
+        print(json.dumps({"event": "prepare", "arm": name}), flush=True)
+        with autotune(tune):
+            fn()
+        checks[name] = [check_rows(out, reference)]
+        stream = torch.cuda.Stream()
+        stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(stream):
+            for _ in range(3):
+                fn()
+        torch.cuda.current_stream().wait_stream(stream)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            fn()
+        graphs[name], outputs[name] = graph, out
+        print(json.dumps({"event": "captured", "arm": name}), flush=True)
+
+    # Freeze both default graphs before ANY autotuning; later cache choices
+    # cannot change kernels already captured in these graphs.
+    for tuned in (False, True):
+        for backend in ("cublaslt", "cute-dsl"):
+            name = backend + ("_tuned" if tuned else "_default")
+            out = torch.empty(args.m, args.n, device="cuda", dtype=torch.bfloat16)
+
+            def call(backend=backend, out=out):
+                return mm_bf16(a, b, out=out, backend=backend, pdl=False)
+
+            capture(name, call, out, tuned)
+    tactic = default_tactic(args.m, args.n, args.k)
+    out = torch.empty_like(outputs["cute-dsl_default"])
+    capture("direct_default", lambda: run_direct_dense(a, b, out, False, tactic), out)
+
+    for mutate in (False, True):
+        for _ in range(10):
+            if mutate:
+                a.normal_()
+                reference = a.float() @ b_fp32
+            for name, graph in graphs.items():
+                graph.replay()
+                checks[name].append(check_rows(outputs[name], reference))
+    a.copy_(initial_a)
+    torch.cuda.synchronize()
+    print(json.dumps({"event": "correctness_passed", "arms": list(graphs)}), flush=True)
+    result["timings"] = {}
+
+    def measure(name):
+        times = bench_gpu_time_with_cupti(
+            graphs[name].replay,
+            dry_run_iters=20,
+            repeat_iters=args.iterations,
+            use_cuda_graph=False,
+            cold_l2_cache=True,
+        )
+        if len(times) != args.iterations:
+            raise RuntimeError("CUPTI did not report every requested replay")
+        return [float(t) * 1000 for t in times]
+
+    for name in graphs:
+        if name == "cublaslt_tuned":
+            continue
+        trials = result["timings"].setdefault(name, [])
+        for _ in range(3):
+            a1, candidate, a2 = (
+                measure("cublaslt_tuned"),
+                measure(name),
+                measure("cublaslt_tuned"),
+            )
+            trials.append(
+                {
+                    **bracket(a1, candidate, a2),
+                    "samples_us": {"before": a1, "candidate": candidate, "after": a2},
+                }
+            )
+            print(
+                json.dumps(
+                    {
+                        "event": "bracket",
+                        "arm": name,
+                        "trial": len(trials),
+                        **bracket(a1, candidate, a2),
+                    }
+                ),
+                flush=True,
+            )
+    result["status"] = "complete"
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    result = {
+        "shape": {a: getattr(args, a) for a in ("m", "n", "k")},
+        "seed": args.seed,
+        "pdl": False,
+        "bias": False,
+        "status": "incomplete",
+    }
+    # Refuse overwriting a previous run; retain partial evidence if a gate fails.
+    with args.output.open("x") as output:
+        try:
+            run(args, result)
+        except Exception as exc:
+            result["error_type"] = type(exc).__name__
+            raise
+        finally:
+            json.dump(result, output, indent=2, allow_nan=False)
+            output.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/test_bench_bf16_low_m.py
+++ b/benchmarks/test_bench_bf16_low_m.py
@@ -1,6 +1,7 @@
 """CPU-only tests; these do not validate CUDA execution or timings."""
 
 import importlib.util
+import json
 import math
 from pathlib import Path
 import tempfile
@@ -18,11 +19,15 @@ spec.loader.exec_module(bench)
 
 
 class TestLowMGemmReproduction(unittest.TestCase):
+    """Exercise evidence-quality gates without importing the GPU backends."""
+
     def test_exact_and_zero_rows(self):
+        """Accept exact matches, including zero-reference rows."""
         x = torch.tensor([[1.0, -2.0], [0.0, 0.0]])
         self.assertEqual(bench.check_rows(x, x)["max_nrmse"], 0)
 
     def test_one_bad_row_is_not_hidden_by_aggregation(self):
+        """Guard against global averages concealing a failing row."""
         ref = torch.ones(8, 4)
         bad = ref.clone()
         bad[-1].neg_()
@@ -30,43 +35,102 @@ class TestLowMGemmReproduction(unittest.TestCase):
             bench.check_rows(bad, ref)
 
     def test_nonfinite_is_rejected(self):
+        """Reject non-finite values before computing error metrics."""
         for value in (math.nan, math.inf):
             with self.subTest(value=value), self.assertRaises(AssertionError):
                 bench.check_rows(torch.tensor([[value]]), torch.ones(1, 1))
 
     def test_nonzero_against_zero_is_rejected(self):
+        """Do not let zero-reference normalization hide output errors."""
         with self.assertRaises(AssertionError):
             bench.check_rows(torch.ones(1, 2), torch.zeros(1, 2))
 
     def test_gain_error_is_rejected_even_with_perfect_cosine(self):
+        """Catch magnitude errors that cosine similarity cannot detect."""
         with self.assertRaises(AssertionError):
             bench.check_rows(torch.ones(1, 2) * 1.02, torch.ones(1, 2))
 
     def test_bracket(self):
+        """Normalize speedup against the mean control median, not either endpoint."""
         result = bench.bracket([9, 10, 11], [4, 5, 6], [11, 12, 13])
         self.assertAlmostEqual(result["speedup"], 2.2)
         self.assertAlmostEqual(result["control_drift"], 2 / 11)
 
     def test_invalid_samples(self):
+        """Reject timings that cannot yield a meaningful speedup."""
         for value in (0, -1, math.nan, math.inf):
             with self.subTest(value=value), self.assertRaises(ValueError):
                 bench.bracket([1], [value], [1])
 
     def test_failure_receipt_and_no_overwrite(self):
+        """Retain useful gate failures without overwriting existing evidence."""
         with tempfile.TemporaryDirectory() as directory:
             output = Path(directory) / "result.json"
             argv = ["--m", "1", "--n", "16", "--k", "128", "--output", str(output)]
+            failure = bench.BenchmarkGateError("requires SM100 or SM103")
             with (
-                patch.object(bench, "run", side_effect=RuntimeError("test failure")),
-                self.assertRaises(RuntimeError),
+                patch.object(bench, "run", side_effect=failure),
+                self.assertRaises(RuntimeError) as raised,
             ):
                 bench.main(argv)
+            self.assertIs(raised.exception, failure)
             receipt = output.read_text()
-            self.assertIn('"status": "incomplete"', receipt)
-            self.assertIn('"error_type": "RuntimeError"', receipt)
+            result = json.loads(receipt)
+            self.assertEqual(result["status"], "incomplete")
+            self.assertEqual(result["error_type"], "BenchmarkGateError")
+            self.assertEqual(result["error_message"], "requires SM100 or SM103")
             with self.assertRaises(FileExistsError):
                 bench.main(argv)
             self.assertEqual(output.read_text(), receipt)
+
+    def test_gate_failure_messages_are_distinct(self):
+        """Distinguish benchmark gates even when their exception types match."""
+        messages = (
+            "disable inherited file-based tuning for a default comparison",
+            "requires SM100 or SM103",
+            "requires the current warp-capable CuTe DSL >=4.7 runtime",
+            "requires cupti-python >=13",
+            "CUPTI did not report every requested replay",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            for index, message in enumerate(messages):
+                output = Path(directory) / f"result-{index}.json"
+                argv = ["--m", "1", "--n", "16", "--k", "128", "--output", str(output)]
+                with (
+                    self.subTest(message=message),
+                    patch.object(
+                        bench, "run", side_effect=bench.BenchmarkGateError(message)
+                    ),
+                    self.assertRaises(bench.BenchmarkGateError),
+                ):
+                    bench.main(argv)
+                result = json.loads(output.read_text())
+                self.assertEqual(result["error_type"], "BenchmarkGateError")
+                self.assertEqual(result["error_message"], message)
+
+    def test_unexpected_failure_does_not_export_private_details(self):
+        """Preserve the original exception without copying private paths into JSON."""
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "result.json"
+            argv = ["--m", "1", "--n", "16", "--k", "128", "--output", str(output)]
+            failure = RuntimeError(
+                f"backend compilation failed at {directory}/kernel.py"
+            )
+            with (
+                patch.object(bench, "run", side_effect=failure),
+                self.assertRaises(RuntimeError) as raised,
+            ):
+                bench.main(argv)
+            self.assertIs(raised.exception, failure)
+            receipt = output.read_text()
+            result = json.loads(receipt)
+            self.assertEqual(result["status"], "incomplete")
+            self.assertEqual(result["error_type"], "RuntimeError")
+            self.assertEqual(
+                result["error_message"], "Failure details are available in stderr."
+            )
+            self.assertNotIn(directory, receipt)
+            self.assertNotIn(str(failure), receipt)
 
 
 if __name__ == "__main__":

--- a/benchmarks/test_bench_bf16_low_m.py
+++ b/benchmarks/test_bench_bf16_low_m.py
@@ -1,0 +1,73 @@
+"""CPU-only tests; these do not validate CUDA execution or timings."""
+
+import importlib.util
+import math
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import torch
+
+
+spec = importlib.util.spec_from_file_location(
+    "bench_bf16_low_m", Path(__file__).with_name("bench_bf16_low_m.py")
+)
+bench = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bench)
+
+
+class TestLowMGemmReproduction(unittest.TestCase):
+    def test_exact_and_zero_rows(self):
+        x = torch.tensor([[1.0, -2.0], [0.0, 0.0]])
+        self.assertEqual(bench.check_rows(x, x)["max_nrmse"], 0)
+
+    def test_one_bad_row_is_not_hidden_by_aggregation(self):
+        ref = torch.ones(8, 4)
+        bad = ref.clone()
+        bad[-1].neg_()
+        with self.assertRaises(AssertionError):
+            bench.check_rows(bad, ref)
+
+    def test_nonfinite_is_rejected(self):
+        for value in (math.nan, math.inf):
+            with self.subTest(value=value), self.assertRaises(AssertionError):
+                bench.check_rows(torch.tensor([[value]]), torch.ones(1, 1))
+
+    def test_nonzero_against_zero_is_rejected(self):
+        with self.assertRaises(AssertionError):
+            bench.check_rows(torch.ones(1, 2), torch.zeros(1, 2))
+
+    def test_gain_error_is_rejected_even_with_perfect_cosine(self):
+        with self.assertRaises(AssertionError):
+            bench.check_rows(torch.ones(1, 2) * 1.02, torch.ones(1, 2))
+
+    def test_bracket(self):
+        result = bench.bracket([9, 10, 11], [4, 5, 6], [11, 12, 13])
+        self.assertAlmostEqual(result["speedup"], 2.2)
+        self.assertAlmostEqual(result["control_drift"], 2 / 11)
+
+    def test_invalid_samples(self):
+        for value in (0, -1, math.nan, math.inf):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                bench.bracket([1], [value], [1])
+
+    def test_failure_receipt_and_no_overwrite(self):
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "result.json"
+            argv = ["--m", "1", "--n", "16", "--k", "128", "--output", str(output)]
+            with (
+                patch.object(bench, "run", side_effect=RuntimeError("test failure")),
+                self.assertRaises(RuntimeError),
+            ):
+                bench.main(argv)
+            receipt = output.read_text()
+            self.assertIn('"status": "incomplete"', receipt)
+            self.assertIn('"error_type": "RuntimeError"', receipt)
+            with self.assertRaises(FileExistsError):
+                bench.main(argv)
+            self.assertEqual(output.read_text(), receipt)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 📌 Description

Add a standalone synthetic-data diagnostic for low-M BF16 GEMM selection.
This is a **benchmark-only contribution**, not a new kernel or a dispatch change.
It builds on the existing Direct/cluster/warp kernels and public `mm_bf16`
autotuning support, including #4908 and #5089.

The benchmark:

- Captures both public default graphs before any autotuning, then captures
  tuned cuBLASLt/CuTe DSL graphs and an upstream Direct-default graph.
- Checks every row against FP32, including ten unchanged graph replays and
  ten in-place activation mutations. Requires finite output,
  NRMSE <= 1/256 and cosine >= 0.99999.
- Measures three cold-L2 CUPTI A/B/A brackets per candidate against tuned
  public cuBLASLt. Includes the complete captured operation, including
  split-K reduction, and excludes the L2 eviction.
- Writes source/runtime metadata, raw samples and partial failure receipts;
  refuses to overwrite an existing result. All inputs are seeded synthetic
  tensors; no model weights or serving environment are needed.
- Adds ten CPU-only tests for numerical/timing gates, safe gate diagnostics,
  failure receipts and overwrite protection.

This complements the existing GEMM benchmark with frozen default-versus-tuned
graphs, mutation checks, control-drift measurements and inspectable raw samples.
It does not change the existing benchmark, autotuner or production paths.

### Reproduction

Use a clean source checkout installed in an isolated environment, an
exclusively allocated SM100/SM103 GPU, CuTe DSL >=4.7 and `cupti-python >=13`.
Run each shape in a fresh process; inherited file-based autotuning must be off.

```bash
python benchmarks/bench_bf16_low_m.py --m 1 --n 43008 --k 5376 --output wide.json
python3 -m unittest discover -s benchmarks -p test_bench_bf16_low_m.py -v
```

### Measured smoke case — not a performance improvement from this PR

FlashInfer library source: `ae736b1863082e3eb893753a4d3e54d276486abf`.
The measurements below used benchmark commit
`33bbd44eb62687cc653c7bb46660a22d1e41b1d0`. The review follow-up changes
failure diagnostics, summary reuse and docstrings, with CPU regression tests;
the GPU case has not been rerun on that follow-up.
B300/SM103, PyTorch 2.13.0+cu132, CuTe DSL 4.7.0, CUPTI Python 13.4.0;
local JIT compiler CUDA 13.1.115. BF16 A `[1,5376]`, transposed contiguous
BF16 B `[5376,43008]`, BF16 output; seed 42, no bias, PDL disabled, TF32 off.

All five paths passed 21 checks each: eager, ten unchanged replays, and ten
activation mutations. Worst per-row NRMSE was 0.001681; minimum cosine was
0.99999845. Each timing cell below is a median of 100 complete graph replays
after 20 warmups, with cold L2 per replay.

| Existing path | Trial 1 us | Trial 2 us | Trial 3 us | Speedup vs bracketed tuned cuBLASLt |
|---|---:|---:|---:|---:|
| Public cuBLASLt default | 88.705 | 88.513 | 88.625 | 0.997–0.999x |
| Public CuTe DSL default | 75.841 | 75.905 | 75.889 | 1.164–1.166x |
| Public CuTe DSL tuned | 70.496 | 70.529 | 70.817 | 1.249–1.254x |
| Upstream Direct default | 70.593 | 70.689 | 70.833 | 1.248–1.251x |

Tuned cuBLASLt control medians ranged from 88.306 to 88.529 us across the
brackets; maximum within-bracket control drift was 0.182%.

The result illustrates an existing default-versus-autotuned selection gap at
one shape. It does not justify a heuristic change, establish general speedups,
or measure end-to-end serving throughput. **Only this one GPU shape has been
validated.** The second anchor `(M,N,K)=(1,5376,21504)`, M=2/8/16/32
guardrails, nearby N/K shapes, and SM100/B200 remain unvalidated because
further hardware execution was unavailable in this session. This benchmark
is ready for review with that coverage limitation explicit; no broader GPU
validation is claimed. No competing vLLM default-dispatch change is proposed.

## 🔍 Related Issues

- #4908 — existing warp split-K kernel and runner/autotuner support.
- #5089 — existing CuTe DSL compatibility follow-up.
- vllm-project/vllm#54524 — related integration work; unchanged by this PR.

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

Full repository `pre-commit run --all-files` passed at commit
`a451ec3244476a93cd44726d1995cffeee64ed70` using Python 3.10.20 in an
isolated validation environment. All 14 applicable hooks passed, including
clang-format, mypy, Ruff and the experimental test-scope selftest; the symlink
check had no files to check. Exit code was 0 and the worktree remained clean.
The review follow-up's GitHub pre-commit and documentation checks also passed.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests run for this PR are passing (`unittest`, etc.).

Ten CPU tests pass with CUDA uninitialized, including safe failure-message
handling and preservation of the original exception. Recomputing all twelve
historical bracket summaries gives exactly the recorded values. All nineteen
functions have docstrings. The one GPU smoke case above passed on the original
benchmark commit; the full project suite and remaining GPU matrix were not run.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #
  - [ ] The tracking issue names an owner, the reason for the experimental path, and a graduation plan with a target release.
  - [ ] Core changes are limited to a thin entry point (signature, shared validation, feature-gate check, backend selection, handoff).
  - [ ] Tests live in `tests/experimental/` and were validated on the intended hardware; a runnable example is included.
  - [ ] Nothing is registered in `flashinfer/aot.py`, and no experimental backend is reachable from `backend="auto"` without `FLASHINFER_ALLOW_EXPERIMENTAL_AUTO_BACKENDS=1`. (Calling an `@flashinfer_experimental_api` or naming a backend explicitly is itself the opt-in and needs no environment variable.)
  - [ ] **Test scope declared below.** The experimental CI lane runs exactly these targets, so keep them as narrow as the change allows.

<!-- Required for experimental PRs. Replace the commented lines below with your targets.
     Do not delete the fence or change its `experimental-tests` tag — the experimental-track
     watcher reads it verbatim to decide which targets to ask CI for. -->

```experimental-tests
# One target per line: a directory or a file. (A pytest ::selector is not
# supported -- the sharding runner cannot consume one.) Must be under
# tests/experimental/ and must exist. Delete these comment lines and add yours, e.g.
#
#   tests/experimental/test_my_backend.py
#   tests/experimental/my_backend/
#
# Declaring the whole tree (tests/experimental/) is allowed but means every
# experimental PR pays for every other feature's tests, in every matrix cell.
```

## Reviewer Notes

No kernel, library, serving or backend-selection code is changed. No speedup
is attributed to this PR. The benchmark requires live GPU validation for each
new shape and does not infer runtime correctness from its CPU tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmark for comparing low-M BF16 matrix multiplication performance with autotuned and cuBLASLt-tuned references.
  * Reports correctness metrics, timing data, environment details, and benchmark results in JSON format.
  * Prevents accidental overwriting of existing benchmark results.

* **Tests**
  * Added CPU-only coverage for metric validation, performance comparisons, failure reporting, and output-file protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
