### PR TITLE
fix[mla]: add Q8 floor for tile selection in trtllm-gen sparse mla kernels

### DIFF
--- a/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
+++ b/include/flashinfer/trtllm/fmha/fmhaKernels.cuh
@@ -782,13 +782,15 @@ class TllmGenFmhaKernel {
     return seqLenPerCtaKv <= 1024 && numCtas <= params.mMultiProcessorCount;
   }
 
-  // Return the smallest shipped MLA head tile that contains a non-power-of-two head group below
-  // 64 heads. Power-of-two groups and groups with at least 128 heads return zero so callers
-  // preserve their existing heuristics; the unsupported 65-127 gap has no Q128 MLA cubin.
+  // Return the smallest shipped MLA head tile that contains a head group below 64 heads which
+  // cannot serve as its own tile: non-power-of-two groups, and any group below the Q8 floor.
+  // Power-of-two groups of at least 8 heads and groups with at least 128 heads return zero so
+  // callers preserve their existing heuristics; the unsupported 65-127 gap has no Q128 MLA cubin.
   static int getPaddedMlaTileSizeQ(int numHeadsQPerKv) {
     FLASHINFER_CHECK(numHeadsQPerKv > 0, "The numHeadsQPerKv must be positive, got %d.",
                      numHeadsQPerKv);
-    if (numHeadsQPerKv >= 128 || (numHeadsQPerKv & (numHeadsQPerKv - 1)) == 0) {
+    if (numHeadsQPerKv >= 128 ||
+        (numHeadsQPerKv >= 8 && (numHeadsQPerKv & (numHeadsQPerKv - 1)) == 0)) {
       return 0;
     }
     FLASHINFER_CHECK(numHeadsQPerKv <= 64,
@@ -870,8 +872,8 @@ class TllmGenFmhaKernel {
         selectKernelParams.mHeadDimPerCtaV = 256;
       }
     }
-    // Preserve the legacy heuristic above for power-of-two groups. A non-power-of-two group must
-    // fit in one padded tile because the final head CTA cannot process a partial tile.
+    // Preserve the legacy heuristic above for power-of-two groups of at least 8 heads. Any other
+    // group must fit in one padded tile because the final head CTA cannot process a partial tile.
     if (int const paddedTileSizeQ = getPaddedMlaTileSizeQ(params.mNumHeadsQPerKv);
         paddedTileSizeQ != 0) {
       tileSizeQ = paddedTileSizeQ;

--- a/tests/attention/test_trtllm_gen_mla.py
+++ b/tests/attention/test_trtllm_gen_mla.py
@@ -1145,6 +1145,22 @@ def test_trtllm_batch_decode_sparse_mla_power_of_two_heads(
     )
 
 
+@pytest.mark.parametrize("num_heads", [1, 2, 4])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float8_e4m3fn])
+@pytest.mark.parametrize("topk", [128, 2048])
+def test_trtllm_batch_decode_sparse_mla_small_power_of_two_heads(
+    num_heads: int,
+    dtype: torch.dtype,
+    topk: int,
+) -> None:
+    _run_trtllm_batch_decode_sparse_mla_head_case(
+        num_heads,
+        1,
+        dtype,
+        topk,
+    )
+
+
 @pytest.mark.parametrize(
     "layer_dimensions",
     supported_mla_layer_dimensions,


### PR DESCRIPTION
## 📌 Description

`trtllm_batch_decode_mla` on the sparse path fails kernel lookup before launch when a tensor-parallel split leaves fewer than 8 Q heads per rank *and* that count is a power of two. Reported on v0.6.18 / SM107 with GLM-5.2 under SGLang disaggregated decode at TEP16 — 64 Q heads over 16 ranks leaves `numHeadsQPerKv = 4`:

```
Missing TRTLLM-GEN kernel (decode): qkvLayout=2, maskType=0, kernelType=2,
tileScheduler=0, multiCtasKvMode=1, headDimPerCtaV=512, headDimQk=576,
headDimV=512, tileSizeQ=4, tileSizeKv=128, numTokensPerPage=1, ...
sparseMlaType=1, ...
```

**Cause.** `selectSparseMlaGenerationKernel` sets the base tile to the head group itself (`tileSizeQ = numHeadsQPerKv`), and only the *halving* branch checks the Q8 floor (`halfTileSizeQ >= 8`). The helper that exists to rescue undersized groups, `getPaddedMlaTileSizeQ`, early-returns `0` for **every** power of two — so groups of 1, 2 and 4 skip padding entirely and hash to a kernel that does not exist.

**This is not a cubin coverage gap.** Q8 is the smallest MLA tile that ships: the trtllm-gen generator configures `tileSizeQList = [8, 16, 32]` for the static-token-sparse H576x512 group, 8 is the minimum across every kernel family in that manifest, and no revision of it has ever contained a tile below 8. No cubin publish can resolve this — the selector has to clamp.

**Why it went unnoticed.** Two independent reasons:

- Groups of 5, 6 and 7 already work: they are not powers of two, so they take the padding path and round up to 8. Sub-8 head counts are in fact already covered — `test_trtllm_batch_decode_sparse_mla_generic_non_power_of_two_heads[3-...]` and `..._non_power_of_two_heads[...-6-...]` both pass today. The matrix simply never lands on a power of two below 8.
- Dense MLA already works at these head counts: the non-sparse branch has its own `numHeadsQPerKv <= 8 ? 8 : 16` clamp. Only the sparse path is affected.

**Fix.** Extend the existing padding helper to also pad power-of-two groups below 8, rather than adding a second clamp at the call site, so one place continues to own the floor. Padding a Q8 tile that serves fewer than 8 real heads is the mechanism already in production for 5/6/7-head groups: the launcher sizes the grid from `min(numHeadsQPerKv, kernelMeta.mStepQ)` — the real head count, not the tile — so launch geometry stays correct.

**Blast radius.** Evaluating the selector both ways across SM counts {148, 208, 212} × batch {1, 2, 8, 32, 128} × topK {128, 512, 2048} × seqLenKv {1024, 8192, 131072}: only `numHeadsQPerKv` ∈ {1, 2, 4} changes, all to Q8, on the sparse path only. The dense path is identical at every head count. Everything ≥ 8 is untouched.

## 🔍 Related Issues

Reported internally against v0.6.18 (SM107 / GLM-5.2 / SGLang disaggregated decode, TEP16).

## 🚀 Pull Request Checklist

Thank you for contributing to FlashInfer! Before we review your pull request, please make sure the following items are complete.

### ✅ Pre-commit Checks

- [ ] I have installed `pre-commit` by running `pip install pre-commit` (or used your preferred method).
- [ ] I have installed the hooks with `pre-commit install`.
- [ ] I have run the hooks manually with `pre-commit run --all-files` and fixed any reported issues.

> If you are unsure about how to set up `pre-commit`, see [the pre-commit documentation](https://pre-commit.com/).

## 🧪 Tests

- [x] Tests have been added or updated as needed.
- [x] All tests are passing (`unittest`, etc.).

`test_trtllm_batch_decode_sparse_mla_small_power_of_two_heads` adds the missing corner: heads {1, 2, 4} × {bf16, fp8_e4m3} × topk {128, 2048}, placed next to the existing `..._power_of_two_heads` test which only covers 16.

Validated on SM107 (GR100) in `flashinfer-ci:rubin-latest-py312-amd64` carrying v0.6.18, the version the failure was reported against. The selector logic is byte-identical between this base and 0.6.18.

| | new cases | `-k "heads or sparse"` |
|---|---|---|
| before | 12 failed | 12 failed, 1385 passed |
| after | 12 passed | **1397 passed, 0 failed** |

Fixed by this change: 12. Broken by this change: 0.

## 🔬 Experimental Track

<!-- Only for PRs submitted under the experimental policy (CONTRIBUTING.md → "Experimental APIs and Backends").
     Leave this section untouched for normal PRs. -->

- [ ] This PR is **experimental**: it adds or changes code under `flashinfer/experimental/` and/or an `@flashinfer_experimental_api`. Tracking issue: #

## Reviewer Notes

The functional change is one condition; the other six lines correct two existing comments that the change makes factually false (the helper's doc comment and the call-site comment). No new explanatory prose was added.

Worth a second look: the claim that an oversized tile is safe. It rests on `computeCtaAndClusterConfig` deriving `numHeadsPerCta = min(params.mNumHeadsQPerKv, kernelMeta.mStepQ)`, so the grid follows the real head count rather than the tile — and every shipped Q8 sparse MLA record has `stepQ = 8` with `mGroupsHeadsQ = true`.

One caveat this PR does not address: a Q8 tile serving 4 real heads leaves half the Q tile idle. This makes wide-TEP sparse MLA *work*; whether it is the right performance point for TEP16 versus TEP8 has not been measured here.
