### PR TITLE
fix(attention): validate index tensors in the batch attention wrappers

### DIFF
--- a/csrc/batch_decode.cu
+++ b/csrc/batch_decode.cu
@@ -42,7 +42,7 @@ Array<int64_t> BatchDecodeWithPagedKVCachePlan(
     int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph,
     int64_t window_left, double logits_soft_cap, int64_t head_dim_qk, int64_t head_dim_vo,
     TensorView empty_q_data, TensorView empty_kv_data) {
-  CHECK_INPUT_TYPE(indptr, dl_int32);
+  CHECK_INPUT_TYPE(indptr, dl_dtype_for<IdType>());
 
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * get_element_size(float_workspace_buffer);
@@ -89,7 +89,7 @@ Array<int64_t> BatchDecodeWithPagedKVCacheWorkspaceSize(
   (void)logits_soft_cap;
   (void)empty_q_data;
   (void)empty_kv_data;
-  CHECK_INPUT_TYPE(indptr, dl_int32);
+  CHECK_INPUT_TYPE(indptr, dl_dtype_for<IdType>());
 
   TVM_FFI_ICHECK_EQ(head_dim_qk, head_dim_vo)
       << "CUDA cores template only supports equal head dim for QK and VO, please use tensor "
@@ -134,9 +134,9 @@ void BatchDecodeWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                     TensorView o, Optional<TensorView> maybe_lse,
                                     int64_t kv_layout_code, int64_t window_left,
                                     bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
-  CHECK_INPUT_TYPE(paged_kv_indptr, dl_int32);
-  CHECK_INPUT_TYPE(paged_kv_indices, dl_int32);
-  CHECK_INPUT_TYPE(paged_kv_last_page_len, dl_int32);
+  CHECK_INPUT_TYPE(paged_kv_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_indices, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_last_page_len, dl_dtype_for<IdType>());
 
   DecodePlanInfo plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));

--- a/csrc/batch_prefill.cu
+++ b/csrc/batch_prefill.cu
@@ -51,6 +51,8 @@ Array<int64_t> BatchPrefillWithKVCachePlan(
     int64_t num_kv_heads, int64_t page_size, bool enable_cuda_graph, int64_t head_dim_qk,
     int64_t head_dim_vo, bool causal, int64_t window_left, int64_t fixed_split_size,
     bool disable_split_kv, int64_t num_colocated_ctas = 0, int64_t uniform_q_len = 0) {
+  CHECK_INPUT_TYPE(qo_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(kv_indptr, dl_dtype_for<IdType>());
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * get_element_size(float_workspace_buffer);
   size_t int_workspace_size_in_bytes =
@@ -112,6 +114,8 @@ void BatchPrefillWithRaggedKVCacheRun(TensorView float_workspace_buffer,
                                       Optional<TensorView> maybe_lse, int64_t mask_mode_code,
                                       int64_t layout, int64_t window_left,
                                       bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+  CHECK_INPUT_TYPE(qo_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(kv_indptr, dl_dtype_for<IdType>());
   PrefillPlanInfo plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);
@@ -245,6 +249,11 @@ void BatchPrefillWithPagedKVCacheRun(TensorView float_workspace_buffer,
                                      Optional<TensorView> maybe_lse, int64_t mask_mode_code,
                                      int64_t layout, int64_t window_left,
                                      bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+  CHECK_INPUT_TYPE(qo_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_indices, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_last_page_len, dl_dtype_for<IdType>());
+
   PrefillPlanInfo plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
   QKVLayout kv_layout = static_cast<QKVLayout>(layout);

--- a/csrc/batch_prefill_sm90.cu
+++ b/csrc/batch_prefill_sm90.cu
@@ -49,6 +49,12 @@ Array<int64_t> BatchPrefillWithKVCacheSM90Plan(
     int64_t batch_size, int64_t num_qo_heads, int64_t num_kv_heads, int64_t page_size,
     bool enable_cuda_graph, int64_t head_dim_qk, int64_t head_dim_vo, bool causal,
     int64_t window_left) {
+  CHECK_INPUT_TYPE(qo_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(kv_indptr, dl_dtype_for<IdType>());
+  // kv_len_arr may be the documented uint32 seq_lens; only its width must match IdType.
+  TVM_FFI_ICHECK(kv_len_arr.dtype().bits == 8 * sizeof(IdType) && kv_len_arr.dtype().lanes == 1 &&
+                 (kv_len_arr.dtype().code == kDLInt || kv_len_arr.dtype().code == kDLUInt))
+      << "kv_len_arr must be a " << 8 * sizeof(IdType) << "-bit integer tensor";
   size_t float_workspace_size_in_bytes =
       float_workspace_buffer.size(0) * get_element_size(float_workspace_buffer);
   size_t int_workspace_size_in_bytes =
@@ -80,6 +86,8 @@ void BatchPrefillWithRaggedKVCacheSM90Run(
     ffi::TensorView qo_indptr, ffi::TensorView kv_indptr, ffi::TensorView o,
     Optional<ffi::TensorView> maybe_lse, int64_t mask_mode_code, int64_t layout,
     int64_t window_left, bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+  CHECK_INPUT_TYPE(qo_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(kv_indptr, dl_dtype_for<IdType>());
   PrefillPlanSM90Info plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
 
@@ -170,6 +178,11 @@ void BatchPrefillWithPagedKVCacheSM90Run(
     ffi::TensorView paged_kv_indices, ffi::TensorView paged_kv_last_page_len, ffi::TensorView o,
     Optional<ffi::TensorView> maybe_lse, int64_t mask_mode_code, int64_t layout,
     int64_t window_left, bool enable_pdl ADDITIONAL_FUNC_PARAMS) {
+  CHECK_INPUT_TYPE(qo_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_indptr, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_indices, dl_dtype_for<IdType>());
+  CHECK_INPUT_TYPE(paged_kv_last_page_len, dl_dtype_for<IdType>());
+
   PrefillPlanSM90Info plan_info;
   plan_info.FromVector(std::vector<int64_t>(plan_info_vec.begin(), plan_info_vec.end()));
 

--- a/csrc/tvm_ffi_utils.h
+++ b/csrc/tvm_ffi_utils.h
@@ -22,6 +22,7 @@
 #include <tvm/ffi/function.h>
 
 #include <flashinfer/layout.cuh>
+#include <type_traits>
 
 #include "dlpack/dlpack.h"
 
@@ -60,6 +61,19 @@ constexpr int64_t int64_code = encode_dlpack_dtype(dl_int64);
 constexpr int64_t float8_e4m3fn_code = encode_dlpack_dtype(dl_float8_e4m3fn);
 constexpr int64_t float8_e5m2_code = encode_dlpack_dtype(dl_float8_e5m2);
 constexpr int64_t float4_e2m1fn_code = encode_dlpack_dtype(dl_float4_e2m1fn);
+
+// DLDataType of a module's compiled IdType, so index tensors can be checked
+// against the type the module was built for instead of a hard-coded dl_int32.
+template <typename IdType>
+inline constexpr DLDataType dl_dtype_for() {
+  static_assert(std::is_same_v<IdType, int32_t> || std::is_same_v<IdType, int64_t>,
+                "dl_dtype_for only supports int32_t or int64_t index types");
+  if constexpr (std::is_same_v<IdType, int32_t>) {
+    return dl_int32;
+  } else {
+    return dl_int64;
+  }
+}
 
 constexpr DLDevice cpu = DLDevice{kDLCPU, 0};
 

--- a/flashinfer/decode.py
+++ b/flashinfer/decode.py
@@ -65,6 +65,7 @@ from .utils import (
     TensorLayout,
     _check_block_tables_shape,
     _check_cached_qkv_data_type,
+    _check_index_tensor,
     _check_kv_layout,
     _check_pos_encoding_mode,
     _check_workspace_buffer_alignment,
@@ -899,18 +900,21 @@ class BatchDecodeWithPagedKVCacheWrapper:
 
         paged_kv_indptr_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the indptr of the paged kv cache, the size
-            of the buffer should be ``[batch_size + 1]``.
+            of the buffer should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D,
+            contiguous, and on the same device as ``float_workspace_buffer``.
             Only needed when ``use_cuda_graph`` is ``True``.
 
         paged_kv_indices_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the page indices of the paged kv cache,
             should be large enough to store the maximum number of page indices
-            (``max_num_pages``) during the lifecycle of this wrapper.
+            (``max_num_pages``) during the lifecycle of this wrapper. Must be ``torch.int32``,
+            1D, contiguous, and on the same device as ``float_workspace_buffer``.
             Only needed when ``use_cuda_graph`` is ``True``.
 
         paged_kv_last_page_len_buffer : Optional[torch.Tensor]
             The user reserved buffer on GPU to store the number of entries in the last page, the
-            size of the buffer should be ``[batch_size]``.
+            size of the buffer should be ``[batch_size]``. Must be ``torch.int32``, 1D,
+            contiguous, and on the same device as ``float_workspace_buffer``.
             Only needed when ``use_cuda_graph`` is ``True``.
 
         backend : str
@@ -993,11 +997,28 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 raise ValueError(
                     "paged_kv_last_page_len_buffer should be a torch.Tensor in cudagraph mode"
                 )
+            # Graph replays read these buffers by address; pin dtype, rank,
+            # device and layout once.
+            _check_index_tensor(
+                paged_kv_last_page_len_buffer,
+                "paged_kv_last_page_len_buffer",
+                device=self.device,
+                contiguous=True,
+            )
             self._fixed_batch_size = len(paged_kv_last_page_len_buffer)
-            if len(paged_kv_indptr_buffer) != self._fixed_batch_size + 1:
-                raise ValueError(
-                    "The size of paged_kv_indptr_buffer should be batch_size + 1"
-                )
+            _check_index_tensor(
+                paged_kv_indptr_buffer,
+                "paged_kv_indptr_buffer",
+                expected_len=self._fixed_batch_size + 1,
+                device=self.device,
+                contiguous=True,
+            )
+            _check_index_tensor(
+                paged_kv_indices_buffer,
+                "paged_kv_indices_buffer",
+                device=self.device,
+                contiguous=True,
+            )
         else:
             self._fixed_batch_size = 0
 
@@ -1542,7 +1563,10 @@ class BatchDecodeWithPagedKVCacheWrapper:
             * self._float_workspace_buffer.element_size()
         )
 
+        _check_index_tensor(last_page_len, "last_page_len")
         batch_size = len(last_page_len)
+        _check_index_tensor(indptr, "indptr", expected_len=batch_size + 1)
+        _check_index_tensor(indices, "indices")
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
         if window_right != 0 and self._backend != "cute-dsl":
@@ -1600,13 +1624,15 @@ class BatchDecodeWithPagedKVCacheWrapper:
                 # later in plan()
                 self._qo_indptr_buf.copy_(qo_indptr_host, non_blocking=non_blocking)
         else:
-            self._paged_kv_indptr_buf = indptr.to(
+            # .to() leaves a strided same-device tensor strided; the kernel needs
+            # contiguous memory.
+            self._paged_kv_indptr_buf = indptr.contiguous().to(
                 self.device, non_blocking=non_blocking
             )
-            self._paged_kv_indices_buf = indices.to(
+            self._paged_kv_indices_buf = indices.contiguous().to(
                 self.device, non_blocking=non_blocking
             )
-            self._paged_kv_last_page_len_buf = last_page_len.to(
+            self._paged_kv_last_page_len_buf = last_page_len.contiguous().to(
                 self.device, non_blocking=non_blocking
             )
             self._qo_indptr_buf = qo_indptr_host.to(
@@ -2739,17 +2765,20 @@ class CUDAGraphBatchDecodeWithPagedKVCacheWrapper(BatchDecodeWithPagedKVCacheWra
         indptr_buffer : torch.Tensor
             The user reserved buffer on GPU to store the indptr of the paged kv cache, should
             be large enough to store the indptr of maximum batch size (``[max_batch_size + 1]``)
-            during the lifecycle of this wrapper.
+            during the lifecycle of this wrapper. Must be ``torch.int32``, 1D, contiguous, and
+            on the same device as ``workspace_buffer``.
 
         indices_buffer : torch.Tensor
             The user reserved buffer on GPU to store the page indices of the paged kv cache,
             should be large enough to store the maximum number of page indices
-            (``max_num_pages``) during the lifecycle of this wrapper.
+            (``max_num_pages``) during the lifecycle of this wrapper. Must be ``torch.int32``,
+            1D, contiguous, and on the same device as ``workspace_buffer``.
 
         last_page_len_buffer : torch.Tensor
             The user reserved buffer on GPU to store the number of entries in the last page,
             should be large enough to store the maximum batch size (``[max_batch_size]``)
-            during the lifecycle of this wrapper.
+            during the lifecycle of this wrapper. Must be ``torch.int32``, 1D, contiguous, and
+            on the same device as ``workspace_buffer``.
 
         use_tensor_cores : bool
             Whether to use tensor cores for the computation. Will be faster for large group
@@ -4366,7 +4395,10 @@ def fast_decode_plan(
     - Remove unnecessary device-to-device copy for the cuda graph buffers.
     - Remove unnecessary host-to-device copy for the metadata buffers.
     """
+    _check_index_tensor(last_page_len, "last_page_len")
     batch_size = len(last_page_len)
+    _check_index_tensor(indptr, "indptr", expected_len=batch_size + 1)
+    _check_index_tensor(indices, "indices")
     if getattr(self, "_backend", None) == "prims-ts":
         raise NotImplementedError(
             "fast_decode_plan is not supported by the prims-ts decode backend"
@@ -4440,9 +4472,11 @@ def fast_decode_plan(
         if self.use_tensor_cores and q_len_per_req > 1:
             self._qo_indptr_buf.copy_(qo_indptr_host, non_blocking=non_blocking)
     else:
-        self._paged_kv_indptr_buf = indptr
-        self._paged_kv_indices_buf = indices
-        self._paged_kv_last_page_len_buf = last_page_len
+        # No device copy here by design; .contiguous() is a no-op for the
+        # contiguous tensors this path expects.
+        self._paged_kv_indptr_buf = indptr.contiguous()
+        self._paged_kv_indices_buf = indices.contiguous()
+        self._paged_kv_last_page_len_buf = last_page_len.contiguous()
         if self.use_tensor_cores:
             self._qo_indptr_buf = qo_indptr_host.to(
                 self.device, non_blocking=non_blocking

--- a/flashinfer/prefill.py
+++ b/flashinfer/prefill.py
@@ -59,6 +59,7 @@ from .utils import (
     TensorLayout,
     _check_block_tables_shape,
     _check_cached_qkv_data_type,
+    _check_index_tensor,
     _check_kv_layout,
     _check_pos_encoding_mode,
     _check_workspace_buffer_alignment,
@@ -1718,23 +1719,27 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         qo_indptr_buf : Optional[torch.Tensor]
             The user reserved buffer to store the ``qo_indptr`` array, the size of the buffer
-            should be ``[batch_size + 1]``.
+            should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D, contiguous, and on the
+            same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True``.
 
         paged_kv_indptr_buf : Optional[torch.Tensor]
             The user reserved buffer to store the ``paged_kv_indptr`` array, the size of this
-            buffer should be ``[batch_size + 1]``.
+            buffer should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D, contiguous, and
+            on the same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True``.
 
         paged_kv_indices_buf : Optional[torch.Tensor]
             The user reserved buffer to store the ``paged_kv_indices`` array, should be large
             enough to store the maximum possible size of the ``paged_kv_indices`` array during
-            the lifetime of the wrapper. This argument is only effective when ``use_cuda_graph``
-            is ``True``.
+            the lifetime of the wrapper. Must be ``torch.int32``, 1D, contiguous, and on the
+            same device as ``float_workspace_buffer``. This argument is only effective when
+            ``use_cuda_graph`` is ``True``.
 
         paged_kv_last_page_len_buf : Optional[torch.Tensor]
             The user reserved buffer to store the ``paged_kv_last_page_len`` array, the size of
-            the buffer should be ``[batch_size]``.
+            the buffer should be ``[batch_size]``. Must be ``torch.int32``, 1D, contiguous, and
+            on the same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True``.
 
         custom_mask_buf : Optional[torch.Tensor]
@@ -1745,7 +1750,8 @@ class BatchPrefillWithPagedKVCacheWrapper:
 
         mask_indptr_buf : Optional[torch.Tensor]
             The user reserved buffer to store the ``mask_indptr`` array, the size of the buffer
-            should be ``[batch_size + 1]``.
+            should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D, contiguous, and on the
+            same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True`` and the custom
             mask will be used in attention computation.
 
@@ -1868,16 +1874,41 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 raise ValueError(
                     "paged_kv_last_page_len_buf should be a torch.Tensor in CUDA graph mode"
                 )
+            # Graph replays read these buffers by address; pin dtype, rank,
+            # device and layout once.
+            _check_index_tensor(
+                qo_indptr_buf, "qo_indptr_buf", device=self.device, contiguous=True
+            )
             self._fixed_batch_size = len(qo_indptr_buf) - 1
-            if len(paged_kv_indptr_buf) != self._fixed_batch_size + 1:
-                raise ValueError(
-                    "The length of paged_kv_indptr_buf should be batch_size + 1."
+            _check_index_tensor(
+                paged_kv_indptr_buf,
+                "paged_kv_indptr_buf",
+                expected_len=self._fixed_batch_size + 1,
+                device=self.device,
+                contiguous=True,
+            )
+            _check_index_tensor(
+                paged_kv_indices_buf,
+                "paged_kv_indices_buf",
+                device=self.device,
+                contiguous=True,
+            )
+            _check_index_tensor(
+                paged_kv_last_page_len_buf,
+                "paged_kv_last_page_len_buf",
+                expected_len=self._fixed_batch_size,
+                device=self.device,
+                contiguous=True,
+            )
+            # custom_mask_buf holds packed mask bits, not indices.
+            if mask_indptr_buf is not None:
+                _check_index_tensor(
+                    mask_indptr_buf,
+                    "mask_indptr_buf",
+                    expected_len=self._fixed_batch_size + 1,
+                    device=self.device,
+                    contiguous=True,
                 )
-            if len(paged_kv_last_page_len_buf) != self._fixed_batch_size:
-                raise ValueError(
-                    "The length of paged_kv_last_page_len_buf should be batch_size."
-                )
-            # NOTE(Zihao): do not check custom_mask_buf and mask_indptr_buf here, as they are optional
         else:
             self._fixed_batch_size = 0
 
@@ -2253,16 +2284,19 @@ class BatchPrefillWithPagedKVCacheWrapper:
         Parameters
         ----------
         qo_indptr : torch.Tensor
-            The indptr of the query/output tensor, shape: ``[batch_size + 1]``.
+            The indptr of the query/output tensor, shape: ``[batch_size + 1]``, dtype
+            ``torch.int32``.
             For the ``cudnn`` backend this is interpreted in **element units**
             (``cumsum(seq_lens_q) * num_qo_heads * head_dim_qk``), not token units.
         paged_kv_indptr : torch.Tensor
-            The indptr of the paged kv-cache, shape: ``[batch_size + 1]``.
+            The indptr of the paged kv-cache, shape: ``[batch_size + 1]``, dtype
+            ``torch.int32``.
         paged_kv_indices : torch.Tensor
-            The page indices of the paged kv-cache, shape: ``[paged_kv_indptr[-1]]``.
+            The page indices of the paged kv-cache, shape: ``[paged_kv_indptr[-1]]``, dtype
+            ``torch.int32``.
         paged_kv_last_page_len : torch.Tensor
             The number of entries in the last page of each request in the paged
-            kv-cache, shape: ``[batch_size]``.
+            kv-cache, shape: ``[batch_size]``, dtype ``torch.int32``.
         num_qo_heads : int
             The number of query/output heads.
         num_kv_heads : int
@@ -2392,7 +2426,15 @@ class BatchPrefillWithPagedKVCacheWrapper:
         if fixed_split_size is None:
             fixed_split_size = -1
 
+        _check_index_tensor(qo_indptr, "qo_indptr")
         batch_size = len(qo_indptr) - 1
+        _check_index_tensor(
+            paged_kv_indptr, "paged_kv_indptr", expected_len=batch_size + 1
+        )
+        _check_index_tensor(paged_kv_indices, "paged_kv_indices")
+        _check_index_tensor(
+            paged_kv_last_page_len, "paged_kv_last_page_len", expected_len=batch_size
+        )
         self._batch_size = batch_size
         self._num_qo_heads = num_qo_heads
         self._num_kv_heads = num_kv_heads
@@ -2507,14 +2549,18 @@ class BatchPrefillWithPagedKVCacheWrapper:
                 # NOTE(Zihao): mask_indptr has the same length as qo_indptr
                 self._mask_indptr_buf.copy_(mask_indptr, non_blocking=non_blocking)
         else:
-            self._qo_indptr_buf = qo_indptr.to(self.device, non_blocking=non_blocking)
-            self._paged_kv_indptr_buf = paged_kv_indptr.to(
+            # .to() leaves a strided same-device tensor strided; the kernel needs
+            # contiguous memory.
+            self._qo_indptr_buf = qo_indptr.contiguous().to(
                 self.device, non_blocking=non_blocking
             )
-            self._paged_kv_indices_buf = paged_kv_indices.to(
+            self._paged_kv_indptr_buf = paged_kv_indptr.contiguous().to(
                 self.device, non_blocking=non_blocking
             )
-            self._paged_kv_last_page_len_buf = paged_kv_last_page_len.to(
+            self._paged_kv_indices_buf = paged_kv_indices.contiguous().to(
+                self.device, non_blocking=non_blocking
+            )
+            self._paged_kv_last_page_len_buf = paged_kv_last_page_len.contiguous().to(
                 self.device, non_blocking=non_blocking
             )
             if packed_custom_mask is not None:
@@ -3507,12 +3553,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         qo_indptr_buf : Optional[torch.Tensor]
             The user reserved GPU buffer to store the ``qo_indptr`` array, the size of the buffer
-            should be ``[batch_size + 1]``.
+            should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D, contiguous, and on the
+            same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True``.
 
         kv_indptr_buf : Optional[torch.Tensor]
             The user reserved GPU buffer to store the ``kv_indptr`` array, the size of the buffer
-            should be ``[batch_size + 1]``.
+            should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D, contiguous, and on the
+            same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True``.
 
         custom_mask_buf : Optional[torch.Tensor]
@@ -3523,7 +3571,8 @@ class BatchPrefillWithRaggedKVCacheWrapper:
 
         mask_indptr_buf : Optional[torch.Tensor]
             The user reserved GPU buffer to store the ``mask_indptr`` array, the size of the buffer
-            should be ``[batch_size]``.
+            should be ``[batch_size + 1]``. Must be ``torch.int32``, 1D, contiguous, and on the
+            same device as ``float_workspace_buffer``.
             This argument is only effective when ``use_cuda_graph`` is ``True`` and custom mask
             will be used in attention computation.
 
@@ -3634,15 +3683,26 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 raise ValueError(
                     "kv_indptr_buf should be a torch.Tensor in cuda graph mode"
                 )
+            _check_index_tensor(
+                qo_indptr_buf, "qo_indptr_buf", device=self.device, contiguous=True
+            )
             self._fixed_batch_size = len(qo_indptr_buf) - 1
-            if len(kv_indptr_buf) != self._fixed_batch_size + 1:
-                raise ValueError(
-                    "The length of kv_indptr_buf ({}) should be the same as qo_indptr_buf ({}).".format(
-                        len(kv_indptr_buf), self._fixed_batch_size
-                    )
+            _check_index_tensor(
+                kv_indptr_buf,
+                "kv_indptr_buf",
+                expected_len=self._fixed_batch_size + 1,
+                device=self.device,
+                contiguous=True,
+            )
+            # custom_mask_buf holds packed mask bits, not indices.
+            if mask_indptr_buf is not None:
+                _check_index_tensor(
+                    mask_indptr_buf,
+                    "mask_indptr_buf",
+                    expected_len=self._fixed_batch_size + 1,
+                    device=self.device,
+                    contiguous=True,
                 )
-            # NOTE(Zihao): do not check custom_mask_buf and mask_indptr_buf here,
-            # as they may not be used.
 
         self._qo_indptr_buf = qo_indptr_buf
         self._kv_indptr_buf = kv_indptr_buf
@@ -3721,13 +3781,15 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         Parameters
         ----------
         qo_indptr : torch.Tensor
-            The indptr of the query/output tensor, shape: ``[batch_size + 1]``.
+            The indptr of the query/output tensor, shape: ``[batch_size + 1]``, dtype
+            ``torch.int32``.
             For the ``cudnn`` backend the ``qo_indptr`` and ``kv_indptr`` are
             interpreted in **element units** (``cumsum(seq_lens) * num_heads *
             head_dim_qk``), not token units. The ``cudnn`` backend also requires
             ``kv_layout="NHD"``.
         kv_indptr : torch.Tensor
-            The indptr of the key/value tensor, shape: ``[batch_size + 1]``.
+            The indptr of the key/value tensor, shape: ``[batch_size + 1]``, dtype
+            ``torch.int32``.
         num_qo_heads : int
             The number of query/output heads.
         num_kv_heads : int
@@ -3852,11 +3914,9 @@ class BatchPrefillWithRaggedKVCacheWrapper:
         if logits_soft_cap is None:
             logits_soft_cap = 0.0
 
+        _check_index_tensor(qo_indptr, "qo_indptr")
         batch_size = len(qo_indptr) - 1
-        if len(kv_indptr) != batch_size + 1:
-            raise ValueError(
-                "The kv_indptr length should be equal to mask_indptr length."
-            )
+        _check_index_tensor(kv_indptr, "kv_indptr", expected_len=batch_size + 1)
         if custom_mask is not None or packed_custom_mask is not None:
             mask_indptr = _compute_mask_indptr(qo_indptr, kv_indptr)
         if packed_custom_mask is None and custom_mask is not None:
@@ -3910,8 +3970,14 @@ class BatchPrefillWithRaggedKVCacheWrapper:
                 self._custom_mask_buf[: len(packed_custom_mask)] = packed_custom_mask
                 self._mask_indptr_buf.copy_(mask_indptr, non_blocking=non_blocking)
         else:
-            self._qo_indptr_buf = qo_indptr.to(self.device, non_blocking=non_blocking)
-            self._kv_indptr_buf = kv_indptr.to(self.device, non_blocking=non_blocking)
+            # .to() leaves a strided same-device tensor strided; the kernel needs
+            # contiguous memory.
+            self._qo_indptr_buf = qo_indptr.contiguous().to(
+                self.device, non_blocking=non_blocking
+            )
+            self._kv_indptr_buf = kv_indptr.contiguous().to(
+                self.device, non_blocking=non_blocking
+            )
             if packed_custom_mask is not None:
                 self._custom_mask_buf = packed_custom_mask.to(
                     self.device, non_blocking=non_blocking

--- a/flashinfer/utils.py
+++ b/flashinfer/utils.py
@@ -791,6 +791,37 @@ def check_shape_dtype_device(
         )
 
 
+def _check_index_tensor(
+    x: torch.Tensor,
+    name: str,
+    *,
+    expected_len: Optional[int] = None,
+    device: Optional[torch.device] = None,
+    contiguous: bool = False,
+) -> None:
+    """Validate an index tensor (indptr, indices, last_page_len) for a wrapper.
+
+    The kernels read these buffers as the compiled ``IdType`` (int32 for every
+    module the wrappers build) whatever the tensor's dtype says, so they must be
+    1-D ``torch.int32``. ``expected_len`` cross-checks a
+    companion tensor; ``device`` and ``contiguous`` are for CUDA-graph buffers,
+    which the captured kernels read by address for the wrapper's lifetime.
+    """
+    if x.dtype != torch.int32:
+        raise ValueError(f"{name} must be torch.int32, got {x.dtype}")
+    if x.ndim != 1:
+        raise ValueError(f"{name} must be a 1D tensor, got ndim={x.ndim}")
+    if expected_len is not None and x.shape[0] != expected_len:
+        raise ValueError(f"{name} must have length {expected_len}, got {x.shape[0]}")
+    if contiguous and not x.is_contiguous():
+        raise ValueError(
+            f"{name} must be contiguous, got shape={tuple(x.shape)} "
+            f"strides={x.stride()}"
+        )
+    if device is not None and x.device != device:
+        raise ValueError(f"{name} must be on device {device}, got {x.device}")
+
+
 def _check_workspace_buffer_alignment(
     x: torch.Tensor, name: str, alignment: int = 16
 ) -> None:

--- a/tests/attention/test_index_tensor_validation.py
+++ b/tests/attention/test_index_tensor_validation.py
@@ -1,0 +1,668 @@
+"""
+Copyright (c) 2023 by FlashInfer team.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import itertools
+
+import pytest
+import torch
+from tests.test_helpers.jit_utils import gen_prefill_attention_modules
+
+import flashinfer
+from flashinfer.utils import has_flashinfer_jit_cache, is_sm90a_supported
+
+# Issue #1654: an index tensor whose dtype disagrees with the compiled module
+# used to be misread by the kernel instead of rejected. One kernel variant
+# (fp16, head_dim 128) keeps JIT time small; most tests raise before any
+# module is fetched.
+
+NUM_QO_HEADS = 8
+NUM_KV_HEADS = 2
+HEAD_DIM = 128
+PAGE_SIZE = 16
+DTYPE = torch.float16
+
+
+@pytest.fixture(
+    autouse=not has_flashinfer_jit_cache(),
+    scope="module",
+)
+def warmup_jit():
+    flashinfer.jit.build_jit_specs(
+        gen_prefill_attention_modules(
+            [DTYPE],  # q_dtypes
+            [DTYPE],  # kv_dtypes
+            [HEAD_DIM],  # head_dims
+            [0],  # pos_encoding_modes
+            [False],  # use_sliding_windows
+            [False],  # use_logits_soft_caps
+            [False],  # use_fp16_qk_reductions
+        ),
+        verbose=False,
+    )
+    yield
+
+
+def _workspace_buffer(device="cuda:0"):
+    return torch.empty(128 * 1024 * 1024, dtype=torch.uint8, device=device)
+
+
+def _make_paged_inputs(device="cuda:0"):
+    """A tiny 3-request paged-KV problem, mirroring the issue #1654 repro."""
+    kv_lens = [40, 5, 33]
+    qo_lens = [4, 1, 7]
+    num_pages = [(l + PAGE_SIZE - 1) // PAGE_SIZE for l in kv_lens]
+    total_pages = sum(num_pages)
+
+    qo_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(qo_lens)), dtype=torch.int32, device=device
+    )
+    kv_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(num_pages)), dtype=torch.int32, device=device
+    )
+    kv_indices = torch.arange(total_pages, dtype=torch.int32, device=device)
+    last_page_len = torch.tensor(
+        [((l - 1) % PAGE_SIZE) + 1 for l in kv_lens], dtype=torch.int32, device=device
+    )
+    kv_cache = (
+        torch.randn(
+            total_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device
+        ),
+        torch.randn(
+            total_pages, PAGE_SIZE, NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device
+        ),
+    )
+    q = torch.randn(sum(qo_lens), NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device=device)
+    return {
+        "qo_indptr": qo_indptr,
+        "kv_indptr": kv_indptr,
+        "kv_indices": kv_indices,
+        "last_page_len": last_page_len,
+        "kv_cache": kv_cache,
+        "q": q,
+        "batch_size": len(kv_lens),
+    }
+
+
+def _make_ragged_inputs(device="cuda:0"):
+    qo_lens = [4, 1, 7]
+    kv_lens = [5, 2, 6]
+    qo_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(qo_lens)), dtype=torch.int32, device=device
+    )
+    kv_indptr = torch.tensor(
+        [0] + list(itertools.accumulate(kv_lens)), dtype=torch.int32, device=device
+    )
+    q = torch.randn(sum(qo_lens), NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device=device)
+    k = torch.randn(sum(kv_lens), NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device)
+    v = torch.randn(sum(kv_lens), NUM_KV_HEADS, HEAD_DIM, dtype=DTYPE, device=device)
+    return {"qo_indptr": qo_indptr, "kv_indptr": kv_indptr, "q": q, "k": k, "v": v}
+
+
+def _strided_copy(x: torch.Tensor) -> torch.Tensor:
+    """Return a non-contiguous view holding the same values as ``x``."""
+    buf = torch.full((2 * x.shape[0],), -1, dtype=x.dtype, device=x.device)
+    buf[0::2] = x
+    strided = buf[0::2]
+    assert not strided.is_contiguous()
+    assert torch.equal(strided, x)
+    return strided
+
+
+# ---------------------------------------------------------------------------
+# Regression: mixed int32/int64 last_page_len (the exact issue #1654 repro).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+def test_paged_prefill_rejects_int64_last_page_len(backend):
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend=backend
+    )
+    with pytest.raises(ValueError, match="paged_kv_last_page_len must be torch.int32"):
+        wrapper.plan(
+            p["qo_indptr"],
+            p["kv_indptr"],
+            p["kv_indices"],
+            p["last_page_len"].to(torch.int64),
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            causal=True,
+        )
+
+
+@pytest.mark.parametrize("use_tensor_cores", [False, True])
+def test_decode_rejects_int64_last_page_len(use_tensor_cores):
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=use_tensor_cores
+    )
+    with pytest.raises(ValueError, match="last_page_len must be torch.int32"):
+        wrapper.plan(
+            p["kv_indptr"],
+            p["kv_indices"],
+            p["last_page_len"].to(torch.int64),
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Other index tensors, wrong lengths, and wrong rank.
+# ---------------------------------------------------------------------------
+
+
+def test_paged_prefill_rejects_int64_qo_indptr():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="qo_indptr must be torch.int32"):
+        wrapper.plan(
+            p["qo_indptr"].to(torch.int64),
+            p["kv_indptr"],
+            p["kv_indices"],
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            causal=True,
+        )
+
+
+def test_paged_prefill_rejects_int64_paged_kv_indptr():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="paged_kv_indptr must be torch.int32"):
+        wrapper.plan(
+            p["qo_indptr"],
+            p["kv_indptr"].to(torch.int64),
+            p["kv_indices"],
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            causal=True,
+        )
+
+
+def test_paged_prefill_rejects_int64_paged_kv_indices():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="paged_kv_indices must be torch.int32"):
+        wrapper.plan(
+            p["qo_indptr"],
+            p["kv_indptr"],
+            p["kv_indices"].to(torch.int64),
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            causal=True,
+        )
+
+
+def test_paged_prefill_rejects_wrong_length_paged_kv_indptr():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="paged_kv_indptr must have length"):
+        wrapper.plan(
+            p["qo_indptr"],
+            p["kv_indptr"][:-1].contiguous(),
+            p["kv_indices"],
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            causal=True,
+        )
+
+
+def test_paged_prefill_rejects_2d_last_page_len():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="must be a 1D tensor"):
+        wrapper.plan(
+            p["qo_indptr"],
+            p["kv_indptr"],
+            p["kv_indices"],
+            p["last_page_len"].unsqueeze(-1),
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            causal=True,
+        )
+
+
+def test_ragged_prefill_rejects_int64_qo_indptr():
+    r = _make_ragged_inputs()
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="qo_indptr must be torch.int32"):
+        wrapper.plan(
+            r["qo_indptr"].to(torch.int64),
+            r["kv_indptr"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            causal=True,
+        )
+
+
+def test_ragged_prefill_rejects_int64_kv_indptr():
+    r = _make_ragged_inputs()
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="kv_indptr must be torch.int32"):
+        wrapper.plan(
+            r["qo_indptr"],
+            r["kv_indptr"].to(torch.int64),
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            causal=True,
+        )
+
+
+def test_ragged_prefill_rejects_wrong_length_kv_indptr():
+    r = _make_ragged_inputs()
+    wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    with pytest.raises(ValueError, match="kv_indptr must have length"):
+        wrapper.plan(
+            r["qo_indptr"],
+            torch.cat([r["kv_indptr"], r["kv_indptr"][-1:]]),
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            causal=True,
+        )
+
+
+def test_decode_rejects_int64_indptr():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=True
+    )
+    with pytest.raises(ValueError, match="indptr must be torch.int32"):
+        wrapper.plan(
+            p["kv_indptr"].to(torch.int64),
+            p["kv_indices"],
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+
+
+def test_decode_rejects_int64_indices():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=True
+    )
+    with pytest.raises(ValueError, match="indices must be torch.int32"):
+        wrapper.plan(
+            p["kv_indptr"],
+            p["kv_indices"].to(torch.int64),
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+
+
+def test_decode_rejects_wrong_length_indptr():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=True
+    )
+    with pytest.raises(ValueError, match="indptr must have length"):
+        wrapper.plan(
+            torch.cat([p["kv_indptr"], p["kv_indptr"][-1:]]),
+            p["kv_indices"],
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Non-contiguous plan() inputs must be silently made contiguous, not rejected:
+# the kernel output must match a contiguous run bit-for-bit.
+# ---------------------------------------------------------------------------
+
+
+def test_paged_prefill_strided_last_page_len_matches_contiguous():
+    p = _make_paged_inputs()
+    strided = _strided_copy(p["last_page_len"])
+
+    ref_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    ref_wrapper.plan(
+        p["qo_indptr"],
+        p["kv_indptr"],
+        p["kv_indices"],
+        p["last_page_len"],
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        causal=True,
+    )
+    ref = ref_wrapper.run(p["q"], p["kv_cache"])
+
+    strided_wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend="fa2"
+    )
+    strided_wrapper.plan(
+        p["qo_indptr"],
+        p["kv_indptr"],
+        p["kv_indices"],
+        strided,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        causal=True,
+    )
+    out = strided_wrapper.run(p["q"], p["kv_cache"])
+    assert torch.equal(out, ref)
+
+
+def test_decode_strided_last_page_len_matches_contiguous():
+    p = _make_paged_inputs()
+    strided = _strided_copy(p["last_page_len"])
+    qd = torch.randn(
+        p["batch_size"], NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda:0"
+    )
+
+    ref_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=True
+    )
+    ref_wrapper.plan(
+        p["kv_indptr"],
+        p["kv_indices"],
+        p["last_page_len"],
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+    )
+    ref = ref_wrapper.run(qd, p["kv_cache"])
+
+    strided_wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=True
+    )
+    strided_wrapper.plan(
+        p["kv_indptr"],
+        p["kv_indices"],
+        strided,
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        q_data_type=DTYPE,
+        kv_data_type=DTYPE,
+    )
+    out = strided_wrapper.run(qd, p["kv_cache"])
+    assert torch.equal(out, ref)
+
+
+def test_ragged_prefill_strided_kv_indptr_matches_contiguous():
+    r = _make_ragged_inputs()
+    outputs = []
+    for kv_indptr in (r["kv_indptr"], _strided_copy(r["kv_indptr"])):
+        wrapper = flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            _workspace_buffer(), "NHD", backend="fa2"
+        )
+        wrapper.plan(
+            r["qo_indptr"],
+            kv_indptr,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            causal=False,
+        )
+        outputs.append(wrapper.run(r["q"], r["k"], r["v"]))
+    assert torch.equal(outputs[0], outputs[1])
+
+
+# ---------------------------------------------------------------------------
+# fast_decode_plan (the copy-free plan used by SGLang) validates the same way.
+# ---------------------------------------------------------------------------
+
+
+def test_fast_decode_plan_rejects_int64_last_page_len():
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", use_tensor_cores=True
+    )
+    with pytest.raises(ValueError, match="last_page_len must be torch.int32"):
+        flashinfer.fast_decode_plan(
+            wrapper,
+            p["kv_indptr"],
+            p["kv_indices"],
+            p["last_page_len"].to(torch.int64),
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+
+
+def test_fast_decode_plan_strided_last_page_len_matches_contiguous():
+    p = _make_paged_inputs()
+    qd = torch.randn(
+        p["batch_size"], NUM_QO_HEADS, HEAD_DIM, dtype=DTYPE, device="cuda:0"
+    )
+    outputs = []
+    for last_page_len in (p["last_page_len"], _strided_copy(p["last_page_len"])):
+        wrapper = flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            _workspace_buffer(), "NHD", use_tensor_cores=True
+        )
+        # fast_decode_plan reuses the module that a regular plan() cached.
+        wrapper.plan(
+            p["kv_indptr"],
+            p["kv_indices"],
+            p["last_page_len"],
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+        flashinfer.fast_decode_plan(
+            wrapper,
+            p["kv_indptr"],
+            p["kv_indices"],
+            last_page_len,
+            NUM_QO_HEADS,
+            NUM_KV_HEADS,
+            HEAD_DIM,
+            PAGE_SIZE,
+            q_data_type=DTYPE,
+            kv_data_type=DTYPE,
+        )
+        outputs.append(wrapper.run(qd, p["kv_cache"]))
+    assert torch.equal(outputs[0], outputs[1])
+
+
+# ---------------------------------------------------------------------------
+# The C++ run binding checks the index dtypes against the compiled IdType, so a
+# buffer swapped behind the wrapper's back is rejected too.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", ["fa2", "fa3"])
+def test_paged_prefill_binding_rejects_mismatched_buffer_dtype(backend):
+    if backend == "fa3" and not is_sm90a_supported(torch.device("cuda:0")):
+        pytest.skip("fa3 backend requires SM90a")
+    p = _make_paged_inputs()
+    wrapper = flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+        _workspace_buffer(), "NHD", backend=backend
+    )
+    wrapper.plan(
+        p["qo_indptr"],
+        p["kv_indptr"],
+        p["kv_indices"],
+        p["last_page_len"],
+        NUM_QO_HEADS,
+        NUM_KV_HEADS,
+        HEAD_DIM,
+        PAGE_SIZE,
+        causal=True,
+    )
+    wrapper._paged_kv_last_page_len_buf = wrapper._paged_kv_last_page_len_buf.to(
+        torch.int64
+    )
+    with pytest.raises(RuntimeError, match="paged_kv_last_page_len"):
+        wrapper.run(p["q"], p["kv_cache"])
+
+
+# ---------------------------------------------------------------------------
+# CUDA-graph buffers: validated once in __init__, not per plan() call.
+# ---------------------------------------------------------------------------
+
+
+def test_prefill_paged_cuda_graph_buffers_reject_int64():
+    device = "cuda:0"
+    batch_size = 3
+    with pytest.raises(ValueError, match="paged_kv_indptr_buf must be torch.int32"):
+        flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            _workspace_buffer(),
+            "NHD",
+            use_cuda_graph=True,
+            qo_indptr_buf=torch.zeros(batch_size + 1, dtype=torch.int32, device=device),
+            paged_kv_indptr_buf=torch.zeros(
+                batch_size + 1, dtype=torch.int64, device=device
+            ),
+            paged_kv_indices_buf=torch.zeros(16, dtype=torch.int32, device=device),
+            paged_kv_last_page_len_buf=torch.zeros(
+                batch_size, dtype=torch.int32, device=device
+            ),
+        )
+
+
+def test_prefill_paged_cuda_graph_buffers_reject_noncontiguous():
+    device = "cuda:0"
+    batch_size = 3
+    strided_indptr = _strided_copy(
+        torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    )
+    with pytest.raises(ValueError, match="paged_kv_indptr_buf must be contiguous"):
+        flashinfer.BatchPrefillWithPagedKVCacheWrapper(
+            _workspace_buffer(),
+            "NHD",
+            use_cuda_graph=True,
+            qo_indptr_buf=torch.zeros(batch_size + 1, dtype=torch.int32, device=device),
+            paged_kv_indptr_buf=strided_indptr,
+            paged_kv_indices_buf=torch.zeros(16, dtype=torch.int32, device=device),
+            paged_kv_last_page_len_buf=torch.zeros(
+                batch_size, dtype=torch.int32, device=device
+            ),
+        )
+
+
+def test_ragged_prefill_cuda_graph_buffers_reject_int64():
+    device = "cuda:0"
+    batch_size = 3
+    with pytest.raises(ValueError, match="kv_indptr_buf must be torch.int32"):
+        flashinfer.BatchPrefillWithRaggedKVCacheWrapper(
+            _workspace_buffer(),
+            "NHD",
+            use_cuda_graph=True,
+            qo_indptr_buf=torch.zeros(batch_size + 1, dtype=torch.int32, device=device),
+            kv_indptr_buf=torch.zeros(batch_size + 1, dtype=torch.int64, device=device),
+        )
+
+
+def test_decode_cuda_graph_buffers_reject_int64():
+    device = "cuda:0"
+    batch_size = 3
+    with pytest.raises(ValueError, match="paged_kv_indptr_buffer must be torch.int32"):
+        flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            _workspace_buffer(),
+            "NHD",
+            use_cuda_graph=True,
+            use_tensor_cores=True,
+            paged_kv_indptr_buffer=torch.zeros(
+                batch_size + 1, dtype=torch.int64, device=device
+            ),
+            paged_kv_indices_buffer=torch.zeros(16, dtype=torch.int32, device=device),
+            paged_kv_last_page_len_buffer=torch.zeros(
+                batch_size, dtype=torch.int32, device=device
+            ),
+        )
+
+
+def test_decode_cuda_graph_buffers_reject_noncontiguous():
+    device = "cuda:0"
+    batch_size = 3
+    strided_last_page_len = _strided_copy(
+        torch.zeros(batch_size, dtype=torch.int32, device=device)
+    )
+    with pytest.raises(
+        ValueError, match="paged_kv_last_page_len_buffer must be contiguous"
+    ):
+        flashinfer.BatchDecodeWithPagedKVCacheWrapper(
+            _workspace_buffer(),
+            "NHD",
+            use_cuda_graph=True,
+            use_tensor_cores=True,
+            paged_kv_indptr_buffer=torch.zeros(
+                batch_size + 1, dtype=torch.int32, device=device
+            ),
+            paged_kv_indices_buffer=torch.zeros(16, dtype=torch.int32, device=device),
+            paged_kv_last_page_len_buffer=strided_last_page_len,
+        )


### PR DESCRIPTION
## Description

The batch attention wrappers hand their index tensors (`qo_indptr`, `paged_kv_indptr`, `paged_kv_indices`, `paged_kv_last_page_len`, `kv_indptr`) to kernels that read them as the compiled `IdType`, int32 for every module the wrappers build, whatever dtype the tensor actually has. An int64 `paged_kv_last_page_len` with otherwise int32 inputs therefore gave wrong output for every request after the first, with no error, on paged prefill (fa2 and fa3) and on tensor-core decode (#1654); only the CUDA-core decode path rejected it, from C++. A non-contiguous index tensor that already lived on the device was passed through `x.to(device)` unchanged and read with the wrong stride.

This PR validates the index tensors before anything is planned or launched:

- `_check_index_tensor` (`flashinfer/utils.py`): 1-D, `torch.int32`, optional length cross-check, optional device and contiguity checks; every violation is a `ValueError` naming the tensor, the expectation and the actual value.
- `plan()` of `BatchPrefillWithPagedKVCacheWrapper`, `BatchPrefillWithRaggedKVCacheWrapper` and `BatchDecodeWithPagedKVCacheWrapper`, and the copy-free `fast_decode_plan` used by SGLang, validate dtype, rank and matching lengths (`len(indptr) == batch_size + 1`, `len(last_page_len) == batch_size`). CPU inputs stay allowed, as serving frameworks pass them. In the non-graph path the tensors go through `.contiguous()` before the device copy, which is a no-op for contiguous inputs.
- CUDA-graph buffers passed to `__init__` (`qo_indptr_buf`, `paged_kv_indptr_buf`, `paged_kv_indices_buf`, `paged_kv_last_page_len_buf`, `mask_indptr_buf` when given, and the decode `*_buffer` arguments) must be int32, 1-D, contiguous and on the workspace device, checked once at construction because captured kernels keep reading them by address.
- Defense in depth: the plan, ragged run and paged run bindings in `csrc/batch_prefill.cu` and `csrc/batch_prefill_sm90.cu` check their index tensors against the compiled `IdType` (the SM90 plan checks only the width of `kv_len_arr`, whose documented `seq_lens` source may be uint32) through a new `dl_dtype_for<IdType>()` helper in `csrc/tvm_ffi_utils.h` (a module can be built for int32 or int64, so no hard-coded `dl_int32`); the existing checks in `csrc/batch_decode.cu` switch to the same helper. These checks also cover callers that reach the bindings without the wrappers' Python validation (the block-sparse wrappers and `fast_decode_plan`): an index tensor of the wrong dtype there now raises a `RuntimeError` from `run()` instead of being misread.
- Docstrings state `torch.int32` for each index tensor and the buffer requirements.

int32 is the rule because the CUDA-core decode binding, `docs/tutorials/kv_layout.rst`, every docs example and the AOT-built modules use it; the JIT module is keyed by the dtype of the leading `indptr`, which is how a mixed dtype ended up misread. Consistently int64 index tensors, which used to build an int64 module through the JIT, are now rejected in `plan()` as well.

## Related Issues

Closes #1654.

## Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### Pre-commit Checks

- [x] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [x] I have installed the hooks with `pre-commit install`.
- [x] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

## Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

New file `tests/attention/test_index_tensor_validation.py`:

- The issue's scenario (batch 3, int64 `last_page_len`, other tensors int32) raises `ValueError` from `plan()` on paged prefill (fa2, fa3) and decode (CUDA core, tensor core).
- int64 `qo_indptr`, `paged_kv_indptr`, `paged_kv_indices` and ragged `kv_indptr`, wrong lengths, and a 2-D tensor raise.
- A strided device `last_page_len` (paged prefill and tensor-core decode) or ragged `kv_indptr` gives output identical to the contiguous run.
- CUDA-graph buffers with int64 dtype or a strided layout raise in `__init__` (paged prefill, ragged prefill, decode).
- The C++ binding check: after a valid `plan()`, an int64 buffer swapped in behind the wrapper is rejected by `run()` on fa2 and fa3 (the fa3 case skips without SM90a).
- `fast_decode_plan` rejects an int64 `last_page_len` and gives identical output for a strided one.

Mutation check: with the Python `plan()` validation disabled, the regression test fails; restored, it passes.

Runs on an NVIDIA GH200 480GB (SM90), CUDA 12.8, torch 2.7.0+cu128, from an empty JIT cache (no prebuilt or staged kernels, so every binding was compiled from this branch):

```
pytest tests/attention/test_index_tensor_validation.py    27 passed, 21 warnings (107.08s including the kernel builds)
pytest tests/attention/test_tensor_cores_decode.py         2448 passed, 21 warnings in 389.32s
pytest tests/utils/test_jit_example.py                     14 passed, 21 warnings in 143.13s
pytest tests/attention/test_batch_prefill_kernels.py       8788 passed, 1329 skipped, 5760 xfailed, 21 warnings in 561.73s
pytest tests/attention/test_batch_decode_kernels.py        3081 passed, 181 skipped, 21 warnings in 421.58s
```

## Reviewer Notes

- The same index tensors in the MLA, POD, sparse and cascade wrappers, the `workspace_size()` helpers that mirror `plan()` and the cudnn-only `v_indptr`/`o_indptr` of the ragged wrapper are not covered here (follow-ups).
- `seq_lens` and `block_tables` (documented as uint32) are not validated by this PR.
- Two pre-existing ad-hoc length checks (the paged wrapper's buffer lengths in `__init__` and the ragged wrapper's `kv_indptr` length in `plan()`) are replaced by the helper, so their messages change and now name the actual values.

Made in combination with Claude Fable 5.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent validation for attention index tensors, including dtype, shape, length, device, and contiguity checks.
  * Prevented mismatched index buffers from reaching decode and prefill operations.
  * Automatically handles non-contiguous index tensors where supported, preserving expected results.
  * Improved validation for CUDA graph buffers and custom mask-indirection inputs.

* **Documentation**
  * Clarified requirements for index tensor types, dimensions, lengths, devices, and contiguity across decode and prefill APIs.

* **Tests**
  * Added coverage for invalid inputs, non-contiguous tensors, CUDA graph buffers, and multiple attention backends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->